### PR TITLE
fix(rules): links/anchor-text evaluates links per target, not per link

### DIFF
--- a/docs/rules/links/anchor-text.mdx
+++ b/docs/rules/links/anchor-text.mdx
@@ -15,7 +15,20 @@ Checks for empty or generic anchor text
 
 ## Solution
 
-Descriptive anchor text helps users and search engines understand link destinations. Avoid generic text like 'click here' or 'read more'. Use natural language that describes the target page. For accessibility, anchor text should make sense out of context. Avoid overly long anchor text or keyword stuffing.
+Descriptive anchor text helps users and search engines understand link destinations. Avoid generic text like 'click here' or 'read more'. Use natural language that describes the target page. For accessibility, anchor text should make sense out of context. Avoid overly long anchor text or keyword stuffing. When a card links to the same target more than once (e.g. an image link and a headline link), only one of those links needs descriptive text — the group is evaluated together, not link by link.
+
+## How this rule evaluates links
+
+This rule groups a page's outgoing links by resolved target URL before evaluating them, rather than scoring every `<a>` tag on its own. That matters for the common card pattern — an image link, a headline link, and a "Read more" link all pointing at the same destination — where the headline already names the target and the other two links are intentionally redundant.
+
+A target group is flagged as:
+
+- **`empty-anchor`** only when *no* link in the group carries any accessible name (text content, image `alt`, `aria-label`, `aria-labelledby`, `title`, or an accessible SVG name).
+- **`generic-anchor`** only when *every* link in the group uses generic text (e.g. "read more", "click here") and none carries a descriptive accessible name.
+
+A group with at least one descriptively-labeled link passes, even if its sibling links (an image wrapper, a "Read more" affordance) are empty or generic.
+
+Note this is narrower than it sounds: a genuinely empty single link, or a card where every link is empty or generic, is still reported. If you need to flag empty links in the tab order regardless of sibling context, that's an accessibility concern handled by the `a11y` category — this rule is an SEO check on whether the destination is described.
 
 ## Enable / Disable
 

--- a/packages/rules/src/links/anchor-text.ts
+++ b/packages/rules/src/links/anchor-text.ts
@@ -22,13 +22,53 @@ const GENERIC_ANCHORS = [
   "continue",
 ];
 
+function hasAccessibleName(link: Element, doc: Document): boolean {
+  const text = link.textContent?.trim() || "";
+  const hasImage = link.querySelector("img");
+  const imageAlt = hasImage?.getAttribute("alt") || "";
+  if (text || imageAlt) return true;
+
+  const ariaLabel = link.getAttribute("aria-label")?.trim();
+  if (ariaLabel) return true;
+
+  const labelledBy = link.getAttribute("aria-labelledby");
+  if (labelledBy) {
+    const ids = labelledBy.split(/\s+/);
+    const hasLabel = ids.some((id) => {
+      const el = doc.getElementById(id);
+      return el?.textContent?.trim();
+    });
+    if (hasLabel) return true;
+  }
+
+  const title = link.getAttribute("title")?.trim();
+  if (title) return true;
+
+  const svg = link.querySelector("svg");
+  if (svg) {
+    const svgTitle = svg.querySelector("title")?.textContent?.trim();
+    const svgAriaLabel = svg.getAttribute("aria-label")?.trim();
+    if (svgTitle || svgAriaLabel) return true;
+  }
+
+  const roleImg = link.querySelector('[role="img"]');
+  if (roleImg?.getAttribute("aria-label")?.trim()) return true;
+
+  return false;
+}
+
+function isGeneric(link: Element): boolean {
+  const text = link.textContent?.trim().toLowerCase() || "";
+  return GENERIC_ANCHORS.includes(text);
+}
+
 export const anchorTextRule: Rule = {
   meta: {
     id: "links/anchor-text",
     name: "Anchor Text",
     description: "Checks for empty or generic anchor text",
     solution:
-      "Descriptive anchor text helps users and search engines understand link destinations. Avoid generic text like 'click here' or 'read more'. Use natural language that describes the target page. For accessibility, anchor text should make sense out of context. Avoid overly long anchor text or keyword stuffing.",
+      "Descriptive anchor text helps users and search engines understand link destinations. Avoid generic text like 'click here' or 'read more'. Use natural language that describes the target page. For accessibility, anchor text should make sense out of context. Avoid overly long anchor text or keyword stuffing. When a card links to the same target more than once (e.g. an image link and a headline link), only one of those links needs descriptive text — the group is evaluated together, not link by link.",
     category: "links",
     scope: "page",
     severity: "warning",
@@ -41,66 +81,52 @@ export const anchorTextRule: Rule = {
     if (!doc) return { checks: [] };
 
     const links = doc.querySelectorAll("a[href]");
-    const emptyAnchors: Array<{ href: string; snippet: string }> = [];
-    const genericAnchors: string[] = [];
+
+    // Group links by resolved target URL so redundant links to the same
+    // destination (image + headline + "Read more") are evaluated as one unit.
+    const groups = new Map<string, Element[]>();
 
     for (const link of links) {
       const href = link.getAttribute("href");
       if (!href) continue;
-
-      // Skip anchor-only links
       if (href.startsWith("#")) continue;
 
-      // Get text content, excluding images
-      const text = link.textContent?.trim() || "";
-      const hasImage = link.querySelector("img");
-      const imageAlt = hasImage?.getAttribute("alt") || "";
+      let target: string;
+      try {
+        target = new URL(href, ctx.page.url).href;
+      } catch {
+        target = href;
+      }
 
-      // Check for empty anchor
-      if (!text && !imageAlt) {
-        // Check aria-label on <a>
-        const ariaLabel = link.getAttribute("aria-label")?.trim();
-        if (ariaLabel) continue;
+      const group = groups.get(target);
+      if (group) group.push(link);
+      else groups.set(target, [link]);
+    }
 
-        // Check aria-labelledby on <a>
-        const labelledBy = link.getAttribute("aria-labelledby");
-        if (labelledBy) {
-          const ids = labelledBy.split(/\s+/);
-          const hasLabel = ids.some((id) => {
-            const el = doc.getElementById(id);
-            return el?.textContent?.trim();
-          });
-          if (hasLabel) continue;
-        }
+    const emptyAnchors: Array<{ href: string; snippet: string }> = [];
+    const genericAnchors: string[] = [];
 
-        // Check title on <a>
-        const title = link.getAttribute("title")?.trim();
-        if (title) continue;
+    for (const [target, groupLinks] of groups) {
+      // A group passes if any member carries a descriptive (non-generic) accessible name.
+      const hasDescriptiveLink = groupLinks.some(
+        (link) => hasAccessibleName(link, doc) && !isGeneric(link),
+      );
+      if (hasDescriptiveLink) continue;
 
-        // Check SVG with accessible name
-        const svg = link.querySelector("svg");
-        if (svg) {
-          const svgTitle = svg.querySelector("title")?.textContent?.trim();
-          const svgAriaLabel = svg.getAttribute("aria-label")?.trim();
-          if (svgTitle || svgAriaLabel) continue;
-        }
+      const anyAccessible = groupLinks.some((link) => hasAccessibleName(link, doc));
 
-        // Check role="img" with aria-label
-        const roleImg = link.querySelector('[role="img"]');
-        if (roleImg?.getAttribute("aria-label")?.trim()) continue;
-
+      if (!anyAccessible) {
+        const first = groupLinks[0];
         emptyAnchors.push({
-          href,
-          snippet: truncateHtml(link.outerHTML),
+          href: target,
+          snippet: truncateHtml(first.outerHTML),
         });
         continue;
       }
 
-      // Check for generic anchor text
-      const anchor = text.toLowerCase();
-      if (GENERIC_ANCHORS.includes(anchor)) {
-        genericAnchors.push(`"${text}"`);
-      }
+      const genericLink = groupLinks.find((link) => isGeneric(link));
+      const text = genericLink?.textContent?.trim() || "";
+      genericAnchors.push(`"${text}"`);
     }
 
     if (emptyAnchors.length > 0) {

--- a/packages/rules/tests/anchor-text.test.ts
+++ b/packages/rules/tests/anchor-text.test.ts
@@ -1,0 +1,92 @@
+// links/anchor-text — per-target grouping (#104): a card with an image link,
+// a headline link, and a "Read more" link to the same target is one unit,
+// not three findings.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "linkedom";
+
+import { anchorTextRule } from "../src/links/anchor-text";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+function ctx(html: string): RuleContext {
+  const doc = parseHTML(html).document;
+  return {
+    page: { url: "https://example.com/", html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: { document: doc } as unknown as ParsedPage,
+    options: {},
+  } as unknown as RuleContext;
+}
+
+function run(html: string) {
+  return anchorTextRule.run(ctx(html)).checks;
+}
+
+describe("links/anchor-text", () => {
+  test("descriptive standalone link passes", () => {
+    const checks = run('<a href="/repairs">Commercial freezer repairs</a>');
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("anchor-text");
+    expect(checks[0].status).toBe("pass");
+  });
+
+  test("card pattern: image link + descriptive headline + read-more, all to the same target — no findings", () => {
+    const checks = run(`
+      <div class="card">
+        <a href="/repairs"><img alt=""></a>
+        <a href="/repairs">Commercial freezer repairs</a>
+        <a href="/repairs">Read more</a>
+      </div>
+    `);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("anchor-text");
+    expect(checks[0].status).toBe("pass");
+  });
+
+  test("single empty-alt image link with no sibling to the same target — still reported", () => {
+    const checks = run('<a href="/repairs"><img alt=""></a>');
+    const empty = checks.find((c) => c.name === "empty-anchor");
+    expect(empty).toBeDefined();
+    expect(empty?.status).toBe("warn");
+    expect(empty?.items).toHaveLength(1);
+  });
+
+  test("card where every link is empty or generic — reported once, not three times", () => {
+    const checks = run(`
+      <div class="card">
+        <a href="/widgets"><img alt=""></a>
+        <a href="/widgets">Read more</a>
+        <a href="/widgets">Click here</a>
+      </div>
+    `);
+    const generic = checks.find((c) => c.name === "generic-anchor");
+    expect(generic).toBeDefined();
+    expect(generic?.items).toHaveLength(1);
+    expect(checks.find((c) => c.name === "empty-anchor")).toBeUndefined();
+  });
+
+  test("different targets are evaluated independently", () => {
+    const checks = run(`
+      <a href="/a"><img alt=""></a>
+      <a href="/b">Read more</a>
+    `);
+    const empty = checks.find((c) => c.name === "empty-anchor");
+    const generic = checks.find((c) => c.name === "generic-anchor");
+    expect(empty?.items).toHaveLength(1);
+    expect(generic?.items).toHaveLength(1);
+  });
+
+  test("accessible name via aria-label counts toward the group", () => {
+    const checks = run(`
+      <a href="/repairs" aria-label="Commercial freezer repairs"><img alt=""></a>
+      <a href="/repairs">Read more</a>
+    `);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("anchor-text");
+  });
+
+  test("anchor-only links are ignored", () => {
+    const checks = run('<a href="#section"></a>');
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("anchor-text");
+  });
+});


### PR DESCRIPTION
Closes #104

`links/anchor-text` used to score every `<a>` tag independently, so the standard card pattern (image link + headline link + "Read more" link, all pointing at the same target) produced two findings even though the headline already names the destination.

This groups a page's outgoing links by resolved target URL and evaluates the group: a target passes if any member carries a descriptive accessible name (text, image `alt`, `aria-label`, `aria-labelledby`, `title`, or an accessible SVG name).

## Acceptance Criteria
- [x] `links/anchor-text` groups a page's outgoing links by resolved target URL before evaluating
- [x] A target group is reported as `empty-anchor` only when NO link in the group carries any accessible name
- [x] A target group is reported as `generic-anchor` only when EVERY link in the group has generic text
- [x] Findings are deduplicated per target: one card produces at most one item
- [x] Fixture: card with image/headline/"Read more" links to the same URL — no findings
- [x] Fixture: single empty-alt image link with no sibling — still reported as `empty-anchor`
- [x] Fixture: card where all three links are empty or generic — reported once, not three times
- [x] Existing tests updated, regression test asserts multi-link card yields zero findings
- [x] Docs rule page for `links/anchor-text` updated in `docs/`

## Test plan
- [ ] `bun run typecheck` (packages/rules)
- [ ] `bun test tests` (packages/rules) — new `tests/anchor-text.test.ts` covers the grouping logic

Note: this sandboxed session could not execute `bun` directly (blocked by session permissions), so tests were written and reasoned through but not run locally — CI should verify.