### PR TITLE
feat(rules): add core/canonical-form-drift, canonicals that disagree in form across the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **270 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **271 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler 
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more 
@@ -38,7 +38,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
 | Crawlability | 18 | Whether search engines and agents can reach and index you at all: robots.txt, sitemap validity and coverage, indexability conflicts, redirect and canonical chains, soft 404s |
-| Core SEO | 13 | The per-page fundamentals: title, meta description, H1, canonical, charset, doctype, robots meta, Open Graph and Twitter cards |
+| Core SEO | 14 | The per-page fundamentals: title, meta description, H1, canonical, charset, doctype, robots meta, Open Graph and Twitter cards, plus canonical form drift across the site |
 | Agent Experience | 17 | How ready you are for AI agents to read, discover and act on the site: whether GPTBot and Claude-User get the same content a browser does, AGENTS.md, llms.txt, Markdown responses, API and MCP discovery, licensing and noai signals, pay-per-crawl, response token weight |
 | Site Integrity | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | Security | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 270 rules across 21 categories**
+**Total: 271 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -190,6 +190,7 @@
                   "rules/core/meta-description",
                   "rules/core/canonical",
                   "rules/core/canonical-header",
+                  "rules/core/canonical-form-drift",
                   "rules/core/h1",
                   "rules/core/robots-meta",
                   "rules/core/nosnippet",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="270 Rules, 21 Categories"
+    title="271 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,12 +216,12 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **270 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **271 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
 | **Crawlability** | 18 | Whether search engines and agents can reach and index you at all: robots.txt, sitemap validity and coverage, indexability conflicts, redirect and canonical chains, soft 404s |
-| **Core SEO** | 13 | The per-page fundamentals: title, meta description, H1, canonical, charset, doctype, robots meta, Open Graph and Twitter cards |
+| **Core SEO** | 14 | The per-page fundamentals: title, meta description, H1, canonical, charset, doctype, robots meta, Open Graph and Twitter cards, plus canonical form drift across the site |
 | **Agent Experience** | 17 | How ready you are for AI agents to read, discover and act on the site: whether GPTBot and Claude-User get the same content a browser does, AGENTS.md, llms.txt, Markdown responses, API and MCP discovery, licensing and noai signals, pay-per-crawl, response token weight |
 | **Site Integrity** | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | **Security** | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
@@ -242,7 +242,7 @@ squirrelscan runs **270 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 270 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 271 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/core/canonical-form-drift.mdx
+++ b/docs/rules/core/canonical-form-drift.mdx
@@ -1,0 +1,100 @@
+---
+title: "Canonical Form Drift"
+description: "Finds canonical URLs that disagree in form (www, scheme, trailing slash, tracking params) across the site"
+---
+
+Finds canonical URLs that disagree in form (www, scheme, trailing slash, tracking params) across the site
+
+| | |
+|---|---|
+| **Rule ID** | `core/canonical-form-drift` |
+| **Category** | [Core SEO](/rules/core) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 3/10 |
+
+## How it works
+
+Every canonical this rule looks at is individually valid. What is wrong is
+collective: half your site canonicalises to `https://www.example.com/thing/` and
+half to `https://example.com/thing`, so the two halves consolidate onto different
+URLs and the ranking signal splits between them. No per-page rule can see this,
+because a page only knows its own canonical.
+
+The rule compares four axes of URL form across every canonical in the crawl:
+
+- **Scheme**: `https` versus `http`.
+- **Host**: `www` versus apex.
+- **Trailing slash**: present versus absent.
+- **Tracking parameters**: retained versus stripped (`utm_*`, `gclid`, `fbclid`,
+  `ref`, and friends).
+
+For each axis it works out the site's dominant form and reports only the pages that
+break it.
+
+It stays quiet unless it has grounds to speak:
+
+- Fewer than 10 crawled pages: no site norm exists, so the rule is skipped.
+- Fewer than 10 comparable canonicals on an axis: that axis is dropped, not guessed
+  at.
+- No form reaching 70% on an axis: the site has no convention there, so nobody on
+  that axis is a deviant. A site that genuinely mixes forms is a judgement call for
+  a human, not an accusation from a rule.
+
+Pages built from one template emit canonicals in one form, so they define the norm
+rather than deviate from it. A consistently param-bearing canonical is a form like
+any other: if every page does it, the site is not contradicting itself and nothing
+is reported.
+
+Two axes are only measured where the page had a choice. The site root (`/`) and
+file-like paths (`/feed.xml`) never carry a trailing slash, so they are left out of
+that comparison entirely.
+
+## Validity is a different rule
+
+This rule reports **form only**, so one root cause is never reported twice:
+
+- A missing, relative or unparseable canonical is [Canonical URL](/rules/core/canonical).
+- A `Link: rel="canonical"` header that disagrees with the tag is
+  [Canonical Header](/rules/core/canonical-header).
+- A canonical pointing at another host is [Canonical URL](/rules/core/canonical)
+  as well, and its form follows the other site's conventions, so it is excluded here.
+
+Pages in any of those states are dropped before the comparison runs.
+
+## Solution
+
+Each of these canonicals is valid on its own, but the site does not agree with
+itself: some pages canonicalise to one URL form and some to another. Search engines
+treat the two forms as different URLs, so links, crawl budget and ranking signals
+split between them.
+
+Pick one form, the one your redirects already send traffic to, and emit it
+everywhere: one scheme (`https`), one host (`www` or apex, not both), one
+trailing-slash convention, and never any tracking parameters in the canonical.
+Canonicals are usually generated in one template or middleware, so this is normally
+a single fix in the place that builds the URL rather than a per-page edit.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["core/canonical-form-drift"]
+```
+
+### Disable all Core SEO rules
+
+```toml squirrel.toml
+[rules]
+disable = ["core/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["core/canonical-form-drift"]
+disable = ["*"]
+```

--- a/docs/rules/core/canonical-form-drift.mdx
+++ b/docs/rules/core/canonical-form-drift.mdx
@@ -46,9 +46,15 @@ rather than deviate from it. A consistently param-bearing canonical is a form li
 any other: if every page does it, the site is not contradicting itself and nothing
 is reported.
 
-Two axes are only measured where the page had a choice. The site root (`/`) and
-file-like paths (`/feed.xml`) never carry a trailing slash, so they are left out of
-that comparison entirely.
+Two refinements keep the trailing-slash axis honest, because it is the one most
+likely to accuse a healthy site:
+
+- It is compared **within a section** (the first path segment of the canonical),
+  not site-wide. Using a slash in `/blog/how-to/` and none in `/product` is a normal
+  shape, so each section is judged against itself and needs its own 10 pages and 70%
+  agreement.
+- The site root (`/`) and file-like paths (`/feed.xml`) never carry a trailing slash,
+  so they are left out of that comparison entirely.
 
 ## Validity is a different rule
 
@@ -61,6 +67,11 @@ This rule reports **form only**, so one root cause is never reported twice:
   as well, and its form follows the other site's conventions, so it is excluded here.
 
 Pages in any of those states are dropped before the comparison runs.
+
+[Canonical URL](/rules/core/canonical) also notes, as `info`, that a page's canonical
+points somewhere other than itself. That is a per-page observation with no claim
+about the rest of the site, and it is exactly the input this rule reads: the finding
+here is the site-wide pattern those individual notes add up to.
 
 ## Solution
 

--- a/docs/rules/core/index.mdx
+++ b/docs/rules/core/index.mdx
@@ -8,6 +8,9 @@ Essential meta tags and page structure for search engines
 ## Rules
 
 <CardGroup cols={2}>
+  <Card title="Canonical Form Drift" icon="triangle-exclamation" href="/rules/core/canonical-form-drift">
+    Finds canonical URLs that disagree in form (www, scheme, trailing slash, tracking params) across the site
+  </Card>
   <Card title="Canonical Header Validation" icon="triangle-exclamation" href="/rules/core/canonical-header">
     Detects mismatch between HTML canonical tag and Link header
   </Card>

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 270 audit rules organized by score group and category"
+description: "All 271 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **270 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **271 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -17,7 +17,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Robots.txt, sitemaps, and crawl directives (18 rules)
   </Card>
   <Card title="Core SEO" icon="folder" href="/rules/core">
-    Essential meta tags and page structure for search engines (13 rules)
+    Essential meta tags and page structure for search engines (14 rules)
   </Card>
   <Card title="Links" icon="folder" href="/rules/links">
     Internal and external link health and structure (14 rules)

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -74,13 +74,16 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // own single whole-crawl check (#1363).
       // 98213 -> 98214: url/slug-convention, likewise site-scoped, adds its own
       // single whole-crawl check (#1365).
-      expect(v1.findings.length).toBe(98214);
+      // 98214 -> 98215: core/canonical-form-drift, likewise site-scoped, adds its
+      // own single whole-crawl check (#1366).
+      expect(v1.findings.length).toBe(98215);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
-      // schema/coverage-outlier, 269 -> 270 url/slug-convention; anything else
-      // means a rule id leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(270);
+      // schema/coverage-outlier, 269 -> 270 url/slug-convention, 270 -> 271
+      // core/canonical-form-drift; anything else means a rule id leaked in, so
+      // fix that rather than this number.
+      expect(v1.perRuleTally.length).toBe(271);
     },
     180_000,
   );

--- a/packages/rules/src/core/canonical-form-drift.ts
+++ b/packages/rules/src/core/canonical-form-drift.ts
@@ -1,0 +1,404 @@
+// core/canonical-form-drift - canonicals that disagree in FORM across the site (#1366)
+//
+// Every canonical here is individually valid. What is wrong is collective: half
+// the site canonicalises to `https://www.example.com/thing/` and half to
+// `https://example.com/thing`, so the two halves consolidate onto different
+// URLs and the ranking signal splits. No per-page rule can see this - a page
+// only knows its own canonical - which is why this is a site-scoped rule.
+//
+// Precedence (recorded so one root cause is never reported twice):
+//   - core/canonical owns VALIDITY of the <link rel=canonical>: missing,
+//     relative, unparseable, or pointing somewhere else entirely.
+//   - core/canonical-header owns the HTTP `Link: rel="canonical"` header and its
+//     agreement with the tag.
+//   - this rule owns FORM ONLY, and therefore never even looks at a page whose
+//     canonical those two would already have something to say about. A page with
+//     no canonical, a relative one, an unparseable one, or one pointing at
+//     another registrable host is dropped from the sample before any comparison.
+//
+// Guards, in the order they matter:
+//   1. Site floor (CANONICAL_FORM_MIN_PAGES) - a small crawl has no norm.
+//   2. Per-dimension sample floor (CANONICAL_FORM_MIN_SAMPLE) - a dimension only
+//      a handful of pages can express is dropped, not guessed at.
+//   3. Modal agreement (CANONICAL_FORM_MIN_AGREEMENT) - a dimension needs a clear
+//      dominant form before the minority can be called deviant. A site that
+//      genuinely mixes forms 50/50 has no norm and produces no finding: that is a
+//      judgement call for a human, not an accusation from a rule.
+//
+// Template-uniform pages are safe by construction: pages from one template emit
+// canonicals in one form, so they define the norm rather than deviate from it.
+//
+// Dual path: `ctx.siteQuery` streams `canonical` straight off page_features; the
+// legacy path reads `parsed.meta.canonical` from `ctx.site.pages`. Both feed ONE
+// accumulator and ONE check builder, so the output is byte-identical by
+// construction (same shape as content/duplicate-title, #1021/#1022). No storage
+// schema change: `canonical` is already a stored column.
+
+import type { CheckItem, SiteQuery } from "@squirrelscan/core-contracts";
+import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
+
+/** Crawl-wide page floor: below this there is no site norm to judge against. */
+export const CANONICAL_FORM_MIN_PAGES = 10;
+
+/** Per-dimension sample floor. A dimension under this is dropped, never guessed at. */
+export const CANONICAL_FORM_MIN_SAMPLE = 10;
+
+/**
+ * Share of a dimension's sample that must agree on one form before the remainder
+ * is treated as drift. Below this the site has no established convention and
+ * skipping beats accusing it.
+ */
+export const CANONICAL_FORM_MIN_AGREEMENT = 0.7;
+
+/** Share of judged pages that turns the warning into a failure. */
+export const CANONICAL_FORM_FAIL_SHARE = 0.2;
+
+/** Caps on reported drifts / summarized norms, so one rule cannot bloat a report. */
+const CANONICAL_FORM_MAX_ITEMS = 10;
+
+/** Cap on URLs listed per drift, so one broken template cannot spray a report. */
+const CANONICAL_FORM_MAX_URLS_PER_ITEM = 20;
+
+const CHECK_NAME = "canonical-form-drift";
+
+/**
+ * Query keys that carry no page identity. A canonical retaining one of these is
+ * the classic "we canonicalised the tracked URL" mistake; the point of the
+ * dimension is that a site should do the same thing on every page.
+ *
+ * Deliberately NOT "does the canonical have any query string at all": pagination
+ * and faceted canonicals (`?page=2`) legitimately vary page by page, so presence
+ * of a query is a per-page property, not a site-wide form choice. Comparing it
+ * across pages would flag every healthy paginated site.
+ */
+const TRACKING_PARAM_PREFIXES = ["utm_", "mc_"];
+const TRACKING_PARAM_NAMES = new Set([
+  "_ga",
+  "fbclid",
+  "gclid",
+  "igshid",
+  "mkt_tok",
+  "msclkid",
+  "ref",
+  "source",
+  "ttclid",
+  "yclid",
+]);
+
+/** The form axes compared across the site, in report order. */
+const DIMENSIONS = ["scheme", "host", "trailing slash", "tracking params"] as const;
+type Dimension = (typeof DIMENSIONS)[number];
+
+/** One page's contribution, from either path. */
+interface CanonicalPageRecord {
+  url: string;
+  status: number;
+  canonical: string | null;
+}
+
+interface DimensionSample {
+  /** Parallel arrays: the page url and the form it expressed on this axis. */
+  urls: string[];
+  forms: string[];
+}
+
+interface CanonicalRollup {
+  /** Pages seen by the rule (both paths count the same universe). */
+  pageCount: number;
+  /** Pages with a canonical this rule is allowed to compare (see precedence). */
+  sampleUrls: string[];
+  samples: Map<Dimension, DimensionSample>;
+}
+
+/** One "N of M canonicals use X, these N use Y" finding. */
+interface FormDrift {
+  dimension: Dimension;
+  norm: string;
+  deviant: string;
+  have: number;
+  total: number;
+  deviantUrls: string[];
+}
+
+interface JudgedDimension {
+  dimension: Dimension;
+  pages: number;
+  norm: string;
+}
+
+function emptyRollup(): CanonicalRollup {
+  const samples = new Map<Dimension, DimensionSample>();
+  for (const dimension of DIMENSIONS) samples.set(dimension, { urls: [], forms: [] });
+  return { pageCount: 0, sampleUrls: [], samples };
+}
+
+function stripWww(host: string): string {
+  return host.startsWith("www.") ? host.slice(4) : host;
+}
+
+function isTrackingParam(key: string): boolean {
+  const name = key.toLowerCase();
+  if (TRACKING_PARAM_NAMES.has(name)) return true;
+  return TRACKING_PARAM_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+/**
+ * The trailing-slash axis only exists where the page had a choice. The site root
+ * is always "/", and a path whose last segment looks like a file
+ * (`/whitepaper.pdf`, `/index.html`) never carries one, so both are excluded
+ * rather than counted as "no trailing slash" and dragged into the norm.
+ */
+function slashForm(pathname: string): string | null {
+  if (pathname === "/" || pathname === "") return null;
+  const last = pathname.replace(/\/+$/, "").split("/").pop() ?? "";
+  if (last.includes(".")) return null;
+  return pathname.endsWith("/") ? "trailing slash" : "no trailing slash";
+}
+
+/**
+ * Fold one page in. Anything core/canonical or core/canonical-header would
+ * already report is dropped here: this rule never doubles up on their findings.
+ */
+function accumulatePage(rollup: CanonicalRollup, record: CanonicalPageRecord): void {
+  rollup.pageCount += 1;
+
+  if (record.status < 200 || record.status >= 300) return;
+  const canonical = record.canonical?.trim();
+  // Missing / relative / unparseable canonicals belong to core/canonical.
+  if (!canonical || !/^https?:\/\//i.test(canonical)) return;
+
+  let target: URL;
+  let page: URL;
+  try {
+    target = new URL(canonical);
+    page = new URL(record.url);
+  } catch {
+    return;
+  }
+
+  // Cross-host canonicals belong to core/canonical too, and their form follows
+  // whatever conventions the OTHER site keeps - comparing it here is meaningless.
+  if (stripWww(target.hostname.toLowerCase()) !== stripWww(page.hostname.toLowerCase())) {
+    return;
+  }
+
+  rollup.sampleUrls.push(record.url);
+  const push = (dimension: Dimension, form: string | null): void => {
+    if (!form) return;
+    const sample = rollup.samples.get(dimension)!;
+    sample.urls.push(record.url);
+    sample.forms.push(form);
+  };
+
+  push("scheme", target.protocol === "https:" ? "https" : "http");
+  push("host", target.hostname.toLowerCase().startsWith("www.") ? "www" : "apex");
+  push("trailing slash", slashForm(target.pathname));
+  push(
+    "tracking params",
+    [...target.searchParams.keys()].some(isTrackingParam)
+      ? "tracking params retained"
+      : "tracking params stripped"
+  );
+}
+
+function skip(message: string): CheckResult {
+  return { name: CHECK_NAME, status: "skipped", message };
+}
+
+/** Stable string ordering, so neither path can depend on iteration luck. */
+function byString(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * The rule's full output for one rollup. ONE builder, both paths.
+ *
+ * `sitePageCount` is the crawl-wide page count: the streaming path takes it from
+ * `siteQuery.pageCount()` (which includes rows this rule cannot sample), so the
+ * site floor is judged on the crawl, not on the comparable subset.
+ */
+function buildChecks(rollup: CanonicalRollup, sitePageCount: number): CheckResult[] {
+  if (sitePageCount < CANONICAL_FORM_MIN_PAGES) {
+    return [
+      skip(
+        `Only ${sitePageCount} page(s) crawled; ${CANONICAL_FORM_MIN_PAGES} needed to establish a canonical-form norm`
+      ),
+    ];
+  }
+
+  const judged: JudgedDimension[] = [];
+  const drifts: FormDrift[] = [];
+  const deviantPages = new Set<string>();
+
+  for (const dimension of DIMENSIONS) {
+    const sample = rollup.samples.get(dimension)!;
+    const total = sample.forms.length;
+    if (total < CANONICAL_FORM_MIN_SAMPLE) continue;
+
+    const counts = new Map<string, number>();
+    for (const form of sample.forms) counts.set(form, (counts.get(form) ?? 0) + 1);
+
+    // The modal form, ties broken by name so the two paths cannot disagree.
+    let norm = "";
+    let normCount = 0;
+    for (const [form, count] of counts) {
+      if (count > normCount || (count === normCount && byString(form, norm) < 0)) {
+        norm = form;
+        normCount = count;
+      }
+    }
+    if (normCount / total < CANONICAL_FORM_MIN_AGREEMENT) continue;
+
+    judged.push({ dimension, pages: total, norm });
+
+    const deviantUrls = new Map<string, string[]>();
+    for (const [i, form] of sample.forms.entries()) {
+      if (form === norm) continue;
+      const url = sample.urls[i]!;
+      deviantPages.add(url);
+      const urls = deviantUrls.get(form) ?? [];
+      urls.push(url);
+      deviantUrls.set(form, urls);
+    }
+
+    for (const [deviant, urls] of [...deviantUrls.entries()].sort((a, b) =>
+      byString(a[0], b[0])
+    )) {
+      drifts.push({
+        dimension,
+        norm,
+        deviant,
+        have: normCount,
+        total,
+        deviantUrls: urls,
+      });
+    }
+  }
+
+  if (judged.length === 0) {
+    return [
+      skip(
+        `No canonical form is shared by ${Math.round(CANONICAL_FORM_MIN_AGREEMENT * 100)}% of at least ${CANONICAL_FORM_MIN_SAMPLE} comparable pages`
+      ),
+    ];
+  }
+
+  const judgedPages = rollup.sampleUrls.length;
+  const normSummary = judged.map((d) => `${d.dimension} ${d.norm}`).join(", ");
+  const details: Record<string, unknown> = {
+    judgedPages,
+    judgedDimensions: judged.length,
+    flaggedPages: deviantPages.size,
+    norms: judged.map((d) => ({ dimension: d.dimension, pages: d.pages, form: d.norm })),
+  };
+
+  if (drifts.length === 0) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "pass",
+        message: `All ${judgedPages} comparable canonical(s) share one form (${normSummary})`,
+        value: judgedPages,
+        details,
+      },
+    ];
+  }
+
+  // Widest drift first; dimension order then form name break ties so the list
+  // never depends on crawl order.
+  drifts.sort(
+    (a, b) =>
+      b.deviantUrls.length - a.deviantUrls.length ||
+      DIMENSIONS.indexOf(a.dimension) - DIMENSIONS.indexOf(b.dimension) ||
+      byString(a.deviant, b.deviant)
+  );
+  const items: CheckItem[] = drifts.slice(0, CANONICAL_FORM_MAX_ITEMS).map((d) => ({
+    id: `${d.dimension}:${d.deviant}`,
+    label: `${d.have} of ${d.total} canonicals use ${d.norm}, these ${d.deviantUrls.length} use ${d.deviant}`,
+    sourcePages: d.deviantUrls.slice(0, CANONICAL_FORM_MAX_URLS_PER_ITEM),
+    meta: {
+      dimension: d.dimension,
+      norm: d.norm,
+      deviant: d.deviant,
+      have: d.have,
+      total: d.total,
+      drifted: d.deviantUrls.length,
+    },
+  }));
+
+  const share = deviantPages.size / judgedPages;
+  return [
+    {
+      name: CHECK_NAME,
+      status: share >= CANONICAL_FORM_FAIL_SHARE ? "fail" : "warn",
+      message: `${deviantPages.size} of ${judgedPages} canonical(s) are declared in a different form than the rest of the site (${normSummary})`,
+      value: deviantPages.size,
+      items,
+      details,
+    },
+  ];
+}
+
+/**
+ * Streaming path (#1366): read `canonical` off the page_features cursor in
+ * normalized_url order (== the legacy `site.pages` order). Only the per-dimension
+ * form strings stay resident; no parsed page is held.
+ *
+ * The site floor is judged on `pageCount()`, which counts page_features rows; the
+ * legacy universe additionally carries the error pages v1 appends to `site.pages`.
+ * Only a crawl sitting exactly on the floor with non-auditable pages can word the
+ * skip differently, and neither path can judge such a crawl anyway. That is a
+ * property of this seam shared with every site rule on it (see
+ * content/duplicate-title), not something specific to this rule.
+ */
+async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
+  const rollup = emptyRollup();
+  for await (const row of siteQuery.pagesMatching(() => true)) {
+    accumulatePage(rollup, {
+      url: row.normalizedUrl,
+      status: row.status,
+      canonical: row.canonical,
+    });
+  }
+
+  return { checks: buildChecks(rollup, siteQuery.pageCount()) };
+}
+
+export const canonicalFormDriftRule: Rule = {
+  meta: {
+    id: "core/canonical-form-drift",
+    name: "Canonical Form Drift",
+    description:
+      "Finds canonical URLs that disagree in form (www, scheme, trailing slash, tracking params) across the site",
+    solution:
+      "Each of these canonicals is valid on its own, but the site does not agree with itself: some pages canonicalise to one URL form and some to another. Search engines treat the two forms as different URLs, so links, crawl budget and ranking signals split between them. Pick one form - the one your redirects already send traffic to - and emit it everywhere: one scheme (https), one host (www or apex, not both), one trailing-slash convention, and never any tracking parameters in the canonical. Canonicals are usually generated in one template or middleware, so this is normally a single fix in the place that builds the URL rather than a per-page edit.",
+    category: "core",
+    scope: "site",
+    severity: "warning",
+    // Deliberately light, and one site-wide check with capped items rather than a
+    // per-page finding, so this rule cannot dominate the core category score.
+    weight: 3,
+  },
+
+  run(ctx: RuleContext): RuleResult | Promise<RuleResult> {
+    if (ctx.siteQuery) {
+      return runViaSiteQuery(ctx.siteQuery);
+    }
+
+    const pages = ctx.site?.pages;
+    if (!pages || pages.length === 0) {
+      return { checks: [skip("No pages available for analysis")] };
+    }
+
+    const rollup = emptyRollup();
+    for (const page of pages) {
+      accumulatePage(rollup, {
+        url: page.url,
+        status: page.statusCode,
+        canonical: page.parsed?.meta?.canonical ?? null,
+      });
+    }
+
+    return { checks: buildChecks(rollup, rollup.pageCount) };
+  },
+};

--- a/packages/rules/src/core/canonical-form-drift.ts
+++ b/packages/rules/src/core/canonical-form-drift.ts
@@ -15,15 +15,23 @@
 //     canonical those two would already have something to say about. A page with
 //     no canonical, a relative one, an unparseable one, or one pointing at
 //     another registrable host is dropped from the sample before any comparison.
+//     core/canonical additionally emits an `info` on any non-self-referential
+//     canonical; that is a per-page note with no site-wide claim in it, and it is
+//     deliberately left alone - it is what this rule reads as its input, not a
+//     finding this rule repeats.
 //
 // Guards, in the order they matter:
 //   1. Site floor (CANONICAL_FORM_MIN_PAGES) - a small crawl has no norm.
-//   2. Per-dimension sample floor (CANONICAL_FORM_MIN_SAMPLE) - a dimension only
-//      a handful of pages can express is dropped, not guessed at.
-//   3. Modal agreement (CANONICAL_FORM_MIN_AGREEMENT) - a dimension needs a clear
+//   2. Per-bucket sample floor (CANONICAL_FORM_MIN_SAMPLE) - an axis only a
+//      handful of pages can express is dropped, not guessed at.
+//   3. Modal agreement (CANONICAL_FORM_MIN_AGREEMENT) - an axis needs a clear
 //      dominant form before the minority can be called deviant. A site that
 //      genuinely mixes forms 50/50 has no norm and produces no finding: that is a
 //      judgement call for a human, not an accusation from a rule.
+//   4. Sectioning (SECTIONED_DIMENSIONS) - the trailing-slash axis is compared
+//      within a section rather than site-wide, because using a slash in /blog and
+//      not in /product is a normal, healthy pattern and a site-wide vote would
+//      call the smaller section drift.
 //
 // Template-uniform pages are safe by construction: pages from one template emit
 // canonicals in one form, so they define the norm rather than deviate from it.
@@ -55,6 +63,7 @@ export const CANONICAL_FORM_FAIL_SHARE = 0.2;
 
 /** Caps on reported drifts / summarized norms, so one rule cannot bloat a report. */
 const CANONICAL_FORM_MAX_ITEMS = 10;
+const CANONICAL_FORM_MAX_NORMS = 10;
 
 /** Cap on URLs listed per drift, so one broken template cannot spray a report. */
 const CANONICAL_FORM_MAX_URLS_PER_ITEM = 20;
@@ -89,6 +98,16 @@ const TRACKING_PARAM_NAMES = new Set([
 const DIMENSIONS = ["scheme", "host", "trailing slash", "tracking params"] as const;
 type Dimension = (typeof DIMENSIONS)[number];
 
+/**
+ * Scheme, host and tracking params are ONE decision for a whole site, so they are
+ * compared site-wide. Trailing slash is not: plenty of healthy sites use a slash
+ * for one section (`/blog/how-to/`) and none for another (`/product`), and a
+ * site-wide comparison would call the smaller section drift. So that axis is
+ * compared inside a section - the first path segment of the canonical - and each
+ * section must clear the sample floor and the agreement bar on its own.
+ */
+const SECTIONED_DIMENSIONS = new Set<Dimension>(["trailing slash"]);
+
 /** One page's contribution, from either path. */
 interface CanonicalPageRecord {
   url: string;
@@ -97,6 +116,9 @@ interface CanonicalPageRecord {
 }
 
 interface DimensionSample {
+  dimension: Dimension;
+  /** "" for a site-wide axis; the section path (e.g. "/blog") otherwise. */
+  scope: string;
   /** Parallel arrays: the page url and the form it expressed on this axis. */
   urls: string[];
   forms: string[];
@@ -105,14 +127,14 @@ interface DimensionSample {
 interface CanonicalRollup {
   /** Pages seen by the rule (both paths count the same universe). */
   pageCount: number;
-  /** Pages with a canonical this rule is allowed to compare (see precedence). */
-  sampleUrls: string[];
-  samples: Map<Dimension, DimensionSample>;
+  /** Keyed `dimension scope`; insertion order is crawl order on both paths. */
+  samples: Map<string, DimensionSample>;
 }
 
 /** One "N of M canonicals use X, these N use Y" finding. */
 interface FormDrift {
   dimension: Dimension;
+  scope: string;
   norm: string;
   deviant: string;
   have: number;
@@ -122,14 +144,24 @@ interface FormDrift {
 
 interface JudgedDimension {
   dimension: Dimension;
+  scope: string;
   pages: number;
   norm: string;
 }
 
 function emptyRollup(): CanonicalRollup {
-  const samples = new Map<Dimension, DimensionSample>();
-  for (const dimension of DIMENSIONS) samples.set(dimension, { urls: [], forms: [] });
-  return { pageCount: 0, sampleUrls: [], samples };
+  return { pageCount: 0, samples: new Map() };
+}
+
+/**
+ * The section a sectioned axis compares within: the first path segment, but only
+ * for paths that HAVE a sub-path. A flat site (`/about`, `/pricing`) keeps every
+ * page in the one root section rather than shattering into a section per page,
+ * where nothing could ever reach the sample floor.
+ */
+function sectionOf(pathname: string): string {
+  const segments = pathname.split("/").filter(Boolean);
+  return segments.length > 1 ? `/${segments[0]}` : "/";
 }
 
 function stripWww(host: string): string {
@@ -182,10 +214,15 @@ function accumulatePage(rollup: CanonicalRollup, record: CanonicalPageRecord): v
     return;
   }
 
-  rollup.sampleUrls.push(record.url);
   const push = (dimension: Dimension, form: string | null): void => {
     if (!form) return;
-    const sample = rollup.samples.get(dimension)!;
+    const scope = SECTIONED_DIMENSIONS.has(dimension) ? sectionOf(target.pathname) : "";
+    const key = `${dimension} ${scope}`;
+    let sample = rollup.samples.get(key);
+    if (!sample) {
+      sample = { dimension, scope, urls: [], forms: [] };
+      rollup.samples.set(key, sample);
+    }
     sample.urls.push(record.url);
     sample.forms.push(form);
   };
@@ -229,9 +266,21 @@ function buildChecks(rollup: CanonicalRollup, sitePageCount: number): CheckResul
   const judged: JudgedDimension[] = [];
   const drifts: FormDrift[] = [];
   const deviantPages = new Set<string>();
+  // Only pages inside a bucket that actually got judged. Pages an axis had to
+  // exclude (the site root on the trailing-slash axis, a section under the floor)
+  // must not dilute the deviant share they were never eligible for.
+  const judgedUrls = new Set<string>();
 
-  for (const dimension of DIMENSIONS) {
-    const sample = rollup.samples.get(dimension)!;
+  // Fixed axis order, sections sorted by path: neither path can depend on the
+  // order pages happened to arrive in.
+  const buckets = [...rollup.samples.values()].sort(
+    (a, b) =>
+      DIMENSIONS.indexOf(a.dimension) - DIMENSIONS.indexOf(b.dimension) ||
+      byString(a.scope, b.scope)
+  );
+
+  for (const sample of buckets) {
+    const { dimension, scope } = sample;
     const total = sample.forms.length;
     if (total < CANONICAL_FORM_MIN_SAMPLE) continue;
 
@@ -249,10 +298,11 @@ function buildChecks(rollup: CanonicalRollup, sitePageCount: number): CheckResul
     }
     if (normCount / total < CANONICAL_FORM_MIN_AGREEMENT) continue;
 
-    judged.push({ dimension, pages: total, norm });
+    judged.push({ dimension, scope, pages: total, norm });
 
     const deviantUrls = new Map<string, string[]>();
     for (const [i, form] of sample.forms.entries()) {
+      judgedUrls.add(sample.urls[i]!);
       if (form === norm) continue;
       const url = sample.urls[i]!;
       deviantPages.add(url);
@@ -266,6 +316,7 @@ function buildChecks(rollup: CanonicalRollup, sitePageCount: number): CheckResul
     )) {
       drifts.push({
         dimension,
+        scope,
         norm,
         deviant,
         have: normCount,
@@ -283,13 +334,21 @@ function buildChecks(rollup: CanonicalRollup, sitePageCount: number): CheckResul
     ];
   }
 
-  const judgedPages = rollup.sampleUrls.length;
-  const normSummary = judged.map((d) => `${d.dimension} ${d.norm}`).join(", ");
+  const judgedPages = judgedUrls.size;
+  const normSummary = judged
+    .slice(0, CANONICAL_FORM_MAX_NORMS)
+    .map((d) => `${d.dimension}${d.scope ? ` in ${d.scope}` : ""} ${d.norm}`)
+    .join(", ");
   const details: Record<string, unknown> = {
     judgedPages,
     judgedDimensions: judged.length,
     flaggedPages: deviantPages.size,
-    norms: judged.map((d) => ({ dimension: d.dimension, pages: d.pages, form: d.norm })),
+    norms: judged.slice(0, CANONICAL_FORM_MAX_NORMS).map((d) => ({
+      dimension: d.dimension,
+      scope: d.scope,
+      pages: d.pages,
+      form: d.norm,
+    })),
   };
 
   if (drifts.length === 0) {
@@ -304,20 +363,22 @@ function buildChecks(rollup: CanonicalRollup, sitePageCount: number): CheckResul
     ];
   }
 
-  // Widest drift first; dimension order then form name break ties so the list
-  // never depends on crawl order.
+  // Widest drift first; axis order, then section, then form name break ties so
+  // the list never depends on crawl order.
   drifts.sort(
     (a, b) =>
       b.deviantUrls.length - a.deviantUrls.length ||
       DIMENSIONS.indexOf(a.dimension) - DIMENSIONS.indexOf(b.dimension) ||
+      byString(a.scope, b.scope) ||
       byString(a.deviant, b.deviant)
   );
   const items: CheckItem[] = drifts.slice(0, CANONICAL_FORM_MAX_ITEMS).map((d) => ({
-    id: `${d.dimension}:${d.deviant}`,
-    label: `${d.have} of ${d.total} canonicals use ${d.norm}, these ${d.deviantUrls.length} use ${d.deviant}`,
+    id: `${d.dimension}${d.scope ? `@${d.scope}` : ""}:${d.deviant}`,
+    label: `${d.have} of ${d.total} canonicals${d.scope ? ` in ${d.scope}` : ""} use ${d.norm}, these ${d.deviantUrls.length} use ${d.deviant}`,
     sourcePages: d.deviantUrls.slice(0, CANONICAL_FORM_MAX_URLS_PER_ITEM),
     meta: {
       dimension: d.dimension,
+      scope: d.scope,
       norm: d.norm,
       deviant: d.deviant,
       have: d.have,

--- a/packages/rules/src/core/index.ts
+++ b/packages/rules/src/core/index.ts
@@ -3,6 +3,7 @@
 import type { Rule } from "../types";
 
 import { canonicalRule } from "./canonical";
+import { canonicalFormDriftRule } from "./canonical-form-drift";
 import { canonicalHeaderRule } from "./canonical-header";
 import { charsetRule } from "./charset";
 import { doctypeRule } from "./doctype";
@@ -23,6 +24,7 @@ export const rules: Rule[] = [
   metaDescriptionRule,
   canonicalRule,
   canonicalHeaderRule,
+  canonicalFormDriftRule,
   h1Rule,
   robotsMetaRule,
   nosnippetRule,
@@ -34,6 +36,7 @@ export const rules: Rule[] = [
 
 // Re-export individual rules
 export {
+  canonicalFormDriftRule,
   canonicalHeaderRule,
   canonicalRule,
   charsetRule,

--- a/packages/rules/tests/core-canonical-form-drift.test.ts
+++ b/packages/rules/tests/core-canonical-form-drift.test.ts
@@ -258,7 +258,7 @@ describe("core/canonical-form-drift — template-uniform pages sit inside the no
     expect(check.value).toBe(30);
     expect(check.message).toContain("scheme https");
     expect(check.message).toContain("host apex");
-    expect(check.message).toContain("trailing slash no trailing slash");
+    expect(check.message).toContain("trailing slash in / no trailing slash");
     expect(check.message).toContain("tracking params tracking params stripped");
   });
 
@@ -276,7 +276,7 @@ describe("core/canonical-form-drift — template-uniform pages sit inside the no
     );
     expect(check.status).toBe("pass");
     expect(check.message).toContain("host www");
-    expect(check.message).toContain("trailing slash trailing slash");
+    expect(check.message).toContain("trailing slash in / trailing slash");
   });
 
   test("the site root and file-like paths do not join the trailing-slash norm", async () => {
@@ -293,6 +293,49 @@ describe("core/canonical-form-drift — template-uniform pages sit inside the no
       (n) => n.dimension === "trailing slash"
     );
     expect(slashNorm?.pages).toBe(12);
+  });
+
+  test("a section that uses trailing slashes does not make the section that does not a deviant", async () => {
+    // The expensive false positive this rule has to avoid: /blog/ pages with a
+    // trailing slash and top-level /product pages without one is a normal shape,
+    // not a site contradicting itself. Each section is judged against itself.
+    const specs = [
+      ...Array.from({ length: 21 }, (_, i) => ({
+        url: `https://example.com/product-${i}`,
+        canonical: `https://example.com/product-${i}`,
+      })),
+      ...Array.from({ length: 12 }, (_, i) => ({
+        url: `https://example.com/blog/post-${i}/`,
+        canonical: `https://example.com/blog/post-${i}/`,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(
+      (check.details?.norms as { dimension: string; scope: string; form: string }[])
+        .filter((n) => n.dimension === "trailing slash")
+        .map((n) => [n.scope, n.form])
+    ).toEqual([
+      ["/", "no trailing slash"],
+      ["/blog", "trailing slash"],
+    ]);
+  });
+
+  test("a section under the sample floor is dropped rather than judged by the rest of the site", async () => {
+    const specs = [
+      ...uniform(20, healthy),
+      ...Array.from({ length: 4 }, (_, i) => ({
+        url: `https://example.com/blog/post-${i}/`,
+        canonical: `https://example.com/blog/post-${i}/`,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(
+      (check.details?.norms as { dimension: string; scope: string }[])
+        .filter((n) => n.dimension === "trailing slash")
+        .map((n) => n.scope)
+    ).toEqual(["/"]);
   });
 
   test("query strings that are not tracking parameters never split the norm", async () => {
@@ -313,11 +356,12 @@ describe("core/canonical-form-drift — drift", () => {
     );
     expect(check.items).toHaveLength(1);
     expect(check.items?.[0]?.label).toBe(
-      "26 of 30 canonicals use no trailing slash, these 4 use trailing slash"
+      "26 of 30 canonicals in / use no trailing slash, these 4 use trailing slash"
     );
     expect(check.items?.[0]?.sourcePages).toHaveLength(4);
     expect(check.items?.[0]?.meta).toEqual({
       dimension: "trailing slash",
+      scope: "/",
       norm: "no trailing slash",
       deviant: "trailing slash",
       have: 26,
@@ -349,6 +393,23 @@ describe("core/canonical-form-drift — drift", () => {
     expect(check.status).toBe("warn");
     expect(check.items?.[0]?.meta?.dimension).toBe("tracking params");
     expect(check.items?.[0]?.meta?.deviant).toBe("tracking params retained");
+  });
+
+  test("drift INSIDE a section is still caught, and named against that section", async () => {
+    const specs = [
+      ...uniform(20, healthy),
+      ...Array.from({ length: 14 }, (_, i) => ({
+        url: `https://example.com/blog/post-${i}`,
+        canonical: `https://example.com/blog/post-${i}${i < 12 ? "/" : ""}`,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0]?.label).toBe(
+      "12 of 14 canonicals in /blog use trailing slash, these 2 use no trailing slash"
+    );
+    expect(check.items?.[0]?.meta?.scope).toBe("/blog");
   });
 
   test("fails once the drifted share crosses the fail threshold", async () => {

--- a/packages/rules/tests/core-canonical-form-drift.test.ts
+++ b/packages/rules/tests/core-canonical-form-drift.test.ts
@@ -1,0 +1,400 @@
+// core/canonical-form-drift — canonicals that disagree in form across the site (#1366).
+//
+// The rule accuses a site of contradicting itself, so most of this file defends
+// the silence cases: a small crawl, too few comparable canonicals, a site that
+// genuinely mixes forms, template-uniform pages, and every canonical shape that
+// core/canonical or core/canonical-header already owns. The positive cases pin
+// the one thing it is for: a minority of pages emitting a different URL form
+// from the rest of the site.
+//
+// Every fixture runs through `bothPaths`, so the legacy `ctx.site.pages` path and
+// the streaming `SiteQuery` path are asserted byte-identical on all of them.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult, PageFeatureRow, SiteQuery } from "@squirrelscan/core-contracts";
+
+import {
+  CANONICAL_FORM_MIN_PAGES,
+  CANONICAL_FORM_MIN_SAMPLE,
+  canonicalFormDriftRule,
+} from "../src/core/canonical-form-drift";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+interface PageSpec {
+  /** The page's own crawled URL; defaults to `https://example.com/pNNN`. */
+  url?: string;
+  canonical: string | null;
+  status?: number;
+}
+
+function url(i: number): string {
+  return `https://example.com/p${String(i).padStart(3, "0")}`;
+}
+
+/** N pages whose canonical is `prefix + path`, self-referential in the given form. */
+function uniform(count: number, canonical: (i: number) => string | null): PageSpec[] {
+  return Array.from({ length: count }, (_, i) => ({ canonical: canonical(i) }));
+}
+
+/** The healthy shape this site keeps: apex host, https, no trailing slash, no params. */
+function healthy(i: number): string {
+  return url(i);
+}
+
+const baseCtx = {
+  page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+  parsed: {} as ParsedPage,
+  options: {},
+};
+
+/** Legacy path: specs become `ctx.site.pages` in crawl (url ascending) order. */
+function legacyCtx(specs: PageSpec[]): RuleContext {
+  return {
+    ...baseCtx,
+    site: {
+      baseUrl: "https://example.com/",
+      pages: specs.map((spec, i) => ({
+        url: spec.url ?? url(i),
+        statusCode: spec.status ?? 200,
+        parsed: { meta: { canonical: spec.canonical } } as unknown as ParsedPage,
+      })),
+      robotsTxt: null,
+      sitemaps: null,
+    },
+  };
+}
+
+function featureRow(spec: PageSpec, i: number): PageFeatureRow {
+  return {
+    normalizedUrl: spec.url ?? url(i),
+    status: spec.status ?? 200,
+    depth: 1,
+    title: null,
+    titleHash: null,
+    description: null,
+    descHash: null,
+    contentHash: null,
+    wordCount: null,
+    pageType: null,
+    schemaTypes: [],
+    robotsNoindex: false,
+    canonical: spec.canonical,
+    visibleAuthor: false,
+    visibleDate: false,
+    transferBytes: null,
+    templateFp: null,
+    secretHits: null,
+    metaNoindex: false,
+    indexableReasons: [],
+    richResultTypes: [],
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
+  };
+}
+
+/**
+ * Streaming path: the rule only ever calls `pagesMatching` + `pageCount`, so the
+ * rest of the SiteQuery surface throws — a stub that silently returned empties
+ * could hide the rule reading something it must not.
+ */
+function siteQueryCtx(specs: PageSpec[]): RuleContext {
+  const rows = specs.map(featureRow);
+  const unused = (): never => {
+    throw new Error("canonical-form-drift must not use this SiteQuery method");
+  };
+  const siteQuery: SiteQuery = {
+    pageCount: () => rows.length,
+    duplicateGroups: unused,
+    incomingLinkCounts: unused,
+    pagesByType: unused,
+    templateClusters: unused,
+    sumTransferBytes: unused,
+    sumSecretHits: unused,
+    homepage: unused,
+    async *pagesMatching(pred: (row: PageFeatureRow) => boolean) {
+      for (const row of rows) if (pred(row)) yield row;
+    },
+  };
+  return {
+    ...baseCtx,
+    // EMPTY pages — the streaming path must not read them.
+    site: { baseUrl: "https://example.com/", pages: [], robotsTxt: null, sitemaps: null },
+    siteQuery,
+  };
+}
+
+async function checks(ctx: RuleContext): Promise<CheckResult[]> {
+  return (await Promise.resolve(canonicalFormDriftRule.run(ctx))).checks;
+}
+
+/** Run BOTH paths over one fixture, assert byte-identical output, return it. */
+async function bothPaths(specs: PageSpec[]): Promise<CheckResult> {
+  const legacy = await checks(legacyCtx(specs));
+  const streamed = await checks(siteQueryCtx(specs));
+  expect(streamed).toEqual(legacy);
+  expect(JSON.stringify(streamed)).toBe(JSON.stringify(legacy));
+  expect(legacy).toHaveLength(1);
+  return legacy[0]!;
+}
+
+/** `total` pages in the healthy form, except the last `drifted` in `other` form. */
+function mostly(
+  total: number,
+  drifted: number,
+  other: (i: number) => string
+): PageSpec[] {
+  return Array.from({ length: total }, (_, i) => ({
+    canonical: i < total - drifted ? healthy(i) : other(i),
+  }));
+}
+
+describe("core/canonical-form-drift — silence guards", () => {
+  test("skips a crawl below the site page floor", async () => {
+    const check = await bothPaths(uniform(CANONICAL_FORM_MIN_PAGES - 1, healthy));
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${CANONICAL_FORM_MIN_PAGES} needed`);
+  });
+
+  test("a single-page site never fires", async () => {
+    const check = await bothPaths([{ canonical: "https://example.com/" }]);
+    expect(check.status).toBe("skipped");
+  });
+
+  test("skips when too few pages carry a comparable canonical", async () => {
+    // 20 pages crawled, but only 9 declare a canonical at all: no dimension
+    // reaches its sample floor, so there is nothing to form a norm from.
+    const specs = [
+      ...uniform(9, healthy),
+      ...uniform(11, () => null),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${CANONICAL_FORM_MIN_SAMPLE} comparable pages`);
+  });
+
+  test("skips a site that genuinely mixes every form 50/50 — no dominant norm", async () => {
+    // Nothing here is a majority on any axis, so nothing here is a deviant.
+    const specs = Array.from({ length: 20 }, (_, i) =>
+      i % 2 === 0
+        ? { canonical: url(i) }
+        : { canonical: `http://www.example.com/p${String(i).padStart(3, "0")}/?utm_source=x` }
+    );
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain("70%");
+  });
+
+  test("an axis just under the agreement threshold is dropped, not judged", async () => {
+    // 13 of 20 = 65% < 70%: the majority is not enough to call the other 7 wrong.
+    // The three axes the site IS consistent on are still judged, and pass.
+    const check = await bothPaths(mostly(20, 7, (i) => `${url(i)}/`));
+    expect(check.status).toBe("pass");
+    expect(
+      (check.details?.norms as { dimension: string }[]).map((n) => n.dimension)
+    ).toEqual(["scheme", "host", "tracking params"]);
+  });
+
+  test("non-2xx pages are excluded from the norm and never flagged", async () => {
+    const specs = [
+      ...uniform(12, healthy),
+      ...Array.from({ length: 3 }, (_, i) => ({
+        canonical: `http://www.example.com/gone${i}/`,
+        status: 404,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(12);
+  });
+});
+
+describe("core/canonical-form-drift — validity belongs to core/canonical", () => {
+  test("missing canonicals are not drift", async () => {
+    const specs = [...uniform(12, healthy), ...uniform(6, () => null)];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(12);
+  });
+
+  test("relative canonicals are not drift", async () => {
+    const specs = [...uniform(12, healthy), ...uniform(6, (i) => `/p${i}`)];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(12);
+  });
+
+  test("unparseable canonicals are not drift", async () => {
+    const specs = [...uniform(12, healthy), ...uniform(6, () => "https://[not a url")];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(12);
+  });
+
+  test("cross-domain canonicals are not drift", async () => {
+    // Syndicated pages canonicalising to the origin publisher use that site's
+    // conventions (http, www, trailing slash) — comparing them here would report
+    // core/canonical's finding a second time under a different name.
+    const specs = [
+      ...uniform(12, healthy),
+      ...uniform(6, (i) => `http://www.origin-publisher.com/story-${i}/`),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(12);
+  });
+});
+
+describe("core/canonical-form-drift — template-uniform pages sit inside the norm", () => {
+  test("passes when every canonical shares one form", async () => {
+    const check = await bothPaths(uniform(30, healthy));
+    expect(check.status).toBe("pass");
+    expect(check.items).toBeUndefined();
+    expect(check.value).toBe(30);
+    expect(check.message).toContain("scheme https");
+    expect(check.message).toContain("host apex");
+    expect(check.message).toContain("trailing slash no trailing slash");
+    expect(check.message).toContain("tracking params tracking params stripped");
+  });
+
+  test("a consistently param-bearing form is a form, not drift", async () => {
+    // Every canonical keeps the same tracking parameter. Ugly, but the site is
+    // not contradicting itself, and this rule only reports contradictions.
+    const check = await bothPaths(uniform(30, (i) => `${url(i)}?utm_source=newsletter`));
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("tracking params tracking params retained");
+  });
+
+  test("a consistently www + trailing-slash site is clean", async () => {
+    const check = await bothPaths(
+      uniform(30, (i) => `https://www.example.com/p${String(i).padStart(3, "0")}/`)
+    );
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("host www");
+    expect(check.message).toContain("trailing slash trailing slash");
+  });
+
+  test("the site root and file-like paths do not join the trailing-slash norm", async () => {
+    // "/" and "/feed.xml" have no trailing-slash choice to make, so they must not
+    // be counted as deviants of a site that otherwise uses trailing slashes.
+    const specs = [
+      ...uniform(12, (i) => `https://example.com/p${String(i).padStart(3, "0")}/`),
+      { url: "https://example.com/", canonical: "https://example.com/" },
+      { url: "https://example.com/feed.xml", canonical: "https://example.com/feed.xml" },
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    const slashNorm = (check.details?.norms as { dimension: string; pages: number }[]).find(
+      (n) => n.dimension === "trailing slash"
+    );
+    expect(slashNorm?.pages).toBe(12);
+  });
+
+  test("query strings that are not tracking parameters never split the norm", async () => {
+    // A paginated listing legitimately canonicalises to `?page=N`.
+    const check = await bothPaths(uniform(30, (i) => `${url(i)}?page=${i}`));
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("tracking params tracking params stripped");
+  });
+});
+
+describe("core/canonical-form-drift — drift", () => {
+  test("warns and names the ratio it is arguing from", async () => {
+    const check = await bothPaths(mostly(30, 4, (i) => `${url(i)}/`));
+    expect(check.status).toBe("warn");
+    expect(check.value).toBe(4);
+    expect(check.message).toContain(
+      "4 of 30 canonical(s) are declared in a different form than the rest of the site"
+    );
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0]?.label).toBe(
+      "26 of 30 canonicals use no trailing slash, these 4 use trailing slash"
+    );
+    expect(check.items?.[0]?.sourcePages).toHaveLength(4);
+    expect(check.items?.[0]?.meta).toEqual({
+      dimension: "trailing slash",
+      norm: "no trailing slash",
+      deviant: "trailing slash",
+      have: 26,
+      total: 30,
+      drifted: 4,
+    });
+  });
+
+  test("catches www drift against an apex norm", async () => {
+    const check = await bothPaths(
+      mostly(30, 4, (i) => `https://www.example.com/p${String(i).padStart(3, "0")}`)
+    );
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0]?.meta?.dimension).toBe("host");
+    expect(check.items?.[0]?.meta?.deviant).toBe("www");
+  });
+
+  test("catches http drift against an https norm", async () => {
+    const check = await bothPaths(
+      mostly(30, 4, (i) => `http://example.com/p${String(i).padStart(3, "0")}`)
+    );
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0]?.meta?.dimension).toBe("scheme");
+    expect(check.items?.[0]?.meta?.deviant).toBe("http");
+  });
+
+  test("catches tracking parameters retained on a minority of canonicals", async () => {
+    const check = await bothPaths(mostly(30, 4, (i) => `${url(i)}?utm_campaign=spring`));
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0]?.meta?.dimension).toBe("tracking params");
+    expect(check.items?.[0]?.meta?.deviant).toBe("tracking params retained");
+  });
+
+  test("fails once the drifted share crosses the fail threshold", async () => {
+    // 21 of 30 keep the norm (70%, exactly the agreement floor) → 9/30 = 30%.
+    const check = await bothPaths(mostly(30, 9, (i) => `${url(i)}/`));
+    expect(check.status).toBe("fail");
+    expect(check.value).toBe(9);
+  });
+
+  test("a page drifting on two axes counts once toward the drifted share", async () => {
+    const check = await bothPaths(
+      mostly(30, 4, (i) => `http://www.example.com/p${String(i).padStart(3, "0")}`)
+    );
+    // Two drifts reported (scheme + host), but 4 drifted pages, not 8.
+    expect(check.items).toHaveLength(2);
+    expect(check.value).toBe(4);
+    expect(check.details?.flaggedPages).toBe(4);
+  });
+
+  test("reports the widest drift first", async () => {
+    const specs = Array.from({ length: 40 }, (_, i) => {
+      if (i >= 34) return { canonical: `${url(i)}/` }; // 6 slash drifts
+      if (i >= 32) return { canonical: `http://example.com/p${String(i).padStart(3, "0")}` }; // 2 scheme drifts
+      return { canonical: healthy(i) };
+    });
+    const check = await bothPaths(specs);
+    expect(check.items?.map((item) => item.meta?.dimension)).toEqual([
+      "trailing slash",
+      "scheme",
+    ]);
+  });
+});
+
+describe("core/canonical-form-drift — legacy-path edge cases", () => {
+  test("an empty site skips rather than throwing", async () => {
+    const result = await checks(legacyCtx([]));
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe("skipped");
+    expect(result[0]?.message).toBe("No pages available for analysis");
+  });
+
+  test("a page with no parsed meta skips rather than throwing", async () => {
+    const ctx = legacyCtx(uniform(12, healthy));
+    ctx.site!.pages[0]!.parsed = {} as unknown as ParsedPage;
+    const result = await checks(ctx);
+    expect(result[0]?.status).toBe("pass");
+    expect(result[0]?.details?.judgedPages).toBe(11);
+  });
+});


### PR DESCRIPTION
New site-wide rule `core/canonical-form-drift`. Every canonical it looks at is individually valid; what is wrong is collective. Half a site canonicalising to `https://www.example.com/thing/` and half to `https://example.com/thing` splits the ranking signal between two URLs, and no per-page rule can see it.

Compares four axes of URL form across the stored `canonical` column:

- scheme: `https` vs `http` (site-wide)
- host: `www` vs apex (site-wide)
- tracking parameters: retained vs stripped (site-wide) — `utm_*`, `gclid`, `fbclid`, `ref`, ...
- trailing slash: present vs absent, **compared within a section** (first path segment)

Reads only `canonical`, so no storage schema change lands with it.

### Precedence

`core/canonical` owns validity (missing, relative, unparseable, cross-host) and `core/canonical-header` owns the `Link: rel="canonical"` header. Pages in any of those states are dropped from the sample before the comparison runs, so one root cause is never reported twice. `core/canonical` also emits an `info` when a canonical is not self-referential; that is a per-page note with no site-wide claim in it, and it is the input this rule reads rather than a finding this rule repeats. Documented on the rule page and asserted by four unit tests.

### Norm guards

- `skipped` below a 10-page crawl floor.
- Each bucket needs 10 comparable canonicals, and a form reaching 70% agreement, before the minority is called deviant. A bucket under either bar is dropped, not guessed at; if no bucket clears both, the whole rule is `skipped`.
- **Trailing slash is section-scoped.** A site using `/blog/how-to/` with a slash and `/product` without one is a normal shape, not a contradiction, so each section is judged against itself. Scheme, host and tracking params genuinely are one decision for a whole site and stay site-wide.
- The site root and file-like paths are excluded from the trailing-slash axis: they never had the choice.
- Query presence in general is deliberately NOT an axis: `?page=2` legitimately varies per page. Only tracking params, which never carry page identity, are compared.
- The deviant share is measured against pages a judged bucket actually covered, so pages an axis had to exclude cannot dilute it.

### Scoring density

One site-wide check, items capped at 10 (20 URLs each), weight 3 (vs 6 for `core/canonical`). It contributes a single warn/fail unit to the core category no matter how many pages drift.

### Dual path

Legacy `ctx.site.pages` and streaming `SiteQuery` feed one accumulator and one check builder. Every unit fixture asserts the two are deep-equal AND `JSON.stringify`-equal, and the canonical 518-page v1/v2 golden passes with its pins moved by exactly one rule (98214 -> 98215 findings, 270 -> 271 tally).

### Smoke: https://sweetdeals.com.au

`squirrel audit https://sweetdeals.com.au --max-pages 200` — **200 pages scanned**, published score 52.

**Findings from the new rule: 0** (status `pass`), all four axes judged:

| axis | scope | comparable pages | norm |
|---|---|---|---|
| scheme | site | 200 | https |
| host | site | 200 | apex |
| trailing slash | `/p` | 198 | no trailing slash |
| tracking params | site | 200 | stripped |

The 198 template-generated product pages all emit the same canonical form, so nothing template-shaped is flagged. The root section holds only `/about` once `/` is excluded from the slash axis, so it falls under the 10-page floor and is dropped rather than judged off a sample of one.

**Spot-check that it fires on genuine outliers** — same 200-page corpus replayed with a few canonicals perturbed:

1. 8 product pages rewritten to `https://www.sweetdeals.com.au/p/...` -> `warn`, item `192 of 200 canonicals use apex, these 8 use www`. Real outlier: the other 192 are apex.
2. 5 given a trailing slash -> `193 of 198 canonicals in /p use no trailing slash, these 5 use trailing slash`. Scoped to `/p`, which is where the disagreement actually is.
3. 3 given `?utm_source=facebook` -> `197 of 200 canonicals use tracking params stripped, these 3 use tracking params retained`. Overall 16 of 200 pages flagged (a page drifting on two axes counts once).
4. 50 pages (25%) rewritten to www -> `fail`, one item, 50 flagged: the share crosses the 20% fail threshold.

### Rule count

271 rules, Core SEO 14. README, `docs/index.mdx`, `docs/rules/index.mdx`, the category card and the golden pins updated to match.

### Tests

- `packages/rules`: 1237 pass (27 new)
- `packages/audit-engine`: 270 pass / 3 skip, including the 518-page canonical golden
- `apps/cli`: 1722 pass
- `tsgo --noEmit` clean, `make validate` clean in `docs/`

Refs squirrelscan/repo#1366
