### PR TITLE
feat(rules): add schema/rating-scope, AggregateRating that is not about its page (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **272 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **273 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler 
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more 
@@ -46,7 +46,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Content | 17 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | Performance | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | Images | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
-| Structured Data | 11 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search |
+| Structured Data | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus rating markup that is not about the page it sits on |
 | Accessibility | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | Mobile | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
 | Social Media | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 272 rules across 21 categories**
+**Total: 273 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -260,6 +260,7 @@
                   "rules/schema/organization",
                   "rules/schema/video",
                   "rules/schema/review",
+                  "rules/schema/rating-scope",
                   "rules/schema/coverage-outlier"
                 ]
               },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="272 Rules, 21 Categories"
+    title="273 Rules, 21 Categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **272 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **273 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -229,7 +229,7 @@ squirrelscan runs **272 rules** across **21 categories**, plus opt-in cloud gap 
 | **Content** | 17 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | **Performance** | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
-| **Structured Data** | 11 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have |
+| **Structured Data** | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have and rating markup that is not about the page it sits on |
 | **Accessibility** | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
 | **Mobile** | 6 | Viewport configuration, tap-target size, legible font sizes, horizontal scroll, blocked zoom, intrusive interstitials |
 | **Social Media** | 4 | Open Graph and Twitter Card completeness, image dimensions, canonical URL match, social profile links |
@@ -242,7 +242,7 @@ squirrelscan runs **272 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 272 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 273 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 272 audit rules organized by score group and category"
+description: "All 273 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **272 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **273 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -26,7 +26,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Text quality, readability, and content structure (17 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
-    Structured data and rich snippet eligibility (11 rules)
+    Structured data and rich snippet eligibility (12 rules)
   </Card>
   <Card title="Images" icon="folder" href="/rules/images">
     Image optimization and accessibility (15 rules)

--- a/docs/rules/schema/index.mdx
+++ b/docs/rules/schema/index.mdx
@@ -29,6 +29,9 @@ Structured data and rich snippet eligibility
   <Card title="Product Schema" icon="triangle-exclamation" href="/rules/schema/product">
     Validates Product schema for e-commerce
   </Card>
+  <Card title="Rating Scope" icon="triangle-exclamation" href="/rules/schema/rating-scope">
+    Finds AggregateRating markup that is not about the page it sits on, or that no reader can see
+  </Card>
   <Card title="Review Schema" icon="triangle-exclamation" href="/rules/schema/review">
     Validates Review and AggregateRating schema
   </Card>

--- a/docs/rules/schema/rating-scope.mdx
+++ b/docs/rules/schema/rating-scope.mdx
@@ -1,0 +1,94 @@
+---
+title: "Rating Scope"
+description: "Finds AggregateRating markup that is not about the page it sits on, or that no reader can see"
+---
+
+Finds AggregateRating markup that is not about the page it sits on, or that no reader can see
+
+| | |
+|---|---|
+| **Rule ID** | `schema/rating-scope` |
+| **Category** | [Structured Data](/rules/schema) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 4/10 |
+
+## How it works
+
+[Review Schema](/rules/schema/review) checks the *shape* of `AggregateRating`: does it have a
+`ratingValue`, does it have a `ratingCount` or `reviewCount`. A single sitewide rating block
+emitted by a template satisfies all of that on every page of the site — including the privacy
+policy, the terms page and every blog post. This rule asks the two questions the shape check
+cannot:
+
+1. **Can a reader see a rating on this page at all?** Google requires the rating to be visible in
+   the page content. Rating markup that exists only in the JSON-LD is a structured-data policy
+   violation, not a validation error, and it is the classic cause of a manual action.
+2. **Is the rated entity the subject of this page?** A `LocalBusiness` rating attached to a
+   privacy policy, a terms page or a blog post is a rating of the site, not of the page carrying
+   it.
+
+Repetition on its own is deliberately **not** the signal. On a legitimate local-business site the
+review badge really is on screen on most pages, and the rating really is about the business the
+page is about — a rule that fired on "AggregateRating appears on many pages" would flag every one
+of them. What is reported is the relationship between the rating and the page it sits on.
+
+The rule stays quiet unless it has grounds to speak:
+
+- A page with no `AggregateRating` produces no output at all.
+- A rating visible anywhere in the rendered page text clears the visibility check — a star badge
+  (`★★★★★ 4.9`), "4.9 out of 5", "18 reviews", a decimal rating printed in the copy, or the same
+  wording in `alt` / `aria-label` / `title` text.
+- A third-party review widget (Trustpilot, Yotpo, Judge.me, Elfsight and friends) renders its
+  badge client-side, so the rating is legitimately absent from a raw-HTML crawl. Its presence
+  clears the visibility check rather than accusing the page.
+- The subject check runs only on page types where a rating cannot be about the page: privacy
+  policies, terms pages and articles or blog posts. Everything else — homepages, location pages,
+  product pages, category pages — is left alone.
+- On an article the subject check reports only a rating attached to the site's own business or
+  organization entity. An article that reviews a `Product` legitimately carries that product's
+  rating.
+
+Each finding names the page type and the rated entity, so it reads as "this `LocalBusiness` rating
+is on your privacy policy", not as a missing field.
+
+## Solution
+
+`AggregateRating` must describe the thing **this** page is about, and the rating has to be visible
+to the reader in the page content. A single sitewide rating emitted by a template lands on pages
+that cannot be rated, where it becomes a self-serving rating of the site rather than markup about
+the page.
+
+Google treats invisible or off-topic rating markup as a structured-data policy violation and
+issues manual actions for it, which costs the whole site its rich results — not just the page that
+was flagged.
+
+- Move the rating onto the pages whose subject it actually describes: the `LocalBusiness` on the
+  homepage and location pages, the `Product` on its own product page.
+- Drop the rating block from templates that render legal pages and blog posts.
+- Where a page keeps the markup, make sure the same rating is on screen for readers, with the same
+  value the markup claims.
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["schema/rating-scope"]
+```
+
+### Disable all Structured Data rules
+
+```toml squirrel.toml
+[rules]
+disable = ["schema/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["schema/rating-scope"]
+disable = ["*"]
+```

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -78,15 +78,18 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // own single whole-crawl check (#1366).
       // 98215 -> 98216: content/title-pattern-outlier, likewise site-scoped, adds
       // its own single whole-crawl check (#1361).
+      // Unmoved by schema/rating-scope (#106): it is page-scoped but speaks ONLY
+      // when a page carries an AggregateRating, and the fixture emits no JSON-LD
+      // at all — so it contributes a tally key below without a single finding.
       expect(v1.findings.length).toBe(98216);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
       // schema/coverage-outlier, 269 -> 270 url/slug-convention, 270 -> 271
-      // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier;
-      // anything else means a rule id leaked in, so fix that rather than this
-      // number.
-      expect(v1.perRuleTally.length).toBe(272);
+      // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier,
+      // 272 -> 273 schema/rating-scope; anything else means a rule id leaked in,
+      // so fix that rather than this number.
+      expect(v1.perRuleTally.length).toBe(273);
     },
     180_000,
   );

--- a/packages/rules/src/schema/index.ts
+++ b/packages/rules/src/schema/index.ts
@@ -10,6 +10,7 @@ import { jsonLdValidRule } from "./json-ld-valid";
 import { localBusinessSchemaRule } from "./local-business";
 import { organizationSchemaRule } from "./organization";
 import { productSchemaRule } from "./product";
+import { ratingScopeRule } from "./rating-scope";
 import { reviewSchemaRule } from "./review";
 import { videoSchemaRule } from "./video";
 import { websiteSearchSchemaRule } from "./website-search";
@@ -25,6 +26,7 @@ export const rules: Rule[] = [
   organizationSchemaRule,
   videoSchemaRule,
   reviewSchemaRule,
+  ratingScopeRule,
   schemaCoverageOutlierRule,
 ];
 
@@ -36,6 +38,7 @@ export {
   localBusinessSchemaRule,
   organizationSchemaRule,
   productSchemaRule,
+  ratingScopeRule,
   reviewSchemaRule,
   schemaCoverageOutlierRule,
   videoSchemaRule,

--- a/packages/rules/src/schema/rating-scope.ts
+++ b/packages/rules/src/schema/rating-scope.ts
@@ -1,0 +1,507 @@
+// schema/rating-scope - AggregateRating that is not about the page it sits on (#106)
+//
+// schema/review validates the SHAPE of AggregateRating (ratingValue, ratingCount)
+// and nothing else, so a single sitewide "5/5 from 18 reviews" block emitted by a
+// template passes on every page of the site — including the privacy policy. This
+// rule asks the two questions the shape check cannot:
+//
+//   1. Can a reader see a rating on this page at all? Google requires the rating
+//      to be visible in the page content; markup-only ratings are the classic
+//      structured-data manual action, not a validation error.
+//   2. Is the rated entity the subject of THIS page? A LocalBusiness rating on a
+//      privacy policy, a terms page or a blog post is about the site, not the
+//      page it is attached to.
+//
+// The honest half (#106): "AggregateRating appears on many pages" is NOT the
+// signal. On most pages of a legitimate LocalBusiness site the review badge is
+// genuinely on screen and the rating really is about the business the page is
+// about — flagging repetition would flag every one of them. The signal is the
+// RELATIONSHIP between the rating and the page, which is why both checks are
+// page-local: a visible rating anywhere on the page clears the visibility check,
+// and only page types where a rating cannot apply (privacy, terms, article) can
+// fail the subject check.
+//
+// Deliberately conservative:
+//   - A third-party review widget (Trustpilot, Yotpo, Judge.me, ...) means the
+//     badge is rendered client-side, so a raw-HTML crawl cannot see it. Presence
+//     of a widget clears the visibility check rather than accusing the page.
+//   - On article pages only a BUSINESS/organization carrier is reported. An
+//     article that reviews a Product legitimately carries that Product's rating,
+//     so a non-business carrier is left alone.
+//   - Structural validity is untouched: schema/review still owns ratingValue /
+//     ratingCount and its messages are unchanged.
+
+import { getPathname } from "@squirrelscan/utils";
+import { EEAT_PAGE_PATTERNS, LOCAL_BUSINESS_TYPES } from "@squirrelscan/utils/constants";
+
+import type { Document } from "linkedom";
+
+import type { CheckItem } from "@squirrelscan/core-contracts";
+
+import { isPrivacyPage } from "../shared/privacy-page";
+import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
+
+const VISIBILITY_CHECK = "rating-visible";
+const SUBJECT_CHECK = "rating-subject";
+
+/** Cap on entities listed per check, so one listing page cannot spray a report. */
+const MAX_ITEMS = 10;
+
+/** Depth cap for the carrier walk — JSON-LD nests, adversarial JSON-LD nests a lot. */
+const MAX_DEPTH = 6;
+
+/**
+ * Carrier @types that represent the SITE's own entity rather than the subject of
+ * an individual page. A rating hanging off one of these on an article/blog post
+ * is the sitewide review badge, not a rating of that post.
+ */
+const BUSINESS_CARRIER_TYPES = new Set(
+  [
+    ...LOCAL_BUSINESS_TYPES,
+    "Organization",
+    "Corporation",
+    "OnlineBusiness",
+    "OnlineStore",
+    "NGO",
+    "EducationalOrganization",
+    "GovernmentOrganization",
+    "PerformingGroup",
+    "SportsOrganization",
+    "Brand",
+    "WebSite",
+    "WebPage",
+  ].map((t) => t.toLowerCase()),
+);
+
+/** Page kinds on which a rating cannot be about the page's subject. */
+type IneligiblePageKind = "privacy" | "terms" | "article";
+
+const PAGE_KIND_LABEL: Record<IneligiblePageKind, string> = {
+  privacy: "privacy policy",
+  terms: "terms",
+  article: "article",
+};
+
+/** A rating found on the page, with the entity it is attached to. */
+interface RatedEntity {
+  /** Carrier @type as authored ("LocalBusiness", "AutoRepair", ...), or null. */
+  type: string | null;
+  /** Every carrier @type, lowercased — generators array-wrap @type freely. */
+  types: string[];
+  /** Carrier `name`, or null when the markup does not name the entity. */
+  name: string | null;
+  ratingValue: string | null;
+  ratingCount: string | null;
+}
+
+/** Star glyphs — a rendered badge is often glyphs plus a number. */
+const STAR_GLYPH_RE = /[★☆⭐✩✪✭✮]/;
+
+/**
+ * Rating phrasings a reader would recognize: "4.9 / 5", "4.9 out of 5",
+ * "4.9 stars", "rated 4.9", "18 reviews". Matching ANY of these clears the
+ * visibility check — a false "visible" is far cheaper than accusing a page that
+ * shows its rating in wording this rule did not anticipate.
+ */
+const VISIBLE_RATING_PATTERNS: RegExp[] = [
+  // Trailing `(?!\s*\/)` keeps a d/m/yyyy date ("1/5/2026") out of the match.
+  /\b\d(?:[.,]\d+)?\s*(?:\/|out\s+of)\s*(?:5|10)\b(?!\s*\/)/i,
+  /\b\d(?:[.,]\d+)?[\s-]*stars?\b/i,
+  // "note" is deliberately NOT here: "Note: updated March 2026" is boilerplate on
+  // exactly the legal pages this rule exists to catch.
+  /\b(?:rated|rating|bewertung|calificaci[oó]n)\b[^.\n]{0,24}?\d(?:[.,]\d+)?/i,
+  /\b\d{1,7}\s*\+?\s*(?:\w+\s+){0,2}(?:reviews?|ratings?)\b/i,
+];
+
+/**
+ * Third-party review platforms. Their badge is injected client-side, so on a
+ * raw-HTML crawl the rating is legitimately absent from the DOM text.
+ */
+const REVIEW_WIDGET_SRC_TOKENS = [
+  "trustpilot",
+  "trustindex",
+  "trustmary",
+  "reviews.io",
+  "reviewsio",
+  "reviewsonmywebsite",
+  "yotpo",
+  "judge.me",
+  "judgeme",
+  "feefo",
+  "birdeye",
+  "elfsight",
+  "shopperapproved",
+  "stamped.io",
+  "okendo",
+  "loox",
+  "junip",
+  "reputon",
+  "nicejob",
+  "podium",
+  "sitejabber",
+  "endorsal",
+  "sociablekit",
+];
+
+/** Placeholder containers the same widgets hydrate into. */
+const REVIEW_WIDGET_SELECTOR = [
+  ".trustpilot-widget",
+  ".ti-widget",
+  ".yotpo",
+  ".jdgm-widget",
+  ".stamped-container",
+  ".okendo-widget",
+  ".loox-reviews",
+  "[data-elfsight-app-lazy]",
+  "[data-yotpo-instance-id]",
+  "[data-reviews-io-widget]",
+].join(", ");
+
+export const ratingScopeRule: Rule = {
+  meta: {
+    id: "schema/rating-scope",
+    name: "Rating Scope",
+    description: "Checks AggregateRating is about the page's subject and visible to readers",
+    solution:
+      "AggregateRating must describe the thing THIS page is about, and the rating has to be visible to the reader in the page content. A single sitewide rating emitted by a template lands on pages that cannot be rated — privacy policies, terms, blog posts — where it is a self-serving rating of the site rather than markup about the page. Google treats invisible or off-topic rating markup as a structured-data policy violation and issues manual actions for it, which costs the whole site its rich results, not just this page. Move the rating onto the pages whose subject it actually describes (the LocalBusiness on the homepage or location pages, the Product on its product page) and make sure the same rating is on screen.",
+    category: "schema",
+    scope: "page",
+    severity: "warning",
+    weight: 4,
+    // A soft-404 page serves the site template (rating block included) for a URL
+    // that does not exist — don't argue about scope on a broken URL.
+    skipOnSoft404: true,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const doc = ctx.parsed.document;
+    if (!doc) return { checks: [] };
+
+    const entities = collectRatedEntities(ctx);
+    if (entities.length === 0) return { checks: [] };
+
+    const checks: CheckResult[] = [];
+    const kind = ineligiblePageKind(ctx);
+
+    checks.push(buildVisibilityCheck(ctx, doc, entities, pageLabel(ctx, kind)));
+    if (kind) checks.push(buildSubjectCheck(entities, kind));
+
+    return { checks };
+  },
+};
+
+// ============================================================================
+// Rating collection
+// ============================================================================
+
+/**
+ * Every AggregateRating on the page with the entity carrying it. Walks the
+ * parsed schema nodes (already `@graph`-flattened) because a rating is usually
+ * a property of a nested node, not a top-level one.
+ */
+function collectRatedEntities(ctx: RuleContext): RatedEntity[] {
+  const found: RatedEntity[] = [];
+  const seen = new Set<string>();
+
+  const push = (entity: RatedEntity): void => {
+    const key = `${entity.type}|${entity.name}|${entity.ratingValue}|${entity.ratingCount}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    found.push(entity);
+  };
+
+  for (const node of ctx.parsed.schemas.all) {
+    walkForRatings(node, null, 0, push);
+  }
+
+  return found;
+}
+
+/**
+ * Depth-bounded walk collecting `aggregateRating` properties and standalone
+ * `AggregateRating` nodes, attributing each to the nearest enclosing typed node.
+ */
+function walkForRatings(
+  value: unknown,
+  carrier: Record<string, unknown> | null,
+  depth: number,
+  push: (entity: RatedEntity) => void,
+): void {
+  if (depth > MAX_DEPTH || !value || typeof value !== "object") return;
+
+  if (Array.isArray(value)) {
+    for (const item of value) walkForRatings(item, carrier, depth + 1, push);
+    return;
+  }
+
+  const node = value as Record<string, unknown>;
+  const isRatingNode = typeNames(node).some((t) => t === "aggregaterating");
+  const nextCarrier = isRatingNode ? carrier : hasType(node) ? node : carrier;
+
+  if (isRatingNode) {
+    push(toEntity(nextCarrier, node));
+  } else if (node["aggregateRating"]) {
+    const rating = firstObject(node["aggregateRating"]);
+    if (rating) push(toEntity(node, rating));
+  }
+
+  for (const [key, child] of Object.entries(node)) {
+    if (key === "aggregateRating" || key.startsWith("@")) continue;
+    walkForRatings(child, nextCarrier, depth + 1, push);
+  }
+}
+
+function toEntity(
+  carrier: Record<string, unknown> | null,
+  rating: Record<string, unknown>,
+): RatedEntity {
+  return {
+    type: carrier ? (typeNames(carrier, false)[0] ?? null) : null,
+    types: carrier ? typeNames(carrier) : [],
+    name: carrier ? readString(carrier["name"]) : null,
+    ratingValue: readString(rating["ratingValue"]),
+    ratingCount: readString(rating["ratingCount"] ?? rating["reviewCount"]),
+  };
+}
+
+/** `@type` values, lowercased by default (some generators array-wrap @type). */
+function typeNames(node: Record<string, unknown>, lower = true): string[] {
+  const raw = node["@type"];
+  const list: unknown[] = Array.isArray(raw) ? (raw as unknown[]) : [raw];
+  return list
+    .filter((t): t is string => typeof t === "string" && t.length > 0)
+    .map((t) => (lower ? t.toLowerCase() : t));
+}
+
+function hasType(node: Record<string, unknown>): boolean {
+  return typeNames(node).length > 0;
+}
+
+/** Some generators array-wrap AggregateRating (#721); take the first object. */
+function firstObject(raw: unknown): Record<string, unknown> | null {
+  const candidate = Array.isArray(raw)
+    ? raw.find((r) => r && typeof r === "object" && !Array.isArray(r))
+    : raw;
+  return candidate && typeof candidate === "object"
+    ? (candidate as Record<string, unknown>)
+    : null;
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+// ============================================================================
+// Visibility
+// ============================================================================
+
+function buildVisibilityCheck(
+  ctx: RuleContext,
+  doc: Document,
+  entities: RatedEntity[],
+  label: string | null,
+): CheckResult {
+  if (hasReviewWidget(doc)) {
+    return {
+      name: VISIBILITY_CHECK,
+      status: "pass",
+      message: "AggregateRating backed by a third-party review widget on the page",
+      details: { pageType: label, ratedEntities: entities.length },
+    };
+  }
+
+  const text = visibleText(ctx, doc);
+  if (hasVisibleRating(text, entities)) {
+    return {
+      name: VISIBILITY_CHECK,
+      status: "pass",
+      message: "AggregateRating has a rating visible on the page",
+      details: { pageType: label, ratedEntities: entities.length },
+    };
+  }
+
+  const primary = entities[0];
+  return {
+    name: VISIBILITY_CHECK,
+    status: "warn",
+    message:
+      `${describeRating(primary)} on ${describeEntity(primary)} is not visible anywhere on ` +
+      `${pagePhrase(label)} — a rating readers cannot see is a structured-data policy violation ` +
+      "and risks a manual action, not just a lost rich result",
+    details: {
+      pageType: label,
+      ratedEntityType: primary.type,
+      ratedEntityName: primary.name,
+      ratingValue: primary.ratingValue,
+      ratingCount: primary.ratingCount,
+      reason: "no-visible-rating",
+    },
+    items: toItems(entities),
+  };
+}
+
+/**
+ * Rendered page text plus the attributes a badge is commonly rendered into.
+ * `content.textContent` drops `<svg>`, so a star-glyph SVG badge would otherwise
+ * read as "no rating on the page".
+ */
+function visibleText(ctx: RuleContext, doc: Document): string {
+  const parts = [ctx.parsed.content?.textContent ?? ""];
+  for (const el of doc.querySelectorAll("[alt], [aria-label], [title]")) {
+    parts.push(
+      el.getAttribute("alt") ?? "",
+      el.getAttribute("aria-label") ?? "",
+      el.getAttribute("title") ?? "",
+    );
+  }
+  return parts.join(" ");
+}
+
+function hasVisibleRating(text: string, entities: RatedEntity[]): boolean {
+  if (STAR_GLYPH_RE.test(text)) return true;
+  if (VISIBLE_RATING_PATTERNS.some((p) => p.test(text))) return true;
+
+  // A decimal rating value printed verbatim ("4.7", "4,7") is unambiguous on its
+  // own. A whole-number one ("5") is not, and is left to the patterns above.
+  return entities.some((e) => {
+    const value = e.ratingValue;
+    if (!value || !/^\d+[.,]\d+$/.test(value)) return false;
+    const alternates = new Set([value, value.replace(".", ","), value.replace(",", ".")]);
+    return [...alternates].some((v) => new RegExp(`(?<!\\d)${escapeRe(v)}(?!\\d)`).test(text));
+  });
+}
+
+function hasReviewWidget(doc: Document): boolean {
+  for (const el of doc.querySelectorAll("script[src], iframe[src], link[href]")) {
+    const src = (el.getAttribute("src") ?? el.getAttribute("href") ?? "").toLowerCase();
+    if (REVIEW_WIDGET_SRC_TOKENS.some((token) => src.includes(token))) return true;
+  }
+  try {
+    return doc.querySelector(REVIEW_WIDGET_SELECTOR) !== null;
+  } catch {
+    // Skip selectors the parser rejects.
+    return false;
+  }
+}
+
+function escapeRe(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ============================================================================
+// Subject
+// ============================================================================
+
+function buildSubjectCheck(entities: RatedEntity[], kind: IneligiblePageKind): CheckResult {
+  const label = PAGE_KIND_LABEL[kind];
+  // Legal pages have no rateable subject at all, so every rating on them is out
+  // of scope. An article's subject CAN be rateable (a product review), so only
+  // the sitewide business entity is reported there.
+  const offenders =
+    kind === "article" ? entities.filter((e) => isBusinessCarrier(e.types)) : entities;
+
+  if (offenders.length === 0) {
+    return {
+      name: SUBJECT_CHECK,
+      status: "pass",
+      message: `AggregateRating on this ${label} page rates the page's own subject`,
+      details: { pageType: label, ratedEntities: entities.length },
+    };
+  }
+
+  const primary = offenders[0];
+  return {
+    name: SUBJECT_CHECK,
+    status: "warn",
+    message:
+      `AggregateRating on ${describeEntity(primary)} is not the subject of this ${label} page — ` +
+      "sitewide rating markup on a page that cannot be rated is a structured-data policy " +
+      "violation and risks a manual action, not just a lost rich result",
+    details: {
+      pageType: label,
+      ratedEntityType: primary.type,
+      ratedEntityName: primary.name,
+      ratingValue: primary.ratingValue,
+      ratingCount: primary.ratingCount,
+      reason: "entity-not-page-subject",
+    },
+    items: toItems(offenders),
+  };
+}
+
+function isBusinessCarrier(types: string[]): boolean {
+  return types.some((t) => BUSINESS_CARRIER_TYPES.has(t));
+}
+
+/**
+ * Page kind on which a rating cannot be about the page's subject. Legal pages
+ * are matched slug- and heading-first (a `/legal/privacy` page is still a
+ * privacy policy); articles come from the parser's page-type classifier.
+ */
+function ineligiblePageKind(ctx: RuleContext): IneligiblePageKind | null {
+  const page = { url: ctx.page.url, parsed: ctx.parsed };
+  if (isPrivacyPage(page)) return "privacy";
+  if (isTermsPage(ctx)) return "terms";
+  if (ctx.parsed.pageType === "article") return "article";
+  return null;
+}
+
+const TERMS_HEADING_RE =
+  /^(?:terms(?:\s*(?:&|and)\s*conditions|\s+of\s+(?:service|use|sale))?|terms|conditions\s+of\s+use|allgemeine\s+gesch[aä]ftsbedingungen|nutzungsbedingungen|t[eé]rminos\s+y\s+condiciones|conditions\s+g[eé]n[eé]rales(?:\s+d['’]utilisation)?)$/i;
+const TITLE_SEPARATORS = /[|–—\-:·•]+/;
+
+function isTermsPage(ctx: RuleContext): boolean {
+  const path = getPathname(ctx.page.url) || ctx.page.url;
+  if (EEAT_PAGE_PATTERNS.terms.some((p) => p.test(path))) return true;
+
+  const headings = [ctx.parsed.meta?.title ?? "", ...(ctx.parsed.h1?.texts ?? [])];
+  return headings.some((heading) =>
+    heading.split(TITLE_SEPARATORS).some((seg) => TERMS_HEADING_RE.test(seg.trim())),
+  );
+}
+
+// ============================================================================
+// Reporting
+// ============================================================================
+
+/**
+ * Page label used in both the message and `details.pageType`: the legal kind,
+ * else the classified page type, else null when the classifier could not name it.
+ */
+function pageLabel(ctx: RuleContext, kind: IneligiblePageKind | null): string | null {
+  if (kind) return PAGE_KIND_LABEL[kind];
+  const pageType = ctx.parsed.pageType;
+  return !pageType || pageType === "unknown" ? null : pageType;
+}
+
+function pagePhrase(label: string | null): string {
+  return label ? `this ${label} page` : "this page";
+}
+
+function describeEntity(entity: RatedEntity): string {
+  if (entity.type && entity.name) return `${entity.type} "${entity.name}"`;
+  if (entity.type) return entity.type;
+  if (entity.name) return `"${entity.name}"`;
+  return "an untyped entity";
+}
+
+function describeRating(entity: RatedEntity): string {
+  if (!entity.ratingValue) return "AggregateRating";
+  const count = entity.ratingCount ? ` from ${entity.ratingCount} reviews` : "";
+  return `AggregateRating ${entity.ratingValue}${count}`;
+}
+
+function toItems(entities: RatedEntity[]): CheckItem[] {
+  return entities.slice(0, MAX_ITEMS).map((entity, index) => ({
+    id: `rated-entity-${index + 1}`,
+    label: `${describeRating(entity)} on ${describeEntity(entity)}`,
+    meta: {
+      ratedEntityType: entity.type,
+      ratedEntityName: entity.name,
+      ratingValue: entity.ratingValue,
+      ratingCount: entity.ratingCount,
+    },
+  }));
+}

--- a/packages/rules/tests/schema-rating-scope.test.ts
+++ b/packages/rules/tests/schema-rating-scope.test.ts
@@ -1,0 +1,263 @@
+// schema/rating-scope — AggregateRating that is not about the page it sits on (#106).
+//
+// schema/review only ever checked the SHAPE of AggregateRating, so a sitewide
+// "5/5 from 18 reviews" block emitted by a template passed on every page of the
+// site, privacy policy included. These lock in the two relationship signals that
+// separate a real finding from a legitimate LocalBusiness badge:
+//
+//   - is a rating visible to the reader anywhere on the page, and
+//   - is the rated entity the subject of THIS page.
+//
+// The false-positive side matters as much as the true-positive side (#106: the
+// naive "AggregateRating on many pages" version claimed 379 offending pages, the
+// relationship version 53), so the negative cases below are load-bearing: a
+// LocalBusiness homepage with a visible badge and a Product page whose rating
+// matches its on-page reviews must stay silent.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult } from "@squirrelscan/core-contracts";
+
+import { parsePage } from "@squirrelscan/parser";
+
+import { ratingScopeRule } from "../src/schema/rating-scope";
+import { rules as schemaRules } from "../src/schema";
+import type { ParsedPage, Rule, RuleContext } from "../src/types";
+
+function pageCtx(html: string, url = "https://example.com/"): RuleContext {
+  return {
+    page: { url, html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: parsePage(html, url) as ParsedPage,
+    options: {},
+  };
+}
+
+function run(rule: Rule, ctx: RuleContext): CheckResult[] {
+  return rule.run(ctx).checks as CheckResult[];
+}
+
+function check(checks: CheckResult[], name: string): CheckResult | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+function page(schema: unknown, body: string, head = ""): string {
+  return `<html><head><title>Page</title>${head}<script type="application/ld+json">${JSON.stringify(
+    schema,
+  )}</script></head><body>${body}</body></html>`;
+}
+
+/** The sitewide badge: one LocalBusiness rating the template prints everywhere. */
+const SITEWIDE_BUSINESS = {
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  name: "Northgate Auto Repair",
+  aggregateRating: { "@type": "AggregateRating", ratingValue: "4.9", ratingCount: "18" },
+};
+
+const LEGAL_BODY =
+  "<h1>Privacy Policy</h1><p>We collect the information you give us when you book a repair " +
+  "and keep it only as long as we need it. You can ask us to delete it at any time.</p>";
+
+describe("schema/rating-scope — visibility", () => {
+  test("privacy policy carrying the sitewide rating with nothing visible → warns", () => {
+    const html = page(SITEWIDE_BUSINESS, LEGAL_BODY);
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/privacy"));
+    const visible = check(checks, "rating-visible");
+
+    expect(visible?.status).toBe("warn");
+    // Names the page type, the rated entity, and frames it as a policy risk.
+    expect(visible?.message).toContain("privacy policy page");
+    expect(visible?.message).toContain('LocalBusiness "Northgate Auto Repair"');
+    expect(visible?.message).toContain("manual action");
+    expect(visible?.message).not.toContain("missing");
+    expect(visible?.details?.["ratedEntityType"]).toBe("LocalBusiness");
+    expect(visible?.details?.["reason"]).toBe("no-visible-rating");
+  });
+
+  test("rating value that exists ONLY in the JSON-LD is not counted as visible", () => {
+    // 4.9 appears in the markup; the visible text never says it.
+    const html = page(SITEWIDE_BUSINESS, LEGAL_BODY);
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/privacy"));
+
+    expect(check(checks, "rating-visible")?.status).toBe("warn");
+  });
+
+  test("visible star badge on a LocalBusiness homepage → no warning", () => {
+    const html = page(
+      SITEWIDE_BUSINESS,
+      '<h1>Northgate Auto Repair</h1><div class="badge">★★★★★ 4.9 from 18 reviews</div>',
+    );
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/"));
+
+    expect(check(checks, "rating-visible")?.status).toBe("pass");
+    expect(checks.every((c) => c.status !== "warn")).toBe(true);
+  });
+
+  test("Product page whose rating matches visible on-page reviews → no warning", () => {
+    const html = page(
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        name: "Trail Runner 3",
+        aggregateRating: { "@type": "AggregateRating", ratingValue: "4.6", reviewCount: "23" },
+      },
+      "<h1>Trail Runner 3</h1><p>4.6 out of 5 stars based on 23 reviews</p>",
+    );
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/products/trail-runner-3"));
+
+    expect(check(checks, "rating-visible")?.status).toBe("pass");
+    expect(checks.every((c) => c.status !== "warn")).toBe(true);
+  });
+
+  test("decimal rating printed verbatim in the copy counts as visible", () => {
+    const html = page(SITEWIDE_BUSINESS, "<h1>Northgate Auto Repair</h1><p>Our customers score us 4.9.</p>");
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/"));
+
+    expect(check(checks, "rating-visible")?.status).toBe("pass");
+  });
+
+  test("badge rendered as an image → alt text counts as visible", () => {
+    const html = page(
+      SITEWIDE_BUSINESS,
+      '<h1>Northgate Auto Repair</h1><img src="/stars.svg" alt="Rated 4.9 out of 5 by our customers">',
+    );
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/"));
+
+    expect(check(checks, "rating-visible")?.status).toBe("pass");
+  });
+
+  test("third-party review widget → visibility is not asserted against a raw-HTML crawl", () => {
+    const html = page(
+      SITEWIDE_BUSINESS,
+      '<h1>Northgate Auto Repair</h1><div class="trustpilot-widget" data-businessunit-id="x"></div>',
+      '<script src="https://widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js"></script>',
+    );
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/"));
+
+    expect(check(checks, "rating-visible")?.status).toBe("pass");
+    expect(check(checks, "rating-visible")?.message).toContain("review widget");
+  });
+
+  test("no AggregateRating anywhere → the rule says nothing at all", () => {
+    const html = page(
+      { "@context": "https://schema.org", "@type": "Organization", name: "Northgate" },
+      "<h1>Northgate</h1><p>We fix cars.</p>",
+    );
+
+    expect(run(ratingScopeRule, pageCtx(html, "https://example.com/"))).toEqual([]);
+  });
+
+  test("array-wrapped aggregateRating (#721) is still read", () => {
+    const html = page(
+      {
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        name: "Northgate Auto Repair",
+        aggregateRating: [{ "@type": "AggregateRating", ratingValue: "4.9", ratingCount: "18" }],
+      },
+      LEGAL_BODY,
+    );
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/privacy"));
+
+    expect(check(checks, "rating-visible")?.status).toBe("warn");
+    expect(check(checks, "rating-visible")?.message).toContain("AggregateRating 4.9 from 18 reviews");
+  });
+});
+
+describe("schema/rating-scope — page subject", () => {
+  test("privacy policy carrying the sitewide business rating → warns on scope", () => {
+    const html = page(SITEWIDE_BUSINESS, LEGAL_BODY);
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/privacy"));
+    const subject = check(checks, "rating-subject");
+
+    expect(subject?.status).toBe("warn");
+    expect(subject?.message).toContain("privacy policy page");
+    expect(subject?.message).toContain('LocalBusiness "Northgate Auto Repair"');
+    expect(subject?.message).toContain("manual action");
+    expect(subject?.details?.["reason"]).toBe("entity-not-page-subject");
+    expect(subject?.items?.[0]?.label).toContain("Northgate Auto Repair");
+  });
+
+  test("privacy policy showing a visible badge still warns on scope", () => {
+    // Visibility is not the excuse here: a policy page has no rateable subject.
+    const html = page(SITEWIDE_BUSINESS, `${LEGAL_BODY}<footer>★★★★★ 4.9 from 18 reviews</footer>`);
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/privacy"));
+
+    expect(check(checks, "rating-visible")?.status).toBe("pass");
+    expect(check(checks, "rating-subject")?.status).toBe("warn");
+  });
+
+  test("terms page carrying the sitewide business rating → warns", () => {
+    const html = page(
+      SITEWIDE_BUSINESS,
+      "<h1>Terms and Conditions</h1><p>These terms govern your use of the site.</p>",
+    );
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/terms-and-conditions"));
+
+    expect(check(checks, "rating-subject")?.status).toBe("warn");
+    expect(check(checks, "rating-subject")?.message).toContain("terms page");
+  });
+
+  test("blog post carrying the sitewide business rating → warns", () => {
+    const html = page(
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "BlogPosting",
+            headline: "Five signs your brakes need attention",
+            datePublished: "2026-02-03",
+          },
+          SITEWIDE_BUSINESS,
+        ],
+      },
+      "<h1>Five signs your brakes need attention</h1><p>Grinding, pulling, a soft pedal.</p>",
+    );
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/news/brake-signs"));
+    const subject = check(checks, "rating-subject");
+
+    expect(subject?.status).toBe("warn");
+    expect(subject?.message).toContain("article page");
+    expect(subject?.message).toContain('LocalBusiness "Northgate Auto Repair"');
+    expect(subject?.details?.["ratedEntityName"]).toBe("Northgate Auto Repair");
+  });
+
+  test("review article rating the product it is about → scope passes", () => {
+    const html = page(
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          { "@type": "Article", headline: "Trail Runner 3 reviewed" },
+          {
+            "@type": "Product",
+            name: "Trail Runner 3",
+            aggregateRating: { "@type": "AggregateRating", ratingValue: "4.6", ratingCount: "23" },
+          },
+        ],
+      },
+      "<h1>Trail Runner 3 reviewed</h1><p>Readers rate it 4.6 out of 5 across 23 reviews.</p>",
+    );
+    const checks = run(ratingScopeRule, pageCtx(html, "https://example.com/blog/trail-runner-3"));
+
+    expect(check(checks, "rating-subject")?.status).toBe("pass");
+    expect(checks.every((c) => c.status !== "warn")).toBe(true);
+  });
+
+  test("home and product pages get no subject check at all", () => {
+    const html = page(SITEWIDE_BUSINESS, "<h1>Northgate Auto Repair</h1><p>★★★★★ 4.9 from 18 reviews</p>");
+
+    expect(check(run(ratingScopeRule, pageCtx(html, "https://example.com/")), "rating-subject")).toBeUndefined();
+  });
+});
+
+describe("schema/rating-scope — registration", () => {
+  test("registered in the schema rules catalog", () => {
+    expect(schemaRules.map((r) => r.meta.id)).toContain("schema/rating-scope");
+  });
+
+  test("rule metadata is page-scoped and a warning", () => {
+    expect(ratingScopeRule.meta.category).toBe("schema");
+    expect(ratingScopeRule.meta.scope).toBe("page");
+    expect(ratingScopeRule.meta.severity).toBe("warning");
+  });
+});


### PR DESCRIPTION
Closes #106

`schema/review` validates only the **shape** of AggregateRating, so one sitewide rating block emitted by a template passes on every page of a site — including privacy policies, terms pages and blog posts (the issue's evidence: 53 pages across four production sites).

New sibling rule `schema/rating-scope` (page-scoped, warning, weight 4) asks the two questions the shape check cannot:

- **`rating-visible`** — is a rating visible anywhere in the rendered page text? Star glyphs, "4.9 out of 5", "18 reviews", a decimal value printed in the copy, or the same wording in `alt` / `aria-label` / `title`. A third-party review widget (Trustpilot, Yotpo, Judge.me, Elfsight, …) clears the check, because its badge is injected client-side and a raw-HTML crawl cannot see it.
- **`rating-subject`** — is the rated entity the subject of THIS page? Runs only where a rating cannot apply: privacy, terms and article/blog page types. On articles it reports only a business/organization carrier, so a review article rating its own `Product` stays silent.

Repetition is deliberately **not** the signal: on a legitimate LocalBusiness site the badge really is on screen and the rating really is about the business the page is about. Both findings name the page type and the rated entity, and frame the risk as a structured-data manual action rather than a validation error.

`schema/review` is untouched — same checks, same messages.

## Acceptance criteria

- [x] `schema/review` gains a scope check (or a new sibling rule `schema/rating-scope`) registered in the rules catalog — new rule, registered in `packages/rules/src/schema/index.ts`
- [x] Warns when AggregateRating is present and NO rating value is visible in the rendered page text
- [x] Warns when AggregateRating is attached to an entity that is not the page's subject on page types where a rating cannot apply — privacy, terms and article/blog
- [x] The finding names the page type and the rated entity, and states that the markup risks a structured-data manual action rather than reporting it as a validation error
- [x] Does NOT warn on a LocalBusiness homepage that emits AggregateRating and shows a visible review badge
- [x] Does NOT warn on a Product page whose AggregateRating matches visible on-page reviews
- [x] Fixture: privacy policy carrying a sitewide LocalBusiness AggregateRating with no visible rating — warns
- [x] Fixture: blog post carrying the sitewide business AggregateRating — warns
- [x] Existing structural checks and their messages are unchanged; `tests/review-aggregate-rating.test.ts` untouched
- [x] Docs rule page added (`docs/rules/schema/rating-scope.mdx`), nav + category index + rule counts updated

## Changes

- `packages/rules/src/schema/rating-scope.ts` — new rule
- `packages/rules/src/schema/index.ts` — catalog registration
- `packages/rules/tests/schema-rating-scope.test.ts` — 16 tests, positive and negative cases
- `packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts` — tally pin 272 → 273 (the canonical fixture emits no JSON-LD, so the rule adds a tally key and zero findings; `findings.length` stays 98216)
- `docs/` — rule page, `docs.json` nav, schema index card, rule counts 272 → 273 / Structured Data 11 → 12; `README.md` likewise

## Verification

Tests and typecheck could not be executed in this sandbox (the runtime is not permitted here), so CI is the first run of `bun test`, `bun run typecheck` and `bun run docs:check` for this branch.