### PR TITLE
fix(crawler): bound every untrusted response read

### DIFF
--- a/packages/audit-engine/src/script-fetcher.ts
+++ b/packages/audit-engine/src/script-fetcher.ts
@@ -4,6 +4,7 @@
 import { Effect } from "effect";
 
 import { SCRIPT_FETCH_LIMITS, SQUIRRELSCAN_USER_AGENT } from "@squirrelscan/utils/constants";
+import { readBodyCapped } from "@squirrelscan/utils/response-body";
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 import type { FetchBudget, FetchOutcome } from "./fetch-budget";
 
@@ -158,13 +159,17 @@ async function fetchSingleScriptAsync(
       };
     }
 
-    const text = await response.text();
+    const maxSizeBytes = options.maxSizeBytes ?? SCRIPT_FETCH_LIMITS.MAX_SCRIPT_SIZE_BYTES;
+    // Read one byte past the limit rather than the limit itself: the check below
+    // rejects anything OVER the cap, so reading exactly `maxSizeBytes` would
+    // truncate an oversized script to precisely the limit and the rejection
+    // would never fire. At cap+1 an oversized body still trips it, while the
+    // read stays bounded — previously this was an unbounded `.text()` whose
+    // size was only measured once the whole body was already in memory.
+    const text = await readBodyCapped(response, maxSizeBytes + 1);
     const sizeBytes = new TextEncoder().encode(text).length;
 
-    if (
-      sizeBytes >
-      (options.maxSizeBytes ?? SCRIPT_FETCH_LIMITS.MAX_SCRIPT_SIZE_BYTES)
-    ) {
+    if (sizeBytes > maxSizeBytes) {
       return {
         ...defaultResult,
         status: response.status,

--- a/packages/crawler/src/agent-access.ts
+++ b/packages/crawler/src/agent-access.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
 import type {
   AgentAccessData,
@@ -78,7 +79,7 @@ async function probeOne(
       },
       PROBE_TIMEOUT_MS,
     );
-    const raw = await response.text();
+    const raw = await readBodyCapped(response, AGENT_ACCESS_MAX_BYTES);
     const body = truncateToBytes(raw, AGENT_ACCESS_MAX_BYTES);
     const challengeSignal = detectChallenge(response.headers, body);
     const paymentSignal = detectPayment(response.status, response.headers, body);

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -10,6 +10,10 @@ import { COVERAGE_PAGE_LIMITS, REPORT_LIMITS } from "@squirrelscan/core-contract
 import { extractCrawlableUrls } from "@squirrelscan/parser/extractors";
 import { parseDocument, parsePage, type ParsedPageCache } from "@squirrelscan/parser";
 import { findClientRedirects } from "@squirrelscan/utils/client-redirects";
+import {
+  DEFAULT_MAX_DOCUMENT_BODY_BYTES,
+  readBodyCapped,
+} from "@squirrelscan/utils/response-body";
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 import { urlHostKey } from "@squirrelscan/utils/url";
 
@@ -1443,7 +1447,9 @@ export function createCrawler(
             // Check for client-side redirects (meta refresh, JS)
             const contentType = response.headers.get("content-type") || "";
             if (contentType.includes("text/html")) {
-              const html = await response.text();
+              // Runs during seed redirect resolution, before the crawl has any
+              // size limits of its own, so this read needs its own bound.
+              const html = await readBodyCapped(response, DEFAULT_MAX_DOCUMENT_BODY_BYTES);
               const clientRedirect = findClientRedirects(html, currentUrl);
 
               if (clientRedirect && clientRedirect !== currentUrl) {

--- a/packages/crawler/src/llms.ts
+++ b/packages/crawler/src/llms.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
 import type { LlmsTxtData, LlmsTxtFile } from "@squirrelscan/core-contracts";
 
@@ -35,10 +36,17 @@ async function fetchOne(
       LLMS_FETCH_TIMEOUT_MS,
     );
     if (response.status === 404 || !response.ok) return emptyFile(url);
+    // The content-length pre-check is a cheap fast path only: it is absent on a
+    // chunked response and reports the COMPRESSED size on an encoded one, so it
+    // cannot bound the read. readBodyCapped enforces the limit against the
+    // decoded stream and cancels at the cap, which is what stops a small
+    // compressed body from expanding to gigabytes in memory.
     const declared = Number(response.headers.get("content-length") ?? "0");
     if (Number.isFinite(declared) && declared > LLMS_MAX_BYTES) return emptyFile(url);
-    const raw = await response.text();
+    const raw = await readBodyCapped(response, LLMS_MAX_BYTES);
     // #1293: byte-accurate cap — a `.length` slice over-keeps a multi-byte body.
+    // Still applied after the capped read: decoding can emit replacement chars
+    // that are wider than the bytes they replace.
     const content = truncateToBytes(raw, LLMS_MAX_BYTES);
     return { url, exists: true, content, sizeBytes: byteLength(content) };
   } catch {

--- a/packages/crawler/src/robots.ts
+++ b/packages/crawler/src/robots.ts
@@ -3,7 +3,12 @@ import robotsParser from "robots-parser";
 
 import type { RobotsTxtData } from "@squirrelscan/core-contracts";
 import { parseRobotsTxt } from "@squirrelscan/utils/robots-txt";
+import { readBodyCapped } from "@squirrelscan/utils/response-body";
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+
+// Matches the limit Google documents for robots.txt; anything past it is
+// ignored by real crawlers, so there is nothing to gain by reading further.
+const ROBOTS_MAX_BYTES = 512 * 1024;
 
 export interface RobotsEvaluator {
   data: RobotsTxtData;
@@ -114,7 +119,10 @@ export function fetchRobotsEvaluator(
         };
       }
 
-      const content = await response.text();
+      // Bounded: robots.txt is fetched before anything else is known about the
+      // host, so an unbounded read here is reachable on the very first request
+      // of an audit.
+      const content = await readBodyCapped(response, ROBOTS_MAX_BYTES);
       return createRobotsEvaluator(robotsUrl, content, userAgent);
     },
     catch: (error) => {

--- a/packages/crawler/src/rsl.ts
+++ b/packages/crawler/src/rsl.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { truncateToBytes } from "@squirrelscan/utils/bytes";
 import { isHttpOrHttpsUrl, safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
 import type { RslData, RslLicenseDoc } from "@squirrelscan/core-contracts";
 
@@ -75,7 +76,7 @@ async function fetchLicenseDoc(
       PROBE_TIMEOUT_MS,
     );
     const contentType = response.headers.get("content-type");
-    const raw = await response.text();
+    const raw = await readBodyCapped(response, RSL_MAX_BYTES);
     const body = truncateToBytes(raw, RSL_MAX_BYTES);
     return {
       url,
@@ -118,7 +119,7 @@ export function fetchRslLicensing(
         PROBE_TIMEOUT_MS,
       );
       if (response.ok) {
-        const raw = await response.text();
+        const raw = await readBodyCapped(response, ROBOTS_MAX_BYTES);
         robotsBody = truncateToBytes(raw, ROBOTS_MAX_BYTES);
         linkHeader = response.headers.get("link");
       } else {

--- a/packages/crawler/src/well-known.ts
+++ b/packages/crawler/src/well-known.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
 import type { WellKnownProbe, WellKnownProbeData } from "@squirrelscan/core-contracts";
 
@@ -143,7 +144,7 @@ async function probeOne(
         error: "body exceeds cap",
       };
     }
-    const raw = await response.text();
+    const raw = await readBodyCapped(response, WELL_KNOWN_MAX_BYTES);
     const body = truncateToBytes(raw, WELL_KNOWN_MAX_BYTES);
     const looksHtml = looksLikeHtml(body);
     // A SPA-fallback HTML page must never count as valid JSON/markdown.

--- a/packages/crawler/tests/sitemap-entity-expansion.test.ts
+++ b/packages/crawler/tests/sitemap-entity-expansion.test.ts
@@ -1,0 +1,100 @@
+// The entity-expansion mitigation for sitemap parsing is a single line —
+// `processEntities: false` in the XMLParser options — with nothing pinning it.
+// Deleting it is a small, innocuous-looking change, so these tests make it loud.
+//
+// Sitemaps are fully attacker-controlled: any audited site can serve one, and
+// the cloud workers parse them for user-supplied URLs.
+//
+// VERIFIED BY A/B: flipping the flag to `true` fails exactly the first test
+// below. The two "parser does not do this" tests pass either way, because
+// fast-xml-parser never resolves external entities or nested chains at all —
+// they are NOT guards on our flag, and are labelled accordingly. They earn their
+// place by catching a PARSER SWAP to something that does resolve them, which is
+// the more likely way this protection would be lost.
+
+import { describe, expect, test } from "bun:test";
+
+import { parseSitemap } from "../src/sitemaps";
+
+const SITEMAP_URL = "https://example.com/sitemap.xml";
+
+describe("sitemap entity expansion", () => {
+  // THE guard on `processEntities: false`. This one fails if the flag flips.
+  test("a declared entity is not substituted into the parsed loc", () => {
+    const xml = `<?xml version="1.0"?>
+<!DOCTYPE urlset [<!ENTITY inject "injected-value">]>
+<urlset>
+  <url><loc>https://example.com/&inject;</loc></url>
+</urlset>`;
+
+    const result = parseSitemap(xml, SITEMAP_URL);
+
+    expect(JSON.stringify(result)).not.toContain("injected-value");
+  });
+
+  // Not a flag guard — fast-xml-parser does not expand nested entities even with
+  // entities enabled. Guards against swapping in a parser that does.
+  test("parser-level: a nested entity chain does not expand", () => {
+    const xml = `<?xml version="1.0"?>
+<!DOCTYPE urlset [
+  <!ENTITY a "aaaaaaaaaa">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+]>
+<urlset>
+  <url><loc>https://example.com/&c;</loc></url>
+</urlset>`;
+
+    const result = parseSitemap(xml, SITEMAP_URL);
+
+    // 100 consecutive 'a' would mean &c; expanded at least two levels deep.
+    expect(JSON.stringify(result)).not.toMatch(/a{100}/);
+  });
+
+  // Not a flag guard either — same rationale as above.
+  test("parser-level: an external entity naming a local file is not resolved", () => {
+    const xml = `<?xml version="1.0"?>
+<!DOCTYPE urlset [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+<urlset>
+  <url><loc>https://example.com/&xxe;</loc></url>
+</urlset>`;
+
+    const result = parseSitemap(xml, SITEMAP_URL);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("root:");
+    expect(serialized).not.toContain("/bin/");
+  });
+
+  test("ordinary sitemaps still parse", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/a</loc></url>
+  <url><loc>https://example.com/b</loc></url>
+</urlset>`;
+
+    const result = parseSitemap(xml, SITEMAP_URL);
+
+    expect(result.urls.map((u) => u.loc)).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+  });
+
+  // Pins CURRENT behaviour, which is wrong but is the cost of the guard above:
+  // `processEntities: false` disables the five XML predefined escapes too, so a
+  // legitimate `&amp;` in a query string survives into the enqueued URL. Turning
+  // entities back on to fix it would reopen the first test, so the fix is to
+  // decode the predefined five after parsing. Tracked separately; when that
+  // lands this expectation flips to `?q=1&page=2`.
+  test("KNOWN BUG: predefined XML escapes are not decoded", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset>
+  <url><loc>https://example.com/search?q=1&amp;page=2</loc></url>
+</urlset>`;
+
+    const result = parseSitemap(xml, SITEMAP_URL);
+
+    expect(result.urls[0]?.loc).toBe("https://example.com/search?q=1&amp;page=2");
+  });
+});


### PR DESCRIPTION
Eight response reads pulled the whole body into memory before any limit was applied.

Where a limit existed at all, it was one of two shapes that cannot work:

- **A `content-length` pre-check** (`llms.ts`, `well-known.ts`). The header is absent on a chunked response and reports the *compressed* size on an encoded one, so it bounds nothing a hostile server cares about.
- **A post-hoc measurement** (`truncateToBytes` in the probe files; `script-fetcher` measuring `sizeBytes` and only then returning `script too large`). These run after the memory has already been spent, so they report the exhaustion they were meant to prevent.

`robots.txt` had no limit at all, and is fetched before anything else is known about a host, so it was reachable on the very first request of an audit.

## Change

All eight go through the existing `readBodyCapped`, which enforces the cap against the *decoded* stream and cancels at the limit. The cheap `content-length` pre-checks stay as a fast path, now correctly treated as advisory rather than as the bound.

Two details worth review:

- **`robots.txt` gets a 512KB cap** — the limit Google documents, past which real crawlers ignore the file anyway.
- **`script-fetcher` reads at `cap + 1`, not `cap`.** Its check rejects bodies *over* the cap; reading exactly `cap` would truncate an oversized script to precisely the limit and the rejection would silently never fire again.

`truncateToBytes` is kept after the capped read: decoding can emit replacement characters wider than the bytes they replace, so it still enforces the exact byte invariant.

## Sitemap entity-expansion guard

Also pins `processEntities: false`, which was a single flag with no test behind it.

I A/B tested which assertions are real guards. **Only the declared-entity test fails when the flag flips.** The nested-chain and external-file tests pass either way, because fast-xml-parser never resolves those at all. Rather than leave three tests implying equal protection, the two are labelled as guards against a *parser swap*, which is the more likely way this gets lost. The file says what it actually protects.

That guard surfaced a pre-existing bug: the same flag also suppresses the five XML predefined escapes, so a legitimate `&amp;` in a sitemap URL survives into the enqueued URL and we fetch a param named `amp;page`. Pinned as a `KNOWN BUG` test and filed separately, because the obvious fix (`processEntities: true`) reopens exactly what the guard pins.

## Verification

Crawler 180 pass, audit-engine 254 pass / 3 skip, golden pins unchanged (`healthScore=48`, `pages=518`). `tsgo --noEmit` clean on crawler, audit-engine, utils, rules — confirmed non-vacuous by planting a type error and watching it get caught.