### PR TITLE
feat(rules): content/mojibake — encoding corruption in visible text

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -238,7 +238,8 @@
                   "rules/content/mime-type",
                   "rules/content/article-links",
                   "rules/content/quality",
-                  "rules/content/stale-copyright"
+                  "rules/content/stale-copyright",
+                  "rules/content/mojibake"
                 ]
               },
               {

--- a/docs/rules/content/mojibake.mdx
+++ b/docs/rules/content/mojibake.mdx
@@ -1,0 +1,68 @@
+---
+title: "Encoding Corruption"
+description: "Detects mojibake and replacement characters in visible text"
+---
+
+Detects mojibake and replacement characters in visible text
+
+| | |
+|---|---|
+| **Rule ID** | `content/mojibake` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 5/10 |
+
+## Solution
+
+Mojibake means the bytes and the declared encoding disagree. Fix the declaration first: serve `<meta charset="utf-8">` as the first thing in the head, and send `Content-Type: text/html; charset=utf-8`. If the declaration is already utf-8, the source itself was double-encoded, usually by a CMS migration that read utf-8 bytes as latin1 and re-encoded them. Re-import the affected content from the original source rather than search-and-replacing the visible symptoms, because the same corruption is usually present in fields you cannot see, such as meta descriptions and alt text.
+
+## What it checks
+
+Three families of corruption, in visible text only:
+
+| Kind | Example | Meaning |
+|---|---|---|
+| `utf8-as-latin1` | `Itâ€™s`, `cafÃ©` | utf-8 bytes decoded as latin1 or cp1252 |
+| `replacement-char` | `caf�` | the decoder gave up on those bytes |
+| `double-encoded-entity` | visible `&amp;nbsp;` | the source said `&amp;amp;nbsp;` |
+
+The check reads text with `<script>`, `<style>` and `<noscript>` excluded, never raw HTML, so an encoded sequence inside a script body is not reported. A page with no body is skipped rather than passed.
+
+**Severity depends on certainty.** The replacement character is unambiguous corruption and fails. The other families warn.
+
+## Cause attribution
+
+The finding cross-checks `<meta charset>` so the message names the actual fix rather than just reporting odd characters:
+
+- **No charset declared**: the browser guessed. Add `<meta charset="utf-8">`.
+- **Charset is utf-8**: the declaration is right, so the source is double-encoded. Re-import the content.
+- **Charset is something else**: correct the declaration, then re-check whether the source is also double-encoded.
+
+## False positives
+
+Correctly-decoded accented text is not corruption. Copy such as `Un café à Paris`, `Grüße aus Köln`, `jalapeño`, `25°` or curly quotes stays clean, because the rule matches multi-character *sequences* that only arise from a bad decode, not individual accented letters.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/mojibake"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/mojibake"]
+disable = ["*"]
+```

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -65,8 +65,8 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // rule-surface drift tripwire (see golden-baseline.test.ts for the same fixture).
       expect(v1.meta.pageCount).toBeGreaterThanOrEqual(GOLDEN_BASELINE_PAGE_COUNT);
       expect(v1.healthScore.overall).toBe(48);
-      expect(v1.findings.length).toBe(95209);
-      expect(v1.perRuleTally.length).toBe(263);
+      expect(v1.findings.length).toBe(95709);
+      expect(v1.perRuleTally.length).toBe(264);
     },
     180_000,
   );

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -11,6 +11,7 @@ import { freshnessRule } from "./freshness";
 import { headingHierarchyRule } from "./heading-hierarchy";
 import { keywordStuffingRule } from "./keyword-stuffing";
 import { metaInBodyRule } from "./meta-in-body";
+import { mojibakeRule } from "./mojibake";
 import { mimeTypeRule } from "./mime-type";
 import { contentQualityRule } from "./quality";
 import { readingLevelRule } from "./reading-level";
@@ -31,6 +32,7 @@ export const rules: Rule[] = [
   authorInfoRule,
   metaInBodyRule,
   mimeTypeRule,
+  mojibakeRule,
   staleCopyrightRule,
 ];
 
@@ -46,6 +48,7 @@ export {
   keywordStuffingRule,
   metaInBodyRule,
   mimeTypeRule,
+  mojibakeRule,
   readingLevelRule,
   staleCopyrightRule,
   wordCountRule,

--- a/packages/rules/src/content/mojibake.ts
+++ b/packages/rules/src/content/mojibake.ts
@@ -1,0 +1,184 @@
+// content/mojibake - Encoding corruption visible in rendered copy
+
+import { getAttrCI, querySelectorByAttrValueCI } from "@squirrelscan/utils";
+
+import { getTextExcludingScripts } from "./text-content";
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+
+/**
+ * UTF-8 bytes decoded as latin1/cp1252. Every one of these is a real UTF-8 lead byte
+ * (0xC2/0xC3/0xE2) rendered as its latin1 character, so they only co-occur in genuinely
+ * broken text — matching the SEQUENCE rather than the individual accented letters is
+ * what keeps legitimate French, German and Spanish copy clean.
+ */
+const MOJIBAKE_SEQUENCES = [
+  "â€™", // ' right single quote
+  "â€œ", // " left double quote
+  "â€", // " right double quote
+  "â€“", // – en dash
+  "â€”", // — em dash
+  "â€¦", // … ellipsis
+  "Ã©", // é
+  "Ã¨", // è
+  "Ã¤", // ä
+  "Ã¶", // ö
+  "Ã¼", // ü
+  "Ã±", // ñ
+  "Ã§", // ç
+  "Ã ", // à
+  "Â ", // non-breaking space
+  "Â©", // ©
+  "Â®", // ®
+  "Â°", // °
+] as const;
+
+/** U+FFFD: the decoder already gave up on these bytes. Unambiguous corruption. */
+const REPLACEMENT_CHAR = "�";
+
+/**
+ * Entities that survived one decode too few and render literally as their own source.
+ * `&amp;nbsp;` on screen means the source said `&amp;amp;nbsp;`.
+ */
+const DOUBLE_ENCODED_RE = /&amp;(?:nbsp|amp|quot|lt|gt|#\d+|[a-z]{2,8});/gi;
+
+type Corruption = { kind: string; sample: string; count: number };
+
+/**
+ * One alternation, LONGEST FIRST. This ordering is load-bearing: `â€` is a prefix of
+ * `â€™`, `â€œ`, `â€“`, `â€”` and `â€¦`, so counting each sequence independently counts
+ * every long one twice — once as itself and once as its own prefix. Regex alternation
+ * is first-match-wins, so longest-first consumes the full sequence and the counts stay
+ * honest.
+ */
+const MOJIBAKE_RE = new RegExp(
+  [...MOJIBAKE_SEQUENCES]
+    .sort((a, b) => b.length - a.length)
+    .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("|"),
+  "g",
+);
+
+/** Every corruption family present in `text`, with a sample and a count for each. */
+export function findMojibake(text: string): Corruption[] {
+  const out: Corruption[] = [];
+
+  const seqMatches = [...text.matchAll(MOJIBAKE_RE)].map((m) => m[0]);
+  if (seqMatches.length > 0) {
+    const tally = new Map<string, number>();
+    for (const s of seqMatches) tally.set(s, (tally.get(s) ?? 0) + 1);
+    out.push({
+      kind: "utf8-as-latin1",
+      // Most frequent sequence is the most useful thing to show first.
+      sample: [...tally.entries()].sort((a, b) => b[1] - a[1])[0]![0],
+      count: seqMatches.length,
+    });
+  }
+
+  const replacements = text.split(REPLACEMENT_CHAR).length - 1;
+  if (replacements > 0)
+    out.push({ kind: "replacement-char", sample: REPLACEMENT_CHAR, count: replacements });
+
+  const doubles = [...text.matchAll(DOUBLE_ENCODED_RE)];
+  if (doubles.length > 0)
+    out.push({ kind: "double-encoded-entity", sample: doubles[0]![0], count: doubles.length });
+
+  return out;
+}
+
+/** The page's declared encoding, from `<meta charset>` or the http-equiv form, lowercased. */
+export function declaredCharset(
+  doc: NonNullable<RuleContext["parsed"]["document"]>,
+): string | undefined {
+  for (const meta of doc.querySelectorAll("meta")) {
+    const val = getAttrCI(meta, "charset");
+    if (val !== null && val.trim()) return val.trim().toLowerCase();
+  }
+  const httpEquiv = querySelectorByAttrValueCI(doc, "meta", "http-equiv", "Content-Type");
+  const match = (httpEquiv?.getAttribute("content") || "").match(/charset=([^\s;]+)/i);
+  return match?.[1]?.trim().toLowerCase();
+}
+
+const isUtf8 = (charset: string | undefined): boolean => charset === "utf-8" || charset === "utf8";
+
+export const mojibakeRule: Rule = {
+  meta: {
+    id: "content/mojibake",
+    name: "Encoding Corruption",
+    description: "Detects mojibake and replacement characters in visible text",
+    solution:
+      'Mojibake means the bytes and the declared encoding disagree. Fix the declaration first: serve `<meta charset="utf-8">` as the first thing in the head, and send `Content-Type: text/html; charset=utf-8`. If the declaration is already utf-8, the source itself was double-encoded, usually by a CMS migration that read utf-8 bytes as latin1 and re-encoded them. Re-import the affected content from the original source rather than search-and-replacing the visible symptoms, because the same corruption is usually present in fields you cannot see, such as meta descriptions and alt text.',
+    category: "content",
+    scope: "page",
+    severity: "warning",
+    weight: 5,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const checks: CheckResult[] = [];
+    const doc = ctx.parsed.document;
+    if (!doc) {
+      checks.push({
+        name: "encoding-corruption",
+        status: "skipped",
+        message: "No document available",
+        skipReason: "Parse error",
+      });
+      return { checks };
+    }
+
+    const body = doc.querySelector("body");
+    if (!body) {
+      checks.push({
+        name: "encoding-corruption",
+        status: "skipped",
+        message: "No body element to read visible text from",
+        skipReason: "no-body",
+      });
+      return { checks };
+    }
+
+    // Visible text only, never raw HTML: a `&amp;nbsp;` in an attribute or an
+    // encoded sequence inside a <script> is not something a reader ever sees.
+    const text = getTextExcludingScripts(body);
+    const found = findMojibake(text);
+
+    if (found.length === 0) {
+      checks.push({
+        name: "encoding-corruption",
+        status: "pass",
+        message: "No encoding corruption in visible text",
+      });
+      return { checks };
+    }
+
+    const charset = declaredCharset(doc);
+    const total = found.reduce((sum, f) => sum + f.count, 0);
+    const kinds = found.map((f) => f.kind).join(", ");
+
+    // Attributing the CAUSE is what makes this actionable: "you have weird
+    // characters" is not a fix, and the two causes have different fixes.
+    const cause =
+      charset === undefined
+        ? 'no charset is declared, so the browser guessed the encoding: add <meta charset="utf-8">'
+        : isUtf8(charset)
+          ? "charset is correctly utf-8, so the source itself is double-encoded: re-import the content from its original source"
+          : `charset is declared as "${charset}", not utf-8: correct the declaration, then re-check whether the source is also double-encoded`;
+
+    // U+FFFD is unambiguous corruption; the rest can be argued with, so only the
+    // replacement character escalates to a hard failure.
+    const hasReplacement = found.some((f) => f.kind === "replacement-char");
+
+    checks.push({
+      name: "encoding-corruption",
+      status: hasReplacement ? "fail" : "warn",
+      message: `${total} encoding corruption occurrence(s) in visible text (${kinds}): ${cause}`,
+      value: total,
+      details: {
+        charset: charset ?? null,
+        kinds: found.map((f) => ({ kind: f.kind, sample: f.sample, count: f.count })),
+      },
+    });
+    return { checks };
+  },
+};

--- a/packages/rules/tests/mojibake.test.ts
+++ b/packages/rules/tests/mojibake.test.ts
@@ -1,0 +1,141 @@
+// content/mojibake: encoding corruption a reader can actually see.
+//
+// The rule's whole risk is false positives on legitimate non-English copy, so the
+// clean-accents fixture matters more than any of the detection cases.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "linkedom";
+
+import { declaredCharset, findMojibake, mojibakeRule } from "../src/content/mojibake";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+function run(html: string) {
+  const { document } = parseHTML(html);
+  const ctx: RuleContext = {
+    page: { url: "https://example.com/", html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: { document } as unknown as ParsedPage,
+    options: {},
+  };
+  return mojibakeRule.run(ctx).checks;
+}
+
+const page = (body: string, head = '<meta charset="utf-8">') =>
+  `<html><head>${head}</head><body>${body}</body></html>`;
+
+describe("findMojibake", () => {
+  test("detects the utf8-as-latin1 family", () => {
+    const found = findMojibake("Itâ€™s a â€œquoteâ€ and a cafÃ©");
+    expect(found.find((f) => f.kind === "utf8-as-latin1")).toBeDefined();
+  });
+
+  // The prefix trap: `â€` is a prefix of `â€™`/`â€œ`/`â€“`/`â€”`/`â€¦`, so counting each
+  // sequence independently counts every long one twice. Longest-first alternation fixes it.
+  test("a long sequence is counted once, not also as its own prefix", () => {
+    const one = findMojibake("Itâ€™s").find((f) => f.kind === "utf8-as-latin1");
+    expect(one?.count).toBe(1);
+    const three = findMojibake("aâ€™b â€œc â€“d").find((f) => f.kind === "utf8-as-latin1");
+    expect(three?.count).toBe(3);
+  });
+
+  test("detects the replacement character", () => {
+    const found = findMojibake("caf�");
+    expect(found.find((f) => f.kind === "replacement-char")?.count).toBe(1);
+  });
+
+  test("detects literally-rendered double-encoded entities", () => {
+    const found = findMojibake("hello&amp;nbsp;world and &amp;quot;quoted&amp;quot;");
+    expect(found.find((f) => f.kind === "double-encoded-entity")?.count).toBe(3);
+  });
+
+  test("clean text of every kind yields nothing", () => {
+    expect(findMojibake("Perfectly ordinary copy.")).toEqual([]);
+    // Correctly-decoded accents, curly quotes and symbols: the false positive that matters.
+    expect(findMojibake("Un café à Paris — “élan”, naïve, jalapeño, 25° © 2026")).toEqual([]);
+  });
+});
+
+describe("declaredCharset", () => {
+  test("reads <meta charset> and the http-equiv form", () => {
+    const a = parseHTML('<html><head><meta charset="UTF-8"></head><body></body></html>').document;
+    expect(declaredCharset(a)).toBe("utf-8");
+    const b = parseHTML(
+      '<html><head><meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"></head><body></body></html>',
+    ).document;
+    expect(declaredCharset(b)).toBe("iso-8859-1");
+  });
+  test("absent when nothing is declared", () => {
+    const doc = parseHTML("<html><head></head><body></body></html>").document;
+    expect(declaredCharset(doc)).toBeUndefined();
+  });
+});
+
+describe("mojibakeRule", () => {
+  test("clean page passes", () => {
+    expect(run(page("<p>Ordinary copy.</p>"))[0]?.status).toBe("pass");
+  });
+
+  test("legitimate accented copy declared as utf-8 stays clean", () => {
+    // A rule that flagged this would be unusable on any non-English site.
+    const [check] = run(
+      page("<p>Un café à Paris. Grüße aus Köln. El niño jugó. 25° © 2026 “élan”</p>"),
+    );
+    expect(check?.status).toBe("pass");
+  });
+
+  test("mojibake warns", () => {
+    const [check] = run(page("<p>Itâ€™s a cafÃ©</p>"));
+    expect(check?.status).toBe("warn");
+    expect(check?.value).toBe(2);
+  });
+
+  test("the replacement character escalates to fail", () => {
+    // U+FFFD is not arguable: the decoder already gave up.
+    const [check] = run(page("<p>caf�</p>"));
+    expect(check?.status).toBe("fail");
+  });
+
+  test("cause is attributed: missing charset names the declaration fix", () => {
+    const [check] = run(page("<p>Itâ€™s</p>", ""));
+    expect(check?.message).toMatch(/no charset is declared/i);
+    expect(check?.message).toMatch(/meta charset/i);
+    expect((check?.details as { charset: string | null } | undefined)?.charset).toBeNull();
+  });
+
+  test("cause is attributed: correct utf-8 points at a double-encoded source", () => {
+    const [check] = run(page("<p>Itâ€™s</p>"));
+    expect(check?.message).toMatch(/double-encoded/i);
+    expect(check?.message).toMatch(/re-import/i);
+  });
+
+  test("cause is attributed: a wrong charset names the declaration", () => {
+    const [check] = run(page("<p>Itâ€™s</p>", '<meta charset="iso-8859-1">'));
+    expect(check?.message).toMatch(/iso-8859-1/);
+    expect(check?.message).toMatch(/not utf-8/i);
+  });
+
+  test("script and style contents are not visible text", () => {
+    const [check] = run(
+      page('<script>var s = "Itâ€™s";</script><style>/* cafÃ© */</style><p>Clean.</p>'),
+    );
+    expect(check?.status).toBe("pass");
+  });
+
+  // Reachable: linkedom does NOT synthesize a <body>, so a head-only document really
+  // does reach the rule with nothing to read. Skipped, not passed — "we could not look"
+  // must never be recorded as "we looked and it was fine".
+  test("no body is skipped, not passed", () => {
+    const [check] = run("<html><head><meta charset='utf-8'></head></html>");
+    expect(check?.status).toBe("skipped");
+    expect(check?.skipReason).toBe("no-body");
+  });
+
+  test("no document is skipped", () => {
+    const ctx = {
+      page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+      parsed: { document: null } as unknown as ParsedPage,
+      options: {},
+    } as RuleContext;
+    const [check] = mojibakeRule.run(ctx).checks;
+    expect(check?.status).toBe("skipped");
+  });
+});

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -439,7 +439,7 @@ export type OrgLogoContentType = (typeof ORG_LOGO_CONTENT_TYPES)[number];
 // Public rule/category counts for marketing and doc copy that can't read the
 // live catalog (MDX, plugin manifests, skill files, MCP tool descriptions).
 // PUBLIC_RULE_COUNT_FLOOR is deliberately rounded DOWN from the live total
-// (currently 263) so copy doesn't need a bump on every rule add/remove;
+// (currently 264) so copy doesn't need a bump on every rule add/remove;
 // PUBLIC_CATEGORY_COUNT tracks exactly since categories change far less often.
 // The hosted catalog drift guard fails if the floor exceeds the live count.
 // Bump both by hand when the


### PR DESCRIPTION
Adds `content/mojibake`: encoding corruption visible in rendered copy.

Silent, common on CMS migrations, and invisible to tools that only check markup validity.

## What it detects

| Kind | Example | Meaning |
|---|---|---|
| `utf8-as-latin1` | `Itâ€™s`, `cafÃ©` | utf-8 bytes decoded as latin1/cp1252 |
| `replacement-char` | `caf<U+FFFD>` | the decoder gave up on those bytes |
| `double-encoded-entity` | visible `&amp;nbsp;` | the source said `&amp;amp;nbsp;` |

Severity tracks certainty: U+FFFD is unambiguous corruption and **fails**; the other two **warn**.

## The part that decides whether this rule is usable

It matches multi-character **sequences**, never individual accented letters. `Un café à Paris`, `Grüße aus Köln`, `jalapeño`, `25°` and curly quotes all stay clean. A rule that flagged those would be unrunnable on any non-English site, so there is a dedicated fixture for it.

## One subtlety worth calling out

`â€` is a prefix of `â€™`, `â€œ`, `â€“`, `â€”` and `â€¦`. Counting each sequence independently counts every long one **twice**, once as itself and once as its own prefix. Detection uses a single longest-first alternation so matches are non-overlapping, and a test pins the counts (`aâ€™b â€œc â€“d` is 3, not 6).

## Cause attribution

"You have weird characters" is not a fix, and the two causes have different ones. The finding cross-checks `<meta charset>`:

- no charset declared → add `<meta charset="utf-8">`
- charset already utf-8 → the source is double-encoded, re-import it
- charset is something else → correct the declaration, then re-check the source

## Notes

Reads visible text through the shared non-mutating extraction with `script`/`style`/`noscript` excluded, never raw HTML. A document with no body is **skipped**, not passed.

Golden merge-gate pins moved deliberately, since they are a rule-surface drift tripwire: `perRuleTally` 263 → 264, `findings` 95209 → 95709. The +500 is one `pass` per page with a body across the 518-page fixture. `healthScore` stays 48 and the v1↔v2 byte-identity assertions still pass, so the rule behaves the same in both engines.

```
packages/rules: 976 pass / 0 fail (17 new)
audit-engine golden gate: pass
tsgo --noEmit, oxlint, oxfmt: clean
```
