### PR TITLE
feat(rules): add content/thin-vs-site-norm, word-count outliers vs the site's own norm

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -240,7 +240,8 @@
                   "rules/content/article-links",
                   "rules/content/quality",
                   "rules/content/stale-copyright",
-                  "rules/content/mojibake"
+                  "rules/content/mojibake",
+                  "rules/content/thin-vs-site-norm"
                 ]
               },
               {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="267 Rules, 21 Categories"
+    title="268 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **267 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **268 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -226,7 +226,7 @@ squirrelscan runs **267 rules** across **21 categories**, plus opt-in cloud gap 
 | **Site Integrity** | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | **Security** | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | **Links** | 14 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, HTTPS downgrades |
-| **Content** | 15 | Text quality and honesty: duplicate titles and descriptions, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| **Content** | 16 | Text quality and honesty: duplicate titles and descriptions, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | **Performance** | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | **Structured Data** | 10 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search |

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -47,6 +47,9 @@ Text quality, readability, and content structure
   <Card title="Reading Level" icon="circle-info" href="/rules/content/reading-level">
     Analyzes content readability using Flesch-Kincaid
   </Card>
+  <Card title="Thin Content vs Site Norm" icon="triangle-exclamation" href="/rules/content/thin-vs-site-norm">
+    Finds pages far shorter than the site's own norm for their page type
+  </Card>
   <Card title="Word Count" icon="triangle-exclamation" href="/rules/content/word-count">
     Checks content length for thin content issues
   </Card>

--- a/docs/rules/content/thin-vs-site-norm.mdx
+++ b/docs/rules/content/thin-vs-site-norm.mdx
@@ -1,0 +1,72 @@
+---
+title: "Thin Content vs Site Norm"
+description: "Finds pages far shorter than the site's own norm for their page type"
+---
+
+Finds pages far shorter than the site's own norm for their page type
+
+| | |
+|---|---|
+| **Rule ID** | `content/thin-vs-site-norm` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 3/10 |
+
+## How it works
+
+There is no universal "enough words" number, so this rule never uses one. It groups
+the crawled pages by page type (article, product, category, docs, and so on),
+computes the median and MAD (median absolute deviation) of the word count within
+each group, and flags only the pages that sit far below their own group.
+
+A 200-word product page on a site whose products all run to 200 words is normal. A
+200-word article on a site whose articles median 1,800 words is not, and that is the
+only case this rule reports.
+
+It stays quiet unless it has grounds to speak:
+
+- Fewer than 10 crawled pages: no site norm exists, so the rule is skipped.
+- Fewer than 8 pages of a given page type: that type is dropped, not guessed at.
+- A page type whose word counts do not cluster (under 70% of its pages within 50%
+  of the median): the type is legitimately varied, so nothing in it is a deviant.
+- Pages under 300 words: those belong to [Word Count](/rules/content/word-count),
+  which stays absolute-only. The two rules never both flag the same page.
+
+A flagged page must be both under half its group's median and more than three
+robust deviations below it, so template-uniform pages with small natural variation
+are never reported.
+
+## Solution
+
+These pages are much shorter than the other pages of the same type on your own site,
+which is a stronger thin-content signal than any absolute word count: your articles
+set the expectation for what an article on this site looks like. Either expand each
+page to the depth its siblings have, consolidate it into a fuller page, or noindex it
+if it exists only for navigation. If a page is deliberately short (a stub, a redirect
+landing page), that is fine: the point is that it does not match what the rest of its
+page type promises.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/thin-vs-site-norm"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/thin-vs-site-norm"]
+disable = ["*"]
+```

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 267 audit rules organized by score group and category"
+description: "All 268 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **267 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **268 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -23,7 +23,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Internal and external link health and structure (14 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (15 rules)
+    Text quality, readability, and content structure (16 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (10 rules)

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -68,12 +68,14 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // 97711 -> 98211: content/hidden-text emits one page check across the 500
       // fixture pages that have a document, and passes on every one of them. The
       // overall score is unmoved.
-      expect(v1.findings.length).toBe(98211);
+      // 98211 -> 98212: content/thin-vs-site-norm is site-scoped, so it adds
+      // exactly ONE check for the whole crawl (#1362).
+      expect(v1.findings.length).toBe(98212);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
-      // content/hidden-text; anything else means a rule id leaked in, so fix
-      // that rather than this number.
-      expect(v1.perRuleTally.length).toBe(267);
+      // content/hidden-text, 267 -> 268 content/thin-vs-site-norm; anything else
+      // means a rule id leaked in, so fix that rather than this number.
+      expect(v1.perRuleTally.length).toBe(268);
     },
     180_000,
   );

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -17,6 +17,7 @@ import { mimeTypeRule } from "./mime-type";
 import { contentQualityRule } from "./quality";
 import { readingLevelRule } from "./reading-level";
 import { staleCopyrightRule } from "./stale-copyright";
+import { thinVsSiteNormRule } from "./thin-vs-site-norm";
 import { wordCountRule } from "./word-count";
 
 export const rules: Rule[] = [
@@ -36,6 +37,7 @@ export const rules: Rule[] = [
   mimeTypeRule,
   mojibakeRule,
   staleCopyrightRule,
+  thinVsSiteNormRule,
 ];
 
 export {
@@ -54,5 +56,6 @@ export {
   mojibakeRule,
   readingLevelRule,
   staleCopyrightRule,
+  thinVsSiteNormRule,
   wordCountRule,
 };

--- a/packages/rules/src/content/thin-vs-site-norm.ts
+++ b/packages/rules/src/content/thin-vs-site-norm.ts
@@ -271,6 +271,13 @@ function buildChecks(rollup: ThinRollup, sitePageCount: number): CheckResult[] {
  * Streaming path (#1362): read (pageType, wordCount) off the page_features cursor
  * in normalized_url order (== the legacy `site.pages` order). Only the per-group
  * word-count arrays stay resident; no parsed page is held.
+ *
+ * The site floor is judged on `pageCount()`, which counts page_features rows; the
+ * legacy universe additionally carries the error pages v1 appends to `site.pages`.
+ * Only a crawl sitting exactly on the floor with non-auditable pages can word the
+ * skip differently, and neither path can judge such a crawl anyway. That is a
+ * property of this seam shared with every site rule on it (see
+ * content/duplicate-title), not something specific to this rule.
  */
 async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
   const rollup = emptyRollup();

--- a/packages/rules/src/content/thin-vs-site-norm.ts
+++ b/packages/rules/src/content/thin-vs-site-norm.ts
@@ -1,0 +1,326 @@
+// content/thin-vs-site-norm - word-count outliers judged against the site's own norm (#1362)
+//
+// Absolute word-count thresholds are wrong on most sites: a 200-word product page
+// is fine, a 200-word article on a site whose articles median 1800 is not. So this
+// rule never compares against a fixed number. It groups pages by `pageType`,
+// computes the median + MAD (median absolute deviation) of `wordCount` per group,
+// and flags only the low outliers of a group.
+//
+// Guards, in the order they matter:
+//   1. Site floor (THIN_NORM_MIN_PAGES) - a small crawl has no norm to speak of.
+//   2. Group floor (THIN_NORM_MIN_GROUP_PAGES) - a page type with 3 pages cannot
+//      support a distribution; the group is dropped, not guessed at.
+//   3. Modal agreement (THIN_NORM_MIN_AGREEMENT) - a group whose pages do not
+//      cluster around their own median is legitimately heterogeneous, and nothing
+//      in it is a "deviant". Skipping beats accusing a healthy site.
+//   4. A robust-z floor AND a relative floor must BOTH be crossed, so a tight
+//      distribution (template-uniform pages, MAD ~ 0) cannot make an ordinary
+//      sibling look like an outlier.
+//
+// Precedence over content/word-count (#1362): word-count stays absolute-only and
+// owns every page under its `min_words` default; this rule DEFERS to it and never
+// considers a page below {@link WORD_COUNT_MIN_WORDS}. Above that floor word-count
+// only ever emits pass/info, so the two never both raise a finding on one page.
+//
+// Dual path: `ctx.siteQuery` streams (pageType, wordCount) straight off
+// page_features; the legacy path reads the same two fields from `ctx.site.pages`.
+// Both feed ONE accumulator and ONE check builder, so the output is byte-identical
+// by construction (same shape as content/duplicate-title, #1021/#1022).
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+import type { CheckItem, SiteQuery } from "@squirrelscan/core-contracts";
+
+import { WORD_COUNT_MIN_WORDS } from "./word-count";
+
+/** Crawl-wide page floor: below this there is no site norm to judge against. */
+export const THIN_NORM_MIN_PAGES = 10;
+
+/** Per-`pageType` sample floor. A group under this is dropped, never guessed at. */
+export const THIN_NORM_MIN_GROUP_PAGES = 8;
+
+/**
+ * Share of a group that must sit inside {@link THIN_NORM_BAND} of its median before
+ * the median is treated as that group's norm. Below this the group is genuinely
+ * varied and no member is a deviant.
+ */
+export const THIN_NORM_MIN_AGREEMENT = 0.7;
+
+/** Half-width of the "inside the norm" band, as a share of the group median. */
+export const THIN_NORM_BAND = 0.5;
+
+/**
+ * A flagged page must be under this share of its group median. Paired with the
+ * robust-z test so neither a tight nor a wide distribution can fire on its own.
+ */
+export const THIN_NORM_MAX_RATIO = 0.5;
+
+/** Robust z (deviations of 1.4826*MAD below the median) a flagged page must clear. */
+export const THIN_NORM_MIN_Z = 3;
+
+/**
+ * Floor on the robust sigma, as a share of the median. Template-uniform groups have
+ * MAD 0, which would otherwise make every sub-median page infinitely deviant.
+ */
+export const THIN_NORM_SIGMA_FLOOR = 0.1;
+
+/** Share of judged pages that turns the warning into a failure. */
+export const THIN_NORM_FAIL_SHARE = 0.2;
+
+/** Caps on reported items / groups, so one rule cannot bloat a report. */
+const THIN_NORM_MAX_ITEMS = 10;
+const THIN_NORM_MAX_GROUPS = 10;
+
+const CHECK_NAME = "thin-vs-site-norm";
+
+/** MAD -> standard-deviation scaling for a normal distribution. */
+const MAD_TO_SIGMA = 1.4826;
+
+/** One page's contribution, from either path. */
+interface ThinPageRecord {
+  url: string;
+  status: number;
+  pageType: string | null;
+  wordCount: number | null;
+}
+
+interface ThinGroup {
+  pageType: string;
+  urls: string[];
+  wordCounts: number[];
+}
+
+interface ThinRollup {
+  /** Pages seen by the rule (both paths count the same universe). */
+  pageCount: number;
+  /** Pages that carry a usable (pageType, wordCount) pair. */
+  sampleCount: number;
+  groups: Map<string, ThinGroup>;
+}
+
+interface ThinOutlier {
+  url: string;
+  pageType: string;
+  wordCount: number;
+  median: number;
+  ratio: number;
+}
+
+interface JudgedGroup {
+  pageType: string;
+  pages: number;
+  median: number;
+  mad: number;
+}
+
+function emptyRollup(): ThinRollup {
+  return { pageCount: 0, sampleCount: 0, groups: new Map() };
+}
+
+/**
+ * Fold one page in. Untyped ("unknown") pages are excluded deliberately: that
+ * bucket is a grab-bag of everything the classifier could not place, so its
+ * distribution means nothing.
+ */
+function accumulatePage(rollup: ThinRollup, record: ThinPageRecord): void {
+  rollup.pageCount += 1;
+
+  if (record.status < 200 || record.status >= 300) return;
+  if (record.wordCount === null || record.wordCount < 0) return;
+  const pageType = record.pageType?.trim().toLowerCase();
+  if (!pageType || pageType === "unknown") return;
+
+  rollup.sampleCount += 1;
+  let group = rollup.groups.get(pageType);
+  if (!group) {
+    group = { pageType, urls: [], wordCounts: [] };
+    rollup.groups.set(pageType, group);
+  }
+  group.urls.push(record.url);
+  group.wordCounts.push(record.wordCount);
+}
+
+/** Median of a non-empty list (does not mutate the input). */
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 1 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+function skip(message: string): CheckResult {
+  return { name: CHECK_NAME, status: "skipped", message };
+}
+
+/**
+ * The rule's full output for one rollup. ONE builder, both paths.
+ *
+ * `sitePageCount` is the crawl-wide page count: the streaming path takes it from
+ * `siteQuery.pageCount()` (which includes rows this rule cannot sample), so the
+ * site floor is judged on the crawl, not on the sampled subset.
+ */
+function buildChecks(rollup: ThinRollup, sitePageCount: number): CheckResult[] {
+  if (sitePageCount < THIN_NORM_MIN_PAGES) {
+    return [
+      skip(
+        `Only ${sitePageCount} page(s) crawled; ${THIN_NORM_MIN_PAGES} needed to establish a site norm`
+      ),
+    ];
+  }
+
+  const judged: JudgedGroup[] = [];
+  const outliers: ThinOutlier[] = [];
+  let judgedPages = 0;
+
+  for (const group of rollup.groups.values()) {
+    if (group.wordCounts.length < THIN_NORM_MIN_GROUP_PAGES) continue;
+
+    const med = median(group.wordCounts);
+    // A group whose median is 0 has no content to compare against.
+    if (med <= 0) continue;
+
+    // Heterogeneous groups have no norm: say nothing rather than pick a side.
+    const inBand = group.wordCounts.filter(
+      (wc) => Math.abs(wc - med) <= THIN_NORM_BAND * med
+    ).length;
+    if (inBand / group.wordCounts.length < THIN_NORM_MIN_AGREEMENT) continue;
+
+    const mad = median(group.wordCounts.map((wc) => Math.abs(wc - med)));
+    const sigma = Math.max(MAD_TO_SIGMA * mad, THIN_NORM_SIGMA_FLOOR * med);
+    const zFloor = med - THIN_NORM_MIN_Z * sigma;
+
+    judged.push({ pageType: group.pageType, pages: group.wordCounts.length, median: med, mad });
+    judgedPages += group.wordCounts.length;
+
+    for (const [i, wordCount] of group.wordCounts.entries()) {
+      // content/word-count owns everything under its absolute floor.
+      if (wordCount < WORD_COUNT_MIN_WORDS) continue;
+      if (wordCount >= THIN_NORM_MAX_RATIO * med || wordCount >= zFloor) continue;
+      outliers.push({
+        url: group.urls[i]!,
+        pageType: group.pageType,
+        wordCount,
+        median: med,
+        ratio: wordCount / med,
+      });
+    }
+  }
+
+  if (judged.length === 0) {
+    return [
+      skip(
+        `No page type has ${THIN_NORM_MIN_GROUP_PAGES}+ comparable pages with a clear word-count norm`
+      ),
+    ];
+  }
+
+  judged.sort((a, b) => (a.pageType < b.pageType ? -1 : a.pageType > b.pageType ? 1 : 0));
+  const typeSummary = judged
+    .slice(0, THIN_NORM_MAX_GROUPS)
+    .map((g) => `${g.pageType} ${Math.round(g.median)}`)
+    .join(", ");
+  const details: Record<string, unknown> = {
+    judgedPages,
+    judgedTypes: judged.length,
+    flaggedPages: outliers.length,
+    norms: judged.slice(0, THIN_NORM_MAX_GROUPS).map((g) => ({
+      pageType: g.pageType,
+      pages: g.pages,
+      medianWords: g.median,
+      mad: g.mad,
+    })),
+  };
+
+  if (outliers.length === 0) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "pass",
+        message: `All ${judgedPages} comparable page(s) sit within their page type's word-count norm (median words: ${typeSummary})`,
+        value: judgedPages,
+        details,
+      },
+    ];
+  }
+
+  // Worst offenders first; url breaks ties so the list never depends on crawl order.
+  outliers.sort((a, b) => a.ratio - b.ratio || (a.url < b.url ? -1 : a.url > b.url ? 1 : 0));
+  const items: CheckItem[] = outliers.slice(0, THIN_NORM_MAX_ITEMS).map((o) => ({
+    id: o.url,
+    label: `${o.wordCount} words vs the ${o.pageType} norm of ${Math.round(o.median)} (${Math.round(o.ratio * 100)}%)`,
+    sourcePages: [o.url],
+    meta: {
+      pageType: o.pageType,
+      wordCount: o.wordCount,
+      medianWords: o.median,
+    },
+  }));
+
+  const share = outliers.length / judgedPages;
+  return [
+    {
+      name: CHECK_NAME,
+      status: share >= THIN_NORM_FAIL_SHARE ? "fail" : "warn",
+      message: `${outliers.length} of ${judgedPages} page(s) are far shorter than the norm for their page type (median words: ${typeSummary})`,
+      value: outliers.length,
+      items,
+      details,
+    },
+  ];
+}
+
+/**
+ * Streaming path (#1362): read (pageType, wordCount) off the page_features cursor
+ * in normalized_url order (== the legacy `site.pages` order). Only the per-group
+ * word-count arrays stay resident; no parsed page is held.
+ */
+async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
+  const rollup = emptyRollup();
+  for await (const row of siteQuery.pagesMatching(() => true)) {
+    accumulatePage(rollup, {
+      url: row.normalizedUrl,
+      status: row.status,
+      pageType: row.pageType,
+      wordCount: row.wordCount,
+    });
+  }
+
+  return { checks: buildChecks(rollup, siteQuery.pageCount()) };
+}
+
+export const thinVsSiteNormRule: Rule = {
+  meta: {
+    id: "content/thin-vs-site-norm",
+    name: "Thin Content vs Site Norm",
+    description: "Finds pages far shorter than the site's own norm for their page type",
+    solution:
+      "These pages are much shorter than the other pages of the same type on your own site, which is a stronger thin-content signal than any absolute word count: your articles set the expectation for what an article on this site looks like. Either expand each page to the depth its siblings have, consolidate it into a fuller page, or noindex it if it exists only for navigation. If a page is deliberately short (a stub, a redirect landing page), that is fine - the point is that it does not match what the rest of its page type promises.",
+    category: "content",
+    scope: "site",
+    severity: "warning",
+    // Deliberately light: one site-wide check, capped items, so a single rule
+    // cannot dominate the content category score.
+    weight: 3,
+  },
+
+  run(ctx: RuleContext): RuleResult | Promise<RuleResult> {
+    if (ctx.siteQuery) {
+      return runViaSiteQuery(ctx.siteQuery);
+    }
+
+    const pages = ctx.site?.pages;
+    if (!pages || pages.length === 0) {
+      return { checks: [skip("No pages available for analysis")] };
+    }
+
+    const rollup = emptyRollup();
+    for (const page of pages) {
+      accumulatePage(rollup, {
+        url: page.url,
+        status: page.statusCode,
+        pageType: page.parsed?.pageType ?? null,
+        wordCount: page.parsed?.content?.wordCount ?? null,
+      });
+    }
+
+    return { checks: buildChecks(rollup, rollup.pageCount) };
+  },
+};

--- a/packages/rules/src/content/word-count.ts
+++ b/packages/rules/src/content/word-count.ts
@@ -4,8 +4,15 @@ import { z } from "zod";
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
+/**
+ * Absolute thin-content floor. Also the precedence boundary with
+ * content/thin-vs-site-norm (#1362): this rule owns every page BELOW it, and the
+ * site-norm rule never considers one, so the two never both flag a page.
+ */
+export const WORD_COUNT_MIN_WORDS = 300;
+
 export const optionsSchema = z.object({
-  min_words: z.number().default(300).describe("Minimum word count"),
+  min_words: z.number().default(WORD_COUNT_MIN_WORDS).describe("Minimum word count"),
   warn_threshold: z
     .number()
     .default(500)

--- a/packages/rules/tests/thin-vs-site-norm.test.ts
+++ b/packages/rules/tests/thin-vs-site-norm.test.ts
@@ -1,0 +1,290 @@
+// content/thin-vs-site-norm — word-count outliers vs the site's own norm (#1362).
+//
+// The rule's whole value is what it does NOT say, so most of this file defends the
+// silence cases: a small crawl, a page type with too few samples, a heterogeneous
+// group, a site that is uniformly short, and a page already owned by
+// content/word-count. The positive cases pin the one thing it is for: a page far
+// below its OWN page type's median, on a site where that type has a clear norm.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult, PageFeatureRow, SiteQuery } from "@squirrelscan/core-contracts";
+
+import {
+  thinVsSiteNormRule,
+  THIN_NORM_MIN_GROUP_PAGES,
+  THIN_NORM_MIN_PAGES,
+} from "../src/content/thin-vs-site-norm";
+import { WORD_COUNT_MIN_WORDS } from "../src/content/word-count";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+interface PageSpec {
+  pageType: string | null;
+  wordCount: number | null;
+  status?: number;
+}
+
+function url(i: number): string {
+  return `https://example.com/p${String(i).padStart(3, "0")}`;
+}
+
+/** N pages of one type, all at the same word count. */
+function uniform(pageType: string, wordCount: number, count: number): PageSpec[] {
+  return Array.from({ length: count }, () => ({ pageType, wordCount }));
+}
+
+const baseCtx = {
+  page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+  parsed: {} as ParsedPage,
+  options: {},
+};
+
+/** Legacy path: specs become `ctx.site.pages` in crawl (url ascending) order. */
+function legacyCtx(specs: PageSpec[]): RuleContext {
+  return {
+    ...baseCtx,
+    site: {
+      baseUrl: "https://example.com/",
+      pages: specs.map((spec, i) => ({
+        url: url(i),
+        statusCode: spec.status ?? 200,
+        parsed: {
+          pageType: spec.pageType,
+          content: { wordCount: spec.wordCount },
+        } as unknown as ParsedPage,
+      })),
+      robotsTxt: null,
+      sitemaps: null,
+    },
+  };
+}
+
+function featureRow(spec: PageSpec, i: number): PageFeatureRow {
+  return {
+    normalizedUrl: url(i),
+    status: spec.status ?? 200,
+    depth: 1,
+    title: null,
+    titleHash: null,
+    description: null,
+    descHash: null,
+    contentHash: null,
+    wordCount: spec.wordCount,
+    pageType: spec.pageType,
+    schemaTypes: [],
+    robotsNoindex: false,
+    canonical: null,
+    visibleAuthor: false,
+    visibleDate: false,
+    transferBytes: null,
+    templateFp: null,
+    secretHits: null,
+    metaNoindex: false,
+    indexableReasons: [],
+    richResultTypes: [],
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
+  };
+}
+
+/**
+ * Streaming path: the rule only ever calls `pagesMatching` + `pageCount`, so the
+ * rest of the SiteQuery surface throws — a stub that silently returned empties
+ * could hide the rule reading something it must not.
+ */
+function siteQueryCtx(specs: PageSpec[]): RuleContext {
+  const rows = specs.map(featureRow);
+  const unused = (): never => {
+    throw new Error("thin-vs-site-norm must not use this SiteQuery method");
+  };
+  const siteQuery: SiteQuery = {
+    pageCount: () => rows.length,
+    duplicateGroups: unused,
+    incomingLinkCounts: unused,
+    pagesByType: unused,
+    templateClusters: unused,
+    sumTransferBytes: unused,
+    sumSecretHits: unused,
+    homepage: unused,
+    async *pagesMatching(pred: (row: PageFeatureRow) => boolean) {
+      for (const row of rows) if (pred(row)) yield row;
+    },
+  };
+  return {
+    ...baseCtx,
+    // EMPTY pages — the streaming path must not read them.
+    site: { baseUrl: "https://example.com/", pages: [], robotsTxt: null, sitemaps: null },
+    siteQuery,
+  };
+}
+
+async function checks(ctx: RuleContext): Promise<CheckResult[]> {
+  return (await Promise.resolve(thinVsSiteNormRule.run(ctx))).checks;
+}
+
+/** Run BOTH paths over one fixture, assert byte-identical output, return it. */
+async function bothPaths(specs: PageSpec[]): Promise<CheckResult> {
+  const legacy = await checks(legacyCtx(specs));
+  const streamed = await checks(siteQueryCtx(specs));
+  expect(streamed).toEqual(legacy);
+  expect(JSON.stringify(streamed)).toBe(JSON.stringify(legacy));
+  expect(legacy).toHaveLength(1);
+  return legacy[0]!;
+}
+
+describe("content/thin-vs-site-norm — silence guards", () => {
+  test("skips a crawl below the site page floor", async () => {
+    const check = await bothPaths(uniform("article", 1800, THIN_NORM_MIN_PAGES - 1));
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${THIN_NORM_MIN_PAGES} needed`);
+  });
+
+  test("skips when no page type has enough comparable pages", async () => {
+    // 12 pages, but spread thin: every type is under the group floor.
+    const specs = [
+      ...uniform("article", 1800, 4),
+      ...uniform("product", 200, 4),
+      ...uniform("about", 400, 4),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${THIN_NORM_MIN_GROUP_PAGES}+ comparable pages`);
+  });
+
+  test("skips a heterogeneous group — no modal norm to deviate from", async () => {
+    // Word counts scattered across an order of magnitude: fewer than 70% of the
+    // group sits within ±50% of the median, so the median is not a norm.
+    const scattered = [300, 400, 900, 1500, 2600, 4000, 6000, 9000, 12000, 16000];
+    const specs = scattered.map((wordCount) => ({ pageType: "article", wordCount }));
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+  });
+
+  test("untyped pages never form a group", async () => {
+    const specs = [
+      ...uniform("article", 1800, 10),
+      ...Array.from({ length: 4 }, () => ({ pageType: "unknown", wordCount: 40 })),
+      ...Array.from({ length: 4 }, () => ({ pageType: null, wordCount: 40 })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(10);
+  });
+
+  test("non-2xx pages are excluded from the distribution", async () => {
+    const specs = [
+      ...uniform("article", 1800, 10),
+      ...Array.from({ length: 5 }, () => ({ pageType: "article", wordCount: 12, status: 404 })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(10);
+  });
+});
+
+describe("content/thin-vs-site-norm — the no-false-positive fixtures", () => {
+  test("a site of uniformly short pages stays clean because the norm is short", async () => {
+    // Every page is 120 words. An absolute rule screams; the norm IS 120.
+    const check = await bothPaths(uniform("product", 120, 20));
+    expect(check.status).toBe("pass");
+  });
+
+  test("template-uniform siblings sit inside the norm", async () => {
+    // Same template, small natural jitter — nothing here is an outlier.
+    const jitter = [980, 1000, 1010, 1020, 995, 1005, 1030, 970, 1000, 1015, 990, 1008];
+    const check = await bothPaths(jitter.map((wordCount) => ({ pageType: "product", wordCount })));
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("within their page type's word-count norm");
+  });
+
+  test("a short page type is judged against itself, not against the long one", async () => {
+    // 200-word products are the product norm; 200-word articles are not the
+    // article norm. Only the article is flagged.
+    const specs = [
+      ...uniform("product", 200, 10),
+      ...uniform("article", 1800, 10),
+      { pageType: "article", wordCount: 320 },
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0]?.meta?.pageType).toBe("article");
+    expect(check.items?.[0]?.meta?.wordCount).toBe(320);
+  });
+
+  test("defers to content/word-count below its absolute floor", async () => {
+    // 200 words in an 1800-word article group IS an outlier by distribution, but
+    // content/word-count already owns every page under its min_words, so this
+    // rule stays silent about it and the two never both flag one page.
+    const specs = [
+      ...uniform("article", 1800, 10),
+      { pageType: "article", wordCount: WORD_COUNT_MIN_WORDS - 1 },
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+});
+
+describe("content/thin-vs-site-norm — findings", () => {
+  test("warns on a sparse handful of outliers", async () => {
+    const specs = [
+      ...uniform("article", 1800, 20),
+      { pageType: "article", wordCount: 400 },
+      { pageType: "article", wordCount: 350 },
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(check.value).toBe(2);
+    expect(check.items).toHaveLength(2);
+    // Worst offender first.
+    expect(check.items?.[0]?.meta?.wordCount).toBe(350);
+    expect(check.details?.flaggedPages).toBe(2);
+  });
+
+  test("fails once a fifth of the judged pages are outliers", async () => {
+    const specs = [
+      ...uniform("article", 1800, 10),
+      ...uniform("article", 400, 4),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("fail");
+    expect(check.value).toBe(4);
+  });
+
+  test("caps the reported items", async () => {
+    const specs = [
+      ...uniform("article", 1800, 40),
+      ...uniform("article", 400, 12),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("fail");
+    expect(check.items?.length).toBe(10);
+    expect(check.details?.flaggedPages).toBe(12);
+  });
+
+  test("dual paths agree on a mixed fixture regardless of crawl-order ties", async () => {
+    const specs = [
+      ...uniform("article", 1500, 12),
+      ...uniform("product", 240, 12),
+      { pageType: "article", wordCount: 380 },
+      { pageType: "product", wordCount: 310 },
+    ];
+    const check = await bothPaths(specs);
+    // The 310-word product is ABOVE its own type's 240 norm: only the article fires.
+    expect(check.status).toBe("warn");
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0]?.meta?.pageType).toBe("article");
+  });
+});
+
+describe("content/thin-vs-site-norm — empty crawl", () => {
+  test("legacy path with no pages skips", async () => {
+    const result = await checks(legacyCtx([]));
+    expect(result[0]?.status).toBe("skipped");
+  });
+});


### PR DESCRIPTION
Adds `content/thin-vs-site-norm`: a site-wide rule that flags thin pages by comparing each page against the site's own word-count distribution **within its page type**, instead of against an absolute threshold.

Tracked privately as squirrelscan/repo#1362 (part of the consistency/content rules wave).

## What it does

- Groups crawled pages by `pageType`, computes the **median + MAD** of `wordCount` per group, flags only low outliers of that group.
- Reads only `wordCount` and `pageType` off `PageFeatureRow`. **No storage schema change.**
- **Dual path**: legacy `ctx.site.pages` and streaming `SiteQuery` feed ONE accumulator and ONE check builder, so output is byte-identical by construction (same shape as `content/duplicate-title`, #1021/#1022). The canonical 518-page v1 vs v2 golden proves it end to end.

## Guards (silence beats accusing a healthy site)

| Guard | Value |
|---|---|
| Site page floor | 10 |
| Per-`pageType` group floor | 8 |
| Modal agreement within a group (pages within 50% of the median) | >=70% |
| Relative test | page < 50% of its group median |
| Robust-z test | page < median - 3 x 1.4826*MAD, with a sigma floor of 0.1 x median |

Both the relative and the robust-z test must be crossed, so a template-uniform group (MAD ~ 0) can never make an ordinary sibling look deviant.

## Precedence vs `content/word-count`

**`content/word-count` stays absolute-only and wins; this rule defers to it.** `thin-vs-site-norm` never considers a page under `WORD_COUNT_MIN_WORDS` (300, now exported from `word-count.ts` as the single source of that boundary). Above 300 `word-count` only ever emits pass/info, so the two never both raise a finding on one page.

## Scoring density

One site-wide check, items capped at 10, weight 3 (vs 6 for the duplicate-* site rules). It contributes a single warn/fail unit to the content category no matter how many pages deviate.

## Smoke: https://sweetdeals.com.au

`squirrel audit https://sweetdeals.com.au --max-pages 200` (200 pages scanned, published report score 52).

**Findings from the new rule: 0.** Status `pass`. The site is 3-4 templates over thousands of pages, which is exactly the shape that breaks naive outlier rules:

```
product   n=198  median=399  MAD=16  min=282  max=736
category  n=1    (homepage)
about     n=1
```

- The 198 template-generated product pages cluster tightly (MAD 16 on a 399 median), so every one of them sits inside the norm. Nothing template-shaped is flagged.
- `category` and `about` have one page each: below the group floor, so they are dropped rather than judged off a sample of one.
- `content/word-count` separately (and correctly) warns on 27 product pages at 282-287 words, purely on its absolute 300 floor. The new rule is silent on all 27: the precedence rule holds on live data.

Because the product norm here is 399 words, half of it (200) is below word-count's 300 floor, so on this site the absolute rule owns the whole outlier space by construction. 0 findings is the correct output, not a rule that failed to run.

**Spot-check that it fires on a real outlier:** replaying the same 200-page corpus with every word count x4 (a site whose products read like buying guides, norm 1596) and three pages left at their real length flags exactly one page:

- `/p/8bitdo-ultimate-wireless-controller`: 355 words vs the product norm of 1596 (22%), warn.
- `/` (`category`) and `/about` (`about`) are NOT flagged: their groups have one page each and stay below the group floor.

## Tests

- `packages/rules/tests/thin-vs-site-norm.test.ts`: 14 cases covering pass / warn / fail / skipped, both paths asserted deep-equal AND `JSON.stringify`-equal on every fixture, plus the no-false-positive fixtures (uniformly short site, template jitter, short type judged against itself, deferral to word-count) and the silence guards (site floor, group floor, heterogeneous group, untyped pages, non-2xx pages).
- Golden pins updated: `findings` 98211 to 98212 (one site-scoped check), `perRuleTally` 267 to 268.
- Docs: new rule page + nav entry + rule-count literals (267 to 268, Content 15 to 16).

`bun test` green for `packages/rules` (1142), `packages/audit-engine` (269) and `apps/cli` (1706); `tsgo --noEmit` clean; `make validate` clean in `docs/`.
