### PR TITLE
fix(security): harden untrusted-key object building against prototype pollution

### DIFF
--- a/apps/cli/src/audit/cloud.ts
+++ b/apps/cli/src/audit/cloud.ts
@@ -209,7 +209,10 @@ function extractJsonLdBlocks(doc: Document): string[] {
 
 /** og:* / twitter:* / name meta tags → a flat name→content map (identity signals). */
 function extractMetaNameContent(doc: Document): Record<string, string> {
-  const out: Record<string, string> = {};
+  // Object.create(null): `key` is page-controlled, so on a plain object the
+  // `key in out` guard below is true for `constructor`/`__proto__` inherited
+  // from the prototype chain and those tags never reach the cloud payload.
+  const out: Record<string, string> = Object.create(null);
   const metas = doc.querySelectorAll("meta");
   for (const meta of metas) {
     const el = meta as Element;
@@ -554,7 +557,8 @@ function extractScriptSrcs(html: string): string[] {
  * detectors are the backstop for any tag this misses (e.g. content-first order).
  */
 function extractMetaTags(html: string): Record<string, string> {
-  const out: Record<string, string> = {};
+  // Object.create(null) — same reason as extractMetaNameContent above.
+  const out: Record<string, string> = Object.create(null);
   // Parse each <meta> tag and read its name/content attrs INDEPENDENTLY so
   // either attribute order works — some CMSes (Joomla, Drupal) emit
   // `<meta content="…" name="generator">`, and `generator` is the key CMS signal.

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -2,6 +2,7 @@
 // Schema + types + defaults come from @squirrelscan/config.
 // This file adds CLI-specific TOML loading, file discovery, and process.exit.
 
+import { isUnsafeObjectKey } from "@squirrelscan/core-contracts/untrusted-keys";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
@@ -75,12 +76,22 @@ export function getGlobalConfigPath(): string | undefined {
 }
 
 // Deep merge utility — arrays replace, objects deep merge
+//
+// `source` is TOML from a `squirrel.toml` we did not write (audits run inside
+// checkouts), and smol-toml turns a `[__proto__]` table into a real own key.
+// Merging that key would read `target["__proto__"]` (Object.prototype) as the
+// recursion target and then assign the result back through the inherited
+// setter, repointing the merged config's prototype. Skip those keys: no
+// SquirrelScanConfig field is named any of them.
 function deepMerge<T extends Record<string, unknown>>(
   target: T,
   source: Partial<T>
 ): T {
   const result = { ...target };
   for (const key of Object.keys(source) as (keyof T)[]) {
+    // String(key), not a `typeof key === "string"` guard: narrowing `key` here
+    // would also narrow it for the `result[key] = …` writes below.
+    if (isUnsafeObjectKey(String(key))) continue;
     const sourceVal = source[key];
     const targetVal = target[key];
     if (

--- a/apps/cli/src/controllers/config.ts
+++ b/apps/cli/src/controllers/config.ts
@@ -1,5 +1,6 @@
 // Generic config command - interface-agnostic
 
+import { isUnsafeObjectKey } from "@squirrelscan/core-contracts/untrusted-keys";
 import { existsSync, readFileSync } from "node:fs";
 import { parse as parseTOML } from "smol-toml";
 
@@ -174,6 +175,22 @@ export function setConfigValue(
   // Set the value (supports dot notation for nested keys)
   // Note: writing back with stringifyTOML will lose any comments/formatting
   const keys = key.split(".");
+  // `config` comes from parseTOML and inherits Object.prototype, so descending
+  // into a `__proto__`/`constructor`/`prototype` segment hands back the shared
+  // prototype and the final write lands on every object in the process. No
+  // config key is named any of these, so reject rather than silently skip.
+  const unsafeSegment = keys.find((segment) => isUnsafeObjectKey(segment));
+  if (unsafeSegment) {
+    return err(
+      commandError(
+        ErrorCodes.INVALID_VALUE,
+        `Invalid config key segment: ${unsafeSegment}`,
+        {
+          key,
+        }
+      )
+    );
+  }
   let obj: Record<string, unknown> = config;
   for (let i = 0; i < keys.length - 1; i++) {
     if (!(keys[i] in obj)) {

--- a/apps/cli/tests/security/prototype-pollution.test.ts
+++ b/apps/cli/tests/security/prototype-pollution.test.ts
@@ -1,0 +1,253 @@
+// Prototype-pollution regression suite for every path that turns an untrusted
+// document into a JS object: JSON-LD (including nested `@graph`), `.well-known`
+// and OpenAPI JSON, sitemap XML, response headers, `<meta>` maps, and the
+// TOML config a repo under audit can ship.
+//
+// Every assertion is on the GLOBAL prototype, not on the returned value: a
+// pollution that only shows up as `({}).polluted` is invisible in the parsed
+// object, so checking the return value alone would pass against vulnerable code.
+//
+// Fixtures are built with real `JSON.parse`, never object literals. A literal
+// `{ __proto__: {...} }` is spec-special-cased to SET THE PROTOTYPE at
+// construction time instead of creating an own property, so a fixture written
+// that way cannot reproduce the bug at all and the test would be a false
+// negative.
+
+import { clampDetailsRecord } from "@squirrelscan/core-contracts/clamp";
+import { isUnsafeObjectKey } from "@squirrelscan/core-contracts/untrusted-keys";
+import { varyMatches } from "@squirrelscan/crawler";
+import { parseSitemap } from "@squirrelscan/crawler/sitemaps";
+import {
+  extractOAuthFields,
+  sniffJson,
+} from "@squirrelscan/crawler/well-known";
+import { createFetchDocumentFetcher } from "@squirrelscan/fetchers";
+import { flattenJsonLdNodes } from "@squirrelscan/utils/schema-rich-results";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadConfig } from "@/config";
+import { setConfigValue } from "@/controllers/config";
+
+const CANARY = "polluted";
+// Held in a const so the lookups below are computed, not a literal `["__proto__"]`
+// member access (which oxlint's no-proto rule rejects on sight).
+const PROTO_KEY = "__proto__";
+
+let baselineProtoKeys: string[] = [];
+
+beforeEach(() => {
+  baselineProtoKeys = Object.getOwnPropertyNames(Object.prototype);
+});
+
+afterEach(() => {
+  const added = Object.getOwnPropertyNames(Object.prototype).filter(
+    (key) => !baselineProtoKeys.includes(key)
+  );
+  const canary = (Object.prototype as Record<string, unknown>)[CANARY];
+  // Clean up before asserting so one leak can't cascade into every later test.
+  for (const key of added)
+    delete (Object.prototype as Record<string, unknown>)[key];
+  expect(added).toEqual([]);
+  expect(canary).toBeUndefined();
+  expect(({} as Record<string, unknown>)[CANARY]).toBeUndefined();
+});
+
+/** A JSON-LD document whose `@graph` nests the three dangerous keys at every level. */
+const HOSTILE_JSONLD = JSON.stringify({
+  "@context": "https://schema.org",
+  "@graph": [
+    { "@type": "Article", headline: "benign" },
+    JSON.parse(`{"@type":"Person","name":"a","__proto__":{"${CANARY}":"yes"}}`),
+    JSON.parse(
+      `{"@type":"Organization","constructor":{"prototype":{"${CANARY}":"yes"}}}`
+    ),
+    JSON.parse(`{"@type":"WebSite","prototype":{"${CANARY}":"yes"}}`),
+    JSON.parse(
+      `{"@graph":[{"@type":"BreadcrumbList","__proto__":{"${CANARY}":"yes"},"itemListElement":[{"@type":"ListItem","constructor":{"prototype":{"${CANARY}":"yes"}}}]}]}`
+    ),
+  ],
+});
+
+const HOSTILE_JSON_DOC = `{"__proto__":{"${CANARY}":"yes"},"constructor":{"prototype":{"${CANARY}":"yes"}},"prototype":{"${CANARY}":"yes"},"registration_endpoint":"https://idp.test/register","client_id_metadata_document_supported":true}`;
+
+describe("prototype pollution — JSON-LD", () => {
+  test("flattenJsonLdNodes leaves the global prototype alone for a hostile @graph", () => {
+    const nodes = flattenJsonLdNodes(HOSTILE_JSONLD);
+    // The nested @graph is walked, so the hostile nodes really were visited.
+    expect(nodes.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test("flattenJsonLdNodes survives multi-block raw joined by blank lines", () => {
+    const raw = `${HOSTILE_JSONLD}\n\n${HOSTILE_JSONLD}`;
+    expect(flattenJsonLdNodes(raw).length).toBeGreaterThanOrEqual(6);
+  });
+
+  test("parsing a page whose JSON-LD and meta tags are hostile pollutes nothing", async () => {
+    const { parsePage } = await import("@squirrelscan/parser");
+    const html = `<!doctype html><html><head><title>t</title>
+      <script type="application/ld+json">${HOSTILE_JSONLD}</script>
+      <meta name="__proto__" content="x"><meta name="constructor" content="y">
+      <meta property="prototype" content="z"><meta name="generator" content="WordPress">
+      </head><body><h1>h</h1></body></html>`;
+    const parsed = parsePage(html, "https://hostile.test/");
+    expect(parsed).toBeDefined();
+  });
+});
+
+describe("prototype pollution — .well-known and OpenAPI JSON", () => {
+  test("sniffJson reports the dangerous keys instead of dropping or applying them", () => {
+    const result = sniffJson(HOSTILE_JSON_DOC);
+    expect(result.valid).toBe(true);
+    expect(result.keys).toContain("__proto__");
+    expect(result.keys).toContain("constructor");
+  });
+
+  test("extractOAuthFields reads real fields past the dangerous keys", () => {
+    const fields = extractOAuthFields(HOSTILE_JSON_DOC);
+    expect(fields.registrationEndpoint).toBe("https://idp.test/register");
+    expect(fields.clientIdMetadataDocumentSupported).toBe(true);
+  });
+});
+
+describe("prototype pollution — sitemap XML", () => {
+  test("a sitemap carrying reserved element names still yields its real URLs or a parse error", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url><loc>https://hostile.test/a</loc></url>
+      </urlset>`;
+    const clean = parseSitemap(xml, "https://hostile.test/sitemap.xml");
+    expect(clean.urls.map((u) => u.loc)).toEqual(["https://hostile.test/a"]);
+
+    // Reserved tag names and attributes must not reach a bracket assignment.
+    for (const hostile of [
+      `<urlset><__proto__><${CANARY}>yes</${CANARY}></__proto__><url><loc>https://hostile.test/b</loc></url></urlset>`,
+      `<urlset><constructor><prototype><${CANARY}>yes</${CANARY}></prototype></constructor><url><loc>https://hostile.test/c</loc></url></urlset>`,
+      `<urlset><url __proto__="x" constructor="y"><loc>https://hostile.test/d</loc></url></urlset>`,
+    ]) {
+      const parsed = parseSitemap(hostile, "https://hostile.test/sitemap.xml");
+      // Either the URL survives or the parse is rejected outright; both are
+      // acceptable, silently polluting the prototype is not.
+      expect(parsed.urls.length + parsed.errors.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("prototype pollution — response headers", () => {
+  test("a `__proto__` response header is recorded, not silently swallowed", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        const headers = new Headers({ "content-type": "text/html" });
+        headers.set("__proto__", "hostile-value");
+        headers.set("constructor", "hostile-value");
+        return new Response("<html><body>ok</body></html>", {
+          status: 200,
+          headers,
+        });
+      },
+    });
+
+    try {
+      const fetcher = createFetchDocumentFetcher();
+      const response = await fetcher.fetch({ url: server.url.toString() });
+      // The whole point of the null-prototype accumulator: the header survives
+      // as an own property instead of vanishing into the inherited setter.
+      expect(response.headers[PROTO_KEY]).toBe("hostile-value");
+      expect(response.headers["constructor"]).toBe("hostile-value");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("varyMatches compares real headers, not inherited Object.prototype members", () => {
+    const stored = JSON.parse('{"accept":"text/html"}') as Record<
+      string,
+      string
+    >;
+    const current = JSON.parse('{"accept":"text/html"}') as Record<
+      string,
+      string
+    >;
+    // A site can name any header in Vary, so the lookup keys are attacker-chosen.
+    // Nothing here is currently mis-decided on a plain `{}` (both sides resolve
+    // the same inherited function and compare equal) — this pins the behaviour
+    // now that the lookup map has no prototype to fall through to.
+    expect(varyMatches("accept, constructor, __proto__", stored, current)).toBe(
+      true
+    );
+
+    const differing = JSON.parse(
+      '{"accept":"text/html","constructor":"x"}'
+    ) as Record<string, string>;
+    expect(varyMatches("constructor", stored, differing)).toBe(false);
+  });
+});
+
+describe("prototype pollution — CLI config", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "squirrel-proto-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // The schema parse at the end of loadConfig already discards a repointed
+  // prototype, so this passes without the deepMerge guard too. It pins the
+  // end-to-end guarantee so a future refactor that drops or moves that parse
+  // cannot quietly expose the merge.
+  test("a hostile squirrel.toml cannot repoint the loaded config's prototype", async () => {
+    const configPath = join(dir, "squirrel.toml");
+    writeFileSync(
+      configPath,
+      `[project]\nname = "x"\n\n[__proto__]\n${CANARY} = "yes"\n\n[constructor.prototype]\n${CANARY} = "yes"\n`
+    );
+
+    const config = await loadConfig(configPath, { silent: true });
+    expect(Object.getPrototypeOf(config)).toBe(Object.prototype);
+    expect((config as Record<string, unknown>)[CANARY]).toBeUndefined();
+  });
+
+  test("`config set` rejects a dotted key that walks through the prototype", () => {
+    const configPath = join(dir, "squirrel.toml");
+    writeFileSync(configPath, `[project]\nname = "x"\n`);
+
+    for (const key of [
+      "__proto__.polluted",
+      "constructor.prototype.polluted",
+      "prototype.x",
+    ]) {
+      const result = setConfigValue(configPath, key, "yes");
+      expect(result.ok).toBe(false);
+    }
+
+    // A normal nested key still works.
+    const ok = setConfigValue(configPath, "project.name", "renamed");
+    expect(ok.ok).toBe(true);
+  });
+});
+
+describe("prototype pollution — clamped check details", () => {
+  test("clamping an oversized hostile details record keeps the dangerous key as data", () => {
+    const details = JSON.parse(
+      `{"__proto__":{"${CANARY}":"yes"},"constructor":{"prototype":{"${CANARY}":"yes"}},"blob":"${"x".repeat(200_000)}"}`
+    ) as Record<string, unknown>;
+    const clamped = clampDetailsRecord(details);
+    expect(clamped).toBeDefined();
+  });
+});
+
+describe("unsafe key helper", () => {
+  test("covers exactly the three keys that reach Object.prototype", () => {
+    expect(isUnsafeObjectKey("__proto__")).toBe(true);
+    expect(isUnsafeObjectKey("constructor")).toBe(true);
+    expect(isUnsafeObjectKey("prototype")).toBe(true);
+    expect(isUnsafeObjectKey("toString")).toBe(false);
+    expect(isUnsafeObjectKey("project")).toBe(false);
+  });
+});

--- a/packages/audit-engine/src/cloud-prefetch-run.ts
+++ b/packages/audit-engine/src/cloud-prefetch-run.ts
@@ -102,7 +102,10 @@ function extractJsonLdBlocks(doc: Document): string[] {
 }
 
 function extractMetaNameContent(doc: Document): Record<string, string> {
-  const out: Record<string, string> = {};
+  // Object.create(null): `key` is page-controlled, so on a plain object the
+  // `key in out` guard below is true for `constructor`/`__proto__` inherited
+  // from the prototype chain and those tags never reach the cloud payload.
+  const out: Record<string, string> = Object.create(null);
   for (const meta of doc.querySelectorAll("meta")) {
     const el = meta as Element;
     const key = (el.getAttribute("property") ?? el.getAttribute("name") ?? "").trim().toLowerCase();

--- a/packages/core-contracts/package.json
+++ b/packages/core-contracts/package.json
@@ -10,6 +10,7 @@
     "./limits": "./src/limits.ts",
     "./clamp": "./src/clamp.ts",
     "./control-chars": "./src/control-chars.ts",
+    "./untrusted-keys": "./src/untrusted-keys.ts",
     "./credits": "./src/credits.ts",
     "./services": "./src/services.ts",
     "./api-keys": "./src/api-keys.ts",

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -10,6 +10,7 @@ export * from "./credits";
 export * from "./limits";
 export * from "./clamp";
 export * from "./control-chars";
+export * from "./untrusted-keys";
 
 // Org-scoped API keys — token format, env→prefix map, scopes (shared by
 // API mint/parse, dashboard display, CLI precedence).

--- a/packages/core-contracts/src/untrusted-keys.ts
+++ b/packages/core-contracts/src/untrusted-keys.ts
@@ -1,0 +1,50 @@
+// Object keys that must never be written through bracket notation onto a plain
+// `{}` when they came from an audited page, a response header, or a config file.
+//
+// The crawler turns untrusted documents into objects constantly: JSON-LD blocks,
+// `.well-known/*.json`, sitemap XML, response headers, `<meta name=…>` maps. All
+// of those key spaces are chosen by whoever owns the site being audited.
+//
+// Two distinct hazards, and only the first is a "pollution" in the usual sense:
+//
+//  1. `target[key] = value` where `target` is a plain `{}` invokes the inherited
+//     `__proto__` setter instead of creating an own property. With an object
+//     value that repoints `target`'s prototype; with a string value it is a
+//     silent no-op and the key vanishes from `Object.keys`/`JSON.stringify`.
+//  2. Walking INTO `target[key]` — a dotted-path setter or a recursive merge —
+//     resolves `__proto__`/`constructor.prototype` through the chain and hands
+//     back `Object.prototype` itself. A write there is a real global pollution.
+//
+// The fix depends on which shape a call site has:
+//
+//  - Accumulating untrusted keys into a fresh map → `Object.create(null)`. A
+//    null-prototype object has no inherited accessor to trigger, so bracket
+//    assignment is always a plain own-property write and nothing is dropped.
+//  - Walking into or merging onto an object you did not create → skip these
+//    keys explicitly, because the traversal target is a caller-supplied object
+//    that still has `Object.prototype` in its chain.
+//
+// Note `JSON.parse` itself is safe: it builds properties with CreateDataProperty,
+// so `{"__proto__": {…}}` becomes a real own property and the parsed object's
+// prototype is untouched. The danger is only in what we copy that key ONTO.
+// Object-literal spread and `Object.fromEntries` are safe for the same reason.
+
+/**
+ * Keys that resolve to `Object.prototype` (or repoint a prototype) when used
+ * with bracket notation on an object that inherits from `Object.prototype`.
+ */
+export const UNSAFE_OBJECT_KEYS: readonly string[] = ["__proto__", "constructor", "prototype"];
+
+const UNSAFE_OBJECT_KEY_SET: ReadonlySet<string> = new Set(UNSAFE_OBJECT_KEYS);
+
+/**
+ * True when `key` must not be used to index or assign into an object that
+ * inherits from `Object.prototype`.
+ *
+ * Only for the "walk into / merge onto a caller's object" shape. Call sites that
+ * build a fresh accumulator should use `Object.create(null)` instead and keep
+ * every key, including these three.
+ */
+export function isUnsafeObjectKey(key: string): boolean {
+  return UNSAFE_OBJECT_KEY_SET.has(key);
+}

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -9,6 +9,7 @@
     "./frontier": "./src/frontier.ts",
     "./robots": "./src/robots.ts",
     "./sitemaps": "./src/sitemaps.ts",
+    "./well-known": "./src/well-known.ts",
     "./storage": "./src/storage/index.ts"
   },
   "dependencies": {

--- a/packages/crawler/src/incremental.ts
+++ b/packages/crawler/src/incremental.ts
@@ -444,7 +444,10 @@ export function varyMatches(
   if (fields.length === 0) return true;
 
   const lower = (h: Record<string, string> | null): Record<string, string> => {
-    const out: Record<string, string> = {};
+    // Object.create(null): `fields` comes from the site's Vary header, so the
+    // lookups below would otherwise resolve `constructor`/`toString` off
+    // Object.prototype and compare inherited functions instead of headers.
+    const out: Record<string, string> = Object.create(null);
     if (h) for (const [k, v] of Object.entries(h)) out[k.toLowerCase()] = v;
     return out;
   };

--- a/packages/fetchers/src/index.ts
+++ b/packages/fetchers/src/index.ts
@@ -130,7 +130,11 @@ interface RenderJobStatusResponse {
 // (packages/rules/src/security/cookie-flags.ts) splits back into individual
 // cookies on this exact separator; hosted rendering produces the same shape.
 function headersToRecord(headers: Headers): Record<string, string> {
-  const result: Record<string, string> = {};
+  // Object.create(null), NOT {}: header names are chosen by the audited site and
+  // `__proto__` is a valid HTTP token, so `result["__proto__"] = value` on a
+  // plain object hits the inherited setter and silently discards the header
+  // instead of recording it — a header an audit is specifically meant to see.
+  const result: Record<string, string> = Object.create(null);
   headers.forEach((value, key) => {
     if (key.toLowerCase() === "set-cookie") return;
     result[key.toLowerCase()] = value;

--- a/packages/tech-detect/src/detect.ts
+++ b/packages/tech-detect/src/detect.ts
@@ -119,7 +119,10 @@ function extractVersion(fingerprint: TechFingerprint, input: TechDetectInput): s
  * attribute orders are handled — some CMSes emit `content=… name=generator`.
  */
 function extractMetaFromHtml(html: string): Record<string, string> {
-  const out: Record<string, string> = {};
+  // Object.create(null): `name` is page-controlled, so on a plain object the
+  // `key in out` guard below would be true for `constructor`/`__proto__` from
+  // the prototype chain and drop those tags before they reach a detector.
+  const out: Record<string, string> = Object.create(null);
   // Quoted attributes only — unquoted generator tags are vanishingly rare.
   const sample = html.slice(0, 51200);
   const tagRe = /<meta\b[^>]*>/gi;

--- a/packages/tech-detect/tests/untrusted-meta.test.ts
+++ b/packages/tech-detect/tests/untrusted-meta.test.ts
@@ -1,0 +1,56 @@
+// `<meta name=…>` is page-controlled, so the auto-extracted meta map is keyed by
+// attacker-chosen strings. On a plain `{}` accumulator the `key in out` de-dupe
+// guard is satisfied by Object.prototype's own members, which drops those tags
+// before any detector sees them.
+
+import { describe, expect, test } from "bun:test";
+
+import { detectTechnologies } from "../src/detect";
+import type { TechDetectInput } from "../src/types";
+
+const FINGERPRINTS = [
+  {
+    id: "proto-canary",
+    name: "Proto Canary",
+    category: "cms" as const,
+    detectors: [{ type: "meta" as const, name: "constructor", pattern: /canary/ }],
+  },
+];
+
+function input(html: string): TechDetectInput {
+  return { url: "https://hostile.test/", html, headers: {} };
+}
+
+describe("tech-detect meta extraction over untrusted names", () => {
+  test("a meta tag named after a prototype member still reaches its detector", () => {
+    const detected = detectTechnologies(
+      input('<meta name="constructor" content="canary">'),
+      FINGERPRINTS
+    );
+    expect(detected.map((d) => d.id)).toEqual(["proto-canary"]);
+  });
+
+  test("hostile meta names do not touch the global prototype", () => {
+    const before = Object.getOwnPropertyNames(Object.prototype);
+    detectTechnologies(
+      input(
+        '<meta name="__proto__" content="polluted"><meta name="constructor" content="polluted">' +
+          '<meta name="prototype" content="polluted"><meta name="generator" content="WordPress">'
+      )
+    );
+    const added = Object.getOwnPropertyNames(Object.prototype).filter(
+      (key) => !before.includes(key)
+    );
+    for (const key of added) delete (Object.prototype as Record<string, unknown>)[key];
+    expect(added).toEqual([]);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  test("a caller-supplied meta map is still honoured", () => {
+    const detected = detectTechnologies(
+      { ...input("<html></html>"), meta: { constructor: "canary" } },
+      FINGERPRINTS
+    );
+    expect(detected.map((d) => d.id)).toEqual(["proto-canary"]);
+  });
+});

--- a/packages/utils/src/schema-rich-results.ts
+++ b/packages/utils/src/schema-rich-results.ts
@@ -10,6 +10,11 @@ import type { SchemaCollection } from "@squirrelscan/core-contracts";
  * wrappers (nested recursively). Returns [] for unparseable input.
  * Rules that JSON.parse `schema.raw` and only inspect top-level keys
  * silently miss everything on @graph sites — always go through this.
+ *
+ * The returned nodes are raw JSON.parse output from an audited page, so a node
+ * can carry an OWN property literally named `__proto__` or `constructor`. That
+ * is harmless to hold and to read, but a consumer must never bracket-copy those
+ * keys onto a plain `{}` — see @squirrelscan/core-contracts/untrusted-keys.
  */
 export function flattenJsonLdNodes(raw: string): Record<string, unknown>[] {
   // raw may be several JSON-LD blocks joined with blank lines (one per


### PR DESCRIPTION
## What

A pass over every path that turns an audited site's bytes into JavaScript objects, checking each one for the prototype-pollution sink shapes: computed member assignment where the key comes from a parsed document, `Object.assign`/spread onto a non-literal target, and hand-rolled deep-merge or flatten helpers.

Surfaces covered: JSON-LD blocks including nested `@graph`, `.well-known/*.json` and `openapi.json`, sitemap XML, HTTP response headers, `<meta name=…>` maps, and the `squirrel.toml` a repo under audit can ship.

## What was already fine

Most of it, and it is worth writing down why so the next reader does not have to re-derive it:

- `JSON.parse` builds properties with CreateDataProperty, so `{"__proto__": {...}}` becomes a real own property and the parsed object's prototype is untouched. The hazard is only in what a consumer copies that key **onto**.
- JSON-LD flattening pushes parsed nodes into an array and normalises with object-literal spread, which is also CreateDataProperty. No computed-key assignment anywhere in that path.
- The `.well-known` and OpenAPI probes only call `Object.keys()` and read fixed literal field names.
- The XML parser rejects reserved element names, and attributes are namespaced with a prefix.

## What needed fixing

Several accumulators keyed by site-controlled strings were plain `{}`, which is wrong in two different ways:

- **Response header records and meta-tag maps silently lost data.** Assigning a string to `__proto__` on a plain object hits the inherited setter and is a no-op, so a `__proto__` response header vanished. The `key in out` de-dupe guard on the meta maps consults the prototype chain, so `<meta name="constructor">` was skipped before any detector saw it. These accumulators are now `Object.create(null)`, which has no inherited accessor to trigger and no inherited keys to collide with.
- **`squirrel config set` wrote through the prototype.** The dotted-key setter descended into `obj[segment]` without checking the segment, so a key path beginning `__proto__.` or `constructor.prototype.` resolved to the shared prototype and the final assignment landed there. Those segments are now rejected. The config deep-merge skips the same keys, since TOML can express them as tables.

## Also in here

- A shared `untrusted-keys` module in `core-contracts` that documents the two shapes and which fix each one needs: a fresh accumulator wants `Object.create(null)` and should keep every key; walking into or merging onto an object you did not create wants an explicit key skip.
- A regression suite driven by hostile fixtures built with real `JSON.parse` (an object literal `{ __proto__: … }` is spec-special-cased to set the prototype at construction time, so a fixture written that way cannot reproduce the bug and the test would be a false negative). Every assertion is on the **global** prototype, not on the returned object.
- `well-known` gets a subpath export so it is reachable from the suite that CI actually runs.

## Verification

- `bun test` in `apps/cli`: 1702 pass, 0 fail.
- `bun run typecheck` across all workspaces: clean.
- `bun run lint` and `bun run format:check`: clean.
- Package suites for crawler, fetchers, core-contracts, parser and tech-detect: all pass.
- Each behavioural fix was confirmed to fail without it (revert, red, restore).