### PR TITLE
fix(cli): retry transient failures in the pre-flight reachability probe

### DIFF
--- a/apps/cli/src/utils/reachability.ts
+++ b/apps/cli/src/utils/reachability.ts
@@ -12,6 +12,47 @@ const REACHABILITY_TIMEOUT_MS = 10000;
 const REACHABILITY_BODY_SAMPLE_BYTES = 10240;
 const REACHABILITY_BODY_SAMPLE_TIMEOUT_MS = 1500;
 
+// The probe runs before any crawling, and a single transient blip used to abort
+// the whole audit (the crawler itself has retried since forever). Retry only
+// errors that can plausibly succeed on a second try, and bound the total spend
+// so a genuinely dead host still fails fast.
+export const REACHABILITY_MAX_ATTEMPTS = 3;
+const REACHABILITY_RETRY_BASE_DELAY_MS = 300;
+const REACHABILITY_TOTAL_BUDGET_MS = 20000;
+
+/**
+ * Errors worth a second attempt. Definitive answers (DNS says the name does not
+ * exist, the port actively refused, the certificate is bad) are not retried:
+ * they resolve in milliseconds and repeating them only delays the failure.
+ */
+export function isTransientReachabilityError(
+  error: string | undefined
+): boolean {
+  if (!error) return false;
+  const message = error.toLowerCase();
+  if (
+    message.includes("dns") ||
+    message.includes("host not found") ||
+    message.includes("refused") ||
+    message.includes("certificate") ||
+    message.includes("ssl") ||
+    message.includes("tls")
+  ) {
+    return false;
+  }
+  return (
+    message.includes("timed out") ||
+    message.includes("timeout") ||
+    message.includes("socket") ||
+    message.includes("network") ||
+    message.includes("econnreset") ||
+    message.includes("fetch failed")
+  );
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 export interface ReachabilityResult {
   reachable: boolean;
   error?: string;
@@ -111,10 +152,34 @@ async function readBodySample(
  * Check if a URL is reachable
  * Uses browser-like headers for WAF compatibility
  * Detects WAF/bot protection on target site
+ *
+ * Transient failures are retried with a short backoff (see
+ * isTransientReachabilityError); definitive ones fail on the first attempt.
  */
 export async function checkReachability(
   url: string
 ): Promise<ReachabilityResult> {
+  const deadline = Date.now() + REACHABILITY_TOTAL_BUDGET_MS;
+  let result = await attemptReachability(url);
+
+  for (let attempt = 2; attempt <= REACHABILITY_MAX_ATTEMPTS; attempt++) {
+    if (result.reachable || !isTransientReachabilityError(result.error)) break;
+    const delay = REACHABILITY_RETRY_BASE_DELAY_MS * 2 ** (attempt - 2);
+    if (Date.now() + delay >= deadline) break;
+    logger.debug(
+      "reachability retry",
+      url,
+      `attempt ${attempt}`,
+      result.error ?? ""
+    );
+    await sleep(delay);
+    result = await attemptReachability(url);
+  }
+
+  return result;
+}
+
+async function attemptReachability(url: string): Promise<ReachabilityResult> {
   // Fast path for localhost/loopback using native fetch (no WAF detection needed)
   let isLocalhost = false;
   try {

--- a/apps/cli/tests/utils/reachability-retry.test.ts
+++ b/apps/cli/tests/utils/reachability-retry.test.ts
@@ -1,0 +1,95 @@
+// The pre-flight probe aborts the whole audit before any crawling, so one
+// transient blip used to discard a run that would otherwise succeed (#1408).
+// It now retries transient failures only — definitive answers (DNS, refused,
+// bad certificate) still fail on the first attempt so dead hosts stay fast.
+import { describe, expect, test } from "bun:test";
+
+import {
+  checkReachability,
+  isTransientReachabilityError,
+  REACHABILITY_MAX_ATTEMPTS,
+} from "../../src/utils/reachability";
+
+describe("isTransientReachabilityError", () => {
+  test("retries timeouts and socket/network blips", () => {
+    for (const message of [
+      "Connection timed out",
+      "request timeout",
+      "fetch failed",
+      "socket hang up",
+      "ECONNRESET",
+      "network error",
+    ]) {
+      expect(isTransientReachabilityError(message)).toBe(true);
+    }
+  });
+
+  test("does not retry definitive failures", () => {
+    for (const message of [
+      "DNS lookup failed - domain may not exist",
+      "Host not found",
+      "Connection refused - server may be down",
+      "SSL/TLS error - certificate issue",
+    ]) {
+      expect(isTransientReachabilityError(message)).toBe(false);
+    }
+  });
+
+  test("treats an absent error as non-transient", () => {
+    expect(isTransientReachabilityError(undefined)).toBe(false);
+  });
+});
+
+describe("checkReachability retry", () => {
+  test("recovers when the first attempt fails transiently", async () => {
+    // A raw TCP listener, not Bun.serve: a handler that throws yields an HTTP
+    // 500, which the probe correctly counts as reachable. The transient case is
+    // a socket-level failure, so hang up on the first connection and answer the
+    // second.
+    let connections = 0;
+    const server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          connections++;
+          if (connections === 1) {
+            socket.end();
+            return;
+          }
+          socket.write(
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+          );
+          socket.flush();
+          socket.end();
+        },
+        data() {},
+      },
+    });
+
+    try {
+      const result = await checkReachability(
+        `http://localhost:${server.port}/`
+      );
+      expect(result.reachable).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(connections).toBeGreaterThan(1);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a dead port is not retried to exhaustion", async () => {
+    // Nothing is listening: connection refused is definitive, so this must
+    // return after a single attempt rather than burning the retry budget.
+    const started = Date.now();
+    const result = await checkReachability("http://localhost:1/");
+    expect(result.reachable).toBe(false);
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+
+  test("exposes a bounded attempt count", () => {
+    expect(REACHABILITY_MAX_ATTEMPTS).toBeGreaterThan(1);
+    expect(REACHABILITY_MAX_ATTEMPTS).toBeLessThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
The pre-flight probe got exactly one attempt, and its failure hard-aborts the audit before any crawling. A single transient blip therefore discarded a whole run (observed: a 10s timeout while `curl` reached the same host in 42ms, with three subsequent runs succeeding at byte-identical scores). The crawler itself has retried with exponential backoff since forever; only this check did not.

- retries up to 3 attempts with short exponential backoff
- retries **only** transient errors (timeout, socket, network, reset, fetch-failed); DNS failures, refused connections and TLS/certificate errors are definitive and still fail on the first attempt
- a total budget caps the worst case, so a genuinely unreachable host still fails fast

Tests cover the classifier both ways, an end-to-end recovery against a raw TCP listener that hangs up on the first connection and answers the second, and that a dead port returns quickly rather than burning the retry budget.