### PR TITLE
docs(readme): correct the per-category rule counts to match the engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Site Integrity | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | Security | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | Links | 14 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, HTTPS downgrades |
-| Content | 15 | Text quality and honesty: duplicate titles and descriptions, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| Content | 16 | Text quality and honesty: duplicate titles and descriptions, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | Performance | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | Images | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
-| Structured Data | 10 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search |
+| Structured Data | 11 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search |
 | Accessibility | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | Mobile | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
 | Social Media | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |


### PR DESCRIPTION
The README's per-category table summed to **267** while the headline two lines below it said **269**.

`content` and `schema` each gained a rule — `content/thin-vs-site-norm` (#89) and `schema/coverage-outlier` (#91) — and neither category row was bumped when those landed.

| category | was | now |
|---|---|---|
| Content | 15 | 16 |
| Structured Data | 10 | 11 |

Counts read from `loadAllRules()` rather than incremented by hand. The 21 rows now sum to 269, matching `**Total: 269 rules across 21 categories**`.

## Why it drifted

This table has no drift guard. The count-consistency suite (`apps/api/tests/routes/rule-count-consistency.test.ts`) lives in the monorepo and covers `repo-public/docs/**`, but its `README.md` entry refers to the *monorepo's* README — every repo-public path in that file is explicitly prefixed. So this file is guarded by nothing, in either the exact-count list or the per-category one. Tracked as squirrelscan/repo#1424.

A guard covering both the totals and this table's row sum is going up on the monorepo side alongside this.