### PR TITLE
fix(crawler): decode the five XML predefined escapes in sitemap locs

### DIFF
--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -13,6 +13,28 @@ const logger = {
   debug: (_message: string, ..._args: unknown[]) => {},
 };
 
+/**
+ * Decode the five XML predefined escapes.
+ *
+ * The parser runs with `processEntities: false` to block declared-entity
+ * substitution (billion-laughs / XXE, pinned by sitemap-entity-expansion.test.ts).
+ * That flag also suppresses the predefined five, which are not declarations and
+ * are the spec-mandated way to encode `&` in a sitemap URL — without this a
+ * `?q=1&amp;page=2` loc is fetched literally, hitting a different URL than the
+ * sitemap advertised.
+ *
+ * `&amp;` is decoded LAST so `&amp;lt;` yields the literal `&lt;` rather than
+ * double-decoding to `<`.
+ */
+function decodeXmlEscapes(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
 export function parseSitemap(content: string, url: string): SitemapData {
   const errors: string[] = [];
   const parser = new XMLParser({
@@ -37,7 +59,8 @@ export function parseSitemap(content: string, url: string): SitemapData {
       const sitemapEntries = ensureArray(sitemapIndex.sitemap);
       const childSitemaps = sitemapEntries
         .map((entry) => entry.loc?.trim())
-        .filter((loc): loc is string => Boolean(loc));
+        .filter((loc): loc is string => Boolean(loc))
+        .map(decodeXmlEscapes);
 
       return {
         url,
@@ -69,8 +92,9 @@ export function parseSitemap(content: string, url: string): SitemapData {
       const urls: SitemapUrl[] = [];
 
       for (const entry of urlEntries) {
-        const loc = entry.loc?.trim();
-        if (!loc) continue;
+        const rawLoc = entry.loc?.trim();
+        if (!rawLoc) continue;
+        const loc = decodeXmlEscapes(rawLoc);
 
         const priorityRaw = entry.priority;
         const priority =

--- a/packages/crawler/tests/sitemap-entity-expansion.test.ts
+++ b/packages/crawler/tests/sitemap-entity-expansion.test.ts
@@ -81,13 +81,11 @@ describe("sitemap entity expansion", () => {
     ]);
   });
 
-  // Pins CURRENT behaviour, which is wrong but is the cost of the guard above:
-  // `processEntities: false` disables the five XML predefined escapes too, so a
-  // legitimate `&amp;` in a query string survives into the enqueued URL. Turning
-  // entities back on to fix it would reopen the first test, so the fix is to
-  // decode the predefined five after parsing. Tracked separately; when that
-  // lands this expectation flips to `?q=1&page=2`.
-  test("KNOWN BUG: predefined XML escapes are not decoded", () => {
+  // The other half of the guard above: `processEntities: false` also suppresses
+  // the five XML predefined escapes, so they are decoded after parsing. Declared
+  // entities stay unexpanded (first test) while a legitimate `&amp;` in a query
+  // string reaches the crawler as `&`. Escape coverage: sitemap-xml-escapes.test.ts.
+  test("predefined XML escapes are decoded", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset>
   <url><loc>https://example.com/search?q=1&amp;page=2</loc></url>
@@ -95,6 +93,6 @@ describe("sitemap entity expansion", () => {
 
     const result = parseSitemap(xml, SITEMAP_URL);
 
-    expect(result.urls[0]?.loc).toBe("https://example.com/search?q=1&amp;page=2");
+    expect(result.urls[0]?.loc).toBe("https://example.com/search?q=1&page=2");
   });
 });

--- a/packages/crawler/tests/sitemap-xml-escapes.test.ts
+++ b/packages/crawler/tests/sitemap-xml-escapes.test.ts
@@ -1,0 +1,52 @@
+// The parser runs with processEntities:false to block declared-entity
+// substitution. That also suppresses the five XML predefined escapes, which
+// are the spec-mandated way to encode `&` in a sitemap URL — so they must be
+// decoded after parsing, or a `?q=1&amp;page=2` loc gets fetched literally and
+// we crawl a different URL than the sitemap advertised.
+import { describe, expect, test } from "bun:test";
+
+import { parseSitemap } from "../src/sitemaps";
+
+function urlset(...locs: string[]): string {
+  const entries = locs.map((loc) => `<url><loc>${loc}</loc></url>`).join("");
+  return `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${entries}</urlset>`;
+}
+
+describe("sitemap predefined XML escapes", () => {
+  test("decodes &amp; in a query string", () => {
+    const data = parseSitemap(
+      urlset("https://example.com/search?q=1&amp;page=2"),
+      "https://example.com/sitemap.xml",
+    );
+    expect(data.urls.map((u) => u.loc)).toEqual(["https://example.com/search?q=1&page=2"]);
+  });
+
+  test("decodes the remaining four predefined escapes", () => {
+    const data = parseSitemap(
+      urlset("https://example.com/a?x=&lt;&gt;&quot;&apos;"),
+      "https://example.com/sitemap.xml",
+    );
+    expect(data.urls[0]?.loc).toBe("https://example.com/a?x=<>\"'");
+  });
+
+  test("does not double-decode: &amp;lt; yields the literal &lt;", () => {
+    const data = parseSitemap(
+      urlset("https://example.com/a?x=&amp;lt;"),
+      "https://example.com/sitemap.xml",
+    );
+    expect(data.urls[0]?.loc).toBe("https://example.com/a?x=&lt;");
+  });
+
+  test("decodes escapes in sitemap index child locs", () => {
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+      `<sitemap><loc>https://example.com/sitemap.xml?shard=1&amp;v=2</loc></sitemap></sitemapindex>`;
+    const data = parseSitemap(xml, "https://example.com/sitemap-index.xml");
+    expect(data.childSitemaps).toEqual(["https://example.com/sitemap.xml?shard=1&v=2"]);
+  });
+
+  test("leaves unescaped URLs untouched", () => {
+    const data = parseSitemap(urlset("https://example.com/plain"), "https://example.com/s.xml");
+    expect(data.urls[0]?.loc).toBe("https://example.com/plain");
+  });
+});


### PR DESCRIPTION
`processEntities: false` (the declared-entity / billion-laughs guard) also suppresses the five XML predefined escapes, which are the spec-mandated way to encode `&` in a sitemap URL. A legitimate `<loc>https://example.com/search?q=1&amp;amp;page=2</loc>` survived as the literal string, so the crawler fetched a URL with a param named `amp;page` — a different URL than the sitemap advertised.

Decodes the five after parsing (urlset locs + index child locs), with `&amp;amp;` last so `&amp;amp;lt;` yields the literal `&amp;lt;` instead of double-decoding to `<`. The declared-entity guard is untouched and still passes; the companion KNOWN-BUG expectation in that file flips to the fixed behaviour, exactly as its comment anticipated. New coverage in `sitemap-xml-escapes.test.ts`; full crawler suite green (200 tests).