### PR TITLE
fix(report): order issues by severity globally, not within each category

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -273,7 +273,7 @@
         "filename": "packages/report/src/output/html.tsx",
         "hashed_secret": "a9fe535612f1aff3358c2e17f1e0e50fc60a66dc",
         "is_verified": false,
-        "line_number": 1101
+        "line_number": 1103
       }
     ],
     "packages/report/tests/screenshot-section.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-24T08:42:27Z"
+  "generated_at": "2026-08-05T00:24:48Z"
 }

--- a/apps/cli/tests/reports/output/llm.test.ts
+++ b/apps/cli/tests/reports/output/llm.test.ts
@@ -92,7 +92,11 @@ describe("generateLlmReport", () => {
     const content = readFileSync(outputPath, "utf-8");
 
     expect(content).toContain("<issues>");
-    expect(content).toContain("<category");
+    // #1536: no <category> wrapper — issues are one flat severity-ordered list
+    // and each rule carries its category/group as attributes.
+    expect(content).not.toContain("<category");
+    expect(content).toContain('category="Core SEO"');
+    expect(content).toContain('group="seo"');
     expect(content).toContain('rule id="core/meta-title"');
     // Docs URL for LLM to look up rule details
     expect(content).toContain(

--- a/apps/cli/tests/reports/output/markdown.test.ts
+++ b/apps/cli/tests/reports/output/markdown.test.ts
@@ -84,11 +84,11 @@ describe("generateMarkdownReport", () => {
     const content = readFileSync(outputPath, "utf-8");
 
     expect(content).toContain("## Issues");
-    // #626: issues nest under a top-level group heading. The SEO group here has a
-    // single issue-category (core), so its redundant category heading collapses and
-    // the rule promotes directly under the group (h3 → h4).
-    expect(content).toContain("### SEO");
-    expect(content).toContain("#### Meta Title");
+    // #1536: issues nest under a SEVERITY heading (global order), with the
+    // category as the sub-heading beneath it.
+    expect(content).toContain("### Errors");
+    expect(content).toContain("#### Core SEO");
+    expect(content).toContain("##### Meta Title");
     expect(content).toContain("**[ERROR]**");
   });
 

--- a/docs/configuration/output.mdx
+++ b/docs/configuration/output.mdx
@@ -260,14 +260,12 @@ For a 51-page audit:
 </score>
 <summary passed="83" warnings="13" failed="9"/>
 <issues>
- <category name="Content" errors="2" warnings="3">
-  <rule id="content/word-count" severity="warning" status="warn">
-   Low word count detected
-   Desc: Pages should have sufficient content for good SEO
-   Fix: Add more relevant content to improve page depth
-   Pages (3): /blog/post-1, /blog/post-2, /about
-  </rule>
- </category>
+ <rule id="content/word-count" severity="warning" category="Content" group="seo" status="warn">
+  Low word count detected
+  Desc: Pages should have sufficient content for good SEO
+  Fix: Add more relevant content to improve page depth
+  Pages (3): /blog/post-1, /blog/post-2, /about
+ </rule>
 </issues>
 </audit>
 ```
@@ -329,20 +327,18 @@ See [OUTPUT-FORMAT.md](https://github.com/squirrelscan/squirrelscan/blob/main/sk
     </categories>
   </score>
   <issues>
-    <category>
-      <name>Content</name>
-      <rules>
-        <rule>
-          <id>content/word-count</id>
-          <description>Pages should have sufficient content</description>
-          <solution>Add more relevant content</solution>
-          <pages>
-            <page>/blog/post-1</page>
-            <page>/blog/post-2</page>
-          </pages>
-        </rule>
-      </rules>
-    </category>
+    <rule id="content/word-count" severity="warning" category="Content" group="seo">
+      <name>Word Count</name>
+      <description>Pages should have sufficient content</description>
+      <solution>Add more relevant content</solution>
+      <check name="word-count" status="warn">
+        <message>Low word count: 150 words (min: 300)</message>
+        <affected-pages count="2" examples="2" has-more="false">
+          <page url="https://example.com/blog/post-1"/>
+          <page url="https://example.com/blog/post-2"/>
+        </affected-pages>
+      </check>
+    </rule>
   </issues>
 </audit>
 ```

--- a/docs/reports.mdx
+++ b/docs/reports.mdx
@@ -85,6 +85,19 @@ Each category (core, content, links, etc.) receives its own score:
 
 squirrelscan supports multiple report formats optimized for different use cases.
 
+### Issue ordering
+
+Every format lists issues in the same order, so the top of the list is always
+the work to do first:
+
+1. **Severity** - errors, then recommendations, then warnings.
+2. **Category** - within a severity, issues from the same category stay together,
+   higher-priority categories first.
+3. **Rule weight** - within a category, heavier rules first.
+
+Categories are not top-level sections: a category with both an error and a
+warning appears under both severities.
+
 ### console (Default)
 
 Human-readable terminal output with colors and formatting.
@@ -243,9 +256,18 @@ Overall: **87/100** (B)
 
 ## Issues
 
-### Content (2 errors, 3 warnings)
+### Errors
 
-#### ⚠️ Word Count
+#### Images
+
+##### Image Alt Text
+Images are missing alt attributes on 6 pages.
+
+### Warnings
+
+#### Content
+
+##### Word Count
 Low word count detected on 3 pages.
 ```
 
@@ -295,23 +317,19 @@ squirrel report -f llm | claude "analyze this audit and prioritize fixes"
 </score>
 <summary passed="83" warnings="13" failed="9"/>
 <issues>
- <category name="Content" errors="2" warnings="3">
-  <rule id="content/word-count" severity="warning" status="warn">
-   Low word count: 150 words (min: 300)
-   Desc: Pages should have sufficient content for good SEO
-   Fix: Add more relevant content to improve page depth
-   Pages (3): /blog/post-1, /blog/post-2, /about
-  </rule>
- </category>
- <category name="Images" errors="6" warnings="0">
-  <rule id="images/alt-text" severity="error" status="fail">
-   Desc: All images must have descriptive alt text
-   Fix: Add alt attributes to img tags
-   Items (6):
-    - /products/widget.png (from: /products)
-    - /hero.jpg (from: /)
-  </rule>
- </category>
+ <rule id="images/alt-text" severity="error" category="Images" group="seo" status="fail">
+  Desc: All images must have descriptive alt text
+  Fix: Add alt attributes to img tags
+  Items (6):
+   - /products/widget.png (from: /products)
+   - /hero.jpg (from: /)
+ </rule>
+ <rule id="content/word-count" severity="warning" category="Content" group="seo" status="warn">
+  Low word count: 150 words (min: 300)
+  Desc: Pages should have sufficient content for good SEO
+  Fix: Add more relevant content to improve page depth
+  Pages (3): /blog/post-1, /blog/post-2, /about
+ </rule>
 </issues>
 <locked-rules count="7" audience="anonymous-upsell">
  Cloud-powered checks (page rendering, AI content analysis, link-rot, brand protection, and more) run with a free squirrelscan account.
@@ -375,20 +393,18 @@ squirrel report -f xml -o report.xml
     </categories>
   </score>
   <issues>
-    <category>
-      <name>Content</name>
-      <rules>
-        <rule>
-          <id>content/word-count</id>
-          <description>Pages should have sufficient content</description>
-          <solution>Add more relevant content to improve page depth</solution>
-          <pages>
-            <page>/blog/post-1</page>
-            <page>/blog/post-2</page>
-          </pages>
-        </rule>
-      </rules>
-    </category>
+    <rule id="content/word-count" severity="warning" category="Content" group="seo">
+      <name>Word Count</name>
+      <description>Pages should have sufficient content</description>
+      <solution>Add more relevant content to improve page depth</solution>
+      <check name="word-count" status="warn">
+        <message>Low word count: 150 words (min: 300)</message>
+        <affected-pages count="2" examples="2" has-more="false">
+          <page url="https://example.com/blog/post-1"/>
+          <page url="https://example.com/blog/post-2"/>
+        </affected-pages>
+      </check>
+    </rule>
   </issues>
 </audit>
 ```

--- a/packages/report/src/categories.ts
+++ b/packages/report/src/categories.ts
@@ -157,8 +157,11 @@ export function isValidGroup(code: string): boolean {
  */
 export function severityLabel(
   severity: "error" | "warning" | "info",
-  options?: { titleCase?: boolean }
+  options?: { titleCase?: boolean; plural?: boolean }
 ): string {
-  const label = severity === "info" ? "recommendation" : severity;
+  const singular = severity === "info" ? "recommendation" : severity;
+  // Every label is regular, so a bare "s" is enough for the section headings
+  // the severity-first renderers emit (#1536).
+  const label = options?.plural ? `${singular}s` : singular;
   return options?.titleCase ? label.charAt(0).toUpperCase() + label.slice(1) : label;
 }

--- a/packages/report/src/grouping.ts
+++ b/packages/report/src/grouping.ts
@@ -435,3 +435,51 @@ export function groupCategoriesByGroup(
   }
   return groups;
 }
+
+/** A rule lifted out of its category, carrying the category context a flat renderer needs. */
+export interface FlatIssue extends GroupedRule {
+  /** Category code, e.g. "crawl". */
+  categoryCode: string;
+  /** Category display name, e.g. "Crawlability". */
+  categoryName: string;
+  /** Top-level group code (#626), e.g. "seo". */
+  group: string;
+}
+
+/**
+ * Flatten every category's rules into ONE list ordered by severity first
+ * (#1536): error → recommendation (info) → warning, then category priority,
+ * then rule weight, then rule id.
+ *
+ * {@link groupIssuesByCategory} sorts severity only WITHIN a category, so a
+ * renderer that concatenates categories interleaves severities — crawl's
+ * errors and warnings both land above a11y's errors. Severity is the property
+ * a reader (or a coding agent) triages on, so it has to be the outermost key.
+ * Renderers that still want the category tree keep using the grouped shape.
+ */
+export function flattenIssuesBySeverity(categories: GroupedCategory[]): FlatIssue[] {
+  const flat: FlatIssue[] = categories.flatMap((category) =>
+    category.rules.map((rule) => ({
+      ...rule,
+      categoryCode: category.code,
+      categoryName: category.name,
+      group: category.group,
+    }))
+  );
+
+  return flat.sort((a, b) => {
+    const sevDiff = RULE_SEVERITY_RANK[a.severity] - RULE_SEVERITY_RANK[b.severity];
+    if (sevDiff !== 0) return sevDiff;
+    const priDiff = getCategoryPriority(b.categoryCode) - getCategoryPriority(a.categoryCode);
+    if (priDiff !== 0) return priDiff;
+    // Equal-priority categories: keep each one's rules together rather than
+    // interleaving two categories that happen to share a priority.
+    if (a.categoryCode !== b.categoryCode) {
+      return a.categoryCode < b.categoryCode ? -1 : 1;
+    }
+    const weightDiff = b.weight - a.weight;
+    if (weightDiff !== 0) return weightDiff;
+    // Stable across repeat audits (#150).
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -30,6 +30,7 @@ export {
   isValidGroup,
   getSubcategoryName,
   getSubcategoryPriority,
+  severityLabel,
   normalizeCategoryCode,
   deriveBlockingSubcategory,
 } from "./categories";
@@ -39,8 +40,8 @@ export type { CategoryInfo, GroupInfo, RuleGroup } from "./categories";
 export { checkOccurrences } from "./occurrences";
 
 // Grouping
-export { groupIssuesByCategory, groupCategoriesByGroup } from "./grouping";
-export type { GroupedCheck, GroupedRule, GroupedCategory, GroupedGroup } from "./grouping";
+export { groupIssuesByCategory, groupCategoriesByGroup, flattenIssuesBySeverity } from "./grouping";
+export type { GroupedCheck, GroupedRule, GroupedCategory, GroupedGroup, FlatIssue } from "./grouping";
 
 // Scoring
 export { getScoreGrade, getScoreColor, getGroupColor, GROUP_COLORS } from "./scoring";

--- a/packages/report/src/output/html.tsx
+++ b/packages/report/src/output/html.tsx
@@ -20,7 +20,7 @@ import {
   REPORT_PAGES_INLINE_CAP,
   REPORT_PAGES_HARD_CAP,
 } from "../constants";
-import { groupIssuesByCategory, groupCategoriesByGroup, type GroupedCategory } from "../grouping";
+import { groupIssuesByCategory, flattenIssuesBySeverity, type GroupedCategory } from "../grouping";
 import { groupTechnologies, techChangeSummary } from "../technologies";
 import {
   SITE_PROFILE_NOTE,
@@ -789,23 +789,27 @@ function PagesList({
   );
 }
 
-// Flat issues list: one section per group (anchor target for the score
-// circles), rules in group → category-priority → weight order. No group or
-// category headings — each rule carries its parent group as a small label.
+// Flat issues list in ONE global severity order (#1536): error →
+// recommendation → warning, then category priority, then rule weight. Groups
+// are no longer contiguous, so the `group-*` anchors the score circles link to
+// are stamped on each group's FIRST rule in this order — the jump lands on the
+// highest-severity issue in that group, which is what a reader wants anyway.
+// No group or category headings — each rule carries its parent group as a label.
 function IssuesByGroup({ categories }: { categories: GroupedCategory[] }) {
   if (categories.length === 0) return null;
-  const groups = groupCategoriesByGroup(categories);
+  const issues = flattenIssuesBySeverity(categories);
+  const anchoredGroups = new Set<string>();
   return (
     <>
       <h2>Issues</h2>
-      {groups.map((group) => (
-        <div key={group.code} id={`group-${group.code}`} className="group-section">
-          {group.categories.map((category) => (
-            <React.Fragment key={category.code}>
-              {category.rules.map((rule) => {
-                // Sample-union count — the denominator the carried rollup /
-                // fully-carried check share with carriedPageCount (both known
-                // only for sampled pages; #1135).
+      <div className="group-section">
+        {issues.map((rule) => {
+          const groupCode = rule.group;
+          const isGroupAnchor = !anchoredGroups.has(groupCode);
+          if (isGroupAnchor) anchoredGroups.add(groupCode);
+          // Sample-union count — the denominator the carried rollup /
+          // fully-carried check share with carriedPageCount (both known
+          // only for sampled pages; #1135).
                 const totalPages = ruleAffectedPageCount(rule.checks);
                 // #1023 R-F / #1306: authoritative affected-page total for the
                 // header. `count` is a max-based FLOOR (never a sum — that would
@@ -820,6 +824,7 @@ function IssuesByGroup({ categories }: { categories: GroupedCategory[] }) {
                 return (
                   <React.Fragment key={rule.id}>
                     <details
+                      {...(isGroupAnchor ? { id: `group-${groupCode}` } : {})}
                       className="rule-block"
                       style={{
                         borderLeftColor:
@@ -833,14 +838,14 @@ function IssuesByGroup({ categories }: { categories: GroupedCategory[] }) {
                       <summary className="rule-summary">
                         <span
                           className="group-label"
-                          title={getGroupTitle(group.code)}
+                          title={getGroupTitle(groupCode)}
                           style={{
-                            color: getGroupColor(group.code).text,
-                            background: getGroupColor(group.code).bg,
-                            borderColor: getGroupColor(group.code).border,
+                            color: getGroupColor(groupCode).text,
+                            background: getGroupColor(groupCode).bg,
+                            borderColor: getGroupColor(groupCode).border,
                           }}
                         >
-                          {group.name}
+                          {getGroupName(groupCode)}
                         </span>
                         <span className="rule-name">{rule.name}</span>
                         {/* className keeps the raw severity (drives the .rule-severity.info
@@ -1024,11 +1029,8 @@ function IssuesByGroup({ categories }: { categories: GroupedCategory[] }) {
                     </details>
                   </React.Fragment>
                 );
-              })}
-            </React.Fragment>
-          ))}
-        </div>
-      ))}
+        })}
+      </div>
     </>
   );
 }

--- a/packages/report/src/output/json.ts
+++ b/packages/report/src/output/json.ts
@@ -3,7 +3,7 @@
 import type { AuditReport, AuditStatus, CheckItem } from "../types";
 import { getScoreGrade } from "../scoring";
 import { getGroupName } from "../categories";
-import { groupIssuesByCategory } from "../grouping";
+import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { affectedPages } from "../affected-pages";
 import { techIconUrl } from "../technologies";
 import { domainAgeYears, siteProfileRows } from "../site-metadata";
@@ -181,16 +181,16 @@ function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
           },
         }
       : {}),
-    issues: categoryIssues.flatMap((category) =>
-      category.rules.map((rule) => ({
-        ruleId: rule.id,
-        name: rule.name,
-        description: rule.description,
-        solution: rule.solution,
-        category: category.name,
-        group: category.group,
-        ...(rule.subcategory ? { subcategory: rule.subcategory } : {}),
-        severity: rule.severity,
+    // Severity-first across the whole report (#1536), not category-by-category.
+    issues: flattenIssuesBySeverity(categoryIssues).map((rule) => ({
+      ruleId: rule.id,
+      name: rule.name,
+      description: rule.description,
+      solution: rule.solution,
+      category: rule.categoryName,
+      group: rule.group,
+      ...(rule.subcategory ? { subcategory: rule.subcategory } : {}),
+      severity: rule.severity,
         checks: rule.checks.map((check) => {
           // #1023 R-F: affectedPages is a labeled sample; count is authoritative.
           const ap = affectedPages(check);
@@ -212,9 +212,8 @@ function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
                 }
               : {}),
           };
-        }),
-      })),
-    ),
+      }),
+    })),
     ...(report.technologies && report.technologies.items.length > 0
       ? {
           technologies: {

--- a/packages/report/src/output/llm.ts
+++ b/packages/report/src/output/llm.ts
@@ -3,7 +3,7 @@
 import type { AuditReport, CheckItem } from "../types";
 import { getScoreGrade } from "../scoring";
 import { getGroupName } from "../categories";
-import { groupIssuesByCategory } from "../grouping";
+import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { ruleAffectedPages, ruleAffectedRollup, ruleCarriedPageCount } from "../affected-pages";
 import { getDocsUrl } from "../docs";
 import { domainAgeYears } from "../site-metadata";
@@ -232,118 +232,116 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
 
   if (categoryIssues.length > 0) {
     lines.push("<issues>");
-    for (const category of categoryIssues) {
-      lines.push(
-        `${indent(1)}<category name="${escapeXml(category.name)}" group="${escapeXml(category.group)}" errors="${category.failCount}" warnings="${category.warnCount}">`,
-      );
-      for (const rule of category.rules) {
-        let ruleStatus = "pass";
-        for (const check of rule.checks) {
-          if (check.status === "fail") {
-            ruleStatus = "fail";
-            break;
-          }
-          if (check.status === "warn") ruleStatus = "warn";
+    // Flat and severity-first (#1536): errors, then recommendations, then
+    // warnings, across the whole report. No <category> wrapper — the rule
+    // carries category/group as attributes, so the order an agent reads IS the
+    // order it should fix in.
+    for (const rule of flattenIssuesBySeverity(categoryIssues)) {
+      let ruleStatus = "pass";
+      for (const check of rule.checks) {
+        if (check.status === "fail") {
+          ruleStatus = "fail";
+          break;
         }
-
-        // Smart audits (#110): a rule's findings are "carried" when every
-        // surfaced check came from pages not re-crawled this run.
-        const carriedChecks = rule.checks.filter(
-          (c) => c.carriedCount && c.carriedCount >= c.count,
-        ).length;
-        const allPagesForRule = ruleAffectedPages(rule.checks);
-        const carriedPageCount = ruleCarriedPageCount(rule.checks);
-        // #1135: fully carried → provenance="carried"; some-but-not-all → a
-        // "N/M" fraction attribute so an agent can tell "mixed" from "fresh"
-        // without walking every check.
-        const carriedAttr =
-          carriedChecks > 0 && carriedChecks === rule.checks.length
-            ? ` provenance="carried"`
-            : carriedPageCount > 0
-              ? ` carried_pages="${carriedPageCount}/${allPagesForRule.size}"`
-              : "";
-
-        const docsUrl = getDocsUrl(rule.id);
-        lines.push(
-          `${indent(2)}<rule id="${escapeXml(rule.id)}" severity="${rule.severity}"${rule.subcategory ? ` subcategory="${escapeXml(rule.subcategory)}"` : ""} status="${ruleStatus}"${carriedAttr} docs="${escapeXml(docsUrl)}">`,
-        );
-
-        const messages = rule.checks.map((c) => c.message).filter((m) => m);
-        if (messages.length > 0) lines.push(`${indent(3)}${escapeXml(messages.join("; "))}`);
-        if (rule.mixedProvenanceNote) {
-          lines.push(`${indent(3)}${escapeXml(rule.mixedProvenanceNote)}`);
-        }
-
-        // Union of check.pages + item-level sourcePages / page-URL ids so
-        // site-scope rules (blocked-links, sitemap-*) report real page counts.
-        const allPages = ruleAffectedPages(rule.checks);
-        // #1023 R-F / #1306: authoritative rule total = a max-based FLOOR (per-
-        // check accessor), not the sampled union size — a folded/sampled rule
-        // would otherwise report only its retained sample (e.g. 200/200, not
-        // 200/600). `hasMore` marks the floor as a lower bound (2+ truncated
-        // checks with possibly-disjoint hidden pages) → suffix "+".
-        const rollup = ruleAffectedRollup(rule.checks);
-        const totalPages = rollup.count;
-        const totalLabel = `${totalPages}${rollup.hasMore ? "+" : ""}`;
-
-        if (allPages.size > 0) {
-          const sampledPages = sampleAffectedPagesBreadthFirst(Array.from(allPages), baseOrigin);
-          const pageList = sampledPages
-            .map((p) => escapeXml(compressUrl(p, baseOrigin)))
-            .join(", ");
-          if (sampledPages.length < totalPages) {
-            lines.push(`${indent(3)}Pages (${sampledPages.length}/${totalLabel}): ${pageList}`);
-          } else {
-            lines.push(`${indent(3)}Pages (${totalLabel}): ${pageList}`);
-          }
-        }
-
-        const allItems: CheckItem[] = [];
-        for (const check of rule.checks) {
-          if (check.items && check.items.length > 0) allItems.push(...check.items);
-        }
-
-        if (allItems.length > 0) {
-          const sampledItems = allItems.slice(0, LLM_REPORT.maxItems);
-          lines.push(
-            sampledItems.length < allItems.length
-              ? `${indent(3)}Items (${sampledItems.length}/${allItems.length}):`
-              : `${indent(3)}Items (${allItems.length}):`,
-          );
-
-          for (const item of sampledItems) {
-            const itemId = item.id.startsWith("http") ? compressUrl(item.id, baseOrigin) : item.id;
-            let itemLine = `${indent(4)}- ${escapeXml(itemId)}`;
-            if (item.label && item.label !== item.id) itemLine += ` (${escapeXml(item.label)})`;
-            if (item.snippet) itemLine += ` | ${escapeXml(item.snippet)}`;
-            if (item.meta) {
-              const metaParts: string[] = [];
-              for (const [k, v] of Object.entries(item.meta)) {
-                if (v !== undefined && v !== null) {
-                  const serialized = serializeMetaValue(v);
-                  if (serialized) metaParts.push(`${k}: ${escapeXml(serialized)}`);
-                }
-              }
-              if (metaParts.length > 0) itemLine += ` [${metaParts.join(", ")}]`;
-            }
-            if (item.sourcePages && item.sourcePages.length > 0) {
-              const sourcePages = item.sourcePages.slice(0, LLM_REPORT.maxItemSourcePages);
-              const sources = sourcePages
-                .map((s) => escapeXml(compressUrl(s, baseOrigin)))
-                .join(", ");
-              if (sourcePages.length < item.sourcePages.length) {
-                itemLine += ` (from: ${sources}; +${item.sourcePages.length - sourcePages.length} more)`;
-              } else {
-                itemLine += ` (from: ${sources})`;
-              }
-            }
-            lines.push(itemLine);
-          }
-        }
-
-        lines.push(`${indent(2)}</rule>`);
+        if (check.status === "warn") ruleStatus = "warn";
       }
-      lines.push(`${indent(1)}</category>`);
+  
+      // Smart audits (#110): a rule's findings are "carried" when every
+      // surfaced check came from pages not re-crawled this run.
+      const carriedChecks = rule.checks.filter(
+        (c) => c.carriedCount && c.carriedCount >= c.count,
+      ).length;
+      const allPagesForRule = ruleAffectedPages(rule.checks);
+      const carriedPageCount = ruleCarriedPageCount(rule.checks);
+      // #1135: fully carried → provenance="carried"; some-but-not-all → a
+      // "N/M" fraction attribute so an agent can tell "mixed" from "fresh"
+      // without walking every check.
+      const carriedAttr =
+        carriedChecks > 0 && carriedChecks === rule.checks.length
+          ? ` provenance="carried"`
+          : carriedPageCount > 0
+            ? ` carried_pages="${carriedPageCount}/${allPagesForRule.size}"`
+            : "";
+  
+      const docsUrl = getDocsUrl(rule.id);
+      lines.push(
+        `${indent(1)}<rule id="${escapeXml(rule.id)}" severity="${rule.severity}" category="${escapeXml(rule.categoryName)}" group="${escapeXml(rule.group)}"${rule.subcategory ? ` subcategory="${escapeXml(rule.subcategory)}"` : ""} status="${ruleStatus}"${carriedAttr} docs="${escapeXml(docsUrl)}">`,
+      );
+  
+      const messages = rule.checks.map((c) => c.message).filter((m) => m);
+      if (messages.length > 0) lines.push(`${indent(2)}${escapeXml(messages.join("; "))}`);
+      if (rule.mixedProvenanceNote) {
+        lines.push(`${indent(2)}${escapeXml(rule.mixedProvenanceNote)}`);
+      }
+  
+      // Union of check.pages + item-level sourcePages / page-URL ids so
+      // site-scope rules (blocked-links, sitemap-*) report real page counts.
+      const allPages = ruleAffectedPages(rule.checks);
+      // #1023 R-F / #1306: authoritative rule total = a max-based FLOOR (per-
+      // check accessor), not the sampled union size — a folded/sampled rule
+      // would otherwise report only its retained sample (e.g. 200/200, not
+      // 200/600). `hasMore` marks the floor as a lower bound (2+ truncated
+      // checks with possibly-disjoint hidden pages) → suffix "+".
+      const rollup = ruleAffectedRollup(rule.checks);
+      const totalPages = rollup.count;
+      const totalLabel = `${totalPages}${rollup.hasMore ? "+" : ""}`;
+  
+      if (allPages.size > 0) {
+        const sampledPages = sampleAffectedPagesBreadthFirst(Array.from(allPages), baseOrigin);
+        const pageList = sampledPages
+          .map((p) => escapeXml(compressUrl(p, baseOrigin)))
+          .join(", ");
+        if (sampledPages.length < totalPages) {
+          lines.push(`${indent(2)}Pages (${sampledPages.length}/${totalLabel}): ${pageList}`);
+        } else {
+          lines.push(`${indent(2)}Pages (${totalLabel}): ${pageList}`);
+        }
+      }
+  
+      const allItems: CheckItem[] = [];
+      for (const check of rule.checks) {
+        if (check.items && check.items.length > 0) allItems.push(...check.items);
+      }
+  
+      if (allItems.length > 0) {
+        const sampledItems = allItems.slice(0, LLM_REPORT.maxItems);
+        lines.push(
+          sampledItems.length < allItems.length
+            ? `${indent(2)}Items (${sampledItems.length}/${allItems.length}):`
+            : `${indent(2)}Items (${allItems.length}):`,
+        );
+  
+        for (const item of sampledItems) {
+          const itemId = item.id.startsWith("http") ? compressUrl(item.id, baseOrigin) : item.id;
+          let itemLine = `${indent(3)}- ${escapeXml(itemId)}`;
+          if (item.label && item.label !== item.id) itemLine += ` (${escapeXml(item.label)})`;
+          if (item.snippet) itemLine += ` | ${escapeXml(item.snippet)}`;
+          if (item.meta) {
+            const metaParts: string[] = [];
+            for (const [k, v] of Object.entries(item.meta)) {
+              if (v !== undefined && v !== null) {
+                const serialized = serializeMetaValue(v);
+                if (serialized) metaParts.push(`${k}: ${escapeXml(serialized)}`);
+              }
+            }
+            if (metaParts.length > 0) itemLine += ` [${metaParts.join(", ")}]`;
+          }
+          if (item.sourcePages && item.sourcePages.length > 0) {
+            const sourcePages = item.sourcePages.slice(0, LLM_REPORT.maxItemSourcePages);
+            const sources = sourcePages
+              .map((s) => escapeXml(compressUrl(s, baseOrigin)))
+              .join(", ");
+            if (sourcePages.length < item.sourcePages.length) {
+              itemLine += ` (from: ${sources}; +${item.sourcePages.length - sourcePages.length} more)`;
+            } else {
+              itemLine += ` (from: ${sources})`;
+            }
+          }
+          lines.push(itemLine);
+        }
+      }
+
+      lines.push(`${indent(1)}</rule>`);
     }
     lines.push("</issues>");
   } else {

--- a/packages/report/src/output/markdown.ts
+++ b/packages/report/src/output/markdown.ts
@@ -5,7 +5,7 @@ import type { AuditReport } from "../types";
 import { cacheReasonsLabel, cacheStatsSummaryLine } from "../cache-stats";
 import { getScoreGrade } from "../scoring";
 import { REPORT_SOURCE_PAGES_PREVIEW, REPORT_PAGES_HARD_CAP } from "../constants";
-import { groupIssuesByCategory, groupCategoriesByGroup } from "../grouping";
+import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { groupTechnologies, techChangeSummary, techIconUrl } from "../technologies";
 import { SITE_PROFILE_NOTE, siteProfileFlags, siteProfileRows } from "../site-metadata";
 import { EDITOR_SUMMARY_NOTE } from "../editor-summary";
@@ -240,167 +240,166 @@ export function renderMarkdown(report: AuditReport, options?: MarkdownRenderOpti
     lines.push("## Issues");
     lines.push("");
 
-    // Group → category → rules (#626): categories nest under their group heading.
-    for (const group of groupCategoriesByGroup(categoryIssues)) {
-      lines.push(`### ${group.name}`);
+    // Severity → category → weight (#1536): one global order under severity
+    // headings, so the whole "fix these first" block is contiguous. A category
+    // can appear under more than one severity, which is the point.
+    const flatIssues = flattenIssuesBySeverity(categoryIssues);
+    const subBase = 5;
+    let lastSeverity: string | undefined;
+    let lastCategory: string | undefined;
+    let lastSub: string | undefined;
+    for (const rule of flatIssues) {
+      if (rule.severity !== lastSeverity) {
+        lastSeverity = rule.severity;
+        lastCategory = undefined;
+        const bucket = flatIssues.filter((r) => r.severity === rule.severity);
+        lines.push(`### ${severityLabel(rule.severity, { titleCase: true, plural: true })}`);
+        lines.push("");
+        lines.push(`*${bucket.length} rule(s)*`);
+        lines.push("");
+      }
+      if (rule.categoryCode !== lastCategory) {
+        lastCategory = rule.categoryCode;
+        lastSub = undefined;
+        lines.push(`#### ${rule.categoryName}`);
+        lines.push("");
+      }
+      const hasSub = Boolean(rule.subcategory);
+      if (rule.subcategory && rule.subcategory !== lastSub) {
+        lastSub = rule.subcategory;
+        lines.push(`${"#".repeat(subBase)} ${getSubcategoryName(rule.subcategory)}`);
+        lines.push("");
+      }
+      const severityBadge =
+        rule.severity === "error"
+          ? "**[ERROR]**"
+          : rule.severity === "warning"
+            ? "**[WARN]**"
+            : `*[${severityLabel(rule.severity, { titleCase: true })}]*`;
+      // Demote one level under a sub-header so the hierarchy stays valid.
+      const ruleHeading = "#".repeat(hasSub ? subBase + 1 : subBase);
+      lines.push(`${ruleHeading} ${rule.name} ${severityBadge}`);
       lines.push("");
-      lines.push(`*${group.failCount} error(s), ${group.warnCount} warning(s)*`);
+      lines.push(`\`${rule.id}\``);
       lines.push("");
 
-      // Single-category group (#626): skip the redundant category heading and
-      // promote deeper headings up one level so md heading order stays valid.
-      const single = group.categories.length === 1;
-      const subBase = single ? 4 : 5;
-      for (const category of group.categories) {
-        if (!single) {
-          lines.push(`#### ${category.name}`);
+      if (rule.description) {
+        lines.push(`> ${rule.description}`);
+        lines.push("");
+      }
+
+      if (rule.solution) {
+        lines.push("**Solution:**");
+        lines.push("");
+        lines.push(rule.solution);
+        lines.push("");
+      }
+
+      // #1135: carried-forward rollup + the "clean on every page checked
+      // this run, only carried pages still red" note.
+      const carriedRollup = ruleCarriedRollupLine(
+        ruleCarriedPageCount(rule.checks),
+        ruleAffectedPageCount(rule.checks),
+      );
+      if (carriedRollup) {
+        lines.push(`_${carriedRollup}_`);
+        lines.push("");
+      }
+      if (rule.mixedProvenanceNote) {
+        lines.push(`_${rule.mixedProvenanceNote}_`);
+        lines.push("");
+      }
+
+      lines.push("| Check | Status | Message |");
+      lines.push("|-------|--------|---------|");
+      for (const check of rule.checks) {
+        const statusIcon = check.status === "fail" ? "X" : "!";
+        const escapedMessage = escapeMarkdownTableCell(check.message + carriedTag(check));
+        lines.push(`| ${check.name} | ${statusIcon} ${check.status} | ${escapedMessage} |`);
+      }
+      lines.push("");
+
+      for (const check of rule.checks) {
+        // #1136 review round 3: a site-scope check (blocked-links,
+        // duplicate-title, sitemap-*) stores its affected pages ONLY on
+        // check.items[].sourcePages, not check.pages — reading check.pages
+        // alone left the per-rule rollup above (which DOES use the union)
+        // and this per-check list disagreeing: the rollup would say "N of
+        // M pages carried" while this block listed zero pages. Uses the
+        // SAME checkAffectedPages union html.tsx's PagesList uses.
+        // #1023 R-F: count is the AUTHORITATIVE affected-page total (from the
+        // shared accessor), the listed pages are a labeled example subset.
+        const ap = affectedPages(check);
+        if (ap.sample.length > 0) {
+          const materialized =
+            ap.sample.length > REPORT_PAGES_HARD_CAP
+              ? ap.sample.slice(0, REPORT_PAGES_HARD_CAP)
+              : ap.sample;
+          lines.push(
+            `<details><summary><strong>${check.name}:</strong> ${ap.count} page(s) affected</summary>`,
+          );
           lines.push("");
-          lines.push(`*${category.failCount} error(s), ${category.warnCount} warning(s)*`);
+          if (ap.count > materialized.length) {
+            lines.push(
+              `_Showing ${materialized.length} examples of ${ap.count} affected pages._`,
+            );
+            lines.push("");
+          }
+          // #1135: per-URL provenance — carriedPages is the exact subset
+          // (stamped per check before merging), not inferred from a ratio.
+          const carriedPageSet =
+            check.carriedPages && check.carriedPages.length > 0
+              ? new Set(check.carriedPages)
+              : undefined;
+          for (const page of materialized) {
+            const carried = carriedPageSet?.has(page) ? " (carried)" : "";
+            lines.push(`- [${getPathname(page) || "/"}](${page})${carried}`);
+          }
+          lines.push("");
+          lines.push("</details>");
           lines.push("");
         }
 
-        const hasSub = category.rules.some((r) => r.subcategory);
-        let lastSub: string | undefined;
-        for (const rule of category.rules) {
-          if (hasSub && rule.subcategory !== lastSub) {
-            lastSub = rule.subcategory;
-            if (rule.subcategory) {
-              lines.push(`${"#".repeat(subBase)} ${getSubcategoryName(rule.subcategory)}`);
-              lines.push("");
-            }
-          }
-          const severityBadge =
-            rule.severity === "error"
-              ? "**[ERROR]**"
-              : rule.severity === "warning"
-                ? "**[WARN]**"
-                : `*[${severityLabel(rule.severity, { titleCase: true })}]*`;
-          // Demote one level under a sub-header so the hierarchy stays valid.
-          const ruleHeading = "#".repeat(hasSub ? subBase + 1 : subBase);
-          lines.push(`${ruleHeading} ${rule.name} ${severityBadge}`);
-          lines.push("");
-          lines.push(`\`${rule.id}\``);
-          lines.push("");
-
-          if (rule.description) {
-            lines.push(`> ${rule.description}`);
-            lines.push("");
-          }
-
-          if (rule.solution) {
-            lines.push("**Solution:**");
-            lines.push("");
-            lines.push(rule.solution);
-            lines.push("");
-          }
-
-          // #1135: carried-forward rollup + the "clean on every page checked
-          // this run, only carried pages still red" note.
-          const carriedRollup = ruleCarriedRollupLine(
-            ruleCarriedPageCount(rule.checks),
-            ruleAffectedPageCount(rule.checks),
+        // Items already covered by the unified page list above (a pure
+        // page-URL id with no sourcePages) are dropped here so the same
+        // URL isn't listed twice; items with sourcePages or a non-URL id
+        // (a resource's own identity) keep their row.
+        const visibleItems = check.items?.filter((item) => !isRedundantPageItem(item));
+        if (visibleItems && visibleItems.length > 0) {
+          lines.push(
+            `<details><summary><strong>${check.name}:</strong> ${visibleItems.length} item(s)</summary>`,
           );
-          if (carriedRollup) {
-            lines.push(`_${carriedRollup}_`);
-            lines.push("");
-          }
-          if (rule.mixedProvenanceNote) {
-            lines.push(`_${rule.mixedProvenanceNote}_`);
-            lines.push("");
-          }
-
-          lines.push("| Check | Status | Message |");
-          lines.push("|-------|--------|---------|");
-          for (const check of rule.checks) {
-            const statusIcon = check.status === "fail" ? "X" : "!";
-            const escapedMessage = escapeMarkdownTableCell(check.message + carriedTag(check));
-            lines.push(`| ${check.name} | ${statusIcon} ${check.status} | ${escapedMessage} |`);
+          lines.push("");
+          for (const item of visibleItems) {
+            const label = item.label ?? item.id;
+            const isUrl =
+              item.id.startsWith("http://") ||
+              item.id.startsWith("https://") ||
+              item.id.startsWith("/");
+            const display = isUrl ? `[${label}](${item.id})` : label;
+            lines.push(`- ${display}`);
+            if (item.sourcePages && item.sourcePages.length > 0) {
+              for (const src of item.sourcePages.slice(0, REPORT_SOURCE_PAGES_PREVIEW)) {
+                lines.push(`  - from: [${getPathname(src) || "/"}](${src})`);
+              }
+              if (item.sourcePages.length > REPORT_SOURCE_PAGES_PREVIEW) {
+                // The capped preview here is just for per-item context —
+                // the full, interactive list is the unified page block
+                // above, which already covers this item's sourcePages.
+                lines.push(
+                  `  - +${item.sourcePages.length - REPORT_SOURCE_PAGES_PREVIEW} more (see full list above)`,
+                );
+              }
+            }
           }
           lines.push("");
-
-          for (const check of rule.checks) {
-            // #1136 review round 3: a site-scope check (blocked-links,
-            // duplicate-title, sitemap-*) stores its affected pages ONLY on
-            // check.items[].sourcePages, not check.pages — reading check.pages
-            // alone left the per-rule rollup above (which DOES use the union)
-            // and this per-check list disagreeing: the rollup would say "N of
-            // M pages carried" while this block listed zero pages. Uses the
-            // SAME checkAffectedPages union html.tsx's PagesList uses.
-            // #1023 R-F: count is the AUTHORITATIVE affected-page total (from the
-            // shared accessor), the listed pages are a labeled example subset.
-            const ap = affectedPages(check);
-            if (ap.sample.length > 0) {
-              const materialized =
-                ap.sample.length > REPORT_PAGES_HARD_CAP
-                  ? ap.sample.slice(0, REPORT_PAGES_HARD_CAP)
-                  : ap.sample;
-              lines.push(
-                `<details><summary><strong>${check.name}:</strong> ${ap.count} page(s) affected</summary>`,
-              );
-              lines.push("");
-              if (ap.count > materialized.length) {
-                lines.push(
-                  `_Showing ${materialized.length} examples of ${ap.count} affected pages._`,
-                );
-                lines.push("");
-              }
-              // #1135: per-URL provenance — carriedPages is the exact subset
-              // (stamped per check before merging), not inferred from a ratio.
-              const carriedPageSet =
-                check.carriedPages && check.carriedPages.length > 0
-                  ? new Set(check.carriedPages)
-                  : undefined;
-              for (const page of materialized) {
-                const carried = carriedPageSet?.has(page) ? " (carried)" : "";
-                lines.push(`- [${getPathname(page) || "/"}](${page})${carried}`);
-              }
-              lines.push("");
-              lines.push("</details>");
-              lines.push("");
-            }
-
-            // Items already covered by the unified page list above (a pure
-            // page-URL id with no sourcePages) are dropped here so the same
-            // URL isn't listed twice; items with sourcePages or a non-URL id
-            // (a resource's own identity) keep their row.
-            const visibleItems = check.items?.filter((item) => !isRedundantPageItem(item));
-            if (visibleItems && visibleItems.length > 0) {
-              lines.push(
-                `<details><summary><strong>${check.name}:</strong> ${visibleItems.length} item(s)</summary>`,
-              );
-              lines.push("");
-              for (const item of visibleItems) {
-                const label = item.label ?? item.id;
-                const isUrl =
-                  item.id.startsWith("http://") ||
-                  item.id.startsWith("https://") ||
-                  item.id.startsWith("/");
-                const display = isUrl ? `[${label}](${item.id})` : label;
-                lines.push(`- ${display}`);
-                if (item.sourcePages && item.sourcePages.length > 0) {
-                  for (const src of item.sourcePages.slice(0, REPORT_SOURCE_PAGES_PREVIEW)) {
-                    lines.push(`  - from: [${getPathname(src) || "/"}](${src})`);
-                  }
-                  if (item.sourcePages.length > REPORT_SOURCE_PAGES_PREVIEW) {
-                    // The capped preview here is just for per-item context —
-                    // the full, interactive list is the unified page block
-                    // above, which already covers this item's sourcePages.
-                    lines.push(
-                      `  - +${item.sourcePages.length - REPORT_SOURCE_PAGES_PREVIEW} more (see full list above)`,
-                    );
-                  }
-                }
-              }
-              lines.push("");
-              lines.push("</details>");
-              lines.push("");
-            }
-          }
-
-          lines.push("---");
+          lines.push("</details>");
           lines.push("");
         }
       }
+
+      lines.push("---");
+      lines.push("");
     }
   } else if (report.status !== "failed" && report.status !== "blocked") {
     // #792: only claim "No issues found" for a real completed audit. A 0-page

--- a/packages/report/src/output/text.ts
+++ b/packages/report/src/output/text.ts
@@ -5,7 +5,7 @@ import type { AuditReport } from "../types";
 import { cacheReasonsLabel, cacheStatsSummaryLine } from "../cache-stats";
 import { getScoreGrade } from "../scoring";
 import { REPORT_TEXT_WRAP_WIDTH } from "../constants";
-import { groupIssuesByCategory, groupCategoriesByGroup } from "../grouping";
+import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { affectedPages } from "../affected-pages";
 import { groupTechnologies, techChangeSummary } from "../technologies";
 import { SITE_PROFILE_NOTE, siteProfileFlags, siteProfileRows } from "../site-metadata";
@@ -206,73 +206,71 @@ export function renderText(report: AuditReport, options?: TextRenderOptions): st
   }
 
   const categoryIssues = groupIssuesByCategory(report.ruleResults);
-  // Group → category → rules (#626): issues nest under their top-level group.
-  const groupedIssues = groupCategoriesByGroup(categoryIssues);
+  // Severity → category → weight (#1536): one global order, so everything you
+  // must fix sits above everything you might. Categories are labeled per rule
+  // rather than used as headings, since a category now spans severity sections.
+  const flatIssues = flattenIssuesBySeverity(categoryIssues);
 
   if (categoryIssues.length > 0) {
     write("ISSUES");
     write("-".repeat(40));
     write("");
 
-    for (const group of groupedIssues) {
-      write(`=== ${group.name.toUpperCase()} ===`);
+    let lastSeverity: string | undefined;
+    let lastCategory: string | undefined;
+    let lastSub: string | undefined;
+    for (const rule of flatIssues) {
+      if (rule.severity !== lastSeverity) {
+        lastSeverity = rule.severity;
+        lastCategory = undefined;
+        write(`=== ${severityLabel(rule.severity, { plural: true }).toUpperCase()} ===`);
+        write("");
+      }
+      if (rule.categoryCode !== lastCategory) {
+        lastCategory = rule.categoryCode;
+        lastSub = undefined;
+        write(`[${rule.categoryName.toUpperCase()}]`);
+        write("");
+      }
+      if (rule.subcategory && rule.subcategory !== lastSub) {
+        lastSub = rule.subcategory;
+        write(`  ${getSubcategoryName(rule.subcategory)}`);
+        write("");
+      }
+      write(`  [${severityLabel(rule.severity)}] ${rule.id} - ${rule.name}`);
+      if (rule.description) write(`  Description: ${rule.description}`);
+      if (rule.solution) {
+        const wrapped = wrapText(rule.solution, REPORT_TEXT_WRAP_WIDTH);
+        write(`  Solution: ${wrapped[0]}`);
+        for (const line of wrapped.slice(1)) write(`            ${line}`);
+      }
       write("");
 
-      // Skip the category header when the group has a single category (#626):
-      // the group heading above already names it (avoids "=== PERF ===" / "[PERF]").
-      const showCatHeader = group.categories.length > 1;
-      for (const category of group.categories) {
-        if (showCatHeader) {
-          write(`[${category.name.toUpperCase()}]`);
-          write("");
+      for (const check of rule.checks) {
+        // #1023 R-F: authoritative page count (true pre-sample total) + the
+        // union sample (pages + item page-refs), labeled examples when clipped.
+        const { sample, count, hasMore } = affectedPages(check);
+        const countStr = count > 1 ? ` (${count} pages)` : "";
+        const icon = check.status === "fail" ? "X" : "!";
+        write(`    [${icon}] ${check.name}: ${check.message}${countStr}${carriedTag(check)}`);
+
+        if (sample.length > 0) {
+          for (const page of sample) write(`        -> ${pathOnly(page)}`);
+          if (hasMore) write(`        ... and ${count - sample.length} more`);
         }
 
-        const hasSub = category.rules.some((r) => r.subcategory);
-        let lastSub: string | undefined;
-        for (const rule of category.rules) {
-          if (hasSub && rule.subcategory !== lastSub) {
-            lastSub = rule.subcategory;
-            if (rule.subcategory) {
-              write(`  ${getSubcategoryName(rule.subcategory)}`);
-              write("");
+        if (check.items && check.items.length > 0) {
+          for (const item of check.items) {
+            const label = item.label ?? item.id;
+            write(`        -> ${label}`);
+            if (item.snippet) write(`           ${item.snippet}`);
+            if (item.sourcePages && item.sourcePages.length > 0) {
+              for (const src of item.sourcePages) write(`            from: ${pathOnly(src)}`);
             }
           }
-          write(`  [${severityLabel(rule.severity)}] ${rule.id} - ${rule.name}`);
-          if (rule.description) write(`  Description: ${rule.description}`);
-          if (rule.solution) {
-            const wrapped = wrapText(rule.solution, REPORT_TEXT_WRAP_WIDTH);
-            write(`  Solution: ${wrapped[0]}`);
-            for (const line of wrapped.slice(1)) write(`            ${line}`);
-          }
-          write("");
-
-          for (const check of rule.checks) {
-            // #1023 R-F: authoritative page count (true pre-sample total) + the
-            // union sample (pages + item page-refs), labeled examples when clipped.
-            const { sample, count, hasMore } = affectedPages(check);
-            const countStr = count > 1 ? ` (${count} pages)` : "";
-            const icon = check.status === "fail" ? "X" : "!";
-            write(`    [${icon}] ${check.name}: ${check.message}${countStr}${carriedTag(check)}`);
-
-            if (sample.length > 0) {
-              for (const page of sample) write(`        -> ${pathOnly(page)}`);
-              if (hasMore) write(`        ... and ${count - sample.length} more`);
-            }
-
-            if (check.items && check.items.length > 0) {
-              for (const item of check.items) {
-                const label = item.label ?? item.id;
-                write(`        -> ${label}`);
-                if (item.snippet) write(`           ${item.snippet}`);
-                if (item.sourcePages && item.sourcePages.length > 0) {
-                  for (const src of item.sourcePages) write(`            from: ${pathOnly(src)}`);
-                }
-              }
-            }
-          }
-          write("");
         }
       }
+      write("");
     }
   } else if (report.status !== "failed" && report.status !== "blocked") {
     // #792: don't claim "No issues found" for a 0-page failed/blocked run —

--- a/packages/report/src/output/xml.ts
+++ b/packages/report/src/output/xml.ts
@@ -4,7 +4,7 @@ import type { ReportBranding } from "@squirrelscan/core-contracts";
 import type { AuditReport } from "../types";
 import { getScoreGrade } from "../scoring";
 import { getGroupName } from "../categories";
-import { groupIssuesByCategory } from "../grouping";
+import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { affectedPages } from "../affected-pages";
 import { domainAgeYears } from "../site-metadata";
 
@@ -144,55 +144,53 @@ export function renderXml(report: AuditReport, options?: XmlRenderOptions): stri
 
   if (categoryIssues.length > 0) {
     lines.push(`${indent(1)}<issues>`);
-    for (const category of categoryIssues) {
-      lines.push(`${indent(2)}<category name="${escapeXml(category.name)}" group="${escapeXml(category.group)}" errors="${category.failCount}" warnings="${category.warnCount}">`);
-      for (const rule of category.rules) {
-        lines.push(`${indent(3)}<rule id="${escapeXml(rule.id)}" severity="${rule.severity}"${rule.subcategory ? ` subcategory="${escapeXml(rule.subcategory)}"` : ""}>`);
-        lines.push(`${indent(4)}<name>${escapeXml(rule.name)}</name>`);
-        lines.push(`${indent(4)}<description>${escapeXml(rule.description)}</description>`);
-        if (rule.solution) lines.push(`${indent(4)}<solution>${escapeXml(rule.solution)}</solution>`);
+    // Flat and severity-first (#1536): no <category> wrapper — each rule carries
+    // its category and group as attributes, so document order IS fix order.
+    for (const rule of flattenIssuesBySeverity(categoryIssues)) {
+      lines.push(`${indent(2)}<rule id="${escapeXml(rule.id)}" severity="${rule.severity}" category="${escapeXml(rule.categoryName)}" group="${escapeXml(rule.group)}"${rule.subcategory ? ` subcategory="${escapeXml(rule.subcategory)}"` : ""}>`);
+      lines.push(`${indent(3)}<name>${escapeXml(rule.name)}</name>`);
+      lines.push(`${indent(3)}<description>${escapeXml(rule.description)}</description>`);
+      if (rule.solution) lines.push(`${indent(3)}<solution>${escapeXml(rule.solution)}</solution>`);
 
-        for (const check of rule.checks) {
-          lines.push(`${indent(4)}<check name="${escapeXml(check.name)}" status="${check.status}">`);
-          lines.push(`${indent(5)}<message>${escapeXml(check.message)}</message>`);
+      for (const check of rule.checks) {
+        lines.push(`${indent(3)}<check name="${escapeXml(check.name)}" status="${check.status}">`);
+        lines.push(`${indent(4)}<message>${escapeXml(check.message)}</message>`);
 
-          // #1023 R-F: count is the authoritative total; the listed pages are a
-          // labeled sample (examples) when has-more.
-          const pages = affectedPages(check);
-          if (pages.sample.length > 0) {
-            lines.push(
-              `${indent(5)}<affected-pages count="${pages.count}" examples="${pages.sample.length}" has-more="${pages.hasMore}">`,
-            );
-            for (const page of pages.sample)
-              lines.push(`${indent(6)}<page url="${escapeXml(page)}"/>`);
-            lines.push(`${indent(5)}</affected-pages>`);
-          }
-
-          if (check.items && check.items.length > 0) {
-            lines.push(`${indent(5)}<items count="${check.items.length}">`);
-            for (const item of check.items) {
-              lines.push(`${indent(6)}<item id="${escapeXml(item.id)}">`);
-              if (item.label && item.label !== item.id) lines.push(`${indent(7)}<label>${escapeXml(item.label)}</label>`);
-              if (item.meta) {
-                for (const [k, v] of Object.entries(item.meta)) {
-                  if (v !== undefined && v !== null) lines.push(`${indent(7)}<${k}>${escapeXml(String(v))}</${k}>`);
-                }
-              }
-              if (item.sourcePages && item.sourcePages.length > 0) {
-                lines.push(`${indent(7)}<source-pages>`);
-                for (const src of item.sourcePages) lines.push(`${indent(8)}<page url="${escapeXml(src)}"/>`);
-                lines.push(`${indent(7)}</source-pages>`);
-              }
-              lines.push(`${indent(6)}</item>`);
-            }
-            lines.push(`${indent(5)}</items>`);
-          }
-
-          lines.push(`${indent(4)}</check>`);
+        // #1023 R-F: count is the authoritative total; the listed pages are a
+        // labeled sample (examples) when has-more.
+        const pages = affectedPages(check);
+        if (pages.sample.length > 0) {
+          lines.push(
+            `${indent(4)}<affected-pages count="${pages.count}" examples="${pages.sample.length}" has-more="${pages.hasMore}">`,
+          );
+          for (const page of pages.sample)
+            lines.push(`${indent(5)}<page url="${escapeXml(page)}"/>`);
+          lines.push(`${indent(4)}</affected-pages>`);
         }
-        lines.push(`${indent(3)}</rule>`);
+
+        if (check.items && check.items.length > 0) {
+          lines.push(`${indent(4)}<items count="${check.items.length}">`);
+          for (const item of check.items) {
+            lines.push(`${indent(5)}<item id="${escapeXml(item.id)}">`);
+            if (item.label && item.label !== item.id) lines.push(`${indent(6)}<label>${escapeXml(item.label)}</label>`);
+            if (item.meta) {
+              for (const [k, v] of Object.entries(item.meta)) {
+                if (v !== undefined && v !== null) lines.push(`${indent(6)}<${k}>${escapeXml(String(v))}</${k}>`);
+              }
+            }
+            if (item.sourcePages && item.sourcePages.length > 0) {
+              lines.push(`${indent(6)}<source-pages>`);
+              for (const src of item.sourcePages) lines.push(`${indent(7)}<page url="${escapeXml(src)}"/>`);
+              lines.push(`${indent(6)}</source-pages>`);
+            }
+            lines.push(`${indent(5)}</item>`);
+          }
+          lines.push(`${indent(4)}</items>`);
+        }
+
+        lines.push(`${indent(3)}</check>`);
       }
-      lines.push(`${indent(2)}</category>`);
+      lines.push(`${indent(2)}</rule>`);
     }
     lines.push(`${indent(1)}</issues>`);
   } else {

--- a/packages/report/tests/group-nesting.test.ts
+++ b/packages/report/tests/group-nesting.test.ts
@@ -157,10 +157,14 @@ describe("renderers surface groups (#626)", () => {
     expect(parsed.score.groups).toEqual([]);
   });
 
-  test("text: emits group headings above the category sections", () => {
+  test("text: emits severity headings above the category sections (#1536)", () => {
     const out = renderText(reportWithGroups());
-    expect(out).toContain("=== SEO ===");
-    expect(out).toContain("=== PERFORMANCE ===");
+    // #1536 replaced the group headings in the ISSUES body with severity ones;
+    // the group breakdown up in the score section is unaffected.
+    expect(out).toContain("=== ERRORS ===");
+    expect(out).toContain("=== WARNINGS ===");
+    expect(out).toContain("[CORE SEO]");
+    expect(out).toContain("[PERFORMANCE]");
     expect(out).toContain("Group Breakdown:");
     // Breakdown name derives from the group code, not the stored name.
     expect(out).toContain("Agents");
@@ -204,20 +208,24 @@ describe("renderers surface groups (#626)", () => {
 
 // Fixture: seo has 2 categories (core, links); performance/security/ai have 1
 // each — and perf/security display names literally equal their group name.
-describe("single-category groups collapse the redundant heading (#626)", () => {
-  test("text: keeps the group heading but drops the duplicate category line", () => {
+describe("severity headings replace the group headings (#1536)", () => {
+  test("text: severity sections, with every category labeled under them", () => {
     const out = renderText(reportWithGroups());
-    // Group headings present for both single- and multi-category groups.
-    expect(out).toContain("=== PERFORMANCE ===");
-    expect(out).toContain("=== SEO ===");
-    // Single-category groups: no redundant [PERFORMANCE]/[SECURITY] category line.
-    expect(out).not.toContain("[PERFORMANCE]");
-    expect(out).not.toContain("[SECURITY]");
-    // Multi-category seo keeps its category sub-headers.
+    // #1536: the ISSUES body is keyed on severity, so the group headings the
+    // category lines used to be redundant with are gone — every category now
+    // carries its own label, including the single-category ones.
+    expect(out).not.toContain("=== SEO ===");
+    expect(out).toContain("=== ERRORS ===");
+    expect(out).toContain("=== WARNINGS ===");
+    expect(out).toContain("[PERFORMANCE]");
+    expect(out).toContain("[SECURITY]");
     expect(out).toContain("[CORE SEO]");
     expect(out).toContain("[LINKS]");
-    // Only the 2 multi-category categories emit a header line.
-    expect((out.match(/^\[[A-Z]/gm) || []).length).toBe(2);
+    // One label per category (5 categories in this fixture, one rule each).
+    expect((out.match(/^\[[A-Z]/gm) || []).length).toBe(5);
+    // Errors lead: both failing rules sit above every warning.
+    expect(out.indexOf("core/x")).toBeLessThan(out.indexOf("=== WARNINGS ==="));
+    expect(out.indexOf("perf/x")).toBeLessThan(out.indexOf("=== WARNINGS ==="));
   });
 
   test("html: no group/category headings — every rule carries its parent group label", () => {
@@ -236,16 +244,19 @@ describe("single-category groups collapse the redundant heading (#626)", () => {
     }
   });
 
-  test("markdown: drops the #### category heading for single-category groups & keeps levels contiguous", () => {
+  test("markdown: severity (h3) → category (h4) → rule (h5), levels contiguous", () => {
     const md = renderMarkdown(reportWithGroups());
-    expect(md).toContain("### Performance"); // group heading (h3)
-    expect(md).not.toContain("#### Performance"); // no duplicate category heading
-    // Single-category group: rule promoted to h4 directly under the group (h3 → h4, no skip).
-    expect(md).toContain("#### perf/x");
-    // Multi-category seo keeps category headings (h4) with rules nested at h5.
+    expect(md).toContain("### Errors");
+    expect(md).toContain("### Warnings");
+    // Group headings are gone — "SEO" was one and has no category of that name.
+    expect(md).not.toMatch(/^### SEO$/m);
+    // Every category gets an h4 now, single-category groups included.
+    expect(md).toContain("#### Performance");
     expect(md).toContain("#### Core SEO");
     expect(md).toContain("#### Links");
     expect(md).toContain("##### core/x");
+    expect(md).toContain("##### perf/x");
+    expect(md.indexOf("##### perf/x")).toBeLessThan(md.indexOf("### Warnings"));
   });
 
   // A single-category group whose sole category has subcategories (blocking →
@@ -308,13 +319,13 @@ describe("single-category groups collapse the redundant heading (#626)", () => {
     ).toBe(2);
   });
 
-  test("markdown: single-category group with subcategories promotes levels (### group → #### sub → ##### rule)", () => {
+  test("markdown: subcategories nest under the category (### sev → #### cat → ##### sub → ###### rule)", () => {
     const md = renderMarkdown(reportBlockingOnly());
-    expect(md).toContain("### Security"); // group heading (h3)
-    expect(md).not.toContain("#### Blocking"); // collapsed category heading
-    // subBase = 4 for a single-category group: subcategory at h4, rule at h5 — contiguous.
-    expect(md).toContain("#### Ad blocking");
-    expect(md).toContain("##### blocking/tracker");
+    expect(md).toContain("### Errors"); // severity heading (h3), #1536
+    expect(md).toContain("#### Blocking"); // category heading (h4)
+    // Levels stay contiguous: subcategory at h5, rule demoted to h6 beneath it.
+    expect(md).toContain("##### Ad blocking");
+    expect(md).toContain("###### blocking/tracker");
   });
 
   test("html: rules from multiple categories share one group section and label", () => {

--- a/packages/report/tests/severity-first-order-1536.test.ts
+++ b/packages/report/tests/severity-first-order-1536.test.ts
@@ -1,0 +1,111 @@
+// #1536 — issues are ordered by SEVERITY across the whole report, not within
+// each category. Before this, severity was the innermost sort key, so a
+// renderer concatenating categories interleaved them: crawl's errors AND
+// warnings both landed above a11y's errors.
+
+import { describe, expect, test } from "bun:test";
+import type { AuditReport, ReportRuleResult } from "../src/types";
+
+import { groupIssuesByCategory, flattenIssuesBySeverity } from "../src/grouping";
+import { renderJson } from "../src/output/json";
+import { renderText } from "../src/output/text";
+import { renderHtml } from "../src/output/html";
+import { renderMarkdown } from "../src/output/markdown";
+import { renderXml } from "../src/output/xml";
+import { renderLlm } from "../src/output/llm";
+
+function rule(
+  id: string,
+  category: string,
+  severity: "error" | "warning" | "info",
+  checks: ReportRuleResult["checks"],
+): ReportRuleResult {
+  return {
+    meta: { id, name: id, description: "", category, scope: "page", severity, weight: 5 },
+    checks,
+  };
+}
+
+const fail = (msg: string) => ({ name: "c", status: "fail" as const, message: msg });
+const warn = (msg: string) => ({ name: "c", status: "warn" as const, message: msg });
+
+// Two categories that each carry an error AND a warning — the exact shape that
+// interleaved before #1536. `perf/warn` also fails a meta-severity "error" rule
+// with a warn-only check, i.e. an effective warning.
+function mixedSeverities(): Record<string, ReportRuleResult> {
+  return {
+    "core/err": rule("core/err", "core", "error", [fail("no title")]),
+    "core/warn": rule("core/warn", "core", "warning", [warn("short title")]),
+    "core/rec": rule("core/rec", "core", "info", [warn("consider a subtitle")]),
+    "perf/err": rule("perf/err", "perf", "error", [fail("slow LCP")]),
+    "perf/warn": rule("perf/warn", "perf", "error", [warn("chunky bundle")]),
+  };
+}
+
+function report(): AuditReport {
+  return {
+    baseUrl: "https://example.com",
+    timestamp: "2024-01-15T10:30:00.000Z",
+    totalPages: 5,
+    passed: 10,
+    warnings: 3,
+    failed: 2,
+    ruleResults: mixedSeverities(),
+  } as unknown as AuditReport;
+}
+
+describe("flattenIssuesBySeverity (#1536)", () => {
+  test("orders every issue by severity first, across categories", () => {
+    const flat = flattenIssuesBySeverity(groupIssuesByCategory(mixedSeverities()));
+    expect(flat.map((r) => r.severity)).toEqual([
+      "error",
+      "error",
+      "info",
+      "warning",
+      "warning",
+    ]);
+  });
+
+  test("groups a severity's issues by category rather than interleaving them", () => {
+    const flat = flattenIssuesBySeverity(groupIssuesByCategory(mixedSeverities()));
+    const errors = flat.filter((r) => r.severity === "error");
+    expect(errors.map((r) => r.id)).toEqual(["core/err", "perf/err"]);
+    // Category context survives the flattening — renderers label each rule with it.
+    expect(errors[0].categoryName).toBe("Core SEO");
+    expect(errors[0].group).toBe("seo");
+  });
+
+  test("a meta-severity error whose checks only warned sorts as a warning", () => {
+    const flat = flattenIssuesBySeverity(groupIssuesByCategory(mixedSeverities()));
+    const perfWarn = flat.find((r) => r.id === "perf/warn");
+    expect(perfWarn?.severity).toBe("warning");
+    expect(flat.indexOf(perfWarn!)).toBeGreaterThan(
+      flat.findIndex((r) => r.severity === "info"),
+    );
+  });
+});
+
+// Every renderer emits the SAME order. Asserted by index-of comparison rather
+// than an exact snapshot so the tests survive copy changes.
+describe("renderers emit one global severity order (#1536)", () => {
+  const cases: Array<[string, (r: AuditReport) => string]> = [
+    ["json", (r) => renderJson(r)],
+    ["text", (r) => renderText(r)],
+    ["html", (r) => renderHtml(r)],
+    ["markdown", (r) => renderMarkdown(r)],
+    ["xml", (r) => renderXml(r)],
+    ["llm", (r) => renderLlm(r)],
+  ];
+
+  for (const [name, render] of cases) {
+    test(`${name}: both errors precede the recommendation, which precedes both warnings`, () => {
+      const out = render(report());
+      const at = (id: string) => out.indexOf(id);
+      expect(at("core/err")).toBeGreaterThanOrEqual(0);
+      expect(at("perf/err")).toBeLessThan(at("core/rec"));
+      expect(at("core/err")).toBeLessThan(at("core/rec"));
+      expect(at("core/rec")).toBeLessThan(at("core/warn"));
+      expect(at("core/rec")).toBeLessThan(at("perf/warn"));
+    });
+  }
+});


### PR DESCRIPTION
Issues were ordered **group → category → severity → weight**, so severity was the *innermost* key. Renderers concatenate categories, so the flat issue list interleaved: crawl's errors *and* warnings both landed above a11y's errors.

New order is **severity → category priority → rule weight → rule id**, across the whole report. Errors, then recommendations, then warnings.

**Changes**
- `grouping.ts` — new `flattenIssuesBySeverity()`, the single ordering seam. `groupIssuesByCategory()` is unchanged for anyone who still wants the category tree.
- `json` — pure reorder; `issues[]` was already flat with `category`/`group` fields, so the shape is untouched.
- `html` — one flat list. Groups are no longer contiguous, so the `group-*` anchors the score circles link to are now stamped on each group's *first* rule in the new order (the jump lands on that group's most severe issue).
- `text` / `markdown` — section by severity, with the category as a sub-heading beneath it. A category with both an error and a warning now appears under both, which is the point.
- `xml` / `llm` — **breaking shape change**: rules are emitted directly under `<issues>` with `category=` and `group=` attributes; the `<category>` wrapper is gone.
- `severityLabel()` gains a `plural` option for the section headings.
- Docs: the xml/llm samples in `reports.mdx` and `configuration/output.mdx` matched neither the old nor the new output; both are now accurate, plus a new "Issue ordering" section.

**Tests**
- `severity-first-order-1536.test.ts` asserts the ordering at the helper level and that all six renderers agree, using index-of comparisons so copy changes don't break them.
- `group-nesting.test.ts` (#626) updated: the group-heading and single-category-collapse behaviors it covered are superseded by severity headings.