### PR TITLE
fix(rules): missing robots.txt reports as error, not warning

### DIFF
--- a/apps/cli/src/reports/diff/index.ts
+++ b/apps/cli/src/reports/diff/index.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/types";
 
 import { getScoreGrade } from "@/audit/scoring";
+import { CHECK_NAME_ROBOTS_EXISTS, RULE_ID_ROBOTS_TXT } from "@/constants";
 
 import type {
   DiffChange,
@@ -22,6 +23,25 @@ import {
   normalizeTargetId,
   type IssueTargetType,
 } from "./fingerprint";
+
+// Missing robots.txt used to be reported as a "warn" check; reports scored
+// before #1535 still carry that status in storage. Normalize it to "fail"
+// here so diffing an old report against a re-audit of the same still-missing
+// robots.txt doesn't read as a false regression (or an improvement, in the
+// other diff direction).
+function normalizeLegacyCheckStatus(
+  ruleId: string,
+  check: CheckResult
+): CheckResult {
+  if (
+    ruleId === RULE_ID_ROBOTS_TXT &&
+    check.name === CHECK_NAME_ROBOTS_EXISTS &&
+    check.status === "warn"
+  ) {
+    return { ...check, status: "fail" };
+  }
+  return check;
+}
 
 function shouldIncludeCheck(
   check: CheckResult,
@@ -93,7 +113,8 @@ export function buildIssueInstances(
       : Object.entries(report.ruleResults);
 
   for (const [ruleId, rule] of ruleEntries) {
-    for (const check of rule.checks) {
+    for (const rawCheck of rule.checks) {
+      const check = normalizeLegacyCheckStatus(ruleId, rawCheck);
       if (!shouldIncludeCheck(check, severity)) continue;
 
       if (check.items && check.items.length > 0) {

--- a/apps/cli/tests/reports/diff.test.ts
+++ b/apps/cli/tests/reports/diff.test.ts
@@ -172,6 +172,37 @@ describe("diff reports", () => {
     expect(diff.changed[0].changeType).toBe("regression");
   });
 
+  // #1535: missing robots.txt moved from "warn" to "fail". A report scored
+  // before that fix still has "warn" on disk; diffing it against a re-audit
+  // of the SAME still-missing robots.txt must not read as a status change.
+  test("legacy warn robots-txt-exists vs current fail is not a regression", () => {
+    const baseline = makeReport({
+      "crawl/robots-txt": makeRuleResult("crawl/robots-txt", [
+        {
+          name: "robots-txt-exists",
+          status: "warn",
+          message: "No robots.txt found",
+        },
+      ]),
+    });
+
+    const current = makeReport({
+      "crawl/robots-txt": makeRuleResult("crawl/robots-txt", [
+        {
+          name: "robots-txt-exists",
+          status: "fail",
+          message: "No robots.txt found",
+        },
+      ]),
+    });
+
+    const diff = diffReports(baseline, current);
+
+    expect(diff.added.length).toBe(0);
+    expect(diff.removed.length).toBe(0);
+    expect(diff.changed.length).toBe(0);
+  });
+
   // #586: diffing a scored baseline against a failed (0-page) current must keep
   // the failed side's score null (N/A), not coerce it to 0 — else the diff reads
   // as a bogus "-85 point / grade-F regression" instead of "current audit failed".

--- a/apps/cli/tests/scoring.test.ts
+++ b/apps/cli/tests/scoring.test.ts
@@ -254,6 +254,72 @@ describe("calculateHealthScore", () => {
     expect(score.overall).toBe(37);
   });
 
+  test("applies penalty for missing robots.txt with fail status (#1535)", () => {
+    // A missing robots.txt is reported as "fail" (not "warn") so the rule
+    // sorts into the error block, but the -15% penalty must still apply.
+    const mockRobotsMeta = {
+      id: "crawl/robots-txt",
+      name: "Robots.txt",
+      description: "Robots.txt check",
+      solution: "Add robots.txt",
+      category: "crawl" as const,
+      scope: "site" as const,
+      severity: "error" as const,
+      weight: 8,
+    };
+
+    const results = new Map<string, RuleRunResult>([
+      [
+        "core/test-rule",
+        {
+          meta: mockCoreMeta,
+          checks: [
+            { name: "test1", status: "pass", message: "Passed" },
+            { name: "test2", status: "warn", message: "Warning" },
+          ],
+        },
+      ],
+      [
+        "crawl/robots-txt",
+        {
+          meta: mockRobotsMeta,
+          checks: [
+            {
+              name: "robots-txt-exists",
+              status: "fail",
+              message: "No robots.txt found",
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const withPenalty = calculateHealthScore({ results });
+
+    // Same shape but robots-txt-exists passes, isolating the penalty's effect.
+    const passingResults = new Map<string, RuleRunResult>(results);
+    passingResults.set("crawl/robots-txt", {
+      meta: mockRobotsMeta,
+      checks: [
+        {
+          name: "robots-txt-exists",
+          status: "pass",
+          message: "robots.txt exists",
+        },
+      ],
+    });
+    const withoutFailingCheck = calculateHealthScore({
+      results: passingResults,
+    });
+
+    // A failed robots-txt-exists check both drags down the base score (0
+    // credit vs full credit) AND applies the -15% multiplier on top of that.
+    // Base: (10*0.75 + 8*0) / 18 = 41.67%, Curve: 100*0.4167^1.2 ≈ 35,
+    // Penalty: 15% reduction, Overall: 35 × 0.85 ≈ 30
+    expect(withPenalty.overall).toBe(30);
+    expect(withPenalty.overall!).toBeLessThan(withoutFailingCheck.overall!);
+  });
+
   test("applies penalty for robots blocking all", () => {
     const mockRobotsMeta = {
       id: "crawl/robots-txt",

--- a/packages/audit-engine/src/scoring.ts
+++ b/packages/audit-engine/src/scoring.ts
@@ -510,7 +510,9 @@ function calculatePenaltyMultiplier(
     if (disallowCheck?.status === "fail") {
       multiplier *= 1 - PENALTY_ROBOTS_BLOCKS_ALL; // Blocks all
     }
-    if (existsCheck?.status === "warn") {
+    // "fail" is the current status for a missing robots.txt; "warn" is kept
+    // for reports scored before this check's severity was corrected (#1535).
+    if (existsCheck?.status === "fail" || existsCheck?.status === "warn") {
       multiplier *= 1 - PENALTY_NO_ROBOTS_TXT; // Missing
     }
   }

--- a/packages/rules/src/crawl/robots-txt.ts
+++ b/packages/rules/src/crawl/robots-txt.ts
@@ -32,7 +32,7 @@ export const robotsTxtRule: Rule = {
     if (!robotsTxt.exists) {
       checks.push({
         name: "robots-txt-exists",
-        status: "warn",
+        status: "fail",
         message: "No robots.txt found",
         value: "Search engines will crawl all accessible pages",
       });


### PR DESCRIPTION
Closes squirrelscan/repo#1535

`crawl/robots-txt` has meta severity `error`, but the missing-file check emitted `status: "warn"`. Effective severity derives from what actually happened (a rule whose checks only warn is reported as a warning), so a site with no robots.txt rendered as **Warning** in every report — even though the -15% `PENALTY_NO_ROBOTS_TXT` multiplier already treats it as critical.

## What changed
- `robots-txt-exists` now emits `status: "fail"` when robots.txt is absent, so it sorts into the error block.
- `calculatePenaltyMultiplier` in `packages/audit-engine/src/scoring.ts` now applies the -15% penalty for both the new `"fail"` status and the legacy `"warn"` status stored in reports scored before this fix (the rescore path shares this function).
- `apps/cli/src/reports/diff/index.ts` normalizes a legacy `"warn"` on this specific check to `"fail"` before comparing/filtering, so diffing an old report against a re-audit of a site whose robots.txt is *still* missing doesn't read as a false regression.

## Acceptance criteria
- [x] `crawl/robots-txt` emits `status: "fail"` for the `robots-txt-exists` check when robots.txt is absent
- [x] Reports show the rule as `error` (and it sorts into the error block) when robots.txt is missing — via the existing severity-derivation logic in `packages/report/src/grouping.ts` (unchanged, already correct: `failCount > 0` keeps the meta severity)
- [x] The -15% `PENALTY_NO_ROBOTS_TXT` multiplier still applies for the new `fail` status AND for the legacy `warn` status stored in existing reports (rescore path)
- [x] Test covers the penalty applying on a failed robots-txt-exists check

Note: this is a `packages/rules` / `packages/audit-engine` fix, which live in this public repo (`squirrelscan/squirrelscan`), consumed by the private monorepo via a submodule gitlink. No monorepo-side change is needed — the rule's catalog metadata (severity, weight, etc.) is unchanged, only its runtime behavior. Per repo convention, the monorepo's `repo-public` gitlink should only be bumped to this commit once it's merged to `main` here.

## Test plan
- [x] `bun test` in `packages/rules`, `packages/audit-engine`, `packages/report`, and `apps/cli` — all pass
- [x] `bun run typecheck` in `packages/rules`, `packages/audit-engine`, `apps/cli` — clean
- [x] `bun run format` / `bun run lint` — clean
- [x] Added tests: penalty applies on `fail` status (`apps/cli/tests/scoring.test.ts`), diff normalization doesn't false-flag a regression (`apps/cli/tests/reports/diff.test.ts`)