### PR TITLE
chore(deps): clear the dependency-audit gate with same-major overrides

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -77,7 +77,7 @@ runtime dependency closure of `apps/cli`.
 | `gradient-string@3.0.0` | MIT | [source](https://github.com/bokub/gradient-string) |
 | `has-symbols@1.1.0` | MIT | [source](https://github.com/inspect-js/has-symbols) |
 | `hasown@2.0.4` | MIT | [source](https://github.com/inspect-js/hasOwn) |
-| `hono@4.12.31` | MIT | [source](https://github.com/honojs/hono) |
+| `hono@4.13.1` | MIT | [source](https://github.com/honojs/hono) |
 | `html-escaper@3.0.3` | MIT | [source](https://github.com/WebReflection/html-escaper) |
 | `htmlparser2@10.1.0` | MIT | [source](https://github.com/fb55/htmlparser2) |
 | `http-errors@2.0.1` | MIT | [source](https://github.com/jshttp/http-errors) |
@@ -996,7 +996,7 @@ Packages: `xml2js@0.6.2`
 
 ### LICENSE (2e0a854a1106)
 
-Packages: `hono@4.12.31`
+Packages: `hono@4.13.1`
 
     MIT License
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "apps/cli": {
       "name": "@squirrelscan/cli",
-      "version": "0.0.79",
+      "version": "0.0.84",
       "bin": {
         "squirrelscan": "./build/squirrelscan",
       },
@@ -263,8 +263,12 @@
     "@astrojs/vercel": "11.0.3",
     "@hono/node-server": "2.0.11",
     "astro": "7.1.3",
+    "dompurify": "3.4.13",
     "esbuild": "0.28.1",
     "fast-xml-parser": "5.10.1",
+    "hono": "4.13.1",
+    "js-yaml": "3.15.1",
+    "mermaid": "11.16.1",
     "sharp": "0.35.3",
   },
   "packages": {
@@ -1256,7 +1260,7 @@
 
     "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
 
-    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
@@ -1536,7 +1540,7 @@
 
     "domhandler": ["domhandler@6.0.1", "", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
 
-    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
 
     "domutils": ["domutils@4.0.2", "", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
 
@@ -1842,7 +1846,7 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
-    "hono": ["hono@4.12.31", "", {}, "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg=="],
+    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
@@ -1978,7 +1982,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -2128,7 +2132,7 @@
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
-    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
+    "mermaid": ["mermaid@11.16.1", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g=="],
 
     "microdiff": ["microdiff@1.5.0", "", {}, "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q=="],
 
@@ -2978,8 +2982,6 @@
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "gray-matter/js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
-
     "htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "htmlparser2/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
@@ -3049,8 +3051,6 @@
     "eslint-plugin-jsx-a11y/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "htmlparser2/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 

--- a/npm/THIRD_PARTY_NOTICES.md
+++ b/npm/THIRD_PARTY_NOTICES.md
@@ -77,7 +77,7 @@ runtime dependency closure of `apps/cli`.
 | `gradient-string@3.0.0` | MIT | [source](https://github.com/bokub/gradient-string) |
 | `has-symbols@1.1.0` | MIT | [source](https://github.com/inspect-js/has-symbols) |
 | `hasown@2.0.4` | MIT | [source](https://github.com/inspect-js/hasOwn) |
-| `hono@4.12.31` | MIT | [source](https://github.com/honojs/hono) |
+| `hono@4.13.1` | MIT | [source](https://github.com/honojs/hono) |
 | `html-escaper@3.0.3` | MIT | [source](https://github.com/WebReflection/html-escaper) |
 | `htmlparser2@10.1.0` | MIT | [source](https://github.com/fb55/htmlparser2) |
 | `http-errors@2.0.1` | MIT | [source](https://github.com/jshttp/http-errors) |
@@ -996,7 +996,7 @@ Packages: `xml2js@0.6.2`
 
 ### LICENSE (2e0a854a1106)
 
-Packages: `hono@4.12.31`
+Packages: `hono@4.13.1`
 
     MIT License
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:release": "bash scripts/test-changelog-extraction.sh && bun test scripts/release-version.test.ts",
     "docs:check": "cd docs && bun run check",
     "docs:build": "cd docs && bun run build",
-    "audit:dependencies": "bun audit --ignore=GHSA-9wv6-86v2-598j --ignore=GHSA-mh99-v99m-4gvg --ignore=GHSA-mwp4-54f8-5fhr --ignore=GHSA-4xrf-jv44-h6hh --ignore=GHSA-22jq-vg5j-6vgg --ignore=GHSA-rgw5-rvv9-x895 --ignore=GHSA-fxqj-rqcc-2cmp --ignore=GHSA-8xcm-r25x-g524 --ignore=GHSA-4cwx-7wf7-3272 --ignore=GHSA-m8rv-5g2x-5cg5 --ignore=GHSA-jr45-8vmc-qm54 --ignore=GHSA-v3r7-h72x-cjcm --ignore=GHSA-7p8r-x3mc-p8w7 --ignore=GHSA-8j4g-w8fx-2239",
+    "audit:dependencies": "bun audit --ignore=GHSA-9wv6-86v2-598j --ignore=GHSA-mh99-v99m-4gvg --ignore=GHSA-mwp4-54f8-5fhr --ignore=GHSA-4xrf-jv44-h6hh --ignore=GHSA-22jq-vg5j-6vgg --ignore=GHSA-rgw5-rvv9-x895 --ignore=GHSA-fxqj-rqcc-2cmp --ignore=GHSA-8xcm-r25x-g524 --ignore=GHSA-4cwx-7wf7-3272 --ignore=GHSA-m8rv-5g2x-5cg5 --ignore=GHSA-jr45-8vmc-qm54 --ignore=GHSA-v3r7-h72x-cjcm --ignore=GHSA-7p8r-x3mc-p8w7 --ignore=GHSA-8j4g-w8fx-2239 --ignore=GHSA-2v37-7h3g-55p8",
     "notices:generate": "bun run scripts/generate-third-party-notices.ts",
     "notices:check": "bun run scripts/generate-third-party-notices.ts --check",
     "check:psl-freshness": "bun run scripts/check-tldts-freshness.ts",
@@ -34,8 +34,12 @@
     "@astrojs/vercel": "11.0.3",
     "@hono/node-server": "2.0.11",
     "astro": "7.1.3",
+    "dompurify": "3.4.13",
     "esbuild": "0.28.1",
     "fast-xml-parser": "5.10.1",
+    "hono": "4.13.1",
+    "js-yaml": "3.15.1",
+    "mermaid": "11.16.1",
     "sharp": "0.35.3"
   }
 }


### PR DESCRIPTION
The `Dependency audit` check has been failing on `main` with 12 advisories (3 high), and it is a required check, so it currently blocks **every** PR to this repo. All 12 are transitive.

## What changed

Four packages have a fix available inside their current major, so they are pinned via `overrides` and no consumer sees an API change:

| package | pinned | reached via | clears |
|---|---|---|---|
| `hono` | 4.13.1 | `@modelcontextprotocol/sdk` | `memo()` cross-user SSR disclosure, proxy `Connection` headers, language-middleware DoS |
| `js-yaml` | 3.15.1 | `eslint-plugin-github`, `tangly` | `!!omap` quadratic CPU (CVE-2026-59870) |
| `mermaid` | 11.16.1 | `tangly` | prototype pollution, CSS injection, XY-chart + radar DoS |
| `dompurify` | 3.4.13 | `tangly` | detached-subtree XSS (surfaced once mermaid moved) |

`js-yaml` is worth calling out: the advisory title says the fix was not backported, but a `v3-legacy` release **3.15.1** does carry it. That avoids a 3.x to 5.x jump, which would have been a breaking change for both consumers (`safeLoad` was removed in 4.x).

## The one advisory left ignored

`nanoid` (GHSA-2v37-7h3g-55p8) is added to the `--ignore` list rather than overridden. The tree resolves it twice: a vulnerable `3.3.16` via `tangly` and a healthy `5.1.16` elsewhere. `overrides` is a flat map, so pinning it would drag the 5.x consumer down to a 3.x that is ESM-only with a different API — a runtime break in exchange for a bug that requires a custom generator invoked with `size: 0`, which no docs input reaches.

## Verification

- `bun run audit:dependencies` exits 0 (was: 12 vulnerabilities, exit 1)
- `docs` builds clean: 371 pages, 368 indexed — this is the path that exercises mermaid, dompurify and js-yaml through tangly

## Why now

This unblocks the queued rule PRs (#89 and four more behind it), which cannot merge past the required check.