### PR TITLE
fix(crawler): stop inventing trailing-slash redirect chains

### DIFF
--- a/apps/cli/tests/graph/crawler/frontier.test.ts
+++ b/apps/cli/tests/graph/crawler/frontier.test.ts
@@ -3,7 +3,11 @@ import { describe, it, expect } from "bun:test";
 import { normalizeUrl, isInScope } from "../../../src/crawler/frontier";
 
 describe("normalizeUrl", () => {
-  it("normalizes fragments, trailing slashes, and query parameters", () => {
+  it("strips fragments and tracking params but KEEPS the trailing slash", () => {
+    // The normalized URL is the URL the crawler fetches. `/about` and `/about/`
+    // are different request targets, so dropping the slash asked slash-canonical
+    // sites for a URL they never linked and turned their 301 into a reported
+    // redirect (#1510).
     const normalized = normalizeUrl(
       "https://example.com/about/?utm_source=test#section",
       {
@@ -13,7 +17,7 @@ describe("normalizeUrl", () => {
       }
     );
 
-    expect(normalized).toBe("https://example.com/about");
+    expect(normalized).toBe("https://example.com/about/");
   });
 
   it("filters query params with allow list", () => {

--- a/packages/audit-engine/src/cloud-fetcher.ts
+++ b/packages/audit-engine/src/cloud-fetcher.ts
@@ -152,14 +152,25 @@ export function mapRenderItemToResponse(
   const lastHop = item.redirectChain?.[item.redirectChain.length - 1];
   const finalUrl = lastHop?.url ?? item.url ?? requestUrl;
   const status = item.status ?? 0;
-  const hops = [
-    { url: requestUrl, statusCode: status, type: "http" as const },
-    ...(item.redirectChain ?? []).map((hop) => ({
-      url: hop.url,
-      statusCode: hop.status,
-      type: "http" as const,
-    })),
-  ];
+  const renderHops = (item.redirectChain ?? []).map((hop) => ({
+    url: hop.url,
+    statusCode: hop.status,
+    type: "http" as const,
+  }));
+  // The render service reports the LANDING page only, not each hop, so the
+  // status codes of the redirects themselves were never observed. Stamping the
+  // landing page's status onto the request URL produced chains that claimed
+  // `200 → 200` — a first hop that returned 200 did not redirect at all
+  // (#1510). Record the unobserved source hop with status 0 ("no status seen",
+  // the same convention the fetchers use for a response that never arrived)
+  // rather than inventing one. Skip it entirely when the service already
+  // reported the source itself.
+  const needsSourceHop = renderHops.length > 0 && renderHops[0]?.url !== requestUrl;
+  const hops = needsSourceHop
+    ? [{ url: requestUrl, statusCode: 0, type: "http" as const }, ...renderHops]
+    : renderHops.length > 0
+      ? renderHops
+      : [{ url: requestUrl, statusCode: status, type: "http" as const }];
   // Prefer the real render headers (already lowercase from the API); fall back
   // to a synthesized content-type only when the item carries no headers.
   const headers =

--- a/packages/audit-engine/src/cloud-fetcher.ts
+++ b/packages/audit-engine/src/cloud-fetcher.ts
@@ -26,7 +26,12 @@ import type {
 } from "@squirrelscan/core-contracts";
 import { CREDIT_COSTS } from "@squirrelscan/core-contracts/credits";
 import { SERVICE_LIMITS } from "@squirrelscan/core-contracts/limits";
-import type { DocumentFetcher, FetchRequest, FetchResponse } from "@squirrelscan/fetchers";
+import {
+  type DocumentFetcher,
+  type FetchRequest,
+  type FetchResponse,
+  withObservedHopStatuses,
+} from "@squirrelscan/fetchers";
 
 import { CloudClientError, type CloudServicesClient } from "@squirrelscan/cloud-client";
 import { detectWafChallengePage, WAF_CHALLENGE_STATUS_CODES } from "@squirrelscan/waf-detect";
@@ -166,11 +171,15 @@ export function mapRenderItemToResponse(
   // rather than inventing one. Skip it entirely when the service already
   // reported the source itself.
   const needsSourceHop = renderHops.length > 0 && renderHops[0]?.url !== requestUrl;
-  const hops = needsSourceHop
+  const rawHops = needsSourceHop
     ? [{ url: requestUrl, statusCode: 0, type: "http" as const }, ...renderHops]
     : renderHops.length > 0
       ? renderHops
       : [{ url: requestUrl, statusCode: status, type: "http" as const }];
+  // Enforced, not assumed: whatever the service sends, this mapper cannot emit
+  // a 2xx status on a hop it also says redirected. Shared with the other render
+  // passthrough so the invariant has one implementation.
+  const hops = withObservedHopStatuses(rawHops);
   // Prefer the real render headers (already lowercase from the API); fall back
   // to a synthesized content-type only when the item carries no headers.
   const headers =

--- a/packages/audit-engine/tests/cloud-fetcher-redirect-hops.test.ts
+++ b/packages/audit-engine/tests/cloud-fetcher-redirect-hops.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { RenderResultItem } from "@squirrelscan/core-contracts";
+import { withObservedHopStatuses } from "@squirrelscan/fetchers";
 
 import { mapRenderItemToResponse } from "../src/cloud-fetcher";
 
@@ -98,6 +99,56 @@ describe("mapRenderItemToResponse — redirect hops", () => {
       { url: "https://example.com/new/", statusCode: 200, type: "http" },
     ]);
     expect(response.redirectChain!.chainLength).toBe(1);
+  });
+
+  test("a service-reported 2xx on a non-final hop is downgraded, not passed through", () => {
+    // The invariant is enforced, not assumed: whatever the service sends, a hop
+    // that is followed by another hop cannot have returned 2xx, so this mapper
+    // must never be able to emit the reported `200 → 200` shape.
+    const response = map(
+      {
+        url: "https://example.com/o-mnie",
+        status: 200,
+        redirectChain: [
+          { url: "https://example.com/o-mnie", status: 200 },
+          { url: "https://example.com/o-mnie/", status: 200 },
+        ],
+      },
+      "https://example.com/o-mnie",
+    );
+
+    expect(response.redirectChain!.hops).toEqual([
+      { url: "https://example.com/o-mnie", statusCode: 0, type: "http" },
+      { url: "https://example.com/o-mnie/", statusCode: 200, type: "http" },
+    ]);
+  });
+
+  test("a client-side hop keeps its 200 — that document really did return 200", () => {
+    expect(
+      withObservedHopStatuses([
+        { url: "https://example.com/old/", statusCode: 200, type: "javascript" },
+        { url: "https://example.com/new/", statusCode: 200, type: "http" },
+      ]),
+    ).toEqual([
+      { url: "https://example.com/old/", statusCode: 200, type: "javascript" },
+      { url: "https://example.com/new/", statusCode: 200, type: "http" },
+    ]);
+  });
+
+  test("a real 3xx reported for a non-final hop is preserved", () => {
+    const response = map(
+      {
+        url: "https://example.com/a",
+        status: 200,
+        redirectChain: [
+          { url: "https://example.com/a", status: 308 },
+          { url: "https://example.com/b/", status: 200 },
+        ],
+      },
+      "https://example.com/a",
+    );
+
+    expect(response.redirectChain!.hops[0]!.statusCode).toBe(308);
   });
 
   test("scheme downgrade/upgrade flags still derive from source vs landing", () => {

--- a/packages/audit-engine/tests/cloud-fetcher-redirect-hops.test.ts
+++ b/packages/audit-engine/tests/cloud-fetcher-redirect-hops.test.ts
@@ -1,0 +1,116 @@
+// The render service reports the LANDING page only, never the redirect
+// responses that led to it. Stamping the landing page's status onto the request
+// URL produced chains that claimed `200 → 200` (#1510): a first hop that
+// returned 200 did not redirect, so nothing downstream can tell an invented
+// chain from a real one.
+
+import { describe, expect, test } from "bun:test";
+
+import type { RenderResultItem } from "@squirrelscan/core-contracts";
+
+import { mapRenderItemToResponse } from "../src/cloud-fetcher";
+
+const TIMING = { startedAt: 0, responseAt: 1, finishedAt: 2 };
+
+const map = (item: RenderResultItem, requestUrl: string) =>
+  mapRenderItemToResponse(item, requestUrl, TIMING);
+
+describe("mapRenderItemToResponse — redirect hops", () => {
+  test("a landing-page-only chain never claims a 200 first hop", () => {
+    // Exactly what the API sends for a redirect: one entry, the landing page.
+    const response = map(
+      {
+        url: "https://example.com/o-mnie",
+        status: 200,
+        html: "<html></html>",
+        redirectChain: [{ url: "https://example.com/o-mnie/", status: 200 }],
+      },
+      "https://example.com/o-mnie",
+    );
+
+    const hops = response.redirectChain!.hops;
+    expect(hops).toHaveLength(2);
+    expect(hops[0]).toEqual({
+      url: "https://example.com/o-mnie",
+      statusCode: 0,
+      type: "http",
+    });
+    expect(hops[1]!.statusCode).toBe(200);
+    // Still a redirect — the URL genuinely changed — just an honest one.
+    expect(response.finalUrl).toBe("https://example.com/o-mnie/");
+    expect(response.redirectChain!.chainLength).toBe(1);
+  });
+
+  test("no non-final hop is ever 2xx", () => {
+    const response = map(
+      {
+        url: "https://example.com/a",
+        status: 200,
+        redirectChain: [{ url: "https://example.com/b/", status: 200 }],
+      },
+      "https://example.com/a",
+    );
+
+    for (const hop of response.redirectChain!.hops.slice(0, -1)) {
+      const is2xx = hop.statusCode >= 200 && hop.statusCode < 300;
+      expect(is2xx).toBe(false);
+    }
+  });
+
+  test("a page that did not redirect keeps its real status on its single hop", () => {
+    const response = map(
+      { url: "https://example.com/", status: 200, html: "<html></html>" },
+      "https://example.com/",
+    );
+
+    expect(response.redirectChain!.hops).toEqual([
+      { url: "https://example.com/", statusCode: 200, type: "http" },
+    ]);
+    expect(response.redirectChain!.chainLength).toBe(0);
+    expect(response.finalUrl).toBe("https://example.com/");
+  });
+
+  test("an error status is still reported on the page's own hop", () => {
+    const response = map({ url: "https://example.com/gone", status: 404 }, "https://example.com/gone");
+
+    expect(response.status).toBe(404);
+    expect(response.redirectChain!.hops[0]!.statusCode).toBe(404);
+    expect(response.redirectChain!.endsInError).toBe(true);
+  });
+
+  test("a service that reports the source hop itself is not duplicated", () => {
+    // Forward compatibility: if the render service ever reports every hop, the
+    // real statuses are used verbatim and no synthetic source hop is prepended.
+    const response = map(
+      {
+        url: "https://example.com/old",
+        status: 200,
+        redirectChain: [
+          { url: "https://example.com/old", status: 301 },
+          { url: "https://example.com/new/", status: 200 },
+        ],
+      },
+      "https://example.com/old",
+    );
+
+    expect(response.redirectChain!.hops).toEqual([
+      { url: "https://example.com/old", statusCode: 301, type: "http" },
+      { url: "https://example.com/new/", statusCode: 200, type: "http" },
+    ]);
+    expect(response.redirectChain!.chainLength).toBe(1);
+  });
+
+  test("scheme downgrade/upgrade flags still derive from source vs landing", () => {
+    const response = map(
+      {
+        url: "http://example.com/",
+        status: 200,
+        redirectChain: [{ url: "https://example.com/", status: 200 }],
+      },
+      "http://example.com/",
+    );
+
+    expect(response.redirectChain!.httpToHttps).toBe(true);
+    expect(response.redirectChain!.httpsToHttp).toBe(false);
+  });
+});

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -9,6 +9,12 @@ import type { Effect } from "effect";
 
 export interface RedirectHop {
   url: string;
+  /**
+   * The status THIS url returned. `0` means no status was observed for this hop
+   * — the fetcher that produced the chain saw the landing page but not the
+   * redirect responses that led to it. Never substitute the final response's
+   * status: a hop that returns 200 did not redirect (#1510).
+   */
   statusCode: number;
   type: "http" | "javascript" | "meta-refresh";
 }

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -42,7 +42,13 @@ import type {
 } from "./types";
 
 import { fetchPageWithRetry, type CrawlFetcher } from "../fetcher";
-import { normalizeUrl, isInScope, isOffSiteFinalUrl, resolveSeedRedirect } from "../frontier";
+import {
+  normalizeUrl,
+  isInScope,
+  isOffSiteFinalUrl,
+  resolveSeedRedirect,
+  trailingSlashVariant,
+} from "../frontier";
 import {
   buildConditionalHeaders,
   extractChangeDetection,
@@ -393,6 +399,25 @@ export function createCrawler(
             reason: "robots_disallowed",
           });
           return;
+        }
+
+        // Trailing-slash dedupe (#1510): the frontier keeps URLs exactly as the
+        // site linked them, so `/about` and `/about/` are separate entries. Only
+        // ONE of them should be crawled — whichever form was seen first — or a
+        // site that links both forms burns double the budget and the second form
+        // reports a redirect that only exists because we asked for it.
+        //
+        // Deliberately LAST of the eligibility checks, and deliberately blind to
+        // `skipped`/`failed` variants: an entry that robots, scope or the length
+        // cap refused is not a crawl of that path, so it must not suppress the
+        // other form — the two forms can match different robots/include patterns.
+        // A lost race here enqueues both forms, which is only a wasted page, not
+        // a wrong one, so it stays a plain read rather than an atomic claim.
+        const variant = trailingSlashVariant(normalized);
+        if (variant) {
+          const variantEntry = yield* storage.getFrontierEntry(crawlId, variant);
+          if (variantEntry && variantEntry.status !== "skipped" && variantEntry.status !== "failed")
+            return;
         }
 
         // Check max pages (in-memory; the dispatch loop is the authoritative cap)

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -42,13 +42,7 @@ import type {
 } from "./types";
 
 import { fetchPageWithRetry, type CrawlFetcher } from "../fetcher";
-import {
-  normalizeUrl,
-  isInScope,
-  isOffSiteFinalUrl,
-  resolveSeedRedirect,
-  trailingSlashVariant,
-} from "../frontier";
+import { normalizeUrl, isInScope, isOffSiteFinalUrl, resolveSeedRedirect } from "../frontier";
 import {
   buildConditionalHeaders,
   extractChangeDetection,
@@ -401,24 +395,15 @@ export function createCrawler(
           return;
         }
 
-        // Trailing-slash dedupe (#1510): the frontier keeps URLs exactly as the
-        // site linked them, so `/about` and `/about/` are separate entries. Only
-        // ONE of them should be crawled — whichever form was seen first — or a
-        // site that links both forms burns double the budget and the second form
-        // reports a redirect that only exists because we asked for it.
-        //
-        // Deliberately LAST of the eligibility checks, and deliberately blind to
-        // `skipped`/`failed` variants: an entry that robots, scope or the length
-        // cap refused is not a crawl of that path, so it must not suppress the
-        // other form — the two forms can match different robots/include patterns.
-        // A lost race here enqueues both forms, which is only a wasted page, not
-        // a wrong one, so it stays a plain read rather than an atomic claim.
-        const variant = trailingSlashVariant(normalized);
-        if (variant) {
-          const variantEntry = yield* storage.getFrontierEntry(crawlId, variant);
-          if (variantEntry && variantEntry.status !== "skipped" && variantEntry.status !== "failed")
-            return;
-        }
+        // NOTE (#1510): `/about` and `/about/` are deliberately NOT collapsed
+        // into one frontier entry. They are different request targets, and which
+        // of them redirects is exactly what the audit is trying to find out — a
+        // first-seen dedupe would answer it by discovery order, reporting the
+        // redirect on a site that happens to link the redirecting form first and
+        // staying silent on the same site if the links appear the other way
+        // round. Under-reporting a redirect is worse than crawling one extra
+        // page, and this only ever costs a page on a site that already links
+        // both forms of the same path.
 
         // Check max pages (in-memory; the dispatch loop is the authoritative cap)
         if (pagesCommitted >= config.maxPages) {

--- a/packages/crawler/src/frontier.ts
+++ b/packages/crawler/src/frontier.ts
@@ -46,11 +46,28 @@ const TRACKING_PARAM_PREFIXES = new Set([
   "sfmc_id",
 ]);
 
-function normalizeTrailingSlash(pathname: string): string {
-  if (pathname.length > 1 && pathname.endsWith("/")) {
-    return pathname.slice(0, -1);
+/**
+ * The same path with its trailing slash toggled, or null when there is no
+ * meaningful variant (the root path, whose slash is not optional).
+ *
+ * Used purely for DEDUPE: `/about` and `/about/` are different resources on the
+ * wire, so the frontier keeps whichever form the site actually linked, but it
+ * refuses to enqueue the other form once one of them is already queued. Fetching
+ * a form nobody linked invents a redirect that only exists because we asked for
+ * it (#1510) — trailing-slash canonicalization is the default on WordPress,
+ * Hugo and most static hosts, so that mistake fires site-wide.
+ */
+export function trailingSlashVariant(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.pathname === "/") return null;
+    parsed.pathname = parsed.pathname.endsWith("/")
+      ? parsed.pathname.slice(0, -1)
+      : `${parsed.pathname}/`;
+    return parsed.toString();
+  } catch {
+    return null;
   }
-  return pathname;
 }
 
 function shouldDropQueryParam(key: string, allowQueryParams: string[]): boolean {
@@ -85,7 +102,10 @@ export function normalizeUrl(rawUrl: string, options: UrlNormalizationOptions): 
       resolved.port = "";
     }
 
-    resolved.pathname = normalizeTrailingSlash(resolved.pathname);
+    // The trailing slash is NOT noise: `/about` and `/about/` are distinct
+    // request targets, and the normalized URL is the URL we actually fetch.
+    // Stripping it made every slash-canonical site look like it redirected
+    // (#1510). Dedupe across the two forms happens at enqueue time instead.
 
     if (resolved.search) {
       const params = new URLSearchParams(resolved.search);

--- a/packages/crawler/src/frontier.ts
+++ b/packages/crawler/src/frontier.ts
@@ -46,30 +46,6 @@ const TRACKING_PARAM_PREFIXES = new Set([
   "sfmc_id",
 ]);
 
-/**
- * The same path with its trailing slash toggled, or null when there is no
- * meaningful variant (the root path, whose slash is not optional).
- *
- * Used purely for DEDUPE: `/about` and `/about/` are different resources on the
- * wire, so the frontier keeps whichever form the site actually linked, but it
- * refuses to enqueue the other form once one of them is already queued. Fetching
- * a form nobody linked invents a redirect that only exists because we asked for
- * it (#1510) — trailing-slash canonicalization is the default on WordPress,
- * Hugo and most static hosts, so that mistake fires site-wide.
- */
-export function trailingSlashVariant(url: string): string | null {
-  try {
-    const parsed = new URL(url);
-    if (parsed.pathname === "/") return null;
-    parsed.pathname = parsed.pathname.endsWith("/")
-      ? parsed.pathname.slice(0, -1)
-      : `${parsed.pathname}/`;
-    return parsed.toString();
-  } catch {
-    return null;
-  }
-}
-
 function shouldDropQueryParam(key: string, allowQueryParams: string[]): boolean {
   const lowerKey = key.toLowerCase();
 
@@ -103,9 +79,12 @@ export function normalizeUrl(rawUrl: string, options: UrlNormalizationOptions): 
     }
 
     // The trailing slash is NOT noise: `/about` and `/about/` are distinct
-    // request targets, and the normalized URL is the URL we actually fetch.
-    // Stripping it made every slash-canonical site look like it redirected
-    // (#1510). Dedupe across the two forms happens at enqueue time instead.
+    // request targets, and the normalized URL is the URL we actually FETCH
+    // (`fetchPage(entry.normalizedUrl, …)`). Stripping it asked slash-canonical
+    // sites — the WordPress/Hugo/Jekyll default — for a URL they never linked,
+    // and reported the 301 they answered with as the site's own redirect
+    // (#1510). The two forms stay separate frontier entries on purpose: which
+    // one redirects is what the audit is trying to find out.
 
     if (resolved.search) {
       const params = new URLSearchParams(resolved.search);

--- a/packages/crawler/tests/frontier-trailing-slash.test.ts
+++ b/packages/crawler/tests/frontier-trailing-slash.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { normalizeUrl, trailingSlashVariant } from "../src/frontier";
+import { normalizeUrl } from "../src/frontier";
 
 const opts = { baseUrl: "https://example.com/", allowQueryParams: [] as string[] };
 
@@ -39,23 +39,5 @@ describe("frontier normalizeUrl — trailing slash", () => {
     expect(normalizeUrl("HTTPS://EXAMPLE.COM:443/A/?utm_source=x#frag", opts)).toBe(
       "https://example.com/A/",
     );
-  });
-});
-
-describe("trailingSlashVariant", () => {
-  test.each([
-    ["https://example.com/a/", "https://example.com/a"],
-    ["https://example.com/a", "https://example.com/a/"],
-    ["https://example.com/a/?q=1", "https://example.com/a?q=1"],
-  ])("%s ↔ %s", (input, expected) => {
-    expect(trailingSlashVariant(input)).toBe(expected);
-  });
-
-  test("the root has no variant — its slash is not optional", () => {
-    expect(trailingSlashVariant("https://example.com/")).toBeNull();
-  });
-
-  test("an unparseable URL has no variant", () => {
-    expect(trailingSlashVariant("not a url")).toBeNull();
   });
 });

--- a/packages/crawler/tests/frontier-trailing-slash.test.ts
+++ b/packages/crawler/tests/frontier-trailing-slash.test.ts
@@ -1,0 +1,61 @@
+// The frontier's normalized URL is the URL the crawler actually FETCHES, so
+// stripping a trailing slash from it made the crawler request `/about` on a site
+// that only ever links `/about/`. The origin answered 301, and the report blamed
+// the site for a redirect it had never been asked to serve (#1510).
+
+import { describe, expect, test } from "bun:test";
+
+import { normalizeUrl, trailingSlashVariant } from "../src/frontier";
+
+const opts = { baseUrl: "https://example.com/", allowQueryParams: [] as string[] };
+
+describe("frontier normalizeUrl — trailing slash", () => {
+  test("a linked trailing slash survives normalization", () => {
+    expect(normalizeUrl("https://example.com/o-mnie/", opts)).toBe("https://example.com/o-mnie/");
+  });
+
+  test("a linked no-slash URL is not given one", () => {
+    expect(normalizeUrl("https://example.com/o-mnie", opts)).toBe("https://example.com/o-mnie");
+  });
+
+  test("the two forms stay distinct — they are distinct resources on the wire", () => {
+    expect(normalizeUrl("https://example.com/a/", opts)).not.toBe(
+      normalizeUrl("https://example.com/a", opts),
+    );
+  });
+
+  test("relative hrefs resolve with their slash intact", () => {
+    expect(normalizeUrl("/blog/", opts)).toBe("https://example.com/blog/");
+    expect(normalizeUrl("blog/", { ...opts, baseUrl: "https://example.com/x/" })).toBe(
+      "https://example.com/x/blog/",
+    );
+  });
+
+  test("the root path keeps its slash", () => {
+    expect(normalizeUrl("https://example.com", opts)).toBe("https://example.com/");
+  });
+
+  test("everything else still normalizes", () => {
+    expect(normalizeUrl("HTTPS://EXAMPLE.COM:443/A/?utm_source=x#frag", opts)).toBe(
+      "https://example.com/A/",
+    );
+  });
+});
+
+describe("trailingSlashVariant", () => {
+  test.each([
+    ["https://example.com/a/", "https://example.com/a"],
+    ["https://example.com/a", "https://example.com/a/"],
+    ["https://example.com/a/?q=1", "https://example.com/a?q=1"],
+  ])("%s ↔ %s", (input, expected) => {
+    expect(trailingSlashVariant(input)).toBe(expected);
+  });
+
+  test("the root has no variant — its slash is not optional", () => {
+    expect(trailingSlashVariant("https://example.com/")).toBeNull();
+  });
+
+  test("an unparseable URL has no variant", () => {
+    expect(trailingSlashVariant("not a url")).toBeNull();
+  });
+});

--- a/packages/crawler/tests/trailing-slash-canonical-crawl.test.ts
+++ b/packages/crawler/tests/trailing-slash-canonical-crawl.test.ts
@@ -1,0 +1,197 @@
+// End-to-end guard for the false-positive class in #1510: a site whose every
+// internal link ends in `/` (the WordPress / Hugo / Jekyll default) must never
+// be asked for the no-slash form, because the origin answers 301 and the audit
+// then reports a redirect the site never had. The server here is deliberately
+// strict — it 301s any no-slash path — so a single normalization slip shows up
+// as a recorded redirect rather than as a silent extra request.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { createCrawler } from "../src/core/crawler";
+import type { CrawlerConfig } from "../src/core/types";
+import { SQLiteStorage } from "../src/storage/sqlite";
+
+const CONFIG: Partial<CrawlerConfig> = {
+  maxPages: 20,
+  concurrency: 1,
+  perHostConcurrency: 1,
+  delayMs: 0,
+  perHostDelayMs: 0,
+  timeoutMs: 2000,
+  userAgent: "squirrel-test",
+  respectRobots: false,
+  incremental: false,
+  useCacheControl: false,
+  breadthFirst: false,
+  coverageMode: "full",
+};
+
+const PAGES = ["/", "/o-mnie/", "/blog/", "/kontakt/"];
+/** A page that genuinely moved: linked with its slash, and still a real 301. */
+const MOVED = "/stary-wpis/";
+const MOVED_TARGET = "/blog/";
+
+interface Site {
+  origin: string;
+  requested: string[];
+  stop: () => void;
+}
+
+/**
+ * A trailing-slash-canonical site. Every internal href ends in `/`; any request
+ * for the no-slash form gets the 301 a real origin would send.
+ */
+function serveSlashCanonical(
+  options: { alsoLinkNoSlash?: boolean; linkMovedPage?: boolean } = {},
+): Site {
+  const requested: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const path = new URL(req.url).pathname;
+      requested.push(path);
+
+      if (path !== "/" && !path.endsWith("/")) {
+        return new Response(null, { status: 301, headers: { location: `${path}/` } });
+      }
+      if (path === MOVED) {
+        return new Response(null, { status: 301, headers: { location: MOVED_TARGET } });
+      }
+      if (!PAGES.includes(path)) return new Response("not found", { status: 404 });
+
+      const hrefs = PAGES.filter((p) => p !== path).map((p) => `<a href="${p}">${p}</a>`);
+      if (options.alsoLinkNoSlash) {
+        hrefs.push(`<a href="/o-mnie">no-slash</a>`);
+      }
+      if (options.linkMovedPage) {
+        hrefs.push(`<a href="${MOVED}">moved</a>`);
+      }
+      return new Response(
+        `<!doctype html><html><head><title>${path}</title></head><body>${hrefs.join("")}</body></html>`,
+        { headers: { "content-type": "text/html" } },
+      );
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    requested,
+    stop: () => server.stop(true),
+  };
+}
+
+const sites: Site[] = [];
+function track(site: Site): Site {
+  sites.push(site);
+  return site;
+}
+afterEach(() => {
+  while (sites.length > 0) sites.pop()?.stop();
+});
+
+async function crawl(seed: string) {
+  const storage = new SQLiteStorage(":memory:");
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* storage.init();
+      const crawler = yield* createCrawler({ config: CONFIG, storage });
+      const crawlId = yield* crawler.start(seed, seed);
+      return yield* storage.getPages(crawlId);
+    }),
+  );
+}
+
+describe("a trailing-slash-canonical site", () => {
+  test("is never asked for the no-slash form of a linked page", async () => {
+    const site = track(serveSlashCanonical());
+
+    const pages = await crawl(`${site.origin}/`);
+
+    // Non-vacuous: the crawl really did walk the site.
+    expect(pages.length).toBeGreaterThanOrEqual(PAGES.length);
+
+    const documentPaths = site.requested.filter((p) => !p.includes("."));
+    const noSlash = documentPaths.filter((p) => p !== "/" && !p.endsWith("/"));
+    expect(noSlash).toEqual([]);
+  });
+
+  test("records no redirects at all", async () => {
+    const site = track(serveSlashCanonical());
+
+    const pages = await crawl(`${site.origin}/`);
+
+    for (const page of pages) {
+      expect(page.status).toBe(200);
+      expect(page.finalUrl).toBe(page.url);
+      expect(page.redirectChain?.chainLength ?? 0).toBe(0);
+    }
+  });
+
+  test("no stored chain claims a 2xx status on a hop it says redirected", async () => {
+    const site = track(serveSlashCanonical());
+
+    const pages = await crawl(`${site.origin}/`);
+
+    for (const page of pages) {
+      for (const hop of page.redirectChain?.hops.slice(0, -1) ?? []) {
+        const is2xx = hop.statusCode >= 200 && hop.statusCode < 300;
+        expect(is2xx).toBe(false);
+      }
+    }
+  });
+});
+
+describe("a site that links BOTH forms of the same path", () => {
+  test("crawls only one of them — the budget is not spent twice", async () => {
+    const site = track(serveSlashCanonical({ alsoLinkNoSlash: true }));
+
+    const pages = await crawl(`${site.origin}/`);
+
+    const oMnie = pages.filter((p) => p.url.replace(/\/$/, "").endsWith("/o-mnie"));
+    expect(oMnie).toHaveLength(1);
+    // Whichever form was seen first is the one crawled; here the slash form is
+    // linked first, so the no-slash request is never made.
+    expect(oMnie[0]!.url).toBe(`${site.origin}/o-mnie/`);
+  });
+});
+
+describe("a variant the crawl refused", () => {
+  test("does not suppress the form the crawl is allowed to fetch", async () => {
+    // `/o-mnie/` is excluded by scope, so it is recorded as a SKIPPED frontier
+    // entry. That is not a crawl of that path, so the no-slash form — which the
+    // exclude pattern does not match — must still be crawled.
+    const site = track(serveSlashCanonical({ alsoLinkNoSlash: true }));
+
+    const storage = new SQLiteStorage(":memory:");
+    const pages = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* storage.init();
+        const crawler = yield* createCrawler({
+          config: { ...CONFIG, exclude: ["/o-mnie/"] },
+          storage,
+        });
+        const crawlId = yield* crawler.start(`${site.origin}/`, `${site.origin}/`);
+        return yield* storage.getPages(crawlId);
+      }),
+    );
+
+    expect(pages.some((p) => p.url === `${site.origin}/o-mnie/`)).toBe(false);
+    expect(pages.some((p) => p.url === `${site.origin}/o-mnie`)).toBe(true);
+  });
+});
+
+describe("a genuine redirect", () => {
+  test("is still recorded, with the real 301 on the hop that served it", async () => {
+    // A page the site really moved, linked in its canonical (slashed) form.
+    const site = track(serveSlashCanonical({ linkMovedPage: true }));
+
+    const pages = await crawl(`${site.origin}/`);
+
+    const redirected = pages.find((p) => p.url === `${site.origin}${MOVED}`);
+    expect(redirected).toBeDefined();
+    expect(redirected!.finalUrl).toBe(`${site.origin}${MOVED_TARGET}`);
+    expect(redirected!.redirectChain?.chainLength).toBe(1);
+    expect(redirected!.redirectChain?.hops[0]?.statusCode).toBe(301);
+    expect(redirected!.redirectChain?.hops[1]?.statusCode).toBe(200);
+  });
+});

--- a/packages/crawler/tests/trailing-slash-canonical-crawl.test.ts
+++ b/packages/crawler/tests/trailing-slash-canonical-crawl.test.ts
@@ -128,56 +128,99 @@ describe("a trailing-slash-canonical site", () => {
   });
 
   test("no stored chain claims a 2xx status on a hop it says redirected", async () => {
-    const site = track(serveSlashCanonical());
+    // Crawled with the moved page linked, so there ARE multi-hop chains to
+    // inspect — on a purely canonical site every chain is one hop and
+    // `hops.slice(0, -1)` is empty, which would make this assertion vacuous.
+    const site = track(serveSlashCanonical({ linkMovedPage: true, alsoLinkNoSlash: true }));
 
     const pages = await crawl(`${site.origin}/`);
 
-    for (const page of pages) {
-      for (const hop of page.redirectChain?.hops.slice(0, -1) ?? []) {
-        const is2xx = hop.statusCode >= 200 && hop.statusCode < 300;
-        expect(is2xx).toBe(false);
-      }
+    const nonFinalHops = pages.flatMap((p) => p.redirectChain?.hops.slice(0, -1) ?? []);
+    expect(nonFinalHops.length).toBeGreaterThan(0);
+    for (const hop of nonFinalHops) {
+      const is2xx = hop.statusCode >= 200 && hop.statusCode < 300;
+      expect(is2xx).toBe(false);
     }
   });
 });
 
 describe("a site that links BOTH forms of the same path", () => {
-  test("crawls only one of them — the budget is not spent twice", async () => {
+  test("crawls both, so the one that redirects is actually found", async () => {
+    // The two forms are different request targets and only a fetch can say which
+    // of them redirects. Collapsing them would answer that by discovery order.
     const site = track(serveSlashCanonical({ alsoLinkNoSlash: true }));
 
     const pages = await crawl(`${site.origin}/`);
 
-    const oMnie = pages.filter((p) => p.url.replace(/\/$/, "").endsWith("/o-mnie"));
-    expect(oMnie).toHaveLength(1);
-    // Whichever form was seen first is the one crawled; here the slash form is
-    // linked first, so the no-slash request is never made.
-    expect(oMnie[0]!.url).toBe(`${site.origin}/o-mnie/`);
+    const slash = pages.find((p) => p.url === `${site.origin}/o-mnie/`);
+    const noSlash = pages.find((p) => p.url === `${site.origin}/o-mnie`);
+    expect(slash).toBeDefined();
+    expect(noSlash).toBeDefined();
+
+    // The linked no-slash form is the one that genuinely redirects here.
+    expect(noSlash!.redirectChain?.hops[0]?.statusCode).toBe(301);
+    expect(noSlash!.finalUrl).toBe(`${site.origin}/o-mnie/`);
+    expect(slash!.redirectChain?.chainLength ?? 0).toBe(0);
   });
 });
 
-describe("a variant the crawl refused", () => {
-  test("does not suppress the form the crawl is allowed to fetch", async () => {
-    // `/o-mnie/` is excluded by scope, so it is recorded as a SKIPPED frontier
-    // entry. That is not a crawl of that path, so the no-slash form — which the
-    // exclude pattern does not match — must still be crawled.
-    const site = track(serveSlashCanonical({ alsoLinkNoSlash: true }));
+describe("a NO-SLASH-canonical site (canonicalized the other way)", () => {
+  // Mirror image of the reported case: `/o-mnie` is the real page and the SLASH
+  // form is the one that 301s. Discovery order must not decide whether that
+  // redirect is reported.
+  function serveNoSlashCanonical(linkFirst: "slash" | "no-slash"): Site {
+    const requested: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        requested.push(path);
 
-    const storage = new SQLiteStorage(":memory:");
-    const pages = await Effect.runPromise(
-      Effect.gen(function* () {
-        yield* storage.init();
-        const crawler = yield* createCrawler({
-          config: { ...CONFIG, exclude: ["/o-mnie/"] },
-          storage,
-        });
-        const crawlId = yield* crawler.start(`${site.origin}/`, `${site.origin}/`);
-        return yield* storage.getPages(crawlId);
-      }),
-    );
+        if (path !== "/" && path.endsWith("/")) {
+          return new Response(null, {
+            status: 301,
+            headers: { location: path.slice(0, -1) },
+          });
+        }
+        if (path !== "/" && path !== "/o-mnie") {
+          return new Response("not found", { status: 404 });
+        }
 
-    expect(pages.some((p) => p.url === `${site.origin}/o-mnie/`)).toBe(false);
-    expect(pages.some((p) => p.url === `${site.origin}/o-mnie`)).toBe(true);
-  });
+        const hrefs =
+          linkFirst === "slash"
+            ? [`<a href="/o-mnie/">a</a>`, `<a href="/o-mnie">b</a>`]
+            : [`<a href="/o-mnie">b</a>`, `<a href="/o-mnie/">a</a>`];
+        return new Response(
+          `<!doctype html><html><head><title>${path}</title></head><body>${hrefs.join("")}</body></html>`,
+          { headers: { "content-type": "text/html" } },
+        );
+      },
+    });
+    return {
+      origin: `http://127.0.0.1:${server.port}`,
+      requested,
+      stop: () => server.stop(true),
+    };
+  }
+
+  test.each(["slash", "no-slash"] as const)(
+    "reports the slash form's genuine 301 when %s is linked first",
+    async (linkFirst) => {
+      const site = track(serveNoSlashCanonical(linkFirst));
+
+      const pages = await crawl(`${site.origin}/`);
+
+      const slash = pages.find((p) => p.url === `${site.origin}/o-mnie/`);
+      expect(slash).toBeDefined();
+      expect(slash!.redirectChain?.hops[0]?.statusCode).toBe(301);
+      expect(slash!.finalUrl).toBe(`${site.origin}/o-mnie`);
+
+      // The canonical form is crawled too and is not itself a redirect.
+      const canonical = pages.find((p) => p.url === `${site.origin}/o-mnie`);
+      expect(canonical).toBeDefined();
+      expect(canonical!.redirectChain?.chainLength ?? 0).toBe(0);
+    },
+  );
 });
 
 describe("a genuine redirect", () => {

--- a/packages/fetchers/src/index.ts
+++ b/packages/fetchers/src/index.ts
@@ -6,6 +6,33 @@ import {
   readBodyCapped,
 } from "@squirrelscan/utils";
 
+/**
+ * Enforce the one invariant every redirect chain must satisfy: an HTTP hop that
+ * is FOLLOWED by another hop redirected at the HTTP level, so a 2xx recorded
+ * against it is not a status that hop can have returned — it belongs to some
+ * other response, and in practice to the landing page. Downgrade it to `0`
+ * ("no status observed for this hop") instead of passing it on.
+ *
+ * `javascript` and `meta-refresh` hops are left alone: a client-side redirect is
+ * a document that loaded with 200 and THEN redirected, so 2xx is the correct
+ * status there and carries real information.
+ *
+ * Applied at every producer that does not derive hops from responses it watched
+ * itself, so no consumer can read a fabricated `200 → 200` as a redirect
+ * (#1510). Producers that follow redirects by hand only ever append a hop after
+ * seeing a 3xx, so they satisfy this by construction and do not need it.
+ */
+export function withObservedHopStatuses(hops: RedirectChain["hops"]): RedirectChain["hops"] {
+  return hops.map((hop, i) =>
+    i < hops.length - 1 &&
+    hop.type === "http" &&
+    hop.statusCode >= 200 &&
+    hop.statusCode < 300
+      ? { ...hop, statusCode: 0 }
+      : hop,
+  );
+}
+
 export interface FetcherCapabilities {
   jsRendering: boolean;
   cookies: boolean;
@@ -511,28 +538,39 @@ export function createBrowserQueueDocumentFetcher(
           throw new Error(statusData.error ?? "Browser render job failed");
         }
         if (statusData.status === "completed" && statusData.result) {
+          const { sourceUrl, finalUrl, status } = statusData.result;
+          // The render service reports the landing page; the statuses of the
+          // redirects that led to it were never observed. Only the LAST hop can
+          // carry `status`, and a supplied chain is sanitised rather than
+          // trusted, so neither path can claim a 2xx hop redirected (#1510).
+          const redirected = Boolean(finalUrl) && finalUrl !== sourceUrl;
+          const fallbackHops: RedirectChain["hops"] = redirected
+            ? [
+                { url: sourceUrl, statusCode: 0, type: "http" },
+                { url: finalUrl, statusCode: status, type: "http" },
+              ]
+            : [{ url: sourceUrl, statusCode: status, type: "http" }];
           return {
             url: statusData.result.sourceUrl,
             finalUrl: statusData.result.finalUrl,
             status: statusData.result.status,
             headers: statusData.result.headers,
             body: statusData.result.body,
-            redirectChain: statusData.result.redirectChain ?? {
-              sourceUrl: statusData.result.sourceUrl,
-              finalUrl: statusData.result.finalUrl,
-              hops: [
-                {
-                  url: statusData.result.sourceUrl,
-                  statusCode: statusData.result.status,
-                  type: "http",
+            redirectChain: statusData.result.redirectChain
+              ? {
+                  ...statusData.result.redirectChain,
+                  hops: withObservedHopStatuses(statusData.result.redirectChain.hops),
+                }
+              : {
+                  sourceUrl,
+                  finalUrl,
+                  hops: fallbackHops,
+                  chainLength: Math.max(0, fallbackHops.length - 1),
+                  isLoop: false,
+                  endsInError: status >= 400,
+                  httpsToHttp: sourceUrl.startsWith("https://") && finalUrl.startsWith("http://"),
+                  httpToHttps: sourceUrl.startsWith("http://") && finalUrl.startsWith("https://"),
                 },
-              ],
-              chainLength: 0,
-              isLoop: false,
-              endsInError: statusData.result.status >= 400,
-              httpsToHttp: false,
-              httpToHttps: false,
-            },
             timing: {
               startedAt: statusData.result.startedAt,
               responseAt: statusData.result.responseAt,

--- a/packages/rules/src/links/redirect-chains.ts
+++ b/packages/rules/src/links/redirect-chains.ts
@@ -5,6 +5,36 @@ import type { RedirectChain } from "@squirrelscan/core-contracts";
 
 import { normalizeUrl } from "@squirrelscan/utils";
 
+/**
+ * True when the chain contains a hop that actually redirected: a NON-final hop
+ * carrying a 3xx status.
+ *
+ * `chainLength > 0` is not that evidence. A chain whose hops are all 2xx is not
+ * a redirect — it is a chain some fetcher assembled from a source URL and a
+ * landing URL without observing the responses in between (#1510). Treating it
+ * as a redirect made every trailing-slash-canonical site report its own pages as
+ * redirecting, `(200) → (200)`, and blamed every page that linked them.
+ *
+ * The URL-actually-changed test in the caller is the other trigger, and it still
+ * catches a redirect whose hop statuses were never observed — as long as the
+ * destination differs by more than a trailing slash, since `normalizeUrl` folds
+ * that away. A slash-only move with no observed 3xx is therefore reported only by
+ * the fetchers that record real per-hop statuses. That is the intended trade: it
+ * is the exact shape a fabricated chain takes, so accusing on it would put the
+ * false positive straight back.
+ */
+function hasObservedRedirect(chain: RedirectChain | undefined): boolean {
+  if (!chain || chain.hops.length < 2) return false;
+  return chain.hops
+    .slice(0, -1)
+    .some((hop) => hop.statusCode >= 300 && hop.statusCode < 400);
+}
+
+/** `url (301)`, or bare `url` when no status was observed for that hop. */
+function formatHop(hop: { url: string; statusCode: number }): string {
+  return hop.statusCode > 0 ? `${hop.url} (${hop.statusCode})` : hop.url;
+}
+
 export const redirectChainsRule: Rule = {
   meta: {
     id: "links/redirect-chains",
@@ -47,13 +77,11 @@ export const redirectChainsRule: Rule = {
       const original = normalizeUrl(page.url);
       const final = normalizeUrl(page.finalUrl);
 
-      if (original !== final || (page.redirectChain?.chainLength ?? 0) > 0) {
+      if (original !== final || hasObservedRedirect(page.redirectChain)) {
         const chain = page.redirectChain;
         const chainLabel =
           chain && chain.hops.length > 1
-            ? chain.hops
-                .map((hop) => `${hop.url} (${hop.statusCode})`)
-                .join(" → ")
+            ? chain.hops.map(formatHop).join(" → ")
             : `${page.url} → ${page.finalUrl}`;
         redirectTargets.set(original, {
           originalUrl: page.url,

--- a/packages/rules/src/links/redirect-chains.ts
+++ b/packages/rules/src/links/redirect-chains.ts
@@ -3,31 +3,58 @@
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 import type { RedirectChain } from "@squirrelscan/core-contracts";
 
-import { normalizeUrl } from "@squirrelscan/utils";
+/**
+ * Identity of the resource a URL names, for deciding whether a request LANDED
+ * somewhere else and for joining links to redirect targets.
+ *
+ * This is `@squirrelscan/utils`' `normalizeUrl` with the trailing slash KEPT.
+ * `/about` and `/about/` are different request targets, and telling them apart
+ * is the entire point of this rule: folding them together both hides a genuine
+ * `/about → /about/` move and lets a page that links the canonical form get
+ * blamed for the other form's redirect (#1510).
+ */
+function targetKey(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol.toLowerCase()}//${parsed.host.toLowerCase()}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
 
 /**
- * True when the chain contains a hop that actually redirected: a NON-final hop
- * carrying a 3xx status.
- *
- * `chainLength > 0` is not that evidence. A chain whose hops are all 2xx is not
- * a redirect — it is a chain some fetcher assembled from a source URL and a
- * landing URL without observing the responses in between (#1510). Treating it
- * as a redirect made every trailing-slash-canonical site report its own pages as
- * redirecting, `(200) → (200)`, and blamed every page that linked them.
- *
- * The URL-actually-changed test in the caller is the other trigger, and it still
- * catches a redirect whose hop statuses were never observed — as long as the
- * destination differs by more than a trailing slash, since `normalizeUrl` folds
- * that away. A slash-only move with no observed 3xx is therefore reported only by
- * the fetchers that record real per-hop statuses. That is the intended trade: it
- * is the exact shape a fabricated chain takes, so accusing on it would put the
- * false positive straight back.
+ * A NON-final hop we watched actually redirect: an HTTP hop carrying a 3xx, or
+ * any client-side hop at all — a `javascript` / `meta-refresh` hop IS the
+ * redirect, whatever status the document that performed it returned.
  */
 function hasObservedRedirect(chain: RedirectChain | undefined): boolean {
   if (!chain || chain.hops.length < 2) return false;
   return chain.hops
     .slice(0, -1)
-    .some((hop) => hop.statusCode >= 300 && hop.statusCode < 400);
+    .some((hop) => hop.type !== "http" || (hop.statusCode >= 300 && hop.statusCode < 400));
+}
+
+/**
+ * True when the chain contradicts itself: an HTTP hop it says was followed by
+ * another hop reports a 2xx, and an HTTP response that returned 200 did not
+ * redirect.
+ *
+ * Such a chain was assembled from a source URL and a landing URL by something
+ * that never watched the responses in between, and it is what made every
+ * trailing-slash-canonical site report its own pages as redirecting,
+ * `(200) → (200)`, blaming every page that linked them (#1510). The producers
+ * are fixed to record an unobserved hop as `0` rather than borrowing the landing
+ * status; this is the rule refusing to accuse on that shape even if one regresses.
+ *
+ * Client-side hops are exempt: a `javascript` / `meta-refresh` redirect is by
+ * definition a document that returned 200 and then sent the visitor elsewhere,
+ * so a 2xx there is the truth, not a borrowed status.
+ */
+function contradictsItself(chain: RedirectChain | undefined): boolean {
+  if (!chain || chain.hops.length < 2) return false;
+  return chain.hops
+    .slice(0, -1)
+    .some((hop) => hop.type === "http" && hop.statusCode >= 200 && hop.statusCode < 300);
 }
 
 /** `url (301)`, or bare `url` when no status was observed for that hop. */
@@ -74,11 +101,17 @@ export const redirectChainsRule: Rule = {
     for (const page of pages) {
       if (!page.finalUrl) continue;
 
-      const original = normalizeUrl(page.url);
-      const final = normalizeUrl(page.finalUrl);
+      const chain = page.redirectChain;
+      const original = targetKey(page.url);
+      const final = targetKey(page.finalUrl);
 
-      if (original !== final || hasObservedRedirect(page.redirectChain)) {
-        const chain = page.redirectChain;
+      // Two independent kinds of evidence: the request landed on a different
+      // resource, or we watched a hop return a 3xx. Either is a redirect — the
+      // first covers the render path, which reports the landing page but never
+      // the statuses that led to it. A self-contradicting chain is neither.
+      const redirected = original !== final || hasObservedRedirect(chain);
+
+      if (redirected && !contradictsItself(chain)) {
         const chainLabel =
           chain && chain.hops.length > 1
             ? chain.hops.map(formatHop).join(" → ")
@@ -117,12 +150,14 @@ export const redirectChainsRule: Rule = {
         for (const link of links) {
           if (!link.isInternal || !link.url) continue;
           try {
-            const resolved = new URL(link.url, page.url);
-            const normalized = normalizeUrl(resolved.href);
-            if (redirectTargets.has(normalized)) {
-              const sources = linksToRedirect.get(normalized) ?? new Set();
+            // Slash-sensitive join: a page that links `/about/` must not be
+            // blamed for `/about`'s redirect. They are different hrefs and only
+            // one of them is the mistake being reported.
+            const target = targetKey(new URL(link.url, page.url).href);
+            if (redirectTargets.has(target)) {
+              const sources = linksToRedirect.get(target) ?? new Set();
               sources.add(page.url);
-              linksToRedirect.set(normalized, sources);
+              linksToRedirect.set(target, sources);
             }
           } catch {
             continue;

--- a/packages/rules/tests/redirect-chains-trailing-slash.test.ts
+++ b/packages/rules/tests/redirect-chains-trailing-slash.test.ts
@@ -1,0 +1,283 @@
+// links/redirect-chains reported `(200) → (200)` "redirects" on sites whose
+// every internal link is trailing-slash canonical (WordPress, Hugo, Jekyll and
+// most static hosts). Two hops both returning 200 is not a redirect at all — it
+// is a chain assembled from a source URL and a landing URL by a fetcher that
+// never observed the responses in between. These tests pin the rule to real
+// redirect evidence, and pin the label to hops whose status was actually seen.
+
+import { describe, expect, test } from "bun:test";
+
+import type { RedirectChain, RedirectHop } from "@squirrelscan/core-contracts";
+import type { RuleContext } from "../src/types";
+
+import { redirectChainsRule } from "../src/links/redirect-chains";
+
+interface PageInput {
+  url: string;
+  finalUrl: string;
+  redirectChain?: RedirectChain;
+  links?: string[];
+}
+
+function hop(url: string, statusCode: number): RedirectHop {
+  return { url, statusCode, type: "http" };
+}
+
+function chain(sourceUrl: string, finalUrl: string, hops: RedirectHop[]): RedirectChain {
+  return {
+    sourceUrl,
+    finalUrl,
+    hops,
+    chainLength: Math.max(0, hops.length - 1),
+    isLoop: false,
+    endsInError: false,
+    httpsToHttp: false,
+    httpToHttps: false,
+  };
+}
+
+function ctx(pages: PageInput[]): RuleContext {
+  return {
+    page: { url: pages[0]?.url ?? "https://example.com/", html: "", statusCode: 200 },
+    parsed: {},
+    site: {
+      baseUrl: "https://example.com",
+      pages: pages.map((page) => ({
+        url: page.url,
+        finalUrl: page.finalUrl,
+        redirectChain: page.redirectChain,
+        parsed: {
+          links: (page.links ?? []).map((url) => ({ url, isInternal: true })),
+        },
+      })),
+      robotsTxt: null,
+      sitemaps: null,
+    },
+    options: {},
+  } as unknown as RuleContext;
+}
+
+const check = (pages: PageInput[], name: string) =>
+  redirectChainsRule.run(ctx(pages)).checks.find((c) => c.name === name);
+
+describe("links/redirect-chains — trailing-slash false positives", () => {
+  test("the exact reported shape (200 → 200) is not a redirect", () => {
+    // Verbatim from the field report: a slash-canonical page whose chain claims
+    // two hops, both 200. Neither hop redirected, so nothing should be flagged.
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/o-mnie",
+        finalUrl: "https://example.com/o-mnie/",
+        redirectChain: chain("https://example.com/o-mnie", "https://example.com/o-mnie/", [
+          hop("https://example.com/o-mnie", 200),
+          hop("https://example.com/o-mnie/", 200),
+        ]),
+      },
+    ];
+
+    const { checks } = redirectChainsRule.run(ctx(pages));
+
+    expect(checks).toHaveLength(1);
+    expect(checks[0]!.status).toBe("pass");
+    expect(checks[0]!.message).toContain("No redirects");
+  });
+
+  test("a slash-canonical site produces zero phantom chains", () => {
+    // Every page fetched at the URL it was linked at, no redirect anywhere.
+    const pages: PageInput[] = [
+      "https://example.com/",
+      "https://example.com/o-mnie/",
+      "https://example.com/blog/",
+      "https://example.com/kontakt/",
+    ].map((url) => ({
+      url,
+      finalUrl: url,
+      redirectChain: chain(url, url, [hop(url, 200)]),
+      links: ["https://example.com/o-mnie/", "https://example.com/blog/"],
+    }));
+
+    const { checks } = redirectChainsRule.run(ctx(pages));
+
+    expect(checks.map((c) => c.status)).toEqual(["pass"]);
+  });
+
+  test("a page whose links-to-redirect fan-out is driven by a phantom chain stays quiet", () => {
+    // The regression that made this site-wide: `links-to-redirect` inherits
+    // redirect-pages' targets, so one phantom chain blamed every linking page.
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/o-mnie",
+        finalUrl: "https://example.com/o-mnie/",
+        redirectChain: chain("https://example.com/o-mnie", "https://example.com/o-mnie/", [
+          hop("https://example.com/o-mnie", 200),
+          hop("https://example.com/o-mnie/", 200),
+        ]),
+      },
+      ...Array.from({ length: 20 }, (_, i) => ({
+        url: `https://example.com/p${i}/`,
+        finalUrl: `https://example.com/p${i}/`,
+        links: ["https://example.com/o-mnie/"],
+      })),
+    ];
+
+    expect(check(pages, "links-to-redirect")).toBeUndefined();
+  });
+});
+
+describe("links/redirect-chains — genuine redirects still report", () => {
+  test("a real 301 chain is reported", () => {
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/przemyslenia",
+        finalUrl: "https://example.com/przemyslenia-artykuly/",
+        redirectChain: chain(
+          "https://example.com/przemyslenia",
+          "https://example.com/przemyslenia-artykuly/",
+          [
+            hop("https://example.com/przemyslenia", 301),
+            hop("https://example.com/przemyslenia-artykuly/", 200),
+          ],
+        ),
+      },
+    ];
+
+    const redirectPages = check(pages, "redirect-pages");
+    expect(redirectPages?.status).toBe("warn");
+    expect(redirectPages?.items).toHaveLength(1);
+    expect(redirectPages?.items?.[0]?.label).toBe(
+      "https://example.com/przemyslenia (301) → https://example.com/przemyslenia-artykuly/ (200)",
+    );
+  });
+
+  test("a real 301 on a slash-only redirect is still reported", () => {
+    // The one genuine case in the field report: the site really did serve a 301
+    // from the no-slash form. Suppressing on shape alone would have hidden it.
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/o-mnie",
+        finalUrl: "https://example.com/o-mnie/",
+        redirectChain: chain("https://example.com/o-mnie", "https://example.com/o-mnie/", [
+          hop("https://example.com/o-mnie", 301),
+          hop("https://example.com/o-mnie/", 200),
+        ]),
+      },
+    ];
+
+    expect(check(pages, "redirect-pages")?.status).toBe("warn");
+  });
+
+  test("a multi-hop chain is reported and every hop is labelled", () => {
+    const pages: PageInput[] = [
+      {
+        url: "http://example.com/old",
+        finalUrl: "https://example.com/new/",
+        redirectChain: chain("http://example.com/old", "https://example.com/new/", [
+          hop("http://example.com/old", 301),
+          hop("https://example.com/old", 302),
+          hop("https://example.com/new/", 200),
+        ]),
+      },
+    ];
+
+    expect(check(pages, "redirect-pages")?.items?.[0]?.label).toBe(
+      "http://example.com/old (301) → https://example.com/old (302) → https://example.com/new/ (200)",
+    );
+  });
+
+  test("a genuine destination change with unobserved hop statuses still reports", () => {
+    // Browser-rendered pages come back with the landing page only, so the source
+    // hop carries status 0. The URL genuinely changed, so it is still a redirect.
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/old-post/",
+        finalUrl: "https://example.com/new-post/",
+        redirectChain: chain("https://example.com/old-post/", "https://example.com/new-post/", [
+          hop("https://example.com/old-post/", 0),
+          hop("https://example.com/new-post/", 200),
+        ]),
+      },
+    ];
+
+    const redirectPages = check(pages, "redirect-pages");
+    expect(redirectPages?.status).toBe("warn");
+    // An unobserved status is omitted rather than printed as "(0)".
+    expect(redirectPages?.items?.[0]?.label).toBe(
+      "https://example.com/old-post/ → https://example.com/new-post/ (200)",
+    );
+  });
+
+  test("links pointing at a genuinely redirecting URL are still blamed", () => {
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/old",
+        finalUrl: "https://example.com/new/",
+        redirectChain: chain("https://example.com/old", "https://example.com/new/", [
+          hop("https://example.com/old", 301),
+          hop("https://example.com/new/", 200),
+        ]),
+      },
+      {
+        url: "https://example.com/",
+        finalUrl: "https://example.com/",
+        links: ["https://example.com/old"],
+      },
+    ];
+
+    const linksToRedirect = check(pages, "links-to-redirect");
+    expect(linksToRedirect?.status).toBe("warn");
+    expect(linksToRedirect?.items?.[0]?.sourcePages).toEqual(["https://example.com/"]);
+  });
+});
+
+describe("links/redirect-chains — a chain can never claim a 200 first hop", () => {
+  test.each([
+    ["all-2xx two-hop chain", [hop("https://example.com/a", 200), hop("https://example.com/a/", 200)]],
+    ["2xx then 3xx (the redirect is the LAST hop, so it led nowhere)", [
+      hop("https://example.com/a", 200),
+      hop("https://example.com/a/", 301),
+    ]],
+  ])("%s produces no warning", (_name, hops) => {
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/a",
+        finalUrl: "https://example.com/a/",
+        redirectChain: chain("https://example.com/a", "https://example.com/a/", hops),
+      },
+    ];
+
+    expect(check(pages, "redirect-pages")).toBeUndefined();
+  });
+
+  test("no emitted chain has a 2xx status on a non-final hop", () => {
+    // Blanket invariant over a mixed site: whatever the rule chooses to report,
+    // the hop it blames must have actually redirected.
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/phantom",
+        finalUrl: "https://example.com/phantom/",
+        redirectChain: chain("https://example.com/phantom", "https://example.com/phantom/", [
+          hop("https://example.com/phantom", 200),
+          hop("https://example.com/phantom/", 200),
+        ]),
+      },
+      {
+        url: "https://example.com/real",
+        finalUrl: "https://example.com/real-target/",
+        redirectChain: chain("https://example.com/real", "https://example.com/real-target/", [
+          hop("https://example.com/real", 308),
+          hop("https://example.com/real-target/", 200),
+        ]),
+      },
+    ];
+
+    const items = check(pages, "redirect-pages")?.items ?? [];
+    expect(items).toHaveLength(1);
+    for (const item of items) {
+      const emitted = (item.meta as { chain?: RedirectChain } | undefined)?.chain;
+      for (const h of emitted?.hops.slice(0, -1) ?? []) {
+        const is2xx = h.statusCode >= 200 && h.statusCode < 300;
+        expect(is2xx).toBe(false);
+      }
+    }
+  });
+});

--- a/packages/rules/tests/redirect-chains-trailing-slash.test.ts
+++ b/packages/rules/tests/redirect-chains-trailing-slash.test.ts
@@ -19,8 +19,8 @@ interface PageInput {
   links?: string[];
 }
 
-function hop(url: string, statusCode: number): RedirectHop {
-  return { url, statusCode, type: "http" };
+function hop(url: string, statusCode: number, type: RedirectHop["type"] = "http"): RedirectHop {
+  return { url, statusCode, type };
 }
 
 function chain(sourceUrl: string, finalUrl: string, hops: RedirectHop[]): RedirectChain {
@@ -184,6 +184,29 @@ describe("links/redirect-chains — genuine redirects still report", () => {
     );
   });
 
+  test("a SLASH-ONLY move with unobserved hop statuses is still reported", () => {
+    // The render path reports the landing page but never the statuses that led
+    // to it, so a genuine `/o-mnie → /o-mnie/` move arrives as `0 → 200`. Now
+    // that the crawler only ever requests URLs the site actually linked, this
+    // shape is a real redirect and must not be folded away with the slash.
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/o-mnie",
+        finalUrl: "https://example.com/o-mnie/",
+        redirectChain: chain("https://example.com/o-mnie", "https://example.com/o-mnie/", [
+          hop("https://example.com/o-mnie", 0),
+          hop("https://example.com/o-mnie/", 200),
+        ]),
+      },
+    ];
+
+    const redirectPages = check(pages, "redirect-pages");
+    expect(redirectPages?.status).toBe("warn");
+    expect(redirectPages?.items?.[0]?.label).toBe(
+      "https://example.com/o-mnie → https://example.com/o-mnie/ (200)",
+    );
+  });
+
   test("a genuine destination change with unobserved hop statuses still reports", () => {
     // Browser-rendered pages come back with the landing page only, so the source
     // hop carries status 0. The URL genuinely changed, so it is still a redirect.
@@ -204,6 +227,72 @@ describe("links/redirect-chains — genuine redirects still report", () => {
     expect(redirectPages?.items?.[0]?.label).toBe(
       "https://example.com/old-post/ → https://example.com/new-post/ (200)",
     );
+  });
+
+  test("only the pages linking the REDIRECTING form are blamed", () => {
+    // The fan-out complaint in the report: a slash-insensitive join blamed every
+    // page linking the canonical `/o-mnie/` for `/o-mnie`'s redirect. They are
+    // different hrefs and only one of them is the mistake.
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/o-mnie",
+        finalUrl: "https://example.com/o-mnie/",
+        redirectChain: chain("https://example.com/o-mnie", "https://example.com/o-mnie/", [
+          hop("https://example.com/o-mnie", 301),
+          hop("https://example.com/o-mnie/", 200),
+        ]),
+      },
+      {
+        url: "https://example.com/guilty/",
+        finalUrl: "https://example.com/guilty/",
+        links: ["https://example.com/o-mnie"],
+      },
+      ...Array.from({ length: 10 }, (_, i) => ({
+        url: `https://example.com/innocent-${i}/`,
+        finalUrl: `https://example.com/innocent-${i}/`,
+        links: ["https://example.com/o-mnie/"],
+      })),
+    ];
+
+    const linksToRedirect = check(pages, "links-to-redirect");
+    expect(linksToRedirect?.items?.[0]?.sourcePages).toEqual(["https://example.com/guilty/"]);
+  });
+
+  test.each([["javascript"], ["meta-refresh"]] as const)(
+    "a %s redirect is reported even though its source hop returned 200",
+    (type) => {
+      // A client-side redirect IS a document that loaded with 200 and then sent
+      // the visitor elsewhere, so 2xx on the non-final hop is the truth here and
+      // must not be mistaken for a fabricated chain.
+      const pages: PageInput[] = [
+        {
+          url: "https://example.com/old/",
+          finalUrl: "https://example.com/new/",
+          redirectChain: chain("https://example.com/old/", "https://example.com/new/", [
+            hop("https://example.com/old/", 200, type),
+            hop("https://example.com/new/", 200),
+          ]),
+        },
+      ];
+
+      expect(check(pages, "redirect-pages")?.status).toBe("warn");
+    },
+  );
+
+  test("a client-side redirect back to the SAME url is still reported", () => {
+    // Nothing changed about the target, so only the hop type is evidence.
+    const pages: PageInput[] = [
+      {
+        url: "https://example.com/loop/",
+        finalUrl: "https://example.com/loop/",
+        redirectChain: chain("https://example.com/loop/", "https://example.com/loop/", [
+          hop("https://example.com/loop/", 200, "meta-refresh"),
+          hop("https://example.com/loop/", 200),
+        ]),
+      },
+    ];
+
+    expect(check(pages, "redirect-pages")?.status).toBe("warn");
   });
 
   test("links pointing at a genuinely redirecting URL are still blamed", () => {


### PR DESCRIPTION
## The bug

`links/redirect-chains` reports a site's own pages as redirecting on any site whose internal links end in `/` — the default on WordPress, Hugo, Jekyll and most static hosts — and `links-to-redirect` then blames nearly every crawled page as a source. Many of the reported chains read `(200) → (200)`, which is not a redirect at all.

## Three defects, all of them "deciding a redirect by the shape of a record"

**1. The crawler asked for a URL nobody linked.** `packages/crawler/src/frontier.ts` stripped the trailing slash in `normalizeUrl`, and that normalized URL is the URL the crawler actually fetches. On a site that only ever links `/about/` we requested `/about`, the origin answered `301`, and we reported the redirect we had just caused ourselves.

The slash is kept now. `/about` and `/about/` are different request targets, so the frontier keeps whichever form the site linked — and keeps *both* when a site links both. They are deliberately not collapsed: which of the two redirects is exactly what the audit is trying to find out, so a first-seen dedupe would answer it by discovery order, reporting the redirect on a site that happens to link the redirecting form first and staying silent on the same site if the links appear the other way round. The cost is one extra page, and only on a site that already links both forms.

**2. A hop carried a status it never returned.** The render service reports the landing page, never the statuses of the redirects that led to it — so a synthetic source hop stamped with the *landing* status is where `200 → 200` came from, and a hop that returns 200 did not redirect. Two producers did this: the cloud mapper, and the browser-queue passthrough, which trusted a service-supplied chain verbatim and, with no chain at all, labelled the source hop with the landing status.

Both now share `withObservedHopStatuses()`, which records an unobserved hop as `0` — the convention already used for a response that never arrived, now documented on `RedirectHop`. The invariant is enforced at the producer rather than assumed, so no consumer can read a fabricated chain as a redirect.

**3. The rule accepted `chainLength > 0` as evidence.** It now takes either of two independent kinds of evidence — the request landed on a different resource, or a hop was watched returning a 3xx — and refuses to accuse on a chain that contradicts itself (a 2xx on a hop it also says redirected). Its URL comparison and its links-to-redirect join are both slash-sensitive now, so a genuine slash-only move is still reported and a page linking the canonical form is no longer blamed for the other form's redirect.

Client-side hops (`javascript`, `meta-refresh`) are exempt from the invariant throughout: such a redirect is by definition a document that returned 200 and then sent the visitor elsewhere, so a 2xx there is the truth.

## Verification

Unit and integration tests cover: a slash-canonical site produces zero phantom chains and is never asked for the no-slash form; a real 301 chain still reports; a chain can never be emitted with a 2xx on a hop it says redirected; a genuine slash-only `0 → 200` move IS reported; a no-slash-canonical site (canonicalized the other way) reports the slash form's genuine 301 in *both* link orders; only the pages linking the redirecting form are blamed; client-side redirects survive the invariant. Each test was confirmed to fail when its fix is reverted.

Real-site smoke, built CLI, before vs after:

| Site | before | after |
|---|---|---|
| gohugo.io | 16 items | 0 |
| jekyllrb.com | 26 | 0 |
| wordpress.org/news | 11 | 0 |
| blog.rust-lang.org | 6 | 0 |
| css-tricks.com | 26 | 0 |
| a reported WordPress blog | 28 | 0 |
| www.php.net | 0 | 0 |
| httpd.apache.org | genuine 301 | still reported |

`httpd.apache.org` is the positive control: its homepage really does contain `href="/modules"` without a slash, and that URL really does `301`. The rule still reports it.
