### PR TITLE
fix(cli): explain why auth whoami cannot verify an org API key

### DIFF
--- a/apps/cli/src/controllers/auth/status.ts
+++ b/apps/cli/src/controllers/auth/status.ts
@@ -4,7 +4,10 @@
 // authoritative / fail-closed: an invalid env token errors here rather than
 // silently reporting a cached login session.
 
-import type { ApiKeyScope } from "@squirrelscan/core-contracts/api-keys";
+import {
+  type ApiKeyScope,
+  isApiKey,
+} from "@squirrelscan/core-contracts/api-keys";
 
 import { STATUS_REQUEST_TIMEOUT_MS } from "@/constants";
 import { type Result, ok, err, commandError } from "@/controllers/types";
@@ -12,6 +15,7 @@ import { cliApi } from "@/lib/api-client";
 import {
   API_TOKEN_ENV_VAR,
   activeEnvTokenVar,
+  apiKeyNotVerifiableMessage,
   type CredentialSource,
   describeEnvToken,
   envTokenRejectedMessage,
@@ -105,6 +109,21 @@ export async function runAuthStatus(): Promise<Result<StatusResult>> {
 
     if (!res.ok) {
       if (res.status === 401) {
+        // An org API key is ALWAYS 401 here: /v1/auth/whoami is the CLI-session
+        // endpoint and only accepts a `sqcli_…` login token. Saying "invalid,
+        // revoked, expired, or wrong environment" about a key that works for
+        // every other cloud call sends the user hunting for a problem that
+        // isn't there, so name the real reason first.
+        if (isApiKey(credential.token)) {
+          return err(
+            commandError(
+              "API_KEY_NOT_VERIFIABLE",
+              apiKeyNotVerifiableMessage(
+                credential.source === "env" ? activeEnvTokenVar() : null
+              )
+            )
+          );
+        }
         // FAIL-CLOSED: an env token rejected by the server is a hard error; we
         // never fall back to (or silently report) the local login session.
         if (credential.source === "env") {

--- a/apps/cli/src/self/credentials.ts
+++ b/apps/cli/src/self/credentials.ts
@@ -176,18 +176,26 @@ export function envTokenRejectedMessage(): string {
  * way to guess, and still points at the dashboard for the other one.
  *
  * `envVarName` names the env var that supplied the key, when one did; omit it
- * for a key that came from the session file.
+ * for a key that came from the session file. It changes the ADVICE, not just the
+ * wording: an env token is authoritative and keeps shadowing the session (see
+ * the precedence doc at the top of this file), so telling an env-key user to
+ * just log in would hand them the identical error again afterwards — they have
+ * to unset the variable for the session to be consulted at all.
  */
 export function apiKeyNotVerifiableMessage(envVarName?: string | null): string {
   const source = envVarName
     ? `the org API key in ${envVarName}`
     : "an org API key";
+  const howToSeeAccount = envVarName
+    ? `  To see your account, run "squirrel auth login", then unset ${envVarName} —\n` +
+      `  while it is set it takes precedence over the session for every cloud call.\n`
+    : `  To see your account, run: squirrel auth login\n`;
   return (
     `This command cannot verify ${source}.\n` +
     `  ${getApiUrl()} answers identity lookups only for the login token that\n` +
     `  "squirrel auth login" issues, so it refuses an org API key (sq_…) here even\n` +
     `  when that same key works for audits, publishing and credits.\n` +
-    `  To see your account, run: squirrel auth login\n` +
+    howToSeeAccount +
     `  If cloud calls are failing too, the key may be revoked, expired, or from\n` +
     `  another environment: ${API_KEYS_DASHBOARD_URL}`
   );

--- a/apps/cli/src/self/credentials.ts
+++ b/apps/cli/src/self/credentials.ts
@@ -161,6 +161,39 @@ export function envTokenRejectedMessage(): string {
 }
 
 /**
+ * Why `squirrel auth status` / `squirrel auth whoami` cannot report an identity
+ * for an org API key.
+ *
+ * The identity endpoint the command calls (`/v1/auth/whoami`) is the CLI-session
+ * endpoint: it accepts only the `sqcli_…` token that `squirrel auth login`
+ * issues, and refuses an `sq_…` org key at the prefix. So a key that works
+ * everywhere else — audits, publishing, credits, MCP — still 401s HERE, and the
+ * generic rejected-token wording blamed the user's key for being revoked,
+ * expired or from the wrong environment when usually none of that is true.
+ *
+ * We cannot tell that case apart from a genuinely dead key (both are a bare
+ * 401), so this leads with the structural reason, which is the one a user has no
+ * way to guess, and still points at the dashboard for the other one.
+ *
+ * `envVarName` names the env var that supplied the key, when one did; omit it
+ * for a key that came from the session file.
+ */
+export function apiKeyNotVerifiableMessage(envVarName?: string | null): string {
+  const source = envVarName
+    ? `the org API key in ${envVarName}`
+    : "an org API key";
+  return (
+    `This command cannot verify ${source}.\n` +
+    `  ${getApiUrl()} answers identity lookups only for the login token that\n` +
+    `  "squirrel auth login" issues, so it refuses an org API key (sq_…) here even\n` +
+    `  when that same key works for audits, publishing and credits.\n` +
+    `  To see your account, run: squirrel auth login\n` +
+    `  If cloud calls are failing too, the key may be revoked, expired, or from\n` +
+    `  another environment: ${API_KEYS_DASHBOARD_URL}`
+  );
+}
+
+/**
  * Loud warning for a USER session file that exists but couldn't be loaded
  * (EACCES, corrupt JSON, fails schema, ...) — as opposed to genuinely logged
  * out (no file), which stays silent. This is the single implementation of

--- a/apps/cli/tests/controllers/auth-status-org-api-key.test.ts
+++ b/apps/cli/tests/controllers/auth-status-org-api-key.test.ts
@@ -5,19 +5,26 @@
 // "invalid, revoked, expired, or wrong environment" — none of which is true.
 // These tests pin the message that explains what actually happened.
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import { runAuthStatus } from "@/controllers/auth/status";
+import { ok } from "@/controllers/types";
+import * as settingsModule from "@/self/settings";
 
 const API_KEY_ENV = "SQUIRRELSCAN_API_KEY"; // pragma: allowlist secret
 const API_SERVER_ENV = "SQUIRREL_API_SERVER";
 
 // Module-level env snapshot is safe: `bun test` runs the tests in a file
-// sequentially in one process, so each beforeEach/afterEach pair completes
-// before the next test starts. Restore is unconditional so a failing assertion
-// still leaves SQUIRREL_API_SERVER as the rest of the suite expects it.
+// strictly sequentially in one process (no test.concurrent here), so each
+// beforeEach/afterEach pair completes before the next test starts. Restore is
+// unconditional so a failing assertion still leaves SQUIRREL_API_SERVER as the
+// rest of the suite expects it.
 let server: ReturnType<typeof Bun.serve> | null = null;
 const saved: Record<string, string | undefined> = {};
+// Torn down in afterEach rather than a per-test finally: a throw during test
+// SETUP would skip an in-test restore and leak a mocked settings loader into
+// every later file in the run.
+let settingsSpy: { mockRestore: () => void } | null = null;
 
 /** Serve a fixed status on /v1/auth/whoami and point the CLI at it. */
 function serveWhoami(status: number, body?: unknown) {
@@ -39,6 +46,8 @@ beforeEach(() => {
 afterEach(() => {
   server?.stop(true);
   server = null;
+  settingsSpy?.mockRestore();
+  settingsSpy = null;
   for (const [key, value] of Object.entries(saved)) {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
@@ -65,6 +74,9 @@ describe("auth status with an org API key the identity endpoint refuses", () => 
     expect(message).not.toContain("was rejected by");
     // The secret never appears in output.
     expect(message).not.toContain("notarealkey");
+    // Logging in alone would hand back this same error: the env var keeps
+    // shadowing the new session until it is unset.
+    expect(message).toContain(`unset ${API_KEY_ENV}`);
   });
 
   test("a dev-environment key gets the same explanation", async () => {
@@ -101,6 +113,43 @@ describe("auth status with an org API key the identity endpoint refuses", () => 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe("API_ERROR");
+  });
+
+  test("an org API key from the SESSION FILE gets the explanation without the unset advice", async () => {
+    // The branch keys on the token prefix, not on where the credential came
+    // from, so a key hand-written into settings.json is covered too. There is no
+    // env var to unset in that case, so that advice must not appear.
+    //
+    // spyOn, not mock.module: mock.module would replace @/self/settings
+    // process-wide for the rest of the `bun test` run and leak into the tests
+    // that exercise the real loader.
+    settingsSpy = spyOn(settingsModule, "loadUserSettings").mockImplementation(
+      () =>
+        ok({
+          ...settingsModule.DEFAULT_SETTINGS,
+          auth: {
+            token: "sq_notarealkeynotarealkeynotareal", // pragma: allowlist secret
+            userId: "u_1",
+            email: "dev@example.com",
+            name: null,
+            expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+          },
+        })
+    );
+    serveWhoami(401);
+
+    const result = await runAuthStatus();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("API_KEY_NOT_VERIFIABLE");
+    expect(result.error.message).toContain("an org API key");
+    expect(result.error.message).toContain("squirrel auth login");
+    // Provenance, asserted rather than assumed: an env-sourced key would name
+    // its variable and tell the user to unset it. Neither may appear here, which
+    // is what proves this exercised the settings.json path.
+    expect(result.error.message).not.toContain("unset");
+    expect(result.error.message).not.toContain(API_KEY_ENV);
   });
 
   test("an org API key the endpoint DOES accept reports normally", async () => {

--- a/apps/cli/tests/controllers/auth-status-org-api-key.test.ts
+++ b/apps/cli/tests/controllers/auth-status-org-api-key.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { runAuthStatus } from "@/controllers/auth/status";
 
-const API_KEY_ENV = "SQUIRRELSCAN_API_KEY";
+const API_KEY_ENV = "SQUIRRELSCAN_API_KEY"; // pragma: allowlist secret
 const API_SERVER_ENV = "SQUIRREL_API_SERVER";
 
 // Module-level env snapshot is safe: `bun test` runs the tests in a file
@@ -47,7 +47,7 @@ afterEach(() => {
 
 describe("auth status with an org API key the identity endpoint refuses", () => {
   test("explains that the endpoint wants a login token, and does not call the key invalid", async () => {
-    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal";
+    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal"; // pragma: allowlist secret
     serveWhoami(401);
 
     const result = await runAuthStatus();
@@ -68,7 +68,7 @@ describe("auth status with an org API key the identity endpoint refuses", () => 
   });
 
   test("a dev-environment key gets the same explanation", async () => {
-    process.env[API_KEY_ENV] = "sq_dev_notarealkeynotarealkeynot";
+    process.env[API_KEY_ENV] = "sq_dev_notarealkeynotarealkeynot"; // pragma: allowlist secret
     serveWhoami(401);
 
     const result = await runAuthStatus();
@@ -81,7 +81,7 @@ describe("auth status with an org API key the identity endpoint refuses", () => 
   test("a login token that is genuinely rejected still reports as rejected", async () => {
     // Regression guard: the new branch keys on the sq_ prefix, so the existing
     // fail-closed wording for a real dead credential must be untouched.
-    process.env[API_KEY_ENV] = "sqcli_notarealtokennotarealtoken";
+    process.env[API_KEY_ENV] = "sqcli_notarealtokennotarealtoken"; // pragma: allowlist secret
     serveWhoami(401);
 
     const result = await runAuthStatus();
@@ -93,7 +93,7 @@ describe("auth status with an org API key the identity endpoint refuses", () => 
   });
 
   test("a non-401 failure is still a plain API error", async () => {
-    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal";
+    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal"; // pragma: allowlist secret
     serveWhoami(500);
 
     const result = await runAuthStatus();
@@ -106,7 +106,7 @@ describe("auth status with an org API key the identity endpoint refuses", () => 
   test("an org API key the endpoint DOES accept reports normally", async () => {
     // Forward compatibility: if the identity endpoint ever accepts org keys,
     // nothing here suppresses the successful answer.
-    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal";
+    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal"; // pragma: allowlist secret
     serveWhoami(200, {
       user: { id: "u_1", email: "dev@example.com", name: "Dev" },
       authSource: "api-key",

--- a/apps/cli/tests/controllers/auth-status-org-api-key.test.ts
+++ b/apps/cli/tests/controllers/auth-status-org-api-key.test.ts
@@ -1,0 +1,125 @@
+// `/v1/auth/whoami` is the CLI-SESSION identity endpoint: it accepts only the
+// `sqcli_…` token `squirrel auth login` issues and refuses an `sq_…` org API key
+// at the prefix. So a key that authenticates fine for audits, publishing and MCP
+// still 401s here, and the generic wording told the user their key was
+// "invalid, revoked, expired, or wrong environment" — none of which is true.
+// These tests pin the message that explains what actually happened.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { runAuthStatus } from "@/controllers/auth/status";
+
+const API_KEY_ENV = "SQUIRRELSCAN_API_KEY";
+const API_SERVER_ENV = "SQUIRREL_API_SERVER";
+
+// Module-level env snapshot is safe: `bun test` runs the tests in a file
+// sequentially in one process, so each beforeEach/afterEach pair completes
+// before the next test starts. Restore is unconditional so a failing assertion
+// still leaves SQUIRREL_API_SERVER as the rest of the suite expects it.
+let server: ReturnType<typeof Bun.serve> | null = null;
+const saved: Record<string, string | undefined> = {};
+
+/** Serve a fixed status on /v1/auth/whoami and point the CLI at it. */
+function serveWhoami(status: number, body?: unknown) {
+  const payload = body ?? { error: "nope" };
+  server = Bun.serve({
+    port: 0,
+    fetch: () => Response.json(payload, { status }),
+  });
+  process.env[API_SERVER_ENV] = `http://127.0.0.1:${server.port}`;
+}
+
+beforeEach(() => {
+  for (const key of [API_KEY_ENV, API_SERVER_ENV, "SQUIRREL_API_TOKEN"]) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  server?.stop(true);
+  server = null;
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("auth status with an org API key the identity endpoint refuses", () => {
+  test("explains that the endpoint wants a login token, and does not call the key invalid", async () => {
+    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal";
+    serveWhoami(401);
+
+    const result = await runAuthStatus();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("API_KEY_NOT_VERIFIABLE");
+
+    const message = result.error.message;
+    // Names the credential and the command that produces a usable one.
+    expect(message).toContain(API_KEY_ENV);
+    expect(message).toContain("squirrel auth login");
+    // Says what is actually going on, rather than accusing the key.
+    expect(message).toContain("cannot verify");
+    expect(message).not.toContain("was rejected by");
+    // The secret never appears in output.
+    expect(message).not.toContain("notarealkey");
+  });
+
+  test("a dev-environment key gets the same explanation", async () => {
+    process.env[API_KEY_ENV] = "sq_dev_notarealkeynotarealkeynot";
+    serveWhoami(401);
+
+    const result = await runAuthStatus();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("API_KEY_NOT_VERIFIABLE");
+  });
+
+  test("a login token that is genuinely rejected still reports as rejected", async () => {
+    // Regression guard: the new branch keys on the sq_ prefix, so the existing
+    // fail-closed wording for a real dead credential must be untouched.
+    process.env[API_KEY_ENV] = "sqcli_notarealtokennotarealtoken";
+    serveWhoami(401);
+
+    const result = await runAuthStatus();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("TOKEN_INVALID");
+    expect(result.error.message).toContain("was rejected by");
+  });
+
+  test("a non-401 failure is still a plain API error", async () => {
+    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal";
+    serveWhoami(500);
+
+    const result = await runAuthStatus();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("API_ERROR");
+  });
+
+  test("an org API key the endpoint DOES accept reports normally", async () => {
+    // Forward compatibility: if the identity endpoint ever accepts org keys,
+    // nothing here suppresses the successful answer.
+    process.env[API_KEY_ENV] = "sq_notarealkeynotarealkeynotareal";
+    serveWhoami(200, {
+      user: { id: "u_1", email: "dev@example.com", name: "Dev" },
+      authSource: "api-key",
+      apiKey: { name: "ci", scopes: ["audits:write"], keyEnv: "production" },
+      org: { id: "org_1", name: "Example" },
+    });
+
+    const result = await runAuthStatus();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.source).toBe("env");
+    expect(result.data.apiKey?.scopes).toEqual(["audits:write"]);
+    expect(result.data.org?.id).toBe("org_1");
+  });
+});


### PR DESCRIPTION
## The bug

An `sq_` org API key authenticates fine for audits, publishing, credits and MCP, but `squirrel auth status` / `squirrel auth whoami` always rejects it. The message said the credential was "invalid, revoked, expired, or wrong environment" — so a user whose key was perfectly good went hunting for a problem that was not there, and had no way to reconcile "works there, fails here".

## Why it happens

The identity endpoint those two commands call is the CLI **session** endpoint. It accepts only the `sqcli_` token that `squirrel auth login` issues and refuses an org API key at the prefix, so the 401 is structural: it says nothing at all about whether the key is valid. Every other cloud call the CLI makes accepts the key.

## The fix

Message only. The 401 path now recognises an org API key and explains what actually happened:

```
Error: This command cannot verify the org API key in SQUIRRELSCAN_API_KEY.
  https://api.squirrelscan.com answers identity lookups only for the login token that
  "squirrel auth login" issues, so it refuses an org API key (sq_…) here even
  when that same key works for audits, publishing and credits.
  To see your account, run: squirrel auth login
  If cloud calls are failing too, the key may be revoked, expired, or from
  another environment: https://app.squirrelscan.com/settings/api-keys
```

Deliberately not done: making the CLI *accept* org keys for `auth whoami`. The CLI already sends `sq_` keys as the bearer on every route — nothing on this side is blocking. What would have to change is which credentials the identity endpoint honours, which is not a change in this repo.

The last two lines stay because a revoked key produces the same bare 401 and cannot be told apart from here, so the message leads with the reason a user has no way to guess and still names the other one. It remains a hard error, it still never falls back to a cached session, and a genuinely rejected login token keeps the existing wording.

## Tests

`apps/cli/tests/controllers/auth-status-org-api-key.test.ts`: an org key gets the new explanation (production and dev keys alike), the key value never appears in the message, a rejected login token still reports as rejected, a non-401 stays a plain API error, and an org key the endpoint *does* accept reports normally, so this cannot mask the endpoint gaining org-key support later.

### Review follow-up

The message originally pointed the user at `squirrel auth login` and stopped there. An env token is authoritative and keeps shadowing the session, so following that advice would have handed back the identical error. For an env-sourced key it now says to log in **and** unset the named variable, and says why. A key that came from `settings.json` keeps the plain advice, since there is nothing to unset:

```
Error: This command cannot verify the org API key in SQUIRRELSCAN_API_KEY.
  https://api.squirrelscan.com answers identity lookups only for the login token that
  "squirrel auth login" issues, so it refuses an org API key (sq_…) here even
  when that same key works for audits, publishing and credits.
  To see your account, run "squirrel auth login", then unset SQUIRRELSCAN_API_KEY —
  while it is set it takes precedence over the session for every cloud call.
  If cloud calls are failing too, the key may be revoked, expired, or from
  another environment: https://app.squirrelscan.com/settings/api-keys
```
