### PR TITLE
fix(security): harden untrusted CLI inputs

### DIFF
--- a/apps/cli/src/audit/cloud.ts
+++ b/apps/cli/src/audit/cloud.ts
@@ -33,6 +33,7 @@ import {
   loadAllRules,
   type RuleCloudSpec,
 } from "@squirrelscan/rules";
+import { hasUnsafeUrlScheme } from "@squirrelscan/utils";
 
 import type { ExternalBulkChecker, SiteContextPage } from "@/audit/adapter";
 import type { Config } from "@/config";
@@ -250,12 +251,7 @@ function extractVisibleLinks(doc: Document): { href: string; text?: string }[] {
   for (const anchor of anchors) {
     const href = (anchor as Element).getAttribute("href")?.trim();
     if (!href) continue;
-    if (
-      href.startsWith("#") ||
-      href.startsWith("javascript:") ||
-      href.startsWith("data:")
-    )
-      continue;
+    if (href.trimStart().startsWith("#") || hasUnsafeUrlScheme(href)) continue;
     if (seen.has(href)) continue;
     seen.add(href);
     const text = (anchor as Element).textContent?.trim();

--- a/apps/cli/src/controllers/auth/login.ts
+++ b/apps/cli/src/controllers/auth/login.ts
@@ -119,6 +119,7 @@ async function findAvailablePort(): Promise<number> {
  * Open a URL in the default browser
  */
 async function openBrowser(url: string): Promise<void> {
+  const safeUrl = normalizeBrowserUrl(url);
   const { platform } = process;
 
   let command: string;
@@ -126,14 +127,17 @@ async function openBrowser(url: string): Promise<void> {
 
   if (platform === "darwin") {
     command = "open";
-    args = [url];
+    args = [safeUrl];
   } else if (platform === "win32") {
-    command = "cmd";
-    args = ["/c", "start", "", url];
+    // Do not pass the API-provided URL through cmd.exe: shell metacharacters in
+    // the URL would otherwise be interpreted as commands. Explorer delegates
+    // HTTP(S) URLs to the default browser without invoking a command shell.
+    command = "explorer.exe";
+    args = [safeUrl];
   } else {
     // Linux
     command = "xdg-open";
-    args = [url];
+    args = [safeUrl];
   }
 
   const { spawn } = await import("node:child_process");
@@ -147,6 +151,14 @@ async function openBrowser(url: string): Promise<void> {
     // Don't wait for close - browser stays open
     setTimeout(resolve, 500);
   });
+}
+
+export function normalizeBrowserUrl(rawUrl: string): string {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Authentication URL must use HTTP or HTTPS");
+  }
+  return url.toString();
 }
 
 export function fetchSessionStatus(

--- a/apps/cli/src/links/index.ts
+++ b/apps/cli/src/links/index.ts
@@ -1,6 +1,7 @@
 // Internal link analysis - crawl depth, orphan pages, link equity
 // Phase 4 enhancement for comprehensive link analysis
 
+import { shouldSkipUrl } from "@squirrelscan/utils";
 import { parseHTML } from "linkedom";
 
 import type {
@@ -46,12 +47,7 @@ export function extractEnhancedLinks(
     if (!href) continue;
 
     // Skip javascript:, mailto:, tel:, etc.
-    if (
-      href.startsWith("javascript:") ||
-      href.startsWith("mailto:") ||
-      href.startsWith("tel:") ||
-      href.startsWith("#")
-    ) {
+    if (shouldSkipUrl(href)) {
       continue;
     }
 

--- a/apps/cli/src/self/paths.ts
+++ b/apps/cli/src/self/paths.ts
@@ -17,6 +17,14 @@ export interface SquirrelPaths {
   logs: string; // ~/.squirrel/logs
 }
 
+const RELEASE_VERSION_PATTERN =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+/** Release directory names must be canonical SemVer and a single path segment. */
+export function isValidReleaseVersion(version: string): boolean {
+  return RELEASE_VERSION_PATTERN.test(version);
+}
+
 export function getSquirrelPaths(): SquirrelPaths {
   const home = homedir();
   const os = platform() as Platform;
@@ -135,6 +143,9 @@ export function getLocalSettingsDir(): string {
 }
 
 export function getReleasePath(version: string): string {
+  if (!isValidReleaseVersion(version)) {
+    throw new Error(`Invalid release version: ${version}`);
+  }
   return join(getSquirrelPaths().releases, version);
 }
 

--- a/apps/cli/src/self/releases.ts
+++ b/apps/cli/src/self/releases.ts
@@ -9,9 +9,63 @@ import type {
   PlatformArch,
 } from "./types";
 
+import { isValidReleaseVersion } from "./paths";
+
 const GITHUB_API = "https://api.github.com";
 const REPO_OWNER = "squirrelscan";
 const REPO_NAME = "squirrelscan";
+const PLATFORM_ARCHES: PlatformArch[] = [
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-x64",
+  "linux-arm64",
+  "windows-x64",
+];
+const RELEASE_FILENAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+
+function parseReleaseManifest(value: unknown): Result<ReleaseManifest> {
+  if (!value || typeof value !== "object") {
+    return err(
+      commandError("NETWORK_ERROR", "Malformed release metadata response")
+    );
+  }
+
+  const manifest = value as Partial<ReleaseManifest>;
+  if (
+    typeof manifest.version !== "string" ||
+    !isValidReleaseVersion(manifest.version) ||
+    (manifest.channel !== "stable" && manifest.channel !== "beta") ||
+    typeof manifest.released_at !== "string" ||
+    !manifest.binaries ||
+    typeof manifest.binaries !== "object" ||
+    typeof manifest.release_notes_url !== "string"
+  ) {
+    return err(
+      commandError("NETWORK_ERROR", "Malformed release metadata response")
+    );
+  }
+
+  for (const platformArch of PLATFORM_ARCHES) {
+    const binary = manifest.binaries[platformArch];
+    if (!binary) continue;
+    if (
+      typeof binary.filename !== "string" ||
+      !RELEASE_FILENAME_PATTERN.test(binary.filename) ||
+      typeof binary.sha256 !== "string" ||
+      !SHA256_PATTERN.test(binary.sha256) ||
+      typeof binary.size !== "number" ||
+      !Number.isSafeInteger(binary.size) ||
+      binary.size <= 0
+    ) {
+      return err(
+        commandError("NETWORK_ERROR", "Malformed release metadata response")
+      );
+    }
+  }
+
+  return ok(manifest as ReleaseManifest);
+}
 
 // R2-backed release metadata (latest manifest per channel) served by the
 // installer worker. Primary update-check source: the GitHub API below is
@@ -39,13 +93,7 @@ export async function fetchChannelManifest(
         )
       );
     }
-    const manifest = (await response.json()) as ReleaseManifest;
-    if (typeof manifest?.version !== "string" || !manifest.binaries) {
-      return err(
-        commandError("NETWORK_ERROR", "Malformed release metadata response")
-      );
-    }
-    return ok(manifest);
+    return parseReleaseManifest(await response.json());
   } catch (error) {
     return err(commandError("NETWORK_ERROR", (error as Error).message));
   }
@@ -109,7 +157,7 @@ export async function fetchManifest(
         )
       );
     }
-    return ok((await response.json()) as ReleaseManifest);
+    return parseReleaseManifest(await response.json());
   } catch (error) {
     return err(commandError("NETWORK_ERROR", (error as Error).message));
   }
@@ -256,6 +304,9 @@ export async function downloadBinary(
   platformArch: PlatformArch,
   options?: { signal?: AbortSignal }
 ): Promise<Result<ArrayBuffer>> {
+  if (!isValidReleaseVersion(manifest.version)) {
+    return err(commandError("INVALID_RELEASE", "Release version is invalid"));
+  }
   const binary = manifest.binaries[platformArch];
   if (!binary) {
     return err(
@@ -263,6 +314,16 @@ export async function downloadBinary(
         "UNSUPPORTED_PLATFORM",
         `No binary available for ${platformArch}`
       )
+    );
+  }
+  if (
+    !RELEASE_FILENAME_PATTERN.test(binary.filename) ||
+    !SHA256_PATTERN.test(binary.sha256) ||
+    !Number.isSafeInteger(binary.size) ||
+    binary.size <= 0
+  ) {
+    return err(
+      commandError("INVALID_RELEASE", "Release binary metadata is invalid")
     );
   }
 

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -27,6 +27,7 @@ import {
   getSymlinkPath,
   getUpdateLockPath,
   getUnmanagedUpdateHint,
+  isValidReleaseVersion,
   isManagedInstall,
   detectPlatformArch,
 } from "./paths";
@@ -747,14 +748,17 @@ export async function installVersion(
   version: string,
   binaryData: ArrayBuffer
 ): Promise<Result<void>> {
-  const releasePath = getReleasePath(version);
-  const binaryPath = getBinaryPath(version);
-
-  // Write to a temp file and rename into place — a crash mid-write must
-  // never leave a corrupt binary at the path the symlink will point to.
-  const tmpPath = `${binaryPath}.tmp-${process.pid}`;
-
+  let tmpPath: string | null = null;
   try {
+    if (!isValidReleaseVersion(version)) {
+      return err(commandError("INVALID_RELEASE", "Release version is invalid"));
+    }
+    const releasePath = getReleasePath(version);
+    const binaryPath = getBinaryPath(version);
+
+    // Write to a temp file and rename into place — a crash mid-write must
+    // never leave a corrupt binary at the path the symlink will point to.
+    tmpPath = `${binaryPath}.tmp-${process.pid}`;
     if (!existsSync(releasePath)) {
       mkdirSync(releasePath, { recursive: true });
     }
@@ -765,10 +769,12 @@ export async function installVersion(
 
     return ok(undefined);
   } catch (error) {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      // tmp never written or already cleaned up
+    if (tmpPath) {
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // tmp never written or already cleaned up
+      }
     }
     return err(
       commandError(
@@ -787,11 +793,14 @@ export function updateSymlink(
   version: string,
   customBinDir?: string
 ): Result<void> {
-  const binaryPath = getBinaryPath(version);
   const symlinkPath = getSymlinkPath(customBinDir);
   const symlinkDir = dirname(symlinkPath);
 
   try {
+    if (!isValidReleaseVersion(version)) {
+      return err(commandError("INVALID_RELEASE", "Release version is invalid"));
+    }
+    const binaryPath = getBinaryPath(version);
     if (!existsSync(symlinkDir)) {
       mkdirSync(symlinkDir, { recursive: true });
     }

--- a/apps/cli/tests/controllers/auth-login.test.ts
+++ b/apps/cli/tests/controllers/auth-login.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { localApiHint } from "@/controllers/auth/login";
+import { localApiHint, normalizeBrowserUrl } from "@/controllers/auth/login";
 import { DEFAULT_API_URL } from "@/self/api";
 
 describe("auth/login — localApiHint", () => {
@@ -27,5 +27,22 @@ describe("auth/login — localApiHint", () => {
     ]) {
       expect(localApiHint(url)).toBe("");
     }
+  });
+});
+
+describe("auth/login — browser URL validation", () => {
+  test("accepts HTTP(S) authentication URLs", () => {
+    expect(normalizeBrowserUrl("https://example.com/login?a=1")).toBe(
+      "https://example.com/login?a=1"
+    );
+  });
+
+  test("rejects shell-like and executable URL schemes", () => {
+    expect(() => normalizeBrowserUrl("javascript:alert(1)")).toThrow(
+      "must use HTTP or HTTPS"
+    );
+    expect(() => normalizeBrowserUrl("file:///tmp/payload")).toThrow(
+      "must use HTTP or HTTPS"
+    );
   });
 });

--- a/apps/cli/tests/self/releases.test.ts
+++ b/apps/cli/tests/self/releases.test.ts
@@ -76,6 +76,19 @@ describe("releases noRetry option", () => {
     expect(callCount).toBe(1);
   });
 
+  test("fetchManifest rejects path-traversing release versions", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ...mockManifest, version: "../../bin" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    const result = await fetchManifest(mockRelease, { noRetry: true });
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.message).toBe("Malformed release metadata response");
+  });
+
   test("checkForUpdates resolves via the metadata endpoint in one call", async () => {
     const urls: string[] = [];
 

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -301,6 +301,22 @@ describe("updater", () => {
       if (!result.ok) expect(result.error.code).toBe("DOWNLOAD_ABORTED");
     });
 
+    test("rejects invalid release paths before downloading", async () => {
+      let fetched = false;
+      globalThis.fetch = (async () => {
+        fetched = true;
+        return new Response("binary");
+      }) as unknown as typeof fetch;
+
+      const result = await downloadBinary(
+        { ...manifest, version: "../../bin" },
+        "darwin-arm64"
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe("INVALID_RELEASE");
+      expect(fetched).toBe(false);
+    });
+
     test("pre-aborted signal never downloads", async () => {
       let fetched = false;
       globalThis.fetch = ((

--- a/apps/cli/tests/utils/client-redirects.test.ts
+++ b/apps/cli/tests/utils/client-redirects.test.ts
@@ -42,6 +42,12 @@ describe("findClientRedirects", () => {
         "<meta http-equiv='refresh' content='0;url=https://target.com/'>";
       expect(findClientRedirects(html, baseUrl)).toBe("https://target.com/");
     });
+
+    test("handles case-insensitive attributes separated by newlines", () => {
+      const html =
+        '<META\nHTTP-EQUIV="REFRESH"\nCONTENT="0; URL=https://target.com/">';
+      expect(findClientRedirects(html, baseUrl)).toBe("https://target.com/");
+    });
   });
 
   describe("JavaScript redirect detection", () => {

--- a/packages/audit-engine/src/cloaking-probe.ts
+++ b/packages/audit-engine/src/cloaking-probe.ts
@@ -14,6 +14,7 @@
 // capped to `maxPages` so it never multiplies crawl cost.
 
 import { getPathname, normalizeUrl } from "@squirrelscan/utils/url";
+import { stripHtmlForText } from "@squirrelscan/utils";
 
 import { DEFAULT_MAX_BODY_BYTES, readBodyCapped } from "./lib/capped-body-read";
 
@@ -145,12 +146,7 @@ export function selectSuspiciousPaths(
 
 /** Strip markup + script/style and return the set of visible-text tokens. */
 export function visibleTokens(html: string): Set<string> {
-  const text = html
-    .replace(/<script[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style[\s\S]*?<\/style>/gi, " ")
-    .replace(/<!--[\s\S]*?-->/g, " ")
-    .replace(/<[^>]+>/g, " ")
-    .toLowerCase();
+  const text = stripHtmlForText(html, { exclude: ["script", "style"] }).toLowerCase();
   const set = new Set<string>();
   for (const t of text.split(/[^a-z0-9]+/)) {
     if (t.length > 1) set.add(t);

--- a/packages/audit-engine/src/cloud-prefetch-run.ts
+++ b/packages/audit-engine/src/cloud-prefetch-run.ts
@@ -21,7 +21,7 @@ import { SERVICE_LIMITS } from "@squirrelscan/core-contracts/limits";
 import type { Config } from "@squirrelscan/config";
 import { buildEditorSummaryRequest } from "@squirrelscan/report/editor-summary";
 import { filterRules, loadAllRules, type RuleCloudSpec } from "@squirrelscan/rules";
-import { getHostname, getOrigin, getPathname } from "@squirrelscan/utils/url";
+import { getHostname, getOrigin, getPathname, hasUnsafeUrlScheme } from "@squirrelscan/utils/url";
 
 import {
   prefetchCloudData,
@@ -128,8 +128,7 @@ function extractVisibleLinks(doc: Document): { href: string; text?: string }[] {
   const seen = new Set<string>();
   for (const anchor of doc.querySelectorAll("a[href]")) {
     const href = (anchor as Element).getAttribute("href")?.trim();
-    if (!href || href.startsWith("#") || href.startsWith("javascript:") || href.startsWith("data:"))
-      continue;
+    if (!href || href.trimStart().startsWith("#") || hasUnsafeUrlScheme(href)) continue;
     if (seen.has(href)) continue;
     seen.add(href);
     const text = (anchor as Element).textContent?.trim();
@@ -269,7 +268,7 @@ export function buildBlocklistPayload(
 // ── keyword/content gaps payloads (mirrors apps/cli/src/audit/cloud-payloads-gaps.ts) ──
 const MIN_SEED_LENGTH = 3;
 const MAX_SEED_LENGTH = 80;
-const TITLE_SEPARATORS = /\s*[|·—–]\s*|\s+-\s+/;
+const TITLE_SEPARATOR_CHARS = new Set(["|", "·", "—", "–"]);
 
 export type GapsPayloads = Pick<CloudSitePayloads, "keyword-gaps" | "content-gaps">;
 
@@ -304,7 +303,34 @@ function gapsOptions(config: Config, ruleId: string): GapsRuleOptions {
 }
 
 function cleanSeed(text: string): string | null {
-  const segment = (text.split(TITLE_SEPARATORS)[0] ?? "").replace(/\s+/g, " ").trim();
+  let separator = text.length;
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    if (
+      TITLE_SEPARATOR_CHARS.has(char) ||
+      (char === "-" &&
+        i > 0 &&
+        i + 1 < text.length &&
+        text[i - 1].trim() === "" &&
+        text[i + 1].trim() === "")
+    ) {
+      separator = i;
+      break;
+    }
+  }
+  const raw = text.slice(0, separator).trim();
+  const parts: string[] = [];
+  let inWhitespace = false;
+  for (const char of raw) {
+    if (char.trim() === "") {
+      inWhitespace = true;
+    } else {
+      if (inWhitespace && parts.length > 0) parts.push(" ");
+      parts.push(char);
+      inWhitespace = false;
+    }
+  }
+  const segment = parts.join("");
   if (segment.length < MIN_SEED_LENGTH || segment.length > MAX_SEED_LENGTH) return null;
   return segment;
 }

--- a/packages/cloud-client/src/client.ts
+++ b/packages/cloud-client/src/client.ts
@@ -253,7 +253,9 @@ function isRetryableStatus(status: number): boolean {
 }
 
 export function createCloudClient(config: CloudClientConfig): CloudServicesClient {
-  const base = config.apiUrl.replace(/\/+$/, "");
+  let baseEnd = config.apiUrl.length;
+  while (baseEnd > 0 && config.apiUrl[baseEnd - 1] === "/") baseEnd--;
+  const base = config.apiUrl.slice(0, baseEnd);
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxAttempts = config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
 

--- a/packages/fetchers/src/csr-detect.ts
+++ b/packages/fetchers/src/csr-detect.ts
@@ -6,6 +6,8 @@
 // and are never flagged, so static sites pay zero render credits. A missed CSR
 // page (false negative) just audits the shell, same as a plain --http run.
 
+import { stripHtmlForText } from "@squirrelscan/utils";
+
 // Thresholds tuned for LOW false positives so static/SSR sites pay zero render
 // credits.
 /** Visible-text length below which a page counts as "empty-ish" (a shell). */
@@ -24,11 +26,9 @@ const EMPTY_SPA_ROOT_PATTERNS: RegExp[] = [
 
 /** Approximate visible text: strip comments, non-rendered elements, head, tags. */
 export function extractVisibleText(html: string): string {
-  return html
-    .replace(/<!--[\s\S]*?-->/g, " ")
-    .replace(/<(script|style|template|noscript|svg)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
-    .replace(/<head\b[\s\S]*?<\/head>/gi, " ")
-    .replace(/<[^>]+>/g, " ")
+  return stripHtmlForText(html, {
+    exclude: ["script", "style", "template", "noscript", "svg", "head"],
+  })
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/packages/parser/src/extractors/links.ts
+++ b/packages/parser/src/extractors/links.ts
@@ -3,11 +3,14 @@
 
 import type { Document, Element } from "linkedom";
 
-import { coerceSchemelessUrl } from "@squirrelscan/utils";
+import { coerceSchemelessUrl, hasNonCrawlableUrlScheme } from "@squirrelscan/utils";
 import { Effect } from "effect";
 
 // Trace stubs (CLI wraps with rich logger)
-const logger = { traceStart: (_n: string) => "", traceEnd: (_id: string, _m?: Record<string, unknown>) => {} };
+const logger = {
+  traceStart: (_n: string) => "",
+  traceEnd: (_id: string, _m?: Record<string, unknown>) => {},
+};
 
 import type { ExtractedLink, LinkPosition } from "./types";
 
@@ -34,8 +37,7 @@ function detectLinkPosition(element: Element): LinkPosition {
     if (tagName === "footer" || role === "contentinfo") return "footer";
     if (tagName === "nav" || role === "navigation") return "nav";
     if (tagName === "aside" || role === "complementary") return "sidebar";
-    if (tagName === "main" || tagName === "article" || role === "main")
-      return "content";
+    if (tagName === "main" || tagName === "article" || role === "main") return "content";
 
     // Class/id pattern groups — only computed when the element actually has a
     // class or id (use getAttribute for className: SVG elements expose an
@@ -46,18 +48,10 @@ function detectLinkPosition(element: Element): LinkPosition {
       const className = rawClass ? rawClass.toLowerCase() : "";
       const id = rawId ? rawId.toLowerCase() : "";
 
-      if (
-        className.includes("header") ||
-        className.includes("masthead") ||
-        id.includes("header")
-      ) {
+      if (className.includes("header") || className.includes("masthead") || id.includes("header")) {
         return "header";
       }
-      if (
-        className.includes("footer") ||
-        className.includes("colophon") ||
-        id.includes("footer")
-      ) {
+      if (className.includes("footer") || className.includes("colophon") || id.includes("footer")) {
         return "footer";
       }
       if (
@@ -68,11 +62,7 @@ function detectLinkPosition(element: Element): LinkPosition {
       ) {
         return "nav";
       }
-      if (
-        className.includes("sidebar") ||
-        className.includes("aside") ||
-        id.includes("sidebar")
-      ) {
+      if (className.includes("sidebar") || className.includes("aside") || id.includes("sidebar")) {
         return "sidebar";
       }
       if (
@@ -109,9 +99,7 @@ function parseRel(rel: string | null): string[] {
  */
 function hasNofollow(relArray: string[]): boolean {
   return (
-    relArray.includes("nofollow") ||
-    relArray.includes("sponsored") ||
-    relArray.includes("ugc")
+    relArray.includes("nofollow") || relArray.includes("sponsored") || relArray.includes("ugc")
   );
 }
 
@@ -130,11 +118,7 @@ export function extractLinks(doc: Document, baseUrl: string): ExtractedLink[] {
     if (!href) continue;
 
     // Skip javascript:, mailto:, tel:, etc.
-    if (href.startsWith("javascript:")) continue;
-    if (href.startsWith("mailto:")) continue;
-    if (href.startsWith("tel:")) continue;
-    if (href.startsWith("data:")) continue;
-    if (href === "#") continue;
+    if (href.trim() === "#" || hasNonCrawlableUrlScheme(href)) continue;
 
     const normalizedHref = coerceSchemelessUrl(href.trim());
 
@@ -166,20 +150,14 @@ export function extractLinks(doc: Document, baseUrl: string): ExtractedLink[] {
 /**
  * Extract internal links only
  */
-export function extractInternalLinks(
-  doc: Document,
-  baseUrl: string
-): ExtractedLink[] {
+export function extractInternalLinks(doc: Document, baseUrl: string): ExtractedLink[] {
   return extractLinks(doc, baseUrl).filter((link) => link.isInternal);
 }
 
 /**
  * Extract external links only
  */
-export function extractExternalLinks(
-  doc: Document,
-  baseUrl: string
-): ExtractedLink[] {
+export function extractExternalLinks(doc: Document, baseUrl: string): ExtractedLink[] {
   return extractLinks(doc, baseUrl).filter((link) => !link.isInternal);
 }
 

--- a/packages/parser/src/html.ts
+++ b/packages/parser/src/html.ts
@@ -4,7 +4,7 @@
 
 import { clampItemString } from "@squirrelscan/core-contracts/clamp";
 import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
-import { coerceSchemelessUrl } from "@squirrelscan/utils";
+import { coerceSchemelessUrl, shouldSkipUrl } from "@squirrelscan/utils";
 import { parseHTML, type Document, type Element } from "linkedom";
 
 import type {
@@ -51,13 +51,9 @@ import { extractVisibleMeta } from "./visible-meta";
 export function extractMeta(doc: Document): MetaData {
   return {
     title: doc.querySelector("title")?.textContent ?? null,
-    description:
-      doc.querySelector('meta[name="description"]')?.getAttribute("content") ??
-      null,
-    canonical:
-      doc.querySelector('link[rel="canonical"]')?.getAttribute("href") ?? null,
-    robots:
-      doc.querySelector('meta[name="robots"]')?.getAttribute("content") ?? null,
+    description: doc.querySelector('meta[name="description"]')?.getAttribute("content") ?? null,
+    canonical: doc.querySelector('link[rel="canonical"]')?.getAttribute("href") ?? null,
+    robots: doc.querySelector('meta[name="robots"]')?.getAttribute("content") ?? null,
   };
 }
 
@@ -80,9 +76,7 @@ export function extractH1(doc: Document): { count: number; texts: string[] } {
 // Extract Open Graph tags from parsed document
 export function extractOG(doc: Document): OpenGraphData {
   const getOG = (property: string): string | null =>
-    doc
-      .querySelector(`meta[property="og:${property}"]`)
-      ?.getAttribute("content") ?? null;
+    doc.querySelector(`meta[property="og:${property}"]`)?.getAttribute("content") ?? null;
 
   return {
     title: getOG("title"),
@@ -97,9 +91,7 @@ export function extractOG(doc: Document): OpenGraphData {
 // Extract Twitter Card tags from parsed document
 export function extractTwitter(doc: Document): TwitterData {
   const getTwitter = (name: string): string | null =>
-    doc
-      .querySelector(`meta[name="twitter:${name}"]`)
-      ?.getAttribute("content") ?? null;
+    doc.querySelector(`meta[name="twitter:${name}"]`)?.getAttribute("content") ?? null;
 
   return {
     card: getTwitter("card"),
@@ -116,14 +108,7 @@ export function extractLinks(doc: Document, baseUrl: string): LinkData[] {
   const baseUrlObj = new URL(baseUrl);
 
   const shouldSkip = (href: string): boolean => {
-    const trimmed = href.trim();
-    return (
-      trimmed.startsWith("#") ||
-      trimmed.startsWith("javascript:") ||
-      trimmed.startsWith("mailto:") ||
-      trimmed.startsWith("tel:") ||
-      trimmed.startsWith("data:")
-    );
+    return shouldSkipUrl(href);
   };
 
   for (const anchor of anchors) {
@@ -239,7 +224,7 @@ export function extractHeadings(doc: Document): HeadingHierarchy {
       // as extractors/headings.ts; oversize h1s must never leave the parser.
       const text = clampItemString(
         (el as Element).textContent?.trim() ?? "",
-        REPORT_LIMITS.maxMediumString
+        REPORT_LIMITS.maxMediumString,
       );
       const heading = { level, text, order: order++ };
       headings.push(heading);
@@ -259,14 +244,12 @@ export function extractHeadings(doc: Document): HeadingHierarchy {
 
   // Find duplicates
   const duplicateHeadings = headingTexts.filter(
-    (text, index) => headingTexts.indexOf(text) !== index && text !== ""
+    (text, index) => headingTexts.indexOf(text) !== index && text !== "",
   );
 
   // Build outline
   const outline = headings
-    .map(
-      (h: HeadingData) => `${"  ".repeat(h.level - 1)}H${h.level}: ${h.text}`
-    )
+    .map((h: HeadingData) => `${"  ".repeat(h.level - 1)}H${h.level}: ${h.text}`)
     .join("\n");
 
   return {

--- a/packages/parser/src/schema/validator.ts
+++ b/packages/parser/src/schema/validator.ts
@@ -151,7 +151,7 @@ function validatePropertyType(
   prop: string,
   value: unknown,
   rule: PropertyRule,
-  addIssue: (issue: Omit<SchemaValidationIssue, "type">) => void
+  addIssue: (issue: Omit<SchemaValidationIssue, "type">) => void,
 ): void {
   if (isMissing(value)) {
     return;
@@ -254,7 +254,7 @@ function normalizeTypes(schema: ParsedSchema): string[] {
 function validateContext(
   schema: ParsedSchema,
   typeName: string,
-  addIssue: (issue: Omit<SchemaValidationIssue, "type">) => void
+  addIssue: (issue: Omit<SchemaValidationIssue, "type">) => void,
 ): void {
   const context = schema["@context"];
   if (!context) {
@@ -270,7 +270,15 @@ function validateContext(
   const contexts = Array.isArray(context) ? context : [context];
   const hasSchemaOrg = contexts.some((entry) => {
     if (typeof entry !== "string") return false;
-    return entry.includes("schema.org");
+    try {
+      const url = new URL(entry.startsWith("//") ? `https:${entry}` : entry);
+      return (
+        (url.protocol === "http:" || url.protocol === "https:") &&
+        (url.hostname === "schema.org" || url.hostname === "www.schema.org")
+      );
+    } catch {
+      return false;
+    }
   });
   if (!hasSchemaOrg) {
     addIssue({
@@ -286,8 +294,7 @@ function validateSchema(schema: ParsedSchema): SchemaValidationIssue[] {
   const issues: SchemaValidationIssue[] = [];
 
   const baseTypeRaw =
-    (Array.isArray(schema["@type"]) ? schema["@type"][0] : schema["@type"]) ??
-    "Schema";
+    (Array.isArray(schema["@type"]) ? schema["@type"][0] : schema["@type"]) ?? "Schema";
   const baseType = TYPE_ALIASES[baseTypeRaw] ?? baseTypeRaw;
 
   const addIssueForType =
@@ -336,8 +343,6 @@ function validateSchema(schema: ParsedSchema): SchemaValidationIssue[] {
   return issues;
 }
 
-export function validateSchemas(
-  schemas: ParsedSchema[]
-): SchemaValidationIssue[] {
+export function validateSchemas(schemas: ParsedSchema[]): SchemaValidationIssue[] {
   return schemas.flatMap((schema) => validateSchema(schema));
 }

--- a/packages/report/src/output/markdown.ts
+++ b/packages/report/src/output/markdown.ts
@@ -34,6 +34,45 @@ export interface MarkdownRenderOptions {
   branding?: ReportBranding;
 }
 
+function escapeMarkdownTableCell(value: string, escapeBrackets = false): string {
+  const output: string[] = [];
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === "\\") output.push("\\\\");
+    else if (char === "|") output.push("\\|");
+    else if (escapeBrackets && (char === "[" || char === "]")) output.push(`\\${char}`);
+    else if (char === "\r" || char === "\n") {
+      if (char === "\r" && value[i + 1] === "\n") i++;
+      output.push("<br>");
+    } else output.push(char);
+  }
+  return output.join("");
+}
+
+function escapeMarkdownDestination(value: string): string {
+  const output: string[] = [];
+  for (const char of value) {
+    if (char === "\\") output.push("%5C");
+    else if (char === "(") output.push("%28");
+    else if (char === ")") output.push("%29");
+    else output.push(char);
+  }
+  return output.join("");
+}
+
+function siteProfileMarkdownValue(value: string, rawUrl?: string): string {
+  const label = escapeMarkdownTableCell(value, true);
+  if (!rawUrl) return label;
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return label;
+    const destination = escapeMarkdownDestination(url.toString());
+    return `[${label}](${destination})`;
+  } catch {
+    return label;
+  }
+}
+
 export function renderMarkdown(report: AuditReport, options?: MarkdownRenderOptions): string {
   const lines: string[] = [];
   const version = options?.version ?? "";
@@ -141,13 +180,11 @@ export function renderMarkdown(report: AuditReport, options?: MarkdownRenderOpti
     lines.push("| Field | Value |");
     lines.push("|-------|-------|");
     for (const row of siteProfileRows(report.siteMetadata)) {
-      const value = row.url
-        ? `[${row.value.replace(/\|/g, "\\|")}](${row.url})`
-        : row.value.replace(/\|/g, "\\|");
+      const value = siteProfileMarkdownValue(row.value, row.url);
       lines.push(`| ${row.label} | ${value} |`);
     }
     const flags = siteProfileFlags(report.siteMetadata);
-    if (flags) lines.push(`| Flags | ${flags.replace(/\|/g, "\\|")} |`);
+    if (flags) lines.push(`| Flags | ${escapeMarkdownTableCell(flags)} |`);
     lines.push("");
   }
 
@@ -276,7 +313,7 @@ export function renderMarkdown(report: AuditReport, options?: MarkdownRenderOpti
           lines.push("|-------|--------|---------|");
           for (const check of rule.checks) {
             const statusIcon = check.status === "fail" ? "X" : "!";
-            const escapedMessage = (check.message + carriedTag(check)).replace(/\|/g, "\\|");
+            const escapedMessage = escapeMarkdownTableCell(check.message + carriedTag(check));
             lines.push(`| ${check.name} | ${statusIcon} ${check.status} | ${escapedMessage} |`);
           }
           lines.push("");

--- a/packages/report/tests/markdown-escaping.test.ts
+++ b/packages/report/tests/markdown-escaping.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AuditReport } from "../src/types";
+import { renderMarkdown } from "../src/output/markdown";
+
+function report(entityUrl: string): AuditReport {
+  return {
+    baseUrl: "https://example.com",
+    timestamp: "2026-07-24T00:00:00.000Z",
+    totalPages: 1,
+    passed: 0,
+    warnings: 0,
+    failed: 0,
+    ruleResults: {},
+    siteMetadata: {
+      siteType: "blog",
+      title: "Acme\\|Corp\nInjected",
+      entityUrl,
+      isYMYL: false,
+      isLocalBusiness: false,
+      hasOwnershipVerified: false,
+      confidence: "high",
+    },
+  };
+}
+
+describe("Markdown report escaping", () => {
+  test("escapes table control characters and rejects executable links", () => {
+    const output = renderMarkdown(report("javascript:alert(1)"));
+    expect(output).toContain("Acme\\\\\\|Corp<br>Injected");
+    expect(output).not.toContain("](javascript:");
+  });
+
+  test("encodes parentheses in HTTP link destinations", () => {
+    const output = renderMarkdown(report("https://example.com/a_(b)"));
+    expect(output).toContain("https://example.com/a_%28b%29");
+  });
+
+  test("escapes link brackets and CRLF without a second escaping pass", () => {
+    const value = report("https://example.com");
+    value.siteMetadata!.title = "[Acme]\\|Corp\r\nInjected";
+    const output = renderMarkdown(value);
+    expect(output).toContain("[\\[Acme\\]\\\\\\|Corp<br>Injected](https://example.com/)");
+  });
+});

--- a/packages/rules/src/a11y/link-text.ts
+++ b/packages/rules/src/a11y/link-text.ts
@@ -1,6 +1,8 @@
 // a11y/link-text - Check for descriptive link text
 // Based on WCAG 2.4.4 Link Purpose (In Context) (Level A)
 
+import { hasUnsafeUrlScheme } from "@squirrelscan/utils";
+
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
 // Generic link text that doesn't describe the destination
@@ -131,11 +133,7 @@ function hasAccessibleContent(link: Element): {
     const svgTitle = svg.querySelector("title");
     const svgAriaLabel = svg.getAttribute("aria-label");
     const svgAriaLabelledby = svg.getAttribute("aria-labelledby");
-    if (
-      svgTitle?.textContent?.trim() ||
-      svgAriaLabel?.trim() ||
-      svgAriaLabelledby
-    ) {
+    if (svgTitle?.textContent?.trim() || svgAriaLabel?.trim() || svgAriaLabelledby) {
       return { hasContent: true, contentType: "svg" };
     }
     // SVG without accessible name - this is a problem
@@ -144,7 +142,7 @@ function hasAccessibleContent(link: Element): {
 
   // Check for icon font (common patterns)
   const iconElement = link.querySelector(
-    'i[class*="icon"], span[class*="icon"], i[class*="fa-"], span[class*="fa-"]'
+    'i[class*="icon"], span[class*="icon"], i[class*="fa-"], span[class*="fa-"]',
   );
   if (iconElement) {
     return { hasContent: false, contentType: "icon-font" };
@@ -189,13 +187,10 @@ export const linkTextRule: Rule = {
       const href = link.getAttribute("href") || "";
 
       // Skip anchor links and javascript
-      if (href.startsWith("#") || href.startsWith("javascript:")) continue;
+      if (href.trimStart().startsWith("#") || hasUnsafeUrlScheme(href)) continue;
 
       // Get accessible name (aria-labelledby, aria-label, title)
-      const accessibleName = getAccessibleName(
-        link,
-        doc as unknown as Document
-      );
+      const accessibleName = getAccessibleName(link, doc as unknown as Document);
 
       // If has accessible name via ARIA, skip further checks
       if (accessibleName) {
@@ -254,11 +249,7 @@ export const linkTextRule: Rule = {
       });
     }
 
-    if (
-      emptyLinks.length === 0 &&
-      genericLinks.length === 0 &&
-      links.length > 0
-    ) {
+    if (emptyLinks.length === 0 && genericLinks.length === 0 && links.length > 0) {
       checks.push({
         name: "link-text",
         status: "pass",

--- a/packages/rules/src/content/quality.ts
+++ b/packages/rules/src/content/quality.ts
@@ -1,6 +1,7 @@
 // content/quality - LLM-based content quality analysis
 
 import { z } from "zod";
+import { stripHtmlForText } from "@squirrelscan/utils";
 
 import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
 
@@ -11,22 +12,44 @@ const QualitySchema = z.object({
   feedback: z.string(),
 });
 
-// Extract clean text from HTML for LLM analysis
-function extractTextFromHtml(html: string): string {
-  return html
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/<nav[^>]*>[\s\S]*?<\/nav>/gi, "")
-    .replace(/<footer[^>]*>[\s\S]*?<\/footer>/gi, "")
-    .replace(/<header[^>]*>[\s\S]*?<\/header>/gi, "")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/\s+/g, " ")
-    .trim();
+const BASIC_ENTITIES = new Map([
+  ["&nbsp;", " "],
+  ["&amp;", "&"],
+  ["&lt;", "<"],
+  ["&gt;", ">"],
+]);
+
+// Extract clean text from HTML for LLM analysis. Decode each source entity at
+// most once so text such as &amp;lt; cannot turn into markup in a later pass.
+export function extractTextFromHtml(html: string): string {
+  const visible = stripHtmlForText(html, {
+    exclude: ["script", "style", "nav", "footer", "header"],
+  });
+  const output: string[] = [];
+  let pendingSpace = false;
+
+  for (let i = 0; i < visible.length; i++) {
+    let char = visible[i];
+    if (char === "&") {
+      for (const [entity, decoded] of BASIC_ENTITIES) {
+        if (visible.startsWith(entity, i)) {
+          char = decoded;
+          i += entity.length - 1;
+          break;
+        }
+      }
+    }
+
+    if (char.trim() === "") {
+      pendingSpace = output.length > 0;
+    } else {
+      if (pendingSpace) output.push(" ");
+      output.push(char);
+      pendingSpace = false;
+    }
+  }
+
+  return output.join("");
 }
 
 export const contentQualityRule: Rule = {
@@ -83,11 +106,7 @@ Respond with a JSON object containing score (0-100) and feedback (2-3 sentences)
 
 ${content}`;
 
-    const result = await llmCallWithSystem(
-      systemPrompt,
-      userPrompt,
-      QualitySchema
-    );
+    const result = await llmCallWithSystem(systemPrompt, userPrompt, QualitySchema);
 
     if (!result.success) {
       checks.push({

--- a/packages/rules/src/performance/font-loading.ts
+++ b/packages/rules/src/performance/font-loading.ts
@@ -4,6 +4,14 @@ import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
 import { getCWVHints } from "./cwv";
 
+function hasHostname(rawUrl: string, baseUrl: string, hostnames: readonly string[]): boolean {
+  try {
+    return hostnames.includes(new URL(rawUrl, baseUrl).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 export const fontLoadingRule: Rule = {
   meta: {
     id: "perf/font-loading",
@@ -38,20 +46,21 @@ export const fontLoadingRule: Rule = {
     }
 
     // Check for Google Fonts preconnect
-    const hasGoogleFontsPreconnect = hints.preconnectTags.some(
-      (url) =>
-        url.includes("fonts.googleapis.com") ||
-        url.includes("fonts.gstatic.com")
+    const hasGoogleFontsPreconnect = hints.preconnectTags.some((url) =>
+      hasHostname(url, ctx.page.url, ["fonts.googleapis.com", "fonts.gstatic.com"]),
     );
-    const usesGoogleFonts = ctx.page.html.includes("fonts.googleapis.com");
+    const usesGoogleFonts = Array.from(
+      ctx.parsed.document?.querySelectorAll("link[href]") ?? [],
+    ).some((link) =>
+      hasHostname(link.getAttribute("href") ?? "", ctx.page.url, ["fonts.googleapis.com"]),
+    );
 
     if (usesGoogleFonts && !hasGoogleFontsPreconnect) {
       checks.push({
         name: "font-preconnect",
         status: "warn",
         message: "Using Google Fonts without preconnect",
-        value:
-          "Add <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>",
+        value: "Add <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>",
       });
     } else if (usesGoogleFonts) {
       checks.push({

--- a/packages/rules/tests/content-quality-text.test.ts
+++ b/packages/rules/tests/content-quality-text.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractTextFromHtml } from "../src/content/quality";
+
+describe("content quality text extraction", () => {
+  test("decodes source entities once and collapses whitespace", () => {
+    const html = "<main>A &amp; B &lt; C &amp;lt; D\n\tE</main>";
+    expect(extractTextFromHtml(html)).toBe("A & B < C &lt; D E");
+  });
+
+  test("drops excluded element bodies", () => {
+    expect(extractTextFromHtml("<main>Keep<script>drop()</script> this</main>")).toBe(
+      "Keep this",
+    );
+  });
+});

--- a/packages/utils/src/client-redirects.ts
+++ b/packages/utils/src/client-redirects.ts
@@ -6,10 +6,7 @@
  * - Meta refresh: <meta http-equiv="refresh" content="0;url=...">
  * - JavaScript: window.location = "...", window.location.href = "..."
  */
-export function findClientRedirects(
-  html: string,
-  baseUrl: string
-): string | null {
+export function findClientRedirects(html: string, baseUrl: string): string | null {
   // 1. Check for meta refresh
   const metaRefresh = findMetaRefresh(html, baseUrl);
   if (metaRefresh) return metaRefresh;
@@ -29,30 +26,107 @@ export function findClientRedirects(
  * <meta name="viewport" content="0;url=..." http-equiv="refresh">
  */
 function findMetaRefresh(html: string, baseUrl: string): string | null {
-  // Match meta tag with http-equiv="refresh" (attributes in any order)
-  const metaTagRegex = /<meta\s+([^>]*http-equiv=["']refresh["'][^>]*)>/gi;
-  const metaTags = html.matchAll(metaTagRegex);
+  for (const tag of findStartTags(html, "meta")) {
+    if (getAttribute(tag, "http-equiv")?.toLowerCase() !== "refresh") continue;
+    const content = getAttribute(tag, "content");
+    if (!content) continue;
 
-  for (const metaMatch of metaTags) {
-    // Extract content attribute value from the matched tag
-    const contentRegex = /content=["']([^"']+)["']/i;
-    const contentMatch = contentRegex.exec(metaMatch[1]);
-    if (contentMatch) {
-      // Parse the content value: "0;url=..."
-      const urlRegex = /(\d+)\s*;\s*url=([^"';]+)/i;
-      const urlMatch = urlRegex.exec(contentMatch[1]);
-      if (urlMatch?.[2]) {
-        try {
-          // Resolve relative URLs
-          return new URL(urlMatch[2].trim(), baseUrl).toString();
-        } catch {
-          // Invalid URL, continue to next match
-          continue;
-        }
-      }
+    const separator = content.indexOf(";");
+    if (separator < 0 || !isAsciiDigits(content.slice(0, separator).trim())) continue;
+    const directive = content.slice(separator + 1);
+    const equals = directive.indexOf("=");
+    if (equals < 0 || directive.slice(0, equals).trim().toLowerCase() !== "url") continue;
+    const target = directive.slice(equals + 1).trim();
+    if (!target) continue;
+    try {
+      return new URL(target, baseUrl).toString();
+    } catch {
+      // Invalid URL, continue to the next tag.
     }
   }
 
+  return null;
+}
+
+function isAsciiDigits(value: string): boolean {
+  if (!value) return false;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 48 || code > 57) return false;
+  }
+  return true;
+}
+
+function findStartTags(html: string, tagName: string): string[] {
+  const lower = html.toLowerCase();
+  const prefix = `<${tagName}`;
+  const tags: string[] = [];
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const start = lower.indexOf(prefix, cursor);
+    if (start < 0) break;
+    const boundary = lower[start + prefix.length];
+    if (
+      boundary &&
+      boundary !== " " &&
+      boundary !== "\t" &&
+      boundary !== "\n" &&
+      boundary !== "\r" &&
+      boundary !== "/" &&
+      boundary !== ">"
+    ) {
+      cursor = start + prefix.length;
+      continue;
+    }
+
+    let quote: '"' | "'" | null = null;
+    let end = start + prefix.length;
+    for (; end < html.length; end++) {
+      const char = html[end];
+      if (quote) {
+        if (char === quote) quote = null;
+      } else if (char === '"' || char === "'") {
+        quote = char;
+      } else if (char === ">") {
+        break;
+      }
+    }
+    if (end >= html.length) break;
+    tags.push(html.slice(start, end + 1));
+    cursor = end + 1;
+  }
+
+  return tags;
+}
+
+function getAttribute(tag: string, attributeName: string): string | null {
+  let cursor = 1;
+  while (cursor < tag.length && !/\s/.test(tag[cursor]) && tag[cursor] !== ">") cursor++;
+  while (cursor < tag.length) {
+    while (/\s/.test(tag[cursor] ?? "")) cursor++;
+    if (tag[cursor] === ">" || tag[cursor] === "/" || cursor >= tag.length) break;
+    const nameStart = cursor;
+    while (cursor < tag.length && !/[\s=>/]/.test(tag[cursor])) cursor++;
+    const name = tag.slice(nameStart, cursor).toLowerCase();
+    while (/\s/.test(tag[cursor] ?? "")) cursor++;
+    if (tag[cursor] !== "=") {
+      while (cursor < tag.length && !/\s/.test(tag[cursor]) && tag[cursor] !== ">") cursor++;
+      continue;
+    }
+    cursor++;
+    while (/\s/.test(tag[cursor] ?? "")) cursor++;
+    const quote = tag[cursor] === '"' || tag[cursor] === "'" ? tag[cursor++] : null;
+    const valueStart = cursor;
+    if (quote) {
+      while (cursor < tag.length && tag[cursor] !== quote) cursor++;
+    } else {
+      while (cursor < tag.length && !/[\s>]/.test(tag[cursor])) cursor++;
+    }
+    const value = tag.slice(valueStart, cursor);
+    if (name === attributeName) return value;
+    if (quote && tag[cursor] === quote) cursor++;
+  }
   return null;
 }
 

--- a/packages/utils/src/html-text.ts
+++ b/packages/utils/src/html-text.ts
@@ -1,0 +1,106 @@
+export interface HtmlTextOptions {
+  /** Element bodies that are not visible or useful for the caller. */
+  exclude?: readonly string[];
+}
+
+function findTagEnd(html: string, start: number): number {
+  let quote: '"' | "'" | null = null;
+  for (let i = start; i < html.length; i++) {
+    const char = html[i];
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function openingTagName(lowerHtml: string, start: number, end: number): string | null {
+  let cursor = start + 1;
+  while (cursor < end && /\s/.test(lowerHtml[cursor])) cursor++;
+  if (lowerHtml[cursor] === "/" || lowerHtml[cursor] === "!" || lowerHtml[cursor] === "?") {
+    return null;
+  }
+  const nameStart = cursor;
+  while (cursor < end) {
+    const code = lowerHtml.charCodeAt(cursor);
+    const valid =
+      (code >= 97 && code <= 122) ||
+      (code >= 48 && code <= 57) ||
+      lowerHtml[cursor] === "-" ||
+      lowerHtml[cursor] === ":";
+    if (!valid) break;
+    cursor++;
+  }
+  return cursor > nameStart ? lowerHtml.slice(nameStart, cursor) : null;
+}
+
+function findClosingTagEnd(lowerHtml: string, html: string, tag: string, start: number): number {
+  const prefix = `</${tag}`;
+  let cursor = start;
+  while (cursor < html.length) {
+    const closeStart = lowerHtml.indexOf(prefix, cursor);
+    if (closeStart < 0) return html.length;
+    const boundary = lowerHtml[closeStart + prefix.length];
+    if (
+      boundary === ">" ||
+      boundary === " " ||
+      boundary === "\t" ||
+      boundary === "\n" ||
+      boundary === "\r"
+    ) {
+      const closeEnd = findTagEnd(html, closeStart + prefix.length);
+      return closeEnd < 0 ? html.length : closeEnd + 1;
+    }
+    cursor = closeStart + prefix.length;
+  }
+  return html.length;
+}
+
+/**
+ * Strip comments, tags, and selected element bodies in linear passes. This is
+ * intentionally an approximate text extractor for hot paths that do not need a
+ * DOM; it avoids backtracking regexes on hostile or malformed response bodies.
+ */
+export function stripHtmlForText(html: string, options: HtmlTextOptions = {}): string {
+  const excluded = new Set((options.exclude ?? []).map((tag) => tag.toLowerCase()));
+  const lowerHtml = html.toLowerCase();
+  const parts: string[] = [];
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const tagStart = html.indexOf("<", cursor);
+    if (tagStart < 0) {
+      parts.push(html.slice(cursor));
+      break;
+    }
+    if (tagStart > cursor) parts.push(html.slice(cursor, tagStart));
+
+    if (lowerHtml.startsWith("<!--", tagStart)) {
+      const commentEnd = lowerHtml.indexOf("-->", tagStart + 4);
+      cursor = commentEnd < 0 ? html.length : commentEnd + 3;
+      parts.push(" ");
+      continue;
+    }
+
+    const tagEnd = findTagEnd(html, tagStart + 1);
+    if (tagEnd < 0) {
+      parts.push(html.slice(tagStart));
+      break;
+    }
+
+    const tagName = openingTagName(lowerHtml, tagStart, tagEnd);
+    cursor =
+      tagName && excluded.has(tagName)
+        ? findClosingTagEnd(lowerHtml, html, tagName, tagEnd + 1)
+        : tagEnd + 1;
+    parts.push(" ");
+  }
+
+  return parts.join("");
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -9,6 +9,8 @@ export {
   getPathname,
   resolveUrl,
   coerceSchemelessUrl,
+  hasNonCrawlableUrlScheme,
+  hasUnsafeUrlScheme,
   shouldSkipUrl,
   parseUserUrl,
   isLocalhost,
@@ -59,6 +61,8 @@ export { getRandomUserAgent } from "./user-agent";
 export { timingSafeStringEqual } from "./crypto-compare";
 
 export { normalizeHtmlForFingerprint } from "./fingerprint";
+
+export { stripHtmlForText, type HtmlTextOptions } from "./html-text";
 
 export { chunk, mapWithConcurrency } from "./concurrency";
 

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -47,9 +47,7 @@ function isPrivateIPv4(hostname: string): boolean {
 function isPrivateIPv6(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
   return (
-    normalized.startsWith("fc") ||
-    normalized.startsWith("fd") ||
-    normalized.startsWith("fe80:")
+    normalized.startsWith("fc") || normalized.startsWith("fd") || normalized.startsWith("fe80:")
   );
 }
 
@@ -379,14 +377,91 @@ export function resolveUrl(href: string, baseUrl: string): string | null {
 // with common file extensions (.zip, .md, .mov, .sh, .pl, .py) — a bare
 // "index.html"-style href must resolve relative to the page, like browsers do.
 const SCHEMELESS_COERCIBLE_TLDS = new Set([
-  "com", "org", "net", "io", "co", "dev", "app", "ai", "edu", "gov", "mil",
-  "info", "biz", "me", "tv", "cc", "xyz", "site", "online", "store", "shop",
-  "blog", "cloud", "design", "agency", "studio", "tech", "digital", "media",
-  "news", "live", "world", "today", "uk", "de", "fr", "es", "it", "nl", "be",
-  "at", "ch", "se", "no", "dk", "fi", "ie", "pt", "gr", "cz", "ro", "hu",
-  "ru", "ua", "tr", "il", "ae", "sa", "in", "cn", "jp", "kr", "tw", "hk",
-  "sg", "my", "th", "vn", "id", "ph", "au", "nz", "za", "ng", "ke", "eg",
-  "br", "mx", "ar", "cl", "pe", "ca", "us", "eu", "asia",
+  "com",
+  "org",
+  "net",
+  "io",
+  "co",
+  "dev",
+  "app",
+  "ai",
+  "edu",
+  "gov",
+  "mil",
+  "info",
+  "biz",
+  "me",
+  "tv",
+  "cc",
+  "xyz",
+  "site",
+  "online",
+  "store",
+  "shop",
+  "blog",
+  "cloud",
+  "design",
+  "agency",
+  "studio",
+  "tech",
+  "digital",
+  "media",
+  "news",
+  "live",
+  "world",
+  "today",
+  "uk",
+  "de",
+  "fr",
+  "es",
+  "it",
+  "nl",
+  "be",
+  "at",
+  "ch",
+  "se",
+  "no",
+  "dk",
+  "fi",
+  "ie",
+  "pt",
+  "gr",
+  "cz",
+  "ro",
+  "hu",
+  "ru",
+  "ua",
+  "tr",
+  "il",
+  "ae",
+  "sa",
+  "in",
+  "cn",
+  "jp",
+  "kr",
+  "tw",
+  "hk",
+  "sg",
+  "my",
+  "th",
+  "vn",
+  "id",
+  "ph",
+  "au",
+  "nz",
+  "za",
+  "ng",
+  "ke",
+  "eg",
+  "br",
+  "mx",
+  "ar",
+  "cl",
+  "pe",
+  "ca",
+  "us",
+  "eu",
+  "asia",
 ]);
 
 /**
@@ -397,7 +472,8 @@ const SCHEMELESS_COERCIBLE_TLDS = new Set([
  * are treated as authoring mistakes worth coercing.
  */
 export function coerceSchemelessUrl(href: string): string {
-  if (href.startsWith("http://") || href.startsWith("https://")) return href;
+  const lowerHref = href.toLowerCase();
+  if (lowerHref.startsWith("http://") || lowerHref.startsWith("https://")) return href;
   if (href.startsWith("/") || href.startsWith("./") || href.startsWith("../")) return href;
   if (href.includes(":")) return href;
 
@@ -413,16 +489,51 @@ export function coerceSchemelessUrl(href: string): string {
   return href;
 }
 
+function explicitUrlScheme(href: string): string | null {
+  const input = href.trimStart();
+  const colon = input.indexOf(":");
+  if (colon <= 0 || colon > 64) return null;
+
+  let scheme = "";
+  for (let i = 0; i < colon; i++) {
+    const char = input[i];
+    // WHATWG URL parsing ignores ASCII tabs/newlines in schemes. Compact them
+    // here so values such as "java\nscript:" cannot evade the filter.
+    if (char === "\t" || char === "\n" || char === "\r") continue;
+    const code = char.charCodeAt(0);
+    const isAlpha = (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+    const isDigit = code >= 48 && code <= 57;
+    if (
+      (scheme.length === 0 && !isAlpha) ||
+      (!isAlpha && !isDigit && char !== "+" && char !== "-" && char !== ".")
+    ) {
+      return null;
+    }
+    scheme += char.toLowerCase();
+  }
+  return scheme || null;
+}
+
+/** True for browser-executable or inline-data URL schemes. */
+export function hasUnsafeUrlScheme(href: string): boolean {
+  const scheme = explicitUrlScheme(href);
+  return scheme === "javascript" || scheme === "vbscript" || scheme === "data";
+}
+
+/** True when an href has an explicit scheme other than HTTP(S). */
+export function hasNonCrawlableUrlScheme(href: string): boolean {
+  const scheme = explicitUrlScheme(href);
+  return scheme !== null && scheme !== "http" && scheme !== "https";
+}
+
 /**
- * Check if URL should be skipped (javascript:, mailto:, etc.)
+ * Check if a crawl href should be skipped. Relative URLs and HTTP(S) are
+ * crawlable; fragments and every other explicit scheme are not.
  */
 export function shouldSkipUrl(href: string): boolean {
-  return (
-    href.startsWith("javascript:") ||
-    href.startsWith("mailto:") ||
-    href.startsWith("tel:") ||
-    href.startsWith("#")
-  );
+  const trimmed = href.trimStart();
+  if (trimmed.startsWith("#")) return true;
+  return hasNonCrawlableUrlScheme(trimmed);
 }
 
 /**
@@ -463,10 +574,7 @@ export interface ProjectNameContext {
  * Get project name context for a URL
  * Determines if a custom project name should be prompted for local addresses
  */
-export function getProjectNameContext(
-  url: string,
-  configName?: string
-): ProjectNameContext {
+export function getProjectNameContext(url: string, configName?: string): ProjectNameContext {
   try {
     const parsed = new URL(url);
     const local = isLocalhost(parsed.hostname);
@@ -474,8 +582,7 @@ export function getProjectNameContext(
     // Generate suggested name (matches domainToProjectName logic)
     const hostname = parsed.hostname;
     const base = hostname.replace(/\./g, "-");
-    const suggestedName =
-      local && parsed.port ? `${base}-${parsed.port}` : base;
+    const suggestedName = local && parsed.port ? `${base}-${parsed.port}` : base;
 
     return {
       isLocal: local,

--- a/packages/utils/tests/html-text.test.ts
+++ b/packages/utils/tests/html-text.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { stripHtmlForText } from "../src/html-text";
+
+describe("stripHtmlForText", () => {
+  test("drops comments, tags, and excluded element bodies", () => {
+    const html =
+      "<main>Hello<!-- hidden --><script>bad()</script ><style>nope</style><p>world</p></main>";
+    expect(
+      stripHtmlForText(html, { exclude: ["script", "style"] })
+        .replace(/\s+/g, " ")
+        .trim(),
+    ).toBe("Hello world");
+  });
+
+  test("handles malformed repeated opening tags without backtracking", () => {
+    const html = `<script>${"<script>".repeat(20_000)}`;
+    expect(stripHtmlForText(html, { exclude: ["script"] }).trim()).toBe("");
+  });
+});

--- a/packages/utils/tests/url.test.ts
+++ b/packages/utils/tests/url.test.ts
@@ -3,7 +3,14 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { hasNonHttpScheme, isLoopbackHost, isValidDomain, setReservedNames } from "../src/url";
+import {
+  hasNonHttpScheme,
+  hasUnsafeUrlScheme,
+  isLoopbackHost,
+  isValidDomain,
+  setReservedNames,
+  shouldSkipUrl,
+} from "../src/url";
 
 describe("isLoopbackHost", () => {
   test("matches loopback hosts", () => {
@@ -47,6 +54,29 @@ describe("hasNonHttpScheme", () => {
 
   test("accepts schemeless input", () => {
     expect(hasNonHttpScheme("example.com")).toBe(false);
+  });
+});
+
+describe("crawl URL scheme filtering", () => {
+  test("rejects executable schemes case-insensitively and with embedded URL whitespace", () => {
+    for (const href of [
+      "javascript:alert(1)",
+      " JaVaScRiPt:alert(1)",
+      "java\nscript:alert(1)",
+      "vbscript:x",
+      "DATA:text/html,x",
+    ]) {
+      expect(hasUnsafeUrlScheme(href)).toBe(true);
+      expect(shouldSkipUrl(href)).toBe(true);
+    }
+  });
+
+  test("crawls relative and HTTP(S) URLs but skips other explicit schemes", () => {
+    expect(shouldSkipUrl("/docs")).toBe(false);
+    expect(shouldSkipUrl("HTTPS://example.com/docs")).toBe(false);
+    expect(shouldSkipUrl("mailto:hello@example.com")).toBe(true);
+    expect(shouldSkipUrl("ftp://example.com/file")).toBe(true);
+    expect(shouldSkipUrl(" #section")).toBe(true);
   });
 });
 

--- a/packages/waf-detect/src/challenge.ts
+++ b/packages/waf-detect/src/challenge.ts
@@ -10,20 +10,88 @@ import { detectWaf } from "./detect";
 
 function hasChallengeInterstitialMarkers(html: string): boolean {
   const sample = html.slice(0, 10240);
-  return CHALLENGE_INTERSTITIAL_PATTERNS.some((pattern) =>
-    pattern.test(sample),
-  );
+  return CHALLENGE_INTERSTITIAL_PATTERNS.some((pattern) => pattern.test(sample));
 }
 
-/** Approximate visible-text length: drop scripts/styles/tags to tell an interstitial from real content. */
+function tagEnd(html: string, start: number): number {
+  let quote: '"' | "'" | null = null;
+  for (let i = start; i < html.length; i++) {
+    const char = html[i];
+    if (quote) {
+      if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return i;
+    }
+  }
+  return html.length - 1;
+}
+
+function skipElement(lower: string, html: string, tag: string, start: number): number {
+  const prefix = `</${tag}`;
+  let cursor = start;
+  while (cursor < html.length) {
+    const close = lower.indexOf(prefix, cursor);
+    if (close < 0) return html.length;
+    const boundary = lower[close + prefix.length];
+    if (boundary === ">" || /\s/.test(boundary ?? "")) {
+      return tagEnd(html, close + prefix.length) + 1;
+    }
+    cursor = close + prefix.length;
+  }
+  return html.length;
+}
+
+/** Approximate visible-text length without backtracking over hostile markup. */
 function visibleTextLength(html: string): number {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style[\s\S]*?<\/style>/gi, " ")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&[a-z0-9#]+;/gi, " ")
-    .replace(/\s+/g, " ")
-    .trim().length;
+  const lower = html.toLowerCase();
+  let cursor = 0;
+  let length = 0;
+  let pendingSpace = false;
+
+  while (cursor < html.length) {
+    if (html[cursor] === "<") {
+      if (lower.startsWith("<!--", cursor)) {
+        const end = lower.indexOf("-->", cursor + 4);
+        cursor = end < 0 ? html.length : end + 3;
+        pendingSpace = true;
+        continue;
+      }
+
+      const end = tagEnd(html, cursor + 1);
+      let nameStart = cursor + 1;
+      while (/\s/.test(lower[nameStart] ?? "")) nameStart++;
+      let nameEnd = nameStart;
+      while (/[a-z]/.test(lower[nameEnd] ?? "")) nameEnd++;
+      const name = lower.slice(nameStart, nameEnd);
+      cursor =
+        name === "script" || name === "style" ? skipElement(lower, html, name, end + 1) : end + 1;
+      pendingSpace = true;
+      continue;
+    }
+
+    if (html[cursor] === "&") {
+      const entityEnd = html.indexOf(";", cursor + 1);
+      if (entityEnd > cursor && entityEnd - cursor <= 32) {
+        cursor = entityEnd + 1;
+        pendingSpace = true;
+        continue;
+      }
+    }
+
+    if (/\s/.test(html[cursor])) {
+      pendingSpace = true;
+    } else {
+      if (pendingSpace && length > 0) length++;
+      length++;
+      pendingSpace = false;
+      if (length > CHALLENGE_INTERSTITIAL_MAX_TEXT) return length;
+    }
+    cursor++;
+  }
+
+  return length;
 }
 
 /**
@@ -34,19 +102,14 @@ function visibleTextLength(html: string): number {
  * site's normal pages (e.g. a sparse SPA shell), so they additionally require a WAF
  * challenge status to avoid dropping real content.
  */
-function detectFingerprintedChallenge(
-  html: string,
-  status: number,
-): WafChallengeResult {
+function detectFingerprintedChallenge(html: string, status: number): WafChallengeResult {
   const sample = html.slice(0, 20480);
   const challengeStatus = WAF_CHALLENGE_STATUS_CODES.has(status);
   let tinyBody: boolean | null = null; // computed lazily, only once a marker matches
   for (const sig of CHALLENGE_200_SIGNATURES) {
     const strong = sig.strongMarkers.some((pattern) => pattern.test(sample));
     const weak =
-      !strong &&
-      challengeStatus &&
-      sig.weakMarkers.some((pattern) => pattern.test(sample));
+      !strong && challengeStatus && sig.weakMarkers.some((pattern) => pattern.test(sample));
     if (!strong && !weak) {
       continue;
     }
@@ -77,29 +140,22 @@ function buildWafHeaders(page: {
 }
 
 /** Detect whether page HTML appears to be a WAF/challenge interstitial. */
-export function detectWafChallengePage(
-  page: {
-    status: number;
-    headers: { server?: string | null; cfCacheStatus?: string | null; xCache?: string | null };
-    html: string | null;
-  },
-): WafChallengeResult {
+export function detectWafChallengePage(page: {
+  status: number;
+  headers: { server?: string | null; cfCacheStatus?: string | null; xCache?: string | null };
+  html: string | null;
+}): WafChallengeResult {
   if (!page.html) {
     return { detected: false, provider: null };
   }
 
   if (hasChallengeInterstitialMarkers(page.html)) {
     const statusSuggestsChallenge = WAF_CHALLENGE_STATUS_CODES.has(page.status);
-    const wafResult = detectWaf(
-      buildWafHeaders(page),
-      page.html.slice(0, 10240),
-    );
+    const wafResult = detectWaf(buildWafHeaders(page), page.html.slice(0, 10240));
     if (statusSuggestsChallenge || wafResult.detected) {
       return {
         detected: true,
-        provider: wafResult.provider
-          ? getWafProviderName(wafResult.provider)
-          : null,
+        provider: wafResult.provider ? getWafProviderName(wafResult.provider) : null,
       };
     }
   }


### PR DESCRIPTION
## Summary

- validate browser-launch and release metadata inputs before process or filesystem use
- reject executable/non-crawlable URL schemes across extraction and reporting paths
- replace vulnerable HTML/meta parsing regexes with bounded scanners
- escape generated Markdown tables and constrain rendered profile links to HTTP(S)
- validate schema/font hosts structurally instead of with substring matching
- add regression coverage for traversal, command injection, URL obfuscation, Markdown injection, and hostile markup

## Verification

- `bun test` (3581 pass, 4 skip, 0 fail)
- `bun run typecheck`
- `cd apps/cli && bun run lint`
- `bun run format:check`
- `bun run audit:deps`
- isolated `bun run notices:check`
- `detect-secrets-hook --baseline .secrets.baseline`
- `actionlint`
- `git diff --check`
