### PR TITLE
fix(ci): check DCO sign-offs against raw identities, not mailmap

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -25,8 +25,11 @@ jobs:
           failed=0
           while read -r commit; do
             [ -n "$commit" ] || continue
-            author=$(git show -s --format='%aN <%aE>' "$commit")
-            committer=$(git show -s --format='%cN <%cE>' "$commit")
+            # Raw identities (%an/%ae), NOT mailmap-canonicalized (%aN/%aE):
+            # `git commit -s` writes the literal identity, so canonicalizing
+            # here makes the check unpassable for any mailmapped author.
+            author=$(git show -s --format='%an <%ae>' "$commit")
+            committer=$(git show -s --format='%cn <%ce>' "$commit")
             message=$(git show -s --format=%B "$commit")
             if [ "$ACTOR" = "dependabot[bot]" ] && \
                [ "$author" = "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>" ]; then


### PR DESCRIPTION
`git commit -s` writes the literal author identity, but the workflow compared the trailer against the mailmap-canonicalized `%aN <%aE>` / `%cN <%cE>`. Any author with a `.mailmap` canonicalization could never pass the check regardless of a correct sign-off (see PRs #43, #44, #46). Compare raw `%an <%ae>` / `%cn <%ce>` instead: the sign-off is an attestation about the identity actually used on the commit.