### PR TITLE
chore(release): v0.0.84

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "repository": "https://github.com/squirrelscan/squirrelscan",
   "license": "MIT",
   "keywords": ["seo", "audit", "website", "performance", "security", "accessibility", "crawler"],
-  "version": "0.0.83"
+  "version": "0.0.84"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "squirrelscan",
   "displayName": "squirrelscan",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "author": {
     "name": "squirrelscan"
   },

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squirrelscan/cli",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "description": "Free CLI for SEO, performance & security audits. Built for Claude Code, Cursor, and AI workflows.",
   "bin": {
     "squirrelscan": "./build/squirrelscan"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squirrelscan",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "description": "Website QA tool built for coding agents. 260+ rules across SEO, performance, security, accessibility & agent experience, from the CLI, cloud, or MCP.",
   "bin": {
     "squirrel": "bin/squirrel.js"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "squirrelscan",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
   "author": {
     "name": "squirrelscan",


### PR DESCRIPTION
Stamps the release version into the synced manifests so main matches the tag.

`server.json` is excluded: it tracks its own 1.0.x cadence.

Merge this, then re-run `make release` to cut v0.0.84.

---

Created by replicating `ensureVersionLanded()` from `scripts/release.ts` step for step, because the script cannot reach that stage yet: its `checkChangelogSection()` preflight runs first and aborts while the `## v0.0.84` section is still unmerged (that is #76). The result is byte-identical to what the script produces:

- same branch name, same commit message, same five `SYNCED_MANIFESTS` files
- version stamped via the script's own `scripts/sync-plugin-manifests.ts --version 0.0.84`
- `manifestsCarry("0.0.84")`, the gate the release script gets blocked on, returns `true` against this tree

Independent of #76: this touches only manifest version fields, that one touches only `CHANGELOG.md`. Whichever lands first puts the other BEHIND and needs `gh pr update-branch`. Both must be on main before the tag is cut.