### PR TITLE
fix(audit-engine): populate contactLinks on the adapter parse path

### DIFF
--- a/apps/cli/src/audit/adapter.ts
+++ b/apps/cli/src/audit/adapter.ts
@@ -9,6 +9,7 @@ import {
 } from "@squirrelscan/audit-engine";
 import {
   detectPageType,
+  extractContactLinks,
   extractContent,
   extractHeadings,
   extractImages,
@@ -245,6 +246,11 @@ export function parsePageRecord(page: PageRecord): ParsedPage | null {
           rel: l.rel,
           isNofollow: l.isNofollow,
         })),
+        // tel:/mailto: anchors, which `extractLinks` drops as non-crawlable.
+        // This is the THIRD ParsedPage producer (see @squirrelscan/parser's
+        // `parsePage` and audit-engine's `parseHtmlForRules`); a field set on
+        // only some of them is undefined at runtime with every test still green.
+        contactLinks: extractContactLinks(doc),
         images: images.map((i) => ({
           src: i.src,
           alt: i.alt,

--- a/apps/cli/tests/audit/parsed-page-producer-parity.test.ts
+++ b/apps/cli/tests/audit/parsed-page-producer-parity.test.ts
@@ -1,0 +1,105 @@
+// All THREE ParsedPage producers must agree.
+//
+// A `ParsedPage` is built in three separate places:
+//   1. `parsePage`          — @squirrelscan/parser (the canonical one)
+//   2. `parseHtmlForRules`  — @squirrelscan/audit-engine (cloud + page-rule workers)
+//   3. `parsePageRecord`    — apps/cli/src/audit/adapter.ts (this CLI's own copy)
+//
+// Every ParsedPage field is optional or independently defaulted, so adding one to
+// a subset of them COMPILES, and each producer's own tests keep passing. The field
+// is simply `undefined` wherever the un-updated producer ran, which for a rule
+// reading it means silently seeing nothing. That is exactly how `contactLinks`
+// shipped invisible to the CLI audit path.
+//
+// So this asserts parity across producers rather than testing any one of them:
+// this file is the thing that fails when the next field lands in only two of three.
+
+import type { ContactLinkData } from "@squirrelscan/core-contracts";
+
+import { parseHtmlForRules } from "@squirrelscan/audit-engine";
+import { parsePage } from "@squirrelscan/parser";
+import { describe, expect, test } from "bun:test";
+
+import type { PageRecord } from "../../src/crawler/storage/types";
+
+import { parsePageRecord } from "../../src/audit/adapter";
+
+const URL = "https://example.com/contact";
+
+const HTML = `<!DOCTYPE html><html><head><title>Contact</title>
+<script type="application/ld+json">${JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  name: "Acorn Hardware",
+  telephone: "+1 (555) 123-4567",
+  address: {
+    "@type": "PostalAddress",
+    streetAddress: "123 Main St",
+    addressLocality: "Sydney",
+    postalCode: "2000",
+  },
+})}</script></head><body>
+<a href="tel:+1 (555) 123-4567">+1 (555) 123-4567</a>
+<a href="mailto:hi@example.com">Email us</a>
+<a href="/about">About</a>
+</body></html>`;
+
+function pageRecord(): PageRecord {
+  return {
+    url: URL,
+    normalizedUrl: URL,
+    finalUrl: URL,
+    depth: 1,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: HTML.length,
+    loadTimeMs: 5,
+    fetchedAt: 1,
+    etag: null,
+    lastModified: null,
+    contentHash: "h",
+    html: HTML,
+    parsedData: null,
+    headers: { contentType: "text/html" },
+    securityHeaders: {},
+  } as unknown as PageRecord;
+}
+
+const EXPECTED_CONTACT_LINKS: ContactLinkData[] = [
+  { scheme: "tel", value: "+1 (555) 123-4567", text: "+1 (555) 123-4567" },
+  { scheme: "mailto", value: "hi@example.com", text: "Email us" },
+];
+
+describe("ParsedPage producer parity — contactLinks", () => {
+  test("the canonical parser carries tel:/mailto: anchors", () => {
+    expect(parsePage(HTML, URL).contactLinks).toEqual(EXPECTED_CONTACT_LINKS);
+  });
+
+  test("the audit-engine producer agrees with the canonical parser", () => {
+    expect(parseHtmlForRules(HTML, URL).contactLinks).toEqual(
+      EXPECTED_CONTACT_LINKS
+    );
+  });
+
+  test("the CLI producer agrees with the canonical parser", () => {
+    expect(parsePageRecord(pageRecord())?.contactLinks).toEqual(
+      EXPECTED_CONTACT_LINKS
+    );
+  });
+
+  test("all three agree with each other, and none leak contacts into the link graph", () => {
+    const produced = [
+      parsePage(HTML, URL),
+      parseHtmlForRules(HTML, URL),
+      parsePageRecord(pageRecord())!,
+    ];
+
+    for (const parsed of produced) {
+      expect(parsed.contactLinks).toEqual(produced[0]!.contactLinks);
+      // tel:/mailto: are not crawlable and must stay out of `links`.
+      expect(parsed.links.map((l) => l.url)).toEqual([
+        "https://example.com/about",
+      ]);
+    }
+  });
+});

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -4,6 +4,7 @@
 
 import {
   detectPageType,
+  extractContactLinks,
   extractContent,
   extractHeadings,
   extractImages,
@@ -360,6 +361,10 @@ export function parseHtmlForRules(html: string, baseUrl: string): ParsedPage {
       rel: l.rel,
       isNofollow: l.isNofollow,
     })),
+    // tel:/mailto: anchors, which `extractLinks` drops as non-crawlable. This is
+    // the parse path production actually runs (parsePageRecord + the #263 page-rule
+    // workers), so a field populated only by `parsePage` would be invisible live.
+    contactLinks: extractContactLinks(doc),
     images: images.map((i) => ({
       src: i.src,
       alt: i.alt,

--- a/packages/audit-engine/tests/site-query-nap-rule-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-nap-rule-golden.test.ts
@@ -15,10 +15,12 @@ import { Effect } from "effect";
 import { SQLiteStorage } from "@squirrelscan/crawler";
 import { parsePage } from "@squirrelscan/parser";
 import { loadAllRules } from "@squirrelscan/rules";
+import { extractNapSignal } from "@squirrelscan/utils";
 import type { ParsedPage, Rule, RuleContext } from "@squirrelscan/rules";
 import type { PageRecord } from "@squirrelscan/core-contracts";
 
 import { createSiteQuery, extractPageFeatures } from "../src/index";
+import { parseHtmlForRules } from "../src/adapter";
 
 function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
   return Effect.runPromise(eff as Effect.Effect<A, never, never>);
@@ -181,5 +183,35 @@ describe("dual-path golden — local/nap-consistency (extractor → v20 columns 
       samplePages: 12,
     });
     expect(address.items?.[0]?.sourcePages).toEqual(["https://example.com/p12"]);
+  });
+});
+
+describe("parseHtmlForRules carries contactLinks", () => {
+  // There are TWO parsers producing a ParsedPage: `parsePage` (crawler) and
+  // `parseHtmlForRules` (this package — what `parsePageRecord` and the #263
+  // page-rule workers actually run). A field added to only one of them is
+  // invisible in production while every direct-parser test still passes, so pin
+  // that both agree.
+  const HTML =
+    `<html><body><a href="tel:+1 (555) 123-4567">+1 (555) 123-4567</a>` +
+    `<a href="mailto:hi@example.com">Email</a><a href="/about">about</a></body></html>`;
+
+  test("both parse paths produce the same contact links", () => {
+    const viaAdapter = parseHtmlForRules(HTML, BASE);
+    const viaParser = parsePage(HTML, BASE);
+
+    expect(viaAdapter.contactLinks).toEqual([
+      { scheme: "tel", value: "+1 (555) 123-4567", text: "+1 (555) 123-4567" },
+      { scheme: "mailto", value: "hi@example.com", text: "Email" },
+    ]);
+    expect(viaAdapter.contactLinks).toEqual(viaParser.contactLinks);
+  });
+
+  test("a NAP signal survives the adapter parse path", () => {
+    const nap = extractNapSignal(parseHtmlForRules(HTML, BASE));
+    expect(nap.phones).toEqual(["1234567"]);
+    expect(nap.phoneFormats).toEqual(["+1 (555) 123-4567"]);
+    expect(nap.telLink).toBe(true);
+    expect(nap.mailtoLink).toBe(true);
   });
 });

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -9,6 +9,7 @@ export {
   extractOG,
   extractTwitter,
   extractLinks as extractLinksBasic,
+  extractContactLinks,
   extractImages,
   extractSchema,
   extractHeadings,

--- a/packages/rules/src/local/nap-consistency.ts
+++ b/packages/rules/src/local/nap-consistency.ts
@@ -323,7 +323,14 @@ function napFromRow(row: PageFeatureRow): NapSignal {
 /**
  * Streaming path (#1373): fold the per-page NAP scalars straight off the
  * page_features cursor, in normalized_url order (== the legacy `site.pages`
- * order). Only the bounded rollup stays resident; no parsed page is held.
+ * order). Only the rollup stays resident; no parsed page is held.
+ *
+ * Zero rows is read as an empty crawl. A crawl whose pages are ALL non-auditable
+ * (4xx/5xx) also yields zero rows while the legacy universe still appends those
+ * pages with an empty parse, so the two paths word the skip differently there.
+ * That is a property of the streaming universe shared with every other site rule
+ * on this seam (see content/duplicate-title), not something specific to NAP, and
+ * such a crawl cannot resolve the local-business metadata this rule is gated on.
  */
 async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
   const rollup = emptyRollup();

--- a/packages/utils/src/nap.ts
+++ b/packages/utils/src/nap.ts
@@ -36,6 +36,11 @@ export const NAP_PHONE_MIN_DIGITS = 7;
  * ("+1 (555) 123-4567", "555.123.4567", "01555 1234567" all key on "1234567"), so
  * one number written many ways stays ONE number and only the display form differs
  * — which is precisely the format-drift signal this rule reports as a warning.
+ *
+ * The tradeoff is deliberate and one-directional: two genuinely different numbers
+ * sharing a subscriber tail (same 7 digits, different area code) collapse into one
+ * key, so a real conflict is under-reported as format drift. It never invents a
+ * conflict that isn't there, which is the error that would matter.
  */
 const NAP_PHONE_KEY_DIGITS = 7;
 


### PR DESCRIPTION
Follow-up to the cross-page NAP drift work. A review pass after that merged found the new `ParsedPage.contactLinks` field is populated by only one of the two parsers.

## The bug

There are two functions that produce a `ParsedPage`:

- `parsePage` (`@squirrelscan/parser`)
- `parseHtmlForRules` (`packages/audit-engine/src/adapter.ts`), which is what `parsePageRecord` and the page-rule workers actually run

`contactLinks` was added to the first only. So in a real audit the field came back undefined, and `extractNapSignal` reads nothing from it: every phone number declared as a `tel:` link was invisible, along with the `contact-info` contact-page check. Only JSON-LD `telephone` still reached the rule. Every parser-level test passed the whole time, because they call the other parser.

## The fix

`parseHtmlForRules` now calls `extractContactLinks(doc)` (newly exported from the parser barrel), and a regression test asserts the two parse paths produce identical `contactLinks` and that a NAP signal survives the adapter path. That test is the actual guard: a field added to one of two `ParsedPage` producers is invisible without it.

## Also in here (comments only)

Two behaviours worth stating in the source rather than leaving for the next reader to rediscover:

- `napPhoneKey` compares the trailing 7 digits, so two different numbers sharing a subscriber tail collapse into one key. That under-reports a real conflict as format drift and never the reverse, which is the direction that matters.
- The streaming path reads zero feature rows as an empty crawl. A crawl where every page is non-auditable also yields zero rows while the legacy universe still appends them, so the skip is worded differently. That is a property of the streaming universe shared by every site rule on this seam, not something specific to this rule.

## Verification

Root `bun test`: 3788 pass, 0 fail. `bun run test:engine`: 49 pass, 0 fail, with the canonical golden unchanged (findings 95711, `perRuleTally.length` 264, healthScore 48). Typecheck, lint and format check clean.