### PR TITLE
Stop closing terminal after running

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -195,7 +195,6 @@ function Main {
     }
 
     Write-Host ""
-    exit 0
 }
 
 Main


### PR DESCRIPTION
Hi, I tried using this as a fellow Windows user in Powershell but I couldn't get it to work. It annoyed me that I couldn't see the command to copy the save in PATH forever because the terminal closes because I didn't want to install the skill (I was in the root users folder in a new terminal). I think this might be a good change, feel free to reject if you disagree!