### PR TITLE
build(release): tag a reviewed main commit instead of an orphan bump

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "repository": "https://github.com/squirrelscan/squirrelscan",
   "license": "MIT",
   "keywords": ["seo", "audit", "website", "performance", "security", "accessibility", "crawler"],
-  "version": "0.0.82"
+  "version": "0.0.83"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "squirrelscan",
   "displayName": "squirrelscan",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "author": {
     "name": "squirrelscan"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
         run: bun run typecheck
       - name: Check third-party notices
         run: bun run notices:check
+      # Marketplace listings read plugin.json / .claude-plugin from the default
+      # branch, so drift here is publicly visible. Checked on every PR because
+      # nothing else notices until someone reads the repo.
+      - name: Check plugin manifests are in sync
+        run: bun run scripts/sync-plugin-manifests.ts --check
 
   cli-tests:
     name: CLI tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,19 +69,32 @@ jobs:
           # Resolve main from the remote rather than trusting whatever refs
           # actions/checkout happened to create.
           git fetch --no-tags origin main
-          if ! git merge-base --is-ancestor HEAD FETCH_HEAD; then
-            echo "::error::${GITHUB_SHA} is not on main. Dispatch the release from main so the tag lands on a reviewed commit."
+          tip=$(git rev-parse FETCH_HEAD)
+          # Equality, not ancestry: ancestry alone would also accept the bump
+          # commit itself once main has moved past it, and the release would
+          # then ship an older tree than main under a fresh tag. The tag job
+          # relaxes this to ancestry so a merge during the quality gate cannot
+          # abort a release that was already validated here.
+          if [ "$(git rev-parse HEAD)" != "$tip" ]; then
+            echo "::error::${GITHUB_SHA} is not the current tip of main (${tip}). Dispatch the release from main."
             exit 1
           fi
 
-          actual=$(jq -r .version apps/cli/package.json)
-          if [ "$actual" != "$VERSION" ]; then
-            echo "::error::main is at ${actual} but this run would release v${VERSION}. Land the bump on main first (\`make release\` opens that PR), then re-dispatch."
-            exit 1
-          fi
+          # Reuses the same SYNCED_MANIFESTS list the local `make release`
+          # preflight uses, so the two can never disagree about what "carries
+          # this version" means. Throws if a manifest is missing entirely.
+          # shellcheck disable=SC2016  # ${v} is a JS template literal, not shell
+          bun -e '
+            import { manifestsCarry } from "./scripts/release.ts";
+            const v = process.env.VERSION;
+            if (!(await manifestsCarry(v))) {
+              console.log(`::error::main does not carry v${v}. Land the bump on main first (\`make release\` opens that PR), then re-dispatch.`);
+              process.exit(1);
+            }
+          '
 
-          # The vendor manifests fan out from apps/cli/package.json; a partial
-          # bump would ship marketplace listings pointing at the wrong version.
+          # Catches drift the version fields alone miss (descriptions fanned out
+          # from plugin.json into the vendor copies).
           bun run scripts/sync-plugin-manifests.ts --check
 
   quality:
@@ -120,6 +133,9 @@ jobs:
 
       # Re-checked here, not just in `version`: this job checks out again, and
       # tagging the wrong commit is the one failure the later jobs cannot undo.
+      # Ancestry rather than tip-equality: `version` already proved this commit
+      # was the tip when the release started, and main may legitimately have
+      # advanced while the quality gate ran.
       - name: Re-verify the commit being tagged
         env:
           VERSION: ${{ needs.version.outputs.version }}
@@ -130,11 +146,15 @@ jobs:
             echo "::error::${GITHUB_SHA} is not on main; refusing to tag it."
             exit 1
           fi
-          actual=$(jq -r .version apps/cli/package.json)
-          if [ "$actual" != "$VERSION" ]; then
-            echo "::error::main is at ${actual}, expected ${VERSION}."
-            exit 1
-          fi
+          # shellcheck disable=SC2016  # ${v} is a JS template literal, not shell
+          bun -e '
+            import { manifestsCarry } from "./scripts/release.ts";
+            const v = process.env.VERSION;
+            if (!(await manifestsCarry(v))) {
+              console.log(`::error::the commit being tagged does not carry v${v}.`);
+              process.exit(1);
+            }
+          '
           bun run scripts/sync-plugin-manifests.ts --check
 
       - name: Tag the release commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,37 @@ jobs:
             console.log("prerelease=" + (process.env.INPUT_CHANNEL === "beta"));
           ' >> "$GITHUB_OUTPUT"
 
+      # This workflow cannot land the bump itself. `main` is covered by a
+      # ruleset with an empty bypass list, so the job can neither push to it nor
+      # open the PR for it. Releasing therefore reads the version off main
+      # rather than stamping it, and refuses to tag a commit that disagrees --
+      # otherwise the tag would carry a bump reachable from nowhere else and
+      # main would silently stay a release behind (which is how it reached
+      # 0.0.82 while v0.0.83 was the published release).
+      - name: Verify main already carries this version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Resolve main from the remote rather than trusting whatever refs
+          # actions/checkout happened to create.
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor HEAD FETCH_HEAD; then
+            echo "::error::${GITHUB_SHA} is not on main. Dispatch the release from main so the tag lands on a reviewed commit."
+            exit 1
+          fi
+
+          actual=$(jq -r .version apps/cli/package.json)
+          if [ "$actual" != "$VERSION" ]; then
+            echo "::error::main is at ${actual} but this run would release v${VERSION}. Land the bump on main first (\`make release\` opens that PR), then re-dispatch."
+            exit 1
+          fi
+
+          # The vendor manifests fan out from apps/cli/package.json; a partial
+          # bump would ship marketplace listings pointing at the wrong version.
+          bun run scripts/sync-plugin-manifests.ts --check
+
   quality:
     name: Release quality gate
     needs: version
@@ -62,18 +93,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-bun
-      - name: Update manifests
-        env:
-          VERSION: ${{ needs.version.outputs.version }}
-        run: |
-          bun -e '
-            const path = "apps/cli/package.json";
-            const pkg = await Bun.file(path).json();
-            pkg.version = process.env.VERSION;
-            await Bun.write(path, JSON.stringify(pkg, null, 2) + "\n");
-          '
-          bun run scripts/sync-plugin-manifests.ts --version "$VERSION"
-          bun install
+      # No manifest stamping: the `version` job has already established that the
+      # checked-out tree carries $VERSION, so the gate runs against exactly the
+      # bytes that will be tagged.
       - run: bun run format:check
       - run: bun run lint
       - run: bun run typecheck
@@ -92,30 +114,46 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup-bun
-      - name: Update manifests
+
+      # Re-checked here, not just in `version`: this job checks out again, and
+      # tagging the wrong commit is the one failure the later jobs cannot undo.
+      - name: Re-verify the commit being tagged
         env:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
-          bun -e '
-            const path = "apps/cli/package.json";
-            const pkg = await Bun.file(path).json();
-            pkg.version = process.env.VERSION;
-            await Bun.write(path, JSON.stringify(pkg, null, 2) + "\n");
-          '
-          bun run scripts/sync-plugin-manifests.ts --version "$VERSION"
-          bun install
-      - name: Commit and tag
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor HEAD FETCH_HEAD; then
+            echo "::error::${GITHUB_SHA} is not on main; refusing to tag it."
+            exit 1
+          fi
+          actual=$(jq -r .version apps/cli/package.json)
+          if [ "$actual" != "$VERSION" ]; then
+            echo "::error::main is at ${actual}, expected ${VERSION}."
+            exit 1
+          fi
+          bun run scripts/sync-plugin-manifests.ts --check
+
+      - name: Tag the release commit
         env:
-          VERSION: ${{ needs.version.outputs.version }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add apps/cli/package.json npm/package.json plugin.json .cursor-plugin/plugin.json .claude-plugin/plugin.json bun.lock
-          git commit --signoff -m "chore(release): v${VERSION}"
+          set -euo pipefail
+
+          # A tag that already exists means this version was released before.
+          # The tag ruleset blocks deletion and non-fast-forward, so the push
+          # would fail anyway -- fail here with a message that says why.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::${TAG} already exists on origin. Nothing was pushed."
+            exit 1
+          fi
+
           git tag "$TAG"
-          git push origin "$TAG"
+          # Explicit refspec so a same-named branch can never be pushed instead.
+          git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
 
   build:
     name: Build release binaries

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squirrelscan/cli",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "description": "Free CLI for SEO, performance & security audits. Built for Claude Code, Cursor, and AI workflows.",
   "bin": {
     "squirrelscan": "./build/squirrelscan"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squirrelscan",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "description": "Website QA tool built for coding agents. 260+ rules across SEO, performance, security, accessibility & agent experience, from the CLI, cloud, or MCP.",
   "bin": {
     "squirrel": "bin/squirrel.js"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "squirrelscan",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
   "author": {
     "name": "squirrelscan",

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -90,9 +90,17 @@ describe("manifestsCarry", () => {
     await rm(root, { recursive: true, force: true });
   });
 
-  test("absent vendor manifests are skipped, not treated as drift", async () => {
+  // Skipping an absent manifest would let the release gate pass on a tree that
+  // cannot carry a version at all.
+  test("throws when a release manifest is missing rather than passing", async () => {
     const root = await fixture({ "apps/cli/package.json": "0.0.83" });
-    expect(await manifestsCarry("0.0.83", root)).toBe(true);
+    await expect(manifestsCarry("0.0.83", root)).rejects.toThrow("npm/package.json");
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("a missing manifest is reported even when another already disagrees", async () => {
+    const root = await fixture({ "apps/cli/package.json": "0.0.82" });
+    await expect(manifestsCarry("0.0.83", root)).rejects.toThrow(/missing/);
     await rm(root, { recursive: true, force: true });
   });
 

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -3,8 +3,16 @@
 // Expectations mirror the workflow's promote(sed)/beta-bump/semver-inc logic.
 
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { computeNextVersion, latestTaggedVersion } from "./release";
+import {
+  computeNextVersion,
+  latestTaggedVersion,
+  manifestsCarry,
+  SYNCED_MANIFESTS,
+} from "./release";
 
 const cases: Array<{
   current: string;
@@ -47,5 +55,48 @@ describe("latestTaggedVersion", () => {
 
   test("falls back when no release tags exist", () => {
     expect(latestTaggedVersion([], "0.0.1")).toBe("0.0.1");
+  });
+});
+
+// This gate is what stops a release tagging a commit whose manifests still say
+// the previous version — the drift that left main on 0.0.82 while v0.0.83 was
+// the published release.
+describe("manifestsCarry", () => {
+  async function fixture(versions: Record<string, string>): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "release-manifests-"));
+    for (const [rel, version] of Object.entries(versions)) {
+      await Bun.write(join(root, rel), JSON.stringify({ version }) + "\n");
+    }
+    return root;
+  }
+
+  const all = (version: string) => Object.fromEntries(SYNCED_MANIFESTS.map((m) => [m, version]));
+
+  test("true when every manifest is on the version", async () => {
+    const root = await fixture(all("0.0.83"));
+    expect(await manifestsCarry("0.0.83", root)).toBe(true);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("false when the release version is not yet stamped", async () => {
+    const root = await fixture(all("0.0.82"));
+    expect(await manifestsCarry("0.0.83", root)).toBe(false);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("false when only some manifests were bumped", async () => {
+    const root = await fixture({ ...all("0.0.83"), "npm/package.json": "0.0.82" });
+    expect(await manifestsCarry("0.0.83", root)).toBe(false);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("absent vendor manifests are skipped, not treated as drift", async () => {
+    const root = await fixture({ "apps/cli/package.json": "0.0.83" });
+    expect(await manifestsCarry("0.0.83", root)).toBe(true);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("server.json is not one of the synced manifests", () => {
+    expect(SYNCED_MANIFESTS).not.toContain("server.json");
   });
 });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -150,16 +150,18 @@ export const SYNCED_MANIFESTS = [
   ".claude-plugin/plugin.json",
 ];
 
-// A manifest absent from the checkout is skipped, not treated as drift: the
-// vendor copies are optional. A manifest that exists and disagrees is drift,
-// so a half-applied bump can never read as "already landed".
+// Throws when one of these is missing rather than skipping it. They are all
+// tracked files, so absence means a broken checkout -- and "skip what isn't
+// there" would let the release gate pass on a tree that cannot carry a version
+// at all. Returns false only for the real case: present, but disagreeing.
 export async function manifestsCarry(version: string, root = "."): Promise<boolean> {
+  let carried = true;
   for (const rel of SYNCED_MANIFESTS) {
     const file = Bun.file(`${root}/${rel}`);
-    if (!(await file.exists())) continue;
-    if ((JSON.parse(await file.text()) as PackageJson).version !== version) return false;
+    if (!(await file.exists())) throw new Error(`Release manifest is missing: ${rel}`);
+    if ((JSON.parse(await file.text()) as PackageJson).version !== version) carried = false;
   }
-  return true;
+  return carried;
 }
 
 // The release workflow used to stamp the version itself, commit it on a

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -139,6 +139,96 @@ async function checkChangelogSection(version: string): Promise<void> {
   }
 }
 
+// Every manifest that carries the release version. server.json is deliberately
+// absent: it tracks its own 1.0.x cadence because the MCP registry rejects a
+// backwards version jump.
+export const SYNCED_MANIFESTS = [
+  PACKAGE_JSON,
+  "npm/package.json",
+  "plugin.json",
+  ".cursor-plugin/plugin.json",
+  ".claude-plugin/plugin.json",
+];
+
+// A manifest absent from the checkout is skipped, not treated as drift: the
+// vendor copies are optional. A manifest that exists and disagrees is drift,
+// so a half-applied bump can never read as "already landed".
+export async function manifestsCarry(version: string, root = "."): Promise<boolean> {
+  for (const rel of SYNCED_MANIFESTS) {
+    const file = Bun.file(`${root}/${rel}`);
+    if (!(await file.exists())) continue;
+    if ((JSON.parse(await file.text()) as PackageJson).version !== version) return false;
+  }
+  return true;
+}
+
+// The release workflow used to stamp the version itself, commit it on a
+// detached checkout and push only the tag — so the bump was reachable from the
+// tag and nowhere else, and main sat a full release behind forever (0.0.82
+// while v0.0.83 was live). It cannot simply push the branch instead: main is
+// covered by a ruleset with an empty bypass list, so CI can neither push to it
+// nor open the PR (Actions PR creation is off for this repo). The bump has to
+// land the way every other change does, before the tag is cut.
+async function ensureVersionLanded(version: string): Promise<void> {
+  if (await manifestsCarry(version)) {
+    info(`main already carries v${version}.`);
+    return;
+  }
+
+  console.log();
+  warn(`main does not carry v${version} yet — that bump has to merge before the tag is cut.`);
+
+  // A bump PR built on a stale main just gets rejected by the "branch must be
+  // up to date" rule, so require the real tip up front.
+  await $`git fetch --no-tags origin main`.quiet();
+  const head = (await $`git rev-parse HEAD`.text()).trim();
+  const tip = (await $`git rev-parse FETCH_HEAD`.text()).trim();
+  if (head !== tip) {
+    error("HEAD is not at origin/main. Pull main, then re-run.");
+  }
+
+  const branch = `release/v${version}`;
+  // A leftover branch from an abandoned attempt would make `git switch -c` fail
+  // with a message that says nothing about releasing.
+  if (
+    await $`git rev-parse --verify --quiet ${branch}`
+      .quiet()
+      .nothrow()
+      .then((r) => r.exitCode === 0)
+  ) {
+    error(`Branch ${branch} already exists locally. Delete it or finish that PR, then re-run.`);
+  }
+
+  log("Opening the version bump PR:");
+  info(`Branch: ${branch}`);
+  info(`Files:  ${SYNCED_MANIFESTS.join(", ")}`);
+  const answer = await prompt("Create and push it? [y/N] ");
+  if (answer.toLowerCase() !== "y") {
+    error("Aborted — nothing was pushed.");
+  }
+
+  await $`git switch -c ${branch}`;
+  const pkg = await readPackageJson();
+  // Spread keeps `version` in its original position, so the diff stays 1 line.
+  await Bun.write(PACKAGE_JSON, JSON.stringify({ ...pkg, version }, null, 2) + "\n");
+  await $`bun run scripts/sync-plugin-manifests.ts --version ${version}`;
+
+  const title = `chore(release): v${version}`;
+  await $`git add ${SYNCED_MANIFESTS}`;
+  await $`git commit -s -m ${title}`;
+  await $`git push --set-upstream origin ${branch}`;
+  await $`gh pr create --base main --head ${branch} --title ${title} --body ${
+    `Stamps the release version into the synced manifests so main matches the tag.\n\n` +
+    `server.json is excluded: it tracks its own 1.0.x cadence.\n\n` +
+    `Merge this, then re-run \`make release\` to cut v${version}.`
+  }`;
+
+  console.log();
+  log(`Bump PR opened for v${version}.`);
+  info(`Merge it, then: git switch main && git pull && make release`);
+  process.exit(0);
+}
+
 async function promptChannel(): Promise<Channel> {
   console.log("\nChannel:");
   console.log("  1) beta    - Pre-release for early adopters");
@@ -207,6 +297,9 @@ async function main(): Promise<void> {
   const nextVersion = computeNextVersion(currentVersion, channel, bump);
   info(`Next version: v${nextVersion}`);
   await checkChangelogSection(nextVersion);
+  // Exits after opening the bump PR when main is behind; the release is
+  // dispatched on the re-run, once that PR has merged.
+  await ensureVersionLanded(nextVersion);
   console.log();
 
   const confirm = await prompt("Run release workflow? [y/N] ");

--- a/scripts/sync-plugin-manifests.ts
+++ b/scripts/sync-plugin-manifests.ts
@@ -6,6 +6,10 @@
  * Description ← plugin.json (the portable Open Plugin manifest is
  *            the canonical plugin metadata; vendor copies fan out from it).
  *
+ * server.json is deliberately NOT synced. It tracks its own 1.0.x cadence
+ * because the MCP registry can reject a backwards version jump, so stamping the
+ * CLI version into it would break publishing. Do not add it to `edits` below.
+ *
  *   bun run scripts/sync-plugin-manifests.ts            # stamp + write
  *   bun run scripts/sync-plugin-manifests.ts --check    # no writes, exit 1 on drift
  *   bun run scripts/sync-plugin-manifests.ts --version 0.0.79


### PR DESCRIPTION
## What was wrong

The release workflow stamped the version into its own checkout, committed it, then ran `git push origin "$TAG"` — only the tag. That bump commit was reachable from the tag and from nowhere else, so `main` never advanced. Every release left the synced manifests a version behind.

It is publicly visible: Cursor Directory and the Claude Code plugin marketplace read `plugin.json` and `.claude-plugin/plugin.json` from the **default branch**, so the listings advertised a stale version. `main` was on `0.0.82` while `v0.0.83` was the published release.

The orphan is verifiable on the current repo:

```
git merge-base --is-ancestor v0.0.83 origin/main   # false
```

## Why the obvious fix does not work

Adding the branch to that push (`git push origin HEAD:main "$TAG"`) is rejected. `main` is covered by a repository ruleset with a `pull_request` rule, strict required status checks, required linear history, and **an empty bypass list**, so nothing (including the workflow token) can push to it directly.

Having the workflow open a PR instead does not work either: Actions is not permitted to create pull requests on this repo, and a token-authored PR would not trigger the `pull_request` workflows, so the required checks would never report and the PR could never merge.

## What this does instead

Inverts the order. The bump lands the same way every other change does — a reviewed PR — **before** the tag is cut, and the release workflow verifies rather than stamps.

- **`scripts/release.ts`** — when `main` does not already carry the computed version, `make release` opens the bump PR and stops. The release is dispatched on the re-run, after that PR merges.
- **`release.yml` `version` job** — asserts the dispatched commit is the current tip of `main` and already carries the version, before the quality gate runs, so a mistake costs about a minute instead of the full gate.
- **`release.yml` `tag` job** — no longer stamps or commits. It re-verifies (it is a separate checkout), refuses a tag that already exists on the remote, and pushes with an explicit refspec. It uses ancestry rather than tip equality so that an unrelated merge during the quality gate cannot abort an already-validated release.
- **`ci.yml`** — runs the manifest sync check on every PR, so this drift cannot return unnoticed.

CI no longer writes to `main` at all; it only creates a tag. That removes the whole class of "main moved since checkout" and force-push risk by construction.

A side benefit: the tag now points at a commit that is genuinely on `main`, so the `build`, `npm`, and `github-release` jobs, which all check out the tag, build exactly what was reviewed. Previously they built an orphan commit.

## Catch-up commit

The first commit brings the five synced manifests from `0.0.82` to `0.0.83` to match the shipped tag. Each file is byte-identical to the same path at `v0.0.83`.

`server.json` is untouched. It tracks its own 1.0.x cadence because the MCP registry can reject a backwards version jump, and that exclusion is now documented in `sync-plugin-manifests.ts` and asserted by a test.

## Note for the next beta

Because `main` must now carry the exact released version, cutting a beta will put a `-beta.N` version into the marketplace manifests on `main`. Previously `main` showed a stale stable version. Flagging it as a deliberate consequence rather than a surprise.

## Verification

- `actionlint` (with shellcheck) clean on both workflows.
- `format:check`, `lint`, `test:release` green; 19 tests including new coverage for the version gate.
- Each arm of the new verification shell was dry-run against real refs: tip equality rejects a non-tip commit, the version arm correctly refuses today's `main`, the tag-exists guard correctly reports `v0.0.83` taken.
- `scripts/` sits outside every workspace glob so CI does not typecheck it; checked manually against a tsconfig extending `apps/cli`, the changed file carries the same pre-existing errors as `main` and no new ones.

What cannot be proven until a release is actually cut: that the end-to-end sequence produces a tag on `main` with matching manifests. Everything up to the dispatch is verified.
