### PR TITLE
feat(rules): add crawl/sitemap-lastmod-drift (#107)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -178,6 +178,7 @@
                   "rules/crawl/sitemap-coverage",
                   "rules/crawl/sitemap-domain",
                   "rules/crawl/sitemap-lastmod-churn",
+                  "rules/crawl/sitemap-lastmod-drift",
                   "rules/crawl/html-size",
                   "rules/crawl/pdf-size",
                   "rules/crawl/soft-404"

--- a/docs/rules/crawl/index.mdx
+++ b/docs/rules/crawl/index.mdx
@@ -56,6 +56,9 @@ Robots.txt, sitemaps, and crawl directives
   <Card title="Sitemap Exists" icon="circle-exclamation" href="/rules/crawl/sitemap-exists">
     Checks if XML sitemap exists and is referenced in robots.txt
   </Card>
+  <Card title="Sitemap Lastmod Drift" icon="triangle-exclamation" href="/rules/crawl/sitemap-lastmod-drift">
+    Checks that sitemap lastmod matches the page's own dateModified
+  </Card>
   <Card title="Sitemap Valid" icon="circle-exclamation" href="/rules/crawl/sitemap-valid">
     Validates sitemap structure and URL limits
   </Card>

--- a/docs/rules/crawl/sitemap-lastmod-drift.mdx
+++ b/docs/rules/crawl/sitemap-lastmod-drift.mdx
@@ -1,0 +1,80 @@
+---
+title: "Sitemap Lastmod Drift"
+description: "Checks that sitemap lastmod matches the page's own dateModified"
+---
+
+Checks that sitemap lastmod matches the page's own dateModified
+
+| | |
+|---|---|
+| **Rule ID** | `crawl/sitemap-lastmod-drift` |
+| **Category** | [Crawlability](/rules/crawl) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 4/10 |
+
+## What it checks
+
+For every crawled page that appears in a sitemap with a `lastmod`, the rule compares that
+`lastmod` against the page's own strongest date signal: schema.org `dateModified`, else the
+`dateModified`-equivalent markup (`[itemprop="dateModified"]` meta / `<time>`), else the visible
+published date. Pages with no date signal at all are skipped: that is
+[Content Freshness](/rules/content/freshness) territory, not drift.
+
+The two directions are reported as separate checks, because they point at different code:
+
+| Check | Fires when | Usual cause |
+|-------|-----------|-------------|
+| `sitemap-lastmod-behind-page` | `lastmod` is older than the page's `dateModified` by more than 7 days | Stale cached sitemap, or a generator resolving `publishedAt ?? updatedAt` while the page renders `updatedAt ?? publishedAt` |
+| `sitemap-lastmod-ahead-of-page` | `lastmod` is newer than the page's `dateModified` by more than 30 days | `lastmod` stamped at build/deploy time instead of on content change |
+
+Each finding reports both dates and the gap in days. Same-day and within-threshold differences
+never warn.
+
+Lastmod being *older* than the page's own `dateModified` is the more clearly wrong of the two:
+it tells crawlers not to bother re-fetching a page that has in fact changed.
+
+## Solution
+
+A sitemap lastmod that disagrees with the page's own dateModified points at the sitemap generator, not the content. Lastmod OLDER than the page's dateModified tells crawlers not to bother with a page that has in fact changed - usually a stale cached sitemap, or a generator resolving `publishedAt ?? updatedAt` while the page renders `updatedAt ?? publishedAt` (a precedence inversion; both fields are present, so presence checks pass). Lastmod NEWER than the page's dateModified usually means lastmod is stamped at build/deploy time. Drive both values from the same content-modification timestamp.
+
+## Options
+
+This rule supports the following configuration options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `ahead_days` | number | `30` | Days a sitemap lastmod may run ahead of the page's own dateModified before warning |
+| `behind_days` | number | `7` | Days a sitemap lastmod may lag the page's own dateModified before warning |
+
+### Configuration Example
+
+```toml squirrel.toml
+[rules."crawl/sitemap-lastmod-drift"]
+ahead_days = 30
+behind_days = 7
+```
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["crawl/sitemap-lastmod-drift"]
+```
+
+### Disable all Crawlability rules
+
+```toml squirrel.toml
+[rules]
+disable = ["crawl/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["crawl/sitemap-lastmod-drift"]
+disable = ["*"]
+```

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -83,16 +83,18 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // at all — so it contributes a tally key below without a single finding.
       // 98216 -> 98217: crawl/sitemap-lastmod-churn, likewise site-scoped, adds
       // its own single whole-crawl check (#105).
-      expect(v1.findings.length).toBe(98217);
+      // 98217 -> 98218: crawl/sitemap-lastmod-drift, likewise site-scoped, adds
+      // its own single whole-crawl check (#107).
+      expect(v1.findings.length).toBe(98218);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
       // schema/coverage-outlier, 269 -> 270 url/slug-convention, 270 -> 271
       // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier,
-      // 272 -> 273 schema/rating-scope, 273 -> 274 crawl/sitemap-lastmod-churn;
-      // anything else means a rule id leaked in, so fix that rather than this
-      // number.
-      expect(v1.perRuleTally.length).toBe(274);
+      // 272 -> 273 schema/rating-scope, 273 -> 274 crawl/sitemap-lastmod-churn,
+      // 274 -> 275 crawl/sitemap-lastmod-drift; anything else means a rule id
+      // leaked in, so fix that rather than this number.
+      expect(v1.perRuleTally.length).toBe(275);
     },
     180_000,
   );

--- a/packages/rules/src/crawl/index.ts
+++ b/packages/rules/src/crawl/index.ts
@@ -20,6 +20,7 @@ import { sitemapCoverageRule } from "./sitemap-coverage";
 import { sitemapDomainRule } from "./sitemap-domain";
 import { sitemapExistsRule } from "./sitemap-exists";
 import { sitemapLastmodChurnRule } from "./sitemap-lastmod-churn";
+import { sitemapLastmodDriftRule } from "./sitemap-lastmod-drift";
 import { sitemapValidRule } from "./sitemap-valid";
 import { soft404Rule } from "./soft-404";
 
@@ -31,6 +32,7 @@ export const rules: Rule[] = [
   sitemapDomainRule,
   sitemapCoverageRule,
   sitemapLastmodChurnRule,
+  sitemapLastmodDriftRule,
   robotsMetaConflictRule,
   noindexInSitemapRule,
   indexabilityCheck,
@@ -63,6 +65,7 @@ export {
   sitemapExistsRule,
   sitemap4xxRule,
   sitemapLastmodChurnRule,
+  sitemapLastmodDriftRule,
   sitemapValidRule,
   soft404Rule,
 };

--- a/packages/rules/src/crawl/sitemap-lastmod-drift.ts
+++ b/packages/rules/src/crawl/sitemap-lastmod-drift.ts
@@ -1,0 +1,270 @@
+// crawl/sitemap-lastmod-drift - Sitemap lastmod vs the page's own dateModified
+
+import { z } from "zod";
+
+import type { ParsedPage, Rule, RuleContext, RuleResult, CheckResult } from "../types";
+import type { SitemapData } from "@squirrelscan/core-contracts";
+
+import { flattenJsonLdNodes, normalizeUrl } from "@squirrelscan/utils";
+
+const MS_PER_DAY = 86_400_000;
+
+// Findings are capped so a site whose whole sitemap is build-stamped reports a
+// readable sample rather than thousands of items; `details.total` keeps the
+// real count.
+const MAX_ITEMS = 50;
+
+export const optionsSchema = z.object({
+  ahead_days: z
+    .number()
+    .default(30)
+    .describe("Days a sitemap lastmod may run ahead of the page's own dateModified before warning"),
+  behind_days: z
+    .number()
+    .default(7)
+    .describe("Days a sitemap lastmod may lag the page's own dateModified before warning"),
+});
+
+/** Where a page's own date came from — reported so a fix targets the right markup. */
+type DateSource = "schema" | "meta" | "visible";
+
+interface PageDate {
+  value: string;
+  ms: number;
+  source: DateSource;
+}
+
+/** Parse a date string to epoch ms, or null when it isn't a usable date. */
+function parseDate(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** The `dateModified` carried by any JSON-LD node (including `@graph` children). */
+function schemaDateModified(parsed: ParsedPage): string | null {
+  if (!parsed.schema?.raw) return null;
+  // Flattened nodes include @graph children — a top-level-only read misses every
+  // date on Yoast-style sites (same reason eeat/content-dates flattens).
+  for (const node of flattenJsonLdNodes(parsed.schema.raw)) {
+    const value = node["dateModified"];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+/**
+ * The page's strongest own date signal: schema `dateModified`, else the
+ * `dateModified`-equivalent markup the parser lifts from `[itemprop=dateModified]`
+ * meta/`<time>` (`visibleDateModified`), else the visible published date.
+ *
+ * Only parsed-page SCALARS are read — never `parsed.document` — so the rule sees
+ * the same input on the legacy `site.pages` path and on the streaming path, where
+ * every DOM has been dropped before site rules run.
+ */
+function resolvePageDate(parsed: ParsedPage): PageDate | null {
+  const candidates: Array<{ value: string | null | undefined; source: DateSource }> = [
+    { value: schemaDateModified(parsed), source: "schema" },
+    { value: parsed.visibleDateModified, source: "meta" },
+    { value: parsed.visibleDatePublished, source: "visible" },
+  ];
+
+  for (const candidate of candidates) {
+    const value = candidate.value?.trim();
+    const ms = parseDate(value);
+    if (value && ms !== null) return { value, ms, source: candidate.source };
+  }
+  return null;
+}
+
+/** Sitemap `lastmod` by normalized URL; first entry wins on duplicate locs. */
+function collectLastmods(discovered: SitemapData[]): Map<string, string> {
+  const lastmods = new Map<string, string>();
+  for (const sitemap of discovered) {
+    for (const url of sitemap.urls) {
+      if (!url.lastmod) continue;
+      try {
+        const key = normalizeUrl(url.loc);
+        if (!lastmods.has(key)) lastmods.set(key, url.lastmod);
+      } catch {
+        // Skip malformed URLs
+      }
+    }
+  }
+  return lastmods;
+}
+
+interface Drift {
+  url: string;
+  lastmod: string;
+  pageDate: string;
+  source: DateSource;
+  deltaDays: number;
+}
+
+function buildCheck(
+  name: string,
+  drifts: Drift[],
+  message: string,
+  comparedPages: number
+): CheckResult {
+  return {
+    name,
+    status: "warn",
+    message,
+    items: drifts.slice(0, MAX_ITEMS).map((drift) => ({
+      id: drift.url,
+      label: `lastmod ${drift.lastmod} vs dateModified ${drift.pageDate} (${drift.deltaDays} day(s))`,
+      meta: {
+        lastmod: drift.lastmod,
+        pageDate: drift.pageDate,
+        pageDateSource: drift.source,
+        deltaDays: drift.deltaDays,
+      },
+    })),
+    details: { total: drifts.length, comparedPages },
+  };
+}
+
+export const sitemapLastmodDriftRule: Rule = {
+  meta: {
+    id: "crawl/sitemap-lastmod-drift",
+    name: "Sitemap Lastmod Drift",
+    description: "Checks that sitemap lastmod matches the page's own dateModified",
+    solution:
+      "A sitemap lastmod that disagrees with the page's own dateModified points at the sitemap generator, not the content. Lastmod OLDER than the page's dateModified tells crawlers not to bother with a page that has in fact changed - usually a stale cached sitemap, or a generator resolving `publishedAt ?? updatedAt` while the page renders `updatedAt ?? publishedAt` (a precedence inversion; both fields are present, so presence checks pass). Lastmod NEWER than the page's dateModified usually means lastmod is stamped at build/deploy time. Drive both values from the same content-modification timestamp.",
+    category: "crawl",
+    scope: "site",
+    severity: "warning",
+    weight: 4,
+    optionsSchema,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const opts = optionsSchema.parse(ctx.options);
+    const sitemaps = ctx.site?.sitemaps;
+    const pages = ctx.site?.pages;
+
+    if (!sitemaps || sitemaps.discovered.length === 0) {
+      return {
+        checks: [
+          {
+            name: "sitemap-lastmod-drift",
+            status: "skipped",
+            message: "No sitemap to compare",
+            skipReason: "No sitemap found",
+          },
+        ],
+      };
+    }
+
+    if (!pages || pages.length === 0) {
+      return {
+        checks: [
+          {
+            name: "sitemap-lastmod-drift",
+            status: "skipped",
+            message: "No pages to compare",
+            skipReason: "No pages crawled",
+          },
+        ],
+      };
+    }
+
+    const lastmods = collectLastmods(sitemaps.discovered);
+    const behind: Drift[] = [];
+    const ahead: Drift[] = [];
+    let comparedPages = 0;
+
+    for (const page of pages) {
+      let lastmod: string | undefined;
+      try {
+        lastmod = lastmods.get(normalizeUrl(page.url));
+      } catch {
+        continue; // Malformed page URL — nothing to match against.
+      }
+      if (!lastmod) continue;
+
+      const lastmodMs = parseDate(lastmod);
+      if (lastmodMs === null) continue; // Unparseable lastmod is crawl/sitemap-valid's job.
+
+      // No page-side date at all is content/freshness territory, not drift.
+      const pageDate = resolvePageDate(page.parsed);
+      if (!pageDate) continue;
+
+      comparedPages++;
+
+      // Magnitude only — direction is read off the comparison below. Whole days,
+      // so a same-day (and any sub-threshold) difference can never warn.
+      const deltaDays = Math.round(Math.abs(pageDate.ms - lastmodMs) / MS_PER_DAY);
+      const drift: Drift = {
+        url: page.url,
+        lastmod,
+        pageDate: pageDate.value,
+        source: pageDate.source,
+        deltaDays,
+      };
+
+      if (pageDate.ms > lastmodMs && deltaDays > opts.behind_days) behind.push(drift);
+      else if (lastmodMs > pageDate.ms && deltaDays > opts.ahead_days) ahead.push(drift);
+    }
+
+    if (comparedPages === 0) {
+      return {
+        checks: [
+          {
+            name: "sitemap-lastmod-drift",
+            status: "skipped",
+            message: "No sitemap URL carries both a lastmod and a page-side date signal",
+            skipReason: "No comparable dates",
+          },
+        ],
+      };
+    }
+
+    // Worst drift first, URL as the tie-break — deterministic regardless of the
+    // order pages were crawled in.
+    const byDelta = (a: Drift, b: Drift) => b.deltaDays - a.deltaDays || a.url.localeCompare(b.url);
+    behind.sort(byDelta);
+    ahead.sort(byDelta);
+
+    const checks: CheckResult[] = [];
+
+    // Reported separately from the ahead case: they point at different code.
+    // Behind = stale sitemap or inverted date precedence, and it is the more
+    // clearly wrong of the two (crawlers skip a page that really did change).
+    if (behind.length > 0) {
+      checks.push(
+        buildCheck(
+          "sitemap-lastmod-behind-page",
+          behind,
+          `${behind.length} page(s) have a sitemap lastmod older than the page's own dateModified by more than ${opts.behind_days} day(s)`,
+          comparedPages
+        )
+      );
+    }
+
+    // Ahead = lastmod stamped at build/deploy time rather than on content change.
+    if (ahead.length > 0) {
+      checks.push(
+        buildCheck(
+          "sitemap-lastmod-ahead-of-page",
+          ahead,
+          `${ahead.length} page(s) have a sitemap lastmod newer than the page's own dateModified by more than ${opts.ahead_days} day(s)`,
+          comparedPages
+        )
+      );
+    }
+
+    if (checks.length === 0) {
+      checks.push({
+        name: "sitemap-lastmod-drift",
+        status: "pass",
+        message: `${comparedPages} sitemap URL(s) carry a lastmod consistent with the page's own dateModified`,
+        details: { comparedPages },
+      });
+    }
+
+    return { checks };
+  },
+};

--- a/packages/rules/tests/sitemap-lastmod-drift.test.ts
+++ b/packages/rules/tests/sitemap-lastmod-drift.test.ts
@@ -1,0 +1,341 @@
+// crawl/sitemap-lastmod-drift — sitemap lastmod vs the page's own dateModified
+
+import { describe, expect, test } from "bun:test";
+
+import { sitemapLastmodDriftRule } from "../src/crawl/sitemap-lastmod-drift";
+import type { ParsedPage, RuleContext, SiteData } from "../src/types";
+
+const MS_PER_DAY = 86_400_000;
+
+/** `base` shifted by whole days — keeps expected deltas exact without hand arithmetic. */
+function plusDays(base: string, days: number): string {
+  return new Date(new Date(base).getTime() + days * MS_PER_DAY).toISOString();
+}
+
+interface PageSpec {
+  url: string;
+  schemaDateModified?: string;
+  visibleDateModified?: string;
+  visibleDatePublished?: string;
+}
+
+function parsed(spec: PageSpec): ParsedPage {
+  return {
+    schema: {
+      types: [],
+      valid: true,
+      errors: [],
+      raw: spec.schemaDateModified
+        ? JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            dateModified: spec.schemaDateModified,
+          })
+        : null,
+    },
+    visibleDateModified: spec.visibleDateModified ?? null,
+    visibleDatePublished: spec.visibleDatePublished ?? null,
+  } as unknown as ParsedPage;
+}
+
+function site(pages: PageSpec[], sitemapUrls: { loc: string; lastmod?: string }[]): SiteData {
+  return {
+    baseUrl: "https://example.com",
+    pages: pages.map((spec) => ({
+      url: spec.url,
+      statusCode: 200,
+      parsed: parsed(spec),
+    })),
+    robotsTxt: null,
+    sitemaps: {
+      discovered: [
+        {
+          url: "https://example.com/sitemap.xml",
+          type: "urlset",
+          urls: sitemapUrls,
+          childSitemaps: [],
+          errors: [],
+          urlCount: sitemapUrls.length,
+        },
+      ],
+      sources: { robotsTxt: [], commonLocations: [] },
+      totalUrls: sitemapUrls.length,
+      orphanPages: [],
+      missingPages: [],
+      failed: [],
+    },
+  } as unknown as SiteData;
+}
+
+function ctx(
+  pages: PageSpec[],
+  sitemapUrls: { loc: string; lastmod?: string }[],
+  options: Record<string, unknown> = {}
+): RuleContext {
+  return {
+    page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+    parsed: {} as ParsedPage,
+    site: site(pages, sitemapUrls),
+    options,
+  } as unknown as RuleContext;
+}
+
+describe("crawl/sitemap-lastmod-drift", () => {
+  test("no sitemap → skipped", () => {
+    const base = ctx([{ url: "https://example.com/a" }], []);
+    const { checks } = sitemapLastmodDriftRule.run({
+      ...base,
+      site: { ...base.site!, sitemaps: null },
+    } as RuleContext) as { checks: { status: string }[] };
+    expect(checks[0]?.status).toBe("skipped");
+  });
+
+  test("no pages → skipped", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx([], [{ loc: "https://example.com/a", lastmod: "2024-01-01" }])
+    ) as { checks: { status: string }[] };
+    expect(checks[0]?.status).toBe("skipped");
+  });
+
+  test("page with no date signal at all → skipped, not warned (content/freshness territory)", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx([{ url: "https://example.com/a" }], [{ loc: "https://example.com/a", lastmod: "2011-04-02" }])
+    );
+    expect(checks).toHaveLength(1);
+    expect(checks[0]?.status).toBe("skipped");
+    expect(checks[0]?.skipReason).toBe("No comparable dates");
+  });
+
+  test("lastmod tracks dateModified per page → pass", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [
+          { url: "https://example.com/a", schemaDateModified: "2024-03-01T00:00:00Z" },
+          { url: "https://example.com/b", schemaDateModified: "2024-06-14T09:30:00Z" },
+          { url: "https://example.com/c", schemaDateModified: "2023-11-02T00:00:00Z" },
+        ],
+        [
+          { loc: "https://example.com/a", lastmod: "2024-03-01" },
+          { loc: "https://example.com/b", lastmod: "2024-06-14" },
+          { loc: "https://example.com/c", lastmod: "2023-11-02" },
+        ]
+      )
+    );
+    expect(checks).toHaveLength(1);
+    expect(checks[0]?.status).toBe("pass");
+    expect(checks[0]?.details?.comparedPages).toBe(3);
+  });
+
+  test("same-day difference does not warn", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/a", schemaDateModified: "2024-03-01T22:00:00Z" }],
+        [{ loc: "https://example.com/a", lastmod: "2024-03-01T06:00:00Z" }]
+      )
+    );
+    expect(checks[0]?.status).toBe("pass");
+  });
+
+  test("within-threshold difference (20 days ahead, default 30) does not warn", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/a", schemaDateModified: "2024-03-01T00:00:00Z" }],
+        [{ loc: "https://example.com/a", lastmod: "2024-03-21" }]
+      )
+    );
+    expect(checks[0]?.status).toBe("pass");
+  });
+
+  test("build-stamped lastmod years ahead of the page's date → ahead warning with both dates + delta", () => {
+    // The personal-blog case from #107: lastmod is the build date, the page
+    // renders the post's real 2011 date.
+    const pageDate = "2011-04-02T00:00:00.000Z";
+    const lastmod = plusDays(pageDate, 5589);
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/post", schemaDateModified: pageDate }],
+        [{ loc: "https://example.com/post", lastmod }]
+      )
+    );
+    expect(checks).toHaveLength(1);
+    const check = checks[0]!;
+    expect(check.status).toBe("warn");
+    expect(check.name).toBe("sitemap-lastmod-ahead-of-page");
+    expect(check.message).toContain("newer");
+    const item = check.items?.[0];
+    expect(item?.id).toBe("https://example.com/post");
+    expect(item?.meta).toMatchObject({
+      lastmod,
+      pageDate,
+      pageDateSource: "schema",
+      deltaDays: 5589,
+    });
+  });
+
+  test("inverted date precedence (lastmod 433 days behind) → behind warning, distinct check name", () => {
+    // The consultancy case from #107: the generator resolved
+    // `publishedAt ?? updatedAt` while the page rendered `updatedAt ?? publishedAt`.
+    const pageDate = "2025-06-01T00:00:00.000Z";
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/guide", schemaDateModified: pageDate }],
+        [{ loc: "https://example.com/guide", lastmod: plusDays(pageDate, -433) }]
+      )
+    );
+    expect(checks).toHaveLength(1);
+    const check = checks[0]!;
+    expect(check.status).toBe("warn");
+    expect(check.name).toBe("sitemap-lastmod-behind-page");
+    expect(check.name).not.toBe("sitemap-lastmod-ahead-of-page");
+    expect(check.message).toContain("older");
+    expect(check.items?.[0]?.meta).toMatchObject({ deltaDays: 433 });
+  });
+
+  test("behind by 5 days does not warn; behind by 8 does (7-day floor)", () => {
+    const ok = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/a", schemaDateModified: "2024-03-06T00:00:00Z" }],
+        [{ loc: "https://example.com/a", lastmod: "2024-03-01" }]
+      )
+    );
+    expect(ok.checks[0]?.status).toBe("pass");
+
+    const warned = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/a", schemaDateModified: "2024-03-09T00:00:00Z" }],
+        [{ loc: "https://example.com/a", lastmod: "2024-03-01" }]
+      )
+    );
+    expect(warned.checks[0]?.status).toBe("warn");
+    expect(warned.checks[0]?.name).toBe("sitemap-lastmod-behind-page");
+  });
+
+  test("both directions on one site → two separate checks", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [
+          { url: "https://example.com/old", schemaDateModified: "2012-01-01T00:00:00Z" },
+          { url: "https://example.com/revised", schemaDateModified: "2025-06-01T00:00:00Z" },
+        ],
+        [
+          { loc: "https://example.com/old", lastmod: "2026-08-01" },
+          { loc: "https://example.com/revised", lastmod: "2024-03-25" },
+        ]
+      )
+    );
+    expect(checks.map((c) => c.name).sort()).toEqual([
+      "sitemap-lastmod-ahead-of-page",
+      "sitemap-lastmod-behind-page",
+    ]);
+    expect(checks.every((c) => c.status === "warn")).toBe(true);
+  });
+
+  test("ahead threshold is configurable", () => {
+    const pages: PageSpec[] = [{ url: "https://example.com/a", schemaDateModified: "2024-03-01T00:00:00Z" }];
+    const urls = [{ loc: "https://example.com/a", lastmod: "2024-03-21" }];
+    expect(sitemapLastmodDriftRule.run(ctx(pages, urls)).checks[0]?.status).toBe("pass");
+    const tightened = sitemapLastmodDriftRule.run(ctx(pages, urls, { ahead_days: 10 }));
+    expect(tightened.checks[0]?.status).toBe("warn");
+    expect(tightened.checks[0]?.name).toBe("sitemap-lastmod-ahead-of-page");
+  });
+
+  test("falls back to the dateModified-equivalent meta, then the visible date", () => {
+    const viaMeta = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/a", visibleDateModified: "2025-06-01" }],
+        [{ loc: "https://example.com/a", lastmod: "2024-03-25" }]
+      )
+    );
+    expect(viaMeta.checks[0]?.items?.[0]?.meta?.pageDateSource).toBe("meta");
+
+    const viaVisible = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/a", visibleDatePublished: "2025-06-01" }],
+        [{ loc: "https://example.com/a", lastmod: "2024-03-25" }]
+      )
+    );
+    expect(viaVisible.checks[0]?.items?.[0]?.meta?.pageDateSource).toBe("visible");
+  });
+
+  test("schema dateModified wins over the weaker signals", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [
+          {
+            url: "https://example.com/a",
+            schemaDateModified: "2024-03-01T00:00:00Z",
+            visibleDateModified: "2025-06-01",
+            visibleDatePublished: "2011-04-02",
+          },
+        ],
+        [{ loc: "https://example.com/a", lastmod: "2024-03-01" }]
+      )
+    );
+    expect(checks[0]?.status).toBe("pass");
+  });
+
+  test("unparseable dates on either side are ignored, not warned", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [
+          { url: "https://example.com/a", schemaDateModified: "last tuesday" },
+          { url: "https://example.com/b", schemaDateModified: "2024-03-01T00:00:00Z" },
+        ],
+        [
+          { loc: "https://example.com/a", lastmod: "2024-03-01" },
+          { loc: "https://example.com/b", lastmod: "not-a-date" },
+        ]
+      )
+    );
+    expect(checks[0]?.status).toBe("skipped");
+    expect(checks[0]?.skipReason).toBe("No comparable dates");
+  });
+
+  test("pages absent from the sitemap are ignored", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [
+          { url: "https://example.com/a", schemaDateModified: "2011-04-02T00:00:00Z" },
+          { url: "https://example.com/b", schemaDateModified: "2024-03-01T00:00:00Z" },
+        ],
+        [{ loc: "https://example.com/b", lastmod: "2024-03-01" }]
+      )
+    );
+    expect(checks[0]?.status).toBe("pass");
+    expect(checks[0]?.details?.comparedPages).toBe(1);
+  });
+
+  test("worst drift is reported first", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [
+          { url: "https://example.com/a", schemaDateModified: "2024-06-01T00:00:00Z" },
+          { url: "https://example.com/b", schemaDateModified: "2011-04-02T00:00:00Z" },
+        ],
+        [
+          { loc: "https://example.com/a", lastmod: "2025-01-01" },
+          { loc: "https://example.com/b", lastmod: "2026-08-01" },
+        ]
+      )
+    );
+    expect(checks[0]?.items?.map((i) => i.id)).toEqual([
+      "https://example.com/b",
+      "https://example.com/a",
+    ]);
+  });
+
+  test("a siteQuery on the context does not change the output (dual-path parity)", () => {
+    const base = ctx(
+      [{ url: "https://example.com/post", schemaDateModified: "2011-04-02T00:00:00Z" }],
+      [{ loc: "https://example.com/post", lastmod: "2026-08-01T00:00:00Z" }]
+    );
+    const legacy = sitemapLastmodDriftRule.run(base);
+    const streaming = sitemapLastmodDriftRule.run({
+      ...base,
+      // The rule reads only parsed-page scalars, never a DOM — so the streaming
+      // site pass (documents dropped, siteQuery threaded) sees identical input.
+      siteQuery: { pageCount: () => 1 },
+    } as unknown as RuleContext);
+    expect(JSON.stringify(streaming)).toBe(JSON.stringify(legacy));
+  });
+});


### PR DESCRIPTION
Closes #107

New site-scope rule `crawl/sitemap-lastmod-drift`: for every crawled page present in a sitemap with a `lastmod`, compare that `lastmod` against the page's own strongest date signal and report the two directions separately, because they point at different code.

| Check | Fires when | Usual cause |
|---|---|---|
| `sitemap-lastmod-behind-page` | `lastmod` older than the page's `dateModified` by > `behind_days` (7) | stale cached sitemap, or a generator resolving `publishedAt ?? updatedAt` while the route renders `updatedAt ?? publishedAt` |
| `sitemap-lastmod-ahead-of-page` | `lastmod` newer by > `ahead_days` (30, configurable) | `lastmod` stamped at build/deploy time |

Each finding carries both dates, the source tier of the page date, and the delta in days; findings are sorted worst-first (URL tie-break) and capped at 50 items with the real total in `details`.

Page-date tiers: schema `dateModified` (flattened JSON-LD, `@graph` included) → the `dateModified`-equivalent markup the parser lifts from `[itemprop="dateModified"]` meta/`<time>` (`visibleDateModified`) → visible published date. Pages with none of these are skipped — that is `content/freshness` territory, not drift.

### Acceptance criteria

- [x] New site-scope rule `crawl/sitemap-lastmod-drift` under `packages/rules/src/crawl/`, registered in the rules catalog
- [x] For each crawled page present in the sitemap, compares sitemap `lastmod` against the page's own strongest date signal (schema `dateModified`, else `dateModified` equivalent meta, else visible date)
- [x] Warns when `lastmod` is **older** than the page's `dateModified` by more than 7 days, reported as a distinct check name from the ahead case
- [x] Warns when `lastmod` is **newer** than the page's `dateModified` by more than a configurable threshold (default 30 days)
- [x] Each finding reports the two dates and the delta in days
- [x] Skips pages with no page-side date signal at all
- [x] Does NOT warn on same-day or within-threshold differences
- [x] Passes on a fixture where lastmod tracks dateModified per page
- [x] Byte-identical output across the legacy and `siteQuery` paths
- [x] Rule page added to `docs/` (plus `docs.json` nav and the Crawlability card grid)
- [x] `streaming-rules-canonical-golden.test.ts` updated: `v1.findings.length` 98217 → 98218 and `v1.perRuleTally.length` 274 → 275, each with a comment naming this rule, matching the convention used for the rules above it

### Notes

- **Dual-path parity:** the rule reads only parsed-page *scalars* (`parsed.schema.raw`, `visibleDateModified`, `visibleDatePublished`) and never `parsed.document`, so the streaming site pass — where every DOM is dropped before site rules run and `siteQuery` is threaded — sees identical input and emits identical checks. It does not branch on `ctx.siteQuery`; a unit test asserts the output is unchanged when one is present, and the canonical 518-page v1↔v2 gate covers it end to end.
- The "meta" tier resolves through the parser's existing `[itemprop="dateModified"]` meta/`<time>` extraction. OG `article:modified_time` is not carried as a parsed scalar today, so picking it up would need a new parser field across the parser and both audit adapters — deliberately left out of this rule's diff.
- On the canonical golden fixture the sitemap carries no `lastmod` at all, so the rule contributes exactly one `skipped` check (hence +1 finding, +1 tally key, health score unmoved).
- **Local verification:** `bun`/`node` execution is blocked in this environment (every invocation required an approval that could not be granted non-interactively), so the new tests, typecheck and `make validate` in `docs/` were not run locally — CI (quality / cli-tests / engine-tests / docs) is the first execution of this change.