### PR TITLE
fix(installer): capture self install output and fix Windows symlink EPERM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,31 @@ jobs:
       - uses: ./.github/actions/setup-bun
       - run: bun test
 
+  installer-scripts:
+    name: Installer script syntax
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # install.ps1 only ever runs on Windows machines, and the install test
+      # workflow fetches the PUBLISHED script from main — so nothing here ever
+      # parsed a change to it before users did. pwsh ships on the ubuntu runner
+      # and exposes the same parser Windows PowerShell uses.
+      - name: Parse install.ps1
+        shell: pwsh
+        run: |
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path './install.ps1').Path, [ref]$null, [ref]$errors) | Out-Null
+          if ($errors) {
+            $errors | ForEach-Object { Write-Host $_ }
+            exit 1
+          }
+          Write-Host 'install.ps1 parsed clean'
+      - name: Parse install.sh
+        run: bash -n install.sh
+
   dependency-audit:
     name: Dependency audit
     needs: quality

--- a/apps/cli/src/controllers/self/install.ts
+++ b/apps/cli/src/controllers/self/install.ts
@@ -2,7 +2,6 @@ import {
   existsSync,
   mkdirSync,
   copyFileSync,
-  symlinkSync,
   unlinkSync,
   chmodSync,
 } from "node:fs";
@@ -11,6 +10,7 @@ import { dirname } from "node:path";
 import type { InstallResult } from "@/self/types";
 
 import { type Result, ok, err, commandError } from "@/controllers/types";
+import { linkBinary } from "@/self/link-binary";
 import {
   getSquirrelPaths,
   getReleasePath,
@@ -55,11 +55,11 @@ export async function runSelfInstall(
       chmodSync(binaryPath, 0o755);
     }
 
-    // Create/update symlink
+    // Create/update symlink (a copy on Windows, where symlinks need privilege)
     if (existsSync(symlinkPath)) {
       unlinkSync(symlinkPath);
     }
-    symlinkSync(binaryPath, symlinkPath);
+    linkBinary(binaryPath, symlinkPath);
 
     // Initialize settings — preserve anything already there (auth, telemetry
     // opt-out, channel); a reinstall/upgrade must never reset user state.

--- a/apps/cli/src/self/doctor.ts
+++ b/apps/cli/src/self/doctor.ts
@@ -130,6 +130,18 @@ function checkSymlink(): DoctorCheck {
   try {
     const stats = lstatSync(symlinkPath);
     if (!stats.isSymbolicLink()) {
+      // On Windows a plain FILE copy IS how `self install` lands the binary
+      // when symlinks need a privilege the user doesn't have (see
+      // link-binary.ts), so it's the expected shape there, not a suspicious
+      // manual install. Anything else at that path (a directory, a socket)
+      // still warns.
+      if (platform() === "win32" && stats.isFile()) {
+        return {
+          name: "Symlink",
+          status: "pass",
+          message: `Binary copy at: ${symlinkPath}`,
+        };
+      }
       return {
         name: "Symlink",
         status: "warn",

--- a/apps/cli/src/self/link-binary.ts
+++ b/apps/cli/src/self/link-binary.ts
@@ -1,0 +1,44 @@
+import { copyFileSync, symlinkSync } from "node:fs";
+import { platform } from "node:os";
+
+export interface LinkBinaryDeps {
+  symlink?: (target: string, path: string) => void;
+  copy?: (source: string, destination: string) => void;
+  isWindows?: boolean;
+}
+
+/**
+ * Point `linkPath` at `targetPath`, the way this platform can.
+ *
+ * Windows hands SeCreateSymbolicLinkPrivilege only to elevated processes and
+ * to accounts with Developer Mode on, so symlinkSync throws EPERM for a normal
+ * user in Windows PowerShell. That is what made `squirrel self install` exit 1
+ * on stock Windows boxes while install.ps1 could only report the exit code
+ * (#1538). Fall back to a plain copy there: it costs the binary's size on disk
+ * but leaves a working squirrel.exe on PATH, and `self update` overwrites it
+ * the same way. POSIX keeps the symlink (cheap, and self update flips it).
+ *
+ * The fallback is Windows-only on purpose — an EPERM on macOS/Linux is a real
+ * problem (unwritable bin dir) and must keep surfacing instead of silently
+ * turning into a copy that the next update can't swap.
+ */
+export function linkBinary(
+  targetPath: string,
+  linkPath: string,
+  deps: LinkBinaryDeps = {}
+): void {
+  const symlink = deps.symlink ?? symlinkSync;
+  const copy = deps.copy ?? copyFileSync;
+  const isWindows = deps.isWindows ?? platform() === "win32";
+
+  if (!isWindows) {
+    symlink(targetPath, linkPath);
+    return;
+  }
+
+  try {
+    symlink(targetPath, linkPath);
+  } catch {
+    copy(targetPath, linkPath);
+  }
+}

--- a/apps/cli/src/self/paths.ts
+++ b/apps/cli/src/self/paths.ts
@@ -220,12 +220,23 @@ export function getUpdateLockPath(): string {
  * `self install` / install.sh / npm postinstall and `self update` can
  * safely swap the symlink. False for npm-fallback binaries inside
  * node_modules, manual copies, and dev mode (execPath = bun itself).
+ *
+ * Windows is the exception: `self install` lands a COPY at the managed bin
+ * path there (symlinks need a privilege most users don't have — see
+ * link-binary.ts), so the running exe is never under releases/. Without the
+ * win32 branch every Windows install would read as hand-rolled and both
+ * `self update` and auto-update would refuse to run (#1538). Only the DEFAULT
+ * bin path counts; a --bin-dir install stays unmanaged, as it was before.
  */
 export function isManagedInstall(): boolean {
   try {
     const exe = realpathSync(process.execPath);
     const releases = realpathSync(getSquirrelPaths().releases);
-    return exe.startsWith(releases + sep);
+    if (exe.startsWith(releases + sep)) return true;
+    if (platform() === "win32") {
+      return exe === realpathSync(getSymlinkPath());
+    }
+    return false;
   } catch {
     // releases dir missing or execPath unresolvable → not managed
     return false;

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -2,16 +2,16 @@ import { spawn } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   statSync,
   writeFileSync,
   unlinkSync,
-  symlinkSync,
   chmodSync,
 } from "node:fs";
 import { platform } from "node:os";
-import { dirname } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import { AUTO_UPDATE_FALLBACK_THRESHOLD } from "@/constants";
 import { type Result, ok, err, commandError } from "@/controllers/types";
@@ -21,6 +21,7 @@ import type { ReleaseManifest, UpdateResult, UserSettings } from "./types";
 
 import { version } from "../../package.json";
 import { updateSuppressedReason } from "./install-meta";
+import { linkBinary } from "./link-binary";
 import {
   getReleasePath,
   getBinaryPath,
@@ -786,6 +787,27 @@ export async function installVersion(
 }
 
 /**
+ * Delete the `.old-<pid>` binaries a previous Windows update renamed aside.
+ * Best effort: one still being executed stays until the run after that.
+ */
+function sweepReplacedBinaries(symlinkPath: string): void {
+  const dir = dirname(symlinkPath);
+  const prefix = `${basename(symlinkPath)}.old-`;
+  try {
+    for (const entry of readdirSync(dir)) {
+      if (!entry.startsWith(prefix)) continue;
+      try {
+        unlinkSync(join(dir, entry));
+      } catch {
+        // Still loaded by a running process — try again next update.
+      }
+    }
+  } catch {
+    // Unreadable bin dir; the swap below reports the real failure.
+  }
+}
+
+/**
  * Update the symlink to point to a new version
  * Old versions are kept for potential rollback
  */
@@ -814,7 +836,20 @@ export function updateSymlink(
     } catch {
       // no stale tmp link
     }
-    symlinkSync(binaryPath, tmpLink);
+    linkBinary(binaryPath, tmpLink);
+    // On Windows the thing on PATH is a COPY of the binary (link-binary.ts),
+    // and that copy is what's running during an update — Windows refuses to
+    // overwrite or delete a loaded .exe, but it does allow RENAMING one. Move
+    // the old exe aside so the swap below lands, and sweep the leftovers
+    // (deletable once nothing runs them) on the next update. #1538
+    if (platform() === "win32" && existsSync(symlinkPath)) {
+      sweepReplacedBinaries(symlinkPath);
+      try {
+        renameSync(symlinkPath, `${symlinkPath}.old-${process.pid}`);
+      } catch {
+        // Still occupied — the rename below may yet succeed.
+      }
+    }
     try {
       renameSync(tmpLink, symlinkPath);
     } catch {
@@ -822,7 +857,7 @@ export function updateSymlink(
       // links — fall back to the old swap and clean up the tmp link.
       try {
         if (existsSync(symlinkPath)) unlinkSync(symlinkPath);
-        symlinkSync(binaryPath, symlinkPath);
+        linkBinary(binaryPath, symlinkPath);
       } finally {
         try {
           unlinkSync(tmpLink);

--- a/apps/cli/tests/self/link-binary.test.ts
+++ b/apps/cli/tests/self/link-binary.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { linkBinary } from "../../src/self/link-binary";
+
+// Windows refuses symlinks to unprivileged users, which is what made
+// `self install` exit 1 on stock Windows boxes (#1538). The deps are injected
+// so both branches are testable from any host platform.
+function eperm(): never {
+  const error = new Error(
+    "EPERM: operation not permitted, symlink"
+  ) as NodeJS.ErrnoException;
+  error.code = "EPERM";
+  throw error;
+}
+
+describe("linkBinary", () => {
+  test("symlinks on posix", () => {
+    const dir = mkdtempSync(join(tmpdir(), "squirrel-link-"));
+    try {
+      const target = join(dir, "squirrel");
+      const link = join(dir, "bin-squirrel");
+      writeFileSync(target, "binary");
+
+      linkBinary(target, link, { isWindows: false });
+
+      expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to a copy on windows when symlink is denied", () => {
+    const dir = mkdtempSync(join(tmpdir(), "squirrel-link-"));
+    try {
+      const target = join(dir, "squirrel.exe");
+      const link = join(dir, "bin-squirrel.exe");
+      writeFileSync(target, "binary");
+
+      linkBinary(target, link, { isWindows: true, symlink: eperm });
+
+      expect(existsSync(link)).toBe(true);
+      expect(lstatSync(link).isSymbolicLink()).toBe(false);
+      expect(readFileSync(link, "utf-8")).toBe("binary");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the symlink on windows when the privilege is available", () => {
+    let copied = false;
+    const linked: string[] = [];
+
+    linkBinary("C:\\target.exe", "C:\\bin\\squirrel.exe", {
+      isWindows: true,
+      symlink: (target, path) => linked.push(`${target}->${path}`),
+      copy: () => {
+        copied = true;
+      },
+    });
+
+    expect(linked).toEqual(["C:\\target.exe->C:\\bin\\squirrel.exe"]);
+    expect(copied).toBe(false);
+  });
+
+  test("does not swallow a symlink failure on posix", () => {
+    let copied = false;
+
+    expect(() =>
+      linkBinary("/target", "/bin/squirrel", {
+        isWindows: false,
+        symlink: eperm,
+        copy: () => {
+          copied = true;
+        },
+      })
+    ).toThrow("EPERM");
+    // A copy here would leave an install `self update` can't swap.
+    expect(copied).toBe(false);
+  });
+});

--- a/apps/cli/tests/self/link-binary.test.ts
+++ b/apps/cli/tests/self/link-binary.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-  existsSync,
   lstatSync,
   mkdtempSync,
   readFileSync,
@@ -47,8 +46,6 @@ describe("linkBinary", () => {
       writeFileSync(target, "binary");
 
       linkBinary(target, link, { isWindows: true, symlink: eperm });
-
-      expect(existsSync(link)).toBe(true);
       expect(lstatSync(link).isSymbolicLink()).toBe(false);
       expect(readFileSync(link, "utf-8")).toBe("binary");
     } finally {

--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,14 @@ $Platform = "windows-x64"
 function Write-Log { param($Message) Write-Host "==> " -ForegroundColor Green -NoNewline; Write-Host $Message }
 function Write-Info { param($Message) Write-Host ":: " -ForegroundColor Blue -NoNewline; Write-Host $Message }
 function Write-Warn { param($Message) Write-Host "Warning: " -ForegroundColor Yellow -NoNewline; Write-Host $Message }
-function Write-Err { param($Message) Write-Host "Error: " -ForegroundColor Red -NoNewline; Write-Host $Message; Send-ErrorReport -Step $script:CurrentStep -ExitCode 1 -Line "$Message"; exit 1 }
+function Write-Err {
+    param([string]$Message, [string]$Output = "", [int]$ExitCode = 1)
+    Write-Host "Error: " -ForegroundColor Red -NoNewline
+    Write-Host $Message
+    # $Output is the failing command's own stdout/stderr, when we captured it.
+    Send-ErrorReport -Step $script:CurrentStep -ExitCode $ExitCode -Line "$Message" -Output $Output
+    exit 1
+}
 
 # --- Failure reporting -------------------------------------------------
 # On failure, fire a tiny anonymous report to the installer worker (→ Sentry)
@@ -22,28 +29,71 @@ function Write-Err { param($Message) Write-Host "Error: " -ForegroundColor Red -
 # non-empty value, mirroring install.sh and apps/cli/src/self/telemetry.ts).
 # Fire-and-forget: never blocks or fails the install; carries only coarse
 # context (os/arch/step/exit code), never paths/env/hostname/secrets. #1013
-$InstallerReportVersion = "1"
+# v2 adds `error_output` — the tail of the failing command's own output (#1538).
+$InstallerReportVersion = "2"
 $ErrorEndpoint = if ($env:SQUIRREL_ERROR_ENDPOINT) { $env:SQUIRREL_ERROR_ENDPOINT } else { "https://install.squirrelscan.com/error" }
 # Release metadata (latest version per channel) — R2-backed, no rate limits.
 $ReleasesEndpoint = if ($env:SQUIRREL_RELEASES_ENDPOINT) { $env:SQUIRREL_RELEASES_ENDPOINT } else { "https://install.squirrelscan.com/releases" }
+$ErrorLineMax = 200
+$ErrorOutputMax = 1000
 $script:CurrentStep = "init"
+$script:LastCapturedExitCode = 0
+
+# Make an arbitrary string safe to put in a report: reduce to printable ASCII
+# (control chars AND non-ASCII -> space) so truncation can't split a
+# surrogate/multibyte char and no ANSI escape reaches the JSON, scrub the home
+# path -> '~' so no local path leaks, then hard-truncate. Command output keeps
+# its TAIL (-KeepTail) because that's where the error is; a one-line message
+# keeps its head. The worker re-clamps and redacts too.
+function Get-ScrubbedText {
+    param([string]$Text, [int]$MaxLength = 200, [switch]$KeepTail)
+    if (-not $Text) { return "" }
+    $scrubbed = $Text -replace '[^\x20-\x7E]', ' '
+    if ($env:USERPROFILE) { $scrubbed = $scrubbed.Replace($env:USERPROFILE, "~") }
+    if ($HOME) { $scrubbed = $scrubbed.Replace($HOME, "~") }
+    if ($scrubbed.Length -gt $MaxLength) {
+        if ($KeepTail) {
+            $scrubbed = $scrubbed.Substring($scrubbed.Length - $MaxLength)
+        } else {
+            $scrubbed = $scrubbed.Substring(0, $MaxLength)
+        }
+    }
+    return $scrubbed
+}
+
+# Run a native command, echoing its output live AND returning it as one string.
+# `2>&1` merges the command's stderr into the pipeline; under
+# $ErrorActionPreference = "Stop" anything a native command writes to stderr
+# would otherwise become a terminating NativeCommandError, so drop to
+# "Continue" for the duration and restore afterwards. The exit code lands in
+# $script:LastCapturedExitCode.
+function Invoke-CapturedCommand {
+    param([string]$FilePath, [string[]]$Arguments = @())
+
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $lines = & $FilePath @Arguments 2>&1 | ForEach-Object {
+            $text = if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.ToString() } else { "$_" }
+            Write-Host $text
+            $text
+        }
+        $script:LastCapturedExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+    return ($lines -join "`n")
+}
 
 function Send-ErrorReport {
-    param([string]$Step, [int]$ExitCode = 1, [string]$Line = "")
+    param([string]$Step, [int]$ExitCode = 1, [string]$Line = "", [string]$Output = "")
     # Presence disables reporting, including an explicitly empty value.
     if (Test-Path Env:NO_TELEMETRY) { return }
     try {
-        $scrubbed = ""
-        if ($Line) {
-            # Reduce to printable ASCII (control chars AND non-ASCII -> space) so
-            # truncation can't split a surrogate/multibyte char, scrub the home
-            # path -> '~' so no local path leaks, then hard-truncate. The worker
-            # re-clamps and redacts too.
-            $scrubbed = $Line -replace '[^\x20-\x7E]', ' '
-            if ($env:USERPROFILE) { $scrubbed = $scrubbed.Replace($env:USERPROFILE, "~") }
-            if ($HOME) { $scrubbed = $scrubbed.Replace($HOME, "~") }
-            if ($scrubbed.Length -gt 200) { $scrubbed = $scrubbed.Substring(0, 200) }
-        }
+        $scrubbed = Get-ScrubbedText -Text $Line -MaxLength $ErrorLineMax
+        # The tail of the failing command's own stdout/stderr. Without it a
+        # self_install failure carried an exit code and nothing else (#1538).
+        $scrubbedOutput = Get-ScrubbedText -Text $Output -MaxLength $ErrorOutputMax -KeepTail
         $arch = switch ($env:PROCESSOR_ARCHITECTURE) {
             "AMD64" { "x64" }
             "ARM64" { "arm64" }
@@ -59,6 +109,7 @@ function Send-ErrorReport {
             step           = $Step
             exit_code      = $ExitCode
             error_line     = $scrubbed
+            error_output   = $scrubbedOutput
         } | ConvertTo-Json -Compress
         # Fire-and-forget: run the POST in a background job so it never blocks
         # the installer. Not awaited; the 3s timeout inside is the backstop and
@@ -226,13 +277,17 @@ function Install-Squirrel {
         }
         Write-Info "Checksum verified: $($expectedHash.Substring(0, 16))..."
 
-        # Run self install
+        # Run self install. Its output is echoed live AND captured, so a failure
+        # reports what the binary actually said instead of a bare exit code
+        # (#1538) — the tail rides along on the error report.
         $script:CurrentStep = "self_install"
         Write-Log "Running self install..."
-        & $binaryPath self install
+        $selfInstallOutput = Invoke-CapturedCommand -FilePath $binaryPath -Arguments @("self", "install")
+        $selfInstallExit = $script:LastCapturedExitCode
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Err "Self install failed with exit code $LASTEXITCODE"
+        if ($selfInstallExit -ne 0) {
+            Write-Err "Self install failed with exit code $selfInstallExit" `
+                -Output $selfInstallOutput -ExitCode $selfInstallExit
         }
     } finally {
         # Cleanup

--- a/install.sh
+++ b/install.sh
@@ -43,12 +43,20 @@ info() { echo -e "${BLUE}::${NC} $1" >&2; }
 # NO_TELEMETRY (mirrors the CLI, apps/cli/src/self/telemetry.ts), fire-and-
 # forget (never blocks or fails the install), and carries only coarse context
 # (os/arch/step/exit code) — never paths, env, hostname, or secrets. #1013
-INSTALLER_REPORT_VERSION="1"
+# v2 adds `error_output` — the tail of the failing command's own output (#1538).
+INSTALLER_REPORT_VERSION="2"
 ERROR_ENDPOINT="${SQUIRREL_ERROR_ENDPOINT:-https://install.squirrelscan.com/error}"
 # Release metadata (latest version per channel) — R2-backed, no rate limits.
 RELEASES_ENDPOINT="${SQUIRREL_RELEASES_ENDPOINT:-https://install.squirrelscan.com/releases}"
+ERROR_LINE_MAX=200
+# Chars of captured command output carried in a report. The worker clamps again.
+ERROR_OUTPUT_MAX=1000
 CURRENT_STEP="init"
 LAST_ERROR_MSG=""
+# Captured stdout/stderr of the step that failed, when we ran it under tee.
+LAST_ERROR_OUTPUT=""
+# Real exit code of a failed sub-command, when it isn't the one error() exits with.
+LAST_ERROR_CODE=""
 TMPDIR_TO_CLEAN=""
 # Survives command-substitution subshells where LAST_ERROR_MSG can't (see error()).
 ERROR_MSG_FILE="$(mktemp 2>/dev/null || true)"
@@ -61,36 +69,52 @@ json_escape() {
   printf '%s' "$1" | LC_ALL=C tr -cd '\40-\176' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
 }
 
+# Reduce a value to printable ASCII (control chars incl. newlines AND non-ASCII
+# bytes → space) BEFORE truncating, so `cut -c` can't split a multibyte char
+# into invalid UTF-8. Scrub $HOME → '~' so no local path leaks. Command output
+# keeps its TAIL (that's where the error is); a message keeps its head. The
+# worker re-clamps and redacts too.
+scrub_for_report() {
+  local text="$1" max="$2" keep_tail="${3:-head}" scrubbed tilde="~"
+  if [ -z "$text" ]; then
+    return 0
+  fi
+  scrubbed=$(printf '%s' "$text" | LC_ALL=C tr -c '\40-\176' ' ')
+  if [ -n "${HOME:-}" ]; then
+    scrubbed=${scrubbed//"$HOME"/$tilde}
+  fi
+  if [ "$keep_tail" = tail ] && [ "${#scrubbed}" -gt "$max" ]; then
+    printf '%s' "${scrubbed:${#scrubbed}-max}"
+  else
+    printf '%s' "$scrubbed" | cut -c"1-$max"
+  fi
+}
+
 report_error() {
-  local step="$1" code="$2" line="${3:-}"
+  local step="$1" code="$2" line="${3:-}" output="${4:-}"
   # Presence disables reporting, including an explicitly empty value.
   [ "${NO_TELEMETRY+x}" = x ] && return 0
   command -v curl >/dev/null 2>&1 || return 0
 
-  local os arch scrubbed=""
+  local os arch scrubbed="" scrubbed_output=""
   os=$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')
   arch=$(uname -m 2>/dev/null)
 
-  if [ -n "$line" ]; then
-    # Reduce to printable ASCII (control chars incl. newlines AND non-ASCII bytes
-    # → space) BEFORE truncating, so `cut -c` can't split a multibyte char into
-    # invalid UTF-8. Scrub $HOME → '~' so no local path leaks. The worker
-    # re-clamps and redacts too.
-    local tilde="~"
-    scrubbed=$(printf '%s' "$line" | LC_ALL=C tr -c '\40-\176' ' ')
-    [ -n "${HOME:-}" ] && scrubbed=${scrubbed//"$HOME"/$tilde}
-    scrubbed=$(printf '%s' "$scrubbed" | cut -c1-200)
-  fi
+  scrubbed=$(scrub_for_report "$line" "$ERROR_LINE_MAX")
+  # The failing command's own stdout/stderr: without it a self_install failure
+  # carried an exit code and nothing else (#1538).
+  scrubbed_output=$(scrub_for_report "$output" "$ERROR_OUTPUT_MAX" tail)
 
   local payload
-  payload=$(printf '{"script":"sh","script_version":"%s","channel":"%s","os":"%s","arch":"%s","step":"%s","exit_code":%s,"error_line":"%s"}' \
+  payload=$(printf '{"script":"sh","script_version":"%s","channel":"%s","os":"%s","arch":"%s","step":"%s","exit_code":%s,"error_line":"%s","error_output":"%s"}' \
     "$(json_escape "$INSTALLER_REPORT_VERSION")" \
     "$(json_escape "${SQUIRREL_CHANNEL:-stable}")" \
     "$(json_escape "$os")" \
     "$(json_escape "$arch")" \
     "$(json_escape "$step")" \
     "${code:-1}" \
-    "$(json_escape "$scrubbed")")
+    "$(json_escape "$scrubbed")" \
+    "$(json_escape "$scrubbed_output")")
 
   # Fire-and-forget: run the POST in a DETACHED subshell so it never blocks the
   # installer. `( cmd & )` backgrounds curl and lets the subshell exit
@@ -115,7 +139,10 @@ report_on_exit() {
   fi
   [ -n "${ERROR_MSG_FILE:-}" ] && rm -f "$ERROR_MSG_FILE"
   [ "$code" -eq 0 ] && return 0
-  report_error "$CURRENT_STEP" "$code" "$msg"
+  # error() always exits 1; prefer the failing sub-command's own code when the
+  # call site recorded one (self install, which runs under tee).
+  [ -n "$LAST_ERROR_CODE" ] && code="$LAST_ERROR_CODE"
+  report_error "$CURRENT_STEP" "$code" "$msg" "$LAST_ERROR_OUTPUT"
 }
 trap report_on_exit EXIT
 
@@ -489,7 +516,22 @@ download_and_install() {
 
   CURRENT_STEP="self_install"
   log "Running self install..."
-  "$tmpdir/squirrel" self install --bin-dir "$bin_dir"
+  # Tee rather than run bare: the user still sees the output live, and a failure
+  # can report what the binary actually said instead of a bare exit code
+  # (#1538). PIPESTATUS[0] is the binary's code, not tee's.
+  local self_install_log="$tmpdir/self-install.log"
+  set +e
+  "$tmpdir/squirrel" self install --bin-dir "$bin_dir" 2>&1 | tee "$self_install_log"
+  local rc=${PIPESTATUS[0]}
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    # Last lines, not last bytes: a byte cut can split a $HOME path so the
+    # scrubber no longer recognizes it and the username rides along. The tail
+    # is where the failure is; report_error scrubs and clamps what we pass.
+    LAST_ERROR_OUTPUT=$(tail -n 40 "$self_install_log" 2>/dev/null || true)
+    LAST_ERROR_CODE="$rc"
+    error "Self install failed with exit code $rc"
+  fi
 }
 
 # Detect user's shell and config file

--- a/scripts/install-contract.test.ts
+++ b/scripts/install-contract.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const shellInstaller = await Bun.file(new URL("../install.sh", import.meta.url)).text();
 const powershellInstaller = await Bun.file(new URL("../install.ps1", import.meta.url)).text();
@@ -17,4 +20,102 @@ describe("installer privacy and supply-chain contracts", () => {
     expect(npmPostinstall).not.toContain('["skills", "add"');
     expect(npmPostinstall).not.toContain('"-g"');
   });
+});
+
+// A `self install` failure used to report an exit code and nothing else, which
+// made a real Windows break undiagnosable (#1538). Both installers now capture
+// the command's own output and carry a bounded, scrubbed tail of it.
+describe("self install failure reporting", () => {
+  test("both installers send error_output at report version 2", () => {
+    expect(shellInstaller).toContain('INSTALLER_REPORT_VERSION="2"');
+    expect(shellInstaller).toContain('"error_output":"%s"');
+    expect(powershellInstaller).toContain('$InstallerReportVersion = "2"');
+    expect(powershellInstaller).toContain("error_output   = $scrubbedOutput");
+  });
+
+  test("sh runs self install under tee and reports the binary's own exit code", () => {
+    expect(shellInstaller).toContain(
+      'self install --bin-dir "$bin_dir" 2>&1 | tee "$self_install_log"',
+    );
+    // tee's status is not the binary's — PIPESTATUS[0] is.
+    expect(shellInstaller).toContain("local rc=${PIPESTATUS[0]}");
+    expect(shellInstaller).toContain('LAST_ERROR_CODE="$rc"');
+  });
+
+  test("ps1 captures self install output instead of running it bare", () => {
+    expect(powershellInstaller).toContain(
+      'Invoke-CapturedCommand -FilePath $binaryPath -Arguments @("self", "install")',
+    );
+    expect(powershellInstaller).not.toContain("& $binaryPath self install\n");
+    // Native stderr under $ErrorActionPreference = "Stop" would otherwise blow
+    // up as a NativeCommandError before the exit code could be read.
+    expect(powershellInstaller).toContain('$ErrorActionPreference = "Continue"');
+  });
+
+  test("captured output is bounded and home paths are scrubbed before sending", () => {
+    expect(shellInstaller).toContain("ERROR_OUTPUT_MAX=1000");
+    expect(shellInstaller).toContain('scrubbed=${scrubbed//"$HOME"/$tilde}');
+    expect(powershellInstaller).toContain("$ErrorOutputMax = 1000");
+    expect(powershellInstaller).toContain(
+      '$scrubbed.Replace($env:USERPROFILE, "~")',
+    );
+  });
+});
+
+// Behavioural, not textual: source the shell installer's reporting preamble and
+// watch what report_error actually POSTs.
+describe("install.sh report_error payload", () => {
+  test("carries a scrubbed, tail-truncated error_output as valid JSON", async () => {
+    const preambleEnd = shellInstaller.indexOf("trap report_on_exit EXIT");
+    expect(preambleEnd).toBeGreaterThan(0);
+    const preamble = join(tmpdir(), `install-preamble-${process.pid}.sh`);
+    await Bun.write(preamble, shellInstaller.slice(0, preambleEnd));
+
+    const received: Record<string, unknown>[] = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        received.push((await request.json()) as Record<string, unknown>);
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    try {
+      const home = process.env.HOME ?? "";
+      const output = `${"noise ".repeat(400)}EPERM: operation not permitted, symlink -> ${home}/.local/bin/squirrel`;
+      // The reporter POSTs from a detached subshell, so give it a beat to land.
+      const proc = Bun.spawn(
+        [
+          "bash",
+          "-c",
+          'source "$1"; report_error self_install 1 "Self install failed with exit code 1" "$2"; sleep 1',
+          "--",
+          preamble,
+          output,
+        ],
+        {
+          env: {
+            ...process.env,
+            NO_TELEMETRY: undefined,
+            SQUIRREL_ERROR_ENDPOINT: `http://127.0.0.1:${server.port}/error`,
+          } as Record<string, string>,
+        },
+      );
+      await proc.exited;
+      for (let i = 0; i < 100 && received.length === 0; i++) await Bun.sleep(50);
+
+      expect(received).toHaveLength(1);
+      const report = received[0];
+      expect(report.step).toBe("self_install");
+      expect(report.script_version).toBe("2");
+      const errorOutput = report.error_output as string;
+      expect(errorOutput.length).toBe(1000); // bounded
+      // Tail kept: the failure is at the END of a command's output.
+      expect(errorOutput).toEndWith("~/.local/bin/squirrel");
+      if (home) expect(errorOutput).not.toContain(home);
+    } finally {
+      server.stop(true);
+      rmSync(preamble, { force: true });
+    }
+  }, 15_000);
 });


### PR DESCRIPTION
Windows PowerShell installs fail at `squirrel self install`, and the installer only reports the exit code — so the failure is undiagnosable (private tracker squirrelscan/repo#1538, Sentry `INSTALLER-WORKER-A`: 3 events since 2026-08-03, windows/x64/ps1, step `self_install`, exit 1).

## What was wrong

**No diagnostics.** Both installers ran the binary bare (`& $binaryPath self install` / `"$tmpdir/squirrel" self install`), so the error report carried an exit code and nothing else.

**The actual failure.** `runSelfInstall` ends with `fs.symlinkSync(binaryPath, symlinkPath)`. Windows grants `SeCreateSymbolicLinkPrivilege` only to elevated processes and Developer Mode accounts, so this throws `EPERM` for a normal user — every stock Windows install. CI missed it twice over: the GitHub Windows runner is elevated (symlinks succeed), and `test-install.yml` downloads the **published** `install.ps1` from `main` rather than the one under test.

## Changes

- **Capture the output.** `Invoke-CapturedCommand` (ps1) and `tee` + `PIPESTATUS[0]` (sh) echo the command's stdout/stderr live *and* keep it. On failure a scrubbed, bounded tail ships as a new `error_output` field; report version bumps to `2`. Printable ASCII only, `$HOME`/`%USERPROFILE%` → `~`, 1000 chars, tail kept (the failure is at the end). The worker re-clamps and redacts server-side.
- **Fix the root cause.** `linkBinary()` falls back to `copyFileSync` on win32 when the symlink is refused. POSIX still symlinks, and an EPERM there still surfaces rather than silently becoming a copy.
- **Make a copy install a first-class install.** `isManagedInstall()` accepts the managed Windows bin path (otherwise `self update` would refuse and auto-update would be off), `updateSymlink()` renames a running `.exe` aside before the swap (Windows can rename a loaded exe, not overwrite it) and sweeps the leftovers, and `self doctor` treats a Windows file copy as a pass.
- **CI parses install.ps1** with `pwsh` on the ubuntu runner, plus `bash -n install.sh`. Nothing here parsed that file before users did.

## Notes

- Piping the child's output means it is no longer a TTY, so `self install`'s output is now uncoloured during install. Its content is unchanged.
- `install.sh` takes the last 40 **lines**, not bytes: a byte cut can split a `$HOME` path so the scrubber no longer matches it.
- The consuming `/error` endpoint change (accept + surface `error_output` on the Sentry event) lands in the private monorepo alongside this.

## Testing

- `scripts/install-contract.test.ts`: contract assertions for both scripts, plus a behavioural test that sources install.sh's reporting preamble and asserts the JSON `report_error` actually POSTs (bounded to 1000 chars, tail kept, `$HOME` scrubbed).
- `apps/cli/tests/self/link-binary.test.ts`: symlink on posix, copy fallback on windows-denied, no fallback on posix EPERM.
- `bun test apps/cli/tests/self scripts/` → 270 pass; typecheck/lint/format clean.
- PowerShell could not be executed locally (no pwsh on the dev box); the new CI job parses it.