### PR TITLE
feat(rules): add content/title-pattern-outlier, titles that break the site's own template

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **271 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **272 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler 
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more 
@@ -43,7 +43,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Site Integrity | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | Security | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | Links | 14 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, HTTPS downgrades |
-| Content | 16 | Text quality and honesty: duplicate titles and descriptions, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| Content | 17 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | Performance | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | Images | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | Structured Data | 11 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 271 rules across 21 categories**
+**Total: 272 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -242,7 +242,8 @@
                   "rules/content/quality",
                   "rules/content/stale-copyright",
                   "rules/content/mojibake",
-                  "rules/content/thin-vs-site-norm"
+                  "rules/content/thin-vs-site-norm",
+                  "rules/content/title-pattern-outlier"
                 ]
               },
               {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="271 Rules, 21 Categories"
+    title="272 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **271 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **272 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -226,7 +226,7 @@ squirrelscan runs **271 rules** across **21 categories**, plus opt-in cloud gap 
 | **Site Integrity** | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | **Security** | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | **Links** | 14 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, HTTPS downgrades |
-| **Content** | 16 | Text quality and honesty: duplicate titles and descriptions, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| **Content** | 17 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | **Performance** | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | **Structured Data** | 11 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have |
@@ -242,7 +242,7 @@ squirrelscan runs **271 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 271 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 272 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -50,6 +50,9 @@ Text quality, readability, and content structure
   <Card title="Thin Content vs Site Norm" icon="triangle-exclamation" href="/rules/content/thin-vs-site-norm">
     Finds pages far shorter than the site's own norm for their page type
   </Card>
+  <Card title="Title Template Consistency" icon="triangle-exclamation" href="/rules/content/title-pattern-outlier">
+    Finds pages whose title breaks the template the rest of the site follows
+  </Card>
   <Card title="Word Count" icon="triangle-exclamation" href="/rules/content/word-count">
     Checks content length for thin content issues
   </Card>

--- a/docs/rules/content/title-pattern-outlier.mdx
+++ b/docs/rules/content/title-pattern-outlier.mdx
@@ -1,0 +1,87 @@
+---
+title: "Title Template Consistency"
+description: "Finds pages whose title breaks the template the rest of the site follows"
+---
+
+Finds pages whose title breaks the template the rest of the site follows
+
+| | |
+|---|---|
+| **Rule ID** | `content/title-pattern-outlier` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 3/10 |
+
+## How it works
+
+Most sites title their pages with one template: a page name, a separator, and the
+brand. No per-page check can see that template, because it only exists across the
+corpus. This rule infers it from your own crawled titles and reports the pages that
+break it.
+
+It works out two things from the titles themselves:
+
+- the **brand affix**: the segment most titles carry at the same end, first or last
+- the **separator** that sits next to that brand (`|`, `::`, `»`, `>`, ` - `, `: `)
+
+Then it reports four kinds of deviation:
+
+| Deviation | What it means |
+|---|---|
+| Missing brand | The title never mentions the brand the rest of the site carries |
+| Inverted order | The brand is at the opposite end from the norm |
+| Different separator | The brand is separated by something other than the modal separator |
+| Brand only | The title is nothing but the brand, so the page has no name of its own |
+
+Each page is reported once, for its most meaningful deviation.
+
+It stays quiet unless it has grounds to speak:
+
+- Fewer than 10 crawled pages, or fewer than 10 pages with a title: there is no
+  template to infer, so the rule is skipped.
+- No brand affix reaching 70% agreement: the site's titles genuinely follow no
+  single template, so nothing in it is a deviant.
+- On a site with more than one section, a candidate brand only ever seen inside one
+  section is treated as a section label, not the brand.
+- The homepage is exempt: "Acme - tools for X" is a normal home title and a normal
+  departure from the template every other page follows.
+- Pages with no title at all belong to [Meta Title](/rules/core/meta-title), which
+  stays per-page. The two rules never both flag the same page.
+
+Pages generated from the same template sit inside the norm by construction, so a
+large templated site is clean here unless a pocket of pages genuinely drifted.
+
+## Solution
+
+Most of your pages title themselves the same way - a page name, a separator, and your
+brand - and these pages do not. Inconsistent titles cost you brand recall in the
+search results and make templated pages look hand-edited or broken. Fix the template
+at its source (the layout or CMS field that builds the title) rather than page by
+page, keeping the brand on the same side with the same separator everywhere. A page
+that deliberately differs, like the homepage or a campaign landing page, is fine: the
+point is that a handful of pages should not be the exception.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/title-pattern-outlier"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/title-pattern-outlier"]
+disable = ["*"]
+```

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 271 audit rules organized by score group and category"
+description: "All 272 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **271 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **272 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -23,7 +23,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Internal and external link health and structure (14 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (16 rules)
+    Text quality, readability, and content structure (17 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (11 rules)

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -76,14 +76,17 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // single whole-crawl check (#1365).
       // 98214 -> 98215: core/canonical-form-drift, likewise site-scoped, adds its
       // own single whole-crawl check (#1366).
-      expect(v1.findings.length).toBe(98215);
+      // 98215 -> 98216: content/title-pattern-outlier, likewise site-scoped, adds
+      // its own single whole-crawl check (#1361).
+      expect(v1.findings.length).toBe(98216);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
       // schema/coverage-outlier, 269 -> 270 url/slug-convention, 270 -> 271
-      // core/canonical-form-drift; anything else means a rule id leaked in, so
-      // fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(271);
+      // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier;
+      // anything else means a rule id leaked in, so fix that rather than this
+      // number.
+      expect(v1.perRuleTally.length).toBe(272);
     },
     180_000,
   );

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -18,6 +18,7 @@ import { contentQualityRule } from "./quality";
 import { readingLevelRule } from "./reading-level";
 import { staleCopyrightRule } from "./stale-copyright";
 import { thinVsSiteNormRule } from "./thin-vs-site-norm";
+import { titlePatternOutlierRule } from "./title-pattern-outlier";
 import { wordCountRule } from "./word-count";
 
 export const rules: Rule[] = [
@@ -38,6 +39,7 @@ export const rules: Rule[] = [
   mojibakeRule,
   staleCopyrightRule,
   thinVsSiteNormRule,
+  titlePatternOutlierRule,
 ];
 
 export {
@@ -57,5 +59,6 @@ export {
   readingLevelRule,
   staleCopyrightRule,
   thinVsSiteNormRule,
+  titlePatternOutlierRule,
   wordCountRule,
 };

--- a/packages/rules/src/content/title-pattern-outlier.ts
+++ b/packages/rules/src/content/title-pattern-outlier.ts
@@ -1,0 +1,608 @@
+// content/title-pattern-outlier - titles that break the site's own title template (#1361)
+//
+// core/meta-title judges ONE title against fixed ideas of a good title (present,
+// long enough, not too long). None of the per-page rules can see that a site titles
+// 96% of its pages "Page name | Acme" and then ships a pocket of pages with no
+// brand, the brand at the wrong end, or a different separator. That inconsistency is
+// invisible per page and obvious across a corpus, so the template is inferred from
+// the site itself and only the minority form is reported.
+//
+// What is inferred, in order:
+//   1. the modal brand affix - the segment that most titles carry at the same end
+//      (prefix or suffix), after splitting on `|`, `::`, `»`, `>`, ` - `, `: `
+//   2. the modal separator that sits next to that brand
+// Deviations, one class per page, most meaningful first:
+//   brand-only      the title is nothing but the brand
+//   brand-missing   the title never mentions the brand the rest of the site carries
+//   brand-position  the brand is at the opposite end from the norm
+//   separator       the brand is separated by something other than the modal separator
+//
+// Guards, in the order they matter:
+//   1. Site floor (TITLE_NORM_MIN_PAGES) - a small crawl has no norm to speak of.
+//   2. Sample floor (TITLE_NORM_MIN_SAMPLE) - too few titled pages to vote.
+//   3. Modal agreement (TITLE_NORM_MIN_AGREEMENT) - a site whose titles do not
+//      concentrate on one brand affix is legitimately heterogeneous and nothing in
+//      it is a deviant. Skipping beats accusing a healthy site.
+//   4. Cross-section evidence - on a multi-section site the brand candidate must be
+//      seen in at least two sections, so a section label ("Blog | Post name") that
+//      happens to dominate a lopsided crawl is never mistaken for the brand
+//      (the trap from url/slug-convention's trailing-slash axis, #1366).
+//   5. The homepage is exempt: "Acme - tools for X" is a normal home title and a
+//      normal deviation from the template every other page follows.
+// Together these mean a site whose titles follow no dominant template stays clean,
+// and pages generated from the same template sit inside the norm by construction.
+// A site running SEVERAL templates that disagree with each other (products joined by
+// "::", collections by "|") is a finding rather than an exemption: unlike a trailing
+// slash, which is a per-section decision (#1366), the title template comes from one
+// layout and is one decision for the whole site. What is exempted is a template whose
+// pages agree with the rest of the site, not one that is merely internally uniform.
+//
+// Precedence over core/meta-title (#1361): that rule owns missing/empty titles, so a
+// page with no title never votes and is never a deviant here. Above that, meta-title
+// only judges length, which is a different finding from template drift.
+//
+// Dual path: `ctx.siteQuery` streams (normalizedUrl, title) straight off
+// page_features; the legacy path reads the same two fields from `ctx.site.pages`.
+// Both feed ONE accumulator and ONE check builder, and every list is sorted before
+// it is emitted, so the output is byte-identical by construction and independent of
+// crawl order (same shape as content/duplicate-title, #1021/#1022).
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+import type { CheckItem, SiteQuery } from "@squirrelscan/core-contracts";
+
+/** Crawl-wide page floor: below this there is no site norm to judge against. */
+export const TITLE_NORM_MIN_PAGES = 10;
+
+/** Titled 2xx pages needed before a template is inferred at all. */
+export const TITLE_NORM_MIN_SAMPLE = 10;
+
+/** Pages needed in the separator vote before that dimension is judged. */
+export const TITLE_NORM_MIN_SEPARATOR_SAMPLE = 10;
+
+/**
+ * Share of titled pages that must carry the same brand affix before it is treated
+ * as the site's template. Below this the site genuinely mixes and no page deviates.
+ */
+export const TITLE_NORM_MIN_AGREEMENT = 0.7;
+
+/** Share of judged pages that turns the warning into a failure. */
+export const TITLE_NORM_FAIL_SHARE = 0.2;
+
+/** Caps on reported items / urls, so one rule cannot bloat a report. */
+const TITLE_NORM_MAX_ITEMS = 10;
+const TITLE_NORM_MAX_URLS = 10;
+
+const CHECK_NAME = "title-pattern-outlier";
+
+/**
+ * Title separators. `|`, `::`, `»` and `>>` are unambiguous, so padding is optional;
+ * the dashes, the middot, the single `>` and the colon only separate when whitespace
+ * says they do ("e-commerce" and "10:30" are not two segments).
+ *
+ * A title whose brand is joined by something NOT in this set (or by nothing at all)
+ * simply casts no separator vote: it is never reported as using "the wrong
+ * separator", because the rule has no evidence about what it used.
+ */
+const SEPARATOR_RE = /\s*(?:::|\||»|>>)\s*|\s+[-–—·>]\s+|:\s+/g;
+
+/** Deviation classes, in the order they are reported. */
+const CLASSES = ["brand-only", "brand-missing", "brand-position", "separator"] as const;
+type DeviationClass = (typeof CLASSES)[number];
+
+type BrandPosition = "prefix" | "suffix";
+
+/** One page's contribution, from either path. */
+interface TitlePageRecord {
+  url: string;
+  status: number;
+  title: string | null;
+}
+
+/** A titled page the rule can judge. */
+interface TitleSample {
+  url: string;
+  title: string;
+  /** First path segment, or "/" for a single-segment or root path. */
+  section: string;
+  isRoot: boolean;
+}
+
+interface TitleRollup {
+  /** Pages seen by the rule (both paths count the same universe). */
+  pageCount: number;
+  samples: TitleSample[];
+}
+
+/** A brand affix the corpus voted for. */
+interface BrandCandidate {
+  position: BrandPosition;
+  /** Normalized comparison key. */
+  key: string;
+  count: number;
+  sections: Set<string>;
+  /** raw form -> times seen, so the reported spelling never depends on crawl order. */
+  raws: Map<string, number>;
+}
+
+interface BrandNorm {
+  position: BrandPosition;
+  key: string;
+  label: string;
+  count: number;
+  share: number;
+}
+
+interface SeparatorNorm {
+  value: string;
+  count: number;
+  total: number;
+  share: number;
+}
+
+interface Deviation {
+  class: DeviationClass;
+  url: string;
+  /** The form this page used, for the item meta. */
+  value: string;
+}
+
+function emptyRollup(): TitleRollup {
+  return { pageCount: 0, samples: [] };
+}
+
+/** Whitespace-collapsed, trimmed. */
+function collapse(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+/** Comparison key: case- and whitespace-insensitive. */
+function normalizeKey(value: string): string {
+  return collapse(value).toLowerCase();
+}
+
+function pathOf(url: string): string | null {
+  try {
+    return new URL(url).pathname || "/";
+  } catch {
+    return null;
+  }
+}
+
+function segmentsOf(path: string): string[] {
+  return path.split("/").filter((s) => s.length > 0);
+}
+
+/**
+ * Split a title into segments plus the separator used at each boundary.
+ * `seps[i]` is the separator between `segments[i]` and `segments[i + 1]`.
+ */
+function splitTitle(title: string): { segments: string[]; seps: string[] } {
+  const segments: string[] = [];
+  const seps: string[] = [];
+  let last = 0;
+  SEPARATOR_RE.lastIndex = 0;
+  for (let m = SEPARATOR_RE.exec(title); m !== null; m = SEPARATOR_RE.exec(title)) {
+    // A separator with nothing before it is decoration, not a boundary.
+    const segment = title.slice(last, m.index).trim();
+    if (segment.length === 0) {
+      last = m.index + m[0].length;
+      continue;
+    }
+    segments.push(segment);
+    seps.push(m[0].trim());
+    last = m.index + m[0].length;
+  }
+  const tail = title.slice(last).trim();
+  if (tail.length > 0) segments.push(tail);
+  // A trailing separator leaves one more sep than boundaries; drop it.
+  while (seps.length >= segments.length && seps.length > 0) seps.pop();
+  return { segments, seps };
+}
+
+/**
+ * Fold one page in. Untitled pages belong to core/meta-title and never vote here,
+ * so this rule cannot accuse a page that one already owns.
+ */
+function accumulatePage(rollup: TitleRollup, record: TitlePageRecord): void {
+  rollup.pageCount += 1;
+
+  if (record.status < 200 || record.status >= 300) return;
+  const title = collapse(record.title ?? "");
+  if (title.length === 0) return;
+  const path = pathOf(record.url);
+  if (path === null) return;
+
+  const segments = segmentsOf(path);
+  rollup.samples.push({
+    url: record.url,
+    title,
+    // Single-segment paths share the root bucket, or a flat site shatters into one
+    // section per page and nothing ever clears the cross-section bar.
+    section: segments.length > 1 ? segments[0]!.toLowerCase() : "/",
+    isRoot: segments.length === 0,
+  });
+}
+
+function candidateKey(position: BrandPosition, key: string): string {
+  return `${position}:${key}`;
+}
+
+/** Most-seen raw spelling of a candidate; ties break lexicographically. */
+function displayForm(raws: Map<string, number>): string {
+  let best: { raw: string; count: number } | null = null;
+  for (const [raw, count] of raws) {
+    if (best === null || count > best.count || (count === best.count && raw < best.raw)) {
+      best = { raw, count };
+    }
+  }
+  return best!.raw;
+}
+
+/**
+ * The site's brand affix, or null when no affix is dominant enough (or is only
+ * evidenced inside one section of a multi-section crawl, which reads as a section
+ * label rather than a brand).
+ */
+function inferBrand(samples: TitleSample[], multiSection: boolean): BrandNorm | null {
+  const candidates = new Map<string, BrandCandidate>();
+
+  const vote = (position: BrandPosition, raw: string, sample: TitleSample): void => {
+    const key = normalizeKey(raw);
+    if (key.length === 0) return;
+    const id = candidateKey(position, key);
+    let candidate = candidates.get(id);
+    if (!candidate) {
+      candidate = { position, key, count: 0, sections: new Set(), raws: new Map() };
+      candidates.set(id, candidate);
+    }
+    candidate.count += 1;
+    candidate.sections.add(sample.section);
+    candidate.raws.set(collapse(raw), (candidate.raws.get(collapse(raw)) ?? 0) + 1);
+  };
+
+  for (const sample of samples) {
+    const { segments } = splitTitle(sample.title);
+    if (segments.length < 2) continue;
+    vote("prefix", segments[0]!, sample);
+    vote("suffix", segments[segments.length - 1]!, sample);
+  }
+
+  let best: BrandCandidate | null = null;
+  for (const candidate of candidates.values()) {
+    // A single-section candidate on a multi-section site is a section label.
+    if (multiSection && candidate.sections.size < 2) continue;
+    if (
+      best === null ||
+      candidate.count > best.count ||
+      (candidate.count === best.count &&
+        candidateKey(candidate.position, candidate.key) <
+          candidateKey(best.position, best.key))
+    ) {
+      best = candidate;
+    }
+  }
+
+  if (best === null) return null;
+  const share = best.count / samples.length;
+  if (share < TITLE_NORM_MIN_AGREEMENT) return null;
+  return {
+    position: best.position,
+    key: best.key,
+    label: displayForm(best.raws),
+    count: best.count,
+    share,
+  };
+}
+
+/** The separator this page puts next to the brand, or null when it has none. */
+function brandSeparator(sample: TitleSample, brand: BrandNorm): string | null {
+  const { segments, seps } = splitTitle(sample.title);
+  if (segments.length < 2 || seps.length === 0) return null;
+  if (normalizeKey(segments[segments.length - 1]!) === brand.key) {
+    return seps[seps.length - 1]!;
+  }
+  if (normalizeKey(segments[0]!) === brand.key) return seps[0]!;
+  return null;
+}
+
+/** The modal separator sitting next to the brand, or null when there is no norm. */
+function inferSeparator(samples: TitleSample[], brand: BrandNorm): SeparatorNorm | null {
+  const votes = new Map<string, number>();
+  let total = 0;
+  for (const sample of samples) {
+    const sep = brandSeparator(sample, brand);
+    if (sep === null) continue;
+    votes.set(sep, (votes.get(sep) ?? 0) + 1);
+    total += 1;
+  }
+  if (total < TITLE_NORM_MIN_SEPARATOR_SAMPLE) return null;
+
+  let best: { value: string; count: number } | null = null;
+  for (const [value, count] of votes) {
+    if (best === null || count > best.count || (count === best.count && value < best.value)) {
+      best = { value, count };
+    }
+  }
+  if (best === null) return null;
+  const share = best.count / total;
+  if (share < TITLE_NORM_MIN_AGREEMENT) return null;
+  return { value: best.value, count: best.count, total, share };
+}
+
+/**
+ * Where the brand sits in this title, or null when the title never mentions it.
+ * Deliberately a substring test, not a segment test: a title that says the brand
+ * anywhere ("About Acme Deals", "Acme Deals Sydney | Acme Deals") is not a page that
+ * forgot the brand, and accusing it would be the expensive kind of wrong.
+ */
+function brandPlacement(sample: TitleSample, brand: BrandNorm): BrandPosition | "inline" | null {
+  const key = normalizeKey(sample.title);
+  if (!key.includes(brand.key)) return null;
+  if (key.startsWith(brand.key)) return "prefix";
+  if (key.endsWith(brand.key)) return "suffix";
+  return "inline";
+}
+
+/**
+ * One class per page, most meaningful first, so a page is never accused twice for
+ * one root cause.
+ */
+function classify(
+  sample: TitleSample,
+  brand: BrandNorm,
+  separator: SeparatorNorm | null
+): Deviation | null {
+  // The homepage legitimately has its own title: brand-only, brand-first and a
+  // tagline separator are all normal there.
+  if (sample.isRoot) return null;
+
+  const placement = brandPlacement(sample, brand);
+  if (placement === null) {
+    return { class: "brand-missing", url: sample.url, value: sample.title };
+  }
+  if (normalizeKey(sample.title) === brand.key) {
+    return { class: "brand-only", url: sample.url, value: sample.title };
+  }
+  if (placement !== "inline" && placement !== brand.position) {
+    return { class: "brand-position", url: sample.url, value: placement };
+  }
+
+  if (separator !== null) {
+    const sep = brandSeparator(sample, brand);
+    if (sep !== null && sep !== separator.value) {
+      return { class: "separator", url: sample.url, value: sep };
+    }
+  }
+  return null;
+}
+
+function skip(message: string): CheckResult {
+  return { name: CHECK_NAME, status: "skipped", message };
+}
+
+function positionLabel(position: BrandPosition): string {
+  return position === "suffix" ? "last" : "first";
+}
+
+function classLabel(
+  deviation: DeviationClass,
+  count: number,
+  judged: number,
+  brand: BrandNorm,
+  separator: SeparatorNorm | null,
+  value: string
+): string {
+  switch (deviation) {
+    case "brand-only":
+      return `${count} of ${judged} page(s) have a title that is only the brand "${brand.label}"`;
+    case "brand-missing":
+      return `${count} of ${judged} page(s) never mention "${brand.label}", which ${Math.round(brand.share * 100)}% of titles carry`;
+    case "brand-position":
+      return `${count} of ${judged} page(s) put "${brand.label}" ${positionLabel(value as BrandPosition)} but the norm is ${positionLabel(brand.position)}`;
+    case "separator":
+      return `${count} of ${separator?.total ?? judged} page(s) separate "${brand.label}" with "${value}" but the norm is "${separator?.value ?? ""}"`;
+  }
+}
+
+/**
+ * The rule's full output for one rollup. ONE builder, both paths.
+ *
+ * `sitePageCount` is the crawl-wide page count: the streaming path takes it from
+ * `siteQuery.pageCount()` (which includes rows this rule cannot sample), so the
+ * site floor is judged on the crawl, not on the sampled subset.
+ */
+function buildChecks(rollup: TitleRollup, sitePageCount: number): CheckResult[] {
+  if (sitePageCount < TITLE_NORM_MIN_PAGES) {
+    return [
+      skip(
+        `Only ${sitePageCount} page(s) crawled; ${TITLE_NORM_MIN_PAGES} needed to establish a title template`
+      ),
+    ];
+  }
+
+  const samples = rollup.samples;
+  if (samples.length < TITLE_NORM_MIN_SAMPLE) {
+    return [
+      skip(
+        `Only ${samples.length} page(s) have a title; ${TITLE_NORM_MIN_SAMPLE} needed to establish a title template`
+      ),
+    ];
+  }
+
+  const sections = new Set(samples.map((s) => s.section));
+  const brand = inferBrand(samples, sections.size >= 2);
+  if (brand === null) {
+    return [
+      skip(
+        `No title template reaches ${Math.round(TITLE_NORM_MIN_AGREEMENT * 100)}% agreement across the crawled titles`
+      ),
+    ];
+  }
+
+  const separator = inferSeparator(samples, brand);
+  const normSummary = [
+    `brand "${brand.label}" ${positionLabel(brand.position)} ${Math.round(brand.share * 100)}%`,
+    separator === null
+      ? null
+      : `separator "${separator.value}" ${Math.round(separator.share * 100)}%`,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(", ");
+
+  const deviations: Deviation[] = [];
+  for (const sample of samples) {
+    const deviation = classify(sample, brand, separator);
+    if (deviation !== null) deviations.push(deviation);
+  }
+
+  const details: Record<string, unknown> = {
+    judgedPages: samples.length,
+    flaggedPages: deviations.length,
+    norms: [
+      {
+        dimension: "brand",
+        norm: brand.label,
+        position: brand.position,
+        pages: brand.count,
+        agreement: brand.share,
+      },
+      ...(separator === null
+        ? []
+        : [
+            {
+              dimension: "separator",
+              norm: separator.value,
+              pages: separator.count,
+              agreement: separator.share,
+            },
+          ]),
+    ],
+  };
+
+  if (deviations.length === 0) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "pass",
+        message: `All ${samples.length} titled page(s) follow the site's own title template (${normSummary})`,
+        value: samples.length,
+        details,
+      },
+    ];
+  }
+
+  // Group by class (and, for the classes whose form varies, by that form) so one
+  // finding names one root cause instead of one page.
+  const groups = new Map<string, { class: DeviationClass; value: string; urls: string[] }>();
+  for (const deviation of deviations) {
+    const grouped =
+      deviation.class === "brand-position" || deviation.class === "separator"
+        ? deviation.value
+        : "";
+    const id = `${deviation.class}:${grouped}`;
+    const group = groups.get(id);
+    if (group) group.urls.push(deviation.url);
+    else groups.set(id, { class: deviation.class, value: grouped, urls: [deviation.url] });
+  }
+
+  // Biggest group first; the class order breaks ties so the list never depends on
+  // crawl order.
+  const ordered = [...groups.values()].sort(
+    (a, b) =>
+      b.urls.length - a.urls.length ||
+      CLASSES.indexOf(a.class) - CLASSES.indexOf(b.class) ||
+      (a.value < b.value ? -1 : a.value > b.value ? 1 : 0)
+  );
+
+  const items: CheckItem[] = ordered.slice(0, TITLE_NORM_MAX_ITEMS).map((group) => ({
+    id: `${group.class}:${group.value}`,
+    label: classLabel(
+      group.class,
+      group.urls.length,
+      samples.length,
+      brand,
+      separator,
+      group.value
+    ),
+    sourcePages: group.urls.sort().slice(0, TITLE_NORM_MAX_URLS),
+    meta: {
+      deviation: group.class,
+      value: group.value,
+      brand: brand.label,
+      pageCount: group.urls.length,
+    },
+  }));
+
+  const share = deviations.length / samples.length;
+  return [
+    {
+      name: CHECK_NAME,
+      status: share >= TITLE_NORM_FAIL_SHARE ? "fail" : "warn",
+      message: `${deviations.length} of ${samples.length} titled page(s) break the site's own title template (${normSummary})`,
+      value: deviations.length,
+      items,
+      details,
+    },
+  ];
+}
+
+/**
+ * Streaming path (#1361): read (normalizedUrl, title) off the page_features cursor.
+ * Only the titles stay resident - the same bounded scalars content/duplicate-title
+ * already holds; no parsed page is kept.
+ *
+ * The site floor is judged on `pageCount()`, which counts page_features rows; the
+ * legacy universe additionally carries the error pages v1 appends to `site.pages`.
+ * That is a property of this seam shared with every site rule on it (see
+ * content/duplicate-title), not something specific to this rule.
+ */
+async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
+  const rollup = emptyRollup();
+  for await (const row of siteQuery.pagesMatching(() => true)) {
+    accumulatePage(rollup, {
+      url: row.normalizedUrl,
+      status: row.status,
+      title: row.title,
+    });
+  }
+
+  return { checks: buildChecks(rollup, siteQuery.pageCount()) };
+}
+
+export const titlePatternOutlierRule: Rule = {
+  meta: {
+    id: "content/title-pattern-outlier",
+    name: "Title Template Consistency",
+    description: "Finds pages whose title breaks the template the rest of the site follows",
+    solution:
+      "Most of your pages title themselves the same way - a page name, a separator, and your brand - and these pages do not. Inconsistent titles cost you brand recall in the search results and make templated pages look hand-edited or broken. Fix the template at its source (the layout or CMS field that builds the title) rather than page by page, keeping the brand on the same side with the same separator everywhere. A page that deliberately differs, like the homepage or a campaign landing page, is fine: the point is that a handful of pages should not be the exception.",
+    category: "content",
+    scope: "site",
+    severity: "warning",
+    // Deliberately light: one site-wide check, capped items, so a single rule
+    // cannot dominate the content category score.
+    weight: 3,
+  },
+
+  run(ctx: RuleContext): RuleResult | Promise<RuleResult> {
+    if (ctx.siteQuery) {
+      return runViaSiteQuery(ctx.siteQuery);
+    }
+
+    const pages = ctx.site?.pages;
+    if (!pages || pages.length === 0) {
+      return { checks: [skip("No pages available for analysis")] };
+    }
+
+    const rollup = emptyRollup();
+    for (const page of pages) {
+      accumulatePage(rollup, {
+        url: page.url,
+        status: page.statusCode,
+        title: page.parsed?.meta?.title ?? null,
+      });
+    }
+
+    return { checks: buildChecks(rollup, rollup.pageCount) };
+  },
+};

--- a/packages/rules/tests/title-pattern-outlier.test.ts
+++ b/packages/rules/tests/title-pattern-outlier.test.ts
@@ -1,0 +1,451 @@
+// content/title-pattern-outlier — title templates vs the site's own norm (#1361).
+//
+// The rule's whole value is what it does NOT say, so most of this file defends the
+// silence cases: a small crawl, too few titled pages, a site whose titles follow no
+// template, a section label that is not the brand, and the homepage's own title. The
+// positive cases pin the four deviations it is for.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult, PageFeatureRow, SiteQuery } from "@squirrelscan/core-contracts";
+
+import {
+  titlePatternOutlierRule,
+  TITLE_NORM_MIN_AGREEMENT,
+  TITLE_NORM_MIN_PAGES,
+  TITLE_NORM_MIN_SAMPLE,
+} from "../src/content/title-pattern-outlier";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+interface PageSpec {
+  path: string;
+  title?: string | null;
+  status?: number;
+}
+
+function url(path: string): string {
+  return `https://example.com${path}`;
+}
+
+function pad(i: number): string {
+  return String(i).padStart(3, "0");
+}
+
+/** N pages sharing one path + title template, numbered so each url is distinct. */
+function template(
+  makePath: (i: number) => string,
+  makeTitle: (i: number) => string,
+  count: number
+): PageSpec[] {
+  return Array.from({ length: count }, (_, i) => ({ path: makePath(i), title: makeTitle(i) }));
+}
+
+const baseCtx = {
+  page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+  parsed: {} as ParsedPage,
+  options: {},
+};
+
+/** Legacy path: specs become `ctx.site.pages` in crawl order. */
+function legacyCtx(specs: PageSpec[]): RuleContext {
+  return {
+    ...baseCtx,
+    site: {
+      baseUrl: "https://example.com/",
+      pages: specs.map((spec) => ({
+        url: url(spec.path),
+        statusCode: spec.status ?? 200,
+        parsed: { meta: { title: spec.title ?? null } } as unknown as ParsedPage,
+      })),
+      robotsTxt: null,
+      sitemaps: null,
+    },
+  };
+}
+
+function featureRow(spec: PageSpec): PageFeatureRow {
+  return {
+    normalizedUrl: url(spec.path),
+    status: spec.status ?? 200,
+    depth: 1,
+    title: spec.title ?? null,
+    titleHash: null,
+    description: null,
+    descHash: null,
+    contentHash: null,
+    wordCount: null,
+    pageType: null,
+    schemaTypes: [],
+    robotsNoindex: false,
+    canonical: null,
+    visibleAuthor: false,
+    visibleDate: false,
+    transferBytes: null,
+    templateFp: null,
+    secretHits: null,
+    metaNoindex: false,
+    indexableReasons: [],
+    richResultTypes: [],
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
+  };
+}
+
+/**
+ * Streaming path: the rule only ever calls `pagesMatching` + `pageCount`, so the
+ * rest of the SiteQuery surface throws — a stub that silently returned empties
+ * could hide the rule reading something it must not.
+ */
+function siteQueryCtx(specs: PageSpec[]): RuleContext {
+  const rows = specs.map(featureRow);
+  const unused = (): never => {
+    throw new Error("title-pattern-outlier must not use this SiteQuery method");
+  };
+  const siteQuery: SiteQuery = {
+    pageCount: () => rows.length,
+    duplicateGroups: unused,
+    incomingLinkCounts: unused,
+    pagesByType: unused,
+    templateClusters: unused,
+    sumTransferBytes: unused,
+    sumSecretHits: unused,
+    homepage: unused,
+    async *pagesMatching(pred: (row: PageFeatureRow) => boolean) {
+      for (const row of rows) if (pred(row)) yield row;
+    },
+  };
+  return {
+    ...baseCtx,
+    // EMPTY pages — the streaming path must not read them.
+    site: { baseUrl: "https://example.com/", pages: [], robotsTxt: null, sitemaps: null },
+    siteQuery,
+  };
+}
+
+async function checks(ctx: RuleContext): Promise<CheckResult[]> {
+  return (await Promise.resolve(titlePatternOutlierRule.run(ctx))).checks;
+}
+
+/** Run BOTH paths over one fixture, assert byte-identical output, return it. */
+async function bothPaths(specs: PageSpec[]): Promise<CheckResult> {
+  const legacy = await checks(legacyCtx(specs));
+  const streamed = await checks(siteQueryCtx(specs));
+  expect(streamed).toEqual(legacy);
+  expect(JSON.stringify(streamed)).toBe(JSON.stringify(legacy));
+  expect(legacy).toHaveLength(1);
+  return legacy[0]!;
+}
+
+/** The item for a deviation class, or undefined when it was not reported. */
+function itemFor(check: CheckResult, deviation: string): { meta: Record<string, unknown> } | undefined {
+  return check.items?.find((i) => i.meta?.deviation === deviation) as
+    | { meta: Record<string, unknown> }
+    | undefined;
+}
+
+/** The canonical healthy corpus: two sections, one template, brand as a suffix. */
+function uniformSite(count = 20): PageSpec[] {
+  const half = Math.ceil(count / 2);
+  return [
+    ...template((i) => `/deals/offer-${pad(i)}`, (i) => `Offer ${pad(i)} | Acme Deals`, half),
+    ...template(
+      (i) => `/stores/store-${pad(i)}`,
+      (i) => `Store ${pad(i)} | Acme Deals`,
+      count - half
+    ),
+  ];
+}
+
+describe("content/title-pattern-outlier — silence guards", () => {
+  test("skips a crawl below the site page floor", async () => {
+    const check = await bothPaths(uniformSite(TITLE_NORM_MIN_PAGES - 1));
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${TITLE_NORM_MIN_PAGES} needed`);
+  });
+
+  test("skips when too few pages carry a title", async () => {
+    const specs = [
+      ...uniformSite(8),
+      ...template((i) => `/misc/page-${pad(i)}`, () => "", 6),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain("have a title");
+    expect(check.message).toContain(`${TITLE_NORM_MIN_SAMPLE} needed`);
+  });
+
+  test("exactly at the site page floor the rule does judge", async () => {
+    // The floor is the last silent crawl, not the first judged one.
+    const check = await bothPaths(uniformSite(TITLE_NORM_MIN_PAGES));
+    expect(check.status).toBe("pass");
+  });
+
+  test("skips a site whose titles follow no dominant template", async () => {
+    // Every title is shaped differently: nothing here reaches the agreement bar, so
+    // no page is a deviant. This is the no-false-positive fixture.
+    const specs: PageSpec[] = [
+      { path: "/a", title: "Welcome to our shop" },
+      { path: "/b", title: "About | Widgets Inc" },
+      { path: "/c", title: "Contact us today" },
+      { path: "/d", title: "Blue Widget - Best Prices" },
+      { path: "/e", title: "Widgets Inc :: Support" },
+      { path: "/f", title: "How to choose a widget" },
+      { path: "/g", title: "Shipping » Returns" },
+      { path: "/h", title: "Careers at the company" },
+      { path: "/i", title: "Press: our latest news" },
+      { path: "/j", title: "Terms and conditions" },
+      { path: "/k", title: "Widget catalogue 2026" },
+      { path: "/l", title: "Store locator" },
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(
+      `${Math.round(TITLE_NORM_MIN_AGREEMENT * 100)}% agreement`
+    );
+  });
+
+  test("a section label is not mistaken for the brand", async () => {
+    // 16 of 20 titles start with "Blog", but only inside /blog — a section label,
+    // not a site brand, so the 4 shop pages are not accused of omitting it.
+    const specs = [
+      ...template((i) => `/blog/post-${pad(i)}`, (i) => `Blog | Post ${pad(i)}`, 16),
+      ...template((i) => `/shop/item-${pad(i)}`, (i) => `Item ${pad(i)} for sale`, 4),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+  });
+
+  test("non-2xx pages never vote", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...Array.from({ length: 5 }, (_, i) => ({
+        path: `/deals/gone-${pad(i)}`,
+        title: "404 Not Found",
+        status: 404,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+
+  test("untitled pages are left to core/meta-title", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template((i) => `/deals/untitled-${pad(i)}`, () => null as unknown as string, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.details?.judgedPages).toBe(20);
+  });
+});
+
+describe("content/title-pattern-outlier — the no-false-positive fixtures", () => {
+  test("template-uniform siblings sit inside the norm", async () => {
+    const check = await bothPaths(uniformSite(30));
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("follow the site's own title template");
+    const norms = check.details?.norms as { dimension: string; norm: string }[];
+    expect(norms.find((n) => n.dimension === "brand")?.norm).toBe("Acme Deals");
+    expect(norms.find((n) => n.dimension === "separator")?.norm).toBe("|");
+  });
+
+  test("a uniformly brand-first site stays clean", async () => {
+    // The non-default order IS this site's order, so there is no minority to report.
+    const specs = [
+      ...template((i) => `/deals/offer-${pad(i)}`, (i) => `Acme Deals - Offer ${pad(i)}`, 10),
+      ...template((i) => `/stores/store-${pad(i)}`, (i) => `Acme Deals - Store ${pad(i)}`, 10),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    const norms = check.details?.norms as { dimension: string; norm: string; position?: string }[];
+    expect(norms.find((n) => n.dimension === "brand")?.position).toBe("prefix");
+    expect(norms.find((n) => n.dimension === "separator")?.norm).toBe("-");
+  });
+
+  test("the homepage keeps its own title", async () => {
+    // "Acme Deals - the best deals" is brand-first with a different separator on a
+    // brand-last site: normal for a home page, never a finding.
+    const specs = [
+      ...uniformSite(20),
+      { path: "/", title: "Acme Deals - the best deals in Australia" },
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+
+  test("a title that mentions the brand mid-string is not a deviant", async () => {
+    const specs = [
+      ...uniformSite(20),
+      { path: "/deals/about", title: "About Acme Deals | Acme Deals" },
+      { path: "/deals/why", title: "Why shop with Acme Deals and save" },
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+
+  test("hyphenated words and clock times are not separators", async () => {
+    const specs = [
+      ...template(
+        (i) => `/deals/offer-${pad(i)}`,
+        (i) => `E-commerce deal ${pad(i)} at 10:30 | Acme Deals`,
+        10
+      ),
+      ...template(
+        (i) => `/stores/store-${pad(i)}`,
+        (i) => `Store ${pad(i)} | Acme Deals`,
+        10
+      ),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+});
+
+describe("content/title-pattern-outlier — findings", () => {
+  test("warns on a pocket of pages missing the brand", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Legacy offer ${pad(i)}`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(itemFor(check, "brand-missing")?.meta.pageCount).toBe(3);
+    expect(check.items?.[0]?.label).toContain('never mention "Acme Deals"');
+  });
+
+  test("warns on a different separator against the modal one", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Legacy ${pad(i)} - Acme Deals`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    const item = itemFor(check, "separator");
+    expect(item?.meta.value).toBe("-");
+    expect(item?.meta.pageCount).toBe(3);
+    expect(check.items?.[0]?.label).toContain('the norm is "|"');
+  });
+
+  test("warns on an inverted brand order", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Acme Deals | Legacy ${pad(i)}`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(itemFor(check, "brand-position")?.meta.value).toBe("prefix");
+    expect(check.items?.[0]?.label).toContain("first but the norm is last");
+  });
+
+  test("warns on brand-only titles away from the homepage", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template((i) => `/deals/dupe-${pad(i)}`, () => "Acme Deals", 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(itemFor(check, "brand-only")?.meta.pageCount).toBe(3);
+  });
+
+  test("exactly at the agreement threshold a norm still exists", async () => {
+    // 14 of 20 titles carry the brand — the boundary, not a comfortable majority.
+    const specs = [
+      ...template((i) => `/deals/offer-${pad(i)}`, (i) => `Offer ${pad(i)} | Acme Deals`, 7),
+      ...template((i) => `/stores/store-${pad(i)}`, (i) => `Store ${pad(i)} | Acme Deals`, 7),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Legacy offer ${pad(i)}`, 6),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("fail");
+    expect(check.details?.flaggedPages).toBe(6);
+    const norms = check.details?.norms as { dimension: string; agreement: number }[];
+    expect(norms.find((n) => n.dimension === "brand")?.agreement).toBe(TITLE_NORM_MIN_AGREEMENT);
+  });
+
+  test("warn and fail sit either side of the deviant-share threshold", async () => {
+    // 3/20 = 15% warns; 4/20 = 20% is exactly the threshold and fails.
+    const warned = await bothPaths([
+      ...uniformSite(17),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Legacy offer ${pad(i)}`, 3),
+    ]);
+    expect(warned.status).toBe("warn");
+    const failed = await bothPaths([
+      ...uniformSite(16),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Legacy offer ${pad(i)}`, 4),
+    ]);
+    expect(failed.status).toBe("fail");
+  });
+
+  test("templates that disagree with each other are the finding", async () => {
+    // Three internally uniform templates that use three separators for the same
+    // brand: uniformity inside a template does not exempt it from the site's norm.
+    const specs = [
+      ...template((i) => `/deals/offer-${pad(i)}`, (i) => `Offer ${pad(i)} :: Acme Deals`, 14),
+      ...template((i) => `/stores/store-${pad(i)}`, (i) => `Store ${pad(i)} | Acme Deals`, 4),
+      ...template((i) => `/blog/post-${pad(i)}`, (i) => `Post ${pad(i)} - Acme Deals`, 2),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("fail");
+    const norms = check.details?.norms as { dimension: string; norm: string }[];
+    expect(norms.find((n) => n.dimension === "separator")?.norm).toBe("::");
+    expect(check.details?.flaggedPages).toBe(6);
+  });
+
+  test("an unrecognised joiner casts no separator vote", async () => {
+    // The rule only reports a separator it can actually read; a title joined by
+    // something outside its vocabulary is never accused of using the wrong one.
+    const specs = [
+      ...uniformSite(20),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Legacy ${pad(i)} ~ Acme Deals`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+
+  test("fails once a fifth of the titled pages deviate", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Legacy offer ${pad(i)}`, 6),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("fail");
+    expect(check.value).toBe(6);
+    expect(check.details?.flaggedPages).toBe(6);
+  });
+
+  test("each page is accused once, for its most meaningful deviation", async () => {
+    // These pages both omit the brand and use another separator: only the missing
+    // brand is reported.
+    const specs = [
+      ...uniformSite(20),
+      ...template((i) => `/deals/legacy-${pad(i)}`, (i) => `Legacy ${pad(i)} - Old Site`, 3),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.value).toBe(3);
+    expect(itemFor(check, "brand-missing")?.meta.pageCount).toBe(3);
+    expect(itemFor(check, "separator")).toBeUndefined();
+  });
+
+  test("dual paths agree regardless of crawl order", async () => {
+    const deviants = template(
+      (i) => `/deals/legacy-${pad(i)}`,
+      (i) => `Legacy offer ${pad(i)}`,
+      3
+    );
+    const majority = uniformSite(20);
+    const first = await bothPaths([...majority, ...deviants]);
+    const second = await bothPaths([...deviants, ...majority]);
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+  });
+});
+
+describe("content/title-pattern-outlier — empty crawl", () => {
+  test("legacy path with no pages skips", async () => {
+    const result = await checks(legacyCtx([]));
+    expect(result[0]?.status).toBe("skipped");
+  });
+});


### PR DESCRIPTION
New site-wide rule `content/title-pattern-outlier`: infers the site's own title template from the crawled corpus and reports the pages that break it.

Companion to the private monorepo issue #1361 (catalog regen + gitlink bump land there).

## What it does

Infers two things from the titles themselves:

- the **brand affix** - the segment most titles carry at the same end (prefix or suffix)
- the **separator** sitting next to that brand (`|`, `::`, `»`, `>`, ` - `, `: `)

Then reports four deviations, one per page, most meaningful first: missing brand, inverted order, different separator, brand-only.

## Why it stays quiet

- fewer than 10 crawled pages, or fewer than 10 titled pages: skipped
- no brand affix reaching 70% agreement: skipped
- on a multi-section site, a candidate only ever seen inside one section is a section label, not a brand (the trap from #1366's trailing-slash axis)
- the homepage is exempt; untitled pages belong to `core/meta-title`

Dual path (legacy `ctx.site.pages` + streaming `SiteQuery`) feeds one accumulator and one check builder, every list sorted before emit, so output is byte-identical and crawl-order independent. Weight 3, one site-wide check, capped items.

## Smoke: sweetdeals.com.au, 200 pages

- **Real crawl (200 pages): `skipped`.** Only 83/200 titles carry "Sweet Deals"; 116 never mention it. The site genuinely runs two templates (`X - $Y in Australia` and `X - 1 tracked listing | Sweet Deals`), so no affix reaches 70% and the rule refuses to accuse 116 pages.
- **The 83-page template slice: `pass`,** 0 flagged, `brand "Sweet Deals" last 100%, separator "|" 100%`. Template-uniform siblings sit inside the norm.
- **Same slice plus 4 grafted outliers: `warn`, exactly 4 findings** - `brand-only`, `brand-missing`, `brand-position` (prefix against the last-position norm), `separator` (`-` against `|`). No real page was touched. Both paths byte-identical on all three runs.

## Checks

- `packages/rules`: 1262 pass, 0 fail; `tsgo --noEmit` clean
- `packages/audit-engine`: 273 tests, 0 fail, including the 518-page v1/v2 canonical golden gate (pins moved 271 to 272 rules, 98215 to 98216 findings: one site-scoped check)
- rule count literals bumped 271 to 272, Content 16 to 17, across README and docs
