### PR TITLE
build(release): publish installers and channel metadata to R2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,108 @@ jobs:
         working-directory: npm
         run: npm publish --access public --provenance
 
+  installers-publish:
+    name: Publish installers and channel metadata
+    needs: [version, github-release]
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+      # wrangler >= 4.99 requires Node 22+; runners default to Node 20.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22.x"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-binaries
+          path: release-assets
+
+      # install.squirrelscan.com serves the install scripts and the per-channel
+      # "latest release" metadata from R2, because resolving a version through
+      # api.github.com is capped at 60 req/hr per IP and users behind shared
+      # egress (corporate NAT, VPN, CI) get 403s. R2 is only correct while
+      # something keeps writing to it, and that is this job.
+      - name: Build per-channel manifests
+        env:
+          PRERELEASE: ${{ needs.version.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          # The build job generates one manifest.json and it always carries
+          # channel="stable". The beta channel serves every release, so its copy
+          # has to be restamped: a channels/beta.json that says "stable" is how
+          # the two keys ended up byte-identical last time.
+          jq '.channel = "beta"' release-assets/manifest.json > channel-beta.json
+          if [ "$PRERELEASE" != "true" ]; then
+            jq '.channel = "stable"' release-assets/manifest.json > channel-stable.json
+          fi
+
+      - name: Publish installers and channel metadata to R2
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PRERELEASE: ${{ needs.version.outputs.prerelease }}
+          WRANGLER_SEND_METRICS: "false"
+        run: |
+          set -euo pipefail
+          test -n "$CLOUDFLARE_ACCOUNT_ID"
+          test -n "$CLOUDFLARE_API_TOKEN"
+
+          put() {
+            npx --yes wrangler@4.99.0 r2 object put "squirrelscan-installers/$1" \
+              --file "$2" --content-type "$3" --remote
+          }
+
+          put install.sh install.sh "text/x-shellscript; charset=utf-8"
+          put install.ps1 install.ps1 "text/plain; charset=utf-8"
+
+          # Beta tracks every release; stable only non-prereleases. This mirrors
+          # the worker's GitHub fallback (beta accepts prereleases, stable does
+          # not) so the primary and fallback paths can never disagree about what
+          # a channel means.
+          put channels/beta.json channel-beta.json "application/json; charset=utf-8"
+          if [ "$PRERELEASE" != "true" ]; then
+            put channels/stable.json channel-stable.json "application/json; charset=utf-8"
+          fi
+
+      # Writing to a bucket proves nothing about the bucket the deployed worker
+      # reads: they are separate configs and can point at different accounts.
+      # Assert the pairing against the live endpoint instead of assuming it.
+      - name: Verify the live endpoint serves this release
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          PRERELEASE: ${{ needs.version.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          verify() {
+            channel="$1"
+            got_version="" got_channel=""
+            # Responses are edge-cached for 300s, so a colo that answered before
+            # the upload can keep serving the previous object for a few minutes.
+            # Poll past that window rather than racing it.
+            for _ in $(seq 1 24); do
+              body=$(curl -fsS "https://install.squirrelscan.com/releases/${channel}" || true)
+              got_version=$(printf '%s' "$body" | jq -r '.version // ""' 2>/dev/null || true)
+              got_channel=$(printf '%s' "$body" | jq -r '.channel // ""' 2>/dev/null || true)
+              if [ "$got_version" = "$VERSION" ] && [ "$got_channel" = "$channel" ]; then
+                echo "/releases/${channel} -> ${got_version} (${got_channel})"
+                return 0
+              fi
+              sleep 20
+            done
+            echo "::error::/releases/${channel} reports version='${got_version}' channel='${got_channel}', expected version='${VERSION}' channel='${channel}'"
+            return 1
+          }
+
+          verify beta
+          if [ "$PRERELEASE" != "true" ]; then
+            verify stable
+          fi
+
   hosted-release-refresh:
     name: Refresh hosted release cache
     needs: [version, github-release]


### PR DESCRIPTION
## What's broken

`install.squirrelscan.com` serves the install scripts and the per-channel
"latest release" metadata (`channels/stable.json`, `channels/beta.json`) out of
an R2 bucket, so that resolving a version never has to go through
`api.github.com` and hit its 60 req/hr anonymous cap. That works only for as
long as something keeps writing those objects, and nothing has.

The job that wrote them lived in the release workflow before that workflow moved
into this repo. It did not come across. Since then the objects have been frozen
at whatever was uploaded on the last release before the move:

- `/releases/stable` kept advertising a nine-day-old version straight through
  two releases. Every release ran green while it happened.
- The served `install.sh` and `install.ps1` are still the pre-move copies and
  have drifted from `main`.

Nothing errored anywhere. The read succeeds and returns a valid, well-formed,
correctly-signed manifest that is merely old.

## What this does

Adds `installers-publish`, which runs after the GitHub release exists and:

1. Uploads `install.sh` and `install.ps1` from the release tag.
2. Uploads the release manifest to `channels/beta.json`, and to
   `channels/stable.json` when the release is not a prerelease. Beta tracks every
   release and stable skips prereleases, which is exactly how the worker's
   GitHub fallback classifies them, so the primary and fallback paths can't
   disagree about what a channel means.
3. Restamps the `channel` field per key. The build emits a single
   `manifest.json` that always says `"stable"`; copying it verbatim into
   `channels/beta.json` is how the two keys previously ended up byte-identical.
4. Polls `https://install.squirrelscan.com/releases/{channel}` and fails the
   release unless it reports the version just released, on the right channel.

Point 4 is the part that matters. Writing to a bucket proves nothing about the
bucket the deployed worker actually reads: they are separate configs that can
point at different accounts, and this bug was precisely a write path and a read
path disagreeing about where the truth lives. Asserting against the live
endpoint is the only check that covers that. The endpoint is edge-cached for
300s, so the poll runs past that window rather than racing it.

## Notes

- `set -euo pipefail` throughout, all inputs passed via `env:` rather than
  interpolated into shell.
- `wrangler` is version-pinned rather than floating.
- Verified with `actionlint`. The verify loop was exercised against the live
  endpoint in both directions: it passes on a matching version and fails with a
  readable diagnostic on a mismatching one.

## Operational notes

- The job runs in the `production` environment because that is where
  `CLOUDFLARE_API_TOKEN` lives, so it inherits the same manual approval gate
  `hosted-release-refresh` already has. Both go pending on `github-release`, so
  a single approval covers both and a release doesn't stop twice.
- Worth confirming before the next release rather than discovering during one:
  the repo's `CLOUDFLARE_ACCOUNT_ID` has to be the account hosting the bucket
  the deployed worker binds. If it isn't, the verify step fails the release,
  which is the correct outcome but a noisy way to learn it.
