### PR TITLE
fix(rules): report a missing robots.txt as an error

### DIFF
--- a/apps/cli/tests/scoring.test.ts
+++ b/apps/cli/tests/scoring.test.ts
@@ -254,6 +254,72 @@ describe("calculateHealthScore", () => {
     expect(score.overall).toBe(37);
   });
 
+  // The rule emits "fail" for a missing robots.txt (#1535); "warn" above is the
+  // legacy status stored in pre-#1535 reports. Both must keep the penalty —
+  // matching only one silently drops -15% from every score.
+  test("applies penalty for missing robots.txt when the check failed", () => {
+    const mockRobotsMeta = {
+      id: "crawl/robots-txt",
+      name: "Robots.txt",
+      description: "Robots.txt check",
+      solution: "Add robots.txt",
+      category: "crawl" as const,
+      scope: "site" as const,
+      severity: "error" as const,
+      weight: 8,
+    };
+
+    const results = new Map<string, RuleRunResult>([
+      [
+        "core/test-rule",
+        {
+          meta: mockCoreMeta,
+          checks: [{ name: "ok", status: "pass", message: "Passed" }],
+        },
+      ],
+      [
+        "crawl/robots-txt",
+        {
+          meta: mockRobotsMeta,
+          checks: [
+            {
+              name: "robots-txt-exists",
+              status: "fail",
+              message: "No robots.txt found",
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const withPenalty = calculateHealthScore({ results });
+
+    // Same shape, but the robots rule is absent so no penalty multiplier applies.
+    const baselineResults = new Map<string, RuleRunResult>([
+      [
+        "core/test-rule",
+        {
+          meta: mockCoreMeta,
+          checks: [{ name: "ok", status: "pass", message: "Passed" }],
+        },
+      ],
+      [
+        "crawl/other-rule",
+        {
+          meta: { ...mockRobotsMeta, id: "crawl/other-rule" },
+          checks: [{ name: "other", status: "fail", message: "Failed" }],
+        },
+      ],
+    ]);
+    const baseline = calculateHealthScore({ results: baselineResults });
+
+    // ±1 because both scores are rounded independently.
+    expect(
+      Math.abs((withPenalty.overall ?? 0) - (baseline.overall ?? 0) * 0.85)
+    ).toBeLessThanOrEqual(1);
+    expect(baseline.overall).toBeGreaterThan(0);
+  });
+
   test("applies penalty for robots blocking all", () => {
     const mockRobotsMeta = {
       id: "crawl/robots-txt",

--- a/packages/audit-engine/src/scoring.ts
+++ b/packages/audit-engine/src/scoring.ts
@@ -510,7 +510,9 @@ function calculatePenaltyMultiplier(
     if (disallowCheck?.status === "fail") {
       multiplier *= 1 - PENALTY_ROBOTS_BLOCKS_ALL; // Blocks all
     }
-    if (existsCheck?.status === "warn") {
+    // "fail" is what the rule emits now; "warn" is what pre-#1535 reports
+    // stored, and rescoring a stored report must still apply the penalty.
+    if (existsCheck?.status === "fail" || existsCheck?.status === "warn") {
       multiplier *= 1 - PENALTY_NO_ROBOTS_TXT; // Missing
     }
   }

--- a/packages/rules/src/crawl/robots-txt.ts
+++ b/packages/rules/src/crawl/robots-txt.ts
@@ -28,11 +28,14 @@ export const robotsTxtRule: Rule = {
       return { checks };
     }
 
-    // Check existence
+    // Check existence. `fail`, not `warn`: the rule's meta severity only
+    // surfaces as an error when a check fails, and a missing robots.txt is an
+    // error - no crawl directives, no sitemap pointer, and every crawler
+    // (including AI agents) is left to guess.
     if (!robotsTxt.exists) {
       checks.push({
         name: "robots-txt-exists",
-        status: "warn",
+        status: "fail",
         message: "No robots.txt found",
         value: "Search engines will crawl all accessible pages",
       });


### PR DESCRIPTION
`crawl/robots-txt` declares meta severity `error`, but the missing-file check emitted `status: "warn"`. Effective severity derives from what actually happened (a rule whose checks only warn is reported as a warning), so a site with no robots.txt has always rendered as **Warning**, and sorted into the warning block below recommendations.

We already treat a missing robots.txt as critical: it carries a -15% score penalty. This makes the badge match.

**Changes**
- `packages/rules/src/crawl/robots-txt.ts` — missing robots.txt is now `fail`, not `warn`.
- `packages/audit-engine/src/scoring.ts` — the `PENALTY_NO_ROBOTS_TXT` (-15%) multiplier matched `status === "warn"` only. Now matches `fail` **or** `warn`, so the penalty survives the new status and still applies when rescoring reports stored before this change.
- `apps/cli/tests/scoring.test.ts` — test that the penalty applies on a failed `robots-txt-exists` check.

**Effect on scores:** a missing robots.txt now contributes a failed check rather than a warning, so it weighs more in the issue-density penalty (fail units are 2x warn units) on top of the unchanged -15% multiplier.