### PR TITLE
chore(release): sync public manifests to the shipped v0.0.82

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "repository": "https://github.com/squirrelscan/squirrelscan",
   "license": "MIT",
   "keywords": ["seo", "audit", "website", "performance", "security", "accessibility", "crawler"],
-  "version": "0.0.81"
+  "version": "0.0.82"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "squirrelscan",
   "displayName": "squirrelscan",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "author": {
     "name": "squirrelscan"
   },

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squirrelscan/cli",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "description": "Free CLI for SEO, performance & security audits. Built for Claude Code, Cursor, and AI workflows.",
   "bin": {
     "squirrelscan": "./build/squirrelscan"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squirrelscan",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "description": "Website QA tool built for coding agents. 260+ rules across SEO, performance, security, accessibility & agent experience, from the CLI, cloud, or MCP.",
   "bin": {
     "squirrel": "bin/squirrel.js"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "squirrelscan",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
   "author": {
     "name": "squirrelscan",


### PR DESCRIPTION
The release workflow commits the version stamp and then pushes only the tag, so
the bump is reachable from `v0.0.82` and nowhere else. `main` therefore still
reads `0.0.81` in `apps/cli/package.json`, `npm/package.json`, `plugin.json`,
`.cursor-plugin/plugin.json` and `.claude-plugin/plugin.json`.

That matters because the Cursor Directory and the Claude Code plugin marketplace
read `plugin.json` / `.claude-plugin/plugin.json` from the default branch, so the
public listings advertise a version that is one release behind. It also leaves
`sync-plugin-manifests.ts --check` permanently reporting drift, which trains
people to ignore a real drift detector.

This is the release commit from the tag, cherry-picked onto `main` unchanged, so
the two agree exactly. Same follow-up as the v0.0.81 cut.

The underlying workflow bug is still open: the fix is for the release job to push
the branch as well as the tag, or to open this PR itself.