### PR TITLE
feat(rules): content/stale-copyright — footer year behind the current year

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -237,7 +237,8 @@
                   "rules/content/meta-in-body",
                   "rules/content/mime-type",
                   "rules/content/article-links",
-                  "rules/content/quality"
+                  "rules/content/quality",
+                  "rules/content/stale-copyright"
                 ]
               },
               {

--- a/docs/rules/content/stale-copyright.mdx
+++ b/docs/rules/content/stale-copyright.mdx
@@ -1,0 +1,64 @@
+---
+title: "Stale Copyright Year"
+description: "Checks the footer copyright year against the current year"
+---
+
+Checks the footer copyright year against the current year
+
+| | |
+|---|---|
+| **Rule ID** | `content/stale-copyright` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 2/10 |
+
+## Solution
+
+A footer copyright year behind the current year is the most common "this site is abandoned" signal a visitor sees, and it costs nothing to fix. Render the year dynamically from the server or build step rather than hardcoding it, or use a range whose end year updates ("2019-2026"). If the date is a deliberate legal assertion tied to a fixed publication, move it out of site chrome and into the page body so it reads as a statement about that content rather than about the site.
+
+## What it checks
+
+Reads `©`, `(c)`, `&copy;` or the word "Copyright" followed by a year or a year range, and compares the **latest** year found against the current year.
+
+- **Ranges are judged on the end year.** In 2026, `© 2019-2026` is clean and `© 2019-2025` warns.
+- **A year ahead of now is not a finding.** Sites legitimately roll the year over early.
+- **Only site chrome is inspected**: `<footer>`, `[role=contentinfo]`, `.footer`, `#footer`, `.site-footer`, `.page-footer` and `#colophon`. A historical year in body copy is correct as written, and an archived post is supposed to say 2019, so neither is reported.
+- Pages with no footer, or a footer with no copyright notice, are **skipped** rather than passed.
+
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `current_year` | number | current UTC year | Year to compare the footer against |
+
+```toml squirrel.toml
+[rules.options."content/stale-copyright"]
+current_year = 2026
+```
+
+Setting `current_year` pins the comparison, which is useful when auditing an archived snapshot of a site as of a particular year.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/stale-copyright"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/stale-copyright"]
+disable = ["*"]
+```

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -65,8 +65,8 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // rule-surface drift tripwire (see golden-baseline.test.ts for the same fixture).
       expect(v1.meta.pageCount).toBeGreaterThanOrEqual(GOLDEN_BASELINE_PAGE_COUNT);
       expect(v1.healthScore.overall).toBe(48);
-      expect(v1.findings.length).toBe(94709);
-      expect(v1.perRuleTally.length).toBe(262);
+      expect(v1.findings.length).toBe(95209);
+      expect(v1.perRuleTally.length).toBe(263);
     },
     180_000,
   );

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -14,6 +14,7 @@ import { metaInBodyRule } from "./meta-in-body";
 import { mimeTypeRule } from "./mime-type";
 import { contentQualityRule } from "./quality";
 import { readingLevelRule } from "./reading-level";
+import { staleCopyrightRule } from "./stale-copyright";
 import { wordCountRule } from "./word-count";
 
 export const rules: Rule[] = [
@@ -30,6 +31,7 @@ export const rules: Rule[] = [
   authorInfoRule,
   metaInBodyRule,
   mimeTypeRule,
+  staleCopyrightRule,
 ];
 
 export {
@@ -45,5 +47,6 @@ export {
   metaInBodyRule,
   mimeTypeRule,
   readingLevelRule,
+  staleCopyrightRule,
   wordCountRule,
 };

--- a/packages/rules/src/content/stale-copyright.ts
+++ b/packages/rules/src/content/stale-copyright.ts
@@ -1,0 +1,138 @@
+// content/stale-copyright - Footer copyright year older than the current year
+
+import { z } from "zod";
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+
+export const optionsSchema = z.object({
+  // Injected so a test never depends on the wall clock: a rule that reads the
+  // year itself passes in December and fails on 1 January. Defaults to the real
+  // year only when a caller supplies nothing.
+  current_year: z
+    .number()
+    .int()
+    .min(1970)
+    .max(9999)
+    .optional()
+    .describe("Year to compare the footer against; defaults to the current UTC year"),
+});
+
+/**
+ * Where a site-chrome copyright legitimately lives. Restricting to these keeps the
+ * rule off body copy — "© 2019 Acme" quoted inside an archived post, or a dated
+ * legal notice, is correct as written and must not be reported as stale.
+ */
+const FOOTER_SELECTORS = [
+  "footer",
+  "[role=contentinfo]",
+  ".footer",
+  "#footer",
+  ".site-footer",
+  ".page-footer",
+  "#colophon",
+] as const;
+
+/**
+ * `©`, `(c)`, the literal `&copy;` entity, or the word itself, then a year or a
+ * range. The gap allows "Copyright 2019 Acme Inc." and "© Acme 2019" style
+ * padding, but is bounded so a year far away in unrelated text isn't captured.
+ */
+const COPYRIGHT_RE =
+  /(?:©|\(c\)|&copy;|copyright)[^0-9]{0,30}?(\d{4})(?:\s*(?:[-–—]|to)\s*(\d{4}))?/gi;
+
+/** Years a page could plausibly assert. Anything outside is a version or an id, not a year. */
+const MIN_YEAR = 1990;
+const MAX_YEAR = 2999;
+
+/**
+ * Latest copyright year asserted in the given text, or undefined when none is present.
+ * A range is judged on its END year — "2019-2026" is current in 2026 — and a footer
+ * carrying several notices is judged on the newest, since that is the one a visitor
+ * reads as the site's freshness signal.
+ */
+export function latestCopyrightYear(text: string): number | undefined {
+  let latest: number | undefined;
+  for (const match of text.matchAll(COPYRIGHT_RE)) {
+    // The range's end year wins when present; otherwise the single year.
+    for (const raw of [match[2], match[1]]) {
+      if (!raw) continue;
+      const year = Number(raw);
+      if (year < MIN_YEAR || year > MAX_YEAR) continue;
+      if (latest === undefined || year > latest) latest = year;
+      break;
+    }
+  }
+  return latest;
+}
+
+export const staleCopyrightRule: Rule = {
+  meta: {
+    id: "content/stale-copyright",
+    name: "Stale Copyright Year",
+    description: "Checks the footer copyright year against the current year",
+    solution:
+      "A footer copyright year behind the current year is the most common 'this site is abandoned' signal a visitor sees, and it costs nothing to fix. Render the year dynamically from the server or build step rather than hardcoding it, or use a range whose end year updates ('2019-2026'). If the date is a deliberate legal assertion tied to a fixed publication, move it out of site chrome and into the page body so it reads as a statement about that content rather than about the site.",
+    category: "content",
+    scope: "page",
+    // Warning, never error: a stale year is a trust smell, not a defect — the page
+    // works. Weight stays low so one templated footer repeated across every page
+    // cannot dominate the content category score.
+    severity: "warning",
+    weight: 2,
+    optionsSchema,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const opts = optionsSchema.parse(ctx.options);
+    const currentYear = opts.current_year ?? new Date().getUTCFullYear();
+    const doc = ctx.parsed.document;
+    if (!doc) return { checks: [] };
+
+    const checks: CheckResult[] = [];
+    const footerText = FOOTER_SELECTORS.flatMap((selector) =>
+      [...doc.querySelectorAll(selector)].map((el) => el.textContent || ""),
+    )
+      .join(" ")
+      .trim();
+
+    if (!footerText) {
+      checks.push({
+        name: "footer-copyright-year",
+        status: "skipped",
+        message: "No footer or site-chrome region found on this page",
+        skipReason: "no-footer",
+      });
+      return { checks };
+    }
+
+    const year = latestCopyrightYear(footerText);
+    if (year === undefined) {
+      checks.push({
+        name: "footer-copyright-year",
+        status: "skipped",
+        message: "No copyright year in the footer",
+        skipReason: "no-copyright-year",
+      });
+      return { checks };
+    }
+
+    checks.push(
+      year < currentYear
+        ? {
+            name: "footer-copyright-year",
+            status: "warn",
+            message: `Footer copyright year is ${year}, behind the current year ${currentYear}`,
+            value: year,
+            expected: currentYear,
+          }
+        : {
+            name: "footer-copyright-year",
+            status: "pass",
+            // A year AHEAD of now is not a finding: sites legitimately roll over early.
+            message: `Footer copyright year is ${year}`,
+            value: year,
+          },
+    );
+    return { checks };
+  },
+};

--- a/packages/rules/tests/stale-copyright.test.ts
+++ b/packages/rules/tests/stale-copyright.test.ts
@@ -1,0 +1,122 @@
+// content/stale-copyright: a footer year behind the current year is a trust smell.
+//
+// Every test injects `current_year`. A rule that read the clock itself would pass all
+// year and fail every 1 January, which is the worst possible time to learn about it.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "linkedom";
+
+import { latestCopyrightYear, staleCopyrightRule } from "../src/content/stale-copyright";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+const NOW = 2026;
+
+function run(html: string, currentYear: number = NOW) {
+  const { document } = parseHTML(`<html><body>${html}</body></html>`);
+  const ctx: RuleContext = {
+    page: { url: "https://example.com/", html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: { document } as unknown as ParsedPage,
+    options: { current_year: currentYear },
+  };
+  return staleCopyrightRule.run(ctx).checks;
+}
+
+describe("latestCopyrightYear", () => {
+  test("reads the plain forms", () => {
+    expect(latestCopyrightYear("© 2026 Acme")).toBe(2026);
+    expect(latestCopyrightYear("(c) 2026 Acme")).toBe(2026);
+    expect(latestCopyrightYear("Copyright 2026 Acme Inc.")).toBe(2026);
+    expect(latestCopyrightYear("&copy; 2026 Acme")).toBe(2026);
+  });
+  test("a range is judged on its END year, not its start", () => {
+    expect(latestCopyrightYear("© 2019-2026 Acme")).toBe(2026);
+    expect(latestCopyrightYear("© 2019 – 2026 Acme")).toBe(2026);
+    expect(latestCopyrightYear("© 2019 to 2026 Acme")).toBe(2026);
+  });
+  test("the newest notice wins when a footer carries several", () => {
+    expect(latestCopyrightYear("© 2019 Acme · © 2026 Acme Labs")).toBe(2026);
+  });
+  test("no copyright marker means no year, however many numbers are around", () => {
+    expect(latestCopyrightYear("Founded 1998. 4000 customers. Suite 2019.")).toBeUndefined();
+  });
+  test("implausible years are ids or versions, not copyright years", () => {
+    // Bounded to 1990-2999: a 4-digit number next to a © is as likely to be a product
+    // code or an order id as a year, and inventing a "stale" year from one is worse
+    // than staying quiet.
+    expect(latestCopyrightYear("© 1200 Acme")).toBeUndefined();
+    expect(latestCopyrightYear("© 9999 Acme")).toBeUndefined();
+    expect(latestCopyrightYear("© 2026 Acme")).toBe(2026);
+  });
+});
+
+describe("staleCopyrightRule", () => {
+  test("current year in the footer passes", () => {
+    const [check] = run("<footer>© 2026 Acme</footer>");
+    expect(check?.status).toBe("pass");
+  });
+
+  test("a year behind the current year warns — never errors", () => {
+    const [check] = run("<footer>© 2024 Acme</footer>");
+    expect(check?.status).toBe("warn");
+    expect(check?.value).toBe(2024);
+    expect(check?.expected).toBe(NOW);
+    // Severity is a rule-level property; assert it so nobody promotes this to a hard failure.
+    expect(staleCopyrightRule.meta.severity).toBe("warning");
+  });
+
+  test("a range ending this year is clean; ending last year is not", () => {
+    expect(run("<footer>© 2019-2026 Acme</footer>")[0]?.status).toBe("pass");
+    expect(run("<footer>© 2019-2025 Acme</footer>")[0]?.status).toBe("warn");
+  });
+
+  test("a year ahead of now is not a finding — sites roll over early", () => {
+    expect(run("<footer>© 2027 Acme</footer>")[0]?.status).toBe("pass");
+  });
+
+  test("site-chrome regions other than <footer> are matched", () => {
+    for (const html of [
+      '<div role="contentinfo">© 2024 Acme</div>',
+      '<div class="site-footer">© 2024 Acme</div>',
+      '<div id="colophon">© 2024 Acme</div>',
+    ])
+      expect(run(html)[0]?.status).toBe("warn");
+  });
+
+  test("no footer at all is skipped, not passed", () => {
+    const [check] = run("<main><p>© 2024 Acme</p></main>");
+    expect(check?.status).toBe("skipped");
+    expect(check?.skipReason).toBe("no-footer");
+  });
+
+  test("a footer with no copyright notice is skipped", () => {
+    const [check] = run("<footer><a href='/privacy'>Privacy</a></footer>");
+    expect(check?.status).toBe("skipped");
+    expect(check?.skipReason).toBe("no-copyright-year");
+  });
+
+  // The false-positive that would make this rule unshippable: a historical year in
+  // body copy is correct as written, and an archived post is SUPPOSED to say 2019.
+  test("historical years in body copy stay clean", () => {
+    const [check] = run(
+      `<article>
+         <p>Originally published © 2019 by Acme Press. The 2019-2020 season was our first.</p>
+       </article>
+       <footer>© 2026 Acme</footer>`,
+    );
+    expect(check?.status).toBe("pass");
+    expect(check?.value).toBe(2026);
+  });
+
+  test("a dated legal notice in the body does not drag the footer down", () => {
+    const [check] = run(
+      `<main><section class="legal">Terms of Service, last revised © 2021.</section></main>
+       <footer>© 2026 Acme</footer>`,
+    );
+    expect(check?.status).toBe("pass");
+  });
+
+  test("the year is injected, so the verdict moves with the caller's clock, not ours", () => {
+    expect(run("<footer>© 2025 Acme</footer>", 2025)[0]?.status).toBe("pass");
+    expect(run("<footer>© 2025 Acme</footer>", 2026)[0]?.status).toBe("warn");
+  });
+});

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -439,7 +439,7 @@ export type OrgLogoContentType = (typeof ORG_LOGO_CONTENT_TYPES)[number];
 // Public rule/category counts for marketing and doc copy that can't read the
 // live catalog (MDX, plugin manifests, skill files, MCP tool descriptions).
 // PUBLIC_RULE_COUNT_FLOOR is deliberately rounded DOWN from the live total
-// (currently 262) so copy doesn't need a bump on every rule add/remove;
+// (currently 263) so copy doesn't need a bump on every rule add/remove;
 // PUBLIC_CATEGORY_COUNT tracks exactly since categories change far less often.
 // The hosted catalog drift guard fails if the floor exceeds the live count.
 // Bump both by hand when the


### PR DESCRIPTION
Adds `content/stale-copyright`: a per-page rule that flags a footer copyright year older than the current year.

A stale footer year is the most common "this site is abandoned" signal a visitor sees, and it costs nothing to fix.

## What it does

Reads `©`, `(c)`, `&copy;` or the word "Copyright" followed by a year or a year range, and compares the **latest** year found against the current year.

- Ranges are judged on the end year: in 2026, `© 2019-2026` is clean, `© 2019-2025` warns.
- A year ahead of now is not a finding. Sites legitimately roll over early.
- Severity is `warning`, never `error`. The page works. Weight is 2, so one templated footer repeated across every page cannot dominate the content category score.

## Two deliberate restrictions

These are what keep the rule off correct content:

1. **Only site chrome is inspected**: `<footer>`, `[role=contentinfo]`, `.footer`, `#footer`, `.site-footer`, `.page-footer`, `#colophon`. A historical year in body copy is correct as written, and an archived post is supposed to say 2019. Neither fires. A page with no footer, or a footer with no notice, is **skipped** rather than passed: absence of a signal is not a pass.

2. **Years outside 1990-2999 are ignored.** A 4-digit number sitting next to a `©` is as likely to be an order id or product code as a year, and inventing a "stale" year from one is worse than staying quiet.

## Testing

15 unit tests covering pass, warn, skipped, range-end handling, the alternate chrome selectors, and the false positives that would make the rule unshippable (a historical year in body copy, a dated legal notice in the body).

`current_year` is a rule option rather than a clock read, so the suite does not quietly pass all year and then fail on 1 January. It is also useful in its own right when auditing an archived snapshot of a site.

```
packages/rules: 958 pass / 0 fail
tsgo --noEmit: clean
oxlint + oxfmt: clean
```

Rule count goes 262 to 263, no duplicate ids. Docs page and nav entry included.
