### PR TITLE
chore(repo): land v0.0.80 changelog, 2026 license year, status badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,30 @@ How it works:
 Earlier releases (v0.0.56 and prior) are on the
 [GitHub releases page](https://github.com/squirrelscan/squirrelscan/releases).
 
+## v0.0.80
+
+The CLI is now open source under MIT, with the public repo set up as the canonical
+home for the CLI and docs. This release also hardens the public surface and makes
+sure the telemetry opt-out is honored everywhere.
+
+### Added
+
+- **MIT licensed CLI.** `squirrelscan` is now open source under MIT.
+- **Public repo source of truth.** CLI builds and docs now come from the public
+  repository.
+- **Telemetry opt-out respected everywhere.** `NO_TELEMETRY` is honored by the
+  CLI and install flow.
+
+### Fixed
+
+- **Public-repo hardening.** Release and update paths were tightened to avoid
+  command injection, traversal, unsafe URL handling, and Markdown injection
+  issues.
+- **Parser and sanitizer performance issues.** Several regex-heavy paths were
+  rewritten to avoid ReDoS-style slowdowns.
+- **Secret and scheme filtering tightened.** Unsafe URLs and non-http(s) inputs
+  are now rejected more consistently.
+
 ## v0.0.79
 
 Clearer page limits, more armor for audits of slow or messy sites, and a lot of under-the-hood groundwork for auditing much bigger sites. More on that soon.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 squirrelscan
+Copyright (c) 2026 squirrelscan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ squirrelscan audits your website for SEO, performance, security, accessibility a
 [![Add to opencode](https://img.shields.io/badge/Add_to-opencode-383838?style=for-the-badge)](https://squirrelscan.com/add/opencode)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-1f6feb?style=for-the-badge)](https://registry.modelcontextprotocol.io)
 
+[![CI](https://img.shields.io/github/actions/workflow/status/squirrelscan/squirrelscan/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/squirrelscan/squirrelscan/actions/workflows/ci.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/squirrelscan/squirrelscan/codeql.yml?branch=main&style=for-the-badge&label=CodeQL)](https://github.com/squirrelscan/squirrelscan/actions/workflows/codeql.yml)
+[![npm](https://img.shields.io/npm/v/squirrelscan?style=for-the-badge&label=npm)](https://www.npmjs.com/package/squirrelscan)
+[![License: MIT](https://img.shields.io/badge/License-MIT-52a852?style=for-the-badge)](LICENSE)
+
 ## Add to your coding agent
 
 squirrelscan ships as an **MCP server** (hosted at `mcp.squirrelscan.com`), **skills** (autonomous audit + fix workflows), and a **plugin** for Claude Code and Cursor. Cursor installs in one click from the badge above; the rest are a single copy-paste.

--- a/npm/LICENSE
+++ b/npm/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 squirrelscan
+Copyright (c) 2026 squirrelscan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Open-source repo polish:

- CHANGELOG.md: add the v0.0.80 section (release is already published; the summary wording now matches the README's telemetry stance: enabled by default with an opt-out honored everywhere). The published release body was updated to match.
- LICENSE + npm/LICENSE: bump copyright year to 2026.
- README: add CI, CodeQL, npm version, and MIT license badges.