### PR TITLE
feat(rules): add content/hidden-text rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Use the audit-website skill to audit this site and fix all issues but only crawl
 | E-E-A-T | 15 | Authority, trust, expertise signals |
 | Links | 14 | Broken links, redirects, anchor text |
 | Core SEO | 13 | Meta tags, canonical, doctype, charset |
-| Content | 14 | Readability, freshness, word count, encoding, copyright year |
+| Content | 15 | Readability, freshness, word count, encoding, hidden text, copyright year |
 | Structured Data | 10 | JSON-LD, schema validation |
 | Site Integrity | 9 | Injected pages, phishing kits, malware, SEO spam |
 | URL Structure | 8 | Length, format, parameters |
@@ -181,7 +181,7 @@ Use the audit-website skill to audit this site and fix all issues but only crawl
 | Internationalization | 2 | Hreflang, lang attribute |
 | Analytics | 2 | GTM, consent mode |
 
-**Total: 266 rules across 21 categories**
+**Total: 267 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -226,6 +226,7 @@
                 "pages": [
                   "rules/content/index",
                   "rules/content/heading-hierarchy",
+                  "rules/content/hidden-text",
                   "rules/content/word-count",
                   "rules/content/duplicate-title",
                   "rules/content/duplicate-description",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -110,7 +110,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
     Single binary, zero dependencies. Shell completions, self-update, and CI/CD compatible exit codes.
   </Card>
   <Card
-    title="266 Rules, 21 Categories"
+    title="267 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security audits.
@@ -190,7 +190,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **266 rules** across **21 categories**, plus opt-in cloud gap analysis:
+squirrelscan runs **267 rules** across **21 categories**, plus opt-in cloud gap analysis:
 
 | Category | Description |
 |----------|-------------|

--- a/docs/rules/content/hidden-text.mdx
+++ b/docs/rules/content/hidden-text.mdx
@@ -1,0 +1,106 @@
+---
+title: "Hidden Text & Links"
+description: "Detects text and links hidden from users but left visible to search engines"
+---
+
+Detects text and links hidden from users but left visible to search engines
+
+| | |
+|---|---|
+| **Rule ID** | `content/hidden-text` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Per-page |
+| **Severity** | warning (escalates to a failure when hidden links are involved) |
+| **Weight** | 6/10 |
+
+## Solution
+
+Google's spam policies treat text or links that are visible to crawlers but hidden from visitors as deceptive, and pages doing it can lose rankings or be removed from search entirely. Delete the hidden block, or make it genuinely visible to users.
+
+If the content is only meant for screen readers, use the standard visually-hidden pattern: a 1x1 clipped box, or a class named `sr-only` / `visually-hidden`, so it is recognisable as an accessibility affordance. If it is interactive UI that starts collapsed, mark it up as such with `aria-hidden`, the `hidden` attribute, or a role like `tabpanel` or `dialog`, so its hidden state reads as intentional.
+
+Never place keywords or links behind `display:none`, `opacity:0`, a zero font size, an off-screen offset, or same-on-same colour in order to reach a crawler.
+
+## What it checks
+
+squirrelscan reads the page's markup, not a rendered layout: there is no browser here to resolve the full CSS cascade. The rule therefore works from what is directly readable, and it is tuned for precision, so it would rather miss a spam page than accuse an honest one.
+
+**Where styles come from**
+
+- Inline `style` attributes on elements that carry text or links.
+- `<style>` blocks, but only rules whose selector is a bare class (`.promo`) or a bare id (`#promo`). Descendant, compound, pseudo and attribute selectors are skipped, because resolving them correctly needs a cascade.
+- Rules inside `@media`, `@supports`, `@layer` and `@keyframes` are never applied. `@media print { .no-print { display: none } }` hides nothing on screen, and honouring it would manufacture findings. They are not forgotten either: any class or id a conditional block mentions is treated as unresolvable, so the desktop copy of a responsive footer is left alone rather than reported.
+- External stylesheets are not fetched.
+
+**Techniques reported**
+
+| Technique | Example |
+|---|---|
+| `display:none` | `<div style="display:none">` |
+| `visibility:hidden` | `.promo { visibility: hidden }` |
+| `opacity:0` | `<span style="opacity:0">` |
+| Zero font size | `<p style="font-size:0">` |
+| Off-screen text indent | `text-indent: -9999px` |
+| Off-screen positioning | `position:absolute; left:-9999px` |
+| Off-screen margin | `margin-left: -9999px` |
+| Zero-size clipping | `height:0; overflow:hidden` |
+| Colour on colour | `color:#fff` painted on a `#fff` background, or `color:transparent` |
+
+An element is only reported when the hidden content is substantial: at least `min_hidden_chars` characters of text, or at least `min_hidden_links` links. Only the outermost hidden element is reported, so one hidden block produces one finding rather than one per descendant.
+
+The finding is a **warning** for hidden text and escalates to a **failure** once the page carries `min_hidden_links` hidden links or more, since hidden links are the stronger spam signal.
+
+## What it does not flag
+
+The rule deliberately stays quiet on every common, legitimate reason content is hidden.
+
+- **Screen-reader-only text.** The `clip` / `clip-path` idiom, a 1x1 off-screen box, and the usual class names: `sr-only`, `visually-hidden`, `visuallyhidden`, `screen-reader-text`, `skip-link` and friends.
+- **Interactive UI that starts collapsed.** Tab panels, accordions, dropdowns, modals, off-canvas navigation, carousels, toasts and cookie or consent banners, recognised through `role`, `aria-*`, `<dialog>` / `<details>` / `<nav>`, toggle attributes such as `data-bs-toggle`, and class names containing those words. A hidden element nested inside such a container is covered too.
+- **The `hidden` attribute and `aria-hidden="true"`.** These are the platform's own toggle and decoration markers and read as an explicit statement of intent, so they exempt an element rather than incriminate it.
+- **Elements whose class is also targeted by a selector the rule cannot resolve.** If `.drawer` is hidden by a simple rule but `.drawer.open` appears elsewhere in the stylesheet, the element is script-driven and is left alone.
+- **Idioms that look like hiding but are not.** `opacity:0` with a transition (a fade-in), `opacity:0` beside a displacing `transform` (the resting state of an entrance animation), `max-height:0` with a transition (a collapsing accordion), `text-indent:-9999px` with a background image (image replacement), `font-size:0` used only to close inline-block gaps, `color:transparent` with `background-clip:text` (gradient text), and invalid unitless offsets such as `left:-9999`, which no browser applies. A transition declared on a compound selector counts too, so `.card { opacity: 0 }` paired with `.card.in-view { transition: opacity .4s }` reads as a scroll reveal.
+- **Viewport and print variants.** Class names such as `nomobile`, `desktop-only` and `noprint` mark content shown in a medium the rule cannot evaluate.
+- **Elements the page's own JavaScript addresses.** When an inline script names an element by id or class, its hidden state is script-controlled: a form's success message, a tab, a footer revealed after hydration. This applies only to `display:none`, `visibility:hidden` and `opacity:0`, which every toggle library writes. Off-screen offsets, zero font sizes, zero-size clipping and colour-on-colour have no legitimate scripted use and are still reported.
+- **Small amounts of hidden text** with no keyword or link payload.
+- **Light text over unknown backdrops.** Colour matching only fires when both the text colour and the paint behind it are resolvable. Positioned overlays, elements with a `text-shadow`, and anything sitting on a background image or gradient are left alone.
+
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `min_hidden_chars` | number | `50` | Characters of hidden text on one element before it is reported |
+| `min_hidden_links` | number | `10` | Hidden links before the finding escalates from a warning to a failure |
+| `offscreen_px_threshold` | number | `-999` | Offsets at or below this many pixels count as pushed off-screen |
+| `a11y_classes` | string[] | `[]` | Extra screen-reader-only class names to treat as legitimate |
+| `safe_classes` | string[] | `[]` | Extra class names to exempt from hidden-text reporting |
+
+```toml squirrel.toml
+[rules.options."content/hidden-text"]
+min_hidden_chars = 120
+a11y_classes = ["acme-offscreen"]
+safe_classes = ["legacy-print-block"]
+```
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/hidden-text"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/hidden-text"]
+disable = ["*"]
+```

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -32,6 +32,9 @@ Text quality, readability, and content structure
   <Card title="Heading Hierarchy" icon="triangle-exclamation" href="/rules/content/heading-hierarchy">
     Validates heading structure and hierarchy
   </Card>
+  <Card title="Hidden Text and Links" icon="triangle-exclamation" href="/rules/content/hidden-text">
+    Detects text and links hidden from users but left visible to search engines
+  </Card>
   <Card title="Keyword Stuffing" icon="triangle-exclamation" href="/rules/content/keyword-stuffing">
     Detects excessive keyword repetition in content
   </Card>

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 266 audit rules organized by score group and category"
+description: "All 267 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **266 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **267 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -23,7 +23,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Internal and external link health and structure (14 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (14 rules)
+    Text quality, readability, and content structure (15 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (10 rules)

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -65,15 +65,15 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // rule-surface drift tripwire (see golden-baseline.test.ts for the same fixture).
       expect(v1.meta.pageCount).toBeGreaterThanOrEqual(GOLDEN_BASELINE_PAGE_COUNT);
       expect(v1.healthScore.overall).toBe(48);
-      // 95711 -> 97711: a11y/autocomplete-tokens and a11y/input-types emit four
-      // page checks between them (1 + 3) across the 500 fixture pages that have a
-      // document, 518 minus the 18 without one. The overall score is unmoved.
-      expect(v1.findings.length).toBe(97711);
+      // 97711 -> 98211: content/hidden-text emits one page check across the 500
+      // fixture pages that have a document, and passes on every one of them. The
+      // overall score is unmoved.
+      expect(v1.findings.length).toBe(98211);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
-      // is only correct alongside a deliberate new rule id. 264 -> 266 is the two
-      // rules above; anything else means a rule id leaked in, so fix that rather
-      // than this number.
-      expect(v1.perRuleTally.length).toBe(266);
+      // is only correct alongside a deliberate new rule id. 266 -> 267 is
+      // content/hidden-text; anything else means a rule id leaked in, so fix
+      // that rather than this number.
+      expect(v1.perRuleTally.length).toBe(267);
     },
     180_000,
   );

--- a/packages/rules/src/content/hidden-text.ts
+++ b/packages/rules/src/content/hidden-text.ts
@@ -1,0 +1,1277 @@
+// content/hidden-text - Hidden text and link abuse (Google spam policy)
+//
+// There is no layout engine and no CSSOM here, so there is no getComputedStyle
+// and no way to resolve the cascade. Everything below works from what is
+// directly readable on the page: inline `style` attributes, `<style>` rules
+// whose selector is a bare class or id, and the `hidden` / `aria-hidden`
+// attributes. Every judgement call is biased toward precision — telling a site
+// it is cloaking text when it is not is far more damaging than missing a page.
+
+import { z } from "zod";
+
+import type { Document, Element } from "linkedom";
+
+import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
+import { getTextExcludingScripts } from "./text-content";
+
+export const optionsSchema = z.object({
+  min_hidden_chars: z
+    .number()
+    .int()
+    .min(1)
+    .default(50)
+    .describe("Characters of hidden text on one element before it is reported"),
+  min_hidden_links: z
+    .number()
+    .int()
+    .min(1)
+    .default(10)
+    // A collapsed submenu or a responsive footer copy routinely holds a handful
+    // of links, so a low bar here turns ordinary chrome into a link-cloaking
+    // accusation. A block hidden to feed a crawler carries many more.
+    .describe("Hidden links before the finding escalates from a warning to a failure"),
+  offscreen_px_threshold: z
+    .number()
+    .default(-999)
+    .describe("Offsets at or below this many pixels count as pushed off-screen"),
+  a11y_classes: z
+    .array(z.string())
+    .default([])
+    .describe("Extra screen-reader-only class names to treat as legitimate"),
+  safe_classes: z
+    .array(z.string())
+    .default([])
+    .describe("Extra class names to exempt from hidden-text reporting"),
+});
+
+/**
+ * The screen-reader-only idiom under its common names. Text hidden this way is
+ * deliberate, Google handles it, and flagging it would libel every site using a
+ * utility class — so these are exempt before any technique is even considered.
+ */
+const A11Y_CLASSES = new Set([
+  "sr-only",
+  "sronly",
+  "sr-only-focusable",
+  "visually-hidden",
+  "visuallyhidden",
+  "visually-hidden-focusable",
+  "screen-reader-text",
+  "screen-reader-only",
+  "screenreader-only",
+  "show-for-sr",
+  "element-invisible",
+  "a11y-hidden",
+  "hidden-visually",
+  "hiddenvisually",
+  "assistive-text",
+  "skip-link",
+  "skip-to-content",
+]);
+
+/**
+ * Class tokens that mark interactive or stateful UI which is *supposed* to start
+ * hidden: tabs, accordions, dropdowns, modals, off-canvas nav, cookie banners.
+ * Without a CSSOM we cannot see the `.is-open` rule that reveals them, so their
+ * hidden state is treated as intentional rather than as spam.
+ */
+const INTERACTIVE_CLASS_TOKENS = new Set([
+  "accordion",
+  "accordions",
+  "alert",
+  "alertdialog",
+  "backdrop",
+  "banner",
+  "carousel",
+  "collapse",
+  "collapsible",
+  "combobox",
+  "consent",
+  "cookie",
+  "cookies",
+  "ccpa",
+  "dialog",
+  "disclosure",
+  "drawer",
+  "dropdown",
+  "dropdowns",
+  "expander",
+  "flyout",
+  "gdpr",
+  "glide",
+  "hamburger",
+  "lightbox",
+  "megamenu",
+  "menu",
+  "menus",
+  "modal",
+  "modals",
+  "nav",
+  "navbar",
+  "navigation",
+  "notification",
+  "notifications",
+  "offcanvas",
+  "overlay",
+  "panel",
+  "panels",
+  "popover",
+  "popup",
+  "slide",
+  "slides",
+  "slider",
+  "snackbar",
+  "splide",
+  "submenu",
+  "swiper",
+  "tab",
+  "tabs",
+  "tabpanel",
+  "toast",
+  "tooltip",
+  "tooltips",
+  "typeahead",
+]);
+
+/**
+ * Tokens that mark an element as visible only in some other medium or at some
+ * other viewport (`.nomobile`, `.desktop-only`, `.noprint`). `@media` blocks are
+ * stripped before indexing, so the rule that reveals these is one we can never
+ * see — `display:none` on them means "not here", not "nowhere".
+ */
+const MEDIA_VARIANT_CLASS_TOKENS = new Set([
+  "desktop",
+  "handheld",
+  "mobile",
+  "nodesktop",
+  "nomobile",
+  "noprint",
+  "notablet",
+  "phone",
+  "print",
+  "printonly",
+  "screen",
+  "screenonly",
+  "tablet",
+]);
+
+/**
+ * Tokens a framework flips to reveal an element (`.is-open`, `.accordion.show`).
+ * Their presence means the element's visibility is script-driven, and the rule
+ * that reveals it is exactly the kind of compound selector we deliberately skip.
+ */
+const STATE_CLASS_TOKENS = new Set([
+  "active",
+  "closed",
+  "collapsed",
+  "current",
+  "expanded",
+  "hidden",
+  "hide",
+  "inactive",
+  "invisible",
+  "open",
+  "opened",
+  "selected",
+  "show",
+  "shown",
+  "visible",
+]);
+
+/** Landmark/widget roles whose regions are routinely rendered hidden by default. */
+const INTERACTIVE_ROLES = new Set([
+  "alert",
+  "alertdialog",
+  "banner",
+  "combobox",
+  "dialog",
+  "listbox",
+  "log",
+  "menu",
+  "menubar",
+  "navigation",
+  "region",
+  "status",
+  "tablist",
+  "tabpanel",
+  "tooltip",
+  "tree",
+]);
+
+/** Tags that are containers for interactive or stateful UI. */
+const INTERACTIVE_TAGS = new Set(["dialog", "details", "summary", "nav", "menu"]);
+
+/** Never walked into: not indexable content, or handled by other rules. */
+const SKIPPED_TAGS = new Set(["script", "style", "noscript", "template", "iframe", "svg", "canvas"]);
+
+/** Attribute prefixes used by toggle libraries (Bootstrap, Radix, Headless UI, Alpine). */
+const TOGGLE_ATTR_RE =
+  /^(?:data-(?:bs-)?(?:toggle|target|dismiss|state|open|collapse|accordion|dropdown|modal|drawer|menu|popover|tooltip|carousel|slide|tab|cookie|consent)|x-show|x-cloak|v-show|data-headlessui-state|data-radix-[a-z-]+)$/;
+
+const MAX_ANCESTOR_DEPTH = 15;
+const MAX_ELEMENTS = 20_000;
+const MAX_STYLE_CHARS = 400_000;
+const MAX_STYLE_RULES = 4_000;
+const MAX_ITEMS = 10;
+const MAX_SCRIPT_CHARS = 2_000_000;
+/** Below this, a class/id token collides with ordinary script text by chance. */
+const MIN_SCRIPT_TOKEN_LENGTH = 5;
+/** Channel distance below which two opaque colours read as the same paint. */
+const COLOR_MATCH_DISTANCE = 16;
+const EM_TO_PX = 16;
+const EX_TO_PX = 8;
+const PT_TO_PX = 4 / 3;
+
+type Declarations = Map<string, string>;
+
+interface StyleIndex {
+  /** Declarations keyed by class token, merged in stylesheet order (later wins). */
+  byClass: Map<string, Declarations>;
+  /** Declarations keyed by id. */
+  byId: Map<string, Declarations>;
+  /**
+   * Class tokens and ids that also appear in a selector we refused to parse
+   * (descendant, compound, pseudo, attribute). Such an element may well be
+   * revealed by a rule we cannot see, so a stylesheet-only hidden verdict on it
+   * is not trustworthy and is dropped.
+   */
+  ambiguousClasses: Set<string>;
+  ambiguousIds: Set<string>;
+  /**
+   * Class tokens and ids named anywhere in a block that declares a transition or
+   * animation. The fade-in idiom puts the resting `opacity:0` on the element's
+   * own class and the transition on a compound selector (`.card.is-visible`), so
+   * an element-local check alone reads a scroll reveal as hidden text.
+   */
+  animatedClasses: Set<string>;
+  animatedIds: Set<string>;
+}
+
+const NAMED_COLORS: Record<string, [number, number, number]> = {
+  black: [0, 0, 0],
+  white: [255, 255, 255],
+  red: [255, 0, 0],
+  lime: [0, 255, 0],
+  blue: [0, 0, 255],
+  yellow: [255, 255, 0],
+  cyan: [0, 255, 255],
+  aqua: [0, 255, 255],
+  magenta: [255, 0, 255],
+  fuchsia: [255, 0, 255],
+  silver: [192, 192, 192],
+  gray: [128, 128, 128],
+  grey: [128, 128, 128],
+  maroon: [128, 0, 0],
+  olive: [128, 128, 0],
+  green: [0, 128, 0],
+  purple: [128, 0, 128],
+  teal: [0, 128, 128],
+  navy: [0, 0, 128],
+  whitesmoke: [245, 245, 245],
+  snow: [255, 250, 250],
+  ivory: [255, 255, 240],
+  linen: [250, 240, 230],
+};
+
+interface Rgba {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+/** `#fff`, `#ffffffff`, `rgb()/rgba()` (legacy and space-separated), or a named colour. */
+export function parseColor(raw: string): Rgba | null {
+  const value = raw.trim().toLowerCase();
+  if (!value) return null;
+  if (value === "transparent") return { r: 0, g: 0, b: 0, a: 0 };
+
+  const named = NAMED_COLORS[value];
+  if (named) return { r: named[0], g: named[1], b: named[2], a: 1 };
+
+  if (value.startsWith("#")) {
+    const hex = value.slice(1);
+    const expand = (c: string) => Number.parseInt(c + c, 16);
+    if (/^[0-9a-f]{3,4}$/.test(hex)) {
+      return {
+        r: expand(hex[0]),
+        g: expand(hex[1]),
+        b: expand(hex[2]),
+        a: hex.length === 4 ? expand(hex[3]) / 255 : 1,
+      };
+    }
+    if (/^[0-9a-f]{6}$/.test(hex) || /^[0-9a-f]{8}$/.test(hex)) {
+      const byte = (i: number) => Number.parseInt(hex.slice(i, i + 2), 16);
+      return { r: byte(0), g: byte(2), b: byte(4), a: hex.length === 8 ? byte(6) / 255 : 1 };
+    }
+    return null;
+  }
+
+  const fn = value.match(/^rgba?\(([^)]+)\)$/);
+  if (!fn) return null;
+  const parts = fn[1].split(/[,/\s]+/).filter(Boolean);
+  if (parts.length < 3) return null;
+  const channel = (part: string): number | null => {
+    if (part.endsWith("%")) {
+      const pct = Number.parseFloat(part);
+      return Number.isNaN(pct) ? null : Math.round((pct / 100) * 255);
+    }
+    const n = Number.parseFloat(part);
+    return Number.isNaN(n) ? null : Math.round(n);
+  };
+  const r = channel(parts[0]);
+  const g = channel(parts[1]);
+  const b = channel(parts[2]);
+  if (r === null || g === null || b === null) return null;
+  let a = 1;
+  if (parts[3] !== undefined) {
+    a = parts[3].endsWith("%") ? Number.parseFloat(parts[3]) / 100 : Number.parseFloat(parts[3]);
+    if (Number.isNaN(a)) a = 1;
+  }
+  return { r, g, b, a };
+}
+
+/** `background-color`, or the colour inside a `background` shorthand. */
+function backgroundColorOf(decls: Declarations): Rgba | null {
+  const explicit = decls.get("background-color");
+  if (explicit) return parseColor(explicit);
+  const shorthand = decls.get("background");
+  if (!shorthand || shorthand.includes("url(") || shorthand.includes("gradient")) return null;
+  for (const token of shorthand.split(/\s+/)) {
+    const color = parseColor(token);
+    if (color) return color;
+  }
+  return null;
+}
+
+function colorDistance(a: Rgba, b: Rgba): number {
+  return Math.sqrt((a.r - b.r) ** 2 + (a.g - b.g) ** 2 + (a.b - b.b) ** 2);
+}
+
+/**
+ * A CSS length in pixels, or null when it cannot be resolved. Unitless non-zero
+ * values return null on purpose: browsers reject them, so `left:-9999` does not
+ * actually hide anything and must not be reported as if it did.
+ */
+export function parseLengthPx(raw: string): number | null {
+  const value = raw.trim().toLowerCase();
+  const match = value.match(/^(-?\d*\.?\d+)(px|em|rem|pt|ex|ch)?$/);
+  if (!match) return null;
+  const n = Number.parseFloat(match[1]);
+  if (Number.isNaN(n)) return null;
+  const unit = match[2];
+  if (!unit) return n === 0 ? 0 : null;
+  if (unit === "px") return n;
+  if (unit === "pt") return n * PT_TO_PX;
+  // Font-relative units are approximated against a default 16px font. `ex` and
+  // `ch` are roughly half an em; using the em factor for them would read
+  // `-100ch` as twice as far off-screen as it is and flag ordinary indentation.
+  if (unit === "ex" || unit === "ch") return n * EX_TO_PX;
+  return n * EM_TO_PX; // em / rem
+}
+
+function isZeroLength(raw: string): boolean {
+  return /^-?0*(?:\.0+)?(?:px|em|rem|pt|%|vh|vw|ex|ch)?$/.test(raw.trim().toLowerCase());
+}
+
+/**
+ * Index just past a quoted string that starts at `start`. Used by every scanner
+ * below so that punctuation inside a quoted value or a `data:` URL cannot be
+ * mistaken for structure.
+ */
+function skipString(css: string, start: number): number {
+  const quote = css[start];
+  let i = start + 1;
+  while (i < css.length) {
+    if (css[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (css[i] === quote) return i + 1;
+    i++;
+  }
+  return css.length;
+}
+
+/** Index just past a CSS comment starting at `start`, or end of input. */
+function skipComment(css: string, start: number): number {
+  const end = css.indexOf("*/", start + 2);
+  return end === -1 ? css.length : end + 2;
+}
+
+/**
+ * Parses a declaration block (`color:red;display:none`) into a property map.
+ * Splits on the structural `;` and `:` only: `background:url("data:…;base64,…")`
+ * carries both inside a quoted string and a `url()`, and naive splitting there
+ * manufactures declarations that were never written.
+ */
+export function parseDeclarations(css: string): Declarations {
+  const decls: Declarations = new Map();
+  let i = 0;
+  let chunkStart = 0;
+  let depth = 0;
+
+  const flush = (end: number): void => {
+    const chunk = css.slice(chunkStart, end);
+    let colon = -1;
+    let d = 0;
+    for (let k = 0; k < chunk.length; k++) {
+      const c = chunk[k];
+      if (c === "(") d++;
+      else if (c === ")") d--;
+      else if (c === ":" && d === 0) {
+        colon = k;
+        break;
+      }
+    }
+    if (colon === -1) return;
+    const prop = chunk.slice(0, colon).trim().toLowerCase();
+    if (!prop) return;
+    const value = chunk
+      .slice(colon + 1)
+      .replace(/!\s*important/gi, "")
+      .trim()
+      .toLowerCase();
+    if (!value) return;
+    decls.set(prop, value);
+  };
+
+  while (i < css.length) {
+    const ch = css[i];
+    if (ch === '"' || ch === "'") {
+      i = skipString(css, i);
+      continue;
+    }
+    if (ch === "/" && css[i + 1] === "*") {
+      i = skipComment(css, i);
+      continue;
+    }
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    else if (ch === ";" && depth === 0) {
+      flush(i);
+      chunkStart = i + 1;
+    }
+    i++;
+  }
+  flush(css.length);
+  return decls;
+}
+
+/** One style rule lifted out of a sheet, with whether an at-rule encloses it. */
+interface RawRule {
+  selector: string;
+  body: string;
+  /**
+   * The rule sits inside `@media`/`@supports`/`@layer`/`@keyframes`. Such a rule
+   * is never applied — `@media print { .no-print { display:none } }` hides
+   * nothing on screen — but it is not forgotten either: the selectors it names
+   * are the ones that would reveal an element again, so they are marked
+   * untrustworthy instead.
+   */
+  conditional: boolean;
+}
+
+/**
+ * A single linear pass over a stylesheet. Deliberately hand-written: the regex
+ * form (`/([^{}]+)\{([^{}]*)\}/g` over comment-stripped text) backtracks
+ * quadratically, and a page carrying 200KB of brace-less or unterminated-comment
+ * CSS took 26 seconds to index — a crawler-wide stall on attacker-supplied
+ * input. This scanner is O(n) and allocates only the rules it yields.
+ */
+function parseRules(css: string, maxRules: number): RawRule[] {
+  const rules: RawRule[] = [];
+  let i = 0;
+  let preludeStart = 0;
+  let atDepth = 0;
+
+  while (i < css.length && rules.length < maxRules) {
+    const ch = css[i];
+
+    if (ch === "/" && css[i + 1] === "*") {
+      i = skipComment(css, i);
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipString(css, i);
+      continue;
+    }
+    // A statement at-rule (`@import url(…);`) or a stray semicolon: whatever
+    // came before it was not a selector.
+    if (ch === ";") {
+      i++;
+      preludeStart = i;
+      continue;
+    }
+    if (ch === "}") {
+      if (atDepth > 0) atDepth--;
+      i++;
+      preludeStart = i;
+      continue;
+    }
+    if (ch !== "{") {
+      i++;
+      continue;
+    }
+
+    const prelude = css.slice(preludeStart, i).trim();
+    // `@media`, `@supports`, `@layer`, `@keyframes`: descend, marking everything
+    // inside as conditional rather than skipping past it.
+    if (prelude.startsWith("@")) {
+      atDepth++;
+      i++;
+      preludeStart = i;
+      continue;
+    }
+
+    // A style rule. Consume its whole block, including any nested braces, so a
+    // malformed sheet cannot desynchronise the scan.
+    const bodyStart = i + 1;
+    let depth = 1;
+    let j = bodyStart;
+    while (j < css.length && depth > 0) {
+      const c = css[j];
+      if (c === "/" && css[j + 1] === "*") {
+        j = skipComment(css, j);
+        continue;
+      }
+      if (c === '"' || c === "'") {
+        j = skipString(css, j);
+        continue;
+      }
+      if (c === "{") depth++;
+      else if (c === "}") depth--;
+      j++;
+    }
+    rules.push({
+      selector: prelude,
+      body: css.slice(bodyStart, depth === 0 ? j - 1 : css.length),
+      conditional: atDepth > 0,
+    });
+    i = j;
+    preludeStart = i;
+  }
+
+  return rules;
+}
+
+/** Adds every class / id token a selector chunk mentions to the given sets. */
+function harvestSelectorTokens(text: string, classes: Set<string>, ids: Set<string>): void {
+  for (const cls of text.matchAll(/\.([-_a-zA-Z0-9]+)/g)) classes.add(cls[1]);
+  for (const id of text.matchAll(/#([-_a-zA-Z0-9]+)/g)) ids.add(id[1]);
+}
+
+/**
+ * Merges a rule's declarations into the index. Two bare selectors setting the
+ * same property to different values cannot be ordered without tracking
+ * specificity and source order, so the property is recorded as contested and
+ * later dropped rather than guessed at.
+ */
+function mergeInto(
+  target: Map<string, Declarations>,
+  contested: Set<string>,
+  key: string,
+  decls: Declarations,
+): void {
+  const existing = target.get(key);
+  if (!existing) {
+    target.set(key, new Map(decls));
+    return;
+  }
+  for (const [prop, value] of decls) {
+    const previous = existing.get(prop);
+    if (previous !== undefined && previous !== value) contested.add(key);
+    existing.set(prop, value);
+  }
+}
+
+/** Indexes every `<style>` block by bare class / id selector. Complex selectors are skipped. */
+export function buildStyleIndex(styleTexts: string[]): StyleIndex {
+  const index: StyleIndex = {
+    byClass: new Map(),
+    byId: new Map(),
+    ambiguousClasses: new Set(),
+    ambiguousIds: new Set(),
+    animatedClasses: new Set(),
+    animatedIds: new Set(),
+  };
+
+  let budget = MAX_STYLE_CHARS;
+  let ruleBudget = MAX_STYLE_RULES;
+
+  for (const raw of styleTexts) {
+    if (budget <= 0 || ruleBudget <= 0) break;
+    const text = raw.slice(0, budget);
+    budget -= text.length;
+
+    for (const rule of parseRules(text, ruleBudget)) {
+      ruleBudget--;
+
+      if (rule.conditional) {
+        harvestSelectorTokens(rule.selector, index.ambiguousClasses, index.ambiguousIds);
+        continue;
+      }
+
+      const decls = parseDeclarations(rule.body);
+      if (decls.size === 0) continue;
+
+      // A block that animates marks its subjects as animated wherever they were
+      // named, so `.card { opacity:0 }` + `.card.in { transition:opacity .3s }`
+      // reads as a scroll reveal rather than as concealed text.
+      if (hasAnimation(decls)) {
+        harvestSelectorTokens(rule.selector, index.animatedClasses, index.animatedIds);
+      }
+
+      for (const rawSelector of rule.selector.split(",")) {
+        const selector = rawSelector.trim();
+        if (/^\.[-_a-zA-Z0-9]+$/.test(selector)) {
+          mergeInto(index.byClass, index.ambiguousClasses, selector.slice(1), decls);
+          continue;
+        }
+        if (/^#[-_a-zA-Z0-9]+$/.test(selector)) {
+          mergeInto(index.byId, index.ambiguousIds, selector.slice(1), decls);
+          continue;
+        }
+        // Anything else (descendant, compound, pseudo, attribute) is not
+        // resolved; it only marks the tokens it mentions as untrustworthy.
+        harvestSelectorTokens(selector, index.ambiguousClasses, index.ambiguousIds);
+      }
+    }
+  }
+
+  return index;
+}
+
+/**
+ * The element's class attribute as written. Class names are case-sensitive in
+ * standards-mode HTML, so these are matched against the style index verbatim;
+ * only the allowlist comparisons lower-case them.
+ */
+function classTokens(el: Element): string[] {
+  const cls = el.getAttribute("class");
+  if (!cls) return [];
+  return cls.split(/\s+/).filter(Boolean);
+}
+
+/** Class tokens split further on `-` and `_` and lower-cased, for allowlists. */
+function classNameParts(el: Element): string[] {
+  const parts: string[] = [];
+  for (const token of classTokens(el)) {
+    const lower = token.toLowerCase();
+    parts.push(lower);
+    // Hyphenated and underscored compounds count part-by-part:
+    // `cookie-banner`, `tab_panel`.
+    for (const part of lower.split(/[-_]+/)) {
+      if (part && part !== lower) parts.push(part);
+    }
+  }
+  return parts;
+}
+
+function tagOf(el: Element): string {
+  return (el.tagName || "").toLowerCase();
+}
+
+/**
+ * Resolved declarations for one element, applied in ascending specificity:
+ * class rules, then the id rule, then inline. Two class rules that disagree on
+ * a property cannot be ordered without source order, so `mergeInto` has already
+ * marked such a class contested and `ambiguous` drops the verdict entirely.
+ */
+function resolveDeclarations(
+  el: Element,
+  index: StyleIndex,
+): { resolved: Declarations; inline: Declarations; ambiguous: boolean; animated: boolean } {
+  const resolved: Declarations = new Map();
+  let ambiguous = false;
+  let animated = false;
+
+  for (const token of classTokens(el)) {
+    const byClass = index.byClass.get(token);
+    if (byClass) for (const [prop, value] of byClass) resolved.set(prop, value);
+    if (index.ambiguousClasses.has(token)) ambiguous = true;
+    if (index.animatedClasses.has(token)) animated = true;
+  }
+
+  const id = el.getAttribute("id") || "";
+  if (id) {
+    const byId = index.byId.get(id);
+    if (byId) for (const [prop, value] of byId) resolved.set(prop, value);
+    if (index.ambiguousIds.has(id)) ambiguous = true;
+    if (index.animatedIds.has(id)) animated = true;
+  }
+
+  const inline = parseDeclarations(el.getAttribute("style") || "");
+  for (const [prop, value] of inline) resolved.set(prop, value);
+
+  return { resolved, inline, ambiguous, animated };
+}
+
+const NO_DECLARATIONS: Declarations = new Map();
+
+/** True when this element declares itself legitimate hidden UI. */
+function hasLegitimateMarker(el: Element, decls: Declarations, opts: ResolvedOptions): boolean {
+  // The platform's own toggle markers. Without a CSSOM we cannot distinguish a
+  // JS-toggled region from a permanently hidden one, and these attributes are
+  // an explicit statement of intent, so they exempt rather than incriminate.
+  if (el.hasAttribute("hidden")) return true;
+  if (el.getAttribute("aria-hidden") === "true") return true;
+  if (el.hasAttribute("aria-expanded")) return true;
+  if (el.hasAttribute("aria-controls")) return true;
+  if (el.hasAttribute("aria-modal")) return true;
+  if (el.hasAttribute("aria-haspopup")) return true;
+  if (el.hasAttribute("aria-live")) return true;
+
+  if (INTERACTIVE_TAGS.has(tagOf(el))) return true;
+
+  const role = (el.getAttribute("role") || "").toLowerCase();
+  if (role && INTERACTIVE_ROLES.has(role)) return true;
+
+  for (const name of el.getAttributeNames()) {
+    if (TOGGLE_ATTR_RE.test(name.toLowerCase())) return true;
+  }
+
+  for (const part of classNameParts(el)) {
+    if (A11Y_CLASSES.has(part) || opts.a11yClasses.has(part)) return true;
+    if (opts.safeClasses.has(part)) return true;
+    if (INTERACTIVE_CLASS_TOKENS.has(part)) return true;
+    if (MEDIA_VARIANT_CLASS_TOKENS.has(part)) return true;
+    if (STATE_CLASS_TOKENS.has(part)) return true;
+  }
+
+  // The clip / clip-path screen-reader idiom, in any of its spellings.
+  if (decls.has("clip") || decls.has("clip-path")) return true;
+
+  // The other half of that idiom: a 1x1 box parked off-screen.
+  const w = decls.get("width");
+  const h = decls.get("height");
+  if (w && h) {
+    const wpx = parseLengthPx(w);
+    const hpx = parseLengthPx(h);
+    if (wpx !== null && hpx !== null && wpx <= 1 && hpx <= 1) return true;
+  }
+
+  return false;
+}
+
+/**
+ * The same test applied to the ancestor chain, on markup signals only. A tab
+ * panel usually carries no marker of its own — its `role="tablist"` wrapper or
+ * `.cookie-banner` container does — so a hidden element nested inside declared
+ * interactive UI is treated as part of that UI.
+ */
+function ancestorHasLegitimateMarker(el: Element, opts: ResolvedOptions): boolean {
+  let current = el.parentElement as Element | null;
+  let depth = 0;
+  while (current && depth < MAX_ANCESTOR_DEPTH) {
+    if (tagOf(current) === "body") return false;
+    if (hasLegitimateMarker(current, NO_DECLARATIONS, opts)) return true;
+    current = current.parentElement as Element | null;
+    depth++;
+  }
+  return false;
+}
+
+/** A declared transition or animation. Used both per-element and to index selectors. */
+function hasAnimation(decls: Declarations): boolean {
+  for (const prop of decls.keys()) {
+    if (prop.startsWith("transition") || prop.startsWith("animation")) return true;
+  }
+  return false;
+}
+
+/**
+ * The entrance-animation resting state every reveal library writes:
+ * `opacity:0;transform:translateY(25px)`. Text being concealed has no reason to
+ * also be displaced, so a transform alongside the fade is evidence of motion.
+ * A transform that is itself an off-screen shove does not count — that is the
+ * hiding technique, not a guard against it. Element-local only: indexing
+ * `transform` as animation would exempt every `.icon { transform: rotate(45deg) }`.
+ */
+function hasEntranceTransform(decls: Declarations): boolean {
+  const transform = decls.get("transform");
+  if (!transform || transform === "none") return false;
+  return !/-\d{3,}(?:px|em|rem|%)/.test(transform);
+}
+
+/**
+ * Anything painted behind the text that is not a flat colour. Gradients count:
+ * `background:linear-gradient(...)` under white text is a hero banner, and
+ * treating the page's own background colour as what shows through would accuse
+ * it of hiding the caption.
+ */
+function hasBackgroundImage(decls: Declarations): boolean {
+  const bgImage = decls.get("background-image");
+  if (bgImage && bgImage !== "none") return true;
+  const bg = decls.get("background");
+  return Boolean(bg && (bg.includes("url(") || bg.includes("gradient")));
+}
+
+/**
+ * A hiding technique found on one element. `kind` drives how much of the
+ * subtree the technique actually hides; `label` is what the report shows.
+ */
+export interface Technique {
+  kind: "display" | "visibility" | "opacity" | "font-size" | "offscreen" | "zero-size" | "color";
+  label: string;
+}
+
+/**
+ * Techniques a toggle library also writes, so they carry no weight on an element
+ * the page's own scripts address. The rest have no legitimate scripted use.
+ */
+const WEAK_TECHNIQUES = new Set<Technique["kind"]>(["display", "visibility", "opacity"]);
+
+/**
+ * The hiding techniques declared on one element. `decls` is what we trust for
+ * detection; `guards` is the widest view we have and is only ever used to
+ * suppress, so a suppressing declaration is never missed.
+ */
+export function detectTechniques(
+  decls: Declarations,
+  guards: Declarations,
+  offscreenThreshold: number,
+  /** The element is animated by a rule elsewhere in the sheet (scroll reveal). */
+  animatedElsewhere = false,
+): Technique[] {
+  const techniques: Technique[] = [];
+  const animated = animatedElsewhere || hasAnimation(guards) || hasEntranceTransform(guards);
+
+  if (decls.get("display") === "none") techniques.push({ kind: "display", label: "display:none" });
+
+  // `visibility:hidden` and `opacity:0` alongside a transition or animation are
+  // the universal fade-in / crossfade idiom, not concealment.
+  const visibility = decls.get("visibility");
+  if ((visibility === "hidden" || visibility === "collapse") && !animated) {
+    techniques.push({ kind: "visibility", label: "visibility:hidden" });
+  }
+
+  const opacity = decls.get("opacity");
+  if (opacity !== undefined && Number.parseFloat(opacity) === 0 && !animated) {
+    techniques.push({ kind: "opacity", label: "opacity:0" });
+  }
+
+  const fontSize = decls.get("font-size");
+  if (fontSize !== undefined && isZeroLength(fontSize)) {
+    techniques.push({ kind: "font-size", label: "font-size:0" });
+  }
+
+  // Off-screen positioning. A background image means image replacement (a logo
+  // whose alt text is pushed off-screen), which is a design idiom, not spam.
+  if (!hasBackgroundImage(guards)) {
+    const textIndent = decls.get("text-indent");
+    if (textIndent !== undefined) {
+      const px = parseLengthPx(textIndent);
+      const pct = textIndent.endsWith("%") ? Number.parseFloat(textIndent) : null;
+      if ((px !== null && px <= offscreenThreshold) || (pct !== null && pct <= -100)) {
+        techniques.push({ kind: "offscreen", label: "text-indent off-screen" });
+      }
+    }
+
+    const position = decls.get("position");
+    if (position === "absolute" || position === "fixed") {
+      for (const prop of ["left", "top"] as const) {
+        const px = parseLengthPx(decls.get(prop) ?? "");
+        if (px !== null && px <= offscreenThreshold) {
+          techniques.push({
+            kind: "offscreen",
+            label: `position:${position} ${prop}:${decls.get(prop)}`,
+          });
+          break;
+        }
+      }
+    }
+
+    for (const prop of ["margin-left", "margin-top"] as const) {
+      const px = parseLengthPx(decls.get(prop) ?? "");
+      if (px !== null && px <= offscreenThreshold) {
+        techniques.push({ kind: "offscreen", label: `${prop} off-screen` });
+        break;
+      }
+    }
+  }
+
+  // Zero-size clipping. An animated collapse (`max-height:0` + transition) is an
+  // accordion mid-flight, so the animation guard applies here too.
+  const overflow = guards.get("overflow") ?? guards.get("overflow-y") ?? guards.get("overflow-x");
+  if (overflow === "hidden" && !animated) {
+    const collapsed = (["height", "width", "max-height", "max-width"] as const).find((prop) => {
+      const value = decls.get(prop);
+      return value !== undefined && isZeroLength(value);
+    });
+    if (collapsed) {
+      techniques.push({ kind: "zero-size", label: `${collapsed}:0 with overflow:hidden` });
+    }
+  }
+
+  return techniques;
+}
+
+/**
+ * Text painted in (or as) its own backdrop. Only same-element declarations, or
+ * the nearest ancestor that actually paints a background, are compared — the
+ * cascade is never guessed at.
+ */
+function detectColorOnColor(
+  decls: Declarations,
+  guards: Declarations,
+  backdrop: Rgba | null,
+): Technique | null {
+  // A gradient/clipped fill legitimately sets a transparent colour.
+  if (guards.has("-webkit-text-fill-color")) return null;
+  const clip = guards.get("background-clip") ?? guards.get("-webkit-background-clip");
+  if (clip === "text") return null;
+
+  const rawColor = decls.get("color");
+  if (!rawColor) return null;
+  const color = parseColor(rawColor);
+  if (!color) return null;
+
+  if (color.a === 0) return { kind: "color", label: "color:transparent" };
+
+  const rawBg = decls.get("background-color") ?? decls.get("background");
+  const ownBg = backgroundColorOf(decls);
+  const against = ownBg && ownBg.a === 1 ? ownBg : backdrop;
+  if (!against || against.a !== 1 || color.a !== 1) return null;
+  if (colorDistance(color, against) > COLOR_MATCH_DISTANCE) return null;
+
+  return { kind: "color", label: `color ${rawColor} on background ${rawBg ?? "inherited"}` };
+}
+
+/**
+ * Whether any descendant escapes an inherited technique. `color`, `font-size`
+ * and `visibility` are inherited, so a descendant re-declaring one of them
+ * escapes the ancestor's value and its text is still visible. A colour finding
+ * has a second escape: a descendant that paints its own opaque background is no
+ * longer the colour-on-colour the ancestor set up, whatever it inherited.
+ */
+function descendantDeclares(el: Element, index: StyleIndex, prop: string): boolean {
+  const stack: Element[] = [...el.children] as Element[];
+  let budget = 400;
+  while (stack.length > 0) {
+    if (budget-- <= 0) return true; // too large to be sure — assume an override
+    const current = stack.pop() as Element;
+    if (SKIPPED_TAGS.has(tagOf(current))) continue;
+    const { resolved } = resolveDeclarations(current, index);
+    if (resolved.has(prop)) return true;
+    if (prop === "color" && (backgroundColorOf(resolved) || hasBackgroundImage(resolved))) {
+      return true;
+    }
+    for (const child of current.children) stack.push(child as Element);
+  }
+  return false;
+}
+
+/** Whitespace-collapsed length of an element's indexable text. */
+function textLength(el: Element): number {
+  return getTextExcludingScripts(el).replace(/\s+/g, " ").trim().length;
+}
+
+/** Text in this element's own text nodes only (children may reset an inherited font-size). */
+function directTextLength(el: Element): number {
+  let text = "";
+  for (const node of el.childNodes) {
+    if (node.nodeType === 3) text += node.textContent || "";
+  }
+  return text.replace(/\s+/g, " ").trim().length;
+}
+
+/** Leading `scheme:` of a URL, if it has one. */
+const URL_SCHEME_RE = /^([a-z][a-z0-9+.-]*):/i;
+
+/**
+ * Links a crawler would actually follow. An allow-list, not a deny-list: only
+ * http(s) and scheme-relative or relative hrefs are links a search engine
+ * indexes. `mailto:`, `tel:`, `data:`, `javascript:` and the rest carry no link
+ * equity, and counting them would inflate the tally that escalates this check
+ * from a warning to a failure.
+ */
+function countIndexableLinks(el: Element): number {
+  let count = 0;
+  for (const a of el.querySelectorAll("a[href]")) {
+    const href = (a.getAttribute("href") || "").trim();
+    if (!href || href.startsWith("#")) continue;
+    const scheme = href.match(URL_SCHEME_RE)?.[1].toLowerCase();
+    if (scheme && scheme !== "http" && scheme !== "https") continue;
+    count++;
+  }
+  return count;
+}
+
+/**
+ * The page's own inline scripts, lowercased, for the script-reference guard.
+ * Capped: hydration payloads run to megabytes and this is only ever a hint.
+ */
+function collectScriptText(doc: Document): string {
+  let out = "";
+  for (const script of doc.querySelectorAll("script")) {
+    if (out.length >= MAX_SCRIPT_CHARS) break;
+    out += (script.textContent || "").toLowerCase();
+  }
+  return out.slice(0, MAX_SCRIPT_CHARS);
+}
+
+/**
+ * True when the page's own JavaScript names this element by id or class. Such an
+ * element's hidden state is script-controlled — a tab, a form's success message,
+ * a footer revealed after hydration — and we cannot run the script that reveals
+ * it. Text placed to deceive a crawler has no reason to be addressed by the
+ * page's own code. Short tokens are ignored: `cta` or `row` would collide with
+ * ordinary script text and exempt half the page.
+ */
+function isScriptReferenced(el: Element, scriptText: string): boolean {
+  if (!scriptText) return false;
+  const id = (el.getAttribute("id") || "").toLowerCase();
+  if (id.length >= MIN_SCRIPT_TOKEN_LENGTH && scriptText.includes(id)) return true;
+  for (const token of classTokens(el)) {
+    const lower = token.toLowerCase();
+    if (lower.length >= MIN_SCRIPT_TOKEN_LENGTH && scriptText.includes(lower)) return true;
+  }
+  return false;
+}
+
+/** A short, human-readable handle for the offending node. */
+function describeElement(el: Element): string {
+  let label = tagOf(el) || "element";
+  const id = el.getAttribute("id");
+  if (id) label += `#${id}`;
+  const classes = (el.getAttribute("class") || "").trim().split(/\s+/).filter(Boolean);
+  for (const cls of classes.slice(0, 2)) label += `.${cls}`;
+  return label;
+}
+
+/** The colour the page paints behind everything: `<body>`'s background, else `<html>`'s. */
+function pageBackdrop(root: Element | null, body: Element, index: StyleIndex): Rgba | null {
+  for (const el of [body, root]) {
+    if (!el) continue;
+    const decls = resolveDeclarations(el, index).resolved;
+    // A page-wide image or gradient makes the backdrop unknowable, and a
+    // `background-color` declared beside it is only the fallback beneath it.
+    if (hasBackgroundImage(decls)) return null;
+    const color = backgroundColorOf(decls);
+    if (color && color.a === 1) return color;
+  }
+  return null;
+}
+
+interface ResolvedOptions {
+  minHiddenChars: number;
+  minHiddenLinks: number;
+  offscreenThreshold: number;
+  a11yClasses: Set<string>;
+  safeClasses: Set<string>;
+}
+
+interface HiddenFinding {
+  selector: string;
+  techniques: string[];
+  chars: number;
+  links: number;
+  snippet: string;
+}
+
+export const hiddenTextRule: Rule = {
+  meta: {
+    id: "content/hidden-text",
+    name: "Hidden Text & Links",
+    description: "Detects text and links hidden from users but left visible to search engines",
+    solution:
+      "Google's spam policies treat text or links that are visible to crawlers but hidden from visitors as deceptive, and pages doing it can lose rankings or be removed from search entirely. Delete the hidden block, or make it genuinely visible to users. If the content is only meant for screen readers, use the standard visually-hidden pattern (a 1x1 clipped box, or a class named sr-only / visually-hidden) so it is recognisable as an accessibility affordance. If it is interactive UI that starts collapsed, mark it up as such with aria-hidden, the hidden attribute or a role like tabpanel or dialog, so its hidden state reads as intentional. Never place keywords or links behind display:none, opacity:0, a zero font size, an off-screen offset or same-on-same colour in order to reach a crawler.",
+    category: "content",
+    scope: "page",
+    // Warning by default: the check escalates itself to a failure once hidden
+    // LINKS are involved, which is the stronger spam signal.
+    severity: "warning",
+    weight: 6,
+    optionsSchema,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const parsed = optionsSchema.parse(ctx.options);
+    const opts: ResolvedOptions = {
+      minHiddenChars: parsed.min_hidden_chars,
+      minHiddenLinks: parsed.min_hidden_links,
+      offscreenThreshold: parsed.offscreen_px_threshold,
+      a11yClasses: new Set(parsed.a11y_classes.map((c) => c.toLowerCase())),
+      safeClasses: new Set(parsed.safe_classes.map((c) => c.toLowerCase())),
+    };
+
+    const doc = ctx.parsed.document;
+    if (!doc) return { checks: [] };
+
+    const checks: CheckResult[] = [];
+    const body = doc.querySelector("body");
+    if (!body) {
+      checks.push({
+        name: "hidden-text",
+        status: "skipped",
+        message: "No body content to analyze",
+        skipReason: "no-body",
+      });
+      return { checks };
+    }
+
+    // Built on first use: most pages never reach a weak-technique candidate.
+    let scriptText: string | undefined;
+
+    const styleTexts = [...doc.querySelectorAll("style")].map((el) => el.textContent || "");
+    const index = buildStyleIndex(styleTexts);
+
+    const findings: HiddenFinding[] = [];
+    let visited = 0;
+    // Depth-first over elements, outermost first: once a subtree is hidden (or
+    // allowlisted) nothing inside it is inspected, so one hidden block yields
+    // one finding instead of one per descendant.
+    const stack: Element[] = [...body.children].reverse() as Element[];
+    const backdrops = new Map<Element, Rgba | null>();
+    backdrops.set(body as Element, pageBackdrop(doc.documentElement as Element, body as Element, index));
+
+    while (stack.length > 0) {
+      const el = stack.pop() as Element;
+      if (visited++ > MAX_ELEMENTS) break;
+      const tag = tagOf(el);
+      if (SKIPPED_TAGS.has(tag)) continue;
+
+      const { resolved, inline, ambiguous, animated } = resolveDeclarations(el, index);
+
+      // Track the painted backdrop for descendants: background is not inherited,
+      // but what shows behind an element is its nearest painting ancestor.
+      const ownBgColor = backgroundColorOf(resolved);
+      const parentBackdrop = backdrops.get(el.parentElement as Element) ?? null;
+      // An image or gradient makes the backdrop unknowable, and unknown must not
+      // decay into "the page background" — that is how white-on-photo captions
+      // get accused of hiding text.
+      const backdrop = hasBackgroundImage(resolved)
+        ? null
+        : ownBgColor && ownBgColor.a === 1
+          ? ownBgColor
+          : parentBackdrop;
+      backdrops.set(el, backdrop);
+
+      // A stylesheet-only verdict on an element whose class/id also appears in a
+      // selector we could not parse is dropped: the unparsed rule may be the one
+      // that reveals it. Inline styles are unambiguous and always count.
+      const detectFrom = ambiguous ? inline : resolved;
+      const techniques = detectTechniques(detectFrom, resolved, opts.offscreenThreshold, animated);
+      // The inherited backdrop is only trusted for elements that sit in normal
+      // flow and whose own rules we fully resolved. Positioned elements float
+      // over content we cannot see, and a text-shadow is an author telling us
+      // the text is meant to be legible against something unknown.
+      const position = resolved.get("position");
+      const backdropTrusted =
+        !ambiguous &&
+        !resolved.has("text-shadow") &&
+        position !== "absolute" &&
+        position !== "fixed" &&
+        position !== "sticky";
+      const colorFinding = detectColorOnColor(
+        detectFrom,
+        resolved,
+        backdropTrusted ? backdrop : null,
+      );
+      if (colorFinding) techniques.push(colorFinding);
+
+      // `visibility` is inherited but a descendant can set `visibility:visible`
+      // and come back into view, so that claim is dropped when one does.
+      const visibilityIndex = techniques.findIndex((t) => t.kind === "visibility");
+      if (visibilityIndex !== -1 && descendantDeclares(el, index, "visibility")) {
+        techniques.splice(visibilityIndex, 1);
+      }
+
+      // `display:none`, `visibility:hidden` and `opacity:0` are what every
+      // toggle library writes, so on an element the page's own scripts address
+      // they say nothing. The unambiguous techniques below them are kept: no
+      // toggle library has ever shipped `text-indent:-9999px`.
+      if (techniques.length > 0 && techniques.some((t) => WEAK_TECHNIQUES.has(t.kind))) {
+        scriptText ??= collectScriptText(doc);
+        if (isScriptReferenced(el, scriptText)) {
+          for (let i = techniques.length - 1; i >= 0; i--) {
+            if (WEAK_TECHNIQUES.has(techniques[i].kind)) techniques.splice(i, 1);
+          }
+        }
+      }
+
+      if (techniques.length === 0) {
+        // Visible (as far as we can tell) — its children are judged on their own.
+        for (let i = el.children.length - 1; i >= 0; i--) stack.push(el.children[i] as Element);
+        continue;
+      }
+
+      // Hidden, but declared as an accessibility affordance or as interactive UI.
+      if (hasLegitimateMarker(el, resolved, opts) || ancestorHasLegitimateMarker(el, opts)) {
+        continue;
+      }
+
+      // How much of the subtree the techniques actually hide. `display`,
+      // `opacity`, off-screen offsets and zero-size clipping take every
+      // descendant with them; `font-size` and `color` are inherited, so a
+      // descendant that re-declares them stays visible. When only inherited
+      // techniques apply and something below re-declares them, the payload
+      // shrinks to this element's own text nodes — which is also why the
+      // `.grid { font-size: 0 }` whitespace hack (no direct text) never reports.
+      const hidesSubtree = techniques.some(
+        (t) => t.kind !== "font-size" && t.kind !== "color",
+      )
+        ? true
+        : !techniques.some((t) => descendantDeclares(el, index, t.kind));
+      const chars = hidesSubtree ? textLength(el) : directTextLength(el);
+      const links = hidesSubtree ? countIndexableLinks(el) : 0;
+
+      if (chars >= opts.minHiddenChars || links >= opts.minHiddenLinks) {
+        const text = getTextExcludingScripts(el).replace(/\s+/g, " ").trim();
+        findings.push({
+          selector: describeElement(el),
+          techniques: techniques.map((t) => t.label),
+          chars,
+          links,
+          snippet: text.slice(0, 120),
+        });
+      }
+      // Hidden or not reportable, the subtree inherits this element's state —
+      // descending would only re-report the same text.
+    }
+
+    if (findings.length === 0) {
+      checks.push({
+        name: "hidden-text",
+        status: "pass",
+        message: "No hidden text or links detected",
+      });
+      return { checks };
+    }
+
+    const totalLinks = findings.reduce((sum, f) => sum + f.links, 0);
+    const totalChars = findings.reduce((sum, f) => sum + f.chars, 0);
+    // Hidden links are the stronger spam signal and escalate the check to a
+    // failure.
+    const escalated = totalLinks >= opts.minHiddenLinks;
+
+    findings.sort((a, b) => b.links - a.links || b.chars - a.chars);
+
+    checks.push({
+      name: "hidden-text",
+      status: escalated ? "fail" : "warn",
+      message: escalated
+        ? `${findings.length} hidden element(s) containing ${totalLinks} link(s) and ${totalChars} characters of text`
+        : `${findings.length} hidden element(s) containing ${totalChars} characters of text`,
+      items: findings.slice(0, MAX_ITEMS).map((f) => ({
+        id: f.selector,
+        label: `${f.selector} — ${f.techniques.join(", ")}`,
+        meta: {
+          techniques: f.techniques,
+          chars: f.chars,
+          links: f.links,
+          snippet: f.snippet,
+        },
+      })),
+      details: {
+        hiddenElements: findings.length,
+        hiddenLinks: totalLinks,
+        hiddenChars: totalChars,
+        ...(findings.length > MAX_ITEMS ? { additional: findings.length - MAX_ITEMS } : {}),
+      },
+    });
+
+    return { checks };
+  },
+};

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -9,6 +9,7 @@ import { duplicateDescriptionRule } from "./duplicate-description";
 import { duplicateTitleRule } from "./duplicate-title";
 import { freshnessRule } from "./freshness";
 import { headingHierarchyRule } from "./heading-hierarchy";
+import { hiddenTextRule } from "./hidden-text";
 import { keywordStuffingRule } from "./keyword-stuffing";
 import { metaInBodyRule } from "./meta-in-body";
 import { mojibakeRule } from "./mojibake";
@@ -26,6 +27,7 @@ export const rules: Rule[] = [
   duplicateTitleRule,
   duplicateDescriptionRule,
   keywordStuffingRule,
+  hiddenTextRule,
   brokenHtmlRule,
   readingLevelRule,
   freshnessRule,
@@ -45,6 +47,7 @@ export {
   duplicateTitleRule,
   freshnessRule,
   headingHierarchyRule,
+  hiddenTextRule,
   keywordStuffingRule,
   metaInBodyRule,
   mimeTypeRule,

--- a/packages/rules/tests/hidden-text.test.ts
+++ b/packages/rules/tests/hidden-text.test.ts
@@ -1,0 +1,589 @@
+// content/hidden-text — hidden text and link abuse.
+//
+// The rule has no CSSOM, so the negative cases carry as much weight as the
+// positives: every legitimate way of hiding content (screen-reader utilities,
+// collapsed interactive UI, print-only rules, fade-in animations, image
+// replacement) must come back clean, or the rule libels the sites using them.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "linkedom";
+
+import { hiddenTextRule, parseColor, parseLengthPx } from "../src/content/hidden-text";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+function ctx(html: string, options: Record<string, unknown> = {}): RuleContext {
+  const doc = parseHTML(html).document;
+  return {
+    page: { url: "https://example.com/", html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: { document: doc } as unknown as ParsedPage,
+    options,
+  } as unknown as RuleContext;
+}
+
+function run(html: string, options: Record<string, unknown> = {}) {
+  return hiddenTextRule.run(ctx(html, options)).checks[0];
+}
+
+/** 60-odd characters, comfortably over the 50-char default payload floor. */
+const PAYLOAD = "cheap discount widgets wholesale supplier best prices online now";
+
+/** A link-farm payload: over the 10-link default escalation floor. */
+const SPAM_LINKS = [
+  '<a href="/casino">online casino bonus</a>',
+  '<a href="/loans">payday loans fast</a>',
+  '<a href="/pills">cheap pills delivery</a>',
+  '<a href="/poker">poker room deposit</a>',
+  '<a href="/slots">free slots spins</a>',
+  '<a href="/debt">debt consolidation quote</a>',
+  '<a href="/insurance">cheap car insurance</a>',
+  '<a href="/crypto">crypto trading signals</a>',
+  '<a href="/replica">replica watches sale</a>',
+  '<a href="/essay">essay writing service</a>',
+  '<a href="/vpn">vpn discount code</a>',
+  '<a href="/hosting">cheap hosting deal</a>',
+].join(" ");
+
+describe("content/hidden-text — meta", () => {
+  test("declares the expected identity", () => {
+    expect(hiddenTextRule.meta.id).toBe("content/hidden-text");
+    expect(hiddenTextRule.meta.name).toBe("Hidden Text & Links");
+    expect(hiddenTextRule.meta.category).toBe("content");
+    expect(hiddenTextRule.meta.scope).toBe("page");
+    expect(hiddenTextRule.meta.severity).toBe("warning");
+    expect(hiddenTextRule.meta.weight).toBe(6);
+  });
+
+  test("options schema exposes the documented knobs with defaults", () => {
+    const parsed = hiddenTextRule.meta.optionsSchema?.parse({}) as Record<string, unknown>;
+    expect(parsed.min_hidden_chars).toBe(50);
+    expect(parsed.min_hidden_links).toBe(10);
+    expect(parsed.offscreen_px_threshold).toBe(-999);
+    expect(parsed.a11y_classes).toEqual([]);
+    expect(parsed.safe_classes).toEqual([]);
+  });
+});
+
+describe("content/hidden-text — outcomes", () => {
+  test("pass: an ordinary visible page reports nothing", () => {
+    const check = run(`<html><body><p>${PAYLOAD}</p></body></html>`);
+    expect(check.status).toBe("pass");
+  });
+
+  test("skipped: a document with no body is skipped, not passed", () => {
+    const doc = parseHTML("<html></html>").document;
+    doc.querySelector("body")?.remove();
+    const check = hiddenTextRule.run({
+      page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+      parsed: { document: doc } as unknown as ParsedPage,
+      options: {},
+    } as unknown as RuleContext).checks[0];
+    expect(check.status).toBe("skipped");
+    expect(check.skipReason).toBe("no-body");
+  });
+
+  test("warn: hidden text without links stays a warning", () => {
+    const check = run(`<html><body><div style="display:none">${PAYLOAD}</div></body></html>`);
+    expect(check.status).toBe("warn");
+  });
+
+  test("fail: hidden LINKS escalate the finding above hidden text", () => {
+    const check = run(`<html><body><div style="display:none">${SPAM_LINKS}</div></body></html>`);
+    expect(check.status).toBe("fail");
+    expect(check.details?.hiddenLinks).toBe(12);
+  });
+});
+
+describe("content/hidden-text — techniques", () => {
+  test("display:none from an inline style", () => {
+    const check = run(`<html><body><div style="display:none">${PAYLOAD}</div></body></html>`);
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0].meta?.techniques).toEqual(["display:none"]);
+  });
+
+  test("visibility:hidden from a <style> class rule", () => {
+    const html = `<html><head><style>.promo-copy { visibility: hidden; }</style></head>
+      <body><div class="promo-copy">${PAYLOAD}</div></body></html>`;
+    const check = run(html);
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0].meta?.techniques).toEqual(["visibility:hidden"]);
+  });
+
+  test("display:none from a <style> id rule", () => {
+    const html = `<html><head><style>#seo-block { display: none }</style></head>
+      <body><div id="seo-block">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+
+  test("opacity:0", () => {
+    const check = run(`<html><body><div style="opacity:0">${PAYLOAD}</div></body></html>`);
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0].meta?.techniques).toEqual(["opacity:0"]);
+  });
+
+  test("font-size:0 on the element carrying the text", () => {
+    const check = run(`<html><body><div style="font-size:0">${PAYLOAD}</div></body></html>`);
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0].meta?.techniques).toEqual(["font-size:0"]);
+  });
+
+  test("off-screen text-indent", () => {
+    const check = run(`<html><body><div style="text-indent:-9999px">${PAYLOAD}</div></body></html>`);
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0].meta?.techniques).toEqual(["text-indent off-screen"]);
+  });
+
+  test("off-screen absolute positioning", () => {
+    const html = `<html><body><div style="position:absolute;left:-9999px;width:400px;height:200px">${PAYLOAD}</div></body></html>`;
+    const check = run(html);
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0].meta?.techniques).toEqual(["position:absolute left:-9999px"]);
+  });
+
+  test("off-screen negative margin", () => {
+    const check = run(`<html><body><div style="margin-left:-9999px">${PAYLOAD}</div></body></html>`);
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0].meta?.techniques).toEqual(["margin-left off-screen"]);
+  });
+
+  test("zero-size clipping", () => {
+    const html = `<html><body><div style="height:0;overflow:hidden">${PAYLOAD}</div></body></html>`;
+    const check = run(html);
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0].meta?.techniques).toEqual(["height:0 with overflow:hidden"]);
+  });
+
+  test("colour on the same colour, both inline on the element", () => {
+    const html = `<html><body><p style="color:#ffffff;background-color:#fff">${PAYLOAD}</p></body></html>`;
+    const check = run(html);
+    expect(check.status).toBe("warn");
+    expect(String(check.items?.[0].label)).toContain("color #ffffff");
+  });
+
+  test("colour matching the nearest painted backdrop", () => {
+    const html = `<html><body><div style="background-color:#101010"><p style="color:#111">${PAYLOAD}</p></div></body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+
+  test("transparent text colour", () => {
+    const html = `<html><body><p style="color:transparent">${PAYLOAD}</p></body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+
+  test("the off-screen threshold is configurable", () => {
+    const html = `<html><body><div style="text-indent:-200px">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+    expect(run(html, { offscreen_px_threshold: -100 }).status).toBe("warn");
+  });
+});
+
+describe("content/hidden-text — accessibility allowlist", () => {
+  test("the sr-only clip idiom is not flagged", () => {
+    const html = `<html><head><style>.sr-only { position:absolute; width:1px; height:1px; overflow:hidden; clip: rect(0 0 0 0); }</style></head>
+      <body><span class="sr-only">${PAYLOAD}</span></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("clip-path visually-hidden is not flagged", () => {
+    const html = `<html><body><span style="position:absolute;left:-9999px;clip-path:inset(50%)">${PAYLOAD}</span></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a 1x1 off-screen box is read as the visually-hidden idiom", () => {
+    const html = `<html><body><span style="position:absolute;left:-10000px;width:1px;height:1px">${PAYLOAD}</span></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test.each(["sr-only", "visually-hidden", "visuallyhidden", "screen-reader-text"])(
+    "the %s class name is exempt even with a hard display:none",
+    (cls) => {
+      const html = `<html><body><div class="${cls}" style="display:none">${PAYLOAD}</div></body></html>`;
+      expect(run(html).status).toBe("pass");
+    },
+  );
+
+  test("a project-specific class can be added via a11y_classes", () => {
+    const html = `<html><body><div class="acme-offscreen" style="display:none">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("warn");
+    expect(run(html, { a11y_classes: ["acme-offscreen"] }).status).toBe("pass");
+  });
+
+  test("safe_classes exempts an arbitrary class", () => {
+    const html = `<html><body><div class="legacy-template" style="display:none">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("warn");
+    expect(run(html, { safe_classes: ["legacy-template"] }).status).toBe("pass");
+  });
+});
+
+describe("content/hidden-text — interactive UI allowlist", () => {
+  test("an aria-hidden tab panel is not flagged", () => {
+    const html = `<html><body><div role="tabpanel" aria-hidden="true" style="display:none">${PAYLOAD} ${SPAM_LINKS}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a tab panel with no aria-hidden, hidden by a class rule, is not flagged", () => {
+    const html = `<html><head><style>.tab-panel { display: none }</style></head>
+      <body><div class="tab-panel">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a cookie consent banner is not flagged", () => {
+    const html = `<html><head><style>.cookie-banner { display: none }</style></head>
+      <body><div class="cookie-banner">${PAYLOAD} <a href="/privacy">privacy policy</a></div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("collapsed off-canvas navigation with its links is not flagged", () => {
+    const html = `<html><body><nav class="offcanvas-menu" style="display:none">${SPAM_LINKS}</nav></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("the hidden attribute exempts an element", () => {
+    const html = `<html><body><div hidden>${PAYLOAD} ${SPAM_LINKS}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("an accordion body inside a marked container is not flagged", () => {
+    const html = `<html><body><div class="accordion"><div class="item-body" style="display:none">${PAYLOAD}</div></div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a Bootstrap-style data-bs-toggle target is not flagged", () => {
+    const html = `<html><body><div data-bs-toggle="collapse" style="display:none">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a <dialog> is not flagged", () => {
+    const html = `<html><body><dialog style="display:none">${PAYLOAD}</dialog></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a state class such as .is-active marks the element script-driven", () => {
+    const html = `<html><body><div class="promo is-active" style="display:none">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+});
+
+describe("content/hidden-text — cascade and idiom guards", () => {
+  test("a rule inside @media print does not hide anything on screen", () => {
+    const html = `<html><head><style>@media print { .no-print { display: none } }</style></head>
+      <body><div class="no-print">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a class also targeted by a compound selector may be revealed by JS", () => {
+    // The class name is deliberately neutral (no interactive/state token), so
+    // the only thing holding the finding back is the unresolved second rule.
+    const hiddenOnly = `<html><head><style>.detail-copy { display: none }</style></head>
+      <body><div class="detail-copy">${PAYLOAD}</div></body></html>`;
+    expect(run(hiddenOnly).status).toBe("warn");
+
+    const alsoToggled = `<html><head><style>.detail-copy { display: none } .detail-copy.wide { display: block }</style></head>
+      <body><div class="detail-copy">${PAYLOAD}</div></body></html>`;
+    expect(run(alsoToggled).status).toBe("pass");
+  });
+
+  test("a descendant selector leaves the same doubt as a compound one", () => {
+    const html = `<html><head><style>.detail-copy { display: none } .layout .detail-copy { display: block }</style></head>
+      <body><div class="detail-copy">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("an inline style is never second-guessed by an unresolved selector", () => {
+    const html = `<html><head><style>.detail-copy.wide { display: block }</style></head>
+      <body><div class="detail-copy" style="display:none">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+
+  test("opacity:0 with a transition is a fade-in, not spam", () => {
+    const html = `<html><body><div style="opacity:0;transition:opacity .3s ease">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("text-indent with a background image is image replacement", () => {
+    const html = `<html><body><h1 style="text-indent:-9999px;background-image:url(/logo.svg)">${PAYLOAD}</h1></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("max-height:0 with overflow:hidden and a transition is a collapsing accordion", () => {
+    const html = `<html><body><div style="max-height:0;overflow:hidden;transition:max-height .4s">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("font-size:0 as the inline-block whitespace hack is not flagged", () => {
+    const html = `<html><body><div style="font-size:0"><span style="font-size:16px">${PAYLOAD}</span></div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("an unitless offset is invalid CSS and hides nothing", () => {
+    const html = `<html><body><div style="position:absolute;left:-9999">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("transparent text with a clipped gradient fill is not flagged", () => {
+    const html = `<html><body><h2 style="color:transparent;background-clip:text;background-image:linear-gradient(90deg,#f00,#00f)">${PAYLOAD}</h2></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("white caption text over an image backdrop is not flagged", () => {
+    const html = `<html><body style="background-color:#ffffff"><div style="background-image:url(/hero.jpg)"><p style="color:#ffffff">${PAYLOAD}</p></div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("white text on a positioned overlay is not flagged", () => {
+    const html = `<html><body style="background:#fff"><p style="position:absolute;top:20px;left:20px;color:#fff">${PAYLOAD}</p></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("white text over a gradient banner is not flagged", () => {
+    const html = `<html><body style="background-color:#ffffff"><div style="background:linear-gradient(90deg,#004,#008)"><p style="color:#ffffff">${PAYLOAD}</p></div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a page-wide background image leaves the backdrop unknown", () => {
+    const html = `<html><body style="background-color:#ffffff;background-image:url(/paper.png)"><p style="color:#ffffff">${PAYLOAD}</p></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a descendant painting its own backdrop escapes an inherited colour", () => {
+    const html = `<html><body><div style="color:#ffffff;background-color:#ffffff"><p style="background-color:#111111">${PAYLOAD}</p></div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a wrapper whose children re-declare colour is not hiding them", () => {
+    const html = `<html><body><div style="color:#ffffff;background-color:#ffffff"><p style="color:#111">${PAYLOAD}</p></div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a descendant setting visibility:visible comes back into view", () => {
+    const html = `<html><body><div style="visibility:hidden"><p style="visibility:visible">${PAYLOAD}</p></div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("display:none still takes the whole subtree with it", () => {
+    const html = `<html><body><div style="display:none"><p style="color:#111;visibility:visible">${PAYLOAD}</p></div></body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+
+  test("white text on a resolved dark button is not flagged", () => {
+    const html = `<html><head><style>.btn-primary { background-color: #0d6efd }</style></head>
+      <body style="background:#fff"><a class="btn-primary" href="/x" style="color:#fff">${PAYLOAD}</a></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a class the responsive sheet revives inside @media is not flagged", () => {
+    // The desktop copy of a responsive footer: hidden at the top level, shown
+    // again in a media query we deliberately refuse to evaluate.
+    const html = `<html><head><style>
+        .footer-desktop { display: none }
+        @media (min-width: 900px) { .footer-desktop { display: block } }
+      </style></head>
+      <body><div class="footer-desktop">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test.each(["nomobile", "desktop-only", "noprint"])(
+    "the %s viewport-variant class is exempt",
+    (cls) => {
+      const html = `<html><body><div class="${cls}" style="display:none">${PAYLOAD}</div></body></html>`;
+      expect(run(html).status).toBe("pass");
+    },
+  );
+
+  test("a transition declared on a compound selector still reads as a fade-in", () => {
+    // The resting `opacity:0` is on the element's own class; only the reveal
+    // rule carries the transition, and that selector is one we cannot resolve.
+    const html = `<html><head><style>
+        .reveal-card { opacity: 0 }
+        .reveal-card.in-view { opacity: 1; transition: opacity .4s ease }
+      </style></head>
+      <body><div class="reveal-card">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("opacity:0 beside a displacing transform is an entrance animation", () => {
+    const html = `<html><body><div style="opacity:0;transform:translateY(25px)">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a transform that is itself an off-screen shove is no defence", () => {
+    const html = `<html><body><div style="opacity:0;transform:translateX(-9999px)">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+});
+
+describe("content/hidden-text — CSS parsing", () => {
+  test("a semicolon inside a data URL does not manufacture a declaration", () => {
+    const html = `<html><body><div style='background-image:url("data:image/svg+xml;display:none;base64,PHN2Zz48L3N2Zz4=")'>${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("an @ inside a declaration value does not swallow the rest of the sheet", () => {
+    const html = `<html><head><style>
+        .badge::before { content: "@" }
+        .promo-copy { position: absolute; left: -9999px }
+      </style></head>
+      <body><div class="promo-copy">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+
+  test("class selectors are matched case-sensitively", () => {
+    const html = `<html><head><style>.Promo { display: none }</style></head>
+      <body><div class="promo">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("an id rule outranks a class rule", () => {
+    const html = `<html><head><style>.detail-copy { display: none } #shown { display: block }</style></head>
+      <body><div id="shown" class="detail-copy">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("two bare class rules disagreeing on a property are not guessed at", () => {
+    const html = `<html><head><style>.detail-copy { display: none } .detail-copy { display: block }</style></head>
+      <body><div class="detail-copy">${PAYLOAD}</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("malformed CSS is parsed in linear time", () => {
+    // The regex form of this scan backtracked quadratically: 200KB of
+    // brace-less CSS took 26 seconds, stalling the whole crawl.
+    const html = `<html><head><style>${"/*" + "a".repeat(200_000)}</style></head>
+      <body><div style="text-indent:-9999px">${PAYLOAD}</div></body></html>`;
+    const started = performance.now();
+    expect(run(html).status).toBe("warn");
+    expect(performance.now() - started).toBeLessThan(2_000);
+  });
+});
+
+describe("content/hidden-text — script-controlled elements", () => {
+  test("an element the page's own script addresses by id is not flagged", () => {
+    const html = `<html><body>
+      <div id="newsletter-thanks" style="display:none">${PAYLOAD}</div>
+      <script>document.getElementById("newsletter-thanks").style.display = "block";</script>
+      </body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("an element addressed by class name is not flagged", () => {
+    const html = `<html><body>
+      <div class="submit-confirmation" style="display:none">${PAYLOAD}</div>
+      <script>document.querySelector(".submit-confirmation").hidden = false;</script>
+      </body></html>`;
+    expect(run(html).status).toBe("pass");
+  });
+
+  test("a script mentioning an unrelated element does not launder the page", () => {
+    const html = `<html><body>
+      <div class="promo-copy" style="display:none">${PAYLOAD}</div>
+      <script>document.querySelector(".carousel-track").scrollLeft = 0;</script>
+      </body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+
+  test("the script guard does not rescue an off-screen block", () => {
+    // No toggle library ships `text-indent:-9999px`; a script naming the element
+    // says nothing about a technique that has no legitimate scripted use.
+    const html = `<html><body>
+      <div class="promo-copy" style="text-indent:-9999px">${PAYLOAD}</div>
+      <script>document.querySelector(".promo-copy").dataset.seen = "1";</script>
+      </body></html>`;
+    expect(run(html).status).toBe("warn");
+  });
+});
+
+describe("content/hidden-text — payload thresholds and reporting", () => {
+  test("a tiny hidden string with no link payload is not worth reporting", () => {
+    expect(run(`<html><body><div style="display:none">Loading</div></body></html>`).status).toBe(
+      "pass",
+    );
+  });
+
+  test("min_hidden_chars is configurable", () => {
+    const html = `<html><body><div style="display:none">Loading the next page of results</div></body></html>`;
+    expect(run(html).status).toBe("pass");
+    expect(run(html, { min_hidden_chars: 10 }).status).toBe("warn");
+  });
+
+  test("hidden links below min_hidden_links warn rather than fail", () => {
+    const html = `<html><body><div style="display:none">${PAYLOAD} <a href="/a">one</a></div></body></html>`;
+    const check = run(html);
+    expect(check.status).toBe("warn");
+    expect(check.details?.hiddenLinks).toBe(1);
+  });
+
+  test("only http(s) and relative hrefs count as indexable links", () => {
+    // An allow-list: anything a crawler will not follow carries no link equity
+    // and must not inflate the tally that escalates the check to a failure.
+    const html = `<html><body><div style="display:none">${PAYLOAD}
+      <a href="#top">top</a><a href="javascript:void(0)">x</a><a href="">y</a>
+      <a href="mailto:a@b.com">mail</a><a href="tel:+1234">call</a>
+      <a href="data:text/html,<b>hi</b>">data</a><a href="vbscript:msgbox">vb</a>
+      <a href="ftp://example.com/f">ftp</a></div></body></html>`;
+    const check = run(html);
+    expect(check.status).toBe("warn");
+    expect(check.details?.hiddenLinks).toBe(0);
+  });
+
+  test("relative, scheme-relative and https hrefs all count", () => {
+    const html = `<html><body><div style="display:none">${PAYLOAD}
+      <a href="/a">a</a><a href="b.html">b</a><a href="//cdn.example.com/c">c</a>
+      <a href="https://example.com/d">d</a><a href="HTTP://example.com/e">e</a></div></body></html>`;
+    expect(run(html).details?.hiddenLinks).toBe(5);
+  });
+
+  test("items name the offending element, the technique and a snippet", () => {
+    const html = `<html><body><div id="kw" class="seo-block" style="display:none">${PAYLOAD}</div></body></html>`;
+    const check = run(html);
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0].id).toBe("div#kw.seo-block");
+    expect(check.items?.[0].label).toBe("div#kw.seo-block — display:none");
+    expect(check.items?.[0].meta?.chars).toBe(PAYLOAD.length);
+    expect(String(check.items?.[0].meta?.snippet)).toContain("cheap discount widgets");
+  });
+
+  test("only the outermost hidden element is reported, not every descendant", () => {
+    const html = `<html><body><div style="display:none"><section><p>${PAYLOAD}</p><p>${PAYLOAD}</p></section></div></body></html>`;
+    const check = run(html);
+    expect(check.items).toHaveLength(1);
+    expect(check.details?.hiddenElements).toBe(1);
+  });
+
+  test("the item list is capped and the overflow reported in details", () => {
+    const blocks = Array.from(
+      { length: 13 },
+      (_, i) => `<div style="display:none">${PAYLOAD} block ${i}</div>`,
+    ).join("\n");
+    const check = run(`<html><body>${blocks}</body></html>`);
+    expect(check.items).toHaveLength(10);
+    expect(check.details?.hiddenElements).toBe(13);
+    expect(check.details?.additional).toBe(3);
+  });
+
+  test("visible siblings of a hidden block are still walked", () => {
+    const html = `<html><body><div class="wrapper"><p>${PAYLOAD}</p>
+      <div style="display:none">${PAYLOAD}</div></div></body></html>`;
+    const check = run(html);
+    expect(check.status).toBe("warn");
+    expect(check.details?.hiddenElements).toBe(1);
+  });
+});
+
+describe("content/hidden-text — parsing helpers", () => {
+  test("parseColor covers hex, rgb(), named and transparent", () => {
+    expect(parseColor("#fff")).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+    expect(parseColor("#FFFFFF")).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+    expect(parseColor("rgb(255, 255, 255)")).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+    expect(parseColor("rgba(0 0 0 / 0)")).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    expect(parseColor("white")).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+    expect(parseColor("transparent")?.a).toBe(0);
+    expect(parseColor("var(--brand)")).toBeNull();
+  });
+
+  test("parseLengthPx rejects unitless non-zero values", () => {
+    expect(parseLengthPx("-9999px")).toBe(-9999);
+    expect(parseLengthPx("0")).toBe(0);
+    expect(parseLengthPx("-9999")).toBeNull();
+    expect(parseLengthPx("-100%")).toBeNull();
+    expect(parseLengthPx("-10rem")).toBe(-160);
+  });
+});


### PR DESCRIPTION
Adds a new per-page audit rule, `content/hidden-text`, covering [Google's hidden text and links spam policy](https://developers.google.com/search/docs/essentials/spam-policies#hidden-text-and-links).

## What it detects

There is no layout engine and no CSSOM in the audit engine, so the rule works only from what is directly readable: inline `style` attributes, `<style>` rules whose selector is a bare class or id, and the `hidden` / `aria-hidden` attributes. It reports `display:none`, `visibility:hidden`, `opacity:0`, `font-size:0`, off-screen offsets (`text-indent`, `position`, `margin`), zero-size clipping, and colour-on-colour. The finding is a warning, escalating to a failure once the page carries enough hidden links.

## Precision

Telling a site it is cloaking text when it is not is far worse than missing a page, so the rule stays quiet on every common reason content is legitimately hidden:

- Screen-reader utilities: the `clip` / `clip-path` idiom, a 1x1 off-screen box, and the usual class names.
- Collapsed interactive UI: tab panels, accordions, dropdowns, modals, off-canvas nav, carousels, cookie and consent banners.
- Viewport and print variants (`nomobile`, `desktop-only`, `noprint`).
- Fade-ins and entrance animations, including a transition declared on a compound selector, and `opacity:0` beside a displacing `transform`.
- Image replacement, the inline-block `font-size:0` hack, gradient text, invalid unitless offsets.
- Any element whose class or id is named by a selector or media query the rule cannot resolve, so the desktop copy of a responsive footer is left alone.
- Elements the page's own scripts address by id or class, for the three techniques every toggle library writes. Off-screen offsets, zero font sizes, zero-size clipping and colour-on-colour have no legitimate scripted use and are still reported.

Measured against 25 major websites: two warnings, no failures.

## Performance

The stylesheet scan is a hand-written linear scanner rather than a regex. The regex form backtracked quadratically: 200KB of brace-less or unterminated-comment CSS from a crawled page took 26 seconds to index, which would stall a whole crawl on attacker-supplied input. The scanner does the same work in under 5ms, and there is a regression test for it.

## Tests

83 unit tests: one positive case per technique plus a hidden link farm, and negative cases for every allowlisted pattern above, the CSS parsing edge cases (semicolons inside data URLs, `@` inside a declaration value, case-sensitive class matching, id specificity, contested class rules) and the linear-time guard.

`bun test`, `bun run test:engine`, `bun run typecheck`, `bun run lint`, `bun run format:check` and `docs check` all pass. The golden fixture moves by one tally key and 500 passing page checks; the health score is unmoved. Rule count and docs updated to 267.