### PR TITLE
fix(cli): retry a lost register under an idempotency key

### DIFF
--- a/apps/cli/src/lib/run-tracker.ts
+++ b/apps/cli/src/lib/run-tracker.ts
@@ -22,11 +22,20 @@ import { resolveCredential } from "@/self/credentials";
 import { logger } from "@/utils/logger";
 import { parseUserUrl } from "@/utils/url";
 
-// register blocks the audit start by one round-trip, so keep it short; the
-// credits call that established `signedIn` just proved the API is reachable, so
-// 5s is a safe ceiling — a slower response means something just broke and we'd
-// rather start the local audit than wait.
-const REGISTER_TIMEOUT_MS = 5_000;
+// Register runs CONCURRENTLY with the crawl (audit.ts kicks the promise off
+// without awaiting), so a generous ceiling costs nothing at audit start. The old
+// 5s ceiling did cost something else: a register the SERVER committed (run row +
+// 50cr base debit) but whose response arrived late resolved null here, and the
+// audit then ran fully untracked — no markRunning, no finalize, no runId in
+// publish — so the run was reaped as an orphan pending and the delivered audit
+// was refunded to free (#1534, ~9% of CLI runs, concentrated far from us-west).
+// Give the round-trip room, then retry once; only a genuinely dead API falls
+// through to an untracked audit.
+const REGISTER_TIMEOUT_MS = 12_000;
+// The retry's shorter ceiling bounds the total register budget (~20s) so a dead
+// API can't hold the end-of-run finalizer (which awaits this promise) that long
+// past a very fast audit.
+const REGISTER_RETRY_TIMEOUT_MS = 8_000;
 const PATCH_TIMEOUT_MS = 10_000;
 // Progress is the most frequent signal (throttled to ≤1/s at the call site) and
 // the least important — keep its timeout short so a slow tick never piles up.
@@ -139,6 +148,12 @@ function runPath(runId: string, suffix = "", base = lifecycleBase()): string {
   return `${base}/${encodeURIComponent(runId)}${suffix}`;
 }
 
+/** What `POST /register` answers with — ids plus the pricing-v10 extras. */
+type RegisterResponseBody = Partial<RegisteredRun> & {
+  balance?: { total?: number } | null;
+  error?: { code?: string; message?: string };
+};
+
 /**
  * Register-failure codes worth interrupting the user for: persistent, actionable
  * account-state problems where the run then goes untracked/unpublished and the
@@ -160,6 +175,12 @@ const DEFINITIVE_REGISTER_FAILURE_CODES = new Set([
  * it live, or null on ANY failure (no credential, network error, non-2xx, bad
  * body) — the audit then simply proceeds untracked.
  *
+ * A LOST response (timeout / transport failure) is retried ONCE under the same
+ * client-generated idempotency key (#1534). Falling through to null is the
+ * expensive outcome, not the slow one: the server may already have committed the
+ * run row and its 50cr base debit, and an untracked audit then gets reaped as an
+ * orphan pending run and refunded — a delivered audit, for free.
+ *
  * `onWarn` is invoked with the server message ONLY on a DEFINITIVE, actionable
  * failure (see DEFINITIVE_REGISTER_FAILURE_CODES) so the caller can surface it
  * loudly (#816): at the website limit / out of credits / org locked means the
@@ -178,21 +199,35 @@ export async function registerRun(
   // proceeds untracked. Add the scheme for scheme-less input; anything the
   // user typed as a real URL is sent verbatim.
   const parsed = input.url.includes("://") ? null : parseUserUrl(input.url);
-  const { ok, status, data } = await cliApi.request<
-    Partial<RegisteredRun> & {
-      balance?: { total?: number } | null;
-      error?: { code?: string; message?: string };
-    }
-  >(`${base}/register`, {
-    method: "POST",
-    auth: "required",
-    timeoutMs: REGISTER_TIMEOUT_MS,
-    body: {
-      url: parsed?.ok ? parsed.url : input.url,
-      mode: input.mode ?? "audit",
-      ...(input.config ? { config: JSON.stringify(input.config) } : {}),
-    },
-  });
+  // #1534: one key for BOTH attempts, so a retry that races a first attempt the
+  // server is still committing converges on the SAME run row and the SAME
+  // audit_base debit rather than creating (and charging for) a second run.
+  // Servers before #1534 ignore the unknown field, so the retry is only as safe
+  // as the old behavior there — which is why the timeout is generous first.
+  const idempotencyKey = crypto.randomUUID();
+  const body = {
+    url: parsed?.ok ? parsed.url : input.url,
+    mode: input.mode ?? "audit",
+    idempotencyKey,
+    ...(input.config ? { config: JSON.stringify(input.config) } : {}),
+  };
+
+  let ok = false;
+  let status = 0;
+  let data: RegisterResponseBody | null = null;
+  // Attempt 2 is for a LOST response only (`status === 0`: timeout, socket
+  // reset, DNS blip) — that is the #1534 failure mode. A server that answered,
+  // with any status, has decided; re-asking would only duplicate the request.
+  for (const timeoutMs of [REGISTER_TIMEOUT_MS, REGISTER_RETRY_TIMEOUT_MS]) {
+    ({ ok, status, data } = await cliApi.request<RegisterResponseBody>(
+      `${base}/register`,
+      { method: "POST", auth: "required", timeoutMs, body }
+    ));
+    if (ok || status !== 0) break;
+    logger.debug("run-tracker: register lost its response, retrying once", {
+      timeoutMs,
+    });
+  }
 
   if (!ok || !data) {
     if (status !== 0) {

--- a/apps/cli/tests/lib/run-tracker.test.ts
+++ b/apps/cli/tests/lib/run-tracker.test.ts
@@ -194,9 +194,14 @@ describe("registerRun", () => {
   });
 
   test("returns null on a non-2xx response", async () => {
-    globalThis.fetch = (async () =>
-      new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response("nope", { status: 500 });
+    }) as unknown as typeof fetch;
     expect(await registerRun({ url: "https://example.com" })).toBeNull();
+    // A server that ANSWERED has decided — re-asking would only duplicate work.
+    expect(calls).toBe(1);
   });
 
   test("returns null on a network error (never throws)", async () => {
@@ -204,6 +209,79 @@ describe("registerRun", () => {
       throw new Error("ECONNREFUSED");
     }) as unknown as typeof fetch;
     expect(await registerRun({ url: "https://example.com" })).toBeNull();
+  });
+
+  // #1534: the server can commit the run + its 50cr base and still lose the
+  // RESPONSE. The old behavior — resolve null, audit untracked — got that run
+  // reaped as an orphan pending and the delivered audit refunded to free. So a
+  // lost response is retried, under one key the server uses to converge.
+  test("sends a client-generated idempotency key with register", async () => {
+    let sent: Record<string, unknown> = {};
+    globalThis.fetch = (async (_i: unknown, init?: RequestInit) => {
+      sent = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({ runId: "r", websiteId: "w", auditId: "a" }),
+        { status: 201 }
+      );
+    }) as unknown as typeof fetch;
+
+    await registerRun({ url: "https://example.com" });
+    expect(typeof sent.idempotencyKey).toBe("string");
+    expect((sent.idempotencyKey as string).length).toBeGreaterThanOrEqual(8);
+  });
+
+  test("retries a LOST response once, under the SAME idempotency key", async () => {
+    const keys: unknown[] = [];
+    globalThis.fetch = (async (_i: unknown, init?: RequestInit) => {
+      keys.push(
+        (JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>)
+          .idempotencyKey
+      );
+      if (keys.length === 1) throw new Error("The operation timed out.");
+      return new Response(
+        JSON.stringify({
+          runId: "run_r",
+          websiteId: "web_r",
+          auditId: "aud_r",
+        }),
+        { status: 201 }
+      );
+    }) as unknown as typeof fetch;
+
+    const run = await registerRun({ url: "https://example.com" });
+    expect(run?.runId).toBe("run_r");
+    expect(keys).toHaveLength(2);
+    // Same key both times — that is what makes the retry free of a second run
+    // row and a second debit server-side.
+    expect(keys[1]).toBe(keys[0] as string);
+  });
+
+  test("gives up after the retry rather than blocking the audit forever", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      throw new Error("The operation timed out.");
+    }) as unknown as typeof fetch;
+    expect(await registerRun({ url: "https://example.com" })).toBeNull();
+    expect(calls).toBe(2);
+  });
+
+  test("a fresh key per audit — one lost register never adopts another's run", async () => {
+    const keys: unknown[] = [];
+    globalThis.fetch = (async (_i: unknown, init?: RequestInit) => {
+      keys.push(
+        (JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>)
+          .idempotencyKey
+      );
+      return new Response(
+        JSON.stringify({ runId: "r", websiteId: "w", auditId: "a" }),
+        { status: 201 }
+      );
+    }) as unknown as typeof fetch;
+
+    await registerRun({ url: "https://example.com" });
+    await registerRun({ url: "https://example.com" });
+    expect(keys[0]).not.toBe(keys[1] as string);
   });
 
   test("returns null when the response omits required ids", async () => {


### PR DESCRIPTION
A signed-in `squirrel audit` registers its run at start so it shows live in the dashboard. When that register's **response** is lost — or exceeds the old 5s timeout — the CLI resolves `null` and audits fully untracked, even though the server already committed the run row and its 50cr audit base. No `markRunning`, no finalize, no `runId` threaded into publish. The run is later reaped as `failed` and refunded, while the very same audit publishes a real report: a scary failure next to a working report, and a delivered audit for free.

Observed on ~9% of CLI runs over 30 days, across every version 0.0.59–0.0.83, concentrated far from us-west (DE/ID/RU latency tail).

## What changes

- **`REGISTER_TIMEOUT_MS` 5s → 12s.** Register is kicked off *without* awaiting (it overlaps the crawl), so a generous ceiling costs nothing at audit start. The old comment claiming it blocks the audit was stale.
- **One retry, at 8s, for a LOST response only** (`status === 0`: timeout, socket reset, DNS blip). A server that answered — with any status — has decided; re-asking would only duplicate the request. Total register budget stays ~20s so a dead API can't hold the end-of-run finalizer.
- **A client-generated `idempotencyKey`, identical across both attempts.** The server derives the run id from it, so a retry that races a first attempt still committing converges on the same run row and the same `audit_base` debit rather than creating and charging for a second one. Servers that don't know the field ignore it.

## Tests

`apps/cli/tests/lib/run-tracker.test.ts`: register sends a key; a lost response is retried once under the *same* key; a non-2xx is *not* retried; the retry gives up rather than blocking forever; each audit gets a fresh key.

Server side (idempotent register, publish-time adoption of an orphan run, repayment of a stale refund) lands in the private monorepo: squirrelscan/repo#1534.