### PR TITLE
chore(release): sync public manifests to the shipped v0.0.81

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "repository": "https://github.com/squirrelscan/squirrelscan",
   "license": "MIT",
   "keywords": ["seo", "audit", "website", "performance", "security", "accessibility", "crawler"],
-  "version": "0.0.79"
+  "version": "0.0.81"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "squirrelscan",
   "displayName": "squirrelscan",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
-  "version": "0.0.79",
+  "version": "0.0.81",
   "author": {
     "name": "squirrelscan"
   },

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squirrelscan/cli",
-  "version": "0.0.79",
+  "version": "0.0.81",
   "description": "Free CLI for SEO, performance & security audits. Built for Claude Code, Cursor, and AI workflows.",
   "bin": {
     "squirrelscan": "./build/squirrelscan"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squirrelscan",
-  "version": "0.0.79",
+  "version": "0.0.81",
   "description": "Website QA tool built for coding agents. 260+ rules across SEO, performance, security, accessibility & agent experience, from the CLI, cloud, or MCP.",
   "bin": {
     "squirrel": "bin/squirrel.js"
@@ -16,17 +16,7 @@
   "bugs": {
     "url": "https://github.com/squirrelscan/squirrelscan/issues"
   },
-  "keywords": [
-    "seo",
-    "audit",
-    "cli",
-    "website",
-    "llm",
-    "accessibility",
-    "performance",
-    "security",
-    "crawler"
-  ],
+  "keywords": ["seo", "audit", "cli", "website", "llm", "accessibility", "performance", "security", "crawler"],
   "author": "squirrelscan",
   "license": "MIT",
   "publishConfig": {
@@ -35,21 +25,7 @@
   "engines": {
     "node": ">=18"
   },
-  "os": [
-    "darwin",
-    "linux",
-    "win32"
-  ],
-  "cpu": [
-    "x64",
-    "arm64"
-  ],
-  "files": [
-    "bin/",
-    "lib/",
-    "scripts/postinstall.js",
-    "README.md",
-    "LICENSE",
-    "THIRD_PARTY_NOTICES.md"
-  ]
+  "os": ["darwin", "linux", "win32"],
+  "cpu": ["x64", "arm64"],
+  "files": ["bin/", "lib/", "scripts/postinstall.js", "README.md", "LICENSE", "THIRD_PARTY_NOTICES.md"]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "squirrelscan",
-  "version": "0.0.79",
+  "version": "0.0.81",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
   "author": {
     "name": "squirrelscan",


### PR DESCRIPTION
Partial fix for the version drift in squirrelscan/repo#1423.

`main` advertised **0.0.79** in every synced manifest while **v0.0.80 and v0.0.81 had already shipped** — the release workflow stamps the version into a throwaway checkout and pushes only the tag, so the bump never lands on the branch. npm, the Open Plugin manifest and both vendor plugin manifests are exactly what the marketplaces and Cursor Directory read, so the public listings were two releases behind.

- bumps `apps/cli/package.json` (the source of truth the sync script reads) to 0.0.81
- fans out via the repo's own `scripts/sync-plugin-manifests.ts`, so `--check` is clean against this branch
- `npm/package.json` additionally picks up that script's own formatting (arrays inlined). Verified key-for-key identical to `main` apart from `version` — no metadata added or dropped
- `server.json` deliberately untouched, still on its independent 1.0.x cadence

Note the sync script's downgrade guard makes the order matter: stamping the downstream manifests first (`--version 0.0.81`) leaves `apps/cli` behind and the next `--check` then throws `apps/cli version 0.0.79 is below published 0.0.81`. The source of truth has to lead.

**This fixes the current drift only.** Making releases self-syncing (push the branch as well as the tag, or open a bump PR) is the workflow change still open on the issue — deliberately not attempted here, since a mistake in `release.yml` is only discovered at the next release.
