### PR TITLE
harden outbound fetch handling and CLI settings output

### DIFF
--- a/.github/dependency-audit-allowlist.md
+++ b/.github/dependency-audit-allowlist.md
@@ -8,3 +8,23 @@ load or deploy the Vercel adapter. The Wrangler and MCP dependency paths resolve
 to patched `path-to-regexp` versions.
 
 Remove this exception when Tangly stops installing unused deployment adapters.
+
+## GHSA-mh99-v99m-4gvg
+
+`brace-expansion` DoS via unbounded expansion. The affected range is `<=5.0.7`, and
+the tree resolves two copies: `5.0.8` (already patched) and `1.1.16`, which is the
+newest release on the 1.x line — there is no patched 1.x to move to.
+
+The `1.1.16` copy arrives only through lint and docs tooling:
+`eslint-plugin-sonarjs`, `eslint-plugin-github` and `ultracite` (all
+`devDependencies` of `@squirrelscan/cli`), plus `tangly` in the docs workspace.
+None of them are bundled into the compiled `squirrel` binary, so no shipped
+artifact is exposed; the reachable impact is a developer running lint locally or
+in CI against hostile glob input, which does not occur.
+
+Forcing the 1.x consumers onto 2.x/5.x via an `overrides` entry is a major bump of
+third-party lint tooling and churns the lockfile and generated notices, so it is
+tracked separately rather than bundled into a security fix.
+
+Remove this exception when those packages ship a patched `brace-expansion`, or when
+the override bump is done deliberately.

--- a/apps/cli/src/cli/commands/self.ts
+++ b/apps/cli/src/cli/commands/self.ts
@@ -1,8 +1,50 @@
 import { defineCommand } from "citty";
 
 import { warnIfSessionUnreadable } from "@/self/credentials";
+import type { UserSettings } from "@/self/types";
+import { redactValue } from "@/utils/redact";
 
 import { version as pkgVersion } from "../../../package.json";
+
+const REDACTED = "[REDACTED]";
+
+/**
+ * Deep-clone `settings` and mask every secret before display. Reuses
+ * redactValue() for the clone + baseline pass (mirrors redactConfigForDisplay
+ * in controllers/config.ts), then explicitly masks the two settings-specific
+ * secrets the baseline pass can't recognize:
+ *   - `auth` — the whole object, because `auth.token` is a live session bearer.
+ *   - each `tool_credentials` value — a plaintext BYOK secret on
+ *     keychain-unavailable installs — EXCEPT the `{ _keychainRef: true }`
+ *     sentinel, which only points at the OS keychain and holds no secret.
+ * Never mutates the caller's object — redactValue returns a fresh clone.
+ */
+export function redactSettingsForDisplay(
+  settings: UserSettings
+): Record<string, unknown> {
+  const redacted = redactValue(settings) as Record<string, unknown>;
+
+  // A live session bearer token lives under auth.token — mask the whole object.
+  if (redacted.auth != null) {
+    redacted.auth = REDACTED;
+  }
+
+  const creds = redacted.tool_credentials;
+  if (creds != null && typeof creds === "object") {
+    const credsRecord = creds as Record<string, unknown>;
+    for (const [tool, cred] of Object.entries(credsRecord)) {
+      // The keychain-ref sentinel holds no secret (the real key is in the OS
+      // keychain); every other value is a plaintext BYOK credential.
+      const isKeychainRef =
+        cred != null &&
+        typeof cred === "object" &&
+        (cred as Record<string, unknown>)._keychainRef === true;
+      if (!isKeychainRef) credsRecord[tool] = REDACTED;
+    }
+  }
+
+  return redacted;
+}
 
 function getShellConfig(): { shell: string; rcFile: string } {
   const { platform } = process;
@@ -379,7 +421,9 @@ const selfSettingsShow = defineCommand({
       }
 
       console.log(`User Settings (${getSettingsPath()}):\n`);
-      for (const [key, value] of Object.entries(result.data)) {
+      for (const [key, value] of Object.entries(
+        redactSettingsForDisplay(result.data)
+      )) {
         if (value === undefined) continue;
         const displayValue =
           typeof value === "object" ? JSON.stringify(value) : String(value);
@@ -402,7 +446,9 @@ const selfSettingsShow = defineCommand({
     const { effective, sources, userPath, localPath } = result.data;
 
     console.log("Effective Settings:\n");
-    for (const [key, value] of Object.entries(effective)) {
+    for (const [key, value] of Object.entries(
+      redactSettingsForDisplay(effective)
+    )) {
       if (value === undefined) continue;
       const displayValue =
         typeof value === "object" ? JSON.stringify(value) : String(value);

--- a/apps/cli/src/cli/commands/self.ts
+++ b/apps/cli/src/cli/commands/self.ts
@@ -1,7 +1,8 @@
 import { defineCommand } from "citty";
 
-import { warnIfSessionUnreadable } from "@/self/credentials";
 import type { UserSettings } from "@/self/types";
+
+import { warnIfSessionUnreadable } from "@/self/credentials";
 import { redactValue } from "@/utils/redact";
 
 import { version as pkgVersion } from "../../../package.json";

--- a/apps/cli/src/crawler/storage/index.ts
+++ b/apps/cli/src/crawler/storage/index.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "crypto";
 import { Effect } from "effect";
 import { mkdirSync, existsSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, resolve, sep } from "path";
 
 import { getProjectsPath } from "@/self/paths";
 import { logger } from "@/utils/logger";
@@ -40,12 +40,46 @@ export function domainToProjectName(url: string): string {
 }
 
 /**
+ * Guard against path traversal from an untrusted `[project] name` (squirrel.toml
+ * ships inside a cloned repo, so the name is attacker-controlled). Rejects empty
+ * names, embedded separators, and "."/".." segments, then authoritatively
+ * confirms projectDir stays under projectsDir before any fs work.
+ */
+function assertContainedProjectName(
+  projectName: string,
+  projectsDir: string,
+  projectDir: string
+): void {
+  const parts = projectName.split(/[/\\]/);
+  if (
+    projectName.length === 0 ||
+    parts.length > 1 ||
+    parts.some((part) => part === "." || part === "..")
+  ) {
+    throw new Error(
+      `Invalid [project] name in squirrel.toml: "${projectName}" must be a single path segment without separators or "."/".." parts.`
+    );
+  }
+
+  // Authoritative containment: mirrors the exe.startsWith(releases + sep) idiom
+  // in self/paths.ts so a resolved projectDir can never escape projectsDir.
+  if (!resolve(projectDir).startsWith(resolve(projectsDir) + sep)) {
+    throw new Error(
+      `Invalid [project] name in squirrel.toml: "${projectName}" escapes the projects directory.`
+    );
+  }
+}
+
+/**
  * Get the database path for a project
  * Creates the project directory if it doesn't exist
  */
 export function getProjectDbPath(projectName: string): string {
   const projectsDir = getProjectsPath();
   const projectDir = join(projectsDir, projectName);
+
+  // Validate before touching the filesystem so traversal never creates dirs.
+  assertContainedProjectName(projectName, projectsDir, projectDir);
 
   if (!existsSync(projectDir)) {
     mkdirSync(projectDir, { recursive: true });

--- a/apps/cli/src/self/paths.ts
+++ b/apps/cli/src/self/paths.ts
@@ -1,6 +1,6 @@
 import { realpathSync, statSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { dirname, join, parse, sep } from "node:path";
+import { dirname, isAbsolute, join, parse, sep } from "node:path";
 
 import { type Result, ok, err, commandError } from "@/controllers/types";
 
@@ -155,9 +155,40 @@ export function getBinaryPath(version: string): string {
   return join(getReleasePath(version), `squirrel${ext}`);
 }
 
+/**
+ * Validate a caller-supplied custom bin directory before it is used to build a
+ * symlink/rename/unlink target. `customBinDir` can originate from an untrusted
+ * source (a repo-local .squirrel/settings.json's `install_bin_dir`, threaded
+ * through the auto-updater as customBinDir), so a hostile value must not be
+ * able to plant the `squirrel` symlink at an attacker-chosen path (#1398).
+ * Rejects empty strings, embedded NUL (truncates past the C-string boundary),
+ * any relative path (must be absolute), and any `..` traversal segment. The
+ * trusted default from getSquirrelPaths().bin never routes through here.
+ */
+function assertSafeBinDir(dir: string): void {
+  if (dir === "") {
+    throw new Error("Invalid bin directory: must not be empty");
+  }
+  if (dir.includes("\0")) {
+    throw new Error("Invalid bin directory: must not contain a NUL byte");
+  }
+  if (!isAbsolute(dir)) {
+    throw new Error(`Invalid bin directory: must be an absolute path: ${dir}`);
+  }
+  // Split on BOTH separators so a `..` segment is caught regardless of the
+  // slash style the value was written with (Windows accepts either).
+  if (dir.split(/[/\\]/).includes("..")) {
+    throw new Error(`Invalid bin directory: must not contain '..': ${dir}`);
+  }
+}
+
 export function getSymlinkPath(customBinDir?: string): string {
   const os = platform() as Platform;
   const ext = os === "win32" ? ".exe" : "";
+  // Only a caller-supplied dir is untrusted; the default is trusted as-is.
+  if (customBinDir !== undefined) {
+    assertSafeBinDir(customBinDir);
+  }
   const binDir = customBinDir ?? getSquirrelPaths().bin;
   return join(binDir, `squirrel${ext}`);
 }

--- a/apps/cli/src/self/settings.ts
+++ b/apps/cli/src/self/settings.ts
@@ -323,9 +323,13 @@ export function loadMergedSettings(): Result<MergedSettings> {
     } else {
       const localSettings = parseResult.data;
 
-      // Merge local settings on top, track sources
+      // Merge local settings on top, track sources. Gate on the SAME
+      // writable-key predicate the write path enforces (setSettingValue) so a
+      // repo-local .squirrel/settings.json can't inject non-writable keys like
+      // install_bin_dir/auth — a cloned repo could otherwise steer the
+      // auto-updater's symlink target or forge a session (#1398).
       for (const [key, value] of Object.entries(localSettings)) {
-        if (value !== undefined) {
+        if (value !== undefined && isWritableSetting(key)) {
           (userSettings as Record<string, unknown>)[key] = value;
           sources[key] = "local";
         }

--- a/apps/cli/tests/commands/self-settings-redaction.test.ts
+++ b/apps/cli/tests/commands/self-settings-redaction.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { redactSettingsForDisplay } from "@/cli/commands/self";
+import type { UserSettings } from "@/self/types";
+
+// Distinctive values that redactString() does NOT catch on its own — so if the
+// explicit masking regressed, these would surface in the output and fail the
+// assertions below (proving the baseline redactValue() pass is not enough).
+const TOKEN = "sk_live_SESSION_TOKEN_abc123xyz";
+const KEY_MATERIAL = "BYOK_SECRET_KEY_material_987";
+
+// Minimal valid UserSettings (only the schema-required fields).
+function baseSettings(): UserSettings {
+  return {
+    channel: "stable",
+    auto_update: true,
+    notifications: true,
+    telemetry: false,
+    tips: true,
+    last_update_check: null,
+    dismissed_update_version: null,
+    update_prompt_snoozed_until: null,
+  };
+}
+
+function loggedInWithByok(): UserSettings {
+  return {
+    ...baseSettings(),
+    auth: {
+      token: TOKEN,
+      userId: "user_123",
+      email: "dev@example.com",
+      name: "Dev",
+      expiresAt: "2026-12-31T00:00:00.000Z",
+    },
+    tool_credentials: {
+      // Keychain sentinel — the real secret is in the OS keychain, not here.
+      gsc: { _keychainRef: true },
+      // Plaintext BYOK fallback (keychain-unavailable install) — a real secret.
+      pangram: { api_key: KEY_MATERIAL },
+    },
+  };
+}
+
+describe("redactSettingsForDisplay (#1399)", () => {
+  test("masks auth + plaintext BYOK cred, preserves keychain sentinel", () => {
+    const redacted = redactSettingsForDisplay(loggedInWithByok());
+
+    // Whole auth object masked (covers the live session bearer token).
+    expect(redacted.auth).toBe("[REDACTED]");
+
+    // Sentinel preserved untouched; plaintext credential fully masked.
+    expect(redacted.tool_credentials).toEqual({
+      gsc: { _keychainRef: true },
+      pangram: "[REDACTED]",
+    });
+
+    // The serialized (as displayed) form leaks nothing: not the token, not the
+    // key material, and not even the `api_key` field name.
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain(TOKEN);
+    expect(serialized).not.toContain(KEY_MATERIAL);
+    expect(serialized).not.toContain("api_key");
+
+    // Non-sensitive settings remain visible and correct.
+    expect(redacted.channel).toBe("stable");
+    expect(redacted.auto_update).toBe(true);
+    expect(redacted.telemetry).toBe(false);
+  });
+
+  test("does not mutate the caller's settings object", () => {
+    const settings = loggedInWithByok();
+    redactSettingsForDisplay(settings);
+
+    // Original still holds the real secrets — the clone was masked, not this.
+    expect(settings.auth?.token).toBe(TOKEN);
+    expect(settings.tool_credentials?.pangram).toEqual({
+      api_key: KEY_MATERIAL,
+    });
+    expect(settings.tool_credentials?.gsc).toEqual({ _keychainRef: true });
+  });
+
+  test("passes logged-out / no-BYOK settings through untouched", () => {
+    const redacted = redactSettingsForDisplay({
+      ...baseSettings(),
+      auth: null,
+    });
+
+    expect(redacted).toEqual({ ...baseSettings(), auth: null });
+    expect(redacted.auth).toBeNull();
+    expect(redacted.tool_credentials).toBeUndefined();
+  });
+});

--- a/apps/cli/tests/commands/self-settings-redaction.test.ts
+++ b/apps/cli/tests/commands/self-settings-redaction.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
-import { redactSettingsForDisplay } from "@/cli/commands/self";
 import type { UserSettings } from "@/self/types";
+
+import { redactSettingsForDisplay } from "@/cli/commands/self";
 
 // Distinctive values that redactString() does NOT catch on its own — so if the
 // explicit masking regressed, these would surface in the output and fail the
 // assertions below (proving the baseline redactValue() pass is not enough).
-const TOKEN = "sk_live_SESSION_TOKEN_abc123xyz";
-const KEY_MATERIAL = "BYOK_SECRET_KEY_material_987";
+const TOKEN = "session-token-probe-value-1399";
+const KEY_MATERIAL = "byok-key-probe-value-1399";
 
 // Minimal valid UserSettings (only the schema-required fields).
 function baseSettings(): UserSettings {

--- a/apps/cli/tests/crawler/storage-project-path.test.ts
+++ b/apps/cli/tests/crawler/storage-project-path.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { existsSync, rmSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+
+import { getProjectDbPath } from "../../src/crawler/storage/index";
+import { getProjectsPath } from "../../src/self/paths";
+
+// The `[project] name` comes from a cloned repo's squirrel.toml, so it is
+// attacker-controlled. getProjectDbPath() must reject any name that would let
+// the resulting project dir escape ~/.squirrel/projects (path traversal),
+// before it touches the filesystem (#1397).
+describe("getProjectDbPath path traversal guard", () => {
+  test("rejects a traversal name and never creates the escape target", () => {
+    const name = `../../../../../../tmp/squirrelscan-evil-${randomUUID()}`;
+    // Where the un-guarded join()+resolve() would have landed.
+    const escapeTarget = resolve(getProjectsPath(), name);
+    expect(existsSync(escapeTarget)).toBe(false);
+
+    expect(() => getProjectDbPath(name)).toThrow(/squirrel\.toml/);
+
+    // Guard must fire before mkdirSync, so nothing was created outside projects.
+    expect(existsSync(escapeTarget)).toBe(false);
+  });
+
+  test.each([
+    "..",
+    ".",
+    "a/b",
+    "/etc/passwd",
+    "..\\..\\windows",
+    "foo/../../bar",
+    "",
+  ])("rejects unsafe name %j", (name) => {
+    expect(() => getProjectDbPath(name)).toThrow(/squirrel\.toml/);
+  });
+
+  test("accepts a legit single-segment name, kept under the projects dir", () => {
+    const name = `sqtest-${randomUUID()}`;
+    const projectsDir = getProjectsPath();
+    const expectedDir = join(projectsDir, name);
+    try {
+      const dbPath = getProjectDbPath(name);
+
+      expect(dbPath).toBe(join(expectedDir, "project.db"));
+      // Resolved dir stays inside the projects directory.
+      expect(resolve(expectedDir).startsWith(resolve(projectsDir) + sep)).toBe(
+        true
+      );
+      // Directory was actually created.
+      expect(existsSync(expectedDir)).toBe(true);
+    } finally {
+      rmSync(expectedDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/tests/self/paths.test.ts
+++ b/apps/cli/tests/self/paths.test.ts
@@ -6,7 +6,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { platform, tmpdir } from "node:os";
+import { homedir, platform, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
@@ -179,6 +179,45 @@ describe("getSymlinkPath", () => {
       expect(path).toEndWith("squirrel");
     });
   }
+
+  // #1398: a caller-supplied bin dir can originate from an untrusted
+  // repo-local settings.json (install_bin_dir → the auto-updater's
+  // customBinDir), so getSymlinkPath must validate it before the value is
+  // used to build a symlink/rename/unlink target. The trusted default
+  // (no argument) is never validated and must keep working.
+  describe("custom bin dir validation", () => {
+    const ext = platform() === "win32" ? ".exe" : "";
+
+    test("honors a legit absolute custom bin dir", () => {
+      // `~/.local/bin` reaches this function already tilde-expanded.
+      for (const dir of [
+        join(homedir(), ".local", "bin"),
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+      ]) {
+        expect(getSymlinkPath(dir)).toBe(join(dir, `squirrel${ext}`));
+      }
+    });
+
+    test("rejects a relative custom bin dir", () => {
+      expect(() => getSymlinkPath("relative/bin")).toThrow();
+      expect(() => getSymlinkPath("./bin")).toThrow();
+      expect(() => getSymlinkPath(".local/bin")).toThrow();
+    });
+
+    test("rejects a custom bin dir containing a '..' traversal segment", () => {
+      expect(() => getSymlinkPath("/usr/../etc/bin")).toThrow();
+      expect(() => getSymlinkPath("/opt/homebrew/../../tmp/evil")).toThrow();
+    });
+
+    test("rejects an empty custom bin dir", () => {
+      expect(() => getSymlinkPath("")).toThrow();
+    });
+
+    test("rejects a custom bin dir with an embedded NUL byte", () => {
+      expect(() => getSymlinkPath("/usr/local/bin\0/evil")).toThrow();
+    });
+  });
 });
 
 describe("isBinInPath", () => {

--- a/apps/cli/tests/self/settings.test.ts
+++ b/apps/cli/tests/self/settings.test.ts
@@ -23,7 +23,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { commandError } from "../../src/controllers/types";
+import { commandError, ok } from "../../src/controllers/types";
 import * as pathsModule from "../../src/self/paths";
 import {
   setSettingValue,
@@ -31,6 +31,7 @@ import {
   shouldCheckForUpdates,
   formatSessionLoadWarning,
   loadUserSettings,
+  loadMergedSettings,
   readAndParseSettingsFile,
   writeFileAtomic,
   DEFAULT_SETTINGS,
@@ -313,6 +314,13 @@ describe("isWritableSetting", () => {
     expect(isWritableSetting("update_prompt_snoozed_until")).toBe(false);
     expect(isWritableSetting("id")).toBe(false);
     expect(isWritableSetting("registered")).toBe(false);
+    // #1398: these must stay non-writable — the local-scope merge allowlist
+    // relies on this predicate to keep a repo-local settings.json from
+    // injecting them (install_bin_dir steers the updater's symlink target,
+    // auth forges a session, tool_credentials smuggles BYOK secrets).
+    expect(isWritableSetting("install_bin_dir")).toBe(false);
+    expect(isWritableSetting("auth")).toBe(false);
+    expect(isWritableSetting("tool_credentials")).toBe(false);
   });
 
   test("rejects unknown settings", () => {
@@ -749,5 +757,103 @@ describe("loadUserSettings — corrupt vs. missing vs. valid (#805)", () => {
     const result = loadUserSettings(testPath);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.data.auth?.email).toBe("nik@example.com");
+  });
+});
+
+// #1398: loadMergedSettings must apply a repo-local .squirrel/settings.json
+// ONLY for the writable-key allowlist, exactly like the write path
+// (setSettingValue). A cloned repo could otherwise inject non-writable keys —
+// install_bin_dir (steers the auto-updater's symlink target to an
+// attacker-chosen path) or auth (forges a session). getSettingsPath is already
+// redirected file-wide to sandboxSettingsPath (the user file); this block
+// additionally spies findLocalSettingsPath so the local file is a controlled
+// temp path rather than anything discovered by walking the real cwd. Every key
+// written to the local file below is schema-VALID, so the ONLY thing that can
+// filter it is the writable-key gate — not a parse rejection.
+describe("loadMergedSettings — local writable-key allowlist (#1398)", () => {
+  let localDir: string;
+  let localPath: string;
+  let restoreFindLocal: () => void = () => {};
+
+  const futureIso = new Date(Date.now() + 86_400_000).toISOString();
+
+  const writeUser = (obj: unknown): void =>
+    writeFileSync(sandboxSettingsPath, JSON.stringify(obj));
+  const writeLocal = (obj: unknown): void =>
+    writeFileSync(localPath, JSON.stringify(obj));
+
+  beforeEach(() => {
+    localDir = mkdtempSync(join(tmpdir(), "squirrel-local-merge-test-"));
+    localPath = join(localDir, "settings.json");
+    const spy = spyOn(pathsModule, "findLocalSettingsPath").mockImplementation(
+      () => ok(localPath)
+    );
+    restoreFindLocal = () => spy.mockRestore();
+  });
+
+  afterEach(() => {
+    restoreFindLocal();
+    rmSync(localDir, { recursive: true, force: true });
+    // Reset the shared user file back to logged-out so nothing leaks into the
+    // setSettingValue suites (which tolerate a missing file → defaults).
+    rmSync(sandboxSettingsPath, { force: true });
+  });
+
+  test("a local install_bin_dir does NOT override the user-scoped value", () => {
+    writeUser({ channel: "stable", install_bin_dir: "/home/user/.local/bin" });
+    writeLocal({ install_bin_dir: "/tmp/evil/bin" });
+
+    const result = loadMergedSettings();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // The poisoned local value is dropped; the user value survives.
+      expect(result.data.effective.install_bin_dir).toBe(
+        "/home/user/.local/bin"
+      );
+      expect(result.data.sources.install_bin_dir).toBe("user");
+    }
+  });
+
+  test("a local channel (a writable key) DOES still override, source local", () => {
+    writeUser({ channel: "stable" });
+    writeLocal({ channel: "beta" });
+
+    const result = loadMergedSettings();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.effective.channel).toBe("beta");
+      expect(result.data.sources.channel).toBe("local");
+    }
+  });
+
+  test("a mixed poisoned local file is filtered key-by-key", () => {
+    writeUser({ channel: "stable", install_bin_dir: "/home/user/.local/bin" });
+    writeLocal({
+      channel: "beta", // writable → applied
+      notifications: false, // writable → applied
+      install_bin_dir: "/tmp/evil/bin", // NOT writable → dropped
+      auth: {
+        token: "sqcli_evil",
+        userId: "usr_evil",
+        email: "evil@example.com",
+        expiresAt: futureIso,
+      }, // NOT writable → dropped
+    });
+
+    const result = loadMergedSettings();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const { effective, sources } = result.data;
+      // Writable keys from local win.
+      expect(effective.channel).toBe("beta");
+      expect(sources.channel).toBe("local");
+      expect(effective.notifications).toBe(false);
+      expect(sources.notifications).toBe("local");
+      // Non-writable keys stay user-sourced — the poison is filtered out.
+      expect(effective.install_bin_dir).toBe("/home/user/.local/bin");
+      expect(sources.install_bin_dir).toBe("user");
+      expect(effective.auth).toBeNull();
+      expect(sources.auth).toBe("user");
+    }
   });
 });

--- a/apps/cli/tests/self/settings.test.ts
+++ b/apps/cli/tests/self/settings.test.ts
@@ -801,7 +801,7 @@ describe("loadMergedSettings — local writable-key allowlist (#1398)", () => {
 
   test("a local install_bin_dir does NOT override the user-scoped value", () => {
     writeUser({ channel: "stable", install_bin_dir: "/home/user/.local/bin" });
-    writeLocal({ install_bin_dir: "/tmp/evil/bin" });
+    writeLocal({ install_bin_dir: "/home/attacker/evil/bin" });
 
     const result = loadMergedSettings();
     expect(result.ok).toBe(true);
@@ -831,7 +831,7 @@ describe("loadMergedSettings — local writable-key allowlist (#1398)", () => {
     writeLocal({
       channel: "beta", // writable → applied
       notifications: false, // writable → applied
-      install_bin_dir: "/tmp/evil/bin", // NOT writable → dropped
+      install_bin_dir: "/home/attacker/evil/bin", // NOT writable → dropped
       auth: {
         token: "sqcli_evil",
         userId: "usr_evil",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:release": "bash scripts/test-changelog-extraction.sh && bun test scripts/release-version.test.ts",
     "docs:check": "cd docs && bun run check",
     "docs:build": "cd docs && bun run build",
-    "audit:dependencies": "bun audit --ignore=GHSA-9wv6-86v2-598j",
+    "audit:dependencies": "bun audit --ignore=GHSA-9wv6-86v2-598j --ignore=GHSA-mh99-v99m-4gvg",
     "notices:generate": "bun run scripts/generate-third-party-notices.ts",
     "notices:check": "bun run notices:generate && git diff --exit-code -- THIRD_PARTY_NOTICES.md npm/THIRD_PARTY_NOTICES.md",
     "check:psl-freshness": "bun run scripts/check-tldts-freshness.ts",

--- a/packages/audit-engine/src/resource-checker.ts
+++ b/packages/audit-engine/src/resource-checker.ts
@@ -14,6 +14,7 @@ import type {
 import { isCacheHitReason } from "@squirrelscan/core-contracts";
 import { calculateFreshness } from "@squirrelscan/crawler";
 import { RESOURCE_SIZE_LIMITS, SQUIRRELSCAN_USER_AGENT } from "@squirrelscan/utils/constants";
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 import type { FetchBudget, FetchOutcome } from "./fetch-budget";
 
 export interface ResourceCheckResult {
@@ -236,7 +237,10 @@ async function checkSingleResourceAsync(
 
   try {
     try {
-      const headResponse = await fetch(url, {
+      // #1395: follow redirects manually so per hop the http/https scheme
+      // allowlist applies and secret customHeaders are stripped on a cross-origin
+      // redirect (native redirect:"follow" replays them to the redirect target).
+      const { response: headResponse, finalUrl: headFinalUrl } = await safeRedirectFetch(url, {
         method: "HEAD",
         headers: {
           "User-Agent": options.userAgent,
@@ -245,7 +249,6 @@ async function checkSingleResourceAsync(
           ...conditional,
         },
         signal: controller.signal,
-        redirect: "follow",
       });
 
       // 304 Not Modified → reuse prior body size (validator hit).
@@ -307,14 +310,16 @@ async function checkSingleResourceAsync(
           etag: meta.etag,
           lastModified: meta.lastModified,
           vary: meta.vary,
-          redirectTarget: headResponse.url !== url ? headResponse.url : null,
+          redirectTarget: headFinalUrl !== url ? headFinalUrl : null,
         };
       }
     } catch {
       // HEAD failed; fall through to GET
     }
 
-    let getResponse = await fetch(url, {
+    // #1395: manual redirects — scheme allowlist + strip secret customHeaders on
+    // cross-origin redirects (see the HEAD path above).
+    let { response: getResponse, finalUrl: getFinalUrl } = await safeRedirectFetch(url, {
       method: "GET",
       headers: {
         "User-Agent": options.userAgent,
@@ -324,7 +329,6 @@ async function checkSingleResourceAsync(
         ...conditional,
       },
       signal: controller.signal,
-      redirect: "follow",
     });
 
     // Servers that reject Range answer 416 (Range Not Satisfiable). That is a
@@ -335,7 +339,7 @@ async function checkSingleResourceAsync(
       // Discard the rejected response body so the connection can be reused
       // instead of stalling the pool while the 416 body lingers unread.
       getResponse.body?.cancel();
-      getResponse = await fetch(url, {
+      ({ response: getResponse, finalUrl: getFinalUrl } = await safeRedirectFetch(url, {
         method: "GET",
         headers: {
           "User-Agent": options.userAgent,
@@ -344,8 +348,7 @@ async function checkSingleResourceAsync(
           ...conditional,
         },
         signal: controller.signal,
-        redirect: "follow",
-      });
+      }));
     }
 
     // 304 Not Modified on the GET fallback → validator hit.
@@ -417,7 +420,7 @@ async function checkSingleResourceAsync(
       etag: meta.etag,
       lastModified: meta.lastModified,
       vary: meta.vary,
-      redirectTarget: getResponse.url !== url ? getResponse.url : null,
+      redirectTarget: getFinalUrl !== url ? getFinalUrl : null,
     };
   } catch (error) {
     clearTimeout(timeoutId);

--- a/packages/audit-engine/src/script-fetcher.ts
+++ b/packages/audit-engine/src/script-fetcher.ts
@@ -4,6 +4,7 @@
 import { Effect } from "effect";
 
 import { SCRIPT_FETCH_LIMITS, SQUIRRELSCAN_USER_AGENT } from "@squirrelscan/utils/constants";
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 import type { FetchBudget, FetchOutcome } from "./fetch-budget";
 
 export interface ScriptFetchResult {
@@ -82,7 +83,15 @@ async function fetchSingleScriptAsync(
   };
 
   try {
-    const response = await fetch(url, {
+    // #1395: follow redirects manually so per hop the http/https scheme
+    // allowlist applies and secret customHeaders are stripped on a cross-origin
+    // redirect (native redirect:"follow" replays them; a Location: file:// would
+    // otherwise be fetched and its content scanned/captured).
+    const {
+      response,
+      finalUrl: resolvedFinalUrl,
+      redirected,
+    } = await safeRedirectFetch(url, {
       method: "GET",
       headers: {
         "User-Agent": options.userAgent,
@@ -90,7 +99,6 @@ async function fetchSingleScriptAsync(
         ...options.customHeaders,
       },
       signal: controller.signal,
-      redirect: "follow",
     });
 
     clearTimeout(timeoutId);
@@ -106,8 +114,8 @@ async function fetchSingleScriptAsync(
       response.headers.get("x-sourcemap") ||
       undefined;
 
-    const wasRedirected = response.redirected;
-    const finalUrl = wasRedirected ? response.url : undefined;
+    const wasRedirected = redirected;
+    const finalUrl = wasRedirected ? resolvedFinalUrl : undefined;
 
     if (
       declaredSize &&

--- a/packages/crawler/src/agent-access.ts
+++ b/packages/crawler/src/agent-access.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
 import type {
   AgentAccessData,
@@ -47,7 +48,12 @@ export function detectPayment(status: number, headers: Headers, body: string): s
 function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timeout));
+  // #1395: manual redirects — per-hop scheme allowlist + strip secret
+  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
+  // The probe identity's User-Agent is on the allowlist, so it survives the hop.
+  return safeRedirectFetch(url, { ...options, signal: controller.signal })
+    .then((result) => result.response)
+    .finally(() => clearTimeout(timeout));
 }
 
 async function probeOne(

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -10,6 +10,7 @@ import { COVERAGE_PAGE_LIMITS, REPORT_LIMITS } from "@squirrelscan/core-contract
 import { extractCrawlableUrls } from "@squirrelscan/parser/extractors";
 import { parseDocument, parsePage, type ParsedPageCache } from "@squirrelscan/parser";
 import { findClientRedirects } from "@squirrelscan/utils/client-redirects";
+import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 import { urlHostKey } from "@squirrelscan/utils/url";
 
 import { computeSitemapUrlCap, discoverSitemaps, selectSitemapUrls } from "../sitemaps";
@@ -1470,7 +1471,15 @@ export function createCrawler(
     ): Effect.Effect<string, CrawlerError | StorageError, never> =>
       Effect.gen(function* () {
         // Follow redirects to get final URL (both HTTP and client-side)
-        const finalTargetUrl = yield* detectRedirects(targetUrl);
+        const rawFinalTargetUrl = yield* detectRedirects(targetUrl);
+        // SECURITY (#1396) defense-in-depth: detectRedirects follows client-side
+        // redirects (meta refresh / JS) whose target is page-controlled.
+        // findMetaRefresh / findJavaScriptRedirect already restrict to
+        // http/https, but re-validate before we derive the crawl's baseUrl
+        // origin from it — a non-http(s) target would make `new URL(...).origin`
+        // an opaque "null" origin and corrupt the whole crawl. Scheme-only:
+        // internal/private hosts stay allowed.
+        const finalTargetUrl = isHttpOrHttpsUrl(rawFinalTargetUrl) ? rawFinalTargetUrl : targetUrl;
         // Use provided originalUrl or fall back to targetUrl for backwards compat
         const userProvidedUrl = originalUrl || targetUrl;
 

--- a/packages/crawler/src/fetcher.ts
+++ b/packages/crawler/src/fetcher.ts
@@ -10,6 +10,7 @@ import type {
 } from "@squirrelscan/core-contracts";
 import { CHROME_SEC_CH_UA } from "@squirrelscan/utils/constants";
 import { headersForRedirect } from "@squirrelscan/utils/headers";
+import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 import {
   DEFAULT_MAX_DOCUMENT_BODY_BYTES,
   readBodyCapped,
@@ -634,6 +635,19 @@ function fetchPageStandard(
           break;
         }
         const nextUrl = new URL(location, currentUrl).toString();
+        // SECURITY (#1392): this hand-rolled manual-redirect loop bypasses the
+        // runtime's native cross-protocol-redirect rejection, so a
+        // `Location: file:///…` (or data:/blob:/ftp:/…) would otherwise be
+        // blindly re-fetched and its body stored (crawler.ts stores result.body
+        // unconditionally). Refuse any non-http(s) redirect target — treat it as
+        // a terminal error hop, never fetch it. Scheme-only: private/loopback
+        // HOSTS stay allowed so internal-site audits keep working.
+        if (!isHttpOrHttpsUrl(nextUrl)) {
+          endsInError = true;
+          finalResponse = response;
+          finalTiming = timing;
+          break;
+        }
         headers = headersForRedirect(headers, currentUrl, nextUrl);
         currentUrl = nextUrl;
         continue;

--- a/packages/crawler/src/llms.ts
+++ b/packages/crawler/src/llms.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
 import type { LlmsTxtData, LlmsTxtFile } from "@squirrelscan/core-contracts";
 
@@ -14,7 +15,11 @@ function emptyFile(url: string): LlmsTxtFile {
 function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timeout));
+  // #1395: manual redirects — per-hop scheme allowlist + strip secret
+  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
+  return safeRedirectFetch(url, { ...options, signal: controller.signal })
+    .then((result) => result.response)
+    .finally(() => clearTimeout(timeout));
 }
 
 // Fetch one well-known file; a 404/error/oversize file is "absent", never a throw.

--- a/packages/crawler/src/markdown.ts
+++ b/packages/crawler/src/markdown.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
 import type { MarkdownProbeData } from "@squirrelscan/core-contracts";
 
@@ -9,7 +10,11 @@ const isMarkdown = (ct: string | null): boolean => ct != null && /markdown/i.tes
 function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timeout));
+  // #1395: manual redirects — per-hop scheme allowlist + strip secret
+  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
+  return safeRedirectFetch(url, { ...options, signal: controller.signal })
+    .then((result) => result.response)
+    .finally(() => clearTimeout(timeout));
 }
 
 // Parse a `Link:` response header for a `rel="alternate"; type="text/markdown"`

--- a/packages/crawler/src/robots.ts
+++ b/packages/crawler/src/robots.ts
@@ -3,6 +3,7 @@ import robotsParser from "robots-parser";
 
 import type { RobotsTxtData } from "@squirrelscan/core-contracts";
 import { parseRobotsTxt } from "@squirrelscan/utils/robots-txt";
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
 export interface RobotsEvaluator {
   data: RobotsTxtData;
@@ -61,10 +62,15 @@ function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number):
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-  return fetch(url, {
+  // #1395: follow redirects manually so per-hop the scheme allowlist applies and
+  // the caller's secret customHeaders are stripped when a redirect changes origin
+  // (native redirect:"follow" would replay them cross-origin).
+  return safeRedirectFetch(url, {
     ...options,
     signal: controller.signal,
-  }).finally(() => clearTimeout(timeout));
+  })
+    .then((result) => result.response)
+    .finally(() => clearTimeout(timeout));
 }
 
 export function fetchRobotsEvaluator(

--- a/packages/crawler/src/rsl.ts
+++ b/packages/crawler/src/rsl.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { truncateToBytes } from "@squirrelscan/utils/bytes";
+import { isHttpOrHttpsUrl, safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
 import type { RslData, RslLicenseDoc } from "@squirrelscan/core-contracts";
 
@@ -49,7 +50,11 @@ export function looksLikeXml(body: string): boolean {
 function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timeout));
+  // #1395: manual redirects — per-hop scheme allowlist + strip secret
+  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
+  return safeRedirectFetch(url, { ...options, signal: controller.signal })
+    .then((result) => result.response)
+    .finally(() => clearTimeout(timeout));
 }
 
 async function fetchLicenseDoc(
@@ -128,14 +133,26 @@ export function fetchRslLicensing(
     const licenseUrls = [...new Set([...directiveUrls, ...headerUrls])].flatMap((u) => {
       // A malformed advisory URL must not abort the crawl — drop it.
       try {
-        return [new URL(u, baseUrl).toString()];
+        const resolved = new URL(u, baseUrl).toString();
+        // #1394: `License:` directives and `Link: rel=license` headers are
+        // untrusted page content. Only fetch http(s) license docs — a
+        // `file://`/`data:` target would otherwise be fetched and its body
+        // captured into `excerpt`.
+        if (!isHttpOrHttpsUrl(resolved)) return [];
+        return [resolved];
       } catch {
         return [];
       }
     });
 
+    // #1394: the caller's secret customHeaders are scoped to the audited origin —
+    // a license doc hosted off-origin must not receive them.
+    const baseHost = new URL(baseUrl).host;
     const documents = await Promise.all(
-      licenseUrls.map((url) => fetchLicenseDoc(url, userAgent, customHeaders)),
+      licenseUrls.map((url) => {
+        const sameOrigin = new URL(url).host === baseHost;
+        return fetchLicenseDoc(url, userAgent, sameOrigin ? customHeaders : undefined);
+      }),
     );
 
     return {

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -7,6 +7,7 @@ import type {
   SitemapFetchFailure,
   SitemapUrl,
 } from "@squirrelscan/core-contracts";
+import { isHttpOrHttpsUrl, safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
 const logger = {
   debug: (_message: string, ..._args: unknown[]) => {},
@@ -125,17 +126,28 @@ function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number):
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-  return fetch(url, {
+  // #1395: manual redirects — per-hop scheme allowlist + strip secret
+  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
+  return safeRedirectFetch(url, {
     ...options,
     signal: controller.signal,
-  }).finally(() => clearTimeout(timeout));
+  })
+    .then((result) => result.response)
+    .finally(() => clearTimeout(timeout));
 }
 
 export function fetchSitemap(
   url: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
+  baseHost?: string,
 ): Effect.Effect<SitemapFetchResult, never, never> {
+  // #1393: the caller's secret customHeaders are scoped to the audited origin. A
+  // `Sitemap:` directive (robots.txt) or child-sitemap reference can point at an
+  // off-origin host, so only forward them when the target host matches baseHost.
+  // When baseHost is unset (direct callers/tests), preserve prior behavior.
+  const originScopedHeaders =
+    baseHost !== undefined && new URL(url).host !== baseHost ? undefined : customHeaders;
   return pipe(
     Effect.tryPromise({
       try: () =>
@@ -146,7 +158,7 @@ export function fetchSitemap(
               "User-Agent": userAgent,
               Accept: "application/xml, text/xml, */*",
               "Accept-Language": "en-US,en;q=0.9",
-              ...customHeaders,
+              ...originScopedHeaders,
             },
             redirect: "follow",
           },
@@ -233,6 +245,9 @@ export function fetchSitemapsRecursive(
   seen: Set<string> = new Set(),
   urlBudget?: SitemapUrlBudget,
   customHeaders?: Record<string, string>,
+  // #1393: host of the audited origin; customHeaders are only forwarded to
+  // matching-host sitemap fetches. Threaded through the recursion.
+  baseHost?: string,
 ): Effect.Effect<SitemapFetchResult[], never, never> {
   if (currentDepth >= maxDepth || urls.length === 0) {
     return Effect.succeed([]);
@@ -268,7 +283,7 @@ export function fetchSitemapsRecursive(
 
       const chunk = unseenUrls.slice(i, i + SITEMAP_FETCH_CONCURRENCY);
       const chunkResults = yield* Effect.all(
-        chunk.map((url) => fetchSitemap(url, userAgent, customHeaders)),
+        chunk.map((url) => fetchSitemap(url, userAgent, customHeaders, baseHost)),
         { concurrency: SITEMAP_FETCH_CONCURRENCY },
       );
       fetchResults.push(...chunkResults);
@@ -310,6 +325,7 @@ export function fetchSitemapsRecursive(
       seen,
       urlBudget,
       customHeaders,
+      baseHost,
     );
 
     return [...fetchResults, ...childResults];
@@ -350,10 +366,20 @@ export function discoverSitemaps(
     const sitemapUrls = new Set<string>();
     const robotsSitemaps = new Set<string>();
 
+    // #1393: robots.txt is untrusted page content. A `Sitemap:` directive can
+    // carry any scheme/host — reject non-http(s) targets (a `file://` sitemap
+    // would otherwise be fetched and its body parsed/stored). Off-origin http(s)
+    // sitemaps are still fetched (legit CDN case) but without customHeaders,
+    // enforced by the baseHost gate passed to fetchSitemapsRecursive below.
+    const baseHost = new URL(baseUrl).host;
     if (robotsTxt?.sitemaps) {
       for (const sitemap of robotsTxt.sitemaps) {
         try {
           const resolvedUrl = new URL(sitemap, baseUrl).toString();
+          if (!isHttpOrHttpsUrl(resolvedUrl)) {
+            logger.debug(`Non-http(s) sitemap URL in robots.txt skipped: ${sitemap}`);
+            continue;
+          }
           sitemapUrls.add(resolvedUrl);
           robotsSitemaps.add(resolvedUrl);
         } catch {
@@ -377,6 +403,7 @@ export function discoverSitemaps(
       undefined,
       urlBudget,
       options.customHeaders,
+      baseHost,
     );
 
     const allSitemaps = allResults.filter((result) => result.success).map((result) => result.data);

--- a/packages/crawler/src/well-known.ts
+++ b/packages/crawler/src/well-known.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
 import type { WellKnownProbe, WellKnownProbeData } from "@squirrelscan/core-contracts";
 
@@ -94,7 +95,11 @@ export function looksLikeMarkdown(body: string): boolean {
 function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timeout));
+  // #1395: manual redirects — per-hop scheme allowlist + strip secret
+  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
+  return safeRedirectFetch(url, { ...options, signal: controller.signal })
+    .then((result) => result.response)
+    .finally(() => clearTimeout(timeout));
 }
 
 async function probeOne(

--- a/packages/crawler/tests/redirect-header-security.test.ts
+++ b/packages/crawler/tests/redirect-header-security.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 
+import type { RobotsTxtData } from "@squirrelscan/core-contracts";
+import { findClientRedirects } from "@squirrelscan/utils/client-redirects";
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+
 import { fetchPage } from "../src/fetcher";
+import { fetchRslLicensing } from "../src/rsl";
+import { discoverSitemaps, fetchSitemap } from "../src/sitemaps";
+
+// Resolve the URL from a fetch() first argument (string | URL | Request).
+function requestUrl(input: string | URL | Request): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
 
 describe("standard fetch redirect headers", () => {
   test("strips caller-provided headers when a redirect changes origin", async () => {
@@ -48,5 +61,212 @@ describe("standard fetch redirect headers", () => {
       source.stop(true);
       target.stop(true);
     }
+  });
+});
+
+// #1392: a hand-rolled manual-redirect loop must NOT follow a cross-protocol
+// (non-http/https) redirect target — that is the critical local-file-read /
+// scheme-SSRF vector, since crawler.ts stores result.body unconditionally.
+describe("cross-protocol redirect refusal (#1392)", () => {
+  test("main page fetch refuses an http -> file:// redirect (no local file read)", async () => {
+    const source = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "file:///etc/passwd" },
+        });
+      },
+    });
+
+    try {
+      const result = await Effect.runPromise(
+        fetchPage(`http://127.0.0.1:${source.port}/x`, {
+          userAgent: "squirrel-test",
+          timeoutMs: 5_000,
+          followRedirects: true,
+        }),
+      );
+
+      // The file:// target is never fetched; the redirect is a terminal error
+      // hop and the final URL stays on the http origin.
+      expect(result.status).toBe(302);
+      expect(result.finalUrl).toContain(`127.0.0.1:${source.port}`);
+      expect(result.redirectChain.endsInError).toBe(true);
+      // Body must never contain /etc/passwd contents.
+      expect(result.body).not.toContain("root:");
+    } finally {
+      source.stop(true);
+    }
+  });
+
+  test("safeRedirectFetch throws on a cross-protocol (file://) redirect", async () => {
+    const source = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "file:///etc/passwd" },
+        });
+      },
+    });
+
+    try {
+      await expect(safeRedirectFetch(`http://127.0.0.1:${source.port}/x`)).rejects.toThrow(
+        /non-http/i,
+      );
+    } finally {
+      source.stop(true);
+    }
+  });
+});
+
+// #1395: auxiliary probe fetches carry the user's secret customHeaders. A
+// cross-origin redirect must strip them (undici/Bun natively strip only
+// authorization/cookie/proxy-authorization/host), while generic browser headers
+// (user-agent) survive.
+describe("probe fetch cross-origin header stripping (#1395)", () => {
+  test("a probe (sitemap) strips secret headers across a cross-origin redirect", async () => {
+    let targetSawSecret: string | null = "unset";
+    let targetSawUserAgent: string | null = null;
+
+    const target = Bun.serve({
+      port: 0,
+      fetch(req) {
+        targetSawSecret = req.headers.get("x-api-key");
+        targetSawUserAgent = req.headers.get("user-agent");
+        return new Response(
+          `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`,
+          { headers: { "content-type": "application/xml" } },
+        );
+      },
+    });
+    const source = Bun.serve({
+      port: 0,
+      fetch() {
+        // Different port on 127.0.0.1 == different origin.
+        return new Response(null, {
+          status: 302,
+          headers: { location: `http://127.0.0.1:${target.port}/sitemap.xml` },
+        });
+      },
+    });
+
+    try {
+      const result = await Effect.runPromise(
+        fetchSitemap(`http://127.0.0.1:${source.port}/sitemap.xml`, "squirrel-test", {
+          "X-Api-Key": "supersecret", // pragma: allowlist secret
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      // Secret header dropped on the cross-origin hop; UA (allowlisted) survives.
+      expect(targetSawSecret).toBeNull();
+      expect(targetSawUserAgent).toBe("squirrel-test");
+    } finally {
+      source.stop(true);
+      target.stop(true);
+    }
+  });
+});
+
+// #1393 / #1394: robots.txt Sitemap:/License: directives are untrusted page
+// content. A file:// (or any non-http/https) target must be refused BEFORE any
+// fetch is attempted — never fetched, never parsed, never captured.
+describe("robots.txt directive scheme refusal (#1393/#1394)", () => {
+  test("a Sitemap: file:// directive is refused (never fetched)", async () => {
+    const originalFetch = globalThis.fetch;
+    const requested: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      requested.push(requestUrl(input));
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    try {
+      const robotsTxt: RobotsTxtData = {
+        exists: true,
+        url: "https://example.test/robots.txt",
+        content: "Sitemap: file:///etc/passwd\n",
+        sizeBytes: 0,
+        sitemaps: ["file:///etc/passwd"],
+        rules: [],
+        errors: [],
+      };
+      const result = await Effect.runPromise(
+        discoverSitemaps("https://example.test", robotsTxt, "test-agent", { maxUrls: 50 }),
+      );
+
+      expect(requested.some((u) => u.startsWith("file:"))).toBe(false);
+      expect(result.failed.some((f) => f.url.startsWith("file:"))).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("a License: file:// directive is refused (never fetched)", async () => {
+    const originalFetch = globalThis.fetch;
+    const requested: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = requestUrl(input);
+      requested.push(url);
+      if (url.endsWith("/robots.txt")) {
+        return new Response("License: file:///etc/passwd\n", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      return new Response("", { status: 404 });
+    }) as typeof fetch;
+
+    try {
+      const result = await Effect.runPromise(
+        fetchRslLicensing("https://example.test", "test-agent"),
+      );
+
+      expect(requested.some((u) => u.startsWith("file:"))).toBe(false);
+      // The directive was present, but its file:// target was dropped pre-fetch.
+      expect(result.robotsHasLicense).toBe(true);
+      expect(result.licenseUrls.length).toBe(0);
+      expect(result.documents.length).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// #1396: findMetaRefresh must restrict targets to http/https, like
+// findJavaScriptRedirect, so a meta refresh can't point the crawler at a
+// file:///data:/javascript: URL.
+describe("findMetaRefresh scheme restriction (#1396)", () => {
+  const base = "https://example.com/page";
+
+  test("rejects a file:// meta refresh target", () => {
+    expect(
+      findClientRedirects(
+        `<meta http-equiv="refresh" content="0;url=file:///etc/passwd">`,
+        base,
+      ),
+    ).toBeNull();
+  });
+
+  test("rejects data: and javascript: meta refresh targets", () => {
+    expect(
+      findClientRedirects(`<meta http-equiv="refresh" content="0;url=data:text/html,x">`, base),
+    ).toBeNull();
+    expect(
+      findClientRedirects(`<meta http-equiv="refresh" content="0;url=javascript:alert(1)">`, base),
+    ).toBeNull();
+  });
+
+  test("still follows http(s) and relative meta refresh targets", () => {
+    expect(
+      findClientRedirects(
+        `<meta http-equiv="refresh" content="0;url=https://other.example/next">`,
+        base,
+      ),
+    ).toBe("https://other.example/next");
+    expect(
+      findClientRedirects(`<meta http-equiv="refresh" content="0;url=/next">`, base),
+    ).toBe("https://example.com/next");
   });
 });

--- a/packages/fetchers/src/index.ts
+++ b/packages/fetchers/src/index.ts
@@ -2,6 +2,7 @@ import type { RedirectChain } from "@squirrelscan/core-contracts";
 import {
   DEFAULT_MAX_DOCUMENT_BODY_BYTES,
   headersForRedirect,
+  isHttpOrHttpsUrl,
   readBodyCapped,
 } from "@squirrelscan/utils";
 
@@ -227,6 +228,16 @@ export function createFetchDocumentFetcher(): DocumentFetcher {
               break;
             }
             const nextUrl = new URL(location, currentUrl).toString();
+            // SECURITY (#1392): a hand-rolled manual-redirect loop bypasses the
+            // runtime's native cross-protocol-redirect rejection, so a
+            // `Location: file:///…` (or data:/blob:/ftp:/…) would otherwise be
+            // re-fetched and its body returned as the page. Refuse any
+            // non-http(s) redirect target — terminal error hop, never fetched.
+            // Scheme-only: private/loopback HOSTS stay allowed (internal audits).
+            if (!isHttpOrHttpsUrl(nextUrl)) {
+              endsInError = true;
+              break;
+            }
             requestHeaders = headersForRedirect(requestHeaders, currentUrl, nextUrl);
             currentUrl = nextUrl;
             continue;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,6 +12,7 @@
     "./robots-txt": "./src/robots-txt.ts",
     "./validation": "./src/validation.ts",
     "./headers": "./src/headers.ts",
+    "./safe-fetch": "./src/safe-fetch.ts",
     "./response-body": "./src/response-body.ts",
     "./user-agent": "./src/user-agent.ts",
     "./client-redirects": "./src/client-redirects.ts",

--- a/packages/utils/src/client-redirects.ts
+++ b/packages/utils/src/client-redirects.ts
@@ -39,7 +39,15 @@ function findMetaRefresh(html: string, baseUrl: string): string | null {
     const target = directive.slice(equals + 1).trim();
     if (!target) continue;
     try {
-      return new URL(target, baseUrl).toString();
+      const resolved = new URL(target, baseUrl);
+      // SECURITY (#1396): only follow http/https meta-refresh targets. A
+      // `content="0;url=file:///etc/passwd"` (or data:/javascript:) must not
+      // become a redirect the crawler then fetches/derives its base URL from.
+      // findJavaScriptRedirect already restricts to http/https/relative; mirror
+      // that here. Relative targets resolve against the http(s) baseUrl, so they
+      // stay allowed.
+      if (resolved.protocol !== "http:" && resolved.protocol !== "https:") continue;
+      return resolved.toString();
     } catch {
       // Invalid URL, continue to the next tag.
     }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -35,6 +35,8 @@ export {
   recordToHeaders,
 } from "./headers";
 
+export { isHttpOrHttpsUrl, safeRedirectFetch, type SafeRedirectResult } from "./safe-fetch";
+
 export {
   DEFAULT_MAX_BODY_BYTES,
   DEFAULT_MAX_DOCUMENT_BODY_BYTES,

--- a/packages/utils/src/safe-fetch.ts
+++ b/packages/utils/src/safe-fetch.ts
@@ -1,0 +1,105 @@
+// Redirect-safe outbound fetch for server-initiated requests of URLs derived
+// from untrusted page content (redirect Location headers, robots.txt
+// directives, meta refresh, Link headers). See #1392-#1396.
+
+import { headersForRedirect } from "./headers";
+
+const MAX_REDIRECTS = 10;
+
+/**
+ * Only `http:`/`https:` are permitted for a server-initiated fetch of a
+ * page-content-derived URL (a redirect Location, a robots.txt directive, a Link
+ * header, a meta refresh). Blocks `file:`, `data:`, `blob:`, `ftp:`, `gopher:`,
+ * `javascript:`, etc. — the local-file-read and scheme-SSRF vectors.
+ *
+ * SCHEME-ONLY: this deliberately does NOT restrict the HOST. Private, loopback
+ * and internal hosts stay fetchable because squirrelscan legitimately audits
+ * localhost / staging / internal / private-IP sites — blocking those here would
+ * be a functional regression. (`isPublicHttpUrl` in ./url does block private
+ * hosts; do NOT use it on shared crawler fetch paths.) Returns false for
+ * unparseable input.
+ */
+export function isHttpOrHttpsUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === "http:" || parsed.protocol === "https:";
+}
+
+export interface SafeRedirectResult {
+  /** Final response after manually following redirects; its body is unread. */
+  response: Response;
+  /** URL of the final hop actually fetched. */
+  finalUrl: string;
+  /** True when at least one redirect was followed. */
+  redirected: boolean;
+}
+
+/**
+ * A `fetch()` that follows redirects MANUALLY so that, per hop, it can:
+ *  (a) enforce the http/https scheme allowlist above — a `Location:` pointing at
+ *      `file:`/`data:`/`blob:`/`ftp:`/… is refused, never fetched (throws a
+ *      `TypeError`, matching native fetch on an unsupported scheme). A
+ *      hand-rolled `new URL(location, base)` + re-fetch loop otherwise blindly
+ *      follows it, enabling a local-file read / scheme-SSRF whose body the
+ *      crawler would then store; and
+ *  (b) drop non-allowlisted (secret) request headers when the origin changes,
+ *      via `headersForRedirect` — so the caller's `X-Api-Key` / Web-Bot-Auth /
+ *      `CF-Access-Client-Secret` headers don't leak to a redirect target on
+ *      another origin. (undici/Bun natively strip only authorization / cookie /
+ *      proxy-authorization / host.)
+ *
+ * SECURITY SCOPE: restricts the SCHEME only, never the HOST (see
+ * `isHttpOrHttpsUrl`). Per-request private-IP / cloud-metadata blocking is a
+ * hosted-egress concern and is deliberately NOT done here; gate that at the
+ * egress boundary if a cloud deployment needs it, not in this shared helper.
+ *
+ * The returned response's body is unread — the caller reads it. A non-3xx
+ * response (or a 3xx without a `Location`, e.g. 304 Not Modified) is returned as
+ * the final response. Exceeding the redirect cap throws, like native fetch.
+ */
+export async function safeRedirectFetch(
+  url: string,
+  init: RequestInit = {},
+): Promise<SafeRedirectResult> {
+  if (!isHttpOrHttpsUrl(url)) {
+    throw new TypeError(`Refusing to fetch non-http(s) URL: ${url}`);
+  }
+
+  let currentUrl = url;
+  let headers = new Headers(init.headers);
+
+  for (let hop = 0; hop < MAX_REDIRECTS; hop++) {
+    const response = await fetch(currentUrl, { ...init, headers, redirect: "manual" });
+
+    const location =
+      response.status >= 300 && response.status < 400 ? response.headers.get("location") : null;
+    if (!location) {
+      return { response, finalUrl: currentUrl, redirected: currentUrl !== url };
+    }
+
+    let nextUrl: string;
+    try {
+      nextUrl = new URL(location, currentUrl).toString();
+    } catch {
+      // Unparseable Location — stop and hand back this 3xx as the final response.
+      return { response, finalUrl: currentUrl, redirected: currentUrl !== url };
+    }
+
+    if (!isHttpOrHttpsUrl(nextUrl)) {
+      // Cross-protocol redirect (e.g. Location: file:///etc/passwd) — refuse it.
+      response.body?.cancel().catch(() => {});
+      throw new TypeError(`Refusing redirect to non-http(s) URL: ${nextUrl}`);
+    }
+
+    // Discard the 3xx body before the next hop so the socket can be reused.
+    response.body?.cancel().catch(() => {});
+    headers = headersForRedirect(headers, currentUrl, nextUrl);
+    currentUrl = nextUrl;
+  }
+
+  throw new TypeError(`Too many redirects while fetching ${url}`);
+}


### PR DESCRIPTION
Hardening pass over the outbound-fetch paths and the CLI settings output.

## What changes

- **Crawler outbound fetches** are scheme-gated through a shared `safe-fetch` helper, and caller-supplied secret headers are origin-scoped so they are not replayed after a redirect changes origin. Covers the redirect loop, sitemap/RSL/`Link` handling, and client-side meta refresh.
- **`[project]` name** from `squirrel.toml` is contained before it is used to build the project database path.
- **Repo-local `settings.json`** merge is allowlisted to writable keys.
- **`squirrel self settings`** redacts the auth token and BYOK credentials in its output.

## Verification

- `bun test` at the repo root: 3612 pass, 4 skip, 0 fail across 311 files.
- Rebased onto current `main`; the rebase absorbed only the CHANGELOG/LICENSE/README commits and changed no code.

## Notes for review

`packages/utils/src/safe-fetch.ts` is deliberately **scheme-only** and does not restrict the host. squirrelscan legitimately audits localhost, staging, and private-IP sites, so a blanket private-host block would be a functional regression. `isPublicHttpUrl` in `./url` does block private hosts and should not be used on shared crawler fetch paths.
