### PR TITLE
fix(rules): never render the unobserved-hop sentinel as a status

### DIFF
--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -30,6 +30,23 @@ export interface RedirectChain {
   httpToHttps: boolean;
 }
 
+/**
+ * One hop as it appears in a user-facing chain label: `url (301)`, or a bare
+ * `url` when no status was observed for it.
+ *
+ * Lives beside `RedirectHop` because it is part of that type's contract: `0` is
+ * the "not observed" sentinel, and it must never reach a report as `(0)`, which
+ * reads like a real status code and is meaningless to a user. Every rule that
+ * renders a hop uses this rather than interpolating `statusCode` itself.
+ *
+ * `displayUrl` overrides the text for the URL part, for rules that show a
+ * pathname instead of the whole URL.
+ */
+export function formatRedirectHop(hop: RedirectHop, displayUrl?: string): string {
+  const url = displayUrl ?? hop.url;
+  return hop.statusCode > 0 ? `${url} (${hop.statusCode})` : url;
+}
+
 export interface SecurityHeaders {
   hsts: string | null;
   csp: string | null;

--- a/packages/rules/src/crawl/canonical-chain.ts
+++ b/packages/rules/src/crawl/canonical-chain.ts
@@ -2,6 +2,8 @@
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
+import { formatRedirectHop } from "@squirrelscan/core-contracts";
+
 import { normalizeUrl } from "@squirrelscan/utils";
 
 export const canonicalChainRule: Rule = {
@@ -33,9 +35,7 @@ export const canonicalChainRule: Rule = {
     ) {
       const chainLabel =
         redirectChain.hops.length > 1
-          ? redirectChain.hops
-              .map((hop) => `${hop.url} (${hop.statusCode})`)
-              .join(" → ")
+          ? redirectChain.hops.map((hop) => formatRedirectHop(hop)).join(" → ")
           : `${pageUrl} → ${finalUrl}`;
 
       checks.push({
@@ -157,9 +157,7 @@ export const canonicalChainRule: Rule = {
           items: [
             {
               id: absoluteCanonical,
-              label: redirectChain.hops
-                .map((hop) => `${hop.url} (${hop.statusCode})`)
-                .join(" → "),
+              label: redirectChain.hops.map((hop) => formatRedirectHop(hop)).join(" → "),
               meta: { chain: redirectChain, finalUrl },
             },
           ],

--- a/packages/rules/src/crawl/redirect-chain.ts
+++ b/packages/rules/src/crawl/redirect-chain.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
+import { formatRedirectHop } from "@squirrelscan/core-contracts";
+
 import { getPathname } from "@squirrelscan/utils";
 
 export const redirectChainRule: Rule = {
@@ -56,8 +58,8 @@ export const redirectChainRule: Rule = {
       if (!chain || chain.hops.length <= maxHops) continue;
 
       // Build readable chain representation: url1 (301) → url2 (301) → url3 (200)
-      const chainParts = chain.hops.map(
-        (hop) => `${getPathname(hop.url)} (${hop.statusCode})`
+      const chainParts = chain.hops.map((hop) =>
+        formatRedirectHop(hop, getPathname(hop.url))
       );
       // Add final URL if different from last hop
       if (chain.finalUrl && chain.hops.length > 0) {
@@ -87,8 +89,8 @@ export const redirectChainRule: Rule = {
           // This is more of an informational check - entry URL should ideally not redirect
           const chain = entryPage.redirectChain;
           if (chain && chain.hops.length > 0) {
-            const chainParts = chain.hops.map(
-              (hop) => `${getPathname(hop.url)} (${hop.statusCode})`
+            const chainParts = chain.hops.map((hop) =>
+              formatRedirectHop(hop, getPathname(hop.url))
             );
             if (chain.finalUrl) {
               chainParts.push(getPathname(chain.finalUrl) + " (200)");

--- a/packages/rules/src/links/redirect-chains.ts
+++ b/packages/rules/src/links/redirect-chains.ts
@@ -1,7 +1,7 @@
 // links/redirect-chains - Redirect detection
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
-import type { RedirectChain } from "@squirrelscan/core-contracts";
+import { formatRedirectHop, type RedirectChain } from "@squirrelscan/core-contracts";
 
 /**
  * Identity of the resource a URL names, for deciding whether a request LANDED
@@ -57,11 +57,6 @@ function contradictsItself(chain: RedirectChain | undefined): boolean {
     .some((hop) => hop.type === "http" && hop.statusCode >= 200 && hop.statusCode < 300);
 }
 
-/** `url (301)`, or bare `url` when no status was observed for that hop. */
-function formatHop(hop: { url: string; statusCode: number }): string {
-  return hop.statusCode > 0 ? `${hop.url} (${hop.statusCode})` : hop.url;
-}
-
 export const redirectChainsRule: Rule = {
   meta: {
     id: "links/redirect-chains",
@@ -114,7 +109,7 @@ export const redirectChainsRule: Rule = {
       if (redirected && !contradictsItself(chain)) {
         const chainLabel =
           chain && chain.hops.length > 1
-            ? chain.hops.map(formatHop).join(" → ")
+            ? chain.hops.map((hop) => formatRedirectHop(hop)).join(" → ")
             : `${page.url} → ${page.finalUrl}`;
         redirectTargets.set(original, {
           originalUrl: page.url,

--- a/packages/rules/tests/unobserved-hop-label.test.ts
+++ b/packages/rules/tests/unobserved-hop-label.test.ts
@@ -1,0 +1,144 @@
+// `statusCode: 0` is the "no status was observed for this hop" sentinel that the
+// render path produces: the service reports the page it landed on, never the
+// statuses of the redirects that got it there. It is a marker for rules to read,
+// NOT a status code, and it must never reach a report as `(0)` — that reads like
+// a real HTTP status and means nothing to a user.
+//
+// Every rule that renders a hop goes through `formatRedirectHop`. These tests
+// hold that line across all of them at once, so a rule added later that
+// interpolates `statusCode` itself is caught here.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatRedirectHop,
+  type RedirectChain,
+  type RedirectHop,
+} from "@squirrelscan/core-contracts";
+import { parsePage } from "@squirrelscan/parser";
+
+import type { RuleContext } from "../src/types";
+
+import { canonicalChainRule } from "../src/crawl/canonical-chain";
+import { redirectChainRule } from "../src/crawl/redirect-chain";
+import { redirectChainsRule } from "../src/links/redirect-chains";
+
+const SOURCE = "https://example.com/o-mnie";
+const LANDING = "https://example.com/o-mnie/";
+
+function hop(url: string, statusCode: number): RedirectHop {
+  return { url, statusCode, type: "http" };
+}
+
+/** The shape the cloud render path produces: source hop unobserved, landing 200. */
+function renderChain(hops: RedirectHop[]): RedirectChain {
+  return {
+    sourceUrl: hops[0]!.url,
+    finalUrl: hops[hops.length - 1]!.url,
+    hops,
+    chainLength: Math.max(0, hops.length - 1),
+    isLoop: false,
+    endsInError: false,
+    httpsToHttp: false,
+    httpToHttps: false,
+  };
+}
+
+const UNOBSERVED = renderChain([hop(SOURCE, 0), hop(LANDING, 200)]);
+// Long enough to trip crawl/redirect-chain's default maxHops of 2.
+const UNOBSERVED_LONG = renderChain([
+  hop(SOURCE, 0),
+  hop("https://example.com/mid/", 0),
+  hop("https://example.com/mid2/", 0),
+  hop(LANDING, 200),
+]);
+
+const html = `<!doctype html><html><head><title>t</title>
+<link rel="canonical" href="${LANDING}"></head><body><p>hello there</p></body></html>`;
+
+function pageCtx(chain: RedirectChain): RuleContext {
+  return {
+    page: { url: SOURCE, finalUrl: LANDING, statusCode: 200, html, redirectChain: chain },
+    parsed: parsePage(html, LANDING),
+    site: { baseUrl: "https://example.com", pages: [] },
+    options: {},
+  } as unknown as RuleContext;
+}
+
+function siteCtx(chain: RedirectChain): RuleContext {
+  return {
+    page: { url: SOURCE, finalUrl: LANDING, statusCode: 200, html },
+    parsed: parsePage(html, LANDING),
+    site: {
+      baseUrl: "https://example.com",
+      pages: [{ url: SOURCE, finalUrl: LANDING, redirectChain: chain, parsed: { links: [] } }],
+    },
+    options: {},
+  } as unknown as RuleContext;
+}
+
+/**
+ * Every rendered string a rule emitted: labels, messages, item ids, AND the
+ * `meta` / `details` payloads. `crawl/redirect-chain` only ever puts its chain
+ * string in `meta.chain` and `details.chain`, and those are serialized into the
+ * report, so a check that looked at labels alone passed with the bug still in
+ * place.
+ */
+function emittedText(result: { checks: { message?: string; items?: unknown[] }[] }): string[] {
+  const out: string[] = [];
+  for (const check of result.checks) {
+    if (check.message) out.push(check.message);
+    for (const item of (check.items ?? []) as { label?: string; id?: string }[]) {
+      if (item.label) out.push(item.label);
+      if (item.id) out.push(item.id);
+    }
+    // Whole-check serialization, so nothing renderable escapes the assertion.
+    out.push(JSON.stringify(check));
+  }
+  return out;
+}
+
+describe("formatRedirectHop", () => {
+  test("renders an observed status", () => {
+    expect(formatRedirectHop(hop(SOURCE, 301))).toBe(`${SOURCE} (301)`);
+  });
+
+  test("renders an unobserved hop bare, never as (0)", () => {
+    expect(formatRedirectHop(hop(SOURCE, 0))).toBe(SOURCE);
+  });
+
+  test("honours a display URL override", () => {
+    expect(formatRedirectHop(hop(SOURCE, 301), "/o-mnie")).toBe("/o-mnie (301)");
+    expect(formatRedirectHop(hop(SOURCE, 0), "/o-mnie")).toBe("/o-mnie");
+  });
+});
+
+describe("no rule renders (0) for an unobserved hop", () => {
+  const cases: [string, () => { checks: { message?: string; items?: unknown[] }[] }][] = [
+    ["crawl/canonical-chain", () => canonicalChainRule.run(pageCtx(UNOBSERVED))],
+    ["crawl/canonical-chain (long)", () => canonicalChainRule.run(pageCtx(UNOBSERVED_LONG))],
+    ["crawl/redirect-chain", () => redirectChainRule.run(siteCtx(UNOBSERVED_LONG))],
+    ["links/redirect-chains", () => redirectChainsRule.run(siteCtx(UNOBSERVED))],
+  ];
+
+  test.each(cases)("%s", (_name, run) => {
+    const text = emittedText(run());
+    // Non-vacuous: the rule really did report something to inspect.
+    expect(text.length).toBeGreaterThan(0);
+    for (const line of text) {
+      expect(line).not.toContain("(0)");
+    }
+  });
+
+  test("the unobserved hop's URL is still shown, just without a status", () => {
+    const labels = emittedText(canonicalChainRule.run(pageCtx(UNOBSERVED)));
+    const chainLabel = labels.find((l) => l.includes(" → "));
+    expect(chainLabel).toBe(`${SOURCE} → ${LANDING} (200)`);
+  });
+
+  test("an observed status is still rendered", () => {
+    const observed = renderChain([hop(SOURCE, 301), hop(LANDING, 200)]);
+    const labels = emittedText(canonicalChainRule.run(pageCtx(observed)));
+    expect(labels.some((l) => l.includes("(301)"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

`statusCode: 0` marks a redirect hop whose status was never observed. It is what the render path produces: the service reports the page it landed on, never the statuses of the redirects that got it there. It is a marker for rules to read, not a status code.

Only `links/redirect-chains` was taught about it. Two other rules interpolated it straight into user-facing output:

- **`crawl/canonical-chain`** (both chain labels) printed `https://example.com/about (0)`.
- **`crawl/redirect-chain`** did the same in `meta.chain` and `details.chain`. Those are not labels, but they are serialized into the report, so the `(0)` still reaches the user.

`(0)` reads like a real HTTP status and means nothing.

## The fix

`formatRedirectHop` moves to `packages/core-contracts/src/storage.ts`, directly beside `RedirectHop`, because the sentinel is part of that type's contract. All three rules use it instead of each formatting hops their own way. It takes an optional display URL so `crawl/redirect-chain` can keep showing a pathname rather than a whole URL.

`links/redirects.ts` deliberately keeps its own interpolation: it builds chains from responses it watched itself, appending a hop only after reading a real status, so the sentinel cannot occur there. Verified it never reads `page.redirectChain`.

## Tests

`packages/rules/tests/unobserved-hop-label.test.ts` drives all three rules with a render-shaped chain and asserts nothing they emit contains `(0)`, plus that the hop's URL is still shown and an observed status still renders.

The assertion covers **each check's whole serialized payload**, not just labels. That matters: the first version of this test looked only at labels and passed with the bug still in place, because `crawl/redirect-chain` never puts its chain in a label. Both fixes were confirmed load-bearing by reverting each in turn and watching the corresponding cases fail.