### PR TITLE
feat(rules): add social/asset-divergence, site chrome that disagrees across pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **277 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **278 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler 
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more 
@@ -49,7 +49,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Structured Data | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus rating markup that is not about the page it sits on |
 | Accessibility | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | Mobile | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
-| Social Media | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
+| Social Media | 5 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links, site-chrome assets that disagree across pages |
 | URL Structure | 9 | Length, casing, hyphenation, stop words, query parameters, special characters, trailing-slash consistency, site-wide convention consistency |
 | E-E-A-T | 15 | Experience, expertise, authority and trust signals: author bylines and credentials, about and contact pages, citations, editorial policy, disclaimers, YMYL detection |
 | Legal Compliance | 4 | Privacy policy, terms of service, real cookie-consent machinery, subprocessor disclosure |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 277 rules across 21 categories**
+**Total: 278 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **272 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **273 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler 
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more 
@@ -49,7 +49,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Structured Data | 11 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search |
 | Accessibility | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | Mobile | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
-| Social Media | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
+| Social Media | 5 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links, site-chrome assets that disagree across pages |
 | URL Structure | 9 | Length, casing, hyphenation, stop words, query parameters, special characters, trailing-slash consistency, site-wide convention consistency |
 | E-E-A-T | 15 | Experience, expertise, authority and trust signals: author bylines and credentials, about and contact pages, citations, editorial policy, disclaimers, YMYL detection |
 | Legal Compliance | 4 | Privacy policy, terms of service, real cookie-consent machinery, subprocessor disclosure |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 272 rules across 21 categories**
+**Total: 273 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -288,6 +288,7 @@
                 "group": "Social Media",
                 "pages": [
                   "rules/social/index",
+                  "rules/social/asset-divergence",
                   "rules/social/og-image-size",
                   "rules/social/og-url-match",
                   "rules/social/social-profiles",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -296,6 +296,7 @@
                 "group": "Social Media",
                 "pages": [
                   "rules/social/index",
+                  "rules/social/asset-divergence",
                   "rules/social/og-image-size",
                   "rules/social/og-url-match",
                   "rules/social/social-profiles",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="272 Rules, 21 Categories"
+    title="273 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **272 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **273 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -232,7 +232,7 @@ squirrelscan runs **272 rules** across **21 categories**, plus opt-in cloud gap 
 | **Structured Data** | 11 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have |
 | **Accessibility** | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | **Mobile** | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
-| **Social Media** | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
+| **Social Media** | 5 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links, site-chrome assets that disagree across pages |
 | **URL Structure** | 9 | Length, casing, hyphenation, stop words, query parameters, special characters, trailing-slash consistency, site-wide convention consistency |
 | **E-E-A-T** | 15 | Experience, expertise, authority and trust signals: author bylines and credentials, about and contact pages, citations, editorial policy, disclaimers, YMYL detection |
 | **Legal Compliance** | 4 | Privacy policy, terms of service, real cookie-consent machinery, subprocessor disclosure |
@@ -242,7 +242,7 @@ squirrelscan runs **272 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 272 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 273 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="276 Rules, 21 Categories"
+    title="278 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **277 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **278 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -232,7 +232,7 @@ squirrelscan runs **277 rules** across **21 categories**, plus opt-in cloud gap 
 | **Structured Data** | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have and rating markup that is not about the page it sits on |
 | **Accessibility** | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | **Mobile** | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
-| **Social Media** | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
+| **Social Media** | 5 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links, site-chrome assets that disagree across pages |
 | **URL Structure** | 9 | Length, casing, hyphenation, stop words, query parameters, special characters, trailing-slash consistency, site-wide convention consistency |
 | **E-E-A-T** | 15 | Experience, expertise, authority and trust signals: author bylines and credentials, about and contact pages, citations, editorial policy, disclaimers, YMYL detection |
 | **Legal Compliance** | 4 | Privacy policy, terms of service, real cookie-consent machinery, subprocessor disclosure |
@@ -242,7 +242,7 @@ squirrelscan runs **277 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 277 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 278 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -20,7 +20,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Essential meta tags and page structure for search engines (14 rules)
   </Card>
   <Card title="Links" icon="folder" href="/rules/links">
-    Internal and external link health and structure (14 rules)
+    Internal and external link health and structure (15 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
     Text quality, readability, and content structure (18 rules)

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 272 audit rules organized by score group and category"
+description: "All 273 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **272 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **273 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -32,7 +32,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Image optimization and accessibility (15 rules)
   </Card>
   <Card title="Social Media" icon="folder" href="/rules/social">
-    Open Graph and social sharing metadata (4 rules)
+    Open Graph and social sharing metadata (5 rules)
   </Card>
   <Card title="Accessibility" icon="folder" href="/rules/a11y">
     Accessibility for users with disabilities (61 rules)

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 277 audit rules organized by score group and category"
+description: "All 278 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **277 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **278 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -32,7 +32,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Image optimization and accessibility (15 rules)
   </Card>
   <Card title="Social Media" icon="folder" href="/rules/social">
-    Open Graph and social sharing metadata (4 rules)
+    Open Graph and social sharing metadata (5 rules)
   </Card>
   <Card title="Accessibility" icon="folder" href="/rules/a11y">
     Accessibility for users with disabilities (61 rules)

--- a/docs/rules/social/asset-divergence.mdx
+++ b/docs/rules/social/asset-divergence.mdx
@@ -1,0 +1,95 @@
+---
+title: "Site Asset Consistency"
+description: "Finds pages whose favicon, theme-color or default OG image differs from the rest of the site"
+---
+
+Finds pages whose favicon, theme-color or default OG image differs from the rest of the site
+
+| | |
+|---|---|
+| **Rule ID** | `social/asset-divergence` |
+| **Category** | [Social Media](/rules/social) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 3/10 |
+
+## How it works
+
+Your favicon, your `theme-color` and your fallback share image all come from one
+layout, so every page should carry the same three. When a pocket of pages carries
+different ones, those pages are usually running an older template: a section that
+missed a redesign, a cached shell, or a second layout nobody remembers owning.
+Nothing about such a page looks wrong on its own, which is why no per-page check
+can see it.
+
+Three axes are compared across the crawl:
+
+| Axis | What is read |
+|---|---|
+| Favicon | The first `<link rel="icon">` href, resolved to an absolute URL |
+| Theme color | `<meta name="theme-color">` content |
+| Default OG image | `og:image`, on the pages that should share one |
+
+Each axis is judged against your site's own modal value, and only the minority
+form is reported.
+
+### Per-page share images are not a finding
+
+Articles and products (plus recipes, events, profiles and media pages) **should**
+ship their own `og:image`. Those page types never vote on the OG axis and are
+never reported on it. Neither is any page whose `og:image` is used by that page
+alone, whatever its type: a fallback is by definition shared, so a one-off image
+is a per-page asset rather than a template running behind. What the rule compares
+there is the fallback the rest of the site shares. Favicon and theme-color have no
+such exemption: they are browser chrome, not content, and stay uniform even on an
+article.
+
+### It stays quiet unless it has grounds to speak
+
+- Fewer than 10 crawled pages: there is no norm to judge against, so the rule is
+  skipped.
+- Fewer than 10 pages declaring an asset: that axis is not judged at all.
+- No value reaching 70% agreement on any axis: your site genuinely varies its
+  chrome, so nothing in it is a deviant.
+- A page that declares nothing never votes and is never a deviant. A missing
+  favicon belongs to [Favicon](/rules/core/favicon) and a missing share image to
+  the Open Graph rules, so the two never both flag the same page.
+- Apple touch icons and mask icons legitimately differ from the tab icon and never
+  stand in for it. A light/dark `theme-color` pair is normal and reads as one
+  value.
+
+## Solution
+
+Your favicon, theme-color and fallback share image come from one layout, so every
+page should carry the same three. Pages that carry different ones are usually
+running an older template: a section that missed a redesign, a cached shell, or a
+second layout nobody remembers owning. The visible cost is inconsistent link
+previews and a tab icon that changes as visitors move around the site. Fix it
+where the assets are declared (the shared head partial or theme config) rather
+than page by page. Per-page share images on articles and products are correct and
+are not reported here: what this rule compares is the fallback the rest of the
+site shares.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["social/asset-divergence"]
+```
+
+### Disable all Social Media rules
+
+```toml squirrel.toml
+[rules]
+disable = ["social/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["social/asset-divergence"]
+disable = ["*"]
+```

--- a/docs/rules/social/index.mdx
+++ b/docs/rules/social/index.mdx
@@ -8,6 +8,9 @@ Open Graph and social sharing metadata
 ## Rules
 
 <CardGroup cols={2}>
+  <Card title="Site Asset Consistency" icon="triangle-exclamation" href="/rules/social/asset-divergence">
+    Finds pages whose favicon, theme-color or default OG image differs from the rest of the site
+  </Card>
   <Card title="OG Image Size" icon="triangle-exclamation" href="/rules/social/og-image-size">
     Checks og:image meets recommended size (1200x630)
   </Card>

--- a/packages/audit-engine/src/page-features.ts
+++ b/packages/audit-engine/src/page-features.ts
@@ -19,6 +19,8 @@
 import { detectWafChallengePage } from "@squirrelscan/waf-detect";
 import { extractNapSignal, getRichResultTypes, isPageIndexable } from "@squirrelscan/utils";
 
+import { extractSiteChromeSignal } from "@squirrelscan/rules";
+
 import type { PageRecord, PageFeatureRow } from "@squirrelscan/core-contracts";
 import type { ParsedPage } from "@squirrelscan/rules";
 
@@ -95,6 +97,10 @@ export function extractPageFeatures(page: PageRecord, parsed: ParsedPage): PageF
   // Same extractor local/nap-consistency's legacy path calls on the live parsed
   // page, so the stored signal and the re-derived one are identical by construction.
   const nap = extractNapSignal(parsed);
+  // Same extractor social/asset-divergence's legacy path calls on the live parsed
+  // page, resolved against the SAME base URL (`site.pages[].url` is this exact
+  // value), so the stored assets and the re-derived ones are identical.
+  const chrome = extractSiteChromeSignal(parsed, page.normalizedUrl);
 
   return {
     normalizedUrl: page.normalizedUrl,
@@ -128,5 +134,8 @@ export function extractPageFeatures(page: PageRecord, parsed: ParsedPage): PageF
     napAddressFormat: nap.addressFormat,
     napTelLink: nap.telLink,
     napMailtoLink: nap.mailtoLink,
+    faviconHref: chrome.faviconHref,
+    themeColor: chrome.themeColor,
+    ogImage: chrome.ogImage,
   };
 }

--- a/packages/audit-engine/tests/site-query-asset-divergence-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-asset-divergence-golden.test.ts
@@ -1,0 +1,247 @@
+// social/asset-divergence dual-path golden (#1371).
+//
+// The chain under test: parsePage(html) -> extractPageFeatures -> the v21
+// page_features site-chrome columns -> createSiteQuery -> the rule's streaming
+// branch. The legacy branch re-derives the same assets from the SAME parsed
+// pages, so a deep-equal here proves the stored scalars and the live extraction
+// agree — the one invariant that could silently rot, since the two live in
+// different packages.
+//
+// The streaming run is given an EMPTY `site.pages`, so passing also proves the
+// streaming branch reads nothing off the resident page array.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { parsePage } from "@squirrelscan/parser";
+import { extractSiteChromeSignal, loadAllRules } from "@squirrelscan/rules";
+import type { ParsedPage, Rule, RuleContext } from "@squirrelscan/rules";
+import type { PageRecord } from "@squirrelscan/core-contracts";
+
+import { createSiteQuery, extractPageFeatures } from "../src/index";
+import { parseHtmlForRules } from "../src/adapter";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+async function freshStore(): Promise<SQLiteStorage> {
+  const store = new SQLiteStorage(":memory:");
+  await run(store.init());
+  return store;
+}
+
+const CRAWL = "crawl-1";
+const BASE = "https://example.com/";
+const DEFAULT_OG = "https://cdn.example.com/share/default.png";
+
+const assetDivergenceRule = loadAllRules().get("social/asset-divergence")!;
+
+interface Spec {
+  normalizedUrl: string;
+  favicon: string;
+  themeColor: string;
+  ogImage: string;
+  /** Adds Article JSON-LD, which is what makes `pageType` "article". */
+  article?: boolean;
+}
+
+function specHtml(spec: Spec): string {
+  const schema = spec.article
+    ? `<script type="application/ld+json">${JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "Article",
+        headline: "A post",
+      })}</script>`
+    : "";
+  return (
+    `<html><head>` +
+    `<link rel="icon" href="${spec.favicon}">` +
+    `<meta name="theme-color" content="${spec.themeColor}">` +
+    `<meta property="og:image" content="${spec.ogImage}">` +
+    `${schema}</head><body><p>hi</p></body></html>`
+  );
+}
+
+function mkPage(spec: Spec): { page: PageRecord; parsed: ParsedPage } {
+  const html = specHtml(spec);
+  const page = {
+    url: spec.normalizedUrl,
+    normalizedUrl: spec.normalizedUrl,
+    finalUrl: spec.normalizedUrl,
+    depth: 1,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: html.length,
+    loadTimeMs: 5,
+    fetchedAt: 1,
+    etag: null,
+    lastModified: null,
+    contentHash: `h:${spec.normalizedUrl}`,
+    html,
+    parsedData: null,
+    headers: { contentType: "text/html" },
+    securityHeaders: {},
+  } as unknown as PageRecord;
+
+  return { page, parsed: parsePage(html, spec.normalizedUrl) as ParsedPage };
+}
+
+function uniform(i: number): Spec {
+  return {
+    normalizedUrl: `https://example.com/p${String(i).padStart(2, "0")}`,
+    favicon: "/favicon.ico",
+    themeColor: "#0a5c36",
+    ogImage: DEFAULT_OG,
+  };
+}
+
+// normalized_url ASC (== the getPageFeaturesPage cursor order). 14 pages so the
+// 10-page floor is cleared: 10 run the current layout, 2 run a stale one (old
+// favicon AND old fallback share image), and 2 are articles with their own share
+// image — the case that must NOT be reported.
+const FIXTURE: Spec[] = [
+  ...Array.from({ length: 10 }, (_, i) => uniform(i + 1)),
+  {
+    normalizedUrl: "https://example.com/p11",
+    favicon: "/old/favicon.ico",
+    themeColor: "#0a5c36",
+    ogImage: "https://cdn.example.com/share/old-brand.png",
+  },
+  {
+    normalizedUrl: "https://example.com/p12",
+    favicon: "/old/favicon.ico",
+    themeColor: "#0a5c36",
+    ogImage: "https://cdn.example.com/share/old-brand.png",
+  },
+  {
+    normalizedUrl: "https://example.com/p13",
+    favicon: "/favicon.ico",
+    themeColor: "#0a5c36",
+    ogImage: "https://cdn.example.com/share/post-13.png",
+    article: true,
+  },
+  {
+    normalizedUrl: "https://example.com/p14",
+    favicon: "/favicon.ico",
+    themeColor: "#0a5c36",
+    ogImage: "https://cdn.example.com/share/post-14.png",
+    article: true,
+  },
+];
+
+async function seedAndRun(rule: Rule) {
+  const store = await freshStore();
+  const built = FIXTURE.map(mkPage);
+
+  for (const { page, parsed } of built) {
+    await run(store.upsertPageFeatures(CRAWL, extractPageFeatures(page, parsed)));
+  }
+
+  const sitePages = [...built]
+    .sort((a, b) => (a.page.normalizedUrl < b.page.normalizedUrl ? -1 : 1))
+    .map(({ page, parsed }) => ({
+      url: page.normalizedUrl,
+      statusCode: page.status,
+      parsed,
+    }));
+
+  const base = {
+    page: { url: BASE, html: "", statusCode: 200, loadTime: 0, headers: {} },
+    parsed: {} as ParsedPage,
+    options: {},
+  };
+
+  const legacyCtx: RuleContext = {
+    ...base,
+    site: { baseUrl: BASE, pages: sitePages, robotsTxt: null, sitemaps: null },
+  };
+  const legacy = (await Promise.resolve(rule.run(legacyCtx))).checks;
+
+  const siteQuery = await run(createSiteQuery(store, CRAWL));
+  const streamedCtx: RuleContext = {
+    ...base,
+    // EMPTY — the streaming path must read only page_features.
+    site: { baseUrl: BASE, pages: [], robotsTxt: null, sitemaps: null },
+    siteQuery,
+  };
+  const streamed = (await Promise.resolve(rule.run(streamedCtx))).checks;
+
+  await run(store.close());
+  return { legacy, streamed };
+}
+
+describe("dual-path golden — social/asset-divergence (extractor → v21 columns → siteQuery)", () => {
+  test("streaming path is deep-equal to legacy, with the expected divergence verdict", async () => {
+    const { legacy, streamed } = await seedAndRun(assetDivergenceRule);
+
+    expect(streamed).toEqual(legacy);
+    expect(JSON.stringify(streamed)).toBe(JSON.stringify(legacy));
+    expect(legacy).toHaveLength(1);
+
+    const check = legacy[0]!;
+    // 2 of 14 pages run the stale layout → below the fail share, so a warning.
+    expect(check.status).toBe("warn");
+    expect(check.value).toBe(2);
+    expect(check.details).toEqual({
+      judgedPages: 14,
+      flaggedPages: 2,
+      norms: [
+        {
+          dimension: "favicon",
+          norm: "https://example.com/favicon.ico",
+          pages: 12,
+          agreement: 12 / 14,
+        },
+        { dimension: "theme-color", norm: "#0a5c36", pages: 14, agreement: 1 },
+        // Only the 12 non-article pages vote here; the two articles are exempt.
+        { dimension: "og-image", norm: DEFAULT_OG, pages: 10, agreement: 10 / 12 },
+      ],
+    });
+
+    // One item per diverging axis, both naming the same two pages.
+    expect(check.items?.map((i) => [i.meta?.dimension, i.meta?.value, i.sourcePages])).toEqual([
+      [
+        "favicon",
+        "https://example.com/old/favicon.ico",
+        ["https://example.com/p11", "https://example.com/p12"],
+      ],
+      [
+        "og-image",
+        "https://cdn.example.com/share/old-brand.png",
+        ["https://example.com/p11", "https://example.com/p12"],
+      ],
+    ]);
+    // The articles' own share images are never reported.
+    const reported = check.items?.flatMap((i) => i.sourcePages ?? []) ?? [];
+    expect(reported).not.toContain("https://example.com/p13");
+    expect(reported).not.toContain("https://example.com/p14");
+  });
+});
+
+describe("parseHtmlForRules carries the site-chrome assets", () => {
+  // There are TWO parsers producing a ParsedPage: `parsePage` (crawler) and
+  // `parseHtmlForRules` (this package — what `parsePageRecord` and the #263
+  // page-rule workers actually run). A field read from only one of them is
+  // invisible in production while every direct-parser test still passes, so pin
+  // that both agree.
+  const HTML = specHtml({
+    normalizedUrl: BASE,
+    favicon: "/favicon.ico",
+    themeColor: "#0A5C36",
+    ogImage: DEFAULT_OG,
+  });
+
+  test("both parse paths yield the same chrome signal", () => {
+    const viaAdapter = extractSiteChromeSignal(parseHtmlForRules(HTML, BASE), BASE);
+    const viaParser = extractSiteChromeSignal(parsePage(HTML, BASE) as ParsedPage, BASE);
+
+    expect(viaAdapter).toEqual({
+      faviconHref: "https://example.com/favicon.ico",
+      themeColor: "#0a5c36",
+      ogImage: DEFAULT_OG,
+    });
+    expect(viaAdapter).toEqual(viaParser);
+  });
+});

--- a/packages/audit-engine/tests/site-query-content-rules-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-content-rules-golden.test.ts
@@ -75,6 +75,9 @@ function feat(row: Row): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
   };
 }
 

--- a/packages/audit-engine/tests/site-query-link-rules-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-link-rules-golden.test.ts
@@ -490,6 +490,9 @@ function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
     ...over,
   };
 }

--- a/packages/audit-engine/tests/site-query-link-rules-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-link-rules-golden.test.ts
@@ -327,6 +327,9 @@ function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
     ...over,
   };
 }

--- a/packages/audit-engine/tests/site-query-schema-coverage-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-schema-coverage-golden.test.ts
@@ -64,6 +64,9 @@ function feat(row: Row): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
   };
 }
 

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -94,7 +94,10 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // only chrome link the renderer emits is the header nav's link to `/`, and
       // the homepage is exempt, so every other page's contextual count equals its
       // raw count.
-      expect(v1.findings.length).toBe(98219);
+      // 98219 -> 98220: social/asset-divergence, likewise site-scoped, adds its
+      // own single whole-crawl check (#1371). healthScore.overall is UNMOVED at
+      // 48: one weight-3 warning check in a 5-rule category cannot dominate it.
+      expect(v1.findings.length).toBe(98220);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
@@ -102,10 +105,10 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier,
       // 272 -> 273 schema/rating-scope, 273 -> 274 crawl/sitemap-lastmod-churn,
       // 274 -> 275 crawl/sitemap-lastmod-drift, 275 -> 276
-      // content/date-agreement, 276 -> 277 links/no-contextual-inbound;
-      // anything else means a rule id
+      // content/date-agreement, 276 -> 277 links/no-contextual-inbound,
+      // 277 -> 278 social/asset-divergence; anything else means a rule id
       // leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(277);
+      expect(v1.perRuleTally.length).toBe(278);
     },
     180_000,
   );

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -78,15 +78,18 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // own single whole-crawl check (#1366).
       // 98215 -> 98216: content/title-pattern-outlier, likewise site-scoped, adds
       // its own single whole-crawl check (#1361).
-      expect(v1.findings.length).toBe(98216);
+      // 98216 -> 98217: social/asset-divergence, likewise site-scoped, adds its
+      // own single whole-crawl check (#1371). healthScore.overall is UNMOVED at
+      // 48: one weight-3 warning check in a 4-rule category cannot dominate it.
+      expect(v1.findings.length).toBe(98217);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
       // schema/coverage-outlier, 269 -> 270 url/slug-convention, 270 -> 271
-      // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier;
-      // anything else means a rule id leaked in, so fix that rather than this
-      // number.
-      expect(v1.perRuleTally.length).toBe(272);
+      // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier,
+      // 272 -> 273 social/asset-divergence; anything else means a rule id leaked
+      // in, so fix that rather than this number.
+      expect(v1.perRuleTally.length).toBe(273);
     },
     180_000,
   );

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -610,6 +610,21 @@ export interface PageFeatureRow {
   napTelLink: boolean;
   /** The page carries at least one `mailto:` link. */
   napMailtoLink: boolean;
+  /**
+   * The page's site-chrome assets, from `extractSiteChromeSignal`
+   * (@squirrelscan/rules). `social/asset-divergence` compares these across the
+   * corpus to find pages running a different (usually stale) layout, so the SAME
+   * extractor feeds this row and the rule's legacy `ctx.site.pages` path — the
+   * two must never diverge. Each is bounded to
+   * `SITE_CHROME_MAX_VALUE_CHARS` (200).
+   *
+   * Absolute URL of the primary `<link rel="icon">`, or null.
+   */
+  faviconHref: string | null;
+  /** `<meta name="theme-color">` content, lowercased, or null. */
+  themeColor: string | null;
+  /** Absolute URL of the page's `og:image` (the default/fallback one), or null. */
+  ogImage: string | null;
 }
 
 /** Which hashed field a {@link SiteQuery.duplicateGroups} scan is keyed on. */

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -57,7 +57,7 @@ export interface ContentStoreAdapter {
 }
 
 // Schema version - increment when schema changes
-const SCHEMA_VERSION = 20;
+const SCHEMA_VERSION = 21;
 
 // Migrations to run when upgrading from older versions
 const MIGRATIONS: Record<number, string[]> = {
@@ -285,6 +285,23 @@ const MIGRATIONS: Record<number, string[]> = {
     `ALTER TABLE page_features ADD COLUMN nap_address_format TEXT`,
     `ALTER TABLE page_features ADD COLUMN nap_tel_link INTEGER`,
     `ALTER TABLE page_features ADD COLUMN nap_mailto_link INTEGER`,
+  ],
+  // Version 21: page_features site-chrome scalars — the per-page favicon,
+  // theme-color and default OG image the social/asset-divergence rule compares
+  // across the corpus to find pages running a stale layout (#1371), so its
+  // streaming path reads these instead of re-holding every parsed page. ADDITIVE
+  // columns; ALTER is idempotent (the runner swallows "duplicate column name").
+  // Local sqlite only — NOT a prod migration.
+  //
+  // No backfill, for the v19/v20 reason: `extractPageFeatures` always writes a
+  // FULL row via INSERT OR REPLACE keyed by (crawl_id, normalized_url), each
+  // crawl writes only its own crawl_id, and the streaming loop re-extracts every
+  // scored page in the current run — so no pre-v21 row is ever read. NULL reads
+  // back as null, which is the same as "this page declared no such asset".
+  21: [
+    `ALTER TABLE page_features ADD COLUMN favicon_href TEXT`,
+    `ALTER TABLE page_features ADD COLUMN theme_color TEXT`,
+    `ALTER TABLE page_features ADD COLUMN og_image TEXT`,
   ],
 };
 
@@ -685,6 +702,9 @@ CREATE TABLE IF NOT EXISTS page_features (
   nap_address_format TEXT,
   nap_tel_link INTEGER,
   nap_mailto_link INTEGER,
+  favicon_href TEXT,
+  theme_color TEXT,
+  og_image TEXT,
   PRIMARY KEY (crawl_id, normalized_url),
   FOREIGN KEY (crawl_id) REFERENCES crawls(id)
 );
@@ -3430,8 +3450,9 @@ export class SQLiteStorage implements CrawlStorage {
       visible_author, visible_date, transfer_bytes, template_fp, secret_hits,
       meta_noindex, indexable_reasons, rich_result_types,
       nap_name, nap_phones, nap_phone_formats, nap_address, nap_address_format,
-      nap_tel_link, nap_mailto_link
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      nap_tel_link, nap_mailto_link,
+      favicon_href, theme_color, og_image
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `;
 
   private pageFeatureParams(
@@ -3468,6 +3489,9 @@ export class SQLiteStorage implements CrawlStorage {
       row.napAddressFormat,
       row.napTelLink ? 1 : 0,
       row.napMailtoLink ? 1 : 0,
+      row.faviconHref,
+      row.themeColor,
+      row.ogImage,
     ];
   }
 
@@ -3826,6 +3850,9 @@ export class SQLiteStorage implements CrawlStorage {
       napAddressFormat: (row.nap_address_format as string | null) ?? null,
       napTelLink: row.nap_tel_link === 1,
       napMailtoLink: row.nap_mailto_link === 1,
+      faviconHref: (row.favicon_href as string | null) ?? null,
+      themeColor: (row.theme_color as string | null) ?? null,
+      ogImage: (row.og_image as string | null) ?? null,
     };
   }
 }

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -59,7 +59,7 @@ export interface ContentStoreAdapter {
 // Schema version - increment when schema changes.
 // Exported so migration tests can assert "this DB reached the CURRENT version" rather than pinning a
 // literal, which turned every schema bump into two unrelated test failures.
-export const SCHEMA_VERSION = 21;
+export const SCHEMA_VERSION = 22;
 
 // Migrations to run when upgrading from older versions
 const MIGRATIONS: Record<number, string[]> = {
@@ -295,6 +295,26 @@ const MIGRATIONS: Record<number, string[]> = {
   // false, which is the pre-v21 behaviour for every already-stored sitemap.
   // Local sqlite only (crawler's own store) — NOT a prod migration.
   21: ["ALTER TABLE sitemaps ADD COLUMN is_news_sitemap INTEGER"],
+  // Version 22: page_features site-chrome scalars — the per-page favicon,
+  // theme-color and default OG image the social/asset-divergence rule compares
+  // across the corpus to find pages running a stale layout (#1371), so its
+  // streaming path reads these instead of re-holding every parsed page. ADDITIVE
+  // columns; ALTER is idempotent (the runner swallows "duplicate column name").
+  // Local sqlite only — NOT a prod migration.
+  //
+  // Authored as 21 before #115 took that number; renumbered to 22 on rebase.
+  // The two are independent ALTERs on different tables, so ordering is moot.
+  //
+  // No backfill, for the v19/v20 reason: `extractPageFeatures` always writes a
+  // FULL row via INSERT OR REPLACE keyed by (crawl_id, normalized_url), each
+  // crawl writes only its own crawl_id, and the streaming loop re-extracts every
+  // scored page in the current run — so no pre-v22 row is ever read. NULL reads
+  // back as null, which is the same as "this page declared no such asset".
+  22: [
+    `ALTER TABLE page_features ADD COLUMN favicon_href TEXT`,
+    `ALTER TABLE page_features ADD COLUMN theme_color TEXT`,
+    `ALTER TABLE page_features ADD COLUMN og_image TEXT`,
+  ],
 };
 
 // Nullable columns added to `pages` via ALTER migrations over time, with the
@@ -695,6 +715,9 @@ CREATE TABLE IF NOT EXISTS page_features (
   nap_address_format TEXT,
   nap_tel_link INTEGER,
   nap_mailto_link INTEGER,
+  favicon_href TEXT,
+  theme_color TEXT,
+  og_image TEXT,
   PRIMARY KEY (crawl_id, normalized_url),
   FOREIGN KEY (crawl_id) REFERENCES crawls(id)
 );
@@ -3443,8 +3466,9 @@ export class SQLiteStorage implements CrawlStorage {
       visible_author, visible_date, transfer_bytes, template_fp, secret_hits,
       meta_noindex, indexable_reasons, rich_result_types,
       nap_name, nap_phones, nap_phone_formats, nap_address, nap_address_format,
-      nap_tel_link, nap_mailto_link
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      nap_tel_link, nap_mailto_link,
+      favicon_href, theme_color, og_image
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `;
 
   private pageFeatureParams(
@@ -3481,6 +3505,9 @@ export class SQLiteStorage implements CrawlStorage {
       row.napAddressFormat,
       row.napTelLink ? 1 : 0,
       row.napMailtoLink ? 1 : 0,
+      row.faviconHref,
+      row.themeColor,
+      row.ogImage,
     ];
   }
 
@@ -3839,6 +3866,9 @@ export class SQLiteStorage implements CrawlStorage {
       napAddressFormat: (row.nap_address_format as string | null) ?? null,
       napTelLink: row.nap_tel_link === 1,
       napMailtoLink: row.nap_mailto_link === 1,
+      faviconHref: (row.favicon_href as string | null) ?? null,
+      themeColor: (row.theme_color as string | null) ?? null,
+      ogImage: (row.og_image as string | null) ?? null,
     };
   }
 }

--- a/packages/crawler/tests/page-features-store.test.ts
+++ b/packages/crawler/tests/page-features-store.test.ts
@@ -594,7 +594,7 @@ describe("page_features migration (v17 → current)", () => {
     const version = check.prepare("SELECT version FROM schema_version LIMIT 1").get() as {
       version: number;
     };
-    expect(version.version).toBe(21);
+    expect(version.version).toBe(SCHEMA_VERSION);
     check.close();
   });
 

--- a/packages/crawler/tests/page-features-store.test.ts
+++ b/packages/crawler/tests/page-features-store.test.ts
@@ -36,6 +36,9 @@ const NAP_COLUMNS = [
   "nap_mailto_link",
 ];
 
+/** The v22 site-chrome columns (#1371) — asserted on both the fresh and migrated paths. */
+const CHROME_COLUMNS = ["favicon_href", "theme_color", "og_image"];
+
 function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
   return {
     normalizedUrl: "https://example.com/a",
@@ -66,6 +69,9 @@ function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
     ...over,
   };
 }
@@ -122,6 +128,36 @@ describe("page_features store — round-trip", () => {
     expect(got?.napPhoneFormats).toEqual(["(555) 123-4567", "+1 555 765 4321"]);
     expect(got?.napTelLink).toBe(true);
     expect(got?.napMailtoLink).toBe(false);
+    await run(store.close());
+  });
+
+  test("site-chrome columns round-trip (favicon, theme-color, default OG image)", async () => {
+    const store = await freshStore();
+    const row = feat({
+      normalizedUrl: "https://example.com/chrome",
+      faviconHref: "https://example.com/favicon.ico",
+      themeColor: "#0a5c36",
+      ogImage: "https://cdn.example.com/share/default.png",
+    });
+    await run(store.upsertPageFeatures(CRAWL, row));
+
+    const got = await run(store.getPageFeatures(CRAWL, "https://example.com/chrome"));
+    expect(got).toEqual(row);
+    expect(got?.faviconHref).toBe("https://example.com/favicon.ico");
+    expect(got?.themeColor).toBe("#0a5c36");
+    expect(got?.ogImage).toBe("https://cdn.example.com/share/default.png");
+    await run(store.close());
+  });
+
+  test("a page declaring no chrome assets round-trips as null, not empty strings", async () => {
+    const store = await freshStore();
+    await run(
+      store.upsertPageFeatures(CRAWL, feat({ normalizedUrl: "https://example.com/no-chrome" }))
+    );
+    const got = await run(store.getPageFeatures(CRAWL, "https://example.com/no-chrome"));
+    expect(got?.faviconHref).toBeNull();
+    expect(got?.themeColor).toBeNull();
+    expect(got?.ogImage).toBeNull();
     await run(store.close());
   });
 
@@ -477,6 +513,8 @@ describe("page_features migration (v17 → current)", () => {
     expect(cols).toContain("rich_result_types");
     // v20 NAP columns present after migration.
     for (const col of NAP_COLUMNS) expect(cols).toContain(col);
+    // v22 site-chrome columns present after migration.
+    for (const col of CHROME_COLUMNS) expect(cols).toContain(col);
     check.close();
   });
 
@@ -495,6 +533,68 @@ describe("page_features migration (v17 → current)", () => {
       check.prepare("PRAGMA table_info(page_features)").all() as Array<{ name: string }>
     ).map((c) => c.name);
     for (const col of NAP_COLUMNS) expect(cols).toContain(col);
+    check.close();
+  });
+
+  test("v22 site-chrome columns exist on a FRESH database (SCHEMA path, not the migration)", async () => {
+    const path = tmpDbPath();
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    await run(store.close());
+
+    const check = new Database(path);
+    const cols = (
+      check.prepare("PRAGMA table_info(page_features)").all() as Array<{ name: string }>
+    ).map((c) => c.name);
+    for (const col of CHROME_COLUMNS) expect(cols).toContain(col);
+    check.close();
+  });
+
+  test("a DB already at v20 gains the site-chrome columns and keeps its existing rows", async () => {
+    const path = tmpDbPath();
+    // Build a real v22 store, seed a row, then wind the version marker back so the
+    // append-only migration is the only thing that can add the columns.
+    const seed = new SQLiteStorage(path);
+    await run(seed.init());
+    await run(seed.upsertPageFeatures("c1", feat({ normalizedUrl: "https://example.com/legacy" })));
+    await run(seed.close());
+
+    const downgrade = new Database(path);
+    for (const col of CHROME_COLUMNS) {
+      downgrade.exec(`ALTER TABLE page_features DROP COLUMN ${col}`);
+    }
+    downgrade.exec("UPDATE schema_version SET version = 20");
+    downgrade.close();
+
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    const migrated = await run(store.getPageFeatures("c1", "https://example.com/legacy"));
+    // Pre-v22 rows read back as "declared no chrome assets" rather than throwing.
+    expect(migrated?.title).toBe("Title A");
+    expect(migrated?.faviconHref).toBeNull();
+    expect(migrated?.themeColor).toBeNull();
+    expect(migrated?.ogImage).toBeNull();
+    // ...and the migrated table accepts a full v22 write.
+    await run(
+      store.upsertPageFeatures(
+        "c1",
+        feat({
+          normalizedUrl: "https://example.com/new",
+          faviconHref: "https://example.com/favicon.ico",
+          themeColor: "#0a5c36",
+          ogImage: "https://cdn.example.com/share/default.png",
+        })
+      )
+    );
+    const fresh = await run(store.getPageFeatures("c1", "https://example.com/new"));
+    expect(fresh?.faviconHref).toBe("https://example.com/favicon.ico");
+    await run(store.close());
+
+    const check = new Database(path);
+    const version = check.prepare("SELECT version FROM schema_version LIMIT 1").get() as {
+      version: number;
+    };
+    expect(version.version).toBe(21);
     check.close();
   });
 

--- a/packages/crawler/tests/page-features-store.test.ts
+++ b/packages/crawler/tests/page-features-store.test.ts
@@ -36,6 +36,9 @@ const NAP_COLUMNS = [
   "nap_mailto_link",
 ];
 
+/** The v21 site-chrome columns (#1371) — asserted on both the fresh and migrated paths. */
+const CHROME_COLUMNS = ["favicon_href", "theme_color", "og_image"];
+
 function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
   return {
     normalizedUrl: "https://example.com/a",
@@ -66,6 +69,9 @@ function feat(over: Partial<PageFeatureRow> = {}): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
     ...over,
   };
 }
@@ -122,6 +128,36 @@ describe("page_features store — round-trip", () => {
     expect(got?.napPhoneFormats).toEqual(["(555) 123-4567", "+1 555 765 4321"]);
     expect(got?.napTelLink).toBe(true);
     expect(got?.napMailtoLink).toBe(false);
+    await run(store.close());
+  });
+
+  test("site-chrome columns round-trip (favicon, theme-color, default OG image)", async () => {
+    const store = await freshStore();
+    const row = feat({
+      normalizedUrl: "https://example.com/chrome",
+      faviconHref: "https://example.com/favicon.ico",
+      themeColor: "#0a5c36",
+      ogImage: "https://cdn.example.com/share/default.png",
+    });
+    await run(store.upsertPageFeatures(CRAWL, row));
+
+    const got = await run(store.getPageFeatures(CRAWL, "https://example.com/chrome"));
+    expect(got).toEqual(row);
+    expect(got?.faviconHref).toBe("https://example.com/favicon.ico");
+    expect(got?.themeColor).toBe("#0a5c36");
+    expect(got?.ogImage).toBe("https://cdn.example.com/share/default.png");
+    await run(store.close());
+  });
+
+  test("a page declaring no chrome assets round-trips as null, not empty strings", async () => {
+    const store = await freshStore();
+    await run(
+      store.upsertPageFeatures(CRAWL, feat({ normalizedUrl: "https://example.com/no-chrome" }))
+    );
+    const got = await run(store.getPageFeatures(CRAWL, "https://example.com/no-chrome"));
+    expect(got?.faviconHref).toBeNull();
+    expect(got?.themeColor).toBeNull();
+    expect(got?.ogImage).toBeNull();
     await run(store.close());
   });
 
@@ -465,7 +501,7 @@ describe("page_features migration (v17 → current)", () => {
     const version = check.prepare("SELECT version FROM schema_version LIMIT 1").get() as {
       version: number;
     };
-    expect(version.version).toBe(20);
+    expect(version.version).toBe(21);
     const cols = (
       check.prepare("PRAGMA table_info(page_features)").all() as Array<{ name: string }>
     ).map((c) => c.name);
@@ -477,6 +513,8 @@ describe("page_features migration (v17 → current)", () => {
     expect(cols).toContain("rich_result_types");
     // v20 NAP columns present after migration.
     for (const col of NAP_COLUMNS) expect(cols).toContain(col);
+    // v21 site-chrome columns present after migration.
+    for (const col of CHROME_COLUMNS) expect(cols).toContain(col);
     check.close();
   });
 
@@ -495,6 +533,68 @@ describe("page_features migration (v17 → current)", () => {
       check.prepare("PRAGMA table_info(page_features)").all() as Array<{ name: string }>
     ).map((c) => c.name);
     for (const col of NAP_COLUMNS) expect(cols).toContain(col);
+    check.close();
+  });
+
+  test("v21 site-chrome columns exist on a FRESH database (SCHEMA path, not the migration)", async () => {
+    const path = tmpDbPath();
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    await run(store.close());
+
+    const check = new Database(path);
+    const cols = (
+      check.prepare("PRAGMA table_info(page_features)").all() as Array<{ name: string }>
+    ).map((c) => c.name);
+    for (const col of CHROME_COLUMNS) expect(cols).toContain(col);
+    check.close();
+  });
+
+  test("a DB already at v20 gains the site-chrome columns and keeps its existing rows", async () => {
+    const path = tmpDbPath();
+    // Build a real v21 store, seed a row, then wind the version marker back so the
+    // append-only migration is the only thing that can add the columns.
+    const seed = new SQLiteStorage(path);
+    await run(seed.init());
+    await run(seed.upsertPageFeatures("c1", feat({ normalizedUrl: "https://example.com/legacy" })));
+    await run(seed.close());
+
+    const downgrade = new Database(path);
+    for (const col of CHROME_COLUMNS) {
+      downgrade.exec(`ALTER TABLE page_features DROP COLUMN ${col}`);
+    }
+    downgrade.exec("UPDATE schema_version SET version = 20");
+    downgrade.close();
+
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    const migrated = await run(store.getPageFeatures("c1", "https://example.com/legacy"));
+    // Pre-v21 rows read back as "declared no chrome assets" rather than throwing.
+    expect(migrated?.title).toBe("Title A");
+    expect(migrated?.faviconHref).toBeNull();
+    expect(migrated?.themeColor).toBeNull();
+    expect(migrated?.ogImage).toBeNull();
+    // ...and the migrated table accepts a full v21 write.
+    await run(
+      store.upsertPageFeatures(
+        "c1",
+        feat({
+          normalizedUrl: "https://example.com/new",
+          faviconHref: "https://example.com/favicon.ico",
+          themeColor: "#0a5c36",
+          ogImage: "https://cdn.example.com/share/default.png",
+        })
+      )
+    );
+    const fresh = await run(store.getPageFeatures("c1", "https://example.com/new"));
+    expect(fresh?.faviconHref).toBe("https://example.com/favicon.ico");
+    await run(store.close());
+
+    const check = new Database(path);
+    const version = check.prepare("SELECT version FROM schema_version LIMIT 1").get() as {
+      version: number;
+    };
+    expect(version.version).toBe(21);
     check.close();
   });
 
@@ -546,7 +646,7 @@ describe("page_features migration (v17 → current)", () => {
     const version = check.prepare("SELECT version FROM schema_version LIMIT 1").get() as {
       version: number;
     };
-    expect(version.version).toBe(20);
+    expect(version.version).toBe(21);
     check.close();
   });
 });

--- a/packages/rules/src/index.ts
+++ b/packages/rules/src/index.ts
@@ -17,6 +17,14 @@ export {
   ruleApplies,
 } from "./applicability";
 export { setRequestAsync, setLlmCall } from "./tools";
+// Page-time extractor for the social/asset-divergence page_features columns —
+// audit-engine's extractPageFeatures calls the SAME code the rule's legacy path
+// does, so the stored scalars and the re-derived ones can never diverge (#1371).
+export {
+  emptySiteChromeSignal,
+  extractSiteChromeSignal,
+  type SiteChromeSignal,
+} from "./social/asset-divergence";
 
 // Domain re-exports
 export * as content from "./content";

--- a/packages/rules/src/social/asset-divergence.ts
+++ b/packages/rules/src/social/asset-divergence.ts
@@ -1,0 +1,567 @@
+// social/asset-divergence - site-chrome assets that disagree across the corpus (#1371)
+//
+// The favicon, the `theme-color` and the fallback OG image all come from ONE
+// layout, so on a healthy site every page carries the same three. A page that
+// carries a different one is not expressing a per-page decision, it is running a
+// different (usually older) template: the fingerprint of a half-finished
+// redesign, a stale cached shell, or a section that never got migrated. Nothing
+// about that page is wrong when you look at it alone, which is why no per-page
+// rule can see it, and why link previews then degrade inconsistently.
+//
+// Three axes, each judged against the site's OWN modal value:
+//   favicon      the primary `<link rel="icon">` href, resolved absolute
+//   theme-color  `<meta name="theme-color">` content
+//   og-image     the DEFAULT `og:image` — see the exclusion below
+//
+// The OG exclusion is the whole reason this rule can exist: articles and
+// products SHOULD ship their own share image, so those page types never vote on
+// the OG axis and are never deviants on it. Page type alone is not enough —
+// replaying this rule over stored crawls turned up sites shipping a bespoke
+// preview image on pages the classifier calls "unknown" — so an og:image carried
+// by exactly ONE page is dropped from that axis too: a fallback is by definition
+// shared, while a stale template always brings its whole pocket of pages with
+// it. What is judged there is the fallback the rest of the site shares. Favicon
+// and theme-color have no such exemption: they are browser chrome, not content,
+// and are globally uniform on every correctly built site.
+//
+// Guards, in the order they matter:
+//   1. Site floor (ASSET_NORM_MIN_PAGES) - a small crawl has no norm to speak of.
+//   2. Per-axis sample floor (ASSET_NORM_MIN_SAMPLE) - too few pages DECLARE the
+//      asset to vote on it. A page that declares nothing never votes and is never
+//      a deviant: a missing favicon belongs to core/favicon and a missing
+//      og:image to the og-tags rules, so this rule never double-accuses.
+//   3. Modal agreement (ASSET_NORM_MIN_AGREEMENT) - an axis whose values do not
+//      concentrate on one form is a site that legitimately varies it, and nothing
+//      in it is a deviant. Skipping beats accusing a healthy site.
+// An axis that clears all three is judged; the rule reports only when at least
+// one does, and stays silent (skipped) when none do.
+//
+// Dual path: `ctx.siteQuery` streams (normalizedUrl, status, pageType, the three
+// asset scalars) straight off page_features; the legacy path re-derives them from
+// `ctx.site.pages` through the SAME extractor (`extractSiteChromeSignal`, which
+// `extractPageFeatures` also calls to populate those columns). Both feed ONE
+// accumulator and ONE check builder, and every list is sorted before it is
+// emitted, so the output is byte-identical by construction and independent of
+// crawl order (same shape as content/duplicate-title, #1021/#1022).
+
+import type { Rule, RuleContext, RuleResult, CheckResult, ParsedPage } from "../types";
+import type { CheckItem, SiteQuery } from "@squirrelscan/core-contracts";
+
+import { getAttrCI } from "@squirrelscan/utils";
+
+/** Crawl-wide page floor: below this there is no site norm to judge against. */
+export const ASSET_NORM_MIN_PAGES = 10;
+
+/** Pages that must DECLARE an asset before that axis is judged at all. */
+export const ASSET_NORM_MIN_SAMPLE = 10;
+
+/**
+ * Share of declaring pages that must carry the same value before it is treated
+ * as the site's norm. Below this the site genuinely varies the asset and no page
+ * deviates from anything.
+ */
+export const ASSET_NORM_MIN_AGREEMENT = 0.7;
+
+/** Share of judged pages that turns the warning into a failure. */
+export const ASSET_NORM_FAIL_SHARE = 0.2;
+
+/** Caps on reported items / urls, so one rule cannot bloat a report. */
+const ASSET_NORM_MAX_ITEMS = 10;
+const ASSET_NORM_MAX_URLS = 10;
+
+const CHECK_NAME = "asset-divergence";
+
+/**
+ * Per-page cap on each carried value — bounds the stored `page_features` row.
+ * A longer value (a big inline `data:` favicon) is truncated, so two distinct
+ * values sharing a 200-char prefix compare EQUAL and the divergence is missed.
+ * Deliberately the safe direction: the rule never invents a finding, and a
+ * report that names a 4KB data URI helps nobody anyway.
+ */
+export const SITE_CHROME_MAX_VALUE_CHARS = 200;
+
+/**
+ * Page types that SHOULD carry their own share image. They neither vote on the
+ * og-image axis nor are judged by it — a per-page OG image is correct behavior,
+ * and reporting it would be the expensive kind of wrong. Favicon and theme-color
+ * are unaffected: those are chrome, and uniform even on an article.
+ */
+export const PER_PAGE_OG_PAGE_TYPES: ReadonlySet<string> = new Set([
+  "article",
+  "product",
+  "recipe",
+  "event",
+  "profile",
+  "media",
+]);
+
+/**
+ * `rel` tokens that mark a `<link>` as an alternate/platform icon rather than
+ * THE favicon. Apple touch icons and mask icons legitimately differ from the tab
+ * icon, so they never stand in for it.
+ */
+const NON_FAVICON_REL_TOKENS = new Set([
+  "apple-touch-icon",
+  "apple-touch-icon-precomposed",
+  "mask-icon",
+  "fluid-icon",
+]);
+
+/** One page's site-chrome assets, absent fields left null. */
+export interface SiteChromeSignal {
+  /** Absolute URL of the page's primary `<link rel="icon">`, or null. */
+  faviconHref: string | null;
+  /** `<meta name="theme-color">` content, lowercased, or null. */
+  themeColor: string | null;
+  /** Absolute URL of the page's `og:image`, or null. */
+  ogImage: string | null;
+}
+
+export function emptySiteChromeSignal(): SiteChromeSignal {
+  return { faviconHref: null, themeColor: null, ogImage: null };
+}
+
+/** Trimmed, whitespace-collapsed, capped. Empty reads back as null. */
+function bounded(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) return null;
+  return collapsed.slice(0, SITE_CHROME_MAX_VALUE_CHARS);
+}
+
+/**
+ * Resolve `value` against the page URL so a site-root reference ("/favicon.ico")
+ * compares equal from every depth. An unresolvable value is carried verbatim —
+ * comparing the raw forms is still the right answer, and dropping it would hide
+ * a page whose markup is broken in a way the others' is not.
+ */
+function absolute(value: string | null, baseUrl: string): string | null {
+  if (value === null) return null;
+  try {
+    return bounded(new URL(value, baseUrl).href);
+  } catch {
+    return value;
+  }
+}
+
+/** `rel` token list of a `<link>`, lowercased. */
+function relTokens(el: Element): string[] {
+  return (getAttrCI(el, "rel") ?? "").toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * The page's primary favicon: the first `<link>` in document order whose `rel`
+ * carries the `icon` token and no platform-icon token. Document order is the
+ * template's own order, so pages generated from one layout pick the same link
+ * every time; a page generated from a DIFFERENT layout is the finding.
+ */
+function primaryFavicon(doc: Document, baseUrl: string): string | null {
+  for (const link of doc.querySelectorAll("link")) {
+    const tokens = relTokens(link);
+    if (!tokens.includes("icon")) continue;
+    if (tokens.some((token) => NON_FAVICON_REL_TOKENS.has(token))) continue;
+    const href = bounded(getAttrCI(link, "href"));
+    if (href !== null) return absolute(href, baseUrl);
+  }
+  return null;
+}
+
+/**
+ * The page's theme-color. A light/dark pair (two `<meta>`s scoped by `media`) is
+ * normal and MUST NOT read as drift, so the unscoped declaration wins and a
+ * media-scoped-only page falls back to its first declaration — the same choice
+ * on every page of a site that ships the pair.
+ */
+function declaredThemeColor(doc: Document): string | null {
+  let fallback: string | null = null;
+  for (const meta of doc.querySelectorAll("meta")) {
+    if ((getAttrCI(meta, "name") ?? "").toLowerCase() !== "theme-color") continue;
+    const content = bounded(getAttrCI(meta, "content"));
+    if (content === null) continue;
+    if (getAttrCI(meta, "media") === null) return content.toLowerCase();
+    if (fallback === null) fallback = content.toLowerCase();
+  }
+  return fallback;
+}
+
+/**
+ * Read one page's site-chrome assets. Pure + synchronous, exported because it has
+ * TWO callers that must agree byte-for-byte: this rule's legacy `ctx.site.pages`
+ * path reads it live, and `extractPageFeatures` (audit-engine) stores its output
+ * into `page_features` for the streaming path. Same code, one definition.
+ *
+ * `baseUrl` is the page's stored identity URL (`PageRecord.normalizedUrl`, which
+ * is also what `site.pages[].url` carries), so both paths resolve against the
+ * same base. `og:image` comes off the parsed scalar rather than the DOM, so it
+ * survives on a page whose document was released.
+ */
+export function extractSiteChromeSignal(
+  parsed: ParsedPage | null | undefined,
+  baseUrl: string
+): SiteChromeSignal {
+  const signal = emptySiteChromeSignal();
+  if (!parsed) return signal;
+
+  signal.ogImage = absolute(bounded(parsed.og?.image), baseUrl);
+
+  const doc = parsed.document;
+  if (!doc) return signal;
+
+  signal.faviconHref = primaryFavicon(doc, baseUrl);
+  signal.themeColor = declaredThemeColor(doc);
+  return signal;
+}
+
+/** One page's contribution, from either path. */
+interface ChromePageRecord {
+  url: string;
+  status: number;
+  pageType: string | null;
+  chrome: SiteChromeSignal;
+}
+
+/** A 2xx page the rule can judge. */
+interface ChromeSample {
+  url: string;
+  /** True when this page type legitimately ships its own OG image. */
+  perPageOg: boolean;
+  chrome: SiteChromeSignal;
+}
+
+interface ChromeRollup {
+  /** Pages seen by the rule (both paths count the same universe). */
+  pageCount: number;
+  samples: ChromeSample[];
+}
+
+type AxisKey = "favicon" | "theme-color" | "og-image";
+
+interface Axis {
+  key: AxisKey;
+  /** Reported name of the asset. */
+  label: string;
+  /** Verb phrase used in an item label ("... 3 page(s) <verb> "x""). */
+  verb: string;
+  value: (sample: ChromeSample) => string | null;
+  /** Whether this page is allowed to vote on / be judged by the axis at all. */
+  eligible: (sample: ChromeSample) => boolean;
+  /**
+   * Drop values carried by exactly ONE page before judging. A fallback is by
+   * definition shared, so a one-off value is a per-page asset, not a template
+   * running behind — and page type is not enough to spot one (plenty of sites
+   * ship a bespoke preview image on pages the classifier calls "unknown", found
+   * replaying this rule over stored crawls). A stale template always brings its
+   * whole pocket of pages with it, so it survives this filter.
+   */
+  dropSingletons?: boolean;
+}
+
+/** Fixed axis order — the report's item order never depends on crawl order. */
+const AXES: readonly Axis[] = [
+  {
+    key: "favicon",
+    label: "favicon",
+    verb: "load favicon",
+    value: (s) => s.chrome.faviconHref,
+    eligible: () => true,
+  },
+  {
+    key: "theme-color",
+    label: "theme-color",
+    verb: "declare theme-color",
+    value: (s) => s.chrome.themeColor,
+    eligible: () => true,
+  },
+  {
+    key: "og-image",
+    label: "default OG image",
+    verb: "fall back to OG image",
+    value: (s) => s.chrome.ogImage,
+    eligible: (s) => !s.perPageOg,
+    dropSingletons: true,
+  },
+];
+
+/** A judged axis: its modal value plus the pages that disagree with it. */
+interface AxisVerdict {
+  axis: Axis;
+  norm: string;
+  /** Urls of the pages that declared the asset and were eligible to vote. */
+  judged: string[];
+  /** `judged.length`, carried for the item labels. */
+  voters: number;
+  /** Pages carrying the modal value. */
+  agreeing: number;
+  share: number;
+  /** url -> the value that page carries, sorted by url. */
+  deviants: Array<{ url: string; value: string }>;
+}
+
+function emptyRollup(): ChromeRollup {
+  return { pageCount: 0, samples: [] };
+}
+
+/**
+ * Fold one page in. Non-2xx pages carry no template worth comparing (v1 appends
+ * 4xx/5xx pages to `site.pages` with an empty parsed record), so they count
+ * toward the crawl size but never vote.
+ */
+function accumulatePage(rollup: ChromeRollup, record: ChromePageRecord): void {
+  rollup.pageCount += 1;
+
+  if (record.status < 200 || record.status >= 300) return;
+  rollup.samples.push({
+    url: record.url,
+    perPageOg: PER_PAGE_OG_PAGE_TYPES.has(record.pageType ?? ""),
+    chrome: record.chrome,
+  });
+}
+
+/** The pages an axis judges: eligible, declaring, and (optionally) not one-offs. */
+function votersFor(axis: Axis, samples: ChromeSample[]): Array<{ url: string; value: string }> {
+  const declared: Array<{ url: string; value: string }> = [];
+  const seen = new Map<string, number>();
+  for (const sample of samples) {
+    if (!axis.eligible(sample)) continue;
+    const value = axis.value(sample);
+    if (value === null) continue;
+    declared.push({ url: sample.url, value });
+    seen.set(value, (seen.get(value) ?? 0) + 1);
+  }
+  if (!axis.dropSingletons) return declared;
+  return declared.filter((voter) => (seen.get(voter.value) ?? 0) > 1);
+}
+
+/** Modal value of one axis; ties break lexicographically so order never matters. */
+function judgeAxis(axis: Axis, samples: ChromeSample[]): AxisVerdict | null {
+  const voters = votersFor(axis, samples);
+  const votes = new Map<string, number>();
+  for (const voter of voters) votes.set(voter.value, (votes.get(voter.value) ?? 0) + 1);
+  if (voters.length < ASSET_NORM_MIN_SAMPLE) return null;
+
+  let best: { value: string; count: number } | null = null;
+  for (const [value, count] of votes) {
+    if (best === null || count > best.count || (count === best.count && value < best.value)) {
+      best = { value, count };
+    }
+  }
+  if (best === null) return null;
+
+  const share = best.count / voters.length;
+  if (share < ASSET_NORM_MIN_AGREEMENT) return null;
+
+  const norm = best.value;
+  return {
+    axis,
+    norm,
+    judged: voters.map((voter) => voter.url),
+    voters: voters.length,
+    agreeing: best.count,
+    share,
+    deviants: voters
+      .filter((voter) => voter.value !== norm)
+      .sort((a, b) => (a.url < b.url ? -1 : a.url > b.url ? 1 : 0)),
+  };
+}
+
+function skip(message: string): CheckResult {
+  return { name: CHECK_NAME, status: "skipped", message };
+}
+
+function pct(share: number): number {
+  return Math.round(share * 100);
+}
+
+/** Human list ("favicon, theme-color and default OG image"). */
+function joinLabels(labels: string[]): string {
+  if (labels.length <= 1) return labels[0] ?? "";
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+}
+
+/**
+ * The rule's full output for one rollup. ONE builder, both paths.
+ *
+ * `sitePageCount` is the crawl-wide page count: the streaming path takes it from
+ * `siteQuery.pageCount()` (which includes rows this rule cannot sample), so the
+ * site floor is judged on the crawl, not on the sampled subset.
+ */
+function buildChecks(rollup: ChromeRollup, sitePageCount: number): CheckResult[] {
+  if (sitePageCount < ASSET_NORM_MIN_PAGES) {
+    return [
+      skip(
+        `Only ${sitePageCount} page(s) crawled; ${ASSET_NORM_MIN_PAGES} needed to establish a site-asset norm`
+      ),
+    ];
+  }
+
+  const verdicts = AXES.map((axis) => judgeAxis(axis, rollup.samples)).filter(
+    (verdict): verdict is AxisVerdict => verdict !== null
+  );
+
+  if (verdicts.length === 0) {
+    return [
+      skip(
+        `No favicon, theme-color or default OG image is declared by ${ASSET_NORM_MIN_SAMPLE} page(s) with ${pct(ASSET_NORM_MIN_AGREEMENT)}% agreement`
+      ),
+    ];
+  }
+
+  // A page is judged once, however many axes it votes on, so the fail threshold
+  // measures "how much of the site runs the wrong template" rather than counting
+  // one stale layout three times.
+  const judgedPages = new Set<string>();
+  const flaggedPages = new Set<string>();
+  for (const verdict of verdicts) {
+    for (const url of verdict.judged) judgedPages.add(url);
+    for (const deviant of verdict.deviants) flaggedPages.add(deviant.url);
+  }
+
+  const normSummary = verdicts
+    .map((v) => `${v.axis.label} ${pct(v.share)}%`)
+    .join(", ");
+  const details: Record<string, unknown> = {
+    judgedPages: judgedPages.size,
+    flaggedPages: flaggedPages.size,
+    norms: verdicts.map((v) => ({
+      dimension: v.axis.key,
+      norm: v.norm,
+      pages: v.agreeing,
+      agreement: v.share,
+    })),
+  };
+
+  if (flaggedPages.size === 0) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: "pass",
+        message: `All ${judgedPages.size} page(s) share the site's ${joinLabels(verdicts.map((v) => v.axis.label))} (${normSummary})`,
+        value: judgedPages.size,
+        details,
+      },
+    ];
+  }
+
+  // Group by (axis, deviant value) so one finding names one stale template
+  // instead of one page.
+  const groups: Array<{ axis: Axis; value: string; norm: string; voters: number; urls: string[] }> =
+    [];
+  for (const verdict of verdicts) {
+    const byValue = new Map<string, string[]>();
+    for (const deviant of verdict.deviants) {
+      const urls = byValue.get(deviant.value);
+      if (urls) urls.push(deviant.url);
+      else byValue.set(deviant.value, [deviant.url]);
+    }
+    for (const [value, urls] of byValue) {
+      groups.push({
+        axis: verdict.axis,
+        value,
+        norm: verdict.norm,
+        voters: verdict.voters,
+        urls,
+      });
+    }
+  }
+
+  // Biggest group first; axis order then value break ties, so the list never
+  // depends on crawl order.
+  const ordered = groups.sort(
+    (a, b) =>
+      b.urls.length - a.urls.length ||
+      AXES.indexOf(a.axis) - AXES.indexOf(b.axis) ||
+      (a.value < b.value ? -1 : a.value > b.value ? 1 : 0)
+  );
+
+  const items: CheckItem[] = ordered.slice(0, ASSET_NORM_MAX_ITEMS).map((group) => ({
+    id: `${group.axis.key}:${group.value}`,
+    label: `${group.urls.length} of ${group.voters} page(s) ${group.axis.verb} "${group.value}" but the site norm is "${group.norm}"`,
+    sourcePages: group.urls.slice(0, ASSET_NORM_MAX_URLS),
+    meta: {
+      dimension: group.axis.key,
+      value: group.value,
+      norm: group.norm,
+      pageCount: group.urls.length,
+    },
+  }));
+
+  const share = flaggedPages.size / judgedPages.size;
+  return [
+    {
+      name: CHECK_NAME,
+      status: share >= ASSET_NORM_FAIL_SHARE ? "fail" : "warn",
+      message: `${flaggedPages.size} of ${judgedPages.size} page(s) diverge from the site's own ${joinLabels(verdicts.map((v) => v.axis.label))} (${normSummary})`,
+      value: flaggedPages.size,
+      items,
+      details,
+    },
+  ];
+}
+
+/**
+ * Streaming path (#1371): read the three asset scalars off the page_features
+ * cursor. Only bounded strings stay resident — the same shape
+ * content/duplicate-title already holds; no parsed page is kept.
+ *
+ * The site floor is judged on `pageCount()`, which counts page_features rows; the
+ * legacy universe additionally carries the error pages v1 appends to `site.pages`.
+ * That is a property of this seam shared with every site rule on it (see
+ * content/duplicate-title), not something specific to this rule.
+ */
+async function runViaSiteQuery(siteQuery: SiteQuery): Promise<RuleResult> {
+  const rollup = emptyRollup();
+  for await (const row of siteQuery.pagesMatching(() => true)) {
+    accumulatePage(rollup, {
+      url: row.normalizedUrl,
+      status: row.status,
+      pageType: row.pageType,
+      chrome: {
+        faviconHref: row.faviconHref,
+        themeColor: row.themeColor,
+        ogImage: row.ogImage,
+      },
+    });
+  }
+
+  return { checks: buildChecks(rollup, siteQuery.pageCount()) };
+}
+
+export const assetDivergenceRule: Rule = {
+  meta: {
+    id: "social/asset-divergence",
+    name: "Site Asset Consistency",
+    description:
+      "Finds pages whose favicon, theme-color or default OG image differs from the rest of the site",
+    solution:
+      "Your favicon, theme-color and fallback share image come from one layout, so every page should carry the same three. Pages that carry different ones are usually running an older template: a section that missed a redesign, a cached shell, or a second layout nobody remembers owning. The visible cost is inconsistent link previews and a tab icon that changes as visitors move around the site. Fix it where the assets are declared (the shared head partial or theme config) rather than page by page. Per-page share images on articles and products are correct and are not reported here: what this rule compares is the fallback the rest of the site shares.",
+    category: "social",
+    scope: "site",
+    severity: "warning",
+    // Deliberately light: one site-wide check, capped items, so a single rule
+    // cannot dominate the social category score.
+    weight: 3,
+  },
+
+  run(ctx: RuleContext): RuleResult | Promise<RuleResult> {
+    if (ctx.siteQuery) {
+      return runViaSiteQuery(ctx.siteQuery);
+    }
+
+    const pages = ctx.site?.pages;
+    if (!pages || pages.length === 0) {
+      return { checks: [skip("No pages available for analysis")] };
+    }
+
+    const rollup = emptyRollup();
+    for (const page of pages) {
+      accumulatePage(rollup, {
+        url: page.url,
+        status: page.statusCode,
+        pageType: page.parsed?.pageType ?? null,
+        chrome: extractSiteChromeSignal(page.parsed, page.url),
+      });
+    }
+
+    return { checks: buildChecks(rollup, rollup.pageCount) };
+  },
+};

--- a/packages/rules/src/social/index.ts
+++ b/packages/rules/src/social/index.ts
@@ -3,6 +3,7 @@
 
 import type { Rule } from "../types";
 
+import { assetDivergenceRule } from "./asset-divergence";
 import { ogImageSizeRule } from "./og-image-size";
 import { ogUrlMatchRule } from "./og-url-match";
 import { shareButtonsRule } from "./share-buttons";
@@ -13,9 +14,11 @@ export const rules: Rule[] = [
   ogUrlMatchRule,
   socialProfilesRule,
   shareButtonsRule,
+  assetDivergenceRule,
 ];
 
 export {
+  assetDivergenceRule,
   ogImageSizeRule,
   ogUrlMatchRule,
   shareButtonsRule,

--- a/packages/rules/tests/asset-divergence.test.ts
+++ b/packages/rules/tests/asset-divergence.test.ts
@@ -1,0 +1,450 @@
+// social/asset-divergence — site-chrome assets vs the site's own norm (#1371).
+//
+// The rule's whole value is what it does NOT say, so most of this file defends the
+// silence cases: a small crawl, too few pages declaring an asset, a site that
+// legitimately varies one, and — the case the issue calls out by name — articles
+// and products shipping their own OG image over a uniform default. The positive
+// cases pin the three axes it is for.
+//
+// Both paths run over every fixture: the legacy path re-derives the assets from a
+// real parsed DOM, the streaming path reads the stored page_features scalars, and
+// the two must be byte-identical.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "linkedom";
+
+import type { CheckResult, PageFeatureRow, SiteQuery } from "@squirrelscan/core-contracts";
+
+import {
+  assetDivergenceRule,
+  extractSiteChromeSignal,
+  ASSET_NORM_FAIL_SHARE,
+  ASSET_NORM_MIN_AGREEMENT,
+  ASSET_NORM_MIN_PAGES,
+  ASSET_NORM_MIN_SAMPLE,
+} from "../src/social/asset-divergence";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+interface PageSpec {
+  path: string;
+  favicon?: string | null;
+  themeColor?: string | null;
+  ogImage?: string | null;
+  pageType?: string | null;
+  status?: number;
+  /** Raw head markup, when a fixture needs more than the three simple fields. */
+  head?: string;
+}
+
+function url(path: string): string {
+  return `https://example.com${path}`;
+}
+
+function pad(i: number): string {
+  return String(i).padStart(3, "0");
+}
+
+/** The head a spec describes, unless it brought its own markup. */
+function headHtml(spec: PageSpec): string {
+  if (spec.head !== undefined) return spec.head;
+  const parts: string[] = [];
+  if (spec.favicon != null) parts.push(`<link rel="icon" href="${spec.favicon}">`);
+  if (spec.themeColor != null) parts.push(`<meta name="theme-color" content="${spec.themeColor}">`);
+  return parts.join("");
+}
+
+/** A parsed page with a LIVE document, the way the legacy site pass sees one. */
+function parsedFor(spec: PageSpec): ParsedPage {
+  const { document } = parseHTML(`<html><head>${headHtml(spec)}</head><body></body></html>`);
+  return {
+    document,
+    og: { image: spec.ogImage ?? null },
+    pageType: spec.pageType ?? "unknown",
+  } as unknown as ParsedPage;
+}
+
+const baseCtx = {
+  page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+  parsed: {} as ParsedPage,
+  options: {},
+};
+
+/** Legacy path: specs become `ctx.site.pages` in crawl order. */
+function legacyCtx(specs: PageSpec[]): RuleContext {
+  return {
+    ...baseCtx,
+    site: {
+      baseUrl: "https://example.com/",
+      pages: specs.map((spec) => ({
+        url: url(spec.path),
+        statusCode: spec.status ?? 200,
+        parsed: parsedFor(spec),
+      })),
+      robotsTxt: null,
+      sitemaps: null,
+    },
+  };
+}
+
+/**
+ * Streaming path: the stored row, populated by the SAME extractor
+ * `extractPageFeatures` calls — so a divergence between the two paths can only
+ * come from the rule, never from the fixture doing its own extraction.
+ */
+function featureRow(spec: PageSpec): PageFeatureRow {
+  const chrome = extractSiteChromeSignal(parsedFor(spec), url(spec.path));
+  return {
+    normalizedUrl: url(spec.path),
+    status: spec.status ?? 200,
+    depth: 1,
+    title: null,
+    titleHash: null,
+    description: null,
+    descHash: null,
+    contentHash: null,
+    wordCount: null,
+    pageType: spec.pageType ?? "unknown",
+    schemaTypes: [],
+    robotsNoindex: false,
+    canonical: null,
+    visibleAuthor: false,
+    visibleDate: false,
+    transferBytes: null,
+    templateFp: null,
+    secretHits: null,
+    metaNoindex: false,
+    indexableReasons: [],
+    richResultTypes: [],
+    napName: null,
+    napPhones: [],
+    napPhoneFormats: [],
+    napAddress: null,
+    napAddressFormat: null,
+    napTelLink: false,
+    napMailtoLink: false,
+    faviconHref: chrome.faviconHref,
+    themeColor: chrome.themeColor,
+    ogImage: chrome.ogImage,
+  };
+}
+
+/**
+ * The rule only ever calls `pagesMatching` + `pageCount`, so the rest of the
+ * SiteQuery surface throws — a stub that silently returned empties could hide the
+ * rule reading something it must not.
+ */
+function siteQueryCtx(specs: PageSpec[]): RuleContext {
+  const rows = specs.map(featureRow);
+  const unused = (): never => {
+    throw new Error("asset-divergence must not use this SiteQuery method");
+  };
+  const siteQuery: SiteQuery = {
+    pageCount: () => rows.length,
+    duplicateGroups: unused,
+    incomingLinkCounts: unused,
+    pagesByType: unused,
+    templateClusters: unused,
+    sumTransferBytes: unused,
+    sumSecretHits: unused,
+    homepage: unused,
+    async *pagesMatching(pred: (row: PageFeatureRow) => boolean) {
+      for (const row of rows) if (pred(row)) yield row;
+    },
+  };
+  return {
+    ...baseCtx,
+    // EMPTY pages — the streaming path must not read them.
+    site: { baseUrl: "https://example.com/", pages: [], robotsTxt: null, sitemaps: null },
+    siteQuery,
+  };
+}
+
+async function checks(ctx: RuleContext): Promise<CheckResult[]> {
+  return (await Promise.resolve(assetDivergenceRule.run(ctx))).checks;
+}
+
+/** Run BOTH paths over one fixture, assert byte-identical output, return it. */
+async function bothPaths(specs: PageSpec[]): Promise<CheckResult> {
+  const legacy = await checks(legacyCtx(specs));
+  const streamed = await checks(siteQueryCtx(specs));
+  expect(streamed).toEqual(legacy);
+  expect(JSON.stringify(streamed)).toBe(JSON.stringify(legacy));
+  expect(legacy).toHaveLength(1);
+  return legacy[0]!;
+}
+
+/** The item for one axis, or undefined when that axis reported nothing. */
+function itemFor(check: CheckResult, dimension: string) {
+  return check.items?.find((i) => i.meta?.dimension === dimension);
+}
+
+/** N pages off one template, numbered so each url is distinct. */
+function template(count: number, make: (i: number) => PageSpec): PageSpec[] {
+  return Array.from({ length: count }, (_, i) => make(i));
+}
+
+/** The canonical healthy corpus: one layout, one favicon, one tint, one default OG. */
+function uniformSite(count = 20): PageSpec[] {
+  return template(count, (i) => ({
+    path: `/page-${pad(i)}`,
+    favicon: "/favicon.ico",
+    themeColor: "#0a5c36",
+    ogImage: "https://cdn.example.com/default-share.png",
+  }));
+}
+
+describe("social/asset-divergence — silence guards", () => {
+  test("skips a crawl below the site page floor", async () => {
+    const check = await bothPaths(uniformSite(ASSET_NORM_MIN_PAGES - 1));
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${ASSET_NORM_MIN_PAGES} needed`);
+  });
+
+  test("skips when too few pages declare any asset", async () => {
+    // Enough pages to clear the site floor, but only a handful declare anything.
+    const specs = [
+      ...template(ASSET_NORM_MIN_SAMPLE - 1, (i) => ({
+        path: `/bare-${pad(i)}`,
+        favicon: "/favicon.ico",
+        themeColor: "#0a5c36",
+        ogImage: "https://cdn.example.com/default-share.png",
+      })),
+      ...template(ASSET_NORM_MIN_PAGES, (i) => ({ path: `/nothing-${pad(i)}` })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${ASSET_NORM_MIN_SAMPLE} page(s)`);
+  });
+
+  test("skips a site that genuinely varies its chrome (no modal norm)", async () => {
+    // Every page a different favicon/tint/image: nothing reaches the agreement bar.
+    const specs = template(20, (i) => ({
+      path: `/page-${pad(i)}`,
+      favicon: `/icons/icon-${pad(i)}.ico`,
+      themeColor: `#00${pad(i)}`,
+      ogImage: `https://cdn.example.com/share-${pad(i)}.png`,
+    }));
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("skipped");
+    expect(check.message).toContain(`${Math.round(ASSET_NORM_MIN_AGREEMENT * 100)}%`);
+  });
+
+  test("a page that declares nothing is never a deviant", async () => {
+    // Half the corpus ships no chrome at all — that is core/favicon's finding,
+    // not this rule's, and the declaring half is uniform.
+    const specs = [...uniformSite(12), ...template(12, (i) => ({ path: `/bare-${pad(i)}` }))];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    expect(check.value).toBe(12);
+  });
+
+  test("non-2xx pages never vote", async () => {
+    const specs = [
+      ...uniformSite(12),
+      ...template(6, (i) => ({
+        path: `/gone-${pad(i)}`,
+        status: 404,
+        favicon: "/error-favicon.ico",
+        themeColor: "#ff0000",
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+  });
+});
+
+describe("social/asset-divergence — no false positives on per-page OG images", () => {
+  test("articles and products with their own OG image do not flag", async () => {
+    // The exact shape the issue warns about: a uniform default on the marketing
+    // pages, a distinct share image on every article and product.
+    const specs = [
+      ...uniformSite(12),
+      ...template(10, (i) => ({
+        path: `/blog/post-${pad(i)}`,
+        pageType: "article",
+        favicon: "/favicon.ico",
+        themeColor: "#0a5c36",
+        ogImage: `https://cdn.example.com/posts/post-${pad(i)}.png`,
+      })),
+      ...template(10, (i) => ({
+        path: `/shop/item-${pad(i)}`,
+        pageType: "product",
+        favicon: "/favicon.ico",
+        themeColor: "#0a5c36",
+        ogImage: `https://cdn.example.com/products/item-${pad(i)}.png`,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    // Their favicon/theme-color still count — chrome is uniform even on an article.
+    expect(check.value).toBe(32);
+    const norms = (check.details as { norms: Array<{ dimension: string }> }).norms;
+    expect(norms.map((n) => n.dimension)).toEqual(["favicon", "theme-color", "og-image"]);
+  });
+
+  test("a bespoke OG image on an untyped page does not flag", async () => {
+    // Found replaying the rule over a stored crawl of openelectricity.org.au: a
+    // site can ship a per-page preview image on pages the classifier calls
+    // "unknown", which the page-type exemption alone would not cover. A value
+    // carried by exactly ONE page is a per-page asset, not a template.
+    const specs = [
+      ...uniformSite(20),
+      ...template(6, (i) => ({
+        path: `/records/${pad(i)}`,
+        favicon: "/favicon.ico",
+        themeColor: "#0a5c36",
+        ogImage: `https://cdn.example.com/previews/records-${pad(i)}.png`,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("pass");
+    // The 6 one-off images neither vote nor are judged on the OG axis.
+    const norms = (check.details as { norms: Array<{ dimension: string; pages: number }> }).norms;
+    expect(norms.find((n) => n.dimension === "og-image")?.pages).toBe(20);
+    expect(check.value).toBe(26);
+  });
+
+  test("an article whose favicon drifts is still flagged", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template(2, (i) => ({
+        path: `/blog/post-${pad(i)}`,
+        pageType: "article",
+        favicon: "/old-favicon.ico",
+        themeColor: "#0a5c36",
+        ogImage: `https://cdn.example.com/posts/post-${pad(i)}.png`,
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(itemFor(check, "favicon")?.meta?.value).toBe("https://example.com/old-favicon.ico");
+    expect(itemFor(check, "og-image")).toBeUndefined();
+  });
+});
+
+describe("social/asset-divergence — findings", () => {
+  test("warns on a small pocket of pages with a stale favicon", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template(2, (i) => ({
+        path: `/legacy/page-${pad(i)}`,
+        favicon: "/old/favicon.ico",
+        themeColor: "#0a5c36",
+        ogImage: "https://cdn.example.com/default-share.png",
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(check.value).toBe(2);
+    const item = itemFor(check, "favicon");
+    expect(item?.meta?.norm).toBe("https://example.com/favicon.ico");
+    expect(item?.meta?.pageCount).toBe(2);
+    expect(item?.sourcePages).toEqual([
+      "https://example.com/legacy/page-000",
+      "https://example.com/legacy/page-001",
+    ]);
+  });
+
+  test("fails when the divergent pocket is large enough", async () => {
+    const stale = 6; // 6/26 == 23% >= the fail share
+    const specs = [
+      ...uniformSite(20),
+      ...template(stale, (i) => ({
+        path: `/legacy/page-${pad(i)}`,
+        favicon: "/old/favicon.ico",
+        themeColor: "#123456",
+        ogImage: "https://cdn.example.com/old-share.png",
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("fail");
+    expect(stale / (20 + stale)).toBeGreaterThanOrEqual(ASSET_NORM_FAIL_SHARE);
+    // One item per axis, all three named.
+    expect(check.items?.map((i) => i.meta?.dimension).sort()).toEqual([
+      "favicon",
+      "og-image",
+      "theme-color",
+    ]);
+  });
+
+  test("reports a theme-color that drifted on its own", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template(3, (i) => ({
+        path: `/support/page-${pad(i)}`,
+        favicon: "/favicon.ico",
+        themeColor: "#FFFFFF",
+        ogImage: "https://cdn.example.com/default-share.png",
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(check.items).toHaveLength(1);
+    // Lowercased on the way in, so "#FFFFFF" and "#ffffff" are ONE value.
+    expect(itemFor(check, "theme-color")?.meta?.value).toBe("#ffffff");
+  });
+
+  test("reports a divergent DEFAULT og:image on non-article pages", async () => {
+    const specs = [
+      ...uniformSite(20),
+      ...template(3, (i) => ({
+        path: `/landing/page-${pad(i)}`,
+        favicon: "/favicon.ico",
+        themeColor: "#0a5c36",
+        ogImage: "https://cdn.example.com/old-brand-share.png",
+      })),
+    ];
+    const check = await bothPaths(specs);
+    expect(check.status).toBe("warn");
+    expect(itemFor(check, "og-image")?.meta?.norm).toBe(
+      "https://cdn.example.com/default-share.png"
+    );
+  });
+
+  test("passes a site whose chrome is uniform", async () => {
+    const check = await bothPaths(uniformSite(20));
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("favicon, theme-color and default OG image");
+    expect(check.items).toBeUndefined();
+  });
+});
+
+describe("social/asset-divergence — extraction", () => {
+  const chrome = (head: string, base = "https://example.com/a/b") =>
+    extractSiteChromeSignal(parsedFor({ path: "/a/b", head }), base);
+
+  test("resolves a root-relative favicon so depth does not matter", () => {
+    expect(chrome('<link rel="icon" href="/favicon.ico">').faviconHref).toBe(
+      "https://example.com/favicon.ico"
+    );
+  });
+
+  test("apple-touch and mask icons never stand in for the favicon", () => {
+    const signal = chrome(
+      '<link rel="apple-touch-icon" href="/touch.png"><link rel="mask-icon" href="/mask.svg">' +
+        '<link rel="shortcut icon" href="/real.ico">'
+    );
+    expect(signal.faviconHref).toBe("https://example.com/real.ico");
+  });
+
+  test("a light/dark theme-color pair reads as the unscoped declaration", () => {
+    const signal = chrome(
+      '<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">' +
+        '<meta name="theme-color" content="#0a5c36">'
+    );
+    expect(signal.themeColor).toBe("#0a5c36");
+  });
+
+  test("a media-scoped-only page falls back to its first declaration", () => {
+    const signal = chrome(
+      '<meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)">' +
+        '<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">'
+    );
+    expect(signal.themeColor).toBe("#ffffff");
+  });
+
+  test("absent assets read as null, not empty strings", () => {
+    const signal = chrome('<link rel="icon" href="">');
+    expect(signal).toEqual({ faviconHref: null, themeColor: null, ogImage: null });
+  });
+});

--- a/packages/rules/tests/core-canonical-form-drift.test.ts
+++ b/packages/rules/tests/core-canonical-form-drift.test.ts
@@ -95,6 +95,9 @@ function featureRow(spec: PageSpec, i: number): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
   };
 }
 

--- a/packages/rules/tests/schema-coverage-outlier.test.ts
+++ b/packages/rules/tests/schema-coverage-outlier.test.ts
@@ -94,6 +94,9 @@ function featureRow(spec: PageSpec, i: number): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
   };
 }
 

--- a/packages/rules/tests/slug-convention.test.ts
+++ b/packages/rules/tests/slug-convention.test.ts
@@ -93,6 +93,9 @@ function featureRow(spec: PageSpec): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
   };
 }
 

--- a/packages/rules/tests/thin-vs-site-norm.test.ts
+++ b/packages/rules/tests/thin-vs-site-norm.test.ts
@@ -89,6 +89,9 @@ function featureRow(spec: PageSpec, i: number): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
   };
 }
 

--- a/packages/rules/tests/title-pattern-outlier.test.ts
+++ b/packages/rules/tests/title-pattern-outlier.test.ts
@@ -93,6 +93,9 @@ function featureRow(spec: PageSpec): PageFeatureRow {
     napAddressFormat: null,
     napTelLink: false,
     napMailtoLink: false,
+    faviconHref: null,
+    themeColor: null,
+    ogImage: null,
   };
 }
 


### PR DESCRIPTION
New site-wide rule `social/asset-divergence`: the favicon, the `theme-color` and the fallback OG image all come from one layout, so a pocket of pages carrying different ones is a stale template rather than a per-page decision. Nothing about such a page looks wrong on its own, which is why no per-page rule can see it.

Private-repo issue: squirrelscan/repo#1371.

## What it does

Three axes, each judged against the site's own modal value, only the minority form reported:

| Axis | Read from |
|---|---|
| favicon | first `<link rel="icon">` href, resolved absolute (apple-touch/mask icons never stand in) |
| theme-color | `<meta name="theme-color">` content (an unscoped declaration wins over a light/dark `media` pair) |
| default OG image | `og:image`, on the pages that should share one |

## Precision guards

- 10-page crawl floor; 10-page per-axis sample floor; 70% modal agreement, else the axis is not judged and the rule emits one `skipped` check.
- A page that declares nothing never votes and is never a deviant — a missing favicon belongs to `core/favicon`, a missing share image to the Open Graph rules.
- **The OG axis excludes per-page images two ways**: article/product/recipe/event/profile/media page types, *and* any `og:image` carried by exactly one page. The second one came out of replaying the rule over stored real crawls — sites ship bespoke preview images on pages the classifier calls "unknown", which the page-type exemption alone would not cover. A fallback is by definition shared; a stale template always brings its whole pocket of pages with it.

## Dual path

`ctx.siteQuery` streams the three scalars off `page_features`; the legacy `ctx.site.pages` path re-derives them through the SAME exported extractor `extractPageFeatures` calls. One accumulator, one check builder, every list sorted before it is emitted — byte-identical by construction, following `content/duplicate-title` (#1021/#1022).

Storage: three additive `PageFeatureRow` columns (`favicon_href`, `theme_color`, `og_image`) in the fresh-install schema AND an append-only schema-version 21 migration. Local sqlite only, no prod migration, existing versions untouched.

## Scoring density

One site-wide check, weight 3, items capped at 10 groups / 10 urls, warn below a 20% deviant share and fail at or above it. On the canonical 518-page fixture the health score is **unmoved at 48**; `findings` moves 98216 → 98217 (one site-scoped check) and `perRuleTally` 272 → 273.

## Tests

- `packages/rules/tests/asset-divergence.test.ts` — 18 tests: pass / warn / fail / skipped (under-floor, too-few-declaring, no-clear-norm), the no-false-positive fixtures (articles + products with their own share image over a uniform default; a bespoke one-off image on an untyped page), and the extraction edge cases. Every fixture runs BOTH paths and asserts `toEqual` **and** `JSON.stringify` equality.
- `packages/audit-engine/tests/site-query-asset-divergence-golden.test.ts` — the full chain (`parsePage` → `extractPageFeatures` → v21 columns → `createSiteQuery` → streaming branch) against one seeded fixture, with the siteQuery run given empty `site.pages`; plus a pin that both parse paths (`parsePage` and `parseHtmlForRules`) yield the same signal.
- `packages/crawler/tests/page-features-store.test.ts` — round-trip of the three columns, nulls, and the v21 columns on BOTH the fresh-install and migration paths.

## Real-corpus smoke

Replayed over 7 stored crawls (sweetdeals.com.au, openelectricity.org.au, nikcub.me, gohugo.io, httpd.apache.org, digitalpages.com.au, sweetgreen.com): **zero findings, zero false positives** — each correctly `skipped` for want of a norm. openelectricity is the instructive one: 100 pages declare an `og:image` and 95 of them are unique to their page, so nothing there is a deviant.

## Checks

- root `bun test`: 4132 pass, 0 fail
- `bun run test:engine` (golden gates incl. the 518-page v1↔v2 canonical merge gate): 52 pass, 0 fail
- `bun run typecheck`, `bun run lint`, `bun run format:check`, `docs/ bun run check`: clean
