### PR TITLE
feat(rules): detect cross-page NAP drift in local/nap-consistency

### DIFF
--- a/docs/rules/local/nap-consistency.mdx
+++ b/docs/rules/local/nap-consistency.mdx
@@ -5,6 +5,37 @@ description: "Checks for consistent Name, Address, Phone across site"
 
 Checks for consistent Name, Address, Phone across site
 
+## What it checks
+
+The rule reads each page's **declared** contact details: `tel:` and `mailto:` links, and the `telephone` / `address` fields of your `LocalBusiness` or `Organization` JSON-LD. It never guesses phone numbers or addresses out of body text, so order numbers and dates are never mistaken for a NAP.
+
+| Check | What it means |
+|---|---|
+| `local-business-schema` | Whether the site declares `LocalBusiness` or `Organization` schema. |
+| `contact-info` | Your contact page carries a `tel:` or `mailto:` link. |
+| `phone-consistency` | The primary phone number, compared across every page that declares one. |
+| `address-consistency` | The primary postal address, compared across every page that declares one. |
+
+### How drift is graded
+
+`phone-consistency` and `address-consistency` compare the **first** phone or address each page declares, which is the number a directory or an agent treats as your primary contact. A footer listing extra branch numbers does not count against you.
+
+- **Pass**: one value, rendered the same way everywhere.
+- **Warn**: one value, rendered several ways. `+1 (555) 123-4567` and `555.123.4567` are the same number, and `123 Main St` and `123 Main Street` are the same address, but directories and agents cite them as written, which splits your citations.
+- **Fail**: some pages present a genuinely different primary number or address. That is a real NAP conflict, not a formatting nit.
+
+### When it stays quiet
+
+Cross-page comparison only runs when it can say something meaningful:
+
+- **Fewer than 10 pages declare the signal**: skipped. Three pages carrying a phone number cannot support a site-wide consistency claim.
+- **No dominant value (under 70% agreement)**: skipped. A multi-location business or a franchise directory is legitimately varied, and no page is a deviant.
+- **The site is not a local business**: the whole rule is skipped, because `appliesWhen` gates it on the detected site profile.
+
+### Fixing it
+
+Pick one rendering of your name, address, and phone, and use that exact string everywhere: the footer, the contact page, and your `LocalBusiness` JSON-LD. Then use the same string on Google Business Profile and every directory listing.
+
 | | |
 |---|---|
 | **Rule ID** | `local/nap-consistency` |

--- a/packages/audit-engine/src/page-features.ts
+++ b/packages/audit-engine/src/page-features.ts
@@ -17,7 +17,7 @@
 //     empty headers, are E-E's universe-assembly concern, not this function's.)
 
 import { detectWafChallengePage } from "@squirrelscan/waf-detect";
-import { getRichResultTypes, isPageIndexable } from "@squirrelscan/utils";
+import { extractNapSignal, getRichResultTypes, isPageIndexable } from "@squirrelscan/utils";
 
 import type { PageRecord, PageFeatureRow } from "@squirrelscan/core-contracts";
 import type { ParsedPage } from "@squirrelscan/rules";
@@ -92,6 +92,9 @@ export function extractPageFeatures(page: PageRecord, parsed: ParsedPage): PageF
 
   const title = parsed.meta.title;
   const description = parsed.meta.description;
+  // Same extractor local/nap-consistency's legacy path calls on the live parsed
+  // page, so the stored signal and the re-derived one are identical by construction.
+  const nap = extractNapSignal(parsed);
 
   return {
     normalizedUrl: page.normalizedUrl,
@@ -118,5 +121,12 @@ export function extractPageFeatures(page: PageRecord, parsed: ParsedPage): PageF
     metaNoindex: metaRobotsNoindex(parsed.meta.robots),
     indexableReasons: indexability.reasons,
     richResultTypes: getRichResultTypes(parsed.schemas),
+    napName: nap.name,
+    napPhones: nap.phones,
+    napPhoneFormats: nap.phoneFormats,
+    napAddress: nap.address,
+    napAddressFormat: nap.addressFormat,
+    napTelLink: nap.telLink,
+    napMailtoLink: nap.mailtoLink,
   };
 }

--- a/packages/audit-engine/tests/site-query-content-rules-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-content-rules-golden.test.ts
@@ -68,6 +68,13 @@ function feat(row: Row): PageFeatureRow {
     metaNoindex: false,
     indexableReasons: [],
     richResultTypes: [],
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
   };
 }
 

--- a/packages/audit-engine/tests/site-query-link-rules-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-link-rules-golden.test.ts
@@ -320,6 +320,13 @@ function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
     metaNoindex: false,
     indexableReasons: [],
     richResultTypes: [],
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
     ...over,
   };
 }

--- a/packages/audit-engine/tests/site-query-nap-rule-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-nap-rule-golden.test.ts
@@ -1,0 +1,185 @@
+// local/nap-consistency dual-path golden (#1373).
+//
+// The chain under test: parsePage(html) -> extractPageFeatures -> the v20
+// page_features NAP columns -> createSiteQuery -> the rule's streaming branch.
+// The legacy branch re-derives the same NAP from the SAME parsed pages, so a
+// deep-equal here proves the stored scalars and the live extraction agree — the
+// one invariant that could silently rot, since the two live in different packages.
+//
+// The streaming run is given an EMPTY `site.pages`, so passing also proves the
+// streaming branch reads nothing off the resident page array.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { parsePage } from "@squirrelscan/parser";
+import { loadAllRules } from "@squirrelscan/rules";
+import type { ParsedPage, Rule, RuleContext } from "@squirrelscan/rules";
+import type { PageRecord } from "@squirrelscan/core-contracts";
+
+import { createSiteQuery, extractPageFeatures } from "../src/index";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+async function freshStore(): Promise<SQLiteStorage> {
+  const store = new SQLiteStorage(":memory:");
+  await run(store.init());
+  return store;
+}
+
+const CRAWL = "crawl-1";
+const BASE = "https://example.com/";
+
+const napConsistencyRule = loadAllRules().get("local/nap-consistency")!;
+
+interface Spec {
+  normalizedUrl: string;
+  /** Rendered phone; also the tel: href payload. */
+  phone: string | null;
+  /** JSON-LD streetAddress. */
+  street: string | null;
+}
+
+function specHtml(spec: Spec): string {
+  const head = spec.street
+    ? `<script type="application/ld+json">${JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        name: "Acorn Hardware",
+        address: {
+          "@type": "PostalAddress",
+          streetAddress: spec.street,
+          addressLocality: "Sydney",
+          postalCode: "2000",
+        },
+      })}</script>`
+    : "";
+  const body = spec.phone ? `<a href="tel:${spec.phone}">${spec.phone}</a>` : "<p>hi</p>";
+  return `<html><head>${head}</head><body>${body}</body></html>`;
+}
+
+function mkPage(spec: Spec): { page: PageRecord; parsed: ParsedPage } {
+  const html = specHtml(spec);
+  const page = {
+    url: spec.normalizedUrl,
+    normalizedUrl: spec.normalizedUrl,
+    finalUrl: spec.normalizedUrl,
+    depth: 1,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: html.length,
+    loadTimeMs: 5,
+    fetchedAt: 1,
+    etag: null,
+    lastModified: null,
+    contentHash: `h:${spec.normalizedUrl}`,
+    html,
+    parsedData: null,
+    headers: { contentType: "text/html" },
+    securityHeaders: {},
+  } as unknown as PageRecord;
+
+  return { page, parsed: parsePage(html, spec.normalizedUrl) as ParsedPage };
+}
+
+// normalized_url ASC (== the getPageFeaturesPage cursor order). 12 pages so the
+// 10-page floor is cleared: 9 share one number, 3 render it differently, and one
+// address deviates outright — so the run exercises warn AND fail in one pass.
+const FIXTURE: Spec[] = [
+  { normalizedUrl: "https://example.com/p01", phone: "+1 (555) 123-4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p02", phone: "+1 (555) 123-4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p03", phone: "+1 (555) 123-4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p04", phone: "+1 (555) 123-4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p05", phone: "+1 (555) 123-4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p06", phone: "+1 (555) 123-4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p07", phone: "+1 (555) 123-4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p08", phone: "+1 (555) 123-4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p09", phone: "+1 (555) 123-4567", street: "123 Main Street" },
+  { normalizedUrl: "https://example.com/p10", phone: "555.123.4567", street: "123 Main St" },
+  { normalizedUrl: "https://example.com/p11", phone: "555.123.4567", street: "123 Main St" },
+  // Genuinely different address, and no phone at all.
+  { normalizedUrl: "https://example.com/p12", phone: null, street: "77 Other Rd" },
+];
+
+async function seedAndRun(rule: Rule) {
+  const store = await freshStore();
+  const built = FIXTURE.map(mkPage);
+
+  for (const { page, parsed } of built) {
+    await run(store.upsertPageFeatures(CRAWL, extractPageFeatures(page, parsed)));
+  }
+
+  const sitePages = [...built]
+    .sort((a, b) => (a.page.normalizedUrl < b.page.normalizedUrl ? -1 : 1))
+    .map(({ page, parsed }) => ({
+      url: page.normalizedUrl,
+      statusCode: page.status,
+      parsed,
+    }));
+
+  const base = {
+    page: { url: BASE, html: "", statusCode: 200, loadTime: 0, headers: {} },
+    parsed: {} as ParsedPage,
+    options: {},
+  };
+
+  const legacyCtx: RuleContext = {
+    ...base,
+    site: { baseUrl: BASE, pages: sitePages, robotsTxt: null, sitemaps: null },
+  };
+  const legacy = (await Promise.resolve(rule.run(legacyCtx))).checks;
+
+  const siteQuery = await run(createSiteQuery(store, CRAWL));
+  const streamedCtx: RuleContext = {
+    ...base,
+    // EMPTY — the streaming path must read only page_features.
+    site: { baseUrl: BASE, pages: [], robotsTxt: null, sitemaps: null },
+    siteQuery,
+  };
+  const streamed = (await Promise.resolve(rule.run(streamedCtx))).checks;
+
+  await run(store.close());
+  return { legacy, streamed };
+}
+
+describe("dual-path golden — local/nap-consistency (extractor → v20 columns → siteQuery)", () => {
+  test("streaming path is deep-equal to legacy, with the expected drift verdicts", async () => {
+    const { legacy, streamed } = await seedAndRun(napConsistencyRule);
+
+    expect(streamed).toEqual(legacy);
+
+    const byName = new Map(legacy.map((c) => [c.name, c]));
+    expect([...byName.keys()]).toEqual([
+      "local-business-schema",
+      "phone-consistency",
+      "address-consistency",
+    ]);
+
+    // 11 pages declare a phone; one number, two renderings → format drift.
+    const phone = byName.get("phone-consistency")!;
+    expect(phone.status).toBe("warn");
+    expect(phone.message).toBe(
+      "The same phone number is formatted 2 different ways across 11 pages",
+    );
+    expect(phone.items?.map((i) => [i.id, i.meta?.pageCount])).toEqual([
+      ["+1 (555) 123-4567", 9],
+      ["555.123.4567", 2],
+    ]);
+
+    // 12 pages declare an address; "St"/"Street" fold together, so the norm holds
+    // 11/12 and /p12 is a genuine conflict — a fail outranks the format drift.
+    const address = byName.get("address-consistency")!;
+    expect(address.status).toBe("fail");
+    expect(address.details).toEqual({
+      norm: "123 Main St, Sydney, 2000",
+      normPages: 11,
+      deviantValues: 1,
+      deviantPages: 1,
+      samplePages: 12,
+    });
+    expect(address.items?.[0]?.sourcePages).toEqual(["https://example.com/p12"]);
+  });
+});

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -65,7 +65,12 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // rule-surface drift tripwire (see golden-baseline.test.ts for the same fixture).
       expect(v1.meta.pageCount).toBeGreaterThanOrEqual(GOLDEN_BASELINE_PAGE_COUNT);
       expect(v1.healthScore.overall).toBe(48);
-      expect(v1.findings.length).toBe(95709);
+      // 95709 -> 95711: local/nap-consistency gained its two cross-page drift
+      // checks (phone-consistency, address-consistency). Two findings across 518
+      // pages, and the overall score is unmoved — the rule does not dominate.
+      expect(v1.findings.length).toBe(95711);
+      // Tripwire: EXTENDING a rule must never add a tally key. A change here
+      // means a new rule id was introduced; fix that rather than this number.
       expect(v1.perRuleTally.length).toBe(264);
     },
     180_000,

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -1039,6 +1039,19 @@ export interface LinkData {
   isNofollow?: boolean;
 }
 
+/**
+ * A `tel:` / `mailto:` anchor. These are absent from {@link LinkData} on purpose
+ * (they are not crawlable and would pollute the link graph), but they are a
+ * page's DECLARED contact details, so they are carried separately.
+ */
+export interface ContactLinkData {
+  scheme: "tel" | "mailto";
+  /** The href payload with any `?subject=`/`;phone-context=` params stripped. */
+  value: string;
+  /** The anchor's visible text — how the page actually renders the contact. */
+  text: string;
+}
+
 export interface ImageData {
   src: string;
   alt: string | null;
@@ -1185,6 +1198,11 @@ export interface ParsedPage {
   og: OpenGraphData;
   twitter: TwitterData;
   links: LinkData[];
+  /**
+   * `tel:`/`mailto:` anchors. Optional so parsed records serialized before this
+   * field existed stay valid; readers must treat absent as "none declared".
+   */
+  contactLinks?: ContactLinkData[];
   images: ImageData[];
   headings: HeadingHierarchy;
   content: ContentAnalysis;

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -566,6 +566,27 @@ export interface PageFeatureRow {
   indexableReasons: string[];
   /** `getRichResultTypes(parsed.schemas)` — canonical-cased rich-result @types (≤16). */
   richResultTypes: string[];
+  /**
+   * The page's declared NAP (Name / Address / Phone), from `extractNapSignal`
+   * (@squirrelscan/utils). `local/nap-consistency` compares these across pages to
+   * find contact-detail drift, so the SAME extractor feeds this row and the rule's
+   * legacy `ctx.site.pages` path — the two must never diverge.
+   *
+   * Business name from LocalBusiness/Organization JSON-LD, or null.
+   */
+  napName: string | null;
+  /** Canonical phone keys (trailing subscriber digits), deduped, ≤4 per page. */
+  napPhones: string[];
+  /** Display form of `napPhones[i]` as the page rendered it (parallel array). */
+  napPhoneFormats: string[];
+  /** Canonical postal-address key (abbreviations expanded), or null. */
+  napAddress: string | null;
+  /** The postal address as the page rendered it (≤200 chars). */
+  napAddressFormat: string | null;
+  /** The page carries at least one `tel:` link. */
+  napTelLink: boolean;
+  /** The page carries at least one `mailto:` link. */
+  napMailtoLink: boolean;
 }
 
 /** Which hashed field a {@link SiteQuery.duplicateGroups} scan is keyed on. */

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -57,7 +57,7 @@ export interface ContentStoreAdapter {
 }
 
 // Schema version - increment when schema changes
-const SCHEMA_VERSION = 19;
+const SCHEMA_VERSION = 20;
 
 // Migrations to run when upgrading from older versions
 const MIGRATIONS: Record<number, string[]> = {
@@ -265,6 +265,26 @@ const MIGRATIONS: Record<number, string[]> = {
     `ALTER TABLE page_features ADD COLUMN meta_noindex INTEGER`,
     `ALTER TABLE page_features ADD COLUMN indexable_reasons TEXT`,
     `ALTER TABLE page_features ADD COLUMN rich_result_types TEXT`,
+  ],
+  // Version 20: page_features NAP scalars — the per-page Name/Address/Phone the
+  // local/nap-consistency rule compares across pages to find contact-detail drift
+  // (#1373), so its streaming path reads these instead of re-holding every parsed
+  // page. ADDITIVE columns; ALTER is idempotent (the runner swallows "duplicate
+  // column name"). Local sqlite only — NOT a prod migration.
+  //
+  // No backfill, for the v19 reason: `extractPageFeatures` always writes a FULL
+  // row via INSERT OR REPLACE keyed by (crawl_id, normalized_url), each crawl
+  // writes only its own crawl_id, and the streaming loop re-extracts every scored
+  // page in the current run — so no pre-v20 row is ever read. NULL reads back as
+  // null / [] / false, which is the same as "this page declared no NAP".
+  20: [
+    `ALTER TABLE page_features ADD COLUMN nap_name TEXT`,
+    `ALTER TABLE page_features ADD COLUMN nap_phones TEXT`,
+    `ALTER TABLE page_features ADD COLUMN nap_phone_formats TEXT`,
+    `ALTER TABLE page_features ADD COLUMN nap_address TEXT`,
+    `ALTER TABLE page_features ADD COLUMN nap_address_format TEXT`,
+    `ALTER TABLE page_features ADD COLUMN nap_tel_link INTEGER`,
+    `ALTER TABLE page_features ADD COLUMN nap_mailto_link INTEGER`,
   ],
 };
 
@@ -658,6 +678,13 @@ CREATE TABLE IF NOT EXISTS page_features (
   meta_noindex INTEGER,
   indexable_reasons TEXT,
   rich_result_types TEXT,
+  nap_name TEXT,
+  nap_phones TEXT,
+  nap_phone_formats TEXT,
+  nap_address TEXT,
+  nap_address_format TEXT,
+  nap_tel_link INTEGER,
+  nap_mailto_link INTEGER,
   PRIMARY KEY (crawl_id, normalized_url),
   FOREIGN KEY (crawl_id) REFERENCES crawls(id)
 );
@@ -3401,8 +3428,10 @@ export class SQLiteStorage implements CrawlStorage {
       title, title_hash, description, desc_hash, content_hash,
       word_count, page_type, schema_types, robots_noindex, canonical,
       visible_author, visible_date, transfer_bytes, template_fp, secret_hits,
-      meta_noindex, indexable_reasons, rich_result_types
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      meta_noindex, indexable_reasons, rich_result_types,
+      nap_name, nap_phones, nap_phone_formats, nap_address, nap_address_format,
+      nap_tel_link, nap_mailto_link
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `;
 
   private pageFeatureParams(
@@ -3432,6 +3461,13 @@ export class SQLiteStorage implements CrawlStorage {
       row.metaNoindex ? 1 : 0,
       row.indexableReasons.length > 0 ? JSON.stringify(row.indexableReasons) : null,
       row.richResultTypes.length > 0 ? JSON.stringify(row.richResultTypes) : null,
+      row.napName,
+      row.napPhones.length > 0 ? JSON.stringify(row.napPhones) : null,
+      row.napPhoneFormats.length > 0 ? JSON.stringify(row.napPhoneFormats) : null,
+      row.napAddress,
+      row.napAddressFormat,
+      row.napTelLink ? 1 : 0,
+      row.napMailtoLink ? 1 : 0,
     ];
   }
 
@@ -3779,6 +3815,17 @@ export class SQLiteStorage implements CrawlStorage {
       richResultTypes: row.rich_result_types
         ? this.safeJsonParse(row.rich_result_types as string, [] as string[])
         : [],
+      napName: (row.nap_name as string | null) ?? null,
+      napPhones: row.nap_phones
+        ? this.safeJsonParse(row.nap_phones as string, [] as string[])
+        : [],
+      napPhoneFormats: row.nap_phone_formats
+        ? this.safeJsonParse(row.nap_phone_formats as string, [] as string[])
+        : [],
+      napAddress: (row.nap_address as string | null) ?? null,
+      napAddressFormat: (row.nap_address_format as string | null) ?? null,
+      napTelLink: row.nap_tel_link === 1,
+      napMailtoLink: row.nap_mailto_link === 1,
     };
   }
 }

--- a/packages/crawler/tests/page-features-store.test.ts
+++ b/packages/crawler/tests/page-features-store.test.ts
@@ -25,6 +25,17 @@ async function freshStore(): Promise<SQLiteStorage> {
 
 const CRAWL = "crawl-1";
 
+/** The v20 NAP columns (#1373) — asserted on both the fresh and migrated paths. */
+const NAP_COLUMNS = [
+  "nap_name",
+  "nap_phones",
+  "nap_phone_formats",
+  "nap_address",
+  "nap_address_format",
+  "nap_tel_link",
+  "nap_mailto_link",
+];
+
 function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
   return {
     normalizedUrl: "https://example.com/a",
@@ -48,6 +59,13 @@ function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
     metaNoindex: false,
     indexableReasons: [],
     richResultTypes: [],
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
     ...over,
   };
 }
@@ -79,6 +97,43 @@ describe("page_features store — round-trip", () => {
     expect(got?.visibleDate).toBe(true);
     expect(got?.wordCount).toBeNull();
     expect(got?.title).toBeNull();
+    await run(store.close());
+  });
+
+  test("NAP columns round-trip (parallel phone arrays, address pair, link flags)", async () => {
+    const store = await freshStore();
+    const row = feat({
+      normalizedUrl: "https://example.com/contact",
+      napName: "Acme Bakery",
+      napPhones: ["1234567", "7654321"],
+      napPhoneFormats: ["(555) 123-4567", "+1 555 765 4321"],
+      napAddress: "12 main street springfield",
+      napAddressFormat: "12 Main St, Springfield",
+      napTelLink: true,
+      napMailtoLink: false,
+    });
+    await run(store.upsertPageFeatures(CRAWL, row));
+
+    const got = await run(store.getPageFeatures(CRAWL, "https://example.com/contact"));
+    expect(got).toEqual(row);
+    // The two phone arrays are index-parallel; a serialization that reordered
+    // either would silently mis-attribute a display format to a number.
+    expect(got?.napPhones).toEqual(["1234567", "7654321"]);
+    expect(got?.napPhoneFormats).toEqual(["(555) 123-4567", "+1 555 765 4321"]);
+    expect(got?.napTelLink).toBe(true);
+    expect(got?.napMailtoLink).toBe(false);
+    await run(store.close());
+  });
+
+  test("empty NAP arrays round-trip as [] and nullables as null", async () => {
+    const store = await freshStore();
+    await run(store.upsertPageFeatures(CRAWL, feat({ normalizedUrl: "https://example.com/bare" })));
+    const got = await run(store.getPageFeatures(CRAWL, "https://example.com/bare"));
+    expect(got?.napPhones).toEqual([]);
+    expect(got?.napPhoneFormats).toEqual([]);
+    expect(got?.napName).toBeNull();
+    expect(got?.napAddress).toBeNull();
+    expect(got?.napAddressFormat).toBeNull();
     await run(store.close());
   });
 
@@ -410,7 +465,7 @@ describe("page_features migration (v17 → current)", () => {
     const version = check.prepare("SELECT version FROM schema_version LIMIT 1").get() as {
       version: number;
     };
-    expect(version.version).toBe(19);
+    expect(version.version).toBe(20);
     const cols = (
       check.prepare("PRAGMA table_info(page_features)").all() as Array<{ name: string }>
     ).map((c) => c.name);
@@ -420,6 +475,78 @@ describe("page_features migration (v17 → current)", () => {
     expect(cols).toContain("meta_noindex");
     expect(cols).toContain("indexable_reasons");
     expect(cols).toContain("rich_result_types");
+    // v20 NAP columns present after migration.
+    for (const col of NAP_COLUMNS) expect(cols).toContain(col);
+    check.close();
+  });
+
+  // The v20 columns must land on BOTH paths: `init()` execs SCHEMA (fresh install)
+  // BEFORE runMigrations(), so a column added only to MIGRATIONS[20] would never
+  // exist on a brand-new DB, and one added only to SCHEMA would never reach a DB
+  // already recorded at 19. Assert each path separately.
+  test("v20 NAP columns exist on a FRESH database (SCHEMA path, not the migration)", async () => {
+    const path = tmpDbPath();
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    await run(store.close());
+
+    const check = new Database(path);
+    const cols = (
+      check.prepare("PRAGMA table_info(page_features)").all() as Array<{ name: string }>
+    ).map((c) => c.name);
+    for (const col of NAP_COLUMNS) expect(cols).toContain(col);
+    check.close();
+  });
+
+  test("a DB already at v19 gains the NAP columns and keeps its existing rows", async () => {
+    const path = tmpDbPath();
+    // Build a real v19 store, seed a row, then wind the version marker back so the
+    // append-only migration is the only thing that can add the columns.
+    const seed = new SQLiteStorage(path);
+    await run(seed.init());
+    await run(
+      seed.upsertPageFeatures("c1", feat({ normalizedUrl: "https://example.com/legacy" }))
+    );
+    await run(seed.close());
+
+    const downgrade = new Database(path);
+    for (const col of NAP_COLUMNS) downgrade.exec(`ALTER TABLE page_features DROP COLUMN ${col}`);
+    downgrade.exec("UPDATE schema_version SET version = 19");
+    downgrade.close();
+
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    const migrated = await run(store.getPageFeatures("c1", "https://example.com/legacy"));
+    // Pre-v20 rows read back as "declared no NAP" rather than throwing.
+    expect(migrated?.title).toBe("Title A");
+    expect(migrated?.napName).toBeNull();
+    expect(migrated?.napPhones).toEqual([]);
+    expect(migrated?.napTelLink).toBe(false);
+    // ...and the migrated table accepts a full v20 write.
+    await run(
+      store.upsertPageFeatures(
+        "c1",
+        feat({
+          normalizedUrl: "https://example.com/new",
+          napName: "Acme Bakery",
+          napPhones: ["1234567"],
+          napPhoneFormats: ["(555) 123-4567"],
+          napAddress: "12 main street",
+          napAddressFormat: "12 Main St",
+          napTelLink: true,
+          napMailtoLink: true,
+        })
+      )
+    );
+    const fresh = await run(store.getPageFeatures("c1", "https://example.com/new"));
+    expect(fresh?.napPhoneFormats).toEqual(["(555) 123-4567"]);
+    await run(store.close());
+
+    const check = new Database(path);
+    const version = check.prepare("SELECT version FROM schema_version LIMIT 1").get() as {
+      version: number;
+    };
+    expect(version.version).toBe(20);
     check.close();
   });
 });

--- a/packages/parser/src/html.ts
+++ b/packages/parser/src/html.ts
@@ -8,6 +8,7 @@ import { coerceSchemelessUrl, shouldSkipUrl } from "@squirrelscan/utils";
 import { parseHTML, type Document, type Element } from "linkedom";
 
 import type {
+  ContactLinkData,
   ContentAnalysis,
   HeadingData,
   HeadingHierarchy,
@@ -135,6 +136,41 @@ export function extractLinks(doc: Document, baseUrl: string): LinkData[] {
   }
 
   return links;
+}
+
+// Cap on carried contact anchors — a footer repeating one number does not need
+// an unbounded array on every parsed page.
+const MAX_CONTACT_LINKS = 32;
+
+/**
+ * `tel:` / `mailto:` anchors, which `extractLinks` deliberately drops: they are
+ * not crawlable, so they never belonged in the link graph. They ARE the page's
+ * declared contact details though, so site rules that compare contact data across
+ * pages (local/nap-consistency) need them somewhere, and re-walking the DOM is
+ * not an option for a site rule — by then only the ParsedPage survives.
+ */
+export function extractContactLinks(doc: Document): ContactLinkData[] {
+  const contacts: ContactLinkData[] = [];
+
+  for (const anchor of doc.querySelectorAll('a[href^="tel:" i], a[href^="mailto:" i]')) {
+    if (contacts.length >= MAX_CONTACT_LINKS) break;
+    const href = (anchor as Element).getAttribute("href");
+    if (!href) continue;
+
+    const trimmed = href.trim();
+    const colon = trimmed.indexOf(":");
+    const scheme = trimmed.slice(0, colon).toLowerCase();
+    if (scheme !== "tel" && scheme !== "mailto") continue;
+
+    contacts.push({
+      scheme,
+      // `?subject=…` / `;phone-context=…` are routing params, not the address.
+      value: trimmed.slice(colon + 1).split(/[?;]/)[0] ?? "",
+      text: (anchor as Element).textContent?.trim() ?? "",
+    });
+  }
+
+  return contacts;
 }
 
 // Extract images from parsed document
@@ -350,6 +386,7 @@ export function parsePage(html: string, url: string): ParsedPage {
     og: extractOG(doc),
     twitter: extractTwitter(doc),
     links: extractLinks(doc, url),
+    contactLinks: extractContactLinks(doc),
     images: extractImages(doc, url),
     headings: extractHeadings(doc),
     content: extractContent(doc, html),

--- a/packages/parser/tests/contact-links.test.ts
+++ b/packages/parser/tests/contact-links.test.ts
@@ -1,0 +1,83 @@
+// parsePage().contactLinks — tel:/mailto: anchors (#1373).
+//
+// `extractLinks` drops every non-crawlable scheme, so before this field existed a
+// site rule had no way to see a page's declared contact details: by the time a
+// site rule runs, only the ParsedPage survives and the DOM is gone. These lock in
+// that the anchors are captured, that `links` still excludes them, and that the
+// href payload is separated from its routing params.
+
+import { describe, expect, test } from "bun:test";
+
+import { parsePage } from "../src/html";
+
+const URL = "https://example.com/contact";
+
+function page(body: string): string {
+  return `<!DOCTYPE html><html><head><title>t</title></head><body>${body}</body></html>`;
+}
+
+describe("parsePage — contactLinks", () => {
+  test("tel: and mailto: anchors are captured with scheme, payload and text", () => {
+    const parsed = parsePage(
+      page(
+        `<a href="tel:+1 (555) 123-4567">+1 (555) 123-4567</a>` +
+          `<a href="mailto:hi@example.com">Email us</a>`,
+      ),
+      URL,
+    );
+
+    expect(parsed.contactLinks).toEqual([
+      { scheme: "tel", value: "+1 (555) 123-4567", text: "+1 (555) 123-4567" },
+      { scheme: "mailto", value: "hi@example.com", text: "Email us" },
+    ]);
+  });
+
+  test("they stay OUT of the crawlable link graph", () => {
+    const parsed = parsePage(
+      page(`<a href="tel:5551234567">call</a><a href="/about">about</a>`),
+      URL,
+    );
+
+    expect(parsed.links.map((l) => l.url)).toEqual(["https://example.com/about"]);
+    expect(parsed.contactLinks).toHaveLength(1);
+  });
+
+  test("routing params are stripped from the payload but the text is untouched", () => {
+    const parsed = parsePage(
+      page(
+        `<a href="mailto:hi@example.com?subject=Hello&body=Hi">Contact</a>` +
+          `<a href="tel:+15551234567;phone-context=+1">Call</a>`,
+      ),
+      URL,
+    );
+
+    expect(parsed.contactLinks?.map((c) => c.value)).toEqual([
+      "hi@example.com",
+      "+15551234567",
+    ]);
+  });
+
+  test("scheme matching is case-insensitive", () => {
+    const parsed = parsePage(page(`<a href="TEL:5551234567">call</a>`), URL);
+    expect(parsed.contactLinks).toEqual([
+      { scheme: "tel", value: "5551234567", text: "call" },
+    ]);
+  });
+
+  test("other schemes are not contact links", () => {
+    const parsed = parsePage(
+      page(`<a href="sms:5551234567">text</a><a href="javascript:void(0)">x</a>`),
+      URL,
+    );
+    expect(parsed.contactLinks).toEqual([]);
+  });
+
+  test("the carried list is capped", () => {
+    const anchors = Array.from(
+      { length: 50 },
+      (_, i) => `<a href="tel:555000${i}">n${i}</a>`,
+    ).join("");
+    const parsed = parsePage(page(anchors), URL);
+    expect(parsed.contactLinks).toHaveLength(32);
+  });
+});

--- a/packages/rules/src/local/nap-consistency.ts
+++ b/packages/rules/src/local/nap-consistency.ts
@@ -1,8 +1,343 @@
 // local/nap-consistency - NAP (Name, Address, Phone) consistency
+//
+// Two families of check:
+//   1. Presence - LocalBusiness/Organization schema, contact-page tel:/mailto:.
+//   2. Cross-page drift (#1373) - the same phone/address rendered inconsistently
+//      across the site, or a genuinely different primary contact on some pages.
+//
+// The drift half only fires behind a normalisation guard (NAP_DRIFT_MIN_PAGES /
+// NAP_MODAL_MIN_AGREEMENT): a site legitimately listing several branch numbers
+// must not be accused of inconsistency, so we need both enough samples AND a clear
+// modal norm before calling anything a deviation.
+//
+// Dual path: `ctx.siteQuery` streams the per-page NAP scalars out of page_features;
+// the legacy path re-derives them from `ctx.site.pages`. Both feed ONE accumulator
+// and ONE check builder, and both read the SAME extractor (`extractNapSignal`), so
+// the two paths are byte-identical by construction.
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+import type { CheckItem, PageFeatureRow, SiteQuery } from "@squirrelscan/core-contracts";
+import type { NapSignal } from "@squirrelscan/utils";
 
-import { flattenJsonLdNodes, getPathname } from "@squirrelscan/utils";
+import { extractNapSignal, getPathname, NAP_BUSINESS_SCHEMA_TYPES } from "@squirrelscan/utils";
+
+/**
+ * Minimum number of pages that must DECLARE a signal before drift is judged. The
+ * floor is on samples, not on crawl size: a 500-page site where three pages carry
+ * a phone number cannot support a "this site is inconsistent" claim. It is also
+ * the count both paths agree on exactly, since the crawl-wide page count differs
+ * by the error pages v1 appends to `site.pages`.
+ */
+export const NAP_DRIFT_MIN_PAGES = 10;
+
+/**
+ * Share of samples that must agree before the majority value is treated as the
+ * site's norm. Below this the site is genuinely heterogeneous (multi-location,
+ * franchise directory) and no page is a "deviant", so the check skips.
+ */
+export const NAP_MODAL_MIN_AGREEMENT = 0.7;
+
+/** Caps on reported items / example URLs, so one rule cannot bloat a report. */
+const NAP_MAX_ITEMS = 10;
+const NAP_MAX_SAMPLE_URLS = 10;
+
+/** One page's contribution, from either path. */
+interface NapPageRecord {
+  url: string;
+  schemaTypes: string[];
+  nap: NapSignal;
+}
+
+/** Per-value rollup for one signal (phone or address). */
+interface NapKeyBucket {
+  count: number;
+  urls: string[];
+  /** Display form -> how many pages rendered it that way (url list capped). */
+  formats: Map<string, { count: number; urls: string[] }>;
+}
+
+/**
+ * Rollup of one signal across the crawl. Only DISTINCT values and renderings are
+ * held, and every url list is capped at {@link NAP_MAX_SAMPLE_URLS}, so a 100k-page
+ * site with one phone number costs one entry — the resident size tracks how varied
+ * the site's contact data is, not how many pages it has.
+ */
+interface NapSignalRollup {
+  sampleCount: number;
+  byKey: Map<string, NapKeyBucket>;
+}
+
+interface NapRollup {
+  pageCount: number;
+  hasLocalBusiness: boolean;
+  businessName: string | null;
+  /** First contact-ish page in crawl order, and whether it carries contact links. */
+  contactPageSeen: boolean;
+  contactPageHasContact: boolean;
+  phone: NapSignalRollup;
+  address: NapSignalRollup;
+}
+
+function emptySignalRollup(): NapSignalRollup {
+  return { sampleCount: 0, byKey: new Map() };
+}
+
+function emptyRollup(): NapRollup {
+  return {
+    pageCount: 0,
+    hasLocalBusiness: false,
+    businessName: null,
+    contactPageSeen: false,
+    contactPageHasContact: false,
+    phone: emptySignalRollup(),
+    address: emptySignalRollup(),
+  };
+}
+
+/** Record one page's primary value for a signal; `key`/`display` come in pairs. */
+function accumulateSignal(
+  rollup: NapSignalRollup,
+  key: string | null,
+  display: string | null,
+  url: string
+): void {
+  if (!key || !display) return;
+  rollup.sampleCount += 1;
+  let bucket = rollup.byKey.get(key);
+  if (!bucket) {
+    bucket = { count: 0, urls: [], formats: new Map() };
+    rollup.byKey.set(key, bucket);
+  }
+  bucket.count += 1;
+  if (bucket.urls.length < NAP_MAX_SAMPLE_URLS) bucket.urls.push(url);
+  const format = bucket.formats.get(display);
+  if (format) {
+    format.count += 1;
+    if (format.urls.length < NAP_MAX_SAMPLE_URLS) format.urls.push(url);
+  } else {
+    bucket.formats.set(display, { count: 1, urls: [url] });
+  }
+}
+
+/**
+ * Fold one page into the rollup. Both paths call this in crawl order (normalized
+ * url ascending), so every "first page that ..." decision below matches.
+ */
+function accumulatePage(rollup: NapRollup, record: NapPageRecord): void {
+  rollup.pageCount += 1;
+
+  if (
+    !rollup.hasLocalBusiness &&
+    record.schemaTypes.some((type) => NAP_BUSINESS_SCHEMA_TYPES.includes(type))
+  ) {
+    rollup.hasLocalBusiness = true;
+    rollup.businessName = record.nap.name;
+  }
+
+  if (!rollup.contactPageSeen && /\/contact/i.test(getPathname(record.url))) {
+    rollup.contactPageSeen = true;
+    rollup.contactPageHasContact = record.nap.telLink || record.nap.mailtoLink;
+  }
+
+  // A page's FIRST phone is its primary contact number. Counting every number on
+  // every page would make any site carrying a branch list look inconsistent.
+  accumulateSignal(
+    rollup.phone,
+    record.nap.phones[0] ?? null,
+    record.nap.phoneFormats[0] ?? null,
+    record.url
+  );
+  accumulateSignal(rollup.address, record.nap.address, record.nap.addressFormat, record.url);
+}
+
+/** Highest count wins; ties break on the key, so the pick never depends on order. */
+function modalEntry(byKey: Map<string, NapKeyBucket>): { key: string; bucket: NapKeyBucket } | null {
+  let best: { key: string; bucket: NapKeyBucket } | null = null;
+  for (const [key, bucket] of byKey) {
+    if (
+      !best ||
+      bucket.count > best.bucket.count ||
+      (bucket.count === best.bucket.count && key < best.key)
+    ) {
+      best = { key, bucket };
+    }
+  }
+  return best;
+}
+
+/** The most-used rendering of one value; ties break on the text. */
+function modalFormat(bucket: NapKeyBucket): string {
+  let best: { text: string; count: number } | null = null;
+  for (const [text, format] of bucket.formats) {
+    if (!best || format.count > best.count || (format.count === best.count && text < best.text)) {
+      best = { text, count: format.count };
+    }
+  }
+  return best?.text ?? "";
+}
+
+function skip(name: string, message: string): CheckResult {
+  return { name, status: "skipped", message };
+}
+
+/** Turn one signal's rollup into its check. `label` names the thing in prose. */
+function buildSignalCheck(name: string, label: string, rollup: NapSignalRollup): CheckResult {
+  if (rollup.sampleCount === 0) {
+    return skip(name, `No ${label} declared on any page`);
+  }
+  if (rollup.sampleCount < NAP_DRIFT_MIN_PAGES) {
+    return skip(
+      name,
+      `Only ${rollup.sampleCount} page(s) declare a ${label}; ${NAP_DRIFT_MIN_PAGES} needed to judge consistency`
+    );
+  }
+
+  const modal = modalEntry(rollup.byKey);
+  if (!modal) return skip(name, `No ${label} declared on any page`);
+
+  const agreement = modal.bucket.count / rollup.sampleCount;
+  const agreementPct = Math.round(agreement * 100);
+  if (agreement < NAP_MODAL_MIN_AGREEMENT) {
+    return skip(
+      name,
+      `No dominant ${label} across ${rollup.sampleCount} pages (the most common appears on ${agreementPct}%), so the site is too varied to judge`
+    );
+  }
+
+  const modalText = modalFormat(modal.bucket);
+
+  // A different value on some pages is a real NAP conflict, not a formatting nit.
+  const deviants = [...rollup.byKey.entries()]
+    .filter(([key]) => key !== modal.key)
+    .sort((a, b) => b[1].count - a[1].count || (a[0] < b[0] ? -1 : 1));
+  if (deviants.length > 0) {
+    const deviantPages = deviants.reduce((sum, [, bucket]) => sum + bucket.count, 0);
+    const items: CheckItem[] = deviants.slice(0, NAP_MAX_ITEMS).map(([key, bucket]) => ({
+      id: key,
+      label: `"${modalFormat(bucket)}" on ${bucket.count} page(s)`,
+      sourcePages: bucket.urls,
+      meta: { pageCount: bucket.count },
+    }));
+    return {
+      name,
+      status: "fail",
+      message: `${deviantPages} page(s) show a different ${label} to the site norm "${modalText}"`,
+      value: modalText,
+      items,
+      details: {
+        norm: modalText,
+        normPages: modal.bucket.count,
+        deviantValues: deviants.length,
+        deviantPages,
+        samplePages: rollup.sampleCount,
+      },
+    };
+  }
+
+  // One value, several renderings: the classic citation-hurting NAP drift.
+  if (modal.bucket.formats.size > 1) {
+    const variants = [...modal.bucket.formats.entries()].sort(
+      (a, b) => b[1].count - a[1].count || (a[0] < b[0] ? -1 : 1)
+    );
+    const items: CheckItem[] = variants.slice(0, NAP_MAX_ITEMS).map(([text, format]) => ({
+      id: text,
+      label: `"${text}" on ${format.count} page(s)`,
+      sourcePages: format.urls,
+      meta: { pageCount: format.count },
+    }));
+    return {
+      name,
+      status: "warn",
+      message: `The same ${label} is formatted ${variants.length} different ways across ${rollup.sampleCount} pages`,
+      value: modalText,
+      items,
+      details: {
+        norm: modalText,
+        formats: variants.length,
+        samplePages: rollup.sampleCount,
+      },
+    };
+  }
+
+  return {
+    name,
+    status: "pass",
+    message: `The same ${label} is used consistently across ${rollup.sampleCount} pages`,
+    value: modalText,
+  };
+}
+
+/** The rule's full output for a non-empty crawl. ONE builder, both paths. */
+function buildChecks(rollup: NapRollup): CheckResult[] {
+  const checks: CheckResult[] = [];
+
+  if (rollup.hasLocalBusiness) {
+    checks.push({
+      name: "local-business-schema",
+      status: "pass",
+      message: "LocalBusiness/Organization schema found",
+      value: rollup.businessName || undefined,
+    });
+  } else {
+    checks.push({
+      name: "local-business-schema",
+      status: "info",
+      message: "No LocalBusiness schema found",
+      value: "Add schema if this is a local business",
+    });
+  }
+
+  if (rollup.contactPageSeen && rollup.contactPageHasContact) {
+    checks.push({
+      name: "contact-info",
+      status: "pass",
+      message: "Contact page has contact information",
+    });
+  }
+
+  checks.push(buildSignalCheck("phone-consistency", "phone number", rollup.phone));
+  checks.push(buildSignalCheck("address-consistency", "postal address", rollup.address));
+
+  return checks;
+}
+
+const EMPTY_CRAWL_CHECK: CheckResult = {
+  name: "nap-consistency",
+  status: "skipped",
+  message: "No pages available for analysis",
+};
+
+/** Rebuild a page's NapSignal from its stored page_features scalars. */
+function napFromRow(row: PageFeatureRow): NapSignal {
+  return {
+    name: row.napName,
+    phones: row.napPhones,
+    phoneFormats: row.napPhoneFormats,
+    address: row.napAddress,
+    addressFormat: row.napAddressFormat,
+    telLink: row.napTelLink,
+    mailtoLink: row.napMailtoLink,
+  };
+}
+
+/**
+ * Streaming path (#1373): fold the per-page NAP scalars straight off the
+ * page_features cursor, in normalized_url order (== the legacy `site.pages`
+ * order). Only the bounded rollup stays resident; no parsed page is held.
+ */
+async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
+  const rollup = emptyRollup();
+  for await (const row of siteQuery.pagesMatching(() => true)) {
+    accumulatePage(rollup, {
+      url: row.normalizedUrl,
+      schemaTypes: row.schemaTypes,
+      nap: napFromRow(row),
+    });
+  }
+
+  if (rollup.pageCount === 0) return { checks: [EMPTY_CRAWL_CHECK] };
+  return { checks: buildChecks(rollup) };
+}
 
 export const napConsistencyRule: Rule = {
   meta: {
@@ -20,82 +355,25 @@ export const napConsistencyRule: Rule = {
     appliesWhen: { requiresLocalBusiness: true },
   },
 
-  run(ctx: RuleContext): RuleResult {
-    const checks: CheckResult[] = [];
+  run(ctx: RuleContext): RuleResult | Promise<RuleResult> {
+    if (ctx.siteQuery) {
+      return runViaSiteQuery(ctx.siteQuery);
+    }
+
     const pages = ctx.site?.pages;
-
     if (!pages || pages.length === 0) {
-      checks.push({
-        name: "nap-consistency",
-        status: "skipped",
-        message: "No pages available for analysis",
-      });
-      return { checks };
+      return { checks: [EMPTY_CRAWL_CHECK] };
     }
 
-    // Look for LocalBusiness schema
-    let hasLocalBusiness = false;
-    let businessName: string | null = null;
-
+    const rollup = emptyRollup();
     for (const page of pages) {
-      if (
-        page.parsed.schema.types.some((t) =>
-          ["LocalBusiness", "Organization", "Restaurant", "Store"].includes(t)
-        )
-      ) {
-        hasLocalBusiness = true;
-        // Try to extract name from raw schema (flattened — handles @graph)
-        if (page.parsed.schema.raw) {
-          const localBiz = flattenJsonLdNodes(page.parsed.schema.raw).find(
-            (s) =>
-              ["LocalBusiness", "Organization"].includes(s["@type"] as string)
-          );
-          if (localBiz?.name) {
-            businessName = localBiz.name as string;
-          }
-        }
-        break;
-      }
-    }
-
-    if (hasLocalBusiness) {
-      checks.push({
-        name: "local-business-schema",
-        status: "pass",
-        message: "LocalBusiness/Organization schema found",
-        value: businessName || undefined,
-      });
-    } else {
-      checks.push({
-        name: "local-business-schema",
-        status: "info",
-        message: "No LocalBusiness schema found",
-        value: "Add schema if this is a local business",
+      accumulatePage(rollup, {
+        url: page.url,
+        schemaTypes: page.parsed?.schema?.types ?? [],
+        nap: extractNapSignal(page.parsed),
       });
     }
 
-    // Check for contact page NAP
-    const contactPage = pages.find((p) =>
-      /\/contact/i.test(getPathname(p.url))
-    );
-
-    if (contactPage) {
-      const hasPhone = contactPage.parsed.links.some((l) =>
-        l.url.startsWith("tel:")
-      );
-      const hasEmail = contactPage.parsed.links.some((l) =>
-        l.url.startsWith("mailto:")
-      );
-
-      if (hasPhone || hasEmail) {
-        checks.push({
-          name: "contact-info",
-          status: "pass",
-          message: "Contact page has contact information",
-        });
-      }
-    }
-
-    return { checks };
+    return { checks: buildChecks(rollup) };
   },
 };

--- a/packages/rules/src/types.ts
+++ b/packages/rules/src/types.ts
@@ -14,6 +14,7 @@ import type {
   BusinessCategory,
   CheckResult,
   CloakingProbeData,
+  ContactLinkData,
   ContentAnalysis,
   HeadingHierarchy,
   ImageData,
@@ -136,6 +137,9 @@ export interface ParsedPage {
   og: OpenGraphData;
   twitter: TwitterData;
   links: LinkData[];
+  // tel:/mailto: anchors — dropped from `links` (not crawlable), carried here so
+  // site rules can compare declared contact details across pages.
+  contactLinks?: ContactLinkData[];
   images: ImageData[];
   headings: HeadingHierarchy;
   content: ContentAnalysis;

--- a/packages/rules/tests/nap-consistency.test.ts
+++ b/packages/rules/tests/nap-consistency.test.ts
@@ -1,0 +1,322 @@
+// local/nap-consistency — cross-page NAP drift (#1373).
+//
+// The rule compares each page's PRIMARY declared phone/address across the crawl.
+// Three outcomes matter and are easy to get backwards, so each has its own case:
+//   - one number, one rendering  → pass
+//   - one number, several renderings → warn (a citation problem, not a conflict)
+//   - a genuinely different number on some pages → fail (a real NAP conflict)
+//
+// Everything else here defends the SILENCE cases: below the sample floor, or on a
+// legitimately multi-location site, the rule must say nothing rather than accuse a
+// heterogeneous site of being inconsistent.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult, SiteMetadata } from "@squirrelscan/core-contracts";
+import { napAddressKey, napPhoneKey } from "@squirrelscan/utils";
+
+import { parsePage } from "@squirrelscan/parser";
+
+import { ruleApplies } from "../src/applicability";
+import {
+  napConsistencyRule,
+  NAP_DRIFT_MIN_PAGES,
+  NAP_MODAL_MIN_AGREEMENT,
+} from "../src/local/nap-consistency";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+interface PageSpec {
+  /** Rendered phone text; also the `tel:` href payload. */
+  phone?: string;
+  /** JSON-LD `streetAddress`. */
+  street?: string;
+  /** Emit LocalBusiness JSON-LD (name + address). */
+  business?: boolean;
+}
+
+function html(spec: PageSpec): string {
+  const parts: string[] = [];
+  if (spec.business || spec.street) {
+    const node: Record<string, unknown> = {
+      "@context": "https://schema.org",
+      "@type": "LocalBusiness",
+      name: "Acorn Hardware",
+    };
+    if (spec.street) {
+      node.address = {
+        "@type": "PostalAddress",
+        streetAddress: spec.street,
+        addressLocality: "Sydney",
+        postalCode: "2000",
+      };
+    }
+    parts.push(`<script type="application/ld+json">${JSON.stringify(node)}</script>`);
+  }
+  if (spec.phone) {
+    parts.push(`<a href="tel:${spec.phone}">${spec.phone}</a>`);
+  }
+  return `<html><head>${parts.join("")}</head><body><p>Acorn Hardware</p></body></html>`;
+}
+
+/** A site context from per-page specs, in the normalized_url order the rule assumes. */
+function siteCtx(specs: PageSpec[]): RuleContext {
+  const pages = specs.map((spec, i) => {
+    const url = `https://example.com/p${String(i).padStart(3, "0")}`;
+    return {
+      url,
+      statusCode: 200,
+      parsed: parsePage(html(spec), url) as ParsedPage,
+    };
+  });
+  return {
+    page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+    parsed: {} as ParsedPage,
+    options: {},
+    site: { baseUrl: "https://example.com/", pages, robotsTxt: null, sitemaps: null },
+  };
+}
+
+function checks(ctx: RuleContext): CheckResult[] {
+  const result = napConsistencyRule.run(ctx);
+  if (result instanceof Promise) throw new Error("legacy path must be synchronous");
+  return result.checks as CheckResult[];
+}
+
+function named(list: CheckResult[], name: string): CheckResult {
+  const found = list.find((c) => c.name === name);
+  if (!found) throw new Error(`no check named ${name} in [${list.map((c) => c.name).join(", ")}]`);
+  return found;
+}
+
+/** `n` pages, each carrying `phone` and (optionally) `street`. */
+function repeat(n: number, spec: PageSpec): PageSpec[] {
+  return Array.from({ length: n }, () => ({ ...spec }));
+}
+
+const FLOOR = NAP_DRIFT_MIN_PAGES;
+
+describe("local/nap-consistency — identity is unchanged", () => {
+  test("rule id and the local-business gate are untouched", () => {
+    expect(napConsistencyRule.meta.id).toBe("local/nap-consistency");
+    expect(napConsistencyRule.meta.appliesWhen).toEqual({ requiresLocalBusiness: true });
+    expect(napConsistencyRule.meta.scope).toBe("site");
+  });
+
+  test("guard constants are at their documented starting values", () => {
+    expect(NAP_DRIFT_MIN_PAGES).toBe(10);
+    expect(NAP_MODAL_MIN_AGREEMENT).toBe(0.7);
+  });
+});
+
+describe("local/nap-consistency — skipped", () => {
+  test("no pages → single skipped check", () => {
+    const ctx = siteCtx([]);
+    expect(checks(ctx)).toEqual([
+      { name: "nap-consistency", status: "skipped", message: "No pages available for analysis" },
+    ]);
+  });
+
+  test("appliesWhen gates the rule off a non-local site", () => {
+    const meta: SiteMetadata = {
+      siteType: "saas",
+      businessCategory: null,
+      primaryCountry: null,
+      audienceScope: null,
+      isYMYL: false,
+      isLocalBusiness: false,
+      hasOwnershipVerified: false,
+      confidence: "high",
+    };
+    const verdict = ruleApplies(napConsistencyRule.meta.appliesWhen, meta);
+    expect(verdict.applies).toBe(false);
+  });
+
+  test("below the sample floor → skipped with the count in the reason", () => {
+    const ctx = siteCtx(repeat(FLOOR - 1, { phone: "+1 (555) 123-4567", business: true }));
+    const phone = named(checks(ctx), "phone-consistency");
+    expect(phone.status).toBe("skipped");
+    expect(phone.message).toContain(`Only ${FLOOR - 1} page(s)`);
+    expect(phone.message).toContain(`${FLOOR} needed`);
+  });
+
+  test("pages declaring nothing → skipped, not a false 'consistent' pass", () => {
+    const ctx = siteCtx(repeat(FLOOR + 5, { business: true }));
+    expect(named(checks(ctx), "phone-consistency").status).toBe("skipped");
+    expect(named(checks(ctx), "address-consistency").status).toBe("skipped");
+  });
+
+  test("no modal norm (below the agreement floor) → skipped, not a fail", () => {
+    // 5/12 = 42% for the largest group: a multi-location site, not a broken one.
+    const ctx = siteCtx([
+      ...repeat(5, { phone: "555-100-0001", business: true }),
+      ...repeat(4, { phone: "555-100-0002", business: true }),
+      ...repeat(3, { phone: "555-100-0003", business: true }),
+    ]);
+    const phone = named(checks(ctx), "phone-consistency");
+    expect(phone.status).toBe("skipped");
+    expect(phone.message).toContain("No dominant phone number");
+    expect(phone.message).toContain("42%");
+  });
+});
+
+describe("local/nap-consistency — pass (no false positives)", () => {
+  test("one number and one address, identically rendered everywhere → pass", () => {
+    const ctx = siteCtx(repeat(FLOOR + 2, { phone: "+1 (555) 123-4567", street: "123 Main St" }));
+    const list = checks(ctx);
+
+    const phone = named(list, "phone-consistency");
+    expect(phone.status).toBe("pass");
+    expect(phone.value).toBe("+1 (555) 123-4567");
+    expect(phone.items).toBeUndefined();
+
+    const address = named(list, "address-consistency");
+    expect(address.status).toBe("pass");
+
+    // Nothing in the rule's output is a warn/fail on a consistent site.
+    expect(list.some((c) => c.status === "warn" || c.status === "fail")).toBe(false);
+  });
+
+  test("a page carrying extra branch numbers does not make the site inconsistent", () => {
+    // Every page's PRIMARY (first) number is the same; a footer branch list follows.
+    const pages = repeat(FLOOR + 2, { phone: "555-123-4567", business: true });
+    const ctx = siteCtx(pages);
+    const withExtra = ctx.site!.pages.map((p, i) =>
+      i % 2 === 0
+        ? p
+        : {
+            ...p,
+            parsed: parsePage(
+              `<html><body><a href="tel:555-123-4567">555-123-4567</a>` +
+                `<a href="tel:555-999-0000">555-999-0000</a></body></html>`,
+              p.url,
+            ) as ParsedPage,
+          },
+    );
+    ctx.site!.pages = withExtra;
+    expect(named(checks(ctx), "phone-consistency").status).toBe("pass");
+  });
+});
+
+describe("local/nap-consistency — warn (format drift)", () => {
+  test("one number rendered two ways → warn listing both renderings", () => {
+    const ctx = siteCtx([
+      ...repeat(8, { phone: "+1 (555) 123-4567", business: true }),
+      ...repeat(4, { phone: "555.123.4567", business: true }),
+    ]);
+    const phone = named(checks(ctx), "phone-consistency");
+
+    expect(phone.status).toBe("warn");
+    expect(phone.message).toBe(
+      "The same phone number is formatted 2 different ways across 12 pages",
+    );
+    expect(phone.value).toBe("+1 (555) 123-4567");
+    expect(phone.items?.map((i) => i.id)).toEqual(["+1 (555) 123-4567", "555.123.4567"]);
+    expect(phone.items?.map((i) => i.meta?.pageCount)).toEqual([8, 4]);
+    expect(phone.details).toEqual({
+      norm: "+1 (555) 123-4567",
+      formats: 2,
+      samplePages: 12,
+    });
+  });
+
+  test("'123 Main St' vs '123 Main Street' is drift, not a different address", () => {
+    const ctx = siteCtx([
+      ...repeat(8, { street: "123 Main St" }),
+      ...repeat(4, { street: "123 Main Street" }),
+    ]);
+    const address = named(checks(ctx), "address-consistency");
+    expect(address.status).toBe("warn");
+    expect(address.message).toContain("formatted 2 different ways");
+  });
+});
+
+describe("local/nap-consistency — fail (conflicting NAP)", () => {
+  test("a genuinely different number on a minority of pages → fail", () => {
+    const ctx = siteCtx([
+      ...repeat(10, { phone: "555-123-4567", business: true }),
+      ...repeat(2, { phone: "555-987-6543", business: true }),
+    ]);
+    const phone = named(checks(ctx), "phone-consistency");
+
+    expect(phone.status).toBe("fail");
+    expect(phone.message).toBe(
+      '2 page(s) show a different phone number to the site norm "555-123-4567"',
+    );
+    expect(phone.items).toHaveLength(1);
+    expect(phone.items?.[0]?.label).toBe('"555-987-6543" on 2 page(s)');
+    expect(phone.items?.[0]?.sourcePages).toHaveLength(2);
+    expect(phone.details).toEqual({
+      norm: "555-123-4567",
+      normPages: 10,
+      deviantValues: 1,
+      deviantPages: 2,
+      samplePages: 12,
+    });
+  });
+
+  test("a conflicting address outranks its own format drift", () => {
+    const ctx = siteCtx([
+      ...repeat(10, { street: "123 Main St" }),
+      ...repeat(2, { street: "77 Other Rd" }),
+    ]);
+    const address = named(checks(ctx), "address-consistency");
+    expect(address.status).toBe("fail");
+    expect(address.details?.deviantPages).toBe(2);
+  });
+});
+
+describe("local/nap-consistency — presence checks are preserved", () => {
+  test("LocalBusiness schema present → local-business-schema passes with the name", () => {
+    const list = checks(siteCtx(repeat(3, { business: true })));
+    expect(named(list, "local-business-schema")).toEqual({
+      name: "local-business-schema",
+      status: "pass",
+      message: "LocalBusiness/Organization schema found",
+      value: "Acorn Hardware",
+    });
+  });
+
+  test("no business schema → informational, never a failure", () => {
+    const list = checks(siteCtx(repeat(3, { phone: "555-123-4567" })));
+    expect(named(list, "local-business-schema").status).toBe("info");
+  });
+
+  test("a /contact page with contact links → contact-info passes", () => {
+    const ctx = siteCtx(repeat(2, { phone: "555-123-4567" }));
+    ctx.site!.pages[1]!.url = "https://example.com/contact";
+    ctx.site!.pages[1]!.parsed = parsePage(
+      `<html><body><a href="tel:555-123-4567">call</a><a href="mailto:hi@example.com">mail</a></body></html>`,
+      "https://example.com/contact",
+    ) as ParsedPage;
+    expect(named(checks(ctx), "contact-info").status).toBe("pass");
+  });
+});
+
+describe("NAP comparison keys", () => {
+  test("punctuation and country-code variants key to the same phone", () => {
+    const key = napPhoneKey("+1 (555) 123-4567");
+    expect(key).toBe("1234567");
+    expect(napPhoneKey("555.123.4567")).toBe(key);
+    expect(napPhoneKey("5551234567")).toBe(key);
+  });
+
+  test("too few digits is not a phone number", () => {
+    expect(napPhoneKey("ext. 4567")).toBeNull();
+    expect(napPhoneKey("no digits here")).toBeNull();
+  });
+
+  test("street-type abbreviations fold into their long form", () => {
+    expect(napAddressKey("123 Main St.")).toBe(napAddressKey("123 Main Street"));
+    expect(napAddressKey("5 N. Oak Ave")).toBe("5 north oak avenue");
+  });
+
+  test("prototype-chain tokens stay literal (no inherited lookup)", () => {
+    // A `TABLE[token]` lookup on a plain object would fold in `Object`'s source.
+    expect(napAddressKey("1 constructor st")).toBe("1 constructor street");
+    expect(napAddressKey("7 prototype rd")).toBe("7 prototype road");
+  });
+
+  test("keyless input is null, not an empty string", () => {
+    expect(napAddressKey("   ...   ")).toBeNull();
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -56,6 +56,19 @@ export {
   flattenJsonLdNodes,
 } from "./schema-rich-results";
 
+export {
+  extractNapSignal,
+  emptyNapSignal,
+  napAddressKey,
+  napPhoneKey,
+  NAP_BUSINESS_SCHEMA_TYPES,
+  NAP_MAX_ADDRESS_CHARS,
+  NAP_MAX_PHONES_PER_PAGE,
+  NAP_NAME_SCHEMA_TYPES,
+  NAP_PHONE_MIN_DIGITS,
+  type NapSignal,
+} from "./nap";
+
 export { findClientRedirects } from "./client-redirects";
 
 export { getRandomUserAgent } from "./user-agent";

--- a/packages/utils/src/nap.ts
+++ b/packages/utils/src/nap.ts
@@ -1,0 +1,267 @@
+// NAP (Name / Address / Phone) signal extraction — the ONE definition of how a
+// page's contact identity is read off a parsed page.
+//
+// It has two callers that MUST agree byte-for-byte: `local/nap-consistency`'s
+// legacy `ctx.site.pages` path reads it live, and `extractPageFeatures` stores it
+// into `page_features` for the same rule's streaming `ctx.siteQuery` path. Any
+// divergence between them shows up as a v1↔v2 golden failure, so the extraction
+// lives here rather than being written twice.
+//
+// Sources are deliberately limited to DECLARED contact data — `tel:`/`mailto:`
+// links and JSON-LD `telephone`/`address` — never a regex over visible body text.
+// Free-text phone/address scraping produces false positives (order numbers, dates,
+// prices) that would then be reported as NAP drift, which is worse than silence.
+
+import type { ParsedPage } from "@squirrelscan/core-contracts";
+
+import { flattenJsonLdNodes } from "./schema-rich-results";
+
+/** Schema @types that mark a page as declaring a business identity. */
+export const NAP_BUSINESS_SCHEMA_TYPES = [
+  "LocalBusiness",
+  "Organization",
+  "Restaurant",
+  "Store",
+];
+
+/** Schema @types the business NAME is read from (subset of the above). */
+export const NAP_NAME_SCHEMA_TYPES = ["LocalBusiness", "Organization"];
+
+/** Shortest digit run accepted as a phone number — below this it is an extension/id. */
+export const NAP_PHONE_MIN_DIGITS = 7;
+
+/**
+ * How many trailing digits form the comparison key. The subscriber tail is the
+ * part that stays put across country-code, trunk-prefix and punctuation variants
+ * ("+1 (555) 123-4567", "555.123.4567", "01555 1234567" all key on "1234567"), so
+ * one number written many ways stays ONE number and only the display form differs
+ * — which is precisely the format-drift signal this rule reports as a warning.
+ */
+const NAP_PHONE_KEY_DIGITS = 7;
+
+/** Per-page cap on carried phone numbers — bounds the stored page_features row. */
+export const NAP_MAX_PHONES_PER_PAGE = 4;
+
+/** Per-page cap on the carried address string — bounds the stored row. */
+export const NAP_MAX_ADDRESS_CHARS = 200;
+
+/**
+ * Street-type / directional / unit abbreviations folded into their long form for
+ * the comparison key. This is what lets "123 Main St." and "123 Main Street" be
+ * recognised as the SAME address rendered two ways (a warning) rather than two
+ * different addresses (a failure) — the exact drift the rule's solution text
+ * calls out.
+ *
+ * A Map, not an object literal: the lookup key is a token off an audited page, so
+ * `TABLE[token]` on a `{}` would resolve "constructor"/"__proto__" through the
+ * prototype chain and fold a whole function body into the address key.
+ */
+const NAP_ADDRESS_ABBREVIATIONS = new Map<string, string>(Object.entries({
+  st: "street",
+  str: "street",
+  ave: "avenue",
+  av: "avenue",
+  rd: "road",
+  blvd: "boulevard",
+  blv: "boulevard",
+  dr: "drive",
+  ln: "lane",
+  ct: "court",
+  pl: "place",
+  sq: "square",
+  hwy: "highway",
+  pkwy: "parkway",
+  ter: "terrace",
+  cir: "circle",
+  ste: "suite",
+  apt: "apartment",
+  fl: "floor",
+  bldg: "building",
+  rm: "room",
+  n: "north",
+  s: "south",
+  e: "east",
+  w: "west",
+  ne: "northeast",
+  nw: "northwest",
+  se: "southeast",
+  sw: "southwest",
+}));
+
+/** PostalAddress fields joined, in schema.org's own reading order, for display. */
+const NAP_ADDRESS_FIELDS = [
+  "streetAddress",
+  "addressLocality",
+  "addressRegion",
+  "postalCode",
+  "addressCountry",
+];
+
+/** One page's declared contact identity, as stored on `PageFeatureRow`. */
+export interface NapSignal {
+  /** Business name from LocalBusiness/Organization JSON-LD, or null. */
+  name: string | null;
+  /** Canonical phone keys, first-seen order, deduped, capped. */
+  phones: string[];
+  /** Display form of `phones[i]` exactly as the page rendered it (parallel array). */
+  phoneFormats: string[];
+  /** Canonical postal-address key, or null when the page declares none. */
+  address: string | null;
+  /** The postal address exactly as the page rendered it. */
+  addressFormat: string | null;
+  /** The page carries at least one `tel:` link. */
+  telLink: boolean;
+  /** The page carries at least one `mailto:` link. */
+  mailtoLink: boolean;
+}
+
+/** An empty signal — the value for a page that declares no contact data. */
+export function emptyNapSignal(): NapSignal {
+  return {
+    name: null,
+    phones: [],
+    phoneFormats: [],
+    address: null,
+    addressFormat: null,
+    telLink: false,
+    mailtoLink: false,
+  };
+}
+
+/**
+ * Canonical comparison key for a phone number: its trailing
+ * {@link NAP_PHONE_KEY_DIGITS} digits. Null when the input holds too few digits
+ * to be a phone number at all.
+ */
+export function napPhoneKey(raw: string): string | null {
+  const digits = raw.replace(/[^0-9]/g, "");
+  if (digits.length < NAP_PHONE_MIN_DIGITS) return null;
+  return digits.slice(-NAP_PHONE_KEY_DIGITS);
+}
+
+/**
+ * Canonical comparison key for a postal address: lowercased, punctuation
+ * flattened to single spaces, and street-type/directional abbreviations expanded
+ * (see {@link NAP_ADDRESS_ABBREVIATIONS}). Null for input with no alphanumerics.
+ */
+export function napAddressKey(raw: string): string | null {
+  const tokens = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter((token) => token.length > 0)
+    .map((token) => NAP_ADDRESS_ABBREVIATIONS.get(token) ?? token);
+  return tokens.length > 0 ? tokens.join(" ") : null;
+}
+
+/** Collapse whitespace and cap length — the stored display form of an address. */
+function displayAddress(raw: string): string | null {
+  const collapsed = raw.replace(/\s+/g, " ").trim();
+  if (!collapsed) return null;
+  return collapsed.slice(0, NAP_MAX_ADDRESS_CHARS);
+}
+
+/** Render a JSON-LD `address` value (string or PostalAddress node) for display. */
+function readSchemaAddress(value: unknown): string | null {
+  if (typeof value === "string") return displayAddress(value);
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const node = value as Record<string, unknown>;
+  const parts: string[] = [];
+  for (const field of NAP_ADDRESS_FIELDS) {
+    const part = node[field];
+    if (typeof part === "string" && part.trim()) parts.push(part.trim());
+  }
+  return parts.length > 0 ? displayAddress(parts.join(", ")) : null;
+}
+
+/**
+ * Cheap pre-filter over the raw JSON-LD string. Every field this module reads
+ * (`name` on a business node, `telephone`, `address`) requires one of these
+ * substrings to be present, so a raw blob containing none of them cannot
+ * contribute a signal and does not need parsing. Site rules run this per page, so
+ * skipping the JSON.parse on the (common) no-NAP page matters at crawl scale.
+ */
+function mayCarryNap(raw: string): boolean {
+  return (
+    raw.includes("telephone") ||
+    raw.includes("address") ||
+    raw.includes("LocalBusiness") ||
+    raw.includes("Organization")
+  );
+}
+
+/**
+ * Distil one parsed page's declared NAP into its {@link NapSignal}. Pure and
+ * synchronous — reads only already-extracted ParsedPage fields, no DOM, no I/O.
+ *
+ * Extraction order is fixed (contact links first, then JSON-LD nodes in document order)
+ * because the FIRST phone/address found is the one treated as the page's primary
+ * contact by the rule; a stable order keeps both rule paths agreeing.
+ */
+export function extractNapSignal(parsed: ParsedPage | null | undefined): NapSignal {
+  const signal = emptyNapSignal();
+  if (!parsed) return signal;
+
+  const phoneKeys = new Map<string, string>();
+  const addPhone = (key: string | null, display: string): void => {
+    if (!key || phoneKeys.size >= NAP_MAX_PHONES_PER_PAGE || phoneKeys.has(key)) return;
+    phoneKeys.set(key, display);
+  };
+
+  // `parsed.contactLinks`, NOT `parsed.links` — the parser drops non-crawlable
+  // schemes from the link graph, so tel:/mailto: only exist on this field.
+  for (const link of parsed.contactLinks ?? []) {
+    if (link.scheme === "mailto") {
+      signal.mailtoLink = true;
+      continue;
+    }
+    signal.telLink = true;
+    // The href payload is the fallback display; the visible anchor text wins
+    // when it spells out the same number, since that is the citable rendering
+    // a directory (or an agent) copies off the page.
+    const payload = decodeTelPayload(link.value);
+    const key = napPhoneKey(payload);
+    const text = link.text.trim();
+    addPhone(key, key && napPhoneKey(text) === key ? text : payload);
+  }
+
+  const raw = parsed.schema?.raw;
+  if (raw && mayCarryNap(raw)) {
+    const nodes = flattenJsonLdNodes(raw);
+    for (const node of nodes) {
+      if (
+        signal.name === null &&
+        NAP_NAME_SCHEMA_TYPES.includes(node["@type"] as string) &&
+        typeof node.name === "string" &&
+        node.name
+      ) {
+        signal.name = node.name;
+      }
+      if (typeof node.telephone === "string") {
+        const phone = node.telephone.trim();
+        addPhone(napPhoneKey(phone), phone);
+      }
+      if (signal.address === null && node.address !== undefined) {
+        const display = readSchemaAddress(node.address);
+        if (display) {
+          signal.address = napAddressKey(display);
+          signal.addressFormat = signal.address ? display : null;
+        }
+      }
+    }
+  }
+
+  signal.phones = [...phoneKeys.keys()];
+  signal.phoneFormats = [...phoneKeys.values()];
+  return signal;
+}
+
+/** `tel:` payloads may be percent-encoded; fall back to the raw text on bad input. */
+function decodeTelPayload(payload: string): string {
+  try {
+    return decodeURIComponent(payload).trim();
+  } catch {
+    return payload.trim();
+  }
+}


### PR DESCRIPTION
Extends the existing `local/nap-consistency` rule with cross-page comparison of the Name, Address and Phone each page declares. Same rule id, same `requiresLocalBusiness` gate: no new rule was added.

## What changed

`local/nap-consistency` keeps its `local-business-schema` and `contact-info` checks and gains two:

| Check | Verdict |
|---|---|
| `phone-consistency` / `address-consistency` | **pass** when one value is rendered the same way everywhere |
| | **warn** when one value is rendered several ways (`+1 (555) 123-4567` vs `555.123.4567`, `123 Main St` vs `123 Main Street`), which splits citations across directories |
| | **fail** when some pages present a genuinely different primary contact |

Only DECLARED contact data is read: `tel:`/`mailto:` anchors and JSON-LD `telephone`/`address`. No regex over body text, so order numbers, dates and prices are never mistaken for a NAP.

### Guards

A rule that fires on legitimately varied sites is worse than no rule, so the comparison stays quiet unless it can say something meaningful:

- `NAP_DRIFT_MIN_PAGES = 10`: fewer than ten pages declaring the signal cannot support a site-wide claim. The floor is on **declaring pages**, not crawl size, which is also the only count both rule paths agree on exactly (the legacy path's `site.pages` includes appended error pages).
- `NAP_MODAL_MIN_AGREEMENT = 0.7`: below 70% agreement there is no norm, so no page is a deviant. A multi-location business or franchise directory skips with a visible reason.

Each page's **first** declared phone is its primary contact, so a footer branch list does not make a site look inconsistent.

### Dual path

One accumulator and one check builder feed both the legacy `ctx.site.pages` scan and the `ctx.siteQuery` streaming cursor, and both read the same `extractNapSignal`. Only distinct values and renderings stay resident, with every URL list capped, so the streaming path's footprint tracks how varied a site's contact data is rather than how many pages it has.

## Plumbing

- **`extractNapSignal`** (`@squirrelscan/utils`) is the single definition of how a page's contact identity is read. Both rule paths call it, so they cannot drift apart.
- **`ParsedPage.contactLinks`** (new, optional). `extractLinks` drops every non-crawlable scheme, so `tel:`/`mailto:` anchors were unreachable to any site rule once the DOM was gone: a site rule only ever sees the `ParsedPage`. They are now carried on their own field and still stay out of the link graph.
- **`PageFeatureRow`** gains the per-page NAP scalars, persisted in the `page_features` fresh-install schema **and** an append-only v20 migration. Tests assert both paths separately, since `init()` execs the fresh schema before running migrations and a column added to only one of them would diverge.

## Golden delta

`streaming-rules-canonical-golden` on the 518-page fixture:

- `findings.length` 95709 -> **95711** (the two new checks, one each)
- `healthScore.overall` **48**, unchanged: the rule does not dominate the local category
- `perRuleTally.length` **264**, unchanged. This is the tripwire proving no new rule id was introduced; the pin now carries a comment saying to fix the root cause rather than the number.
- v1 vs v2 diff: zero divergences, byte-identical serialization

## Tests

- `packages/rules/tests/nap-consistency.test.ts` (new): pass / warn / fail / skipped, both skip reasons (under floor, no modal norm), the branch-number no-false-positive fixture, the preserved presence checks, and the comparison-key helpers.
- `packages/audit-engine/tests/site-query-nap-rule-golden.test.ts` (new): `parsePage` -> `extractPageFeatures` -> v20 columns -> `createSiteQuery` -> streaming branch, deep-equal to the legacy branch with `site.pages` empty.
- `packages/parser/tests/contact-links.test.ts` (new): capture, exclusion from `links`, param stripping, case-insensitive schemes, cap.
- `packages/crawler/tests/page-features-store.test.ts`: NAP round-trip, plus fresh-schema and v19-upgrade coverage of the new columns.

Root `bun test`: 3762 pass, 0 fail. `bun run test:engine`: 47 pass, 0 fail. Root typecheck, lint, format check and `docs:check` all clean.