### PR TITLE
feat(rules): add schema/coverage-outlier, pages missing their siblings' markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **267 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **269 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler 
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more 
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 267 rules across 21 categories**
+**Total: 269 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -257,7 +257,8 @@
                   "rules/schema/website-search",
                   "rules/schema/organization",
                   "rules/schema/video",
-                  "rules/schema/review"
+                  "rules/schema/review",
+                  "rules/schema/coverage-outlier"
                 ]
               },
               {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -229,7 +229,7 @@ squirrelscan runs **268 rules** across **21 categories**, plus opt-in cloud gap 
 | **Content** | 16 | Text quality and honesty: duplicate titles and descriptions, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | **Performance** | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
-| **Structured Data** | 10 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search |
+| **Structured Data** | 11 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have |
 | **Accessibility** | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | **Mobile** | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
 | **Social Media** | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
@@ -242,7 +242,7 @@ squirrelscan runs **268 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 267 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 268 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="268 Rules, 21 Categories"
+    title="269 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **268 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **269 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -242,7 +242,7 @@ squirrelscan runs **268 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 268 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 269 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 268 audit rules organized by score group and category"
+description: "All 269 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **268 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **269 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -26,7 +26,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Text quality, readability, and content structure (16 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
-    Structured data and rich snippet eligibility (10 rules)
+    Structured data and rich snippet eligibility (11 rules)
   </Card>
   <Card title="Images" icon="folder" href="/rules/images">
     Image optimization and accessibility (15 rules)

--- a/docs/rules/schema/coverage-outlier.mdx
+++ b/docs/rules/schema/coverage-outlier.mdx
@@ -1,0 +1,76 @@
+---
+title: "Structured Data Coverage Outlier"
+description: "Finds pages missing the structured data the rest of their page type carries"
+---
+
+Finds pages missing the structured data the rest of their page type carries
+
+| | |
+|---|---|
+| **Rule ID** | `schema/coverage-outlier` |
+| **Category** | [Structured Data](/rules/schema) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 3/10 |
+
+## How it works
+
+"This page has no structured data" is weak advice, because plenty of pages
+legitimately carry none. "40 of 45 product pages have `Product` schema, these 5 do
+not" is strong advice, because the site has already proved it knows how to emit the
+markup and simply missed some pages.
+
+So this rule never asks whether a page has schema in the abstract. It groups the
+crawled pages by page type (product, article, category, docs, and so on), works out
+which schema.org `@type`s most of each group agrees on, and reports only the members
+that break their own group's pattern.
+
+It stays quiet unless it has grounds to speak:
+
+- Fewer than 10 crawled pages: no site norm exists, so the rule is skipped.
+- Fewer than 8 pages of a given page type: that type is dropped, not guessed at.
+- A `@type` carried by under 70% of a page type: the group has no established
+  pattern, so nothing in it is a deviant. A site with no structured data anywhere
+  therefore reports nothing here. That is the job of the per-type rules such as
+  [Product Schema](/rules/schema/product) and [Article Schema](/rules/schema/article).
+
+Pages built from one template all carry the same markup, so they sit inside their
+own norm and are never reported. Page types the classifier could not identify are
+excluded, as are pages that did not return a 2xx.
+
+The finding names the ratio it is arguing from, and lists the pages that break it.
+
+## Solution
+
+These pages break your own site's pattern: most pages of the same type emit this
+schema `@type` and these do not. That is almost always a template or CMS gap rather
+than a deliberate choice, a product without its `Product` markup or an article
+without its `Article` markup, and it costs those pages the rich results their
+siblings are eligible for. Find where the working pages get their JSON-LD and make
+sure the listed pages run through the same path. If a page genuinely should not
+carry the markup (a discontinued product stub, a landing page filed under the same
+type), leave it: the point is that it is currently the exception.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["schema/coverage-outlier"]
+```
+
+### Disable all Structured Data rules
+
+```toml squirrel.toml
+[rules]
+disable = ["schema/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["schema/coverage-outlier"]
+disable = ["*"]
+```

--- a/docs/rules/schema/index.mdx
+++ b/docs/rules/schema/index.mdx
@@ -32,6 +32,9 @@ Structured data and rich snippet eligibility
   <Card title="Review Schema" icon="triangle-exclamation" href="/rules/schema/review">
     Validates Review and AggregateRating schema
   </Card>
+  <Card title="Structured Data Coverage Outlier" icon="triangle-exclamation" href="/rules/schema/coverage-outlier">
+    Finds pages missing the structured data the rest of their page type carries
+  </Card>
   <Card title="Video Schema" icon="triangle-exclamation" href="/rules/schema/video">
     Validates VideoObject schema for video content
   </Card>

--- a/packages/audit-engine/tests/site-query-schema-coverage-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-schema-coverage-golden.test.ts
@@ -1,0 +1,154 @@
+// SiteQuery dual-path golden test for schema/coverage-outlier (#1363).
+//
+// The rule's unit tests drive the streaming path through a hand-rolled SiteQuery
+// stub. This one drives it through the REAL `createSiteQuery` over a seeded
+// SQLite store, so the array columns the rule depends on (`schemaTypes`,
+// `richResultTypes`) are proved to round-trip through storage rather than being
+// assumed. The rule runs BOTH ways against ONE fixture and the emitted checks
+// must be deep-equal; the siteQuery run is given an EMPTY `site.pages`, so a pass
+// also proves the streaming path reads nothing from the resident page array.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { PageFeatureRow } from "@squirrelscan/core-contracts";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { loadAllRules } from "@squirrelscan/rules";
+import type { ParsedPage, RuleContext } from "@squirrelscan/rules";
+import { getRichResultTypes } from "@squirrelscan/utils";
+
+import { createSiteQuery } from "../src/site-query";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const CRAWL = "crawl-1";
+const BASE = "https://example.com/";
+
+const coverageOutlierRule = loadAllRules().get("schema/coverage-outlier")!;
+
+interface Row {
+  normalizedUrl: string;
+  pageType: string | null;
+  schemaTypes: string[];
+}
+
+function feat(row: Row): PageFeatureRow {
+  return {
+    normalizedUrl: row.normalizedUrl,
+    status: 200,
+    depth: 1,
+    title: null,
+    titleHash: null,
+    description: null,
+    descHash: null,
+    contentHash: null,
+    wordCount: null,
+    pageType: row.pageType,
+    schemaTypes: row.schemaTypes,
+    robotsNoindex: false,
+    canonical: null,
+    visibleAuthor: false,
+    visibleDate: false,
+    transferBytes: null,
+    templateFp: null,
+    secretHits: null,
+    metaNoindex: false,
+    indexableReasons: [],
+    richResultTypes: getRichResultTypes({ types: row.schemaTypes } as never),
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
+  };
+}
+
+// 12 product pages in normalized_url ASC order (== the cursor order): 10 carry
+// Product, 2 do not. 2/12 == 16.7% deviant, under the fail share, so this is the
+// canonical "warn and name the ratio" case.
+const FIXTURE: Row[] = Array.from({ length: 12 }, (_, i) => ({
+  normalizedUrl: `https://example.com/p${String(i).padStart(2, "0")}`,
+  pageType: "product",
+  schemaTypes: i < 10 ? ["Product", "BreadcrumbList"] : ["BreadcrumbList"],
+}));
+
+function legacySitePages() {
+  return FIXTURE.map((r) => ({
+    url: r.normalizedUrl,
+    statusCode: 200,
+    parsed: { pageType: r.pageType, schemas: { types: r.schemaTypes } } as unknown as ParsedPage,
+  }));
+}
+
+describe("SiteQuery dual-path — schema/coverage-outlier", () => {
+  test("streaming path deep-equal to legacy over the real store", async () => {
+    const store = new SQLiteStorage(":memory:");
+    await run(store.init());
+    await run(store.upsertPageFeaturesBatch(CRAWL, FIXTURE.map(feat)));
+
+    const base = {
+      page: { url: BASE, html: "", statusCode: 200, loadTime: 0, headers: {} },
+      parsed: {} as ParsedPage,
+      options: {},
+    };
+
+    const legacy = (
+      await Promise.resolve(
+        coverageOutlierRule.run({
+          ...base,
+          site: { baseUrl: BASE, pages: legacySitePages(), robotsTxt: null, sitemaps: null },
+        } as RuleContext)
+      )
+    ).checks;
+
+    const siteQuery = await run(createSiteQuery(store, CRAWL));
+    const streamed = (
+      await Promise.resolve(
+        coverageOutlierRule.run({
+          ...base,
+          // EMPTY pages — the streaming path must not read them.
+          site: { baseUrl: BASE, pages: [], robotsTxt: null, sitemaps: null },
+          siteQuery,
+        } as RuleContext)
+      )
+    ).checks;
+
+    expect(streamed).toEqual(legacy);
+    expect(legacy).toEqual([
+      {
+        name: "coverage-outlier",
+        status: "warn",
+        message:
+          "2 of 12 page(s) are missing structured data their same-type siblings have (product BreadcrumbList+Product)",
+        value: 2,
+        items: [
+          {
+            id: "product:Product",
+            label: "10 of 12 product pages have Product schema, these 2 do not",
+            sourcePages: ["https://example.com/p10", "https://example.com/p11"],
+            meta: {
+              pageType: "product",
+              schemaType: "Product",
+              richResult: true,
+              have: 10,
+              total: 12,
+              missing: 2,
+            },
+          },
+        ],
+        details: {
+          judgedPages: 12,
+          judgedTypes: 1,
+          flaggedPages: 2,
+          norms: [{ pageType: "product", pages: 12, schemaTypes: ["BreadcrumbList", "Product"] }],
+        },
+      },
+    ]);
+
+    await run(store.close());
+  });
+});

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -70,12 +70,15 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // overall score is unmoved.
       // 98211 -> 98212: content/thin-vs-site-norm is site-scoped, so it adds
       // exactly ONE check for the whole crawl (#1362).
-      expect(v1.findings.length).toBe(98212);
+      // 98212 -> 98213: schema/coverage-outlier, likewise site-scoped, adds its
+      // own single whole-crawl check (#1363).
+      expect(v1.findings.length).toBe(98213);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
-      // content/hidden-text, 267 -> 268 content/thin-vs-site-norm; anything else
+      // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
+      // schema/coverage-outlier; anything else
       // means a rule id leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(268);
+      expect(v1.perRuleTally.length).toBe(269);
     },
     180_000,
   );

--- a/packages/rules/src/schema/coverage-outlier.ts
+++ b/packages/rules/src/schema/coverage-outlier.ts
@@ -1,0 +1,368 @@
+// schema/coverage-outlier - pages missing the structured data their same-type siblings have (#1363)
+//
+// "This page has no schema" is weak advice: plenty of pages legitimately carry
+// none. "40 of 45 product pages have Product schema, these 5 do not" is strong
+// advice, because the site has already proved it knows how to emit it and simply
+// missed some pages. So this rule never asks whether a page has schema in the
+// abstract - only whether it breaks the pattern its own siblings established.
+//
+// Grouping key (#1363, evaluated before fixing the choice): `pageType`, not
+// `richResultTypes`. `richResultTypes` is DERIVED from `schemaTypes` - the very
+// field being judged - so grouping by it is circular: a product page missing its
+// Product markup has an empty `richResultTypes` and lands in a different group
+// from the siblings it is supposed to be compared against, where it can never be
+// an outlier. `pageType` is independent of the markup (schema signals + URL
+// patterns), which is what makes the comparison meaningful. `richResultTypes` is
+// still the better *reporting* lens - a missing rich-result-eligible type costs
+// real SERP features - so it is carried per gap in `details` rather than dropped.
+//
+// Guards, in the order they matter:
+//   1. Site floor (SCHEMA_NORM_MIN_PAGES) - a small crawl has no norm to speak of.
+//   2. Group floor (SCHEMA_NORM_MIN_GROUP_PAGES) - a page type with 3 pages cannot
+//      establish a pattern; the group is dropped, not guessed at.
+//   3. Modal agreement (SCHEMA_NORM_MIN_AGREEMENT) - a type only joins a group's
+//      norm once most of the group carries it. A site with no schema anywhere, or
+//      one whose same-type pages genuinely differ, therefore produces no norm and
+//      the rule stays silent. That case belongs to the per-type schema rules
+//      (schema/product, schema/article, ...), not to an outlier rule.
+//
+// Template-uniform pages are safe by construction: pages built from one template
+// carry the same `schemaTypes`, so they all sit inside their own norm and none of
+// them can be a deviant.
+//
+// Dual path: `ctx.siteQuery` streams (pageType, schemaTypes, richResultTypes)
+// straight off page_features; the legacy path reads the same three fields from
+// `ctx.site.pages`. Both feed ONE accumulator and ONE check builder, so the output
+// is byte-identical by construction (same shape as content/duplicate-title,
+// #1021/#1022). No storage schema change: all three columns already exist.
+
+import { getRichResultTypes } from "@squirrelscan/utils";
+
+import type { CheckItem, SiteQuery } from "@squirrelscan/core-contracts";
+import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
+
+/** Crawl-wide page floor: below this there is no site norm to judge against. */
+export const SCHEMA_NORM_MIN_PAGES = 10;
+
+/** Per-`pageType` sample floor. A group under this is dropped, never guessed at. */
+export const SCHEMA_NORM_MIN_GROUP_PAGES = 8;
+
+/**
+ * Share of a page-type group that must carry a schema @type before that type is
+ * treated as the group's norm. Below this the group has no established pattern
+ * and nothing in it is a deviant - skipping beats accusing a healthy site.
+ */
+export const SCHEMA_NORM_MIN_AGREEMENT = 0.7;
+
+/** Share of judged pages that turns the warning into a failure. */
+export const SCHEMA_NORM_FAIL_SHARE = 0.2;
+
+/** Caps on reported gaps / summarized norms, so one rule cannot bloat a report. */
+const SCHEMA_NORM_MAX_ITEMS = 10;
+const SCHEMA_NORM_MAX_GROUPS = 10;
+
+/** Cap on URLs listed per gap, so one broken template cannot spray a report. */
+const SCHEMA_NORM_MAX_URLS_PER_GAP = 20;
+
+const CHECK_NAME = "coverage-outlier";
+
+/** One page's contribution, from either path. */
+interface SchemaPageRecord {
+  url: string;
+  status: number;
+  pageType: string | null;
+  schemaTypes: string[];
+  richResultTypes: string[];
+}
+
+interface SchemaGroup {
+  pageType: string;
+  urls: string[];
+  /** Parallel to `urls`: the lowercased @type keys present on that page. */
+  typeKeys: Set<string>[];
+  /** Lowercased key -> display casing, first-seen (both paths iterate in url order). */
+  display: Map<string, string>;
+  /** Lowercased keys that are rich-result eligible on at least one page. */
+  richKeys: Set<string>;
+}
+
+interface SchemaRollup {
+  /** Pages seen by the rule (both paths count the same universe). */
+  pageCount: number;
+  /** Pages that carry a usable page type. */
+  sampleCount: number;
+  groups: Map<string, SchemaGroup>;
+}
+
+/** One "N of M <type> pages have X, these N do not" finding. */
+interface SchemaGap {
+  pageType: string;
+  schemaType: string;
+  richResult: boolean;
+  have: number;
+  total: number;
+  missingUrls: string[];
+}
+
+interface JudgedGroup {
+  pageType: string;
+  pages: number;
+  normTypes: string[];
+}
+
+function emptyRollup(): SchemaRollup {
+  return { pageCount: 0, sampleCount: 0, groups: new Map() };
+}
+
+/**
+ * Fold one page in. Untyped ("unknown") pages are excluded deliberately: that
+ * bucket is a grab-bag of everything the classifier could not place, so its
+ * members are not siblings of each other in any useful sense.
+ */
+function accumulatePage(rollup: SchemaRollup, record: SchemaPageRecord): void {
+  rollup.pageCount += 1;
+
+  if (record.status < 200 || record.status >= 300) return;
+  const pageType = record.pageType?.trim().toLowerCase();
+  if (!pageType || pageType === "unknown") return;
+
+  rollup.sampleCount += 1;
+  let group = rollup.groups.get(pageType);
+  if (!group) {
+    group = { pageType, urls: [], typeKeys: [], display: new Map(), richKeys: new Set() };
+    rollup.groups.set(pageType, group);
+  }
+
+  const keys = new Set<string>();
+  for (const type of record.schemaTypes) {
+    const key = type.trim().toLowerCase();
+    if (!key) continue;
+    keys.add(key);
+    if (!group.display.has(key)) group.display.set(key, type.trim());
+  }
+  for (const type of record.richResultTypes) {
+    const key = type.trim().toLowerCase();
+    if (key) group.richKeys.add(key);
+  }
+
+  group.urls.push(record.url);
+  group.typeKeys.push(keys);
+}
+
+function skip(message: string): CheckResult {
+  return { name: CHECK_NAME, status: "skipped", message };
+}
+
+/** Stable string ordering, so neither path can depend on iteration luck. */
+function byString(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * The rule's full output for one rollup. ONE builder, both paths.
+ *
+ * `sitePageCount` is the crawl-wide page count: the streaming path takes it from
+ * `siteQuery.pageCount()` (which includes rows this rule cannot sample), so the
+ * site floor is judged on the crawl, not on the sampled subset.
+ */
+function buildChecks(rollup: SchemaRollup, sitePageCount: number): CheckResult[] {
+  if (sitePageCount < SCHEMA_NORM_MIN_PAGES) {
+    return [
+      skip(
+        `Only ${sitePageCount} page(s) crawled; ${SCHEMA_NORM_MIN_PAGES} needed to establish a structured-data norm`
+      ),
+    ];
+  }
+
+  const judged: JudgedGroup[] = [];
+  const gaps: SchemaGap[] = [];
+  const deviantPages = new Set<string>();
+  let judgedPages = 0;
+
+  for (const group of rollup.groups.values()) {
+    const total = group.urls.length;
+    if (total < SCHEMA_NORM_MIN_GROUP_PAGES) continue;
+
+    // The group's modal schema set: every @type most of the group agrees on.
+    // Computed per @type rather than by exact-set frequency on purpose - an
+    // optional extra (a BreadcrumbList on some pages only) would otherwise
+    // shatter the exact-set mode and hide a real Product gap behind it.
+    const counts = new Map<string, number>();
+    for (const keys of group.typeKeys) {
+      for (const key of keys) counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    const normKeys: string[] = [];
+    for (const [key, count] of counts) {
+      if (count / total >= SCHEMA_NORM_MIN_AGREEMENT) normKeys.push(key);
+    }
+    if (normKeys.length === 0) continue;
+    normKeys.sort(byString);
+
+    judged.push({
+      pageType: group.pageType,
+      pages: total,
+      normTypes: normKeys.map((key) => group.display.get(key) ?? key),
+    });
+    judgedPages += total;
+
+    for (const key of normKeys) {
+      const missingUrls: string[] = [];
+      for (const [i, keys] of group.typeKeys.entries()) {
+        if (keys.has(key)) continue;
+        missingUrls.push(group.urls[i]!);
+        deviantPages.add(group.urls[i]!);
+      }
+      // A type every page of the group carries has no deviants to report.
+      if (missingUrls.length === 0) continue;
+      gaps.push({
+        pageType: group.pageType,
+        schemaType: group.display.get(key) ?? key,
+        richResult: group.richKeys.has(key),
+        have: total - missingUrls.length,
+        total,
+        missingUrls,
+      });
+    }
+  }
+
+  if (judged.length === 0) {
+    return [
+      skip(
+        `No page type has ${SCHEMA_NORM_MIN_GROUP_PAGES}+ comparable pages sharing a structured-data pattern`
+      ),
+    ];
+  }
+
+  judged.sort((a, b) => byString(a.pageType, b.pageType));
+  const normSummary = judged
+    .slice(0, SCHEMA_NORM_MAX_GROUPS)
+    .map((g) => `${g.pageType} ${g.normTypes.join("+")}`)
+    .join(", ");
+  const details: Record<string, unknown> = {
+    judgedPages,
+    judgedTypes: judged.length,
+    flaggedPages: deviantPages.size,
+    norms: judged.slice(0, SCHEMA_NORM_MAX_GROUPS).map((g) => ({
+      pageType: g.pageType,
+      pages: g.pages,
+      schemaTypes: g.normTypes,
+    })),
+  };
+
+  if (gaps.length === 0) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "pass",
+        message: `All ${judgedPages} comparable page(s) carry the structured data their page type establishes (${normSummary})`,
+        value: judgedPages,
+        details,
+      },
+    ];
+  }
+
+  // Widest gaps first; pageType then schemaType break ties so the list never
+  // depends on crawl order.
+  gaps.sort(
+    (a, b) =>
+      b.missingUrls.length - a.missingUrls.length ||
+      byString(a.pageType, b.pageType) ||
+      byString(a.schemaType, b.schemaType)
+  );
+  const items: CheckItem[] = gaps.slice(0, SCHEMA_NORM_MAX_ITEMS).map((g) => ({
+    id: `${g.pageType}:${g.schemaType}`,
+    label: `${g.have} of ${g.total} ${g.pageType} pages have ${g.schemaType} schema, these ${g.missingUrls.length} do not`,
+    sourcePages: g.missingUrls.slice(0, SCHEMA_NORM_MAX_URLS_PER_GAP),
+    meta: {
+      pageType: g.pageType,
+      schemaType: g.schemaType,
+      richResult: g.richResult,
+      have: g.have,
+      total: g.total,
+      missing: g.missingUrls.length,
+    },
+  }));
+
+  const share = deviantPages.size / judgedPages;
+  return [
+    {
+      name: CHECK_NAME,
+      status: share >= SCHEMA_NORM_FAIL_SHARE ? "fail" : "warn",
+      message: `${deviantPages.size} of ${judgedPages} page(s) are missing structured data their same-type siblings have (${normSummary})`,
+      value: deviantPages.size,
+      items,
+      details,
+    },
+  ];
+}
+
+/**
+ * Streaming path (#1363): read (pageType, schemaTypes, richResultTypes) off the
+ * page_features cursor in normalized_url order (== the legacy `site.pages` order).
+ * Only the per-group @type key sets stay resident; no parsed page is held.
+ *
+ * The site floor is judged on `pageCount()`, which counts page_features rows; the
+ * legacy universe additionally carries the error pages v1 appends to `site.pages`.
+ * Only a crawl sitting exactly on the floor with non-auditable pages can word the
+ * skip differently, and neither path can judge such a crawl anyway. That is a
+ * property of this seam shared with every site rule on it (see
+ * content/duplicate-title), not something specific to this rule.
+ */
+async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
+  const rollup = emptyRollup();
+  for await (const row of siteQuery.pagesMatching(() => true)) {
+    accumulatePage(rollup, {
+      url: row.normalizedUrl,
+      status: row.status,
+      pageType: row.pageType,
+      schemaTypes: row.schemaTypes,
+      richResultTypes: row.richResultTypes,
+    });
+  }
+
+  return { checks: buildChecks(rollup, siteQuery.pageCount()) };
+}
+
+export const schemaCoverageOutlierRule: Rule = {
+  meta: {
+    id: "schema/coverage-outlier",
+    name: "Structured Data Coverage Outlier",
+    description:
+      "Finds pages missing the structured data the rest of their page type carries",
+    solution:
+      "These pages break your own site's pattern: most pages of the same type emit this schema @type and these do not. That is almost always a template or CMS gap rather than a deliberate choice - a product without its Product markup, an article without its Article markup - and it costs those pages the rich results their siblings are eligible for. Find where the working pages get their JSON-LD and make sure the listed pages run through the same path. If a page genuinely should not carry the markup (a discontinued product stub, a landing page filed under the same type), leave it: the point is that it is currently the exception.",
+    category: "schema",
+    scope: "site",
+    severity: "warning",
+    // Deliberately light, and one site-wide check with capped items rather than a
+    // per-page finding, so this rule cannot dominate the schema category score.
+    weight: 3,
+  },
+
+  run(ctx: RuleContext): RuleResult | Promise<RuleResult> {
+    if (ctx.siteQuery) {
+      return runViaSiteQuery(ctx.siteQuery);
+    }
+
+    const pages = ctx.site?.pages;
+    if (!pages || pages.length === 0) {
+      return { checks: [skip("No pages available for analysis")] };
+    }
+
+    const rollup = emptyRollup();
+    for (const page of pages) {
+      const schemas = page.parsed?.schemas;
+      accumulatePage(rollup, {
+        url: page.url,
+        status: page.statusCode,
+        pageType: page.parsed?.pageType ?? null,
+        schemaTypes: schemas?.types ?? [],
+        // Same derivation page-features stores, so both paths see one value.
+        richResultTypes: schemas ? getRichResultTypes(schemas) : [],
+      });
+    }
+
+    return { checks: buildChecks(rollup, rollup.pageCount) };
+  },
+};

--- a/packages/rules/src/schema/index.ts
+++ b/packages/rules/src/schema/index.ts
@@ -4,6 +4,7 @@ import type { Rule } from "../types";
 
 import { articleSchemaRule } from "./article";
 import { breadcrumbSchemaRule } from "./breadcrumb";
+import { schemaCoverageOutlierRule } from "./coverage-outlier";
 import { faqSchemaRule } from "./faq";
 import { jsonLdValidRule } from "./json-ld-valid";
 import { localBusinessSchemaRule } from "./local-business";
@@ -24,6 +25,7 @@ export const rules: Rule[] = [
   organizationSchemaRule,
   videoSchemaRule,
   reviewSchemaRule,
+  schemaCoverageOutlierRule,
 ];
 
 export {
@@ -35,6 +37,7 @@ export {
   organizationSchemaRule,
   productSchemaRule,
   reviewSchemaRule,
+  schemaCoverageOutlierRule,
   videoSchemaRule,
   websiteSearchSchemaRule,
 };

--- a/packages/rules/tests/schema-coverage-outlier.test.ts
+++ b/packages/rules/tests/schema-coverage-outlier.test.ts
@@ -1,0 +1,317 @@
+// schema/coverage-outlier — structured-data outliers vs the site's own norm (#1363).
+//
+// The rule's whole value is what it does NOT say, so most of this file defends the
+// silence cases: a small crawl, a page type with too few samples, a site with no
+// schema at all (that is the per-type schema rules' finding, not an outlier), a
+// group whose members genuinely disagree, and template-uniform pages. The positive
+// cases pin the one thing it is for: a handful of pages breaking a pattern the
+// rest of their OWN page type keeps.
+//
+// Every fixture runs through `bothPaths`, so the legacy `ctx.site.pages` path and
+// the streaming `SiteQuery` path are asserted byte-identical on all of them.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult, PageFeatureRow, SiteQuery } from "@squirrelscan/core-contracts";
+import { getRichResultTypes } from "@squirrelscan/utils";
+
+import {
+  schemaCoverageOutlierRule,
+  SCHEMA_NORM_MIN_GROUP_PAGES,
+  SCHEMA_NORM_MIN_PAGES,
+} from "../src/schema/coverage-outlier";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+interface PageSpec {
+  pageType: string | null;
+  schemaTypes: string[];
+  status?: number;
+}
+
+function url(i: number): string {
+  return `https://example.com/p${String(i).padStart(3, "0")}`;
+}
+
+/** N pages of one type, all carrying the same schema @types. */
+function uniform(pageType: string, schemaTypes: string[], count: number): PageSpec[] {
+  return Array.from({ length: count }, () => ({ pageType, schemaTypes }));
+}
+
+const baseCtx = {
+  page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+  parsed: {} as ParsedPage,
+  options: {},
+};
+
+/** Legacy path: specs become `ctx.site.pages` in crawl (url ascending) order. */
+function legacyCtx(specs: PageSpec[]): RuleContext {
+  return {
+    ...baseCtx,
+    site: {
+      baseUrl: "https://example.com/",
+      pages: specs.map((spec, i) => ({
+        url: url(i),
+        statusCode: spec.status ?? 200,
+        parsed: {
+          pageType: spec.pageType,
+          schemas: { types: spec.schemaTypes },
+        } as unknown as ParsedPage,
+      })),
+      robotsTxt: null,
+      sitemaps: null,
+    },
+  };
+}
+
+function featureRow(spec: PageSpec, i: number): PageFeatureRow {
+  return {
+    normalizedUrl: url(i),
+    status: spec.status ?? 200,
+    depth: 1,
+    title: null,
+    titleHash: null,
+    description: null,
+    descHash: null,
+    contentHash: null,
+    wordCount: null,
+    pageType: spec.pageType,
+    schemaTypes: spec.schemaTypes,
+    robotsNoindex: false,
+    canonical: null,
+    visibleAuthor: false,
+    visibleDate: false,
+    transferBytes: null,
+    templateFp: null,
+    secretHits: null,
+    metaNoindex: false,
+    indexableReasons: [],
+    // Exactly what page-features stores, so the two paths see one value.
+    richResultTypes: getRichResultTypes({ types: spec.schemaTypes } as never),
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
+  };
+}
+
+/**
+ * Streaming path: the rule only ever calls `pagesMatching` + `pageCount`, so the
+ * rest of the SiteQuery surface throws — a stub that silently returned empties
+ * could hide the rule reading something it must not.
+ */
+function siteQueryCtx(specs: PageSpec[]): RuleContext {
+  const rows = specs.map(featureRow);
+  const unused = (): never => {
+    throw new Error("coverage-outlier must not use this SiteQuery method");
+  };
+  const siteQuery: SiteQuery = {
+    pageCount: () => rows.length,
+    duplicateGroups: unused,
+    incomingLinkCounts: unused,
+    pagesByType: unused,
+    templateClusters: unused,
+    sumTransferBytes: unused,
+    sumSecretHits: unused,
+    homepage: unused,
+    async *pagesMatching(pred: (row: PageFeatureRow) => boolean) {
+      for (const row of rows) if (pred(row)) yield row;
+    },
+  };
+  return {
+    ...baseCtx,
+    // EMPTY pages — the streaming path must not read them.
+    site: { baseUrl: "https://example.com/", pages: [], robotsTxt: null, sitemaps: null },
+    siteQuery,
+  };
+}
+
+async function checks(ctx: RuleContext): Promise<CheckResult[]> {
+  return (await Promise.resolve(schemaCoverageOutlierRule.run(ctx))).checks;
+}
+
+/** Run BOTH paths over one fixture, assert byte-identical output, return it. */
+async function bothPaths(specs: PageSpec[]): Promise<CheckResult> {
+  const legacy = await checks(legacyCtx(specs));
+  const streamed = await checks(siteQueryCtx(specs));
+  expect(streamed).toEqual(legacy);
+  expect(JSON.stringify(streamed)).toBe(JSON.stringify(legacy));
+  expect(legacy).toHaveLength(1);
+  return legacy[0]!;
+}
+
+/** A group of `total` pages of `pageType` where only `have` carry `schemaTypes`. */
+function partial(
+  pageType: string,
+  schemaTypes: string[],
+  have: number,
+  total: number
+): PageSpec[] {
+  return Array.from({ length: total }, (_, i) => ({
+    pageType,
+    schemaTypes: i < have ? schemaTypes : [],
+  }));
+}
+
+describe("schema/coverage-outlier — silence guards", () => {
+  test("skips a crawl below the site page floor", async () => {
+    const check = await bothPaths(uniform("product", ["Product"], SCHEMA_NORM_MIN_PAGES - 1));
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${SCHEMA_NORM_MIN_PAGES} needed`);
+  });
+
+  test("skips when no page type has enough comparable pages", async () => {
+    // 12 pages, but spread thin: every type is under the group floor.
+    const specs = [
+      ...uniform("product", ["Product"], 4),
+      ...uniform("article", ["Article"], 4),
+      ...uniform("about", ["Organization"], 4),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${SCHEMA_NORM_MIN_GROUP_PAGES}+ comparable pages`);
+  });
+
+  test("a site with no schema anywhere stays clean — that is the per-type rules' finding", async () => {
+    const specs = [...uniform("product", [], 12), ...uniform("article", [], 12)];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain("sharing a structured-data pattern");
+  });
+
+  test("skips a group with no modal agreement — every page marks itself up differently", async () => {
+    // 10 product pages, each with its own @type: no type reaches 70%.
+    const specs = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"].map((t) => ({
+      pageType: "product",
+      schemaTypes: [t],
+    }));
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+  });
+
+  test("a type just under the agreement threshold forms no norm", async () => {
+    // 6 of 10 = 60% < 70%: the majority is not enough to call the other 4 wrong.
+    const check = await bothPaths(partial("product", ["Product"], 6, 10));
+    expect(check.status).toBe("skipped");
+  });
+
+  test("untyped pages never form a group", async () => {
+    const specs = [
+      ...uniform("product", ["Product"], 10),
+      ...uniform("unknown", [], 4),
+      ...Array.from({ length: 4 }, () => ({ pageType: null, schemaTypes: [] })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(10);
+  });
+
+  test("non-2xx pages are excluded from the norm and never flagged", async () => {
+    const specs = [
+      ...uniform("product", ["Product"], 10),
+      ...Array.from({ length: 3 }, () => ({ pageType: "product", schemaTypes: [], status: 404 })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(10);
+  });
+});
+
+describe("schema/coverage-outlier — template-uniform pages sit inside the norm", () => {
+  test("passes when every page of a type carries the same markup", async () => {
+    const specs = [
+      ...uniform("product", ["Product", "BreadcrumbList"], 20),
+      ...uniform("article", ["Article"], 10),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.items).toBeUndefined();
+    expect(check.details?.judgedPages).toBe(30);
+    expect(check.message).toContain("article Article");
+  });
+
+  test("@type casing drift does not split the norm", async () => {
+    const specs = Array.from({ length: 12 }, (_, i) => ({
+      pageType: "product",
+      schemaTypes: [i % 2 === 0 ? "Product" : "product"],
+    }));
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+
+  test("an optional extra on a minority of pages is not a norm, and does not hide a real gap", async () => {
+    // 40/45 carry Product; a BreadcrumbList on 10 of them never reaches 70%.
+    const specs = partial("product", ["Product"], 40, 45).map((spec, i) =>
+      i < 10 ? { ...spec, schemaTypes: [...spec.schemaTypes, "BreadcrumbList"] } : spec
+    );
+    const check = await bothPaths(specs);
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0]?.meta?.schemaType).toBe("Product");
+  });
+});
+
+describe("schema/coverage-outlier — outliers", () => {
+  test("warns and names the ratio it is arguing from", async () => {
+    const check = await bothPaths(partial("product", ["Product"], 40, 45));
+    expect(check.status).toBe("warn");
+    expect(check.value).toBe(5);
+    expect(check.message).toContain("5 of 45 page(s) are missing structured data");
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0]?.label).toBe(
+      "40 of 45 product pages have Product schema, these 5 do not"
+    );
+    expect(check.items?.[0]?.sourcePages).toHaveLength(5);
+    expect(check.items?.[0]?.meta).toEqual({
+      pageType: "product",
+      schemaType: "Product",
+      richResult: true,
+      have: 40,
+      total: 45,
+      missing: 5,
+    });
+  });
+
+  test("fails once the deviant share crosses the fail threshold", async () => {
+    // 7 of 10 carry Product (exactly the agreement floor) → 3/10 = 30% deviant.
+    const check = await bothPaths(partial("product", ["Product"], 7, 10));
+    expect(check.status).toBe("fail");
+    expect(check.value).toBe(3);
+  });
+
+  test("only the deviating page type is flagged; healthy groups stay quiet", async () => {
+    const specs = [
+      ...partial("product", ["Product"], 40, 45),
+      ...uniform("article", ["Article"], 20),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(check.details?.judgedPages).toBe(65);
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0]?.meta?.pageType).toBe("product");
+  });
+
+  test("a page missing two norm types counts once toward the deviant share", async () => {
+    const specs = partial("product", ["Product", "BreadcrumbList"], 40, 45);
+    const check = await bothPaths(specs);
+    // Two gaps reported, but 5 deviant pages, not 10.
+    expect(check.items).toHaveLength(2);
+    expect(check.value).toBe(5);
+    expect(check.details?.flaggedPages).toBe(5);
+  });
+
+  test("a non-rich-result @type is still reported, flagged as such", async () => {
+    const check = await bothPaths(partial("about", ["WebPage"], 10, 12));
+    expect(check.items?.[0]?.meta?.richResult).toBe(false);
+  });
+});
+
+describe("schema/coverage-outlier — legacy-path edge cases", () => {
+  test("an empty site skips rather than throwing", async () => {
+    const result = await checks(legacyCtx([]));
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe("skipped");
+    expect(result[0]?.message).toBe("No pages available for analysis");
+  });
+});


### PR DESCRIPTION
Adds a site-wide structured-data rule: group crawled pages by `pageType`, work out the schema.org `@type`s most of each group agrees on, and flag only the members that break their own group's pattern.

`40 of 45 product pages have Product schema, these 5 do not` is much stronger advice than `this page has no schema` — the site has already proved it knows how to emit the markup and simply missed some pages.

Companion to the private monorepo PR that regenerates the rule catalog (267 → 268).

## Grouping key: `pageType`, not `richResultTypes`

Both were evaluated before the choice was fixed.

`richResultTypes` is **derived from `schemaTypes`**, the very field being judged, so grouping by it is circular: a product page missing its `Product` markup has an empty `richResultTypes` and lands in a *different* group from the siblings it is supposed to be compared against, where it can never be an outlier. Grouping only works on a key independent of the markup, which is what `pageType` (schema signals + URL patterns) is.

`richResultTypes` is still the better *reporting* lens — a missing rich-result-eligible type costs real SERP features — so it is carried per gap in `details.richResult` rather than dropped. It also motivated case-insensitive `@type` keying, so `Product` and `product` cannot split a norm.

## Guards

| guard | value | why |
|---|---|---|
| site floor | 10 pages | below this there is no site norm |
| group floor | 8 pages of a `pageType` | a 3-page type cannot establish a pattern |
| agreement | 70% of a group must carry a `@type` | below this the group is legitimately varied |

Consequences worth stating: a site with **no structured data anywhere** produces no norm and this rule stays silent — that is the per-type rules' finding (`schema/product`, `schema/article`), not an outlier. Template-uniform pages all carry the same markup, so they sit inside their own norm and can never be flagged. Untyped (`unknown`/null) page types and non-2xx pages are excluded.

## Dual path

`ctx.siteQuery` streams `(pageType, schemaTypes, richResultTypes)` off `page_features`; the legacy path reads the same three fields off `ctx.site.pages`. Both feed **one** accumulator and **one** check builder, so output is byte-identical by construction (the `content/duplicate-title` shape, #1021/#1022).

- Every unit fixture runs through both paths and asserts `toEqual` **and** `JSON.stringify` equality.
- `packages/audit-engine/tests/site-query-schema-coverage-golden.test.ts` runs both paths over the **real** `createSiteQuery` + a seeded SQLite store, so the array columns are proved to round-trip through storage rather than assumed.

No storage schema change: all three columns already exist on `PageFeatureRow`.

## Scoring density

Weight 3, one site-wide check (not a per-page finding), items capped at 10 and URLs per gap at 20, so the item-aware fail-density penalty stays bounded. On the canonical 518-page golden fixture the health score is **unmoved at 48** and findings go 98211 → 98212 (exactly one site check).

## Smoke: sweetdeals.com.au

`squirrel audit https://sweetdeals.com.au --max-pages 200` (run from source, v0.0.84).

- **200 pages scanned**, classified `product=198, category=1, about=1`.
- **0 findings from this rule.** It returned `pass`: `All 198 comparable page(s) carry the structured data their page type establishes (product BreadcrumbList+Product)`.

That is the correct answer for this corpus and the point of the exercise: 198 pages from one template all carry `Product` + `BreadcrumbList`, so they all sit inside their own norm and none is an outlier. A rule of this class lighting up across a template would be wrong, not thorough.

Because 0 findings is indistinguishable from "the rule never ran", the detector was proved with a perturbation replay over that same real crawl (read back out of the CLI project db, so identical inputs):

| replay | result |
|---|---|
| real corpus, unperturbed | `pass` — 0 flagged, matching the live audit exactly |
| `Product` stripped from **5** of the 198 product pages | `warn` — `5 of 198 page(s) are missing structured data their same-type siblings have`, item `193 of 198 product pages have Product schema, these 5 do not`, listing exactly the 5 perturbed URLs |
| `Product` stripped from **60** of the 198 | `pass` — 69.7% agreement falls under the 70% floor, so `Product` drops out of the norm entirely and nothing is accused |

Spot-check of the 3 findings from replay 2 (each a genuine outlier by construction — these are the pages whose markup was removed, and no others were named):

1. `https://sweetdeals.com.au/p/apple-airpods-pro-2` — perturbed, flagged.
2. `https://sweetdeals.com.au/p/apple-macbook-air-13-m4` — perturbed, flagged.
3. `https://sweetdeals.com.au/p/8bitdo-ultimate-wireless-controller` — perturbed, flagged.

The other 193 template siblings stayed clean, and replay 3 confirms the rule goes quiet rather than guessing once the norm itself erodes.

## Tests

- `packages/rules/tests/schema-coverage-outlier.test.ts` — 16 tests covering pass / warn / fail / skipped, the site and group floors, the agreement floor, the no-schema-anywhere fixture, `@type` casing drift, untyped and non-2xx exclusion, and dual-path byte-identity on every fixture.
- `packages/audit-engine/tests/site-query-schema-coverage-golden.test.ts` — real-store dual-path golden.
- `packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts` — pins updated (findings +1, tally 267 → 268).
- Docs page, nav entry, category card and the 267 → 268 / schema 10 → 11 count literals updated; `make validate` clean in `docs/`.

`bun test` green for `packages/rules` (1172) and `packages/audit-engine` (270); `tsgo --noEmit` clean for both.
