### PR TITLE
docs: rule counts 262 to 264 after the two new content rules

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -110,7 +110,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
     Single binary, zero dependencies. Shell completions, self-update, and CI/CD compatible exit codes.
   </Card>
   <Card
-    title="262 Rules, 21 Categories"
+    title="264 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security audits.
@@ -190,7 +190,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **262 rules** across **21 categories**, plus opt-in cloud gap analysis:
+squirrelscan runs **264 rules** across **21 categories**, plus opt-in cloud gap analysis:
 
 | Category | Description |
 |----------|-------------|

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 262 audit rules organized by score group and category"
+description: "All 264 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **262 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **264 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -23,7 +23,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Internal and external link health and structure (14 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (12 rules)
+    Text quality, readability, and content structure (14 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (10 rules)


### PR DESCRIPTION
Updates the rule counts in the docs after `content/stale-copyright` (#47) and `content/mojibake` (#48).

- `docs/index.mdx`: "262 Rules, 21 Categories" card and "**262 rules**" → 264
- `docs/rules/index.mdx`: frontmatter description, "**262 rules**", and the Content category card (12 → 14 rules)

Categories stay 21.

These literals are not cosmetic: the consuming repo has rule-count consistency tests that cross-check them against the **live** catalog total, so they go stale the moment a rule is added and fail CI on that side.
