### PR TITLE
ci(docs): deploy docs without a manual approval gate

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,6 +9,7 @@ on:
       - "package.json"
       - ".github/actions/setup-bun/action.yml"
       - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -22,7 +23,10 @@ jobs:
     name: Deploy docs to Cloudflare
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: production
+    # Not `production`: that environment gates on a manual reviewer, which is
+    # right for releases and wrong for docs. Ten consecutive docs deploys sat
+    # unapproved and were cancelled by the next push, so the site went stale.
+    environment: docs-production
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-bun


### PR DESCRIPTION
`Deploy Docs` used the `production` environment, which has a required reviewer. Every run since 2026-07-30 sat waiting for approval and was cancelled when the next push queued behind it — ten runs, zero deploys. `docs.squirrelscan.com` has been serving stale content for about a week.

- new `docs-production` environment: main-only branch policy, no required reviewers
- `production` keeps its reviewer gate for release deploys
- `workflow_dispatch` added so a failed docs deploy can be retried without an empty commit

Merging this touches `.github/workflows/deploy-docs.yml`, which is in the workflow's own path filter, so it self-triggers the first ungated deploy.