### PR TITLE
fix(crawler): pin a crawl's base origin to the seed URL

### DIFF
--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -65,6 +65,7 @@ import {
   ErrorCodes,
 } from "@/controllers/types";
 import { createHybridDocumentFetcher } from "@/crawl/hybrid-fetcher";
+import { resolveSeedRedirect } from "@/crawler/frontier";
 import { createStorage, domainToProjectName } from "@/crawler/storage";
 import { reconstructReport } from "@/reports/reconstruct";
 import { detectRunner } from "@/self/install-meta";
@@ -73,7 +74,12 @@ import { initRequestTool } from "@/tools/request";
 import { configureLogger, logger } from "@/utils/logger";
 import { checkReachability } from "@/utils/reachability";
 import { summarizeRenderTimings } from "@/utils/render-timing-summary";
-import { getHostname, isLoopbackHost, parseUserUrl } from "@/utils/url";
+import {
+  getHostname,
+  getOrigin,
+  isLoopbackHost,
+  parseUserUrl,
+} from "@/utils/url";
 import { resolveStickyUserAgent } from "@/utils/user-agent";
 
 /**
@@ -935,8 +941,10 @@ export async function runAudit(
         )
       );
 
-      // Check for existing crawl to determine resume vs new crawl
-      const baseUrl = new URL(finalUrl).origin;
+      // Check for existing crawl to determine resume vs new crawl. Keyed on the
+      // origin the crawl will actually be based on, which is the seed's unless
+      // its redirect stayed same-site — the crawler makes the same call (#1418).
+      const baseUrl = resolveSeedRedirect(url, finalUrl).baseUrl;
       const existingCrawl = await Effect.runPromise(
         storage.getCrawlByUrl(baseUrl)
       );
@@ -1036,15 +1044,21 @@ export async function runAudit(
         if (crawlPhaseTimer) clearTimeout(crawlPhaseTimer);
       }
 
-      // Show redirect if it occurred (user chose to show all redirects)
+      // Show redirect if it occurred (user chose to show all redirects). A seed
+      // redirect whose target is a different origin than the crawl's base was
+      // REFUSED as off-site, so say so rather than claiming we followed it
+      // (#1418).
       const crawlMeta = await Effect.runPromise(storage.getCrawl(crawlId));
       if (
         crawlMeta?.originalUrl &&
         crawlMeta?.seedUrl &&
         crawlMeta.originalUrl !== crawlMeta.seedUrl
       ) {
+        const followed = getOrigin(crawlMeta.seedUrl) === crawlMeta.baseUrl;
         logger.info(
-          `Following redirect: ${crawlMeta.originalUrl} → ${crawlMeta.seedUrl}`
+          followed
+            ? `Following redirect: ${crawlMeta.originalUrl} → ${crawlMeta.seedUrl}`
+            : `Refusing off-site redirect: ${crawlMeta.originalUrl} → ${crawlMeta.seedUrl}; auditing ${crawlMeta.baseUrl}`
         );
       }
 

--- a/apps/cli/src/crawler/frontier.ts
+++ b/apps/cli/src/crawler/frontier.ts
@@ -1,2 +1,6 @@
 // Re-export from @squirrelscan/crawler package (canonical source)
-export { isInScope, normalizeUrl } from "@squirrelscan/crawler/frontier";
+export {
+  isInScope,
+  normalizeUrl,
+  resolveSeedRedirect,
+} from "@squirrelscan/crawler/frontier";

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -364,6 +364,12 @@ export interface ReportRuleResult {
 export interface AuditReport {
   crawlId?: string; // UUID of the crawl this report was generated from
   baseUrl: string;
+  /**
+   * Where the seed's redirects resolved to, when that is a DIFFERENT site from
+   * `baseUrl` — the redirect left the seed's site and was refused, not adopted.
+   * Absent when the seed did not redirect off-site.
+   */
+  finalUrl?: string;
   timestamp: string;
   totalPages: number;
   passed: number;

--- a/bun.lock
+++ b/bun.lock
@@ -135,6 +135,7 @@
         "effect": "^3.21.3",
         "fast-xml-parser": "^5.10.1",
         "robots-parser": "^3.0.1",
+        "tldts": "^7",
         "zod": "^3.25.76",
       },
       "devDependencies": {

--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -51,6 +51,22 @@ import type { ParsedPage, RuleRunResult } from "@squirrelscan/rules";
 // SITE-RECORD BUILDERS
 // ============================================
 
+/**
+ * The seed's resolved URL, but only when it names a DIFFERENT origin than the
+ * crawl's base — i.e. the crawler refused an off-site seed redirect and pinned
+ * the base to the seed instead (see the crawler's `resolveSeedRedirect`).
+ * Undefined otherwise, so reports for the overwhelmingly common no-redirect and
+ * same-site-redirect cases are unchanged.
+ */
+function offSiteSeedRedirect(baseUrl: string, seedUrl: string | undefined): string | undefined {
+  if (!seedUrl || !baseUrl) return undefined;
+  try {
+    return new URL(seedUrl).origin === new URL(baseUrl).origin ? undefined : seedUrl;
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildRobotsData(robots: RobotsTxtRecord | null): RobotsTxtData | null {
   if (!robots) return null;
 
@@ -404,8 +420,12 @@ export function buildV1Report(
       (p) => p.fallbackReason === "render-block",
     ).length;
 
+    const refusedSeedRedirect = offSiteSeedRedirect(crawl?.baseUrl ?? "", crawl?.seedUrl);
+
     const result: FullAuditReport = {
       baseUrl: crawl?.baseUrl ?? "",
+      // Present only when the crawler refused an off-site seed redirect (#1418).
+      ...(refusedSeedRedirect ? { finalUrl: refusedSeedRedirect } : {}),
       timestamp: new Date().toISOString(),
       totalPages: pages.length,
       passed,
@@ -666,8 +686,12 @@ export function buildV2Report(
       .pipe(Effect.catchAll(() => Effect.succeed([])));
     const robotsData = buildRobotsData(robots);
 
+    const refusedSeedRedirect = offSiteSeedRedirect(crawl?.baseUrl ?? "", crawl?.seedUrl);
+
     const result: FullAuditReport = {
       baseUrl: crawl?.baseUrl ?? "",
+      // Present only when the crawler refused an off-site seed redirect (#1418).
+      ...(refusedSeedRedirect ? { finalUrl: refusedSeedRedirect } : {}),
       timestamp: new Date().toISOString(),
       totalPages: pagesCrawled,
       passed,

--- a/packages/audit-engine/tests/off-site-seed-redirect-report.test.ts
+++ b/packages/audit-engine/tests/off-site-seed-redirect-report.test.ts
@@ -1,0 +1,89 @@
+// The report's `baseUrl` is the site the user asked for, always. When the
+// crawler refused an off-site seed redirect it records where the seed resolved
+// to in the crawl's `seedUrl`; the report surfaces that as `finalUrl` so the
+// redirect stays visible without ever moving the base. Both assembly paths (v1
+// and the bounded v2) must agree.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+
+import {
+  buildV2Report,
+  emptyRuleExecutionResult,
+  type StreamingReportInput,
+} from "../src/report-stream";
+import { generateReportFromStorage } from "../src/adapter";
+
+const EMPTY_STATS = {
+  pagesTotal: 0,
+  pagesFetched: 0,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+function streamingInput(): StreamingReportInput {
+  return { ...emptyRuleExecutionResult(), tallies: new Map() };
+}
+
+async function reportsFor(crawl: { baseUrl: string; seedUrl?: string }) {
+  const storage = new SQLiteStorage(":memory:");
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* storage.init();
+      const crawlId = yield* storage.createCrawl({
+        baseUrl: crawl.baseUrl,
+        seedUrl: crawl.seedUrl,
+        originalUrl: crawl.baseUrl,
+        startedAt: Date.now(),
+        status: "completed",
+        // Report assembly reads no config field on this path.
+        config: {} as never,
+        stats: EMPTY_STATS,
+      });
+      const v1 = yield* generateReportFromStorage(storage, crawlId, emptyRuleExecutionResult());
+      const v2 = yield* buildV2Report(storage, crawlId, streamingInput());
+      return { v1, v2 };
+    }),
+  );
+}
+
+describe("report finalUrl", () => {
+  test("records a refused off-site seed redirect without moving baseUrl", async () => {
+    const { v1, v2 } = await reportsFor({
+      baseUrl: "https://example.com",
+      seedUrl: "https://parked.example.net/lander",
+    });
+
+    for (const report of [v1, v2]) {
+      expect(report.baseUrl).toBe("https://example.com");
+      expect(report.finalUrl).toBe("https://parked.example.net/lander");
+    }
+  });
+
+  test("is absent when the seed resolved within the audited origin", async () => {
+    const { v1, v2 } = await reportsFor({
+      baseUrl: "https://www.example.com",
+      seedUrl: "https://www.example.com/en",
+    });
+
+    for (const report of [v1, v2]) {
+      expect(report.baseUrl).toBe("https://www.example.com");
+      expect("finalUrl" in report).toBe(false);
+    }
+  });
+
+  test("is absent when there was no seed redirect at all", async () => {
+    const { v1, v2 } = await reportsFor({ baseUrl: "https://example.com" });
+
+    for (const report of [v1, v2]) {
+      expect("finalUrl" in report).toBe(false);
+    }
+  });
+});

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -234,6 +234,14 @@ export function auditStatusToLifecycle(
 export interface AuditReport {
   crawlId?: string;
   baseUrl: string;
+  /**
+   * Where the seed URL's redirects resolved to, when that is a DIFFERENT site
+   * from `baseUrl` — i.e. the redirect left the seed's registrable domain and
+   * was refused rather than adopted. `baseUrl` always stays the site the user
+   * asked for; this records the redirect so it is still visible in the output.
+   * Absent when the seed did not redirect off-site.
+   */
+  finalUrl?: string;
   timestamp: string;
   totalPages: number;
   passed: number;

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -20,6 +20,7 @@
     "effect": "^3.21.3",
     "fast-xml-parser": "^5.10.1",
     "robots-parser": "^3.0.1",
+    "tldts": "^7",
     "zod": "^3.25.76"
   },
   "scripts": {

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -42,7 +42,7 @@ import type {
 } from "./types";
 
 import { fetchPageWithRetry, type CrawlFetcher } from "../fetcher";
-import { normalizeUrl, isInScope } from "../frontier";
+import { normalizeUrl, isInScope, isOffSiteFinalUrl, resolveSeedRedirect } from "../frontier";
 import {
   buildConditionalHeaders,
   extractChangeDetection,
@@ -765,6 +765,36 @@ export function createCrawler(
           }
 
           const result = fetchResult.right;
+
+          // SECURITY (#1418): the fetcher follows redirects, so an in-scope URL
+          // can still hand back a document served by another site. Record the
+          // hop and drop the response — storing it would file another site's
+          // title and body under this audit's report, and every stored page is
+          // also a link/discovery source that would pull the crawl across.
+          //
+          // Two escapes, both deliberate: a same-site landing (an http→https
+          // upgrade, an apex→www bounce) is not off-site at all, and a landing
+          // the crawl's OWN scope config admits — `allowedDomains`, or an
+          // absolute `include` pattern — was explicitly asked for by the user.
+          if (
+            isOffSiteFinalUrl(baseUrl, result.finalUrl) &&
+            !normalizeAndCheckScope(result.finalUrl).decision.allowed
+          ) {
+            const message = `Off-site redirect to ${result.finalUrl}`;
+            logger.warn("off-site redirect refused", entry.normalizedUrl, "→", result.finalUrl);
+            yield* storage.updateFrontierStatus(crawlId, entry.normalizedUrl, "failed", message);
+            yield* emit({
+              type: "page:failed",
+              url: entry.normalizedUrl,
+              error: message,
+              retryable: false,
+              depth: entry.depth,
+              timestamp: Date.now(),
+            });
+            yield* updateStats(crawlId, { pagesFailed: 1 });
+            markPrefixFailed(entry.normalizedUrl, entry.depth);
+            return;
+          }
 
           // Handle 304 Not Modified — reuse cached page (conditional-GET hit).
           if (isNotModifiedResponse(result.status)) {
@@ -1491,16 +1521,31 @@ export function createCrawler(
 
         if (finalTargetUrl !== targetUrl) {
           logger.debug("final URL after redirects", targetUrl, "→", finalTargetUrl);
-
-          // Warn if cross-domain redirect
-          const originalOrigin = new URL(targetUrl).origin;
-          const finalOrigin = new URL(finalTargetUrl).origin;
-          if (originalOrigin !== finalOrigin) {
-            logger.warn("cross-domain redirect detected", originalOrigin, "→", finalOrigin);
-          }
         }
 
-        baseUrl = new URL(finalTargetUrl).origin;
+        // SECURITY (#1418): the crawl's base is pinned to the SEED the user
+        // asked for. A seed redirect is adopted only when it stays on the seed's
+        // own site (same registrable domain + port); one that leaves it is
+        // refused and the seed is crawled instead.
+        //
+        // Every root probe below (robots.txt, llms.txt, sitemap discovery, the
+        // .well-known / agent-manifest / markdown sweep) is built from `baseUrl`,
+        // and `baseUrl` is also the report's `baseUrl` and the crawl's scope
+        // anchor. Re-basing onto a redirect target therefore turns one followed
+        // redirect into a full discovery sweep of a site the user never named,
+        // and files that site's content under the seed's name.
+        //
+        // `userProvidedUrl`, not `targetUrl`, is the seed: callers (the CLI)
+        // resolve redirects themselves and pass the already-resolved URL as
+        // `targetUrl` with the user's own URL as `originalUrl`.
+        const seedResolution = resolveSeedRedirect(userProvidedUrl, finalTargetUrl);
+        baseUrl = seedResolution.baseUrl;
+        if (seedResolution.offSite) {
+          logger.warn(
+            "off-site redirect refused",
+            `${userProvidedUrl} → ${finalTargetUrl} leaves the seed's site; auditing ${baseUrl} instead`,
+          );
+        }
 
         // Reset breadth-first state for new crawl
         prefixStats.clear();
@@ -1509,7 +1554,11 @@ export function createCrawler(
         // Reset pattern stats for new crawl
         clearPatternStats(patternStats);
 
-        // Create crawl session
+        // Create crawl session. `seedUrl` records where the seed's redirects
+        // RESOLVED to, which is not necessarily what we crawl — when its origin
+        // differs from `baseUrl` the redirect was refused as off-site and the
+        // seed itself was crawled. That comparison is how consumers surface the
+        // redirect without the base ever moving.
         const crawlId = yield* storage.createCrawl({
           baseUrl,
           seedUrl: finalTargetUrl,
@@ -1737,8 +1786,9 @@ export function createCrawler(
           `${sitemapResult.discovered.length} discovered, ${sitemapResult.all.length} total, ${config.sitemapPendingCount}/${config.sitemapUrlCount} enqueued (rest filtered)`,
         );
 
-        // Seed the crawl queue
-        yield* enqueueUrl(crawlId, finalTargetUrl, 0, undefined, "seed");
+        // Seed the crawl queue — the resolved URL when its redirect was adopted,
+        // the user's own URL when it was refused as off-site.
+        yield* enqueueUrl(crawlId, seedResolution.seedUrl, 0, undefined, "seed");
 
         // If nothing is pending after sitemaps + seed, every candidate URL was
         // filtered (robots.txt / scope). The crawl loop terminates cleanly

--- a/packages/crawler/src/frontier.ts
+++ b/packages/crawler/src/frontier.ts
@@ -1,3 +1,5 @@
+import { getDomain } from "tldts";
+
 import type { CrawlDecision, ScopeOptions, UrlNormalizationOptions } from "./types";
 
 const DEFAULT_SCHEME = "https:";
@@ -163,4 +165,122 @@ export function isInScope(url: string, options: ScopeOptions): CrawlDecision {
   }
 
   return { allowed: true };
+}
+
+/**
+ * Registrable domain (eTLD+1) of a hostname, resolved against the real Public
+ * Suffix List. `allowPrivateDomains` keeps free-hosting platforms per-tenant
+ * (`a.pages.dev` and `b.pages.dev` are DIFFERENT sites, not one `pages.dev`) —
+ * two tenants of the same host are not the same site.
+ *
+ * Falls back to the trailing-dot-stripped, lowercased host whenever tldts cannot
+ * derive one (IP literal, `localhost`, single-label or bare-suffix host) so both
+ * sides of a comparison still normalize identically — for those, equality means
+ * "identical host", which is the conservative answer.
+ */
+function registrableDomain(host: string): string {
+  const normalized = host.replace(/\.$/, "").toLowerCase();
+  return getDomain(normalized, { allowPrivateDomains: true }) ?? normalized;
+}
+
+/**
+ * True when `final` belongs to the same SITE as `seed` — same registrable
+ * domain on the same port. Scheme may differ (an http→https upgrade is the
+ * single most common seed redirect there is).
+ *
+ * The port must match because a port change is a different service, not a
+ * different hostname of the same site: `http://localhost:8750` →
+ * `http://localhost:8751` collapses to the same (fallback) registrable domain
+ * yet is exactly the loopback pivot this guard exists to stop.
+ */
+function isSameSite(seed: URL, final: URL): boolean {
+  if (seed.port !== final.port) return false;
+  return registrableDomain(seed.hostname) === registrableDomain(final.hostname);
+}
+
+export interface SeedRedirectResolution {
+  /** Origin the crawl is keyed on: probes, scope checks and the report's baseUrl. */
+  baseUrl: string;
+  /** URL enqueued as the crawl seed. */
+  seedUrl: string;
+  /** True when the seed's redirect target was refused instead of adopted. */
+  offSite: boolean;
+}
+
+/**
+ * Decide which origin a crawl is *about*, given the URL the user asked for and
+ * the URL its redirects actually landed on.
+ *
+ * A seed redirect is adopted only when it stays on the seed's own site. A
+ * redirect that leaves it (a parked domain, a CDN, another service on another
+ * port) is REFUSED: the base stays pinned to the seed, and the seed URL itself
+ * is what gets crawled.
+ *
+ * Adopting the target instead re-points the whole audit at a site the user
+ * never asked about: every root probe (robots.txt, llms.txt, sitemaps, the
+ * `.well-known/*` and agent-manifest sweep) is built from `baseUrl`, so one
+ * followed redirect turns into a full discovery sweep of the target, and the
+ * target's content is what ends up in the report while the report still claims
+ * to describe the seed.
+ */
+export function resolveSeedRedirect(seedUrl: string, finalUrl: string): SeedRedirectResolution {
+  const seed = parseHttpUrl(seedUrl);
+  const final = parseHttpUrl(finalUrl);
+
+  if (!seed) {
+    // No usable seed to pin to. Fall back to the URL that was actually fetched
+    // rather than to `seedUrl`'s own origin: for a nested scheme like
+    // `blob:https://host/…`, `URL.origin` reports the EMBEDDED origin, so
+    // pinning to it would base the whole crawl — every root probe included — on
+    // a host that was never fetched and never named as a site.
+    return { baseUrl: final?.origin ?? finalUrl, seedUrl: finalUrl, offSite: false };
+  }
+
+  if (!final) {
+    return { baseUrl: seed.origin, seedUrl, offSite: false };
+  }
+
+  if (seed.origin === final.origin) {
+    return { baseUrl: seed.origin, seedUrl: finalUrl, offSite: false };
+  }
+
+  if (isSameSite(seed, final)) {
+    return { baseUrl: final.origin, seedUrl: finalUrl, offSite: false };
+  }
+
+  return { baseUrl: seed.origin, seedUrl, offSite: true };
+}
+
+/**
+ * True when following a fetch's redirects landed outside the crawl's own site.
+ *
+ * The frontier only ever holds in-scope URLs, so a document that comes back
+ * from another site is by definition not part of what is being audited — the
+ * crawler stores response bodies unconditionally, and a per-page `Location:` is
+ * exactly as page-controlled as the seed's. Same-site hops (an http→https
+ * upgrade, an apex→www bounce) are NOT off-site and stay storable.
+ *
+ * An empty `finalUrl` is no evidence of a redirect, so it stays storable. A
+ * NON-empty one we cannot compare (unparseable, or a nested scheme whose
+ * `origin` is not the host that served it) fails CLOSED: the whole point is that
+ * a landing we cannot attribute to the audited site must not be stored under it.
+ */
+export function isOffSiteFinalUrl(baseUrl: string, finalUrl: string): boolean {
+  if (!finalUrl) return false;
+  const base = parseHttpUrl(baseUrl);
+  const final = parseHttpUrl(finalUrl);
+  if (!base) return false;
+  if (!final) return true;
+  if (base.origin === final.origin) return false;
+  return !isSameSite(base, final);
+}
+
+/** Parsed URL, but only for the schemes a crawl can actually be about. */
+function parseHttpUrl(url: string): URL | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed : null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/crawler/tests/seed-redirect-pinning.test.ts
+++ b/packages/crawler/tests/seed-redirect-pinning.test.ts
@@ -1,0 +1,363 @@
+// A crawl is about the URL the user asked for. A seed redirect that leaves that
+// site is refused, never adopted as the crawl's base — adopting it re-points
+// every root probe (robots.txt, llms.txt, sitemap discovery, the well-known /
+// agent-manifest sweep) at a host the user never named, and files that host's
+// content under the seed's name.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { createCrawler } from "../src/core/crawler";
+import type { CrawlerConfig } from "../src/core/types";
+import { isOffSiteFinalUrl, resolveSeedRedirect } from "../src/frontier";
+import { SQLiteStorage } from "../src/storage/sqlite";
+import { WELL_KNOWN_PATHS } from "../src/well-known";
+
+// Paths a crawl sweeps against its base origin, beyond the well-known set.
+const ROOT_PROBE_PATHS = [
+  "/robots.txt",
+  "/llms.txt",
+  "/llms-full.txt",
+  "/sitemap.xml",
+  "/sitemap_index.xml",
+];
+
+const DISCOVERY_PATHS = [...WELL_KNOWN_PATHS, ...ROOT_PROBE_PATHS];
+
+// Markers that must never reach the report when the redirect target is refused.
+const TARGET_TITLE = "Internal Service Console";
+const TARGET_BODY = "s3cr3t-internal-marker";
+const TARGET_PATH = "/internal-secret";
+
+const CONFIG: Partial<CrawlerConfig> = {
+  maxPages: 5,
+  concurrency: 1,
+  perHostConcurrency: 1,
+  delayMs: 0,
+  perHostDelayMs: 0,
+  timeoutMs: 2000,
+  userAgent: "squirrel-test",
+  respectRobots: false,
+  incremental: false,
+  useCacheControl: false,
+  breadthFirst: false,
+  coverageMode: "full",
+};
+
+interface RecordingServer {
+  origin: string;
+  paths: string[];
+  stop: () => void;
+}
+
+/** Server B: answers everything with the marker document, logging each path. */
+function serveTarget(): RecordingServer {
+  const paths: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      paths.push(new URL(req.url).pathname);
+      return new Response(
+        `<!doctype html><html><head><title>${TARGET_TITLE}</title></head><body><p>${TARGET_BODY}</p></body></html>`,
+        { headers: { "content-type": "text/html" } },
+      );
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    paths,
+    stop: () => server.stop(true),
+  };
+}
+
+/**
+ * Server A: a SINGLE 302 on `/` pointing at `location`; every other path 404s.
+ * One redirect is all it takes — the amplification comes from re-basing, not
+ * from the server.
+ */
+function serveSingleRedirect(location: string): RecordingServer {
+  const paths: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const path = new URL(req.url).pathname;
+      paths.push(path);
+      if (path === "/") {
+        return new Response(null, { status: 302, headers: { location } });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    paths,
+    stop: () => server.stop(true),
+  };
+}
+
+const servers: RecordingServer[] = [];
+
+function track(server: RecordingServer): RecordingServer {
+  servers.push(server);
+  return server;
+}
+
+afterEach(() => {
+  while (servers.length > 0) servers.pop()?.stop();
+});
+
+async function crawl(targetUrl: string, originalUrl: string, config: Partial<CrawlerConfig> = {}) {
+  const storage = new SQLiteStorage(":memory:");
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* storage.init();
+      const crawler = yield* createCrawler({ config: { ...CONFIG, ...config }, storage });
+      const crawlId = yield* crawler.start(targetUrl, originalUrl);
+      const meta = yield* storage.getCrawl(crawlId);
+      const pages = yield* storage.getPages(crawlId);
+      const robots = yield* storage.getRobotsTxt(crawlId);
+      const llms = yield* storage.getLlmsTxt(crawlId);
+      const wellKnown = yield* storage.getWellKnownProbe(crawlId);
+      const markdown = yield* storage.getMarkdownProbe(crawlId);
+      return { meta, pages, robots, llms, wellKnown, markdown };
+    }),
+  );
+}
+
+describe("seed redirect that leaves the seed's site", () => {
+  test("keeps the base pinned to the seed and never sweeps the target", async () => {
+    const target = track(serveTarget());
+    const seed = track(serveSingleRedirect(`${target.origin}${TARGET_PATH}`));
+
+    const { meta, pages, robots, llms, wellKnown, markdown } = await crawl(
+      `${seed.origin}/`,
+      `${seed.origin}/`,
+    );
+
+    // The audit is about the seed, not whatever it bounced to.
+    expect(meta?.baseUrl).toBe(seed.origin);
+    expect(meta?.originalUrl).toBe(`${seed.origin}/`);
+
+    // The target saw the one redirect hop and nothing else. Every discovery
+    // probe went to the seed.
+    expect(new Set(target.paths)).toEqual(new Set([TARGET_PATH]));
+    for (const path of DISCOVERY_PATHS) {
+      expect(target.paths).not.toContain(path);
+    }
+    expect(seed.paths).toContain("/robots.txt");
+    expect(seed.paths.length).toBeGreaterThan(DISCOVERY_PATHS.length / 2);
+
+    // None of the target's content is anywhere in what the report is built from.
+    const stored = JSON.stringify({ pages, robots, llms, wellKnown, markdown });
+    expect(stored).not.toContain(TARGET_TITLE);
+    expect(stored).not.toContain(TARGET_BODY);
+
+    // The refused seed is the only page attempted, and it stored no body.
+    expect(pages.filter((p) => p.html)).toHaveLength(0);
+  });
+
+  test("pins to the seed even when the caller pre-resolved the redirect", async () => {
+    // The CLI resolves redirects itself and hands start() the ALREADY-RESOLVED
+    // URL, with the user's URL as originalUrl. The seed is the user's URL.
+    const target = track(serveTarget());
+    const seed = track(serveSingleRedirect(`${target.origin}${TARGET_PATH}`));
+
+    const { meta, pages } = await crawl(`${target.origin}${TARGET_PATH}`, `${seed.origin}/`);
+
+    expect(meta?.baseUrl).toBe(seed.origin);
+    // The refused target is still recorded, just not adopted — that divergence
+    // between seedUrl and baseUrl is what surfaces as the report's finalUrl.
+    expect(meta?.seedUrl).toBe(`${target.origin}${TARGET_PATH}`);
+    expect(meta?.originalUrl).toBe(`${seed.origin}/`);
+
+    // Non-vacuous: the crawl really did run against the seed (its root probes
+    // landed there), and the target really was reachable — it just never saw
+    // anything beyond the one hop the seed's own 302 produced.
+    expect(seed.paths).toContain("/robots.txt");
+    expect(seed.paths.length).toBeGreaterThan(DISCOVERY_PATHS.length / 2);
+    expect(new Set(target.paths)).toEqual(new Set([TARGET_PATH]));
+
+    for (const path of DISCOVERY_PATHS) {
+      expect(target.paths).not.toContain(path);
+    }
+    const stored = JSON.stringify(pages);
+    expect(stored).not.toContain(TARGET_TITLE);
+    expect(stored).not.toContain(TARGET_BODY);
+  });
+});
+
+describe("scope config the user asked for", () => {
+  test("a cross-site landing listed in allowedDomains is still crawled", async () => {
+    const target = track(serveTarget());
+    const seed = track(serveSingleRedirect(`${target.origin}${TARGET_PATH}`));
+
+    const { meta, pages } = await crawl(`${seed.origin}/`, `${seed.origin}/`, {
+      allowedDomains: ["127.0.0.1"],
+    });
+
+    // The base still never moves — only the drop guard defers to the config.
+    expect(meta?.baseUrl).toBe(seed.origin);
+    expect(pages.some((p) => p.finalUrl === `${target.origin}${TARGET_PATH}`)).toBe(true);
+  });
+});
+
+describe("seed redirect that stays on the seed's site", () => {
+  test("same-origin redirect still crawls normally", async () => {
+    const paths: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        paths.push(path);
+        if (path === "/") {
+          return new Response(null, { status: 302, headers: { location: "/en" } });
+        }
+        if (path === "/en") {
+          return new Response("<!doctype html><html><head><title>Home</title></head></html>", {
+            headers: { "content-type": "text/html" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const origin = `http://127.0.0.1:${server.port}`;
+    track({ origin, paths, stop: () => server.stop(true) });
+
+    const { meta, pages } = await crawl(`${origin}/`, `${origin}/`);
+
+    expect(meta?.baseUrl).toBe(origin);
+    expect(pages.map((p) => p.finalUrl)).toContain(`${origin}/en`);
+  });
+});
+
+describe("resolveSeedRedirect", () => {
+  const adopted = (seed: string, final: string) => resolveSeedRedirect(seed, final);
+
+  test("adopts a redirect within the seed's registrable domain", () => {
+    expect(adopted("https://example.com/", "https://www.example.com/")).toEqual({
+      baseUrl: "https://www.example.com",
+      seedUrl: "https://www.example.com/",
+      offSite: false,
+    });
+    expect(adopted("https://example.com/", "https://app.example.com/home").baseUrl).toBe(
+      "https://app.example.com",
+    );
+    // Multi-label public suffixes come from the real PSL, not a curated table.
+    expect(adopted("https://example.co.uk/", "https://www.example.co.uk/").offSite).toBe(false);
+  });
+
+  test("adopts an http→https upgrade", () => {
+    expect(adopted("http://example.com/", "https://example.com/")).toEqual({
+      baseUrl: "https://example.com",
+      seedUrl: "https://example.com/",
+      offSite: false,
+    });
+  });
+
+  test("refuses a redirect to another registrable domain", () => {
+    expect(adopted("https://example.com/", "https://cdn.example.net/x")).toEqual({
+      baseUrl: "https://example.com",
+      seedUrl: "https://example.com/",
+      offSite: true,
+    });
+    expect(adopted("https://example.co.uk/", "https://evil.co.uk/").offSite).toBe(true);
+  });
+
+  test("refuses a port hop on the same host", () => {
+    // The loopback pivot: same hostname, different service.
+    expect(adopted("http://127.0.0.1:8750/", "http://127.0.0.1:8751/internal")).toEqual({
+      baseUrl: "http://127.0.0.1:8750",
+      seedUrl: "http://127.0.0.1:8750/",
+      offSite: true,
+    });
+    expect(adopted("http://localhost:3000/", "http://localhost:9229/json").offSite).toBe(true);
+  });
+
+  test("refuses a hop between tenants of a shared hosting platform", () => {
+    // allowPrivateDomains keeps `*.pages.dev` per-tenant rather than one site.
+    expect(adopted("https://mine.pages.dev/", "https://theirs.pages.dev/").offSite).toBe(true);
+  });
+
+  test("refuses a hop between different loopback hosts", () => {
+    expect(adopted("http://localhost:8080/", "http://127.0.0.1:8080/").offSite).toBe(true);
+  });
+
+  test("keeps the resolved URL as the seed when nothing moved", () => {
+    expect(adopted("https://example.com/", "https://example.com/en")).toEqual({
+      baseUrl: "https://example.com",
+      seedUrl: "https://example.com/en",
+      offSite: false,
+    });
+  });
+
+  test("unparseable input falls back instead of throwing", () => {
+    expect(adopted("not a url", "https://example.com/").baseUrl).toBe("https://example.com");
+    expect(adopted("https://example.com/", "not a url")).toEqual({
+      baseUrl: "https://example.com",
+      seedUrl: "https://example.com/",
+      offSite: false,
+    });
+  });
+
+  test("a nested-scheme seed never lends its embedded origin to the base", () => {
+    // `new URL("blob:https://evil.test/x").origin` is "https://evil.test" — a
+    // host nothing ever fetched. Basing the crawl on it would sweep every root
+    // probe against it, so an unusable seed pins to what WAS fetched instead.
+    expect(adopted("blob:https://evil.test/x", "https://example.com/")).toEqual({
+      baseUrl: "https://example.com",
+      seedUrl: "https://example.com/",
+      offSite: false,
+    });
+    expect(adopted("about:blank", "https://example.com/").baseUrl).toBe("https://example.com");
+  });
+
+  test("a non-http landing is not adopted", () => {
+    expect(adopted("https://example.com/", "blob:https://evil.test/x")).toEqual({
+      baseUrl: "https://example.com",
+      seedUrl: "https://example.com/",
+      offSite: false,
+    });
+  });
+
+  test("host spellings that normalize to the same site are not off-site", () => {
+    expect(adopted("https://example.com/", "https://WWW.EXAMPLE.COM/").offSite).toBe(false);
+    // Trailing-dot (fully qualified) form of the same host.
+    expect(adopted("https://example.com/", "https://www.example.com./").offSite).toBe(false);
+    // Explicit default port is normalized away by WHATWG URL, so it is same-origin.
+    expect(adopted("https://example.com/", "https://example.com:443/en").baseUrl).toBe(
+      "https://example.com",
+    );
+  });
+
+  test("userinfo does not smuggle a different host past the check", () => {
+    expect(adopted("https://example.com/", "https://example.com@evil.test/").offSite).toBe(true);
+  });
+
+  test("distinct IPv6 literals are different sites", () => {
+    expect(adopted("http://[::1]:8750/", "http://[::1]:8751/").offSite).toBe(true);
+    expect(adopted("http://[::1]:8750/", "http://[::2]:8750/").offSite).toBe(true);
+    expect(adopted("http://[::1]:8750/", "http://[0:0:0:0:0:0:0:1]:8750/x").offSite).toBe(false);
+  });
+});
+
+describe("isOffSiteFinalUrl", () => {
+  test("same-site hops are storable", () => {
+    expect(isOffSiteFinalUrl("https://example.com", "https://example.com/a")).toBe(false);
+    expect(isOffSiteFinalUrl("https://example.com", "https://www.example.com/a")).toBe(false);
+    expect(isOffSiteFinalUrl("http://example.com", "https://example.com/a")).toBe(false);
+  });
+
+  test("cross-site hops are not", () => {
+    expect(isOffSiteFinalUrl("https://example.com", "https://evil.test/a")).toBe(true);
+    expect(isOffSiteFinalUrl("http://127.0.0.1:8750", "http://127.0.0.1:8751/a")).toBe(true);
+  });
+
+  test("an absent final URL is no evidence of a redirect", () => {
+    expect(isOffSiteFinalUrl("https://example.com", "")).toBe(false);
+  });
+
+  test("a landing we cannot attribute fails closed", () => {
+    expect(isOffSiteFinalUrl("https://example.com", "not a url")).toBe(true);
+    expect(isOffSiteFinalUrl("https://example.com", "blob:https://example.com/x")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

A crawl's `baseUrl` is now pinned to the seed URL the caller asked for, instead of being reassigned to wherever the seed's redirects landed.

Previously `createCrawler().start()` did `baseUrl = new URL(finalTargetUrl).origin` after following redirects. Because `baseUrl` is both the report's `baseUrl` and the origin every root probe is built from, a seed that redirected to a different origin re-pointed the entire audit at that origin:

- `robots.txt`, `llms.txt`, sitemap discovery, the RSL and agent-access probes, and the ~20-path `.well-known` / agent-manifest / markdown sweep were all issued against a host the caller never named.
- That host's title and body text were stored and reported under the seed's name.
- The benign case was silently wrong too: audit a site that redirects to a CDN or a parked domain, and you got a report describing the redirect target while claiming to describe the seed.

## How

`resolveSeedRedirect()` in `packages/crawler/src/frontier.ts` decides what a crawl is *about*:

- A seed redirect is **adopted** when it stays on the seed's own site: same registrable domain (resolved against the real Public Suffix List via `tldts`, matching how `packages/rules` already does it) on the same port. `http` -> `https` upgrades and apex -> www bounces keep working unchanged.
- A redirect that **leaves** the seed's site is refused. The base stays on the seed, the seed itself is what gets crawled, and the target is recorded as the report's new optional `finalUrl` so the redirect is still visible in output.
- The port must match: `http://localhost:8750` -> `http://localhost:8751` is a different service, and both hosts collapse to the same fallback registrable domain.

The same rule applies per page, not just to the seed. A fetched page whose redirects landed off-site is dropped rather than stored, unless the crawl's own scope config admits it (`allowedDomains`, or an absolute `include` pattern — both are explicit caller intent). Storing it would file another site's content under this audit, and every stored page is also a link source that would pull the crawl across.

Inputs that cannot be attributed to a site are handled explicitly rather than by accident:

- A seed with a nested scheme never lends its embedded origin to the base. `new URL("blob:https://host/x").origin` reports `https://host` even though nothing ever fetched it, so an unusable seed pins to the URL that *was* fetched.
- A non-empty landing URL that cannot be compared fails closed. An absent one is no evidence of a redirect and stays storable.

## Report shape

`AuditReport` gains an optional `finalUrl`, present only when an off-site seed redirect was refused. Reports for the no-redirect and same-site-redirect cases are byte-identical to before.

## Tests

- `packages/crawler/tests/seed-redirect-pinning.test.ts` — live loopback servers. Server A answers `/` with a single 302 to a different origin; the test asserts the base stays on A, that the target sees exactly the one redirect hop and none of the discovery paths, that the target's title/body appear nowhere in what the report is built from, and that A really did receive its root probes (so the assertions cannot pass vacuously). Covers the caller-pre-resolved variant, the same-origin and same-site redirect cases, the `allowedDomains` escape, plus unit coverage for host-spelling normalization, userinfo, IPv6 literals, shared-hosting tenants and nested schemes.
- `packages/audit-engine/tests/off-site-seed-redirect-report.test.ts` — both report assembly paths (v1 and the bounded v2) agree on `baseUrl` and `finalUrl`.

Both files were confirmed to fail against the previous behaviour and pass with this change.

Suites run: `apps/cli` (1702), `packages/crawler` (221), `packages/audit-engine` (257), `packages/core-contracts` (45), plus typecheck, lint and format checks.

No rules were added or changed; the rule count is unaffected.