### PR TITLE
ci(docs): move docs deploy off a stuck concurrency group

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,8 +14,11 @@ on:
 permissions:
   contents: read
 
+# Serialise deploys per ref. The group name is deliberately not the old
+# `deploy-docs-production`: runs queued against that group stopped starting
+# altogether (pending, zero jobs, indefinitely), so it is abandoned.
 concurrency:
-  group: deploy-docs-production
+  group: deploy-docs-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Follow-up to #80. Removing the approval gate was necessary but not sufficient: the run triggered by that merge still sat `pending` with zero jobs and never started, same as the ten before it. Nothing else is in flight, so the `deploy-docs-production` concurrency group is holding a lock that nothing releases.

Key the group off `github.ref` instead. Same per-branch serialisation, on a group name that is not wedged.