### PR TITLE
feat(rules): add url/slug-convention, URL conventions vs the site's own norm

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **269 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **270 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler 
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more 
@@ -50,7 +50,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Accessibility | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | Mobile | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
 | Social Media | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
-| URL Structure | 8 | Length, casing, hyphenation, stop words, query parameters, special characters, trailing-slash consistency |
+| URL Structure | 9 | Length, casing, hyphenation, stop words, query parameters, special characters, trailing-slash consistency, site-wide convention consistency |
 | E-E-A-T | 15 | Experience, expertise, authority and trust signals: author bylines and credentials, about and contact pages, citations, editorial policy, disclaimers, YMYL detection |
 | Legal Compliance | 4 | Privacy policy, terms of service, real cookie-consent machinery, subprocessor disclosure |
 | Internationalization | 2 | hreflang correctness and the document language declaration |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 269 rules across 21 categories**
+**Total: 270 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -382,7 +382,8 @@
                   "rules/url/trailing-slash",
                   "rules/url/parameters",
                   "rules/url/special-chars",
-                  "rules/url/stop-words"
+                  "rules/url/stop-words",
+                  "rules/url/slug-convention"
                 ]
               },
               {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="269 Rules, 21 Categories"
+    title="270 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **269 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **270 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -233,7 +233,7 @@ squirrelscan runs **269 rules** across **21 categories**, plus opt-in cloud gap 
 | **Accessibility** | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | **Mobile** | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
 | **Social Media** | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
-| **URL Structure** | 8 | Length, casing, hyphenation, stop words, query parameters, special characters, trailing-slash consistency |
+| **URL Structure** | 9 | Length, casing, hyphenation, stop words, query parameters, special characters, trailing-slash consistency, site-wide convention consistency |
 | **E-E-A-T** | 15 | Experience, expertise, authority and trust signals: author bylines and credentials, about and contact pages, citations, editorial policy, disclaimers, YMYL detection |
 | **Legal Compliance** | 4 | Privacy policy, terms of service, real cookie-consent machinery, subprocessor disclosure |
 | **Internationalization** | 2 | hreflang correctness and the document language declaration |
@@ -242,7 +242,7 @@ squirrelscan runs **269 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 269 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 270 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 269 audit rules organized by score group and category"
+description: "All 270 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **269 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **270 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -41,7 +41,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Mobile-friendliness and responsive design (6 rules)
   </Card>
   <Card title="URL Structure" icon="folder" href="/rules/url">
-    URL structure, length, and formatting (8 rules)
+    URL structure, length, and formatting (9 rules)
   </Card>
   <Card title="Internationalization" icon="folder" href="/rules/i18n">
     Language declarations and multi-region support (2 rules)

--- a/docs/rules/url/index.mdx
+++ b/docs/rules/url/index.mdx
@@ -14,6 +14,9 @@ URL structure, length, and formatting
   <Card title="Trailing Slash" icon="circle-info" href="/rules/url/trailing-slash">
     Checks for consistent trailing slash usage
   </Card>
+  <Card title="URL Convention Consistency" icon="triangle-exclamation" href="/rules/url/slug-convention">
+    Finds URLs that break the site's own URL conventions
+  </Card>
   <Card title="URL Hyphens" icon="triangle-exclamation" href="/rules/url/hyphens">
     Checks that URLs use hyphens, not underscores
   </Card>

--- a/docs/rules/url/slug-convention.mdx
+++ b/docs/rules/url/slug-convention.mdx
@@ -1,0 +1,93 @@
+---
+title: "URL Convention Consistency"
+description: "Finds URLs that break the site's own URL conventions"
+---
+
+Finds URLs that break the site's own URL conventions
+
+| | |
+|---|---|
+| **Rule ID** | `url/slug-convention` |
+| **Category** | [URL Structure](/rules/url) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 3/10 |
+
+## How it works
+
+Every other URL rule judges one URL against a fixed idea of a good URL. None of them
+can see that a site is internally inconsistent, which is what actually produces
+duplicate-content and canonical bugs: `/My_Page`, `/my-page` and `/my-page/` are
+three different URLs to a crawler even when they serve the same thing.
+
+So the mixing is the finding here, never an individual URL. The rule computes your
+site's own dominant convention in each of five dimensions and reports only the
+minority form standing against it:
+
+| Dimension | Scope | Compares |
+|---|---|---|
+| Slug word separator | site-wide | kebab-case vs snake_case vs camelCase |
+| URL letter case | site-wide | all-lowercase paths vs paths carrying uppercase |
+| Trailing slash | site-wide | present vs absent, on extensionless paths |
+| Date in slug | per page type | dated vs undated posts of the same type |
+| Path depth | per page type | path-segment count within one page type |
+
+A site that is uniformly snake_case, or uniformly slash-terminated, is clean here:
+there is no minority to report. The rule only ever describes the deviants against
+the dominant form.
+
+It stays quiet unless it has grounds to speak:
+
+- Fewer than 10 crawled pages: no site norm exists, so the rule is skipped.
+- Fewer than 10 pages voting in a site-wide dimension (or 8 pages of one page type
+  for the per-type dimensions): the dimension is dropped, not guessed at.
+- No form reaching 70% of a dimension: the site mixes deliberately there, so
+  nothing in it is a deviant.
+
+## Precedence over the per-page URL rules
+
+The per-page rules own their pages, and this rule defers to them so one root cause
+is never reported twice:
+
+- [URL Lowercase](/rules/url/lowercase) already warns on every path containing an
+  uppercase letter, so those pages are dropped from the letter-case dimension.
+- [URL Hyphens](/rules/url/hyphens) already warns on every path containing an
+  underscore, so those pages are dropped from the separator dimension.
+- [Trailing Slash](/rules/url/trailing-slash) only raises on paths with a file
+  extension, so this rule judges the trailing-slash dimension over extensionless
+  paths only.
+
+A dimension whose deviants are entirely deferred is still named in the finding, so
+nothing is silently dropped.
+
+## Solution
+
+Your site uses more than one URL convention: some paths follow one form and a
+minority follow another. Pick the dominant form already used by most of your site,
+migrate the minority onto it, and 301-redirect the old paths so links and rankings
+follow. If a section deliberately differs (a dated archive, a deeper product tree),
+that is fine: the point is that a handful of pages should not be the exception.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["url/slug-convention"]
+```
+
+### Disable all URL Structure rules
+
+```toml squirrel.toml
+[rules]
+disable = ["url/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["url/slug-convention"]
+disable = ["*"]
+```

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -72,13 +72,15 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // exactly ONE check for the whole crawl (#1362).
       // 98212 -> 98213: schema/coverage-outlier, likewise site-scoped, adds its
       // own single whole-crawl check (#1363).
-      expect(v1.findings.length).toBe(98213);
+      // 98213 -> 98214: url/slug-convention, likewise site-scoped, adds its own
+      // single whole-crawl check (#1365).
+      expect(v1.findings.length).toBe(98214);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
-      // schema/coverage-outlier; anything else
+      // schema/coverage-outlier, 269 -> 270 url/slug-convention; anything else
       // means a rule id leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(269);
+      expect(v1.perRuleTally.length).toBe(270);
     },
     180_000,
   );

--- a/packages/rules/src/url/index.ts
+++ b/packages/rules/src/url/index.ts
@@ -7,6 +7,7 @@ import { urlHyphensRule } from "./hyphens";
 import { urlLengthRule } from "./length";
 import { urlLowercaseRule } from "./lowercase";
 import { urlParametersRule } from "./parameters";
+import { slugConventionRule } from "./slug-convention";
 import { slugKeywordsRule } from "./slug-keywords";
 import { specialCharsRule } from "./special-chars";
 import { stopWordsRule } from "./stop-words";
@@ -21,9 +22,11 @@ export const rules: Rule[] = [
   urlParametersRule,
   specialCharsRule,
   stopWordsRule,
+  slugConventionRule,
 ];
 
 export {
+  slugConventionRule,
   slugKeywordsRule,
   specialCharsRule,
   stopWordsRule,

--- a/packages/rules/src/url/slug-convention.ts
+++ b/packages/rules/src/url/slug-convention.ts
@@ -1,0 +1,512 @@
+// url/slug-convention - URL conventions judged against the site's own norm (#1365)
+//
+// Every other url rule judges ONE url against a fixed idea of a good url. None of
+// them can see that a site is internally inconsistent - half its paths ending in a
+// slash and half not, most slugs kebab-case with a pocket of snake_case - which is
+// the thing that actually produces duplicate-content and canonical bugs. So the
+// *mixing* is the finding here, never an individual url: the rule computes the
+// site's own modal convention per dimension and reports only the minority form
+// against the dominant one.
+//
+// Dimensions, each judged independently:
+//   site-wide   separator      kebab-case vs snake_case vs camelCase last segment
+//   site-wide   case           all-lowercase vs a path carrying uppercase
+//   site-wide   trailing-slash present vs absent (extensionless paths only)
+//   per pageType  date-in-slug   dated vs undated posts of the same type
+//   per pageType  depth          path-segment count within one page type
+//
+// Guards, in the order they matter:
+//   1. Site floor (SLUG_NORM_MIN_PAGES) - a small crawl has no norm to speak of.
+//   2. Sample floor per dimension (SLUG_NORM_MIN_SAMPLE site-wide,
+//      SLUG_NORM_MIN_GROUP_PAGES per pageType) - a dimension nobody voted in is
+//      dropped, not guessed at.
+//   3. Modal agreement (SLUG_NORM_MIN_AGREEMENT) - a dimension whose values do not
+//      concentrate on one form is legitimately heterogeneous, and nothing in it is
+//      a deviant. Skipping beats accusing a healthy site.
+//   Together these mean a site that is UNIFORMLY snake_case, or uniformly
+//   slash-terminated, is clean here: there is no minority to report.
+//
+// Precedence (#1365). The direction of suppression is ONE-WAY: the per-page url
+// rules own their pages, and this rule drops any deviant they already flag.
+//   - url/lowercase warns on every path containing [A-Z] -> a deviant url with
+//     uppercase in its path is dropped from the `case` dimension.
+//   - url/hyphens warns on every path containing "_" -> a deviant url with an
+//     underscore is dropped from the `separator` dimension.
+//   - url/trailing-slash only ever raises on paths with a FILE EXTENSION (an
+//     extensionless path gets an `info`), so this rule judges the trailing-slash
+//     dimension over extensionless paths only and the two never overlap.
+// A dimension whose deviants are wholly suppressed is still reported in the
+// message tail + `details.deferredTo`, so the detection stays visible without the
+// site being accused twice for one root cause.
+//
+// Dual path: `ctx.siteQuery` streams (normalizedUrl, pageType) straight off
+// page_features; the legacy path reads the same two fields from `ctx.site.pages`.
+// Both feed ONE accumulator and ONE check builder, and every list is sorted before
+// it is emitted, so the output is byte-identical by construction and independent of
+// crawl order (same shape as content/duplicate-title, #1021/#1022).
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+import type { CheckItem, SiteQuery } from "@squirrelscan/core-contracts";
+
+/** Crawl-wide page floor: below this there is no site norm to judge against. */
+export const SLUG_NORM_MIN_PAGES = 10;
+
+/** Sample floor for a site-wide dimension (pages that actually vote in it). */
+export const SLUG_NORM_MIN_SAMPLE = 10;
+
+/** Sample floor for a per-`pageType` dimension. */
+export const SLUG_NORM_MIN_GROUP_PAGES = 8;
+
+/**
+ * Share of a dimension's pages that must share one value before that value is
+ * treated as the norm. Below this the site genuinely mixes and no form is a
+ * deviant.
+ */
+export const SLUG_NORM_MIN_AGREEMENT = 0.7;
+
+/** Share of crawled pages that turns the warning into a failure. */
+export const SLUG_NORM_FAIL_SHARE = 0.2;
+
+/** Caps on reported items / urls / norms, so one rule cannot bloat a report. */
+const SLUG_NORM_MAX_ITEMS = 10;
+const SLUG_NORM_MAX_URLS = 10;
+const SLUG_NORM_MAX_NORMS = 10;
+
+const CHECK_NAME = "slug-convention";
+
+/** Dimension ids, in the order they are reported. */
+const DIMENSIONS = ["separator", "case", "trailing-slash", "date-in-slug", "depth"] as const;
+type Dimension = (typeof DIMENSIONS)[number];
+
+/** Dimensions computed per `pageType` rather than across the whole site. */
+const PER_TYPE_DIMENSIONS = new Set<Dimension>(["date-in-slug", "depth"]);
+
+/** The per-page rule that already owns a deviant, per dimension. */
+const OWNING_PAGE_RULE: Partial<Record<Dimension, string>> = {
+  case: "url/lowercase",
+  separator: "url/hyphens",
+};
+
+const DIMENSION_LABELS: Record<Dimension, string> = {
+  separator: "slug word separator",
+  case: "URL letter case",
+  "trailing-slash": "trailing slash",
+  "date-in-slug": "date in slug",
+  depth: "path depth",
+};
+
+const VALUE_LABELS: Record<string, string> = {
+  kebab: "kebab-case",
+  snake: "snake_case",
+  camel: "camelCase",
+  lower: "all-lowercase",
+  mixed: "mixed-case",
+  slash: "a trailing slash",
+  bare: "no trailing slash",
+  dated: "a date in the slug",
+  undated: "no date in the slug",
+};
+
+/**
+ * A date embedded in a path: /2026/08/ or /2026-08-13 or -2026-08-13. The year is
+ * pinned to 19xx/20xx and the month/day to real ranges so a product slug like
+ * `widget-2000-50-black` is not read as a date.
+ */
+const DATE_IN_PATH =
+  /(?:^|[/\-])(?:19|20)\d{2}([/\-])(?:0[1-9]|1[0-2])(?:\1(?:0[1-9]|[12]\d|3[01]))?(?:$|[/\-])/;
+
+/** A path whose last segment looks like a file (…/report.pdf). */
+const FILE_EXTENSION = /\.[a-z0-9]{2,5}$/i;
+
+/** One page's contribution, from either path. */
+interface SlugPageRecord {
+  url: string;
+  status: number;
+  pageType: string | null;
+}
+
+/** One dimension's votes, for the site (`pageType: null`) or for one page type. */
+interface DimensionBucket {
+  dimension: Dimension;
+  pageType: string | null;
+  /** value -> urls that voted for it (sorted at judge time). */
+  values: Map<string, string[]>;
+  total: number;
+}
+
+interface SlugRollup {
+  /** Pages seen by the rule (both paths count the same universe). */
+  pageCount: number;
+  /** Pages that carry a parseable url and vote in at least one dimension. */
+  sampleCount: number;
+  buckets: Map<string, DimensionBucket>;
+}
+
+interface JudgedDimension {
+  dimension: Dimension;
+  pageType: string | null;
+  norm: string;
+  share: number;
+  total: number;
+}
+
+interface Deviation {
+  dimension: Dimension;
+  pageType: string | null;
+  value: string;
+  norm: string;
+  urls: string[];
+  /** Pages that voted in this dimension (the denominator the finding quotes). */
+  total: number;
+}
+
+function emptyRollup(): SlugRollup {
+  return { pageCount: 0, sampleCount: 0, buckets: new Map() };
+}
+
+/** Path of a url, or null when it cannot be parsed. */
+function pathOf(url: string): string | null {
+  try {
+    return new URL(url).pathname || "/";
+  } catch {
+    return null;
+  }
+}
+
+/** Non-empty path segments. */
+function segmentsOf(path: string): string[] {
+  return path.split("/").filter((s) => s.length > 0);
+}
+
+/**
+ * Slug style of the last path segment, or null when the segment carries no
+ * separator signal at all (a single word, an id, a number) and so cannot vote.
+ */
+function separatorStyle(segment: string): string | null {
+  const stem = segment.replace(FILE_EXTENSION, "");
+  if (/[a-z][A-Z]/.test(stem)) return "camel";
+  if (stem.includes("_")) return "snake";
+  if (stem.includes("-")) return "kebab";
+  return null;
+}
+
+/** The value this page casts in each dimension (absent key = no vote). */
+function dimensionValues(path: string): Partial<Record<Dimension, string>> {
+  const values: Partial<Record<Dimension, string>> = {};
+  const segments = segmentsOf(path);
+
+  // The root carries no slug, no depth and no meaningful trailing slash.
+  if (segments.length === 0) return values;
+
+  const last = segments[segments.length - 1]!;
+  const separator = separatorStyle(last);
+  if (separator) values.separator = separator;
+
+  values.case = /[A-Z]/.test(path) ? "mixed" : "lower";
+
+  // url/trailing-slash owns extension-bearing paths; this dimension is the
+  // extensionless directory-style paths it deliberately leaves as `info`.
+  if (!FILE_EXTENSION.test(last)) {
+    values["trailing-slash"] = path.endsWith("/") ? "slash" : "bare";
+  }
+
+  values["date-in-slug"] = DATE_IN_PATH.test(path) ? "dated" : "undated";
+  values.depth = String(segments.length);
+
+  return values;
+}
+
+/** True when a per-page url rule already flags this url for this dimension. */
+function ownedByPageRule(dimension: Dimension, url: string): boolean {
+  const path = pathOf(url);
+  if (path === null) return false;
+  if (dimension === "case") return /[A-Z]/.test(path);
+  if (dimension === "separator") return path.includes("_");
+  return false;
+}
+
+function bucketKey(dimension: Dimension, pageType: string | null): string {
+  return `${dimension} ${pageType ?? "*"}`;
+}
+
+/**
+ * Fold one page in. Per-type dimensions need a real classification: untyped
+ * ("unknown") pages are a grab-bag of everything the classifier could not place,
+ * so their depth/date distribution means nothing. They still vote in the
+ * site-wide dimensions, which do not care what a page is.
+ */
+function accumulatePage(rollup: SlugRollup, record: SlugPageRecord): void {
+  rollup.pageCount += 1;
+
+  if (record.status < 200 || record.status >= 300) return;
+  const path = pathOf(record.url);
+  if (path === null) return;
+
+  const values = dimensionValues(path);
+  const pageType = record.pageType?.trim().toLowerCase();
+  const typed = pageType && pageType !== "unknown" ? pageType : null;
+
+  let voted = false;
+  for (const dimension of DIMENSIONS) {
+    const value = values[dimension];
+    if (value === undefined) continue;
+
+    const perType = PER_TYPE_DIMENSIONS.has(dimension);
+    if (perType && typed === null) continue;
+    const scope = perType ? typed : null;
+
+    const key = bucketKey(dimension, scope);
+    let bucket = rollup.buckets.get(key);
+    if (!bucket) {
+      bucket = { dimension, pageType: scope, values: new Map(), total: 0 };
+      rollup.buckets.set(key, bucket);
+    }
+    const urls = bucket.values.get(value);
+    if (urls) urls.push(record.url);
+    else bucket.values.set(value, [record.url]);
+    bucket.total += 1;
+    voted = true;
+  }
+
+  if (voted) rollup.sampleCount += 1;
+}
+
+/** Modal value of a bucket; ties break on the value name so order never matters. */
+function modalValue(bucket: DimensionBucket): { value: string; count: number } {
+  let best: { value: string; count: number } | null = null;
+  for (const [value, urls] of bucket.values) {
+    if (
+      best === null ||
+      urls.length > best.count ||
+      (urls.length === best.count && value < best.value)
+    ) {
+      best = { value, count: urls.length };
+    }
+  }
+  // Buckets are only created when a page votes, so `best` is never null here.
+  return best!;
+}
+
+function valueLabel(dimension: Dimension, value: string): string {
+  if (dimension === "depth") return `${value} path segment(s)`;
+  return VALUE_LABELS[value] ?? value;
+}
+
+function scopeLabel(pageType: string | null): string {
+  return pageType === null ? "page(s)" : `${pageType} page(s)`;
+}
+
+function skip(message: string): CheckResult {
+  return { name: CHECK_NAME, status: "skipped", message };
+}
+
+/** Stable ordering for buckets/norms: dimension order, then page type. */
+function compareScope(
+  a: { dimension: Dimension; pageType: string | null },
+  b: { dimension: Dimension; pageType: string | null }
+): number {
+  const byDimension = DIMENSIONS.indexOf(a.dimension) - DIMENSIONS.indexOf(b.dimension);
+  if (byDimension !== 0) return byDimension;
+  const at = a.pageType ?? "";
+  const bt = b.pageType ?? "";
+  return at < bt ? -1 : at > bt ? 1 : 0;
+}
+
+/**
+ * The rule's full output for one rollup. ONE builder, both paths.
+ *
+ * `sitePageCount` is the crawl-wide page count: the streaming path takes it from
+ * `siteQuery.pageCount()` (which includes rows this rule cannot sample), so the
+ * site floor is judged on the crawl, not on the sampled subset.
+ */
+function buildChecks(rollup: SlugRollup, sitePageCount: number): CheckResult[] {
+  if (sitePageCount < SLUG_NORM_MIN_PAGES) {
+    return [
+      skip(
+        `Only ${sitePageCount} page(s) crawled; ${SLUG_NORM_MIN_PAGES} needed to establish a URL convention norm`
+      ),
+    ];
+  }
+
+  const judged: JudgedDimension[] = [];
+  const deviations: Deviation[] = [];
+  const deferred = new Set<string>();
+
+  const buckets = [...rollup.buckets.values()].sort(compareScope);
+  for (const bucket of buckets) {
+    const floor =
+      bucket.pageType === null ? SLUG_NORM_MIN_SAMPLE : SLUG_NORM_MIN_GROUP_PAGES;
+    if (bucket.total < floor) continue;
+
+    const modal = modalValue(bucket);
+    const share = modal.count / bucket.total;
+    // No dominant form: the site mixes deliberately here, so say nothing.
+    if (share < SLUG_NORM_MIN_AGREEMENT) continue;
+
+    judged.push({
+      dimension: bucket.dimension,
+      pageType: bucket.pageType,
+      norm: modal.value,
+      share,
+      total: bucket.total,
+    });
+
+    for (const [value, urls] of bucket.values) {
+      if (value === modal.value) continue;
+      // The per-page url rule already flags these pages; never accuse twice.
+      const kept = urls.filter((url) => !ownedByPageRule(bucket.dimension, url));
+      if (kept.length < urls.length) {
+        const owner = OWNING_PAGE_RULE[bucket.dimension];
+        if (owner) deferred.add(`${bucket.dimension} -> ${owner}`);
+      }
+      if (kept.length === 0) continue;
+      deviations.push({
+        dimension: bucket.dimension,
+        pageType: bucket.pageType,
+        value,
+        norm: modal.value,
+        urls: kept.sort(),
+        total: bucket.total,
+      });
+    }
+  }
+
+  if (judged.length === 0) {
+    return [
+      skip(
+        `No URL convention reaches ${Math.round(SLUG_NORM_MIN_AGREEMENT * 100)}% agreement across enough comparable pages`
+      ),
+    ];
+  }
+
+  const deferredTo = [...deferred].sort();
+  const deferredTail = deferredTo.length > 0 ? ` (deferred to ${deferredTo.join(", ")})` : "";
+  const normSummary = judged
+    .slice(0, SLUG_NORM_MAX_NORMS)
+    .map(
+      (j) =>
+        `${DIMENSION_LABELS[j.dimension]}${j.pageType ? ` [${j.pageType}]` : ""} ${valueLabel(j.dimension, j.norm)} ${Math.round(j.share * 100)}%`
+    )
+    .join(", ");
+
+  const flaggedUrls = new Set<string>();
+  for (const d of deviations) for (const url of d.urls) flaggedUrls.add(url);
+
+  const details: Record<string, unknown> = {
+    judgedPages: sitePageCount,
+    judgedDimensions: judged.length,
+    flaggedPages: flaggedUrls.size,
+    norms: judged.slice(0, SLUG_NORM_MAX_NORMS).map((j) => ({
+      dimension: j.dimension,
+      pageType: j.pageType,
+      norm: j.norm,
+      pages: j.total,
+      agreement: j.share,
+    })),
+    deferredTo,
+  };
+
+  if (deviations.length === 0) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "pass",
+        message: `All ${sitePageCount} page(s) follow the site's own URL conventions (${normSummary})${deferredTail}`,
+        value: sitePageCount,
+        details,
+      },
+    ];
+  }
+
+  // Biggest deviant group first; the scope key breaks ties so the list never
+  // depends on crawl order.
+  deviations.sort(
+    (a, b) => b.urls.length - a.urls.length || compareScope(a, b) || (a.value < b.value ? -1 : 1)
+  );
+  const items: CheckItem[] = deviations.slice(0, SLUG_NORM_MAX_ITEMS).map((d) => ({
+    id: `${d.dimension}:${d.pageType ?? "*"}:${d.value}`,
+    // Counts, not percentages: one deviant in 200 rounds to "0%", which reads as
+    // a bug rather than as the finding.
+    label: `${d.urls.length} of ${d.total} ${scopeLabel(d.pageType)} use ${valueLabel(d.dimension, d.value)} but the ${DIMENSION_LABELS[d.dimension]} norm is ${valueLabel(d.dimension, d.norm)}`,
+    sourcePages: d.urls.slice(0, SLUG_NORM_MAX_URLS),
+    meta: {
+      dimension: d.dimension,
+      pageType: d.pageType,
+      value: d.value,
+      norm: d.norm,
+      pageCount: d.urls.length,
+    },
+  }));
+
+  const flaggedShare = flaggedUrls.size / sitePageCount;
+  return [
+    {
+      name: CHECK_NAME,
+      status: flaggedShare >= SLUG_NORM_FAIL_SHARE ? "fail" : "warn",
+      message: `${flaggedUrls.size} of ${sitePageCount} page(s) deviate from the site's own URL conventions (${normSummary})${deferredTail}`,
+      value: flaggedUrls.size,
+      items,
+      details,
+    },
+  ];
+}
+
+/**
+ * Streaming path (#1365): read (normalizedUrl, pageType) off the page_features
+ * cursor. Only the per-dimension url lists stay resident; no parsed page is held.
+ *
+ * The site floor is judged on `pageCount()`, which counts page_features rows; the
+ * legacy universe additionally carries the error pages v1 appends to `site.pages`.
+ * That is a property of this seam shared with every site rule on it (see
+ * content/duplicate-title), not something specific to this rule.
+ */
+async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
+  const rollup = emptyRollup();
+  for await (const row of siteQuery.pagesMatching(() => true)) {
+    accumulatePage(rollup, {
+      url: row.normalizedUrl,
+      status: row.status,
+      pageType: row.pageType,
+    });
+  }
+
+  return { checks: buildChecks(rollup, siteQuery.pageCount()) };
+}
+
+export const slugConventionRule: Rule = {
+  meta: {
+    id: "url/slug-convention",
+    name: "URL Convention Consistency",
+    description: "Finds URLs that break the site's own URL conventions",
+    solution:
+      "Your site uses more than one URL convention: some paths follow one form and a minority follow another. Mixed conventions are how duplicate-content and canonical bugs start, because /My_Page, /my-page and /my-page/ are three different URLs to a crawler even when they serve the same thing. Pick the dominant form already used by most of your site, migrate the minority onto it, and 301-redirect the old paths so links and rankings follow. If a section deliberately differs (a dated archive, a deeper product tree), that is fine: the point is that a handful of pages should not be the exception.",
+    category: "url",
+    scope: "site",
+    severity: "warning",
+    // Deliberately light: one site-wide check, capped items, so a single rule
+    // cannot dominate the url category score.
+    weight: 3,
+  },
+
+  run(ctx: RuleContext): RuleResult | Promise<RuleResult> {
+    if (ctx.siteQuery) {
+      return runViaSiteQuery(ctx.siteQuery);
+    }
+
+    const pages = ctx.site?.pages;
+    if (!pages || pages.length === 0) {
+      return { checks: [skip("No pages available for analysis")] };
+    }
+
+    const rollup = emptyRollup();
+    for (const page of pages) {
+      accumulatePage(rollup, {
+        url: page.url,
+        status: page.statusCode,
+        pageType: page.parsed?.pageType ?? null,
+      });
+    }
+
+    return { checks: buildChecks(rollup, rollup.pageCount) };
+  },
+};

--- a/packages/rules/tests/slug-convention.test.ts
+++ b/packages/rules/tests/slug-convention.test.ts
@@ -1,0 +1,388 @@
+// url/slug-convention — URL conventions vs the site's own norm (#1365).
+//
+// The rule's whole value is what it does NOT say, so most of this file defends the
+// silence cases: a small crawl, a dimension with too few voters, a site that mixes
+// deliberately, a site that is uniformly non-default (all snake_case), and the
+// deviants the per-page url rules already own. The positive cases pin the one thing
+// it is for: a minority form standing against a clear dominant one.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult, PageFeatureRow, SiteQuery } from "@squirrelscan/core-contracts";
+
+import {
+  slugConventionRule,
+  SLUG_NORM_MIN_AGREEMENT,
+  SLUG_NORM_MIN_PAGES,
+} from "../src/url/slug-convention";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+interface PageSpec {
+  path: string;
+  pageType?: string | null;
+  status?: number;
+}
+
+function url(path: string): string {
+  return `https://example.com${path}`;
+}
+
+/** N pages sharing one path template, numbered so each url is distinct. */
+function template(
+  make: (i: number) => string,
+  count: number,
+  pageType: string | null = "article"
+): PageSpec[] {
+  return Array.from({ length: count }, (_, i) => ({ path: make(i), pageType }));
+}
+
+function pad(i: number): string {
+  return String(i).padStart(3, "0");
+}
+
+const baseCtx = {
+  page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+  parsed: {} as ParsedPage,
+  options: {},
+};
+
+/** Legacy path: specs become `ctx.site.pages` in crawl order. */
+function legacyCtx(specs: PageSpec[]): RuleContext {
+  return {
+    ...baseCtx,
+    site: {
+      baseUrl: "https://example.com/",
+      pages: specs.map((spec) => ({
+        url: url(spec.path),
+        statusCode: spec.status ?? 200,
+        parsed: { pageType: spec.pageType ?? null } as unknown as ParsedPage,
+      })),
+      robotsTxt: null,
+      sitemaps: null,
+    },
+  };
+}
+
+function featureRow(spec: PageSpec): PageFeatureRow {
+  return {
+    normalizedUrl: url(spec.path),
+    status: spec.status ?? 200,
+    depth: 1,
+    title: null,
+    titleHash: null,
+    description: null,
+    descHash: null,
+    contentHash: null,
+    wordCount: null,
+    pageType: spec.pageType ?? null,
+    schemaTypes: [],
+    robotsNoindex: false,
+    canonical: null,
+    visibleAuthor: false,
+    visibleDate: false,
+    transferBytes: null,
+    templateFp: null,
+    secretHits: null,
+    metaNoindex: false,
+    indexableReasons: [],
+    richResultTypes: [],
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
+  };
+}
+
+/**
+ * Streaming path: the rule only ever calls `pagesMatching` + `pageCount`, so the
+ * rest of the SiteQuery surface throws — a stub that silently returned empties
+ * could hide the rule reading something it must not.
+ */
+function siteQueryCtx(specs: PageSpec[]): RuleContext {
+  const rows = specs.map(featureRow);
+  const unused = (): never => {
+    throw new Error("slug-convention must not use this SiteQuery method");
+  };
+  const siteQuery: SiteQuery = {
+    pageCount: () => rows.length,
+    duplicateGroups: unused,
+    incomingLinkCounts: unused,
+    pagesByType: unused,
+    templateClusters: unused,
+    sumTransferBytes: unused,
+    sumSecretHits: unused,
+    homepage: unused,
+    async *pagesMatching(pred: (row: PageFeatureRow) => boolean) {
+      for (const row of rows) if (pred(row)) yield row;
+    },
+  };
+  return {
+    ...baseCtx,
+    // EMPTY pages — the streaming path must not read them.
+    site: { baseUrl: "https://example.com/", pages: [], robotsTxt: null, sitemaps: null },
+    siteQuery,
+  };
+}
+
+async function checks(ctx: RuleContext): Promise<CheckResult[]> {
+  return (await Promise.resolve(slugConventionRule.run(ctx))).checks;
+}
+
+/** Run BOTH paths over one fixture, assert byte-identical output, return it. */
+async function bothPaths(specs: PageSpec[]): Promise<CheckResult> {
+  const legacy = await checks(legacyCtx(specs));
+  const streamed = await checks(siteQueryCtx(specs));
+  expect(streamed).toEqual(legacy);
+  expect(JSON.stringify(streamed)).toBe(JSON.stringify(legacy));
+  expect(legacy).toHaveLength(1);
+  return legacy[0]!;
+}
+
+/** The one item for a dimension, or undefined when it was not reported. */
+function itemFor(check: CheckResult, dimension: string): unknown {
+  return check.items?.find((i) => i.meta?.dimension === dimension);
+}
+
+describe("url/slug-convention — silence guards", () => {
+  test("skips a crawl below the site page floor", async () => {
+    const check = await bothPaths(
+      template((i) => `/blog/post-${pad(i)}`, SLUG_NORM_MIN_PAGES - 1)
+    );
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${SLUG_NORM_MIN_PAGES} needed`);
+  });
+
+  test("skips a site that mixes deliberately — no dominant convention", async () => {
+    // Half slash-terminated, half bare, and separators split evenly: nothing here
+    // reaches the agreement threshold, so no page is a deviant.
+    const specs: PageSpec[] = [];
+    for (let i = 0; i < 6; i++) {
+      specs.push({ path: `/a/post-${pad(i)}/`, pageType: null });
+      specs.push({ path: `/b/postThing${pad(i)}`, pageType: null });
+    }
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(
+      `${Math.round(SLUG_NORM_MIN_AGREEMENT * 100)}% agreement`
+    );
+  });
+
+  test("a dimension nobody votes in is dropped, not guessed at", async () => {
+    // Slugs are single words: the separator dimension gets zero votes and cannot
+    // invent one, while the other dimensions are uniform.
+    const check = await bothPaths(template((i) => `/p${pad(i)}`, 12));
+    expect(check.status).toBe("pass");
+    const dims = (check.details?.norms as { dimension: string }[]).map((n) => n.dimension);
+    expect(dims).not.toContain("separator");
+  });
+
+  test("non-2xx pages never vote", async () => {
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 12),
+      ...Array.from({ length: 5 }, (_, i) => ({
+        path: `/blog/post_gone_${pad(i)}`,
+        pageType: "article",
+        status: 404,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+
+  test("untyped pages never form a per-type norm", async () => {
+    // 12 "unknown" pages at mixed depths: the depth dimension has no group.
+    const specs = [
+      ...template((i) => `/x/p-${pad(i)}`, 6, "unknown"),
+      ...template((i) => `/x/y/z/p-${pad(i)}`, 6, null),
+    ];
+    const check = await bothPaths(specs);
+    const norms = check.details?.norms as { dimension: string; pageType: string | null }[];
+    expect(norms.every((n) => n.pageType === null)).toBe(true);
+  });
+});
+
+describe("url/slug-convention — the no-false-positive fixtures", () => {
+  test("a uniformly snake_case site stays clean", async () => {
+    // The non-default convention IS this site's convention. url/hyphens will have
+    // its say per page; the site is not internally inconsistent, so this rule
+    // reports nothing.
+    const check = await bothPaths(template((i) => `/blog/post_number_${pad(i)}`, 20));
+    expect(check.status).toBe("pass");
+    const norms = check.details?.norms as { dimension: string; norm: string }[];
+    expect(norms.find((n) => n.dimension === "separator")?.norm).toBe("snake");
+  });
+
+  test("a uniformly slash-terminated site stays clean", async () => {
+    const check = await bothPaths(template((i) => `/blog/post-${pad(i)}/`, 20));
+    expect(check.status).toBe("pass");
+    const norms = check.details?.norms as { dimension: string; norm: string }[];
+    expect(norms.find((n) => n.dimension === "trailing-slash")?.norm).toBe("slash");
+  });
+
+  test("template-uniform siblings sit inside the norm", async () => {
+    // Three templates, each internally consistent — the shape of a real generated
+    // site. Nothing here is an outlier.
+    const specs = [
+      ...template((i) => `/deals/offer-${pad(i)}`, 20, "product"),
+      ...template((i) => `/stores/store-${pad(i)}`, 20, "listing"),
+      ...template((i) => `/blog/article-${pad(i)}`, 20, "article"),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("follow the site's own URL conventions");
+  });
+
+  test("page types are judged against themselves, not against each other", async () => {
+    // Products live one level deeper than articles. Neither is a deviant: depth is
+    // judged within one pageType.
+    const specs = [
+      ...template((i) => `/shop/cat/item-${pad(i)}`, 12, "product"),
+      ...template((i) => `/blog/post-${pad(i)}`, 12, "article"),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+});
+
+describe("url/slug-convention — findings", () => {
+  test("warns on a pocket of camelCase slugs against a kebab-case site", async () => {
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 20),
+      ...template((i) => `/blog/legacyPost${pad(i)}`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    const item = itemFor(check, "separator") as { meta: Record<string, unknown> } | undefined;
+    expect(item?.meta.value).toBe("camel");
+    expect(item?.meta.norm).toBe("kebab");
+    expect(item?.meta.pageCount).toBe(3);
+  });
+
+  test("warns on trailing slashes present on a minority of paths", async () => {
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 20),
+      ...template((i) => `/blog/post-slashed-${pad(i)}/`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    const item = itemFor(check, "trailing-slash") as
+      | { meta: Record<string, unknown> }
+      | undefined;
+    expect(item?.meta.value).toBe("slash");
+    expect(item?.meta.norm).toBe("bare");
+  });
+
+  test("warns on dated slugs for some posts of a type but not others", async () => {
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 20),
+      ...template((i) => `/blog/2026/03/post-${pad(i)}`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    const item = itemFor(check, "date-in-slug") as
+      | { meta: Record<string, unknown> }
+      | undefined;
+    expect(item?.meta.value).toBe("dated");
+    expect(item?.meta.pageType).toBe("article");
+  });
+
+  test("warns on inconsistent depth within one page type", async () => {
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 20),
+      ...template((i) => `/blog/archive/old/post-${pad(i)}`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    const item = itemFor(check, "depth") as { meta: Record<string, unknown> } | undefined;
+    expect(item?.meta.value).toBe("4");
+    expect(item?.meta.norm).toBe("2");
+  });
+
+  test("fails once a fifth of the crawl deviates", async () => {
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 20),
+      ...template((i) => `/blog/post-slashed-${pad(i)}/`, 6),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("fail");
+    expect(check.value).toBe(6);
+  });
+
+  test("the finding names the minority form against the dominant one", async () => {
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 20),
+      ...template((i) => `/blog/post-slashed-${pad(i)}/`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.items?.[0]?.label).toContain("3 of 23 page(s) use a trailing slash");
+    expect(check.items?.[0]?.label).toContain("norm is no trailing slash");
+  });
+
+  test("dual paths agree regardless of crawl order", async () => {
+    const deviants = template((i) => `/blog/post-slashed-${pad(i)}/`, 3);
+    const majority = template((i) => `/blog/post-${pad(i)}`, 20);
+    const first = await bothPaths([...majority, ...deviants]);
+    const second = await bothPaths([...deviants, ...majority]);
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+  });
+});
+
+describe("url/slug-convention — precedence over the per-page url rules", () => {
+  test("defers uppercase deviants to url/lowercase", async () => {
+    // url/lowercase already warns on every one of these paths; flagging them here
+    // too would accuse the site twice for one root cause.
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 20),
+      ...template((i) => `/blog/Legacy-Post-${pad(i)}`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(itemFor(check, "case")).toBeUndefined();
+    expect(check.details?.deferredTo).toEqual(["case -> url/lowercase"]);
+    expect(check.message).toContain("deferred to case -> url/lowercase");
+  });
+
+  test("defers snake_case deviants to url/hyphens", async () => {
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, 20),
+      ...template((i) => `/blog/legacy_post_${pad(i)}`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(itemFor(check, "separator")).toBeUndefined();
+    expect(check.details?.deferredTo).toEqual(["separator -> url/hyphens"]);
+  });
+
+  test("still reports a kebab minority on a snake_case site", async () => {
+    // url/hyphens flags the snake_case MAJORITY here, never these pages, so this
+    // rule and that one are talking about disjoint sets.
+    const specs = [
+      ...template((i) => `/blog/post_number_${pad(i)}`, 20),
+      ...template((i) => `/blog/post-number-${pad(i)}`, 3),
+    ];
+    const check = await bothPaths(specs);
+    const item = itemFor(check, "separator") as { meta: Record<string, unknown> } | undefined;
+    expect(item?.meta.value).toBe("kebab");
+    expect(item?.meta.norm).toBe("snake");
+  });
+
+  test("leaves file URLs to url/trailing-slash", async () => {
+    // A .html path with a trailing slash is url/trailing-slash's finding; this
+    // rule's trailing-slash dimension never sees extension-bearing paths.
+    const specs = [
+      ...template((i) => `/docs/page-${pad(i)}.html`, 12),
+      ...template((i) => `/docs/legacy-${pad(i)}.html/`, 4),
+    ];
+    const check = await bothPaths(specs);
+    const norms = check.details?.norms as { dimension: string }[];
+    expect(norms.some((n) => n.dimension === "trailing-slash")).toBe(false);
+  });
+});
+
+describe("url/slug-convention — empty crawl", () => {
+  test("legacy path with no pages skips", async () => {
+    const result = await checks(legacyCtx([]));
+    expect(result[0]?.status).toBe("skipped");
+  });
+});


### PR DESCRIPTION
Adds `url/slug-convention`: a site-wide rule that judges URL conventions against the site's *own* norm. Part of squirrelscan/repo#1365 / #1349 (T-16).

## What it does

The per-page url rules (`url/lowercase`, `url/trailing-slash`, `url/hyphens`) each judge one URL against a fixed idea of a good URL. None of them can see that a site is internally *inconsistent*, which is the thing that actually produces duplicate-content and canonical bugs. So here the **mixing is the finding**, never an individual URL.

Five dimensions, each judged independently:

| Dimension | Scope | Compares |
|---|---|---|
| Slug word separator | site-wide | kebab-case vs snake_case vs camelCase |
| URL letter case | site-wide | all-lowercase vs paths carrying uppercase |
| Trailing slash | site-wide | present vs absent, extensionless paths only |
| Date in slug | per `pageType` | dated vs undated posts of one type |
| Path depth | per `pageType` | segment count within one page type |

Reads only `normalizedUrl` + `pageType`: **no storage schema change**.

## Norm guard

- Site floor: `pageCount()` under 10 gives `skipped`.
- Sample floor: 10 voters for a site-wide dimension, 8 pages for a per-`pageType` one. A dimension nobody votes in is dropped, never guessed at.
- Modal agreement: a dimension needs 70% or more on one form before that form is a norm. Below that the site mixes deliberately and nothing in it is a deviant.

A site that is uniformly snake_case, or uniformly slash-terminated, is therefore clean here: there is no minority to report.

## Precedence (direction of suppression)

**One-way: the per-page rules own their pages; this rule drops the deviants they already flag.**

- `url/lowercase` warns on every path containing an uppercase letter, so uppercase deviants are dropped from the `case` dimension.
- `url/hyphens` warns on every path containing an underscore, so underscore deviants are dropped from the `separator` dimension.
- `url/trailing-slash` only ever raises on paths with a file extension, so this rule judges the trailing-slash dimension over extensionless paths only and the two sets are disjoint.

The inverse cases are NOT suppressed and are still reported, because there the per-page rule is talking about the majority, not the minority: a kebab-case minority on a snake_case site is this rule's finding while `url/hyphens` nags the majority. A dimension whose deviants are wholly deferred is named in the message tail and in `details.deferredTo`, so nothing is silently dropped.

## Dual path

Legacy `ctx.site.pages` and streaming `SiteQuery` feed ONE accumulator and ONE check builder, and every list is sorted before emit, so output is byte-identical and independent of crawl order (same shape as `content/duplicate-title`, #1021/#1022). `tests/slug-convention.test.ts` runs every fixture through both paths and asserts `JSON.stringify` equality; the 518-page canonical golden merge gate asserts the same at scale.

## Smoke: https://sweetdeals.com.au

`squirrel audit https://sweetdeals.com.au --max-pages 200` on a live site of thousands of pages built from 3-4 templates.

- **200 pages scanned**, **0 findings** from `url/slug-convention`; URL Structure scored **100/100** (no url-category issues at all).
- The rule returned `pass`, not `skipped`. It formed three site-wide norms and found no deviant:
  - separator: **kebab-case, 100%** of the 112 slugs that carry a separator (88 single-word slugs correctly abstain)
  - letter case: **all-lowercase, 100%** of 199 (the root `/` casts no vote)
  - trailing slash: **bare, 100%** of 199
  - no per-`pageType` dimension reached its 8-page floor on this corpus
- That is the correct answer for this site, and it is the AC's "template-uniform pages sit inside the norm" case: `/best/*`, `/deals/*` and `/stores/*` are three templates and none of them lights up.

Because 0 findings cannot distinguish "right" from "didn't run", here is a **perturbation replay** over the same 200-URL corpus with 3 genuine outliers grafted on:

| Grafted URL | Outcome |
|---|---|
| `/deals/legacyOfferPage` | flagged: `1 of 115 page(s) use camelCase but the slug word separator norm is kebab-case` |
| `/deals/legacy-offer-page/` | flagged: `1 of 202 page(s) use a trailing slash but the trailing slash norm is no trailing slash` |
| `/deals/Another-Legacy-Offer` | **deferred to `url/lowercase`** (`details.deferredTo: ["case -> url/lowercase"]`), precedence working on real data |

Status went `pass` to `warn` with 2 items, and the norms moved to 99%/99%/100% rather than collapsing. Spot-checking the three: two are real outliers against a corpus that is otherwise 100% uniform, and the third is correctly left to the per-page rule that already owns it.

## Scoring density

`scope: "site"`, `severity: "warning"`, `weight: 3`. One site-wide check with items capped at 10 (and 10 urls per item), matching `content/thin-vs-site-norm`, so one rule cannot dominate the url category score. The 518-page golden baseline health score is unmoved at 48.

## Tests

`bun test` green for `packages/rules` (1209), `packages/audit-engine` (270, including the canonical 518-page v1/v2 merge gate re-pinned to 98214 findings and 270 rules) and `apps/cli` (1718). `tsgo --noEmit` clean. `make validate` clean in `docs/`.

Rule counts bumped 269 to 270 (and URL Structure 8 to 9) in `README.md`, `docs/index.mdx`, `docs/rules/index.mdx`.
