### PR TITLE
fix(crawler): use node: specifiers for builtin crypto imports

### DIFF
--- a/packages/crawler/src/incremental.ts
+++ b/packages/crawler/src/incremental.ts
@@ -1,7 +1,7 @@
 // Change detection for incremental crawling
 // Uses ETag, Last-Modified, and content hash to detect changes
 
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 import {
   type CacheControl,

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -5,7 +5,7 @@
 // Uses bun:sqlite for native SQLite bindings
 
 import { Database } from "bun:sqlite";
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { Effect } from "effect";
 
 import type { CheckResult } from "@squirrelscan/core-contracts";

--- a/packages/fetchers/src/conditional-render.ts
+++ b/packages/fetchers/src/conditional-render.ts
@@ -44,7 +44,7 @@
 // capabilities so downstream concurrency planning (which keys on the
 // "cloud-render" id) is unaffected.
 
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 import { normalizeHtmlForFingerprint } from "@squirrelscan/utils/fingerprint";
 


### PR DESCRIPTION
Bare `crypto` is also a deprecated npm package name; a resolver that prefers `node_modules` over builtins (or anything installing that name) silently swaps the builtin for the stub, and stricter external bundlers see an undeclared dependency. Prefixes the three outliers with `node:` to match the rest of the repo.