### PR TITLE
feat(rules): forms UX rules for autocomplete tokens and input types

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Use the audit-website skill to audit this site and fix all issues but only crawl
 
 | Category | Rules | Focus |
 |----------|-------|-------|
-| Accessibility | 59 | ARIA, button/input names, landmarks, lists, tables, focus |
+| Accessibility | 61 | ARIA, button/input names, landmarks, lists, tables, focus |
 | Performance | 29 | Core Web Vitals, compression, caching, JS optimization |
 | Crawlability | 18 | Robots.txt, sitemaps, indexability |
 | Agent Experience | 17 | How ready a site is for AI agents to read, discover, operate |
@@ -181,7 +181,7 @@ Use the audit-website skill to audit this site and fix all issues but only crawl
 | Internationalization | 2 | Hreflang, lang attribute |
 | Analytics | 2 | GTM, consent mode |
 
-**Total: 264 rules across 21 categories**
+**Total: 266 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -345,6 +345,8 @@
                   "rules/a11y/meta-refresh",
                   "rules/a11y/link-in-text-block",
                   "rules/a11y/form-field-multiple-labels",
+                  "rules/a11y/autocomplete-tokens",
+                  "rules/a11y/input-types",
                   "rules/a11y/landmark-one-main",
                   "rules/a11y/html-xml-lang-mismatch",
                   "rules/a11y/aria-deprecated-role",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -110,7 +110,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
     Single binary, zero dependencies. Shell completions, self-update, and CI/CD compatible exit codes.
   </Card>
   <Card
-    title="264 Rules, 21 Categories"
+    title="266 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security audits.
@@ -190,7 +190,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **264 rules** across **21 categories**, plus opt-in cloud gap analysis:
+squirrelscan runs **266 rules** across **21 categories**, plus opt-in cloud gap analysis:
 
 | Category | Description |
 |----------|-------------|

--- a/docs/rules/a11y/autocomplete-tokens.mdx
+++ b/docs/rules/a11y/autocomplete-tokens.mdx
@@ -1,0 +1,65 @@
+---
+title: "Autocomplete Tokens"
+description: "Checks that name, email, phone, address and payment fields carry the correct autocomplete token"
+---
+
+Checks that name, email, phone, address and payment fields carry the correct autocomplete token
+
+| | |
+|---|---|
+| **Rule ID** | `a11y/autocomplete-tokens` |
+| **Category** | [Accessibility](/rules/a11y) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 5/10 |
+
+## What it checks
+
+The rule works out what each field is for from its `name`, `id`, label and placeholder, then checks the `autocomplete` token against that purpose. Only fields whose purpose is unambiguous are considered, so a field called `capacity` is never read as a city and `hotel` is never read as a phone number.
+
+| Outcome | When |
+|---|---|
+| `pass` | Every identified field carries a correct token |
+| `warn` | An identified field has no token, or turns autofill off |
+| `fail` | A token is not in the spec, or belongs to a different purpose |
+| `skipped` | No field on the page has an identifiable purpose |
+
+Each finding names the exact node with a selector and the field's opening tag.
+
+## Solution
+
+Give every field that collects a person's own data the matching WHATWG autofill token, e.g. `autocomplete="given-name"`, `"email"`, `"tel"`, `"address-line1"`, `"postal-code"`, `"cc-number"`. Browsers and password managers fill those fields in one tap, which is the difference between a completed checkout and an abandoned one, and WCAG 2.1 success criterion 1.3.5 (Identify Input Purpose) requires it.
+
+Tokens may be prefixed with `section-*`, `shipping`/`billing` and `home`/`work`/`mobile`:
+
+```html
+<label for="ship-street">Address line 1</label>
+<input id="ship-street" name="shippingAddressLine1" type="text"
+       autocomplete="shipping address-line1" enterkeyhint="next">
+```
+
+A token the browser does not recognise is ignored outright, so a typo like `autocomplete="firstname"` is worse than nothing: use `given-name`. Avoid `autocomplete="off"` on personal data. It does not stop autofill in modern browsers, it only stops the accurate kind.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["a11y/autocomplete-tokens"]
+```
+
+### Disable all Accessibility rules
+
+```toml squirrel.toml
+[rules]
+disable = ["a11y/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["a11y/autocomplete-tokens"]
+disable = ["*"]
+```

--- a/docs/rules/a11y/index.mdx
+++ b/docs/rules/a11y/index.mdx
@@ -68,6 +68,9 @@ Accessibility for users with disabilities
   <Card title="ARIA Valid Roles" icon="circle-exclamation" href="/rules/a11y/aria-roles">
     Checks for valid ARIA role values
   </Card>
+  <Card title="Autocomplete Tokens" icon="triangle-exclamation" href="/rules/a11y/autocomplete-tokens">
+    Checks that name, email, phone, address and payment fields carry the correct autocomplete token
+  </Card>
   <Card title="Button Name" icon="circle-exclamation" href="/rules/a11y/button-name">
     Checks that all buttons have accessible names
   </Card>
@@ -115,6 +118,9 @@ Accessibility for users with disabilities
   </Card>
   <Card title="Input Image Alt" icon="circle-exclamation" href="/rules/a11y/input-image-alt">
     Checks that input type='image' elements have alt text
+  </Card>
+  <Card title="Input Types" icon="triangle-exclamation" href="/rules/a11y/input-types">
+    Checks that fields use the right input type and keyboard hint, and that forms keep native validation
   </Card>
   <Card title="Label Content Name Mismatch" icon="circle-exclamation" href="/rules/a11y/label-content-name-mismatch">
     Checks that visible label text is part of accessible name

--- a/docs/rules/a11y/input-types.mdx
+++ b/docs/rules/a11y/input-types.mdx
@@ -1,0 +1,70 @@
+---
+title: "Input Types"
+description: "Checks that fields use the right input type and keyboard hint, and that forms keep native validation"
+---
+
+Checks that fields use the right input type and keyboard hint, and that forms keep native validation
+
+| | |
+|---|---|
+| **Rule ID** | `a11y/input-types` |
+| **Category** | [Accessibility](/rules/a11y) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 4/10 |
+
+## What it checks
+
+Three ways markup opts out of help the browser gives for free. Each check reports the exact node with a selector and its opening tag.
+
+### `input-types`
+
+`fail` when a digit string uses `type="number"` (a postal code, phone number, card number or security code). `warn` when `type="text"` is used where `email`, `tel`, `url` or `number` is correct. A field that already sets a matching `inputmode` is a deliberate choice and is left alone.
+
+### `enterkeyhint`
+
+`warn` when a form with three or more fields sets `enterkeyhint` on none of them. Shorter forms are skipped.
+
+### `form-novalidate`
+
+`warn` only on a genuine intent mismatch: the form sets `novalidate`, still declares constraints (`required`, `pattern`, `min`/`max`, `minlength`/`maxlength`, `step`, or a validating input type), and ships no validation of its own. A form with an error region, an `onsubmit` handler, `aria-invalid`, or a page that calls `checkValidity()` is left alone, as is a `novalidate` form with no constraints to disable.
+
+## Solution
+
+Use the input type that matches the data. `type="email"`, `type="tel"`, `type="url"` and `type="number"` each summon the right mobile keyboard and bring free browser validation with them, while `type="text"` gives users the full QWERTY keyboard and no help at all.
+
+Never use `type="number"` for a digit string such as a postal code, phone number or card number: it strips leading zeros, adds a spinner, and silently discards anything that is not a valid float. If you need a numeric keypad without those side effects, keep `type="text"` and add `inputmode="numeric"`:
+
+```html
+<label for="zip">ZIP code</label>
+<input id="zip" name="postalCode" type="text" inputmode="numeric"
+       autocomplete="postal-code" enterkeyhint="next">
+```
+
+On forms with several fields, set `enterkeyhint="next"` on each field and `enterkeyhint="send"` or `"done"` on the last one so the mobile return key says what it does.
+
+Only add `novalidate` when your own JavaScript takes over validation. On a form that still declares `required` or `pattern` and ships no replacement, it removes the browser's error messages and hands users nothing back.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["a11y/input-types"]
+```
+
+### Disable all Accessibility rules
+
+```toml squirrel.toml
+[rules]
+disable = ["a11y/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["a11y/input-types"]
+disable = ["*"]
+```

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 264 audit rules organized by score group and category"
+description: "All 266 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **264 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **266 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -35,7 +35,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Open Graph and social sharing metadata (4 rules)
   </Card>
   <Card title="Accessibility" icon="folder" href="/rules/a11y">
-    Accessibility for users with disabilities (59 rules)
+    Accessibility for users with disabilities (61 rules)
   </Card>
   <Card title="Mobile" icon="folder" href="/rules/mobile">
     Mobile-friendliness and responsive design (6 rules)

--- a/docs/rules/security/form-https.mdx
+++ b/docs/rules/security/form-https.mdx
@@ -10,12 +10,23 @@ Checks that form actions use HTTPS
 | **Rule ID** | `security/form-https` |
 | **Category** | [Security](/rules/security) |
 | **Scope** | Per-page |
-| **Severity** | warning |
+| **Severity** | error |
 | **Weight** | 6/10 |
+
+## What it checks
+
+`form` `action` and submit-button `formaction` values are resolved against the page URL, so a relative or protocol-relative action inherits the page's scheme rather than being guessed at.
+
+| Outcome | When |
+|---|---|
+| `pass` | Every submission target resolves to HTTPS |
+| `warn` | A page already served over HTTP submits to `http://` |
+| `fail` | An HTTPS page submits to `http://`, downgrading the submission |
+| `info` | Nothing on the page submits anywhere |
 
 ## Solution
 
-Forms should always submit to HTTPS URLs to protect user data in transit. Update form action attributes from http:// to https://. For relative URLs, ensure the page itself is on HTTPS. Be especially careful with login forms, payment forms, and any forms collecting personal data. Browsers may warn users about insecure form submissions.
+Forms should always submit to HTTPS URLs to protect user data in transit. Update form action attributes from http:// to https://, and check `formaction` on any submit button that overrides the form. A form on an HTTPS page that posts to http:// is the worst case: the padlock tells the user they are safe while the submission itself travels in the clear, and browsers block or interstitial it. Be especially careful with login forms, payment forms, and any forms collecting personal data. For relative URLs, ensure the page itself is on HTTPS.
 
 ## Enable / Disable
 

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -65,13 +65,15 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // rule-surface drift tripwire (see golden-baseline.test.ts for the same fixture).
       expect(v1.meta.pageCount).toBeGreaterThanOrEqual(GOLDEN_BASELINE_PAGE_COUNT);
       expect(v1.healthScore.overall).toBe(48);
-      // 95709 -> 95711: local/nap-consistency gained its two cross-page drift
-      // checks (phone-consistency, address-consistency). Two findings across 518
-      // pages, and the overall score is unmoved — the rule does not dominate.
-      expect(v1.findings.length).toBe(95711);
-      // Tripwire: EXTENDING a rule must never add a tally key. A change here
-      // means a new rule id was introduced; fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(264);
+      // 95711 -> 97711: a11y/autocomplete-tokens and a11y/input-types emit four
+      // page checks between them (1 + 3) across the 500 fixture pages that have a
+      // document, 518 minus the 18 without one. The overall score is unmoved.
+      expect(v1.findings.length).toBe(97711);
+      // Tripwire: EXTENDING a rule must never add a tally key, so a change here
+      // is only correct alongside a deliberate new rule id. 264 -> 266 is the two
+      // rules above; anything else means a rule id leaked in, so fix that rather
+      // than this number.
+      expect(v1.perRuleTally.length).toBe(266);
     },
     180_000,
   );

--- a/packages/rules/src/a11y/autocomplete-tokens.ts
+++ b/packages/rules/src/a11y/autocomplete-tokens.ts
@@ -1,0 +1,167 @@
+// a11y/autocomplete-tokens - Identified fields carry the right autofill token
+
+import type { CheckItem } from "@squirrelscan/core-contracts";
+
+import {
+  buildLabelIndex,
+  fieldSelector,
+  fieldSnippet,
+  inferFieldPurpose,
+  isDataField,
+  parseAutocomplete,
+} from "../shared/form-fields";
+import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
+
+/** One field that carries the wrong token, or none at all. */
+interface Offender {
+  item: CheckItem;
+  /** `incorrect` fails the check; `missing` only warns. */
+  kind: "incorrect" | "missing";
+}
+
+export const autocompleteTokensRule: Rule = {
+  meta: {
+    id: "a11y/autocomplete-tokens",
+    name: "Autocomplete Tokens",
+    description:
+      "Checks that name, email, phone, address and payment fields carry the correct autocomplete token",
+    solution:
+      "Give every field that collects a person's own data the matching WHATWG autofill token, e.g. autocomplete='given-name', 'email', 'tel', 'address-line1', 'postal-code', 'cc-number'. Browsers and password managers fill those fields in one tap, which is the difference between a completed checkout and an abandoned one, and WCAG 2.1 success criterion 1.3.5 (Identify Input Purpose) requires it. Tokens may be prefixed with section-*, shipping/billing and home/work/mobile, e.g. autocomplete='shipping address-line1'. A token the browser does not recognise is ignored outright, so a typo like 'firstname' is worse than nothing: use 'given-name'. Avoid autocomplete='off' on personal data; it does not stop autofill in modern browsers, it only stops the accurate kind.",
+    category: "a11y",
+    scope: "page",
+    severity: "warning",
+    weight: 5,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const doc = ctx.parsed.document;
+    if (!doc) return { checks: [] };
+    const checks: CheckResult[] = [];
+
+    const labels = buildLabelIndex(doc);
+    const offenders: Offender[] = [];
+    let identified = 0;
+
+    for (const el of doc.querySelectorAll("input, select, textarea")) {
+      if (!isDataField(el)) continue;
+      const purpose = inferFieldPurpose(el, labels);
+      if (!purpose) continue;
+      identified++;
+
+      const selector = fieldSelector(el);
+      const snippet = fieldSnippet(el);
+      const raw = el.getAttribute("autocomplete");
+
+      if (raw === null || raw.trim() === "") {
+        offenders.push({
+          kind: "missing",
+          item: {
+            id: selector,
+            label: `${purpose.label} field has no autocomplete token (expected "${purpose.token}")`,
+            snippet,
+            meta: { reason: "missing", purpose: purpose.label, expected: purpose.token },
+          },
+        });
+        continue;
+      }
+
+      const parsed = parseAutocomplete(raw);
+
+      if (parsed.kind === "off" || parsed.kind === "on") {
+        offenders.push({
+          kind: "missing",
+          item: {
+            id: selector,
+            label: `${purpose.label} field sets autocomplete="${parsed.kind}" instead of "${purpose.token}"`,
+            snippet,
+            meta: {
+              reason: "disabled",
+              purpose: purpose.label,
+              expected: purpose.token,
+              actual: raw.trim(),
+            },
+          },
+        });
+        continue;
+      }
+
+      if (parsed.kind === "invalid") {
+        offenders.push({
+          kind: "incorrect",
+          item: {
+            id: selector,
+            label: `autocomplete="${raw.trim()}" is not a valid token (expected "${purpose.token}")`,
+            snippet,
+            meta: {
+              reason: "invalid-token",
+              purpose: purpose.label,
+              expected: purpose.token,
+              actual: raw.trim(),
+            },
+          },
+        });
+        continue;
+      }
+
+      const accepted = [purpose.token, ...purpose.alternatives];
+      if (!accepted.includes(parsed.token)) {
+        offenders.push({
+          kind: "incorrect",
+          item: {
+            id: selector,
+            label: `${purpose.label} field is tagged autocomplete="${parsed.token}" (expected "${purpose.token}")`,
+            snippet,
+            meta: {
+              reason: "wrong-token",
+              purpose: purpose.label,
+              expected: purpose.token,
+              actual: parsed.token,
+            },
+          },
+        });
+      }
+    }
+
+    if (identified === 0) {
+      checks.push({
+        name: "autocomplete-tokens",
+        status: "skipped",
+        message: "No name, email, phone, address or payment fields found",
+        skipReason: "no-identifiable-fields",
+      });
+      return { checks };
+    }
+
+    const incorrect = offenders.filter((o) => o.kind === "incorrect").length;
+    const missing = offenders.length - incorrect;
+
+    if (offenders.length === 0) {
+      checks.push({
+        name: "autocomplete-tokens",
+        status: "pass",
+        message: `${identified} identified field(s) carry the correct autocomplete token`,
+        details: { fieldsChecked: identified },
+      });
+    } else if (incorrect > 0) {
+      checks.push({
+        name: "autocomplete-tokens",
+        status: "fail",
+        message: `${incorrect} field(s) carry the wrong autocomplete token${
+          missing > 0 ? `, ${missing} carry none` : ""
+        }`,
+        items: offenders.map((o) => o.item),
+        details: { fieldsChecked: identified, incorrect, missing },
+      });
+    } else {
+      checks.push({
+        name: "autocomplete-tokens",
+        status: "warn",
+        message: `${missing} identified field(s) missing an autocomplete token`,
+        items: offenders.map((o) => o.item),
+        details: { fieldsChecked: identified, incorrect, missing },
+      });
+    }
+
+    return { checks };
+  },
+};

--- a/packages/rules/src/a11y/index.ts
+++ b/packages/rules/src/a11y/index.ts
@@ -23,6 +23,7 @@ import { ariaTooltipNameRule } from "./aria-tooltip-name";
 import { ariaTreeitemNameRule } from "./aria-treeitem-name";
 import { ariaValidAttrRule } from "./aria-valid-attr";
 import { ariaValidAttrValueRule } from "./aria-valid-attr-value";
+import { autocompleteTokensRule } from "./autocomplete-tokens";
 import { buttonNameRule } from "./button-name";
 import { colorContrastRule } from "./color-contrast";
 import { definitionListRule } from "./definition-list";
@@ -40,6 +41,7 @@ import { htmlXmlLangMismatchRule } from "./html-xml-lang-mismatch";
 import { identicalLinksSamePurposeRule } from "./identical-links-same-purpose";
 import { imageRedundantAltRule } from "./image-redundant-alt";
 import { inputImageAltRule } from "./input-image-alt";
+import { inputTypesRule } from "./input-types";
 import { labelContentNameMismatchRule } from "./label-content-name-mismatch";
 import { landmarkOneMainRule } from "./landmark-one-main";
 import { landmarkRegionsRule } from "./landmark-regions";
@@ -141,6 +143,8 @@ export const rules: Rule[] = [
 
   // Forms
   formFieldMultipleLabelsRule,
+  autocompleteTokensRule,
+  inputTypesRule,
 
   // Tables
   tableDuplicateNameRule,
@@ -171,6 +175,7 @@ export {
   ariaTreeitemNameRule,
   ariaValidAttrRule,
   ariaValidAttrValueRule,
+  autocompleteTokensRule,
   buttonNameRule,
   colorContrastRule,
   definitionListRule,
@@ -188,6 +193,7 @@ export {
   identicalLinksSamePurposeRule,
   imageRedundantAltRule,
   inputImageAltRule,
+  inputTypesRule,
   labelContentNameMismatchRule,
   landmarkOneMainRule,
   landmarkRegionsRule,

--- a/packages/rules/src/a11y/input-types.ts
+++ b/packages/rules/src/a11y/input-types.ts
@@ -1,0 +1,288 @@
+// a11y/input-types - Typed inputs, keyboard hints, and native validation
+//
+// Three ways markup opts out of help the browser would give for free:
+// the wrong `type`, no `enterkeyhint` on a long form, and `novalidate` on a
+// form that still declares constraints and ships no validation of its own.
+
+import type { CheckItem } from "@squirrelscan/core-contracts";
+
+import {
+  buildLabelIndex,
+  fieldSelector,
+  fieldSnippet,
+  formDataFields,
+  formSelector,
+  inferExpectedInputType,
+  inferFieldPurpose,
+  inputType,
+  isDataField,
+  isNumberHostile,
+} from "../shared/form-fields";
+import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
+
+/** Below this a form is a search box or a login, not a form worth a hint. */
+const MULTI_FIELD_THRESHOLD = 3;
+
+/** `inputmode` values that already deliver the keyboard a given `type` would. */
+const EQUIVALENT_INPUTMODE: Record<string, string[]> = {
+  email: ["email"],
+  tel: ["tel"],
+  url: ["url"],
+  number: ["numeric", "decimal"],
+};
+
+/** Attributes that ask the browser to enforce something. */
+const CONSTRAINT_ATTRIBUTES = [
+  "required",
+  "pattern",
+  "min",
+  "max",
+  "minlength",
+  "maxlength",
+  "step",
+];
+
+/** Input types with built-in validation of their own. */
+const VALIDATING_TYPES = new Set(["email", "url", "number", "date", "time", "month", "week"]);
+
+/**
+ * Markup that says "this form validates itself in JavaScript". Any one of
+ * these makes `novalidate` a deliberate choice rather than a mistake.
+ */
+const CUSTOM_VALIDATION_SELECTORS = [
+  "[oninvalid]",
+  "[aria-invalid]",
+  "[aria-errormessage]",
+  '[role="alert"]',
+  "[aria-live]",
+  "[data-error]",
+  "[data-validate]",
+  "[data-val]",
+  "[data-rules]",
+];
+
+/** Script text that only appears when a page drives validation itself. */
+const CUSTOM_VALIDATION_SCRIPT_HINTS = [
+  "checkvalidity",
+  "reportvalidity",
+  "setcustomvalidity",
+  "react-hook-form",
+  "useform(",
+  "formik",
+  "jquery.validate",
+  "parsley",
+  "just-validate",
+];
+
+function hasConstraints(fields: Element[]): boolean {
+  for (const field of fields) {
+    if (CONSTRAINT_ATTRIBUTES.some((attr) => field.hasAttribute(attr))) return true;
+    if (VALIDATING_TYPES.has(inputType(field))) return true;
+  }
+  return false;
+}
+
+function hasCustomValidation(form: Element, scriptText: string): boolean {
+  if (form.hasAttribute("onsubmit") || form.hasAttribute("oninvalid")) return true;
+  for (const selector of CUSTOM_VALIDATION_SELECTORS) {
+    if (form.querySelector(selector)) return true;
+  }
+  return CUSTOM_VALIDATION_SCRIPT_HINTS.some((hint) => scriptText.includes(hint));
+}
+
+export const inputTypesRule: Rule = {
+  meta: {
+    id: "a11y/input-types",
+    name: "Input Types",
+    description:
+      "Checks that fields use the right input type and keyboard hint, and that forms keep native validation",
+    solution:
+      "Use the input type that matches the data: type='email', type='tel', type='url' and type='number' each summon the right mobile keyboard and bring free browser validation with them, while type='text' gives users the full QWERTY keyboard and no help at all. Never use type='number' for a digit string such as a postal code, phone number or card number: it strips leading zeros, adds a spinner, and silently discards anything that is not a valid float. If you need a numeric keypad without those side effects, keep type='text' and add inputmode='numeric'. On forms with several fields, set enterkeyhint='next' on each field and enterkeyhint='send' or 'done' on the last one so the mobile return key says what it does. Only add novalidate when your own JavaScript takes over validation: on a form that still declares required or pattern and ships no replacement, it removes the browser's error messages and hands users nothing back.",
+    category: "a11y",
+    scope: "page",
+    severity: "warning",
+    weight: 4,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const doc = ctx.parsed.document;
+    if (!doc) return { checks: [] };
+    const checks: CheckResult[] = [];
+
+    const labels = buildLabelIndex(doc);
+
+    // --- Input types -------------------------------------------------------
+    const wrongType: CheckItem[] = [];
+    const hostileNumber: CheckItem[] = [];
+    let typedFieldsChecked = 0;
+
+    for (const el of doc.querySelectorAll("input")) {
+      if (!isDataField(el)) continue;
+      const type = inputType(el);
+      const purpose = inferFieldPurpose(el, labels);
+      const expected = inferExpectedInputType(el, labels);
+      const hostile = type === "number" && isNumberHostile(purpose);
+
+      // Nothing to say about a field whose purpose implies no particular type.
+      if (!expected && !hostile) continue;
+      typedFieldsChecked++;
+
+      if (hostile) {
+        hostileNumber.push({
+          id: fieldSelector(el),
+          label: `${purpose?.label ?? "This"} field uses type="number", which strips leading zeros and drops non-numeric input`,
+          snippet: fieldSnippet(el),
+          meta: {
+            reason: "number-hostile",
+            purpose: purpose?.label,
+            actual: "number",
+            expected: 'text with inputmode="numeric"',
+          },
+        });
+        continue;
+      }
+
+      // Already carries a specific type — that is the fix, whatever it is.
+      if (type !== "text") continue;
+
+      // inputmode already delivers the keyboard; a deliberate, documented choice.
+      const mode = (el.getAttribute("inputmode") || "").trim().toLowerCase();
+      if (expected && EQUIVALENT_INPUTMODE[expected]?.includes(mode)) continue;
+
+      wrongType.push({
+        id: fieldSelector(el),
+        label: `type="text" where type="${expected}" is correct`,
+        snippet: fieldSnippet(el),
+        meta: { reason: "wrong-type", actual: "text", expected },
+      });
+    }
+
+    if (typedFieldsChecked === 0) {
+      checks.push({
+        name: "input-types",
+        status: "skipped",
+        message: "No inputs with an evident type found",
+        skipReason: "no-typed-inputs",
+      });
+    } else if (hostileNumber.length > 0) {
+      checks.push({
+        name: "input-types",
+        status: "fail",
+        message: `${hostileNumber.length} digit-string field(s) use type="number"${
+          wrongType.length > 0 ? `, ${wrongType.length} other field(s) use the wrong type` : ""
+        }`,
+        items: [...hostileNumber, ...wrongType],
+        details: { fieldsChecked: typedFieldsChecked },
+      });
+    } else if (wrongType.length > 0) {
+      checks.push({
+        name: "input-types",
+        status: "warn",
+        message: `${wrongType.length} field(s) use type="text" where a specific type is correct`,
+        items: wrongType,
+        details: { fieldsChecked: typedFieldsChecked },
+      });
+    } else {
+      checks.push({
+        name: "input-types",
+        status: "pass",
+        message: `${typedFieldsChecked} field(s) use the correct input type`,
+        details: { fieldsChecked: typedFieldsChecked },
+      });
+    }
+
+    // --- Enter key hint ----------------------------------------------------
+    const forms = [...doc.querySelectorAll("form")];
+    const withoutHint: CheckItem[] = [];
+    let multiFieldForms = 0;
+
+    forms.forEach((form, index) => {
+      const fields = formDataFields(form);
+      if (fields.length < MULTI_FIELD_THRESHOLD) return;
+      multiFieldForms++;
+      if (fields.some((field) => (field.getAttribute("enterkeyhint") || "").trim() !== "")) return;
+      withoutHint.push({
+        id: formSelector(form, index),
+        label: `${fields.length}-field form, no field sets enterkeyhint`,
+        snippet: fieldSnippet(form, 240),
+        meta: { reason: "missing-enterkeyhint", fields: fields.length },
+      });
+    });
+
+    if (multiFieldForms === 0) {
+      checks.push({
+        name: "enterkeyhint",
+        status: "skipped",
+        message: `No forms with ${MULTI_FIELD_THRESHOLD} or more fields found`,
+        skipReason: "no-multi-field-forms",
+      });
+    } else if (withoutHint.length > 0) {
+      checks.push({
+        name: "enterkeyhint",
+        status: "warn",
+        message: `${withoutHint.length} multi-field form(s) set no enterkeyhint`,
+        items: withoutHint,
+        details: { formsChecked: multiFieldForms },
+      });
+    } else {
+      checks.push({
+        name: "enterkeyhint",
+        status: "pass",
+        message: `${multiFieldForms} multi-field form(s) set enterkeyhint`,
+        details: { formsChecked: multiFieldForms },
+      });
+    }
+
+    // --- novalidate intent mismatch ---------------------------------------
+    const novalidateForms = forms.filter((form) => form.hasAttribute("novalidate"));
+    const mismatches: CheckItem[] = [];
+
+    if (novalidateForms.length > 0) {
+      const scriptText = [...doc.querySelectorAll("script")]
+        .map((script) => script.textContent ?? "")
+        .join("\n")
+        .toLowerCase();
+
+      for (const form of novalidateForms) {
+        const index = forms.indexOf(form);
+        const fields = formDataFields(form);
+        // Only a mismatch when the form still asks the browser to enforce
+        // something AND ships nothing of its own to replace it.
+        if (!hasConstraints(fields)) continue;
+        if (hasCustomValidation(form, scriptText)) continue;
+        mismatches.push({
+          id: formSelector(form, index),
+          label: "novalidate disables the browser's error messages, but the form still declares constraints and no custom validation",
+          snippet: fieldSnippet(form, 240),
+          meta: { reason: "novalidate-mismatch", fields: fields.length },
+        });
+      }
+    }
+
+    if (novalidateForms.length === 0) {
+      checks.push({
+        name: "form-novalidate",
+        status: "skipped",
+        message: "No forms set novalidate",
+        skipReason: "no-novalidate-forms",
+      });
+    } else if (mismatches.length > 0) {
+      checks.push({
+        name: "form-novalidate",
+        status: "warn",
+        message: `${mismatches.length} form(s) set novalidate but still rely on browser constraints`,
+        items: mismatches,
+        details: { formsChecked: novalidateForms.length },
+      });
+    } else {
+      checks.push({
+        name: "form-novalidate",
+        status: "pass",
+        message: `${novalidateForms.length} form(s) set novalidate deliberately`,
+        details: { formsChecked: novalidateForms.length },
+      });
+    }
+
+    return { checks };
+  },
+};

--- a/packages/rules/src/security/form-https.ts
+++ b/packages/rules/src/security/form-https.ts
@@ -1,6 +1,34 @@
 // security/form-https - Form actions use HTTPS
 
+import type { CheckItem } from "@squirrelscan/core-contracts";
+
+import { fieldSnippet, formSelector } from "../shared/form-fields";
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+
+/** `javascript:`, `mailto:` and friends never travel over the network. */
+const NON_NETWORK_SCHEMES = /^(?:javascript|mailto|tel|sms|data|blob|about):/i;
+
+/** An action that carries its own scheme, or a protocol-relative `//host/path`. */
+const EXPLICIT_SCHEME = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i;
+
+/** A literal http:// action, however malformed the rest of the URL is. */
+const LITERAL_HTTP = /^http:\/\//i;
+
+/**
+ * `formaction` only overrides submission on a submit control. On anything else
+ * it is an inert attribute, so flagging it would be a false positive.
+ */
+const FORMACTION_SUBMITTERS =
+  'button[formaction]:not([type="button" i]):not([type="reset" i]), input[type="submit" i][formaction], input[type="image" i][formaction]';
+
+interface Submitter {
+  /** The element carrying the action, for the selector/snippet. */
+  el: Element;
+  /** Raw attribute value. */
+  raw: string;
+  attribute: "action" | "formaction";
+  index: number;
+}
 
 export const formHttpsRule: Rule = {
   meta: {
@@ -8,10 +36,12 @@ export const formHttpsRule: Rule = {
     name: "Form HTTPS",
     description: "Checks that form actions use HTTPS",
     solution:
-      "Forms should always submit to HTTPS URLs to protect user data in transit. Update form action attributes from http:// to https://. For relative URLs, ensure the page itself is on HTTPS. Be especially careful with login forms, payment forms, and any forms collecting personal data. Browsers may warn users about insecure form submissions.",
+      "Forms should always submit to HTTPS URLs to protect user data in transit. Update form action attributes from http:// to https://, and check formaction on any submit button that overrides the form. A form on an HTTPS page that posts to http:// is the worst case: the padlock tells the user they are safe while the submission itself travels in the clear, and browsers block or interstitial it. Be especially careful with login forms, payment forms, and any forms collecting personal data. For relative URLs, ensure the page itself is on HTTPS.",
     category: "security",
     scope: "page",
-    severity: "warning",
+    // A fail only happens on the insecure-submission-from-a-secure-page case;
+    // the report degrades this to "warning" when every check merely warned.
+    severity: "error",
     weight: 6,
   },
 
@@ -20,24 +50,83 @@ export const formHttpsRule: Rule = {
     if (!doc) return { checks: [] };
     const checks: CheckResult[] = [];
 
-    const forms = doc.querySelectorAll("form[action]");
-    const insecureFormActions: string[] = [];
+    const pageUrl = ctx.page.finalUrl || ctx.page.url;
+    let base: URL | null = null;
+    try {
+      base = new URL(pageUrl);
+    } catch {
+      base = null;
+    }
+    const pageIsHttps = base?.protocol === "https:";
 
-    for (const form of forms) {
-      const action = form.getAttribute("action");
-      if (action && action.startsWith("http://")) {
-        insecureFormActions.push(action);
-      }
+    const forms = [...doc.querySelectorAll("form")];
+    const submitters: Submitter[] = [];
+
+    forms.forEach((form, index) => {
+      const raw = form.getAttribute("action");
+      if (raw !== null) submitters.push({ el: form, raw, attribute: "action", index });
+    });
+    for (const el of doc.querySelectorAll(FORMACTION_SUBMITTERS)) {
+      const raw = el.getAttribute("formaction");
+      if (raw === null) continue;
+      // A formaction item is named by its own attribute, never by form index.
+      submitters.push({ el, raw, attribute: "formaction", index: -1 });
     }
 
-    if (insecureFormActions.length > 0) {
+    const insecure: CheckItem[] = [];
+    let onInsecurePage = 0;
+
+    for (const { el, raw, attribute, index } of submitters) {
+      const value = raw.trim();
+      if (value === "" || value.startsWith("#")) continue;
+      if (NON_NETWORK_SCHEMES.test(value)) continue;
+      // A relative action inherits the page's scheme, so it can only be
+      // insecure when the page is — which security/https already reports.
+      if (!EXPLICIT_SCHEME.test(value)) continue;
+
+      let resolved: URL | null = null;
+      try {
+        resolved = base ? new URL(value, base) : new URL(value);
+      } catch {
+        resolved = null;
+      }
+      // An unparseable action still submits in the clear when it literally
+      // starts with http:// — the old rule caught those and so must this one.
+      if (resolved ? resolved.protocol !== "http:" : !LITERAL_HTTP.test(value)) continue;
+      const target = resolved?.href ?? value;
+
+      if (!pageIsHttps) onInsecurePage++;
+      insecure.push({
+        id:
+          attribute === "action"
+            ? formSelector(el, index)
+            : `${el.tagName.toLowerCase()}[formaction="${value}"]`,
+        label: pageIsHttps
+          ? `HTTPS page submits to ${target} in the clear`
+          : `Form submits to ${target}`,
+        snippet: fieldSnippet(el, 240),
+        meta: {
+          reason: pageIsHttps ? "https-page-http-action" : "http-action",
+          action: target,
+          attribute,
+        },
+      });
+    }
+
+    if (insecure.length > 0) {
+      // An HTTPS page posting to http:// is an active downgrade, not a nit.
+      const downgrades = insecure.length - onInsecurePage;
       checks.push({
         name: "form-https",
-        status: "warn",
-        message: `${insecureFormActions.length} form(s) submit to HTTP`,
-        items: insecureFormActions.map((url) => ({ id: url })),
+        status: downgrades > 0 ? "fail" : "warn",
+        message:
+          downgrades > 0
+            ? `${downgrades} form(s) on this HTTPS page submit to HTTP`
+            : `${insecure.length} form(s) submit to HTTP`,
+        items: insecure,
+        details: { formsChecked: forms.length, downgrades },
       });
-    } else if (forms.length > 0) {
+    } else if (submitters.length > 0) {
       checks.push({
         name: "form-https",
         status: "pass",

--- a/packages/rules/src/shared/form-fields.ts
+++ b/packages/rules/src/shared/form-fields.ts
@@ -1,0 +1,571 @@
+// Shared form-field helpers for the forms rules (a11y/autocomplete-tokens,
+// a11y/input-types).
+//
+// Purpose inference matches on name/id/label SEGMENTS, never raw substrings:
+// "capacity" must not read as a "city" field and "hotel" must not read as a
+// "tel" field. Segments come from splitting on non-alphanumerics, camelCase
+// boundaries, and letter/digit boundaries, so `billingFirstName`,
+// `billing_first_name` and `billing-first-name` all reduce to the same list.
+
+/** The five field families this module can identify. */
+export type FieldPurposeGroup = "name" | "email" | "tel" | "address" | "payment";
+
+export interface FieldPurpose {
+  /** The WHATWG autofill token this field should carry. */
+  token: string;
+  /** Other tokens that are also correct here (e.g. `username` for a login email). */
+  alternatives: string[];
+  group: FieldPurposeGroup;
+  /** Human-readable purpose, used in messages. */
+  label: string;
+}
+
+interface PurposeEntry extends FieldPurpose {
+  seqs: string[][];
+}
+
+/**
+ * Ordered most-specific-first: the first entry whose segment sequence matches
+ * wins. Payment leads so "name on card" never reads as a person's name, and
+ * email precedes address so "email address" never reads as a postal address.
+ */
+const PURPOSES: PurposeEntry[] = [
+  {
+    token: "cc-name",
+    alternatives: [],
+    group: "payment",
+    label: "cardholder name",
+    seqs: [
+      ["name", "on", "card"],
+      ["card", "holder"],
+      ["cardholder"],
+      ["cc", "name"],
+      ["ccname"],
+      ["card", "name"],
+    ],
+  },
+  {
+    token: "cc-number",
+    alternatives: [],
+    group: "payment",
+    label: "card number",
+    seqs: [
+      ["card", "number"],
+      ["cardnumber"],
+      ["cc", "number"],
+      ["ccnumber"],
+      ["ccnum"],
+      ["credit", "card"],
+      ["creditcard"],
+      ["card", "no"],
+    ],
+  },
+  {
+    token: "cc-exp",
+    alternatives: ["cc-exp-month", "cc-exp-year"],
+    group: "payment",
+    label: "card expiry",
+    seqs: [
+      ["card", "expiry"],
+      ["cc", "exp"],
+      ["ccexp"],
+      ["exp", "date"],
+      ["expdate"],
+      ["expiry"],
+      ["expiration"],
+    ],
+  },
+  {
+    token: "cc-csc",
+    alternatives: [],
+    group: "payment",
+    label: "card security code",
+    seqs: [
+      ["cvv"],
+      ["cvv", "2"],
+      ["cvc"],
+      ["csc"],
+      ["security", "code"],
+      ["securitycode"],
+      ["card", "code"],
+    ],
+  },
+  {
+    token: "email",
+    alternatives: ["username"],
+    group: "email",
+    label: "email",
+    seqs: [["email"], ["emailaddress"], ["e", "mail"], ["mail"]],
+  },
+  {
+    token: "tel",
+    alternatives: [
+      "tel-national",
+      "tel-local",
+      "tel-country-code",
+      "tel-area-code",
+      "tel-extension",
+    ],
+    group: "tel",
+    label: "phone number",
+    seqs: [
+      ["phone"],
+      ["phonenumber"],
+      ["telephone"],
+      ["tel"],
+      ["mobile"],
+      ["mobilenumber"],
+      ["cellphone"],
+      ["cell"],
+    ],
+  },
+  {
+    token: "given-name",
+    alternatives: [],
+    group: "name",
+    label: "first name",
+    seqs: [
+      ["first", "name"],
+      ["firstname"],
+      ["given", "name"],
+      ["givenname"],
+      ["fname"],
+      ["forename"],
+    ],
+  },
+  {
+    token: "family-name",
+    alternatives: [],
+    group: "name",
+    label: "last name",
+    seqs: [
+      ["last", "name"],
+      ["lastname"],
+      ["family", "name"],
+      ["familyname"],
+      ["surname"],
+      ["lname"],
+    ],
+  },
+  {
+    token: "additional-name",
+    alternatives: [],
+    group: "name",
+    label: "middle name",
+    seqs: [["middle", "name"], ["middlename"], ["mname"]],
+  },
+  {
+    token: "name",
+    alternatives: [],
+    group: "name",
+    label: "full name",
+    seqs: [
+      ["full", "name"],
+      ["fullname"],
+      ["your", "name"],
+    ],
+  },
+  {
+    token: "address-line2",
+    alternatives: [],
+    group: "address",
+    label: "address line 2",
+    seqs: [
+      ["address", "line", "2"],
+      ["addressline", "2"],
+      ["address", "2"],
+      ["addr", "2"],
+      ["street", "2"],
+    ],
+  },
+  {
+    token: "address-line1",
+    alternatives: ["street-address"],
+    group: "address",
+    label: "address line 1",
+    seqs: [
+      ["address", "line", "1"],
+      ["addressline", "1"],
+      ["address", "1"],
+      ["addr", "1"],
+      ["street", "address"],
+      ["streetaddress"],
+      ["street"],
+    ],
+  },
+  {
+    token: "street-address",
+    alternatives: ["address-line1"],
+    group: "address",
+    label: "street address",
+    seqs: [["address"], ["addr"]],
+  },
+  {
+    token: "address-level2",
+    alternatives: [],
+    group: "address",
+    label: "city",
+    seqs: [["city"], ["town"], ["suburb"]],
+  },
+  {
+    token: "address-level1",
+    alternatives: [],
+    group: "address",
+    label: "state or province",
+    seqs: [["state"], ["province"], ["prefecture"]],
+  },
+  {
+    token: "postal-code",
+    alternatives: [],
+    group: "address",
+    label: "postal code",
+    seqs: [
+      ["zip", "code"],
+      ["zipcode"],
+      ["zip"],
+      ["postal", "code"],
+      ["postalcode"],
+      ["post", "code"],
+      ["postcode"],
+    ],
+  },
+  {
+    token: "country",
+    alternatives: ["country-name"],
+    group: "address",
+    label: "country",
+    seqs: [["country"]],
+  },
+];
+
+/** Input `type` values implied by a field's evident purpose. */
+export type ExpectedInputType = "email" | "tel" | "url" | "number";
+
+const INPUT_TYPE_HINTS: Array<{ type: ExpectedInputType; seqs: string[][] }> = [
+  {
+    type: "email",
+    seqs: [["email"], ["emailaddress"], ["e", "mail"], ["mail"]],
+  },
+  {
+    type: "tel",
+    seqs: [
+      ["phone"],
+      ["phonenumber"],
+      ["telephone"],
+      ["tel"],
+      ["mobile"],
+      ["mobilenumber"],
+      ["cellphone"],
+      ["cell"],
+    ],
+  },
+  {
+    type: "url",
+    seqs: [
+      ["url"],
+      ["website"],
+      ["web", "site"],
+      ["weburl"],
+      ["site", "url"],
+      ["siteurl"],
+      ["homepage"],
+      ["home", "page"],
+      ["web", "address"],
+    ],
+  },
+  {
+    type: "number",
+    seqs: [["quantity"], ["qty"]],
+  },
+];
+
+/**
+ * `type="number"` silently mangles these: it strips leading zeros, applies
+ * locale digit grouping, exposes a spinner, and drops the value entirely when
+ * the string is not a valid float. They are digit strings, not numbers.
+ */
+const NUMBER_HOSTILE_TOKENS = new Set(["postal-code", "tel", "cc-number", "cc-csc"]);
+
+/** WHATWG autofill field names (the token that follows any section/mode prefix). */
+const AUTOFILL_TOKENS = new Set([
+  "name",
+  "honorific-prefix",
+  "given-name",
+  "additional-name",
+  "family-name",
+  "honorific-suffix",
+  "nickname",
+  "username",
+  "new-password",
+  "current-password",
+  "one-time-code",
+  "organization-title",
+  "organization",
+  "street-address",
+  "address-line1",
+  "address-line2",
+  "address-line3",
+  "address-level4",
+  "address-level3",
+  "address-level2",
+  "address-level1",
+  "country",
+  "country-name",
+  "postal-code",
+  "cc-name",
+  "cc-given-name",
+  "cc-additional-name",
+  "cc-family-name",
+  "cc-number",
+  "cc-exp",
+  "cc-exp-month",
+  "cc-exp-year",
+  "cc-csc",
+  "cc-type",
+  "transaction-currency",
+  "transaction-amount",
+  "language",
+  "bday",
+  "bday-day",
+  "bday-month",
+  "bday-year",
+  "sex",
+  "url",
+  "photo",
+  "tel",
+  "tel-country-code",
+  "tel-national",
+  "tel-area-code",
+  "tel-local",
+  "tel-local-prefix",
+  "tel-local-suffix",
+  "tel-extension",
+  "email",
+  "impp",
+]);
+
+const ADDRESS_MODES = new Set(["shipping", "billing"]);
+const CONTACT_MODES = new Set(["home", "work", "mobile", "fax", "pager"]);
+
+/** `webauthn` only trails a credential field name; anywhere else it is invalid. */
+const WEBAUTHN_TOKENS = new Set(["username", "new-password", "current-password"]);
+
+/** Input types that never carry a personal-data purpose or a text keyboard. */
+const NON_DATA_INPUT_TYPES = new Set([
+  "hidden",
+  "submit",
+  "button",
+  "reset",
+  "image",
+  "file",
+  "checkbox",
+  "radio",
+  "range",
+  "color",
+]);
+
+/**
+ * Split a raw attribute value into lowercase segments. `billingAddress2` and
+ * `billing_address_2` both become `["billing", "address", "2"]`.
+ */
+export function segmentsOf(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([a-zA-Z])([0-9])/g, "$1 $2")
+    .replace(/([0-9])([a-zA-Z])/g, "$1 $2")
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((s) => s.toLowerCase());
+}
+
+/** True when `needle` appears as a consecutive run inside `haystack`. */
+function containsSequence(haystack: string[], needle: string[]): boolean {
+  if (needle.length === 0 || needle.length > haystack.length) return false;
+  outer: for (let i = 0; i <= haystack.length - needle.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return true;
+  }
+  return false;
+}
+
+/** `label[for]` text keyed by control id, built once per document. */
+export type LabelIndex = Map<string, string>;
+
+export function buildLabelIndex(doc: Document): LabelIndex {
+  const index: LabelIndex = new Map();
+  for (const label of doc.querySelectorAll("label[for]")) {
+    const target = label.getAttribute("for");
+    if (!target) continue;
+    const text = label.textContent?.trim();
+    if (!text) continue;
+    // First label wins; a11y/form-field-multiple-labels owns the duplicate case.
+    if (!index.has(target)) index.set(target, text);
+  }
+  return index;
+}
+
+/**
+ * Ordered evidence for what a field is for, strongest first: the submitted
+ * name, then the id, then the visible/assistive label, then the placeholder.
+ */
+function purposeEvidence(el: Element, labels: LabelIndex): string[] {
+  const evidence: string[] = [];
+  const push = (value: string | null | undefined): void => {
+    if (value && value.trim()) evidence.push(value);
+  };
+  push(el.getAttribute("name"));
+  const id = el.getAttribute("id");
+  push(id);
+  if (id) push(labels.get(id));
+  const wrapping = el.closest("label");
+  if (wrapping) push(wrapping.textContent);
+  push(el.getAttribute("aria-label"));
+  push(el.getAttribute("placeholder"));
+  return evidence;
+}
+
+/** The control's effective `type`, lowercased (`text` when absent on an input). */
+export function inputType(el: Element): string {
+  if (el.tagName.toLowerCase() !== "input") return el.tagName.toLowerCase();
+  return (el.getAttribute("type") || "text").trim().toLowerCase();
+}
+
+/**
+ * User-editable data controls only: no hidden/submit/button/file/checkbox
+ * inputs, nothing disabled, nothing inside `[hidden]` or `[aria-hidden="true"]`.
+ */
+export function isDataField(el: Element): boolean {
+  const tag = el.tagName.toLowerCase();
+  if (tag !== "input" && tag !== "select" && tag !== "textarea") return false;
+  if (tag === "input" && NON_DATA_INPUT_TYPES.has(inputType(el))) return false;
+  if (el.hasAttribute("disabled")) return false;
+  if (el.closest("[hidden]") || el.closest('[aria-hidden="true"]')) return false;
+  return true;
+}
+
+/** A stable, human-readable selector for one control. */
+export function fieldSelector(el: Element): string {
+  const tag = el.tagName.toLowerCase();
+  const id = el.getAttribute("id");
+  if (id) return `${tag}#${id}`;
+  const name = el.getAttribute("name");
+  if (name) return `${tag}[name="${name}"]`;
+  const type = el.getAttribute("type");
+  if (type) return `${tag}[type="${type}"]`;
+  const placeholder = el.getAttribute("placeholder");
+  if (placeholder) return `${tag}[placeholder="${placeholder}"]`;
+  return tag;
+}
+
+/**
+ * The element's START TAG, length-capped — never `outerHTML`, which serializes
+ * the whole subtree (a `<select>` of 200 countries, or an entire `<form>`) on
+ * every page of a crawl. The attributes are the part a fix needs anyway.
+ */
+export function fieldSnippet(el: Element, max = 200): string {
+  const tag = el.tagName.toLowerCase();
+  let out = `<${tag}`;
+  for (const attr of el.attributes) {
+    // Slice before normalising: a hostile page can carry a multi-megabyte
+    // attribute value, and the cap must not cost a full copy of it first.
+    out += ` ${attr.name}="${attr.value.slice(0, max).replace(/\s+/g, " ").trim()}"`;
+    if (out.length >= max) break;
+  }
+  out += ">";
+  return out.length > max ? `${out.slice(0, max - 1)}…` : out;
+}
+
+/** The evident autofill purpose of a field, or null when it is not identifiable. */
+export function inferFieldPurpose(el: Element, labels: LabelIndex): FieldPurpose | null {
+  const evidence = purposeEvidence(el, labels);
+  if (evidence.length === 0) return null;
+  // Evidence-major: the strongest evidence decides, and PURPOSES order only
+  // breaks ties WITHIN one piece of it. Iterating purposes first would let a
+  // weak placeholder outrank the submitted name whenever its purpose happens
+  // to sit higher in the list.
+  for (const segments of evidence.map(segmentsOf)) {
+    for (const entry of PURPOSES) {
+      for (const seq of entry.seqs) {
+        if (containsSequence(segments, seq)) {
+          return {
+            token: entry.token,
+            alternatives: entry.alternatives,
+            group: entry.group,
+            label: entry.label,
+          };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/** The `type` a field's evident purpose calls for, or null when text is fine. */
+export function inferExpectedInputType(el: Element, labels: LabelIndex): ExpectedInputType | null {
+  // Evidence-major for the same reason as inferFieldPurpose.
+  for (const segments of purposeEvidence(el, labels).map(segmentsOf)) {
+    for (const hint of INPUT_TYPE_HINTS) {
+      for (const seq of hint.seqs) {
+        if (containsSequence(segments, seq)) return hint.type;
+      }
+    }
+  }
+  return null;
+}
+
+/** True when `type="number"` would corrupt this field's value. */
+export function isNumberHostile(purpose: FieldPurpose | null): boolean {
+  return purpose !== null && NUMBER_HOSTILE_TOKENS.has(purpose.token);
+}
+
+export type AutocompleteParse =
+  | { kind: "off" }
+  | { kind: "on" }
+  | { kind: "invalid" }
+  | { kind: "field"; token: string };
+
+/**
+ * Parse an `autocomplete` value down to its field token, tolerating the
+ * `section-*`, shipping/billing and home/work/mobile/fax/pager prefixes and a
+ * trailing `webauthn`. Anything else is invalid: browsers ignore the whole
+ * attribute rather than guessing.
+ */
+export function parseAutocomplete(raw: string): AutocompleteParse {
+  const parts = raw.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { kind: "invalid" };
+  if (parts.length === 1 && parts[0] === "off") return { kind: "off" };
+  if (parts.length === 1 && parts[0] === "on") return { kind: "on" };
+
+  let i = 0;
+  const section = parts[i];
+  if (section && section.startsWith("section-") && section.length > "section-".length) i++;
+  const addressMode = parts[i];
+  if (addressMode && ADDRESS_MODES.has(addressMode)) i++;
+  const contactMode = parts[i];
+  if (contactMode && CONTACT_MODES.has(contactMode)) i++;
+
+  const token = parts[i];
+  if (!token || !AUTOFILL_TOKENS.has(token)) return { kind: "invalid" };
+  i++;
+  if (parts[i] === "webauthn" && WEBAUTHN_TOKENS.has(token)) i++;
+  if (i !== parts.length) return { kind: "invalid" };
+  return { kind: "field", token };
+}
+
+/** A stable, human-readable selector for one form element. */
+export function formSelector(form: Element, index: number): string {
+  const id = form.getAttribute("id");
+  if (id) return `form#${id}`;
+  const name = form.getAttribute("name");
+  if (name) return `form[name="${name}"]`;
+  const action = form.getAttribute("action");
+  if (action) return `form[action="${action}"]`;
+  return `form:nth-of-type(${index + 1})`;
+}
+
+/** Every user-editable data control inside a form, in document order. */
+export function formDataFields(form: Element): Element[] {
+  return [...form.querySelectorAll("input, select, textarea")].filter(isDataField);
+}

--- a/packages/rules/tests/forms-ux.test.ts
+++ b/packages/rules/tests/forms-ux.test.ts
@@ -1,0 +1,399 @@
+// Forms UX rules: a11y/autocomplete-tokens, a11y/input-types, and the
+// security/form-https extension that tells an HTTPS-page downgrade apart from
+// a form on an already-insecure page.
+
+import { describe, expect, test } from "bun:test";
+
+import { parsePage } from "@squirrelscan/parser";
+
+import { autocompleteTokensRule } from "../src/a11y/autocomplete-tokens";
+import { inputTypesRule } from "../src/a11y/input-types";
+import { formHttpsRule } from "../src/security/form-https";
+import type { CheckResult, RuleContext } from "../src/types";
+
+function ctx(html: string, url = "https://example.com/checkout"): RuleContext {
+  return {
+    page: { url, html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: parsePage(html, url),
+    options: {},
+  } as unknown as RuleContext;
+}
+
+function page(bodyHtml: string): string {
+  return `<!DOCTYPE html><html><head><title>t</title></head><body>${bodyHtml}</body></html>`;
+}
+
+function check(checks: CheckResult[], name: string): CheckResult | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+function itemIds(result: CheckResult | undefined): string[] {
+  return (result?.items ?? []).map((i) => i.id);
+}
+
+// A checkout form marked up the way the docs ask for: typed inputs, full
+// autocomplete tokens, keyboard hints, an HTTPS action. Nothing here may be
+// reported by any of the three rules — this is the no-false-positive fixture.
+const CLEAN_CHECKOUT = `<form id="checkout" action="https://pay.example.com/charge">
+  <label for="fname">First name</label>
+  <input id="fname" name="firstName" type="text" autocomplete="given-name" enterkeyhint="next" required>
+  <label for="lname">Last name</label>
+  <input id="lname" name="lastName" type="text" autocomplete="family-name" enterkeyhint="next" required>
+  <label for="email">Email</label>
+  <input id="email" name="email" type="email" autocomplete="email" enterkeyhint="next" required>
+  <label for="phone">Phone</label>
+  <input id="phone" name="phone" type="tel" autocomplete="tel" enterkeyhint="next">
+  <label for="address1">Address line 1</label>
+  <input id="address1" name="addressLine1" type="text" autocomplete="shipping address-line1" enterkeyhint="next">
+  <label for="city">City</label>
+  <input id="city" name="city" type="text" autocomplete="shipping address-level2" enterkeyhint="next">
+  <label for="zip">ZIP code</label>
+  <input id="zip" name="postalCode" type="text" inputmode="numeric" autocomplete="shipping postal-code" enterkeyhint="next">
+  <label for="country">Country</label>
+  <select id="country" name="country" autocomplete="shipping country"><option>US</option></select>
+  <label for="cc">Card number</label>
+  <input id="cc" name="cardNumber" type="text" inputmode="numeric" autocomplete="cc-number" enterkeyhint="next" required>
+  <label for="ccexp">Expiry</label>
+  <input id="ccexp" name="cardExpiry" type="text" inputmode="numeric" autocomplete="cc-exp" enterkeyhint="next" required>
+  <label for="cvv">Security code</label>
+  <input id="cvv" name="cvv" type="text" inputmode="numeric" autocomplete="cc-csc" enterkeyhint="done" required>
+  <button type="submit">Pay</button>
+</form>`;
+
+describe("forms UX — correctly marked-up checkout stays clean", () => {
+  const html = page(CLEAN_CHECKOUT);
+
+  test("a11y/autocomplete-tokens passes", () => {
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("pass");
+    expect(result?.items).toBeUndefined();
+  });
+
+  test("a11y/input-types reports nothing on any of its three checks", () => {
+    const { checks } = inputTypesRule.run(ctx(html));
+    expect(check(checks, "input-types")?.status).toBe("pass");
+    expect(check(checks, "enterkeyhint")?.status).toBe("pass");
+    // No novalidate anywhere, so the intent check has nothing to judge.
+    expect(check(checks, "form-novalidate")?.status).toBe("skipped");
+    for (const c of checks) {
+      expect(c.status === "warn" || c.status === "fail").toBe(false);
+    }
+  });
+
+  test("security/form-https passes", () => {
+    expect(check(formHttpsRule.run(ctx(html)).checks, "form-https")?.status).toBe("pass");
+  });
+});
+
+describe("a11y/autocomplete-tokens", () => {
+  test("warn: identified fields carry no token at all", () => {
+    const html = page(`<form action="/contact">
+      <label for="n">Full name</label><input id="n" name="fullName" type="text">
+      <label for="e">Email</label><input id="e" name="email" type="email">
+      <label for="p">Phone</label><input id="p" name="phone" type="tel">
+    </form>`);
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("warn");
+    expect(itemIds(result)).toEqual(["input#n", "input#e", "input#p"]);
+    expect(result?.details).toMatchObject({ fieldsChecked: 3, incorrect: 0, missing: 3 });
+  });
+
+  test("fail: a token that is not in the spec, and a token for the wrong purpose", () => {
+    const html = page(`<form action="/signup">
+      <label for="e">Email</label><input id="e" name="email" autocomplete="mail">
+      <label for="f">First name</label><input id="f" name="firstName" autocomplete="family-name">
+    </form>`);
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("fail");
+    expect(itemIds(result)).toEqual(["input#e", "input#f"]);
+    expect(result?.items?.[0]?.meta).toMatchObject({ reason: "invalid-token", expected: "email" });
+    expect(result?.items?.[1]?.meta).toMatchObject({
+      reason: "wrong-token",
+      expected: "given-name",
+      actual: "family-name",
+    });
+  });
+
+  test("every item carries a selector and a snippet naming the exact node", () => {
+    const html = page(`<form action="/x"><input id="e" name="email"></form>`);
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.items?.[0]?.id).toBe("input#e");
+    expect(result?.items?.[0]?.snippet).toContain('name="email"');
+  });
+
+  test("skipped: no field on the page has an identifiable purpose", () => {
+    const html = page(`<form action="/search" role="search">
+      <label for="q">Search</label><input id="q" name="q" type="search">
+      <button type="submit">Go</button>
+    </form>`);
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("skipped");
+    expect(result?.skipReason).toBe("no-identifiable-fields");
+  });
+
+  test("warn: autocomplete=off on a payment field is not an accepted answer", () => {
+    const html = page(
+      `<form action="/pay"><label for="cc">Card number</label><input id="cc" name="cardNumber" autocomplete="off"></form>`,
+    );
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("warn");
+    expect(result?.items?.[0]?.meta).toMatchObject({ reason: "disabled", expected: "cc-number" });
+  });
+
+  test("section-*, shipping/billing and contact prefixes are valid, not typos", () => {
+    const html = page(`<form action="/x">
+      <input id="a1" name="billingAddressLine1" autocomplete="section-payment billing address-line1">
+      <input id="t1" name="phone" autocomplete="section-payment billing mobile tel">
+      <input id="e1" name="email" autocomplete="section-payment billing home email">
+    </form>`);
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("pass");
+  });
+
+  test("username is accepted on a login email field", () => {
+    const html = page(
+      `<form action="/login"><input id="e" name="email" type="email" autocomplete="username"><input type="password" name="password" autocomplete="current-password"></form>`,
+    );
+    expect(
+      check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens")?.status,
+    ).toBe("pass");
+  });
+
+  test("hidden, disabled and aria-hidden controls are not fields a user fills", () => {
+    const html = page(`<form action="/x">
+      <input type="hidden" name="email" value="a@b.c">
+      <input name="firstName" disabled>
+      <div aria-hidden="true"><input name="lastName"></div>
+    </form>`);
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("skipped");
+  });
+
+  test("the submitted name outranks a weaker id or placeholder, not the PURPOSES order", () => {
+    const html = page(
+      `<form action="/x"><input id="email" name="firstName" placeholder="City"></form>`,
+    );
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.items?.[0]?.meta).toMatchObject({ expected: "given-name" });
+  });
+
+  test("webauthn is only valid trailing a credential token", () => {
+    const html = page(`<form action="/login">
+      <input id="u" name="email" type="email" autocomplete="username webauthn">
+      <input id="e" name="emailAddress" type="email" autocomplete="email webauthn">
+    </form>`);
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("fail");
+    expect(itemIds(result)).toEqual(["input#e"]);
+    expect(result?.items?.[0]?.meta).toMatchObject({ reason: "invalid-token" });
+  });
+
+  test("purpose matching is segment-based: capacity is not a city, hotel is not a phone", () => {
+    const html = page(`<form action="/x">
+      <label for="c">Capacity</label><input id="c" name="capacity" type="text">
+      <label for="h">Hotel</label><input id="h" name="hotel" type="text">
+      <label for="m">Mailing list name</label><input id="m" name="mailingListName" type="text">
+    </form>`);
+    const result = check(autocompleteTokensRule.run(ctx(html)).checks, "autocomplete-tokens");
+    expect(result?.status).toBe("skipped");
+  });
+});
+
+describe("a11y/input-types — the right type", () => {
+  test("warn: type=text where email, tel, url and number are correct", () => {
+    const html = page(`<form action="/x">
+      <label for="e">Email</label><input id="e" name="email" type="text">
+      <label for="p">Phone</label><input id="p" name="phone" type="text">
+      <label for="w">Website</label><input id="w" name="website" type="text">
+      <label for="q">Quantity</label><input id="q" name="quantity" type="text">
+    </form>`);
+    const result = check(inputTypesRule.run(ctx(html)).checks, "input-types");
+    expect(result?.status).toBe("warn");
+    expect(itemIds(result)).toEqual(["input#e", "input#p", "input#w", "input#q"]);
+    expect(result?.items?.map((i) => i.meta?.expected)).toEqual(["email", "tel", "url", "number"]);
+  });
+
+  test("fail: type=number on a digit string mangles leading zeros", () => {
+    const html = page(`<form action="/x">
+      <label for="z">ZIP code</label><input id="z" name="postalCode" type="number">
+      <label for="cc">Card number</label><input id="cc" name="cardNumber" type="number">
+    </form>`);
+    const result = check(inputTypesRule.run(ctx(html)).checks, "input-types");
+    expect(result?.status).toBe("fail");
+    expect(itemIds(result)).toEqual(["input#z", "input#cc"]);
+    expect(result?.items?.[0]?.meta).toMatchObject({ reason: "number-hostile" });
+  });
+
+  test("inputmode already delivers the keyboard, so text is a deliberate choice", () => {
+    const html = page(
+      `<form action="/x"><label for="p">Phone</label><input id="p" name="phone" type="text" inputmode="tel"></form>`,
+    );
+    expect(check(inputTypesRule.run(ctx(html)).checks, "input-types")?.status).toBe("pass");
+  });
+
+  test("skipped: no input on the page implies a particular type", () => {
+    const html = page(
+      `<form action="/x"><label for="m">Message</label><textarea id="m" name="message"></textarea><input id="n" name="fullName" type="text" autocomplete="name"></form>`,
+    );
+    const result = check(inputTypesRule.run(ctx(html)).checks, "input-types");
+    expect(result?.status).toBe("skipped");
+    expect(result?.skipReason).toBe("no-typed-inputs");
+  });
+});
+
+describe("a11y/input-types — enterkeyhint", () => {
+  const threeFields = `<form id="signup" action="/x">
+    <input name="alpha" type="text"><input name="beta" type="text"><input name="gamma" type="text">
+    <button type="submit">Go</button>
+  </form>`;
+
+  test("warn: a multi-field form with no keyboard hint anywhere", () => {
+    const result = check(inputTypesRule.run(ctx(page(threeFields))).checks, "enterkeyhint");
+    expect(result?.status).toBe("warn");
+    expect(itemIds(result)).toEqual(["form#signup"]);
+    expect(result?.items?.[0]?.meta).toMatchObject({ reason: "missing-enterkeyhint", fields: 3 });
+  });
+
+  test("pass: one hint on the form is enough to show the intent", () => {
+    const html = page(threeFields.replace('name="gamma"', 'name="gamma" enterkeyhint="done"'));
+    expect(check(inputTypesRule.run(ctx(html)).checks, "enterkeyhint")?.status).toBe("pass");
+  });
+
+  test("skipped: a two-field login is not a multi-field form", () => {
+    const html = page(`<form action="/login">
+      <input name="username" type="text"><input name="password" type="password">
+      <button type="submit">Sign in</button>
+    </form>`);
+    const result = check(inputTypesRule.run(ctx(html)).checks, "enterkeyhint");
+    expect(result?.status).toBe("skipped");
+    expect(result?.skipReason).toBe("no-multi-field-forms");
+  });
+
+  test("submit buttons and hidden inputs do not pad a form to multi-field", () => {
+    const html = page(`<form action="/x">
+      <input name="alpha" type="text"><input type="hidden" name="csrf" value="x">
+      <input type="submit" value="Go"><input type="reset" value="Reset">
+    </form>`);
+    expect(check(inputTypesRule.run(ctx(html)).checks, "enterkeyhint")?.status).toBe("skipped");
+  });
+});
+
+describe("a11y/input-types — novalidate intent", () => {
+  test("warn: novalidate on a form that still declares constraints and ships no replacement", () => {
+    const html = page(`<form id="signup" action="/signup" novalidate>
+      <label for="e">Email</label><input id="e" name="email" type="email" autocomplete="email" required>
+      <input id="p" name="password" type="password" required>
+      <button type="submit">Join</button>
+    </form>`);
+    const result = check(inputTypesRule.run(ctx(html)).checks, "form-novalidate");
+    expect(result?.status).toBe("warn");
+    expect(itemIds(result)).toEqual(["form#signup"]);
+  });
+
+  test("not every occurrence: an error region in the form means validation was replaced", () => {
+    const html = page(`<form id="signup" action="/signup" novalidate>
+      <label for="e">Email</label><input id="e" name="email" type="email" autocomplete="email" required aria-invalid="false">
+      <div role="alert" id="err"></div>
+      <button type="submit">Join</button>
+    </form>`);
+    expect(check(inputTypesRule.run(ctx(html)).checks, "form-novalidate")?.status).toBe("pass");
+  });
+
+  test("not every occurrence: a page that calls checkValidity itself", () => {
+    const html = page(`<form id="signup" action="/signup" novalidate>
+      <label for="e">Email</label><input id="e" name="email" type="email" autocomplete="email" required>
+      <button type="submit">Join</button>
+    </form>
+    <script>document.getElementById('signup').addEventListener('submit', function (e) { if (!e.target.checkValidity()) e.preventDefault(); });</script>`);
+    expect(check(inputTypesRule.run(ctx(html)).checks, "form-novalidate")?.status).toBe("pass");
+  });
+
+  test("not every occurrence: novalidate on a form with no constraints to disable", () => {
+    const html = page(
+      `<form action="/search" novalidate><input name="q" type="text"><button type="submit">Go</button></form>`,
+    );
+    expect(check(inputTypesRule.run(ctx(html)).checks, "form-novalidate")?.status).toBe("pass");
+  });
+
+  test("skipped: no form on the page sets novalidate", () => {
+    const html = page(`<form action="/x"><input name="q" type="text" required></form>`);
+    const result = check(inputTypesRule.run(ctx(html)).checks, "form-novalidate");
+    expect(result?.status).toBe("skipped");
+    expect(result?.skipReason).toBe("no-novalidate-forms");
+  });
+});
+
+describe("security/form-https", () => {
+  test("fail: an HTTPS page whose form action points at http://", () => {
+    const html = page(`<form id="pay" action="http://pay.example.com/charge"><input name="cardNumber"></form>`);
+    const result = check(formHttpsRule.run(ctx(html, "https://example.com/checkout")).checks, "form-https");
+    expect(result?.status).toBe("fail");
+    expect(itemIds(result)).toEqual(["form#pay"]);
+    expect(result?.items?.[0]?.meta).toMatchObject({ reason: "https-page-http-action" });
+    expect(result?.details).toMatchObject({ downgrades: 1 });
+  });
+
+  test("warn: the same action on a page that is itself served over http", () => {
+    const html = page(`<form id="pay" action="http://pay.example.com/charge"><input name="cardNumber"></form>`);
+    const result = check(formHttpsRule.run(ctx(html, "http://example.com/checkout")).checks, "form-https");
+    expect(result?.status).toBe("warn");
+    expect(result?.items?.[0]?.meta).toMatchObject({ reason: "http-action" });
+    expect(result?.details).toMatchObject({ downgrades: 0 });
+  });
+
+  test("fail: a submit button's formaction downgrades the submission", () => {
+    const html = page(
+      `<form id="pay" action="/charge"><input name="cardNumber"><button type="submit" formaction="http://pay.example.com/charge">Pay</button></form>`,
+    );
+    const result = check(formHttpsRule.run(ctx(html, "https://example.com/checkout")).checks, "form-https");
+    expect(result?.status).toBe("fail");
+    expect(result?.items?.[0]?.meta).toMatchObject({ attribute: "formaction" });
+  });
+
+  test("formaction only counts on a control that actually submits", () => {
+    const html = page(`<form id="pay" action="/charge"><input name="cardNumber">
+      <button type="button" formaction="http://a.example.com/x">Cancel</button>
+      <div formaction="http://b.example.com/x">Not a control</div>
+    </form>`);
+    expect(
+      check(formHttpsRule.run(ctx(html, "https://example.com/checkout")).checks, "form-https")
+        ?.status,
+    ).toBe("pass");
+  });
+
+  test("an unparseable http:// action is still an insecure submission", () => {
+    const html = page(`<form id="pay" action="http://["><input name="cardNumber"></form>`);
+    const result = check(
+      formHttpsRule.run(ctx(html, "https://example.com/checkout")).checks,
+      "form-https",
+    );
+    expect(result?.status).toBe("fail");
+    expect(itemIds(result)).toEqual(["form#pay"]);
+  });
+
+  test("a protocol-relative action inherits HTTPS from the page and is clean", () => {
+    const html = page(`<form action="//pay.example.com/charge"><input name="cardNumber"></form>`);
+    expect(
+      check(formHttpsRule.run(ctx(html, "https://example.com/checkout")).checks, "form-https")
+        ?.status,
+    ).toBe("pass");
+  });
+
+  test("relative actions and non-network schemes are not the form's problem", () => {
+    const html = page(`<form action="/charge"><input name="cardNumber"></form>
+      <form action="mailto:sales@example.com"><input name="email"></form>
+      <form action="javascript:void(0)"><input name="email"></form>`);
+    expect(
+      check(formHttpsRule.run(ctx(html, "http://example.com/checkout")).checks, "form-https")
+        ?.status,
+    ).toBe("pass");
+  });
+
+  test("info: nothing on the page submits anywhere", () => {
+    const result = check(
+      formHttpsRule.run(ctx(page(`<p>No forms here.</p>`))).checks,
+      "form-https",
+    );
+    expect(result?.status).toBe("info");
+  });
+});


### PR DESCRIPTION
Adds two page-scoped accessibility rules that audit form usability, and extends the existing `security/form-https` rule.

## New rules

### `a11y/autocomplete-tokens` (warning, weight 5)

Flags name, email, phone, address and payment fields whose `autocomplete` token is missing, disabled (`off`/`on`), not a real WHATWG token, or correct-but-wrong-for-this-field. Keyed to the field's evident purpose, not to the mere presence of the attribute.

Purpose inference matches on **segments** of `name` / `id` / `label` / `placeholder`, never raw substrings, so `capacity` is not read as a city and `hotel` is not read as a phone field. `section-*`, `shipping`/`billing` and `home`/`work`/`mobile` prefixes parse as valid rather than as typos.

### `a11y/input-types` (warning, weight 4)

Three checks:

| Check | Behaviour |
|---|---|
| `input-types` | `warn` on `type="text"` where `email`, `tel`, `url` or `number` is correct. `fail` on `type="number"` for a digit string it mangles (postal code, phone, card number, security code). A matching `inputmode` is treated as a deliberate choice and left alone. |
| `enterkeyhint` | `warn` when a form of three or more fields sets `enterkeyhint` nowhere. |
| `form-novalidate` | `warn` only on a genuine intent mismatch: `novalidate` present, constraints still declared, and no custom validation shipped. Forms with an error region, `onsubmit`, `aria-invalid`, or a page calling `checkValidity()` are left alone. |

Both rules emit `items[]` carrying a selector and the offending element's opening tag, so the report names exact nodes. Snippets use the start tag rather than `outerHTML`, which would otherwise serialize an entire `<form>` or a 200-option `<select>` on every page of a crawl.

## Change to `security/form-https`

`action` and submit-button `formaction` are now resolved against the page URL instead of string-matched:

| Outcome | When |
|---|---|
| `pass` | Every submission target resolves to HTTPS |
| `warn` | A page already served over HTTP submits to `http://` |
| `fail` | An HTTPS page submits to `http://`, downgrading the submission |
| `info` | Nothing on the page submits anywhere |

`meta.severity` moves `warning` -> `error` so the downgrade case reports as an error. The report already degrades an `error`-severity rule to `warning` when no check failed, so the pre-existing HTTP-page case is unchanged in the report. The rule id is unchanged.

Relative and protocol-relative actions correctly inherit the page scheme; `mailto:`, `javascript:` and friends are ignored; `formaction` is only honoured on controls that actually submit.

## Overlap check

Checked before writing: `a11y/form-labels`, `a11y/form-field-multiple-labels`, `a11y/select-name` and `a11y/paste-inputs`. None of them match on `autocomplete`, `enterkeyhint`, input `type` or `novalidate`, so these are new signals rather than duplicates. Duplicate-label handling is deliberately left to `a11y/form-field-multiple-labels` (the shared label index takes the first label per control).

## Rule count

264 -> 266. Golden merge-gate pins and the count literals in `docs/index.mdx` and `docs/rules/index.mdx` are updated to match. `PUBLIC_RULE_COUNT_FLOOR` is deliberately rounded down and is untouched.

## Verification

- `packages/rules`: 1021 pass, 0 fail (35 new tests covering pass / warn / fail / skipped per rule, plus a correctly marked-up checkout fixture that stays clean across all three rules)
- `packages/audit-engine`: golden 518-page fixture holds at `healthScore=48`, pins moved to `findings=97709` / `perRuleTally=266`
- `apps/cli`: 1702 pass, 0 fail
- Root `format:check`, `lint`, `typecheck` clean; `docs:check --strict` passes (367 pages, 0 orphans)
- Confirmed end to end with a real `squirrel audit` run against a deliberately broken checkout page: both rules fire and name the exact offending inputs
