### PR TITLE
feat(rules): add content/date-agreement (#108)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -245,7 +245,8 @@
                   "rules/content/stale-copyright",
                   "rules/content/mojibake",
                   "rules/content/thin-vs-site-norm",
-                  "rules/content/title-pattern-outlier"
+                  "rules/content/title-pattern-outlier",
+                  "rules/content/date-agreement"
                 ]
               },
               {

--- a/docs/rules/content/date-agreement.mdx
+++ b/docs/rules/content/date-agreement.mdx
@@ -1,0 +1,116 @@
+---
+title: "Date Agreement"
+description: "Checks the visible date, schema dates and URL/title year agree"
+---
+
+Checks the visible date, schema dates and URL/title year agree
+
+| | |
+|---|---|
+| **Rule ID** | `content/date-agreement` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 4/10 |
+
+## What it checks
+
+A page states its date up to five times: the visible byline, schema.org
+`datePublished` / `dateModified`, a year in the URL or the title, the sitemap `lastmod`, and the
+`Last-Modified` header. [Content Freshness](/rules/content/freshness) passes as soon as **any** of
+them exists and [Content Dates](/rules/eeat/content-dates) reports how many pages carry them, so a
+page whose signals contradict each other passes both. The disagreement is the defect, and this rule
+is the only one that looks for it. (The sitemap side of the same question is
+[Sitemap Lastmod Drift](/rules/crawl/sitemap-lastmod-drift); this rule stays on the page.)
+
+Four page-side signals are extracted and reported on every finding:
+
+| Signal | Read from |
+|--------|-----------|
+| Visible date | The date the reader sees: a rendered `<time>`, byline/entry-meta markup, or a short date-only line at the top of main content |
+| Schema document date | `datePublished` / `dateModified` on a node that describes the DOCUMENT (`Article`, `BlogPosting`, `NewsArticle`, `WebPage`, `FAQPage`, ...), `@graph` included |
+| URL / title year | A four-digit year in the URL path, else in the `<title>` |
+| `Last-Modified` | The HTTP response header |
+
+| Check | Fires when |
+|-------|-----------|
+| `byline-vs-schema-date` | The visible date and the schema document date are more than `tolerance_days` apart. Both values are named in the finding |
+| `visible-date-missing` | An `Article`-family node states dates the page never renders — a date only crawlers can see |
+| `url-title-year` | The year in the URL, else in the title, is not the year of either schema document date |
+| `schema-date-source` | Informational: the page shows a date, but its only schema date sits on a node that does not describe the page |
+
+Every visible date is measured against the **closest** schema date and the best pairing decides, so
+a page showing "Published 6 January · Updated 10 February" is telling the truth about both and stays
+quiet. A page-level node (`WebPage`, `CollectionPage`) alongside several visible dates is an index
+or an archive — those dates belong to the entries it lists, so nothing is compared.
+
+`visible-date-missing` fires only when main content prints no date-shaped string **anywhere**. A
+date this rule declined to read as a byline is still a date on the reader's screen, and "this page
+shows no date" has to be literally true to be worth saying.
+
+`Last-Modified` is reported alongside the others but never raises a warning on its own: origins
+stamp it at deploy time far more often than at content-change time, so a disagreement there is not
+evidence of a defect.
+
+### What it deliberately does not report
+
+Both of these are false positives that a naive version of this check produced in bulk, so they are
+guarded rather than tuned:
+
+- **A date on a node that does not describe the page.** A sitewide `SoftwareApplication`, `Product`
+  or `Organization` node carries its own `datePublished` — the release date of that entity, not the
+  publication date of the post it happens to sit beside. Taking the first `datePublished` in the
+  document attributes one placeholder date to every page on the site. Only document-describing
+  `@type`s can raise a disagreement; a date from anywhere else is reported with its node type noted
+  (`schema-date-source`) and never compared.
+- **A date-shaped string that is not a byline.** A byline is a position, not a pattern: running
+  prose ("INP replaced FID on March 12, 2024") and outbound citations
+  (`<a href="https://web.dev/...">March 12, 2024</a>`) are date-shaped and are not this page's
+  publication date. A candidate must sit near the top of main content **and** look like byline
+  markup — a `<time>` element, `byline`/`entry-meta`-style markup, or a short line that says nothing
+  beyond the date. An anchor's own text never counts.
+
+A `WebPage` node carrying dates is not required to render them: WordPress SEO plugins emit one on
+every page of a site, contact form included, so demanding a visible date there would warn on
+everything.
+
+## Solution
+
+A page states its date more than once - the visible byline, schema.org datePublished/dateModified, a year in the URL or title, the sitemap lastmod, the Last-Modified header - and readers and crawlers do not all read the same one. When they disagree, at least one is wrong, and presence checks cannot tell you which: they pass as soon as any single signal exists. Drive every date on the page from ONE content timestamp. If the visible byline disagrees with the schema, fix whichever renders from the wrong field (a common cause is the template printing a build-time or hardcoded value while the schema prints the CMS field). If the schema carries dates the reader never sees, render the date in the article header - Google asks for a visible date on dated content, and a date only crawlers can see is not one. Check the schema date is attached to the node describing the page (Article/BlogPosting/WebPage): a datePublished on a sitewide SoftwareApplication or Organization node is that entity's own date and says nothing about this page.
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `tolerance_days` | number | `1` | Days the visible byline date may differ from the schema document date before warning |
+
+### Configuration Example
+
+```toml squirrel.toml
+[rule_options."content/date-agreement"]
+tolerance_days = 1
+```
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/date-agreement"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/date-agreement"]
+disable = ["*"]
+```

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -23,6 +23,9 @@ Text quality, readability, and content structure
   <Card title="Content Quality" icon="circle-info" href="/rules/content/quality">
     LLM-based content quality analysis for SEO
   </Card>
+  <Card title="Date Agreement" icon="triangle-exclamation" href="/rules/content/date-agreement">
+    Checks the visible date, schema dates and URL/title year agree
+  </Card>
   <Card title="Duplicate Description" icon="triangle-exclamation" href="/rules/content/duplicate-description">
     Checks for duplicate meta descriptions across the site
   </Card>

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -85,6 +85,10 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // its own single whole-crawl check (#105).
       // 98217 -> 98218: crawl/sitemap-lastmod-drift, likewise site-scoped, adds
       // its own single whole-crawl check (#107).
+      // Unmoved by content/date-agreement (#108): like schema/rating-scope it is
+      // page-scoped but speaks ONLY when a page carries a date on a
+      // document-describing schema node, and the fixture emits no JSON-LD at all —
+      // so it contributes a tally key below without a single finding.
       expect(v1.findings.length).toBe(98218);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
@@ -92,9 +96,10 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // schema/coverage-outlier, 269 -> 270 url/slug-convention, 270 -> 271
       // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier,
       // 272 -> 273 schema/rating-scope, 273 -> 274 crawl/sitemap-lastmod-churn,
-      // 274 -> 275 crawl/sitemap-lastmod-drift; anything else means a rule id
+      // 274 -> 275 crawl/sitemap-lastmod-drift, 275 -> 276
+      // content/date-agreement; anything else means a rule id
       // leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(275);
+      expect(v1.perRuleTally.length).toBe(276);
     },
     180_000,
   );

--- a/packages/rules/src/content/date-agreement.ts
+++ b/packages/rules/src/content/date-agreement.ts
@@ -1,0 +1,703 @@
+// content/date-agreement - visible byline vs schema vs URL/title vs Last-Modified (#108)
+//
+// Both existing date rules are PRESENCE checks: content/freshness passes as soon
+// as any one signal exists, and eeat/content-dates reports the coverage
+// percentage of datePublished / dateModified. A page can therefore carry five
+// date signals that contradict each other and pass both — which is what
+// squirrelscan.com's own site did, in two opposite directions at once:
+//
+//   - /blog/* rendered a visible 2025 date while the only JSON-LD on the page
+//     was the sitewide SoftwareApplication (datePublished 2026, a release date),
+//   - /learn/* emitted Article JSON-LD with dates and showed the reader nothing.
+//
+// The defect this rule looks for is the DISAGREEMENT, so both halves of that
+// have to be reachable without inventing findings. Two false-positive traps cost
+// an internal audit pass two full re-runs (14 findings, 1 real) and are the
+// reason for most of the guards below:
+//
+//   1. A date belongs to the node that describes the DOCUMENT. A sitewide
+//      SoftwareApplication / Product / Organization node carries its own
+//      datePublished (when the software shipped, not when the post was written).
+//      Taking the first datePublished in the document attributed one placeholder
+//      release date to every blog post on the site. Only document-describing
+//      @types feed a disagreement warning; a date from any other node is
+//      reported with its source noted and can never raise one (see
+//      `SCHEMA_SOURCE_CHECK`).
+//   2. A byline is a POSITION, not a date-shaped string. Scanning body text read
+//      running prose ("INP replaced FID on March 12, 2024" on a 2026 page) and
+//      outbound citations (`<a>March 12, 2024</a>` pointing at web.dev) as
+//      publication dates. A candidate must sit near the top of main content AND
+//      look like byline markup, and an anchor's own text never counts.
+//
+// The reader-facing date is read from the DOM here rather than from the parser's
+// `visibleDatePublished`, which prefers a `<time datetime>` attribute: markup can
+// carry a machine-readable date with nothing rendered inside it, and a date the
+// reader cannot see is exactly the /learn/* defect.
+//
+// Last-Modified is extracted and reported alongside the others but never raises a
+// warning on its own — origins stamp it at deploy time far more often than at
+// content-change time, so a disagreement there is not evidence of a defect.
+
+import { z } from "zod";
+
+import type { Document, Element } from "linkedom";
+
+import { flattenJsonLdNodes, getPathname } from "@squirrelscan/utils";
+
+import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
+
+const BYLINE_CHECK = "byline-vs-schema-date";
+const VISIBLE_MISSING_CHECK = "visible-date-missing";
+const URL_TITLE_CHECK = "url-title-year";
+const SCHEMA_SOURCE_CHECK = "schema-date-source";
+
+const MS_PER_DAY = 86_400_000;
+
+/** Years a page could plausibly assert; outside this a 4-digit run is an id. */
+const MIN_YEAR = 1990;
+const MAX_YEAR = 2999;
+
+/** Longest line that can still read as a byline rather than as body copy. */
+const MAX_BYLINE_LEN = 120;
+/** How far into main content the byline zone extends (elements / leaf text). */
+const MAX_ZONE_ELEMENTS = 60;
+const MAX_ZONE_CHARS = 600;
+/** Distinct visible dates considered before the page is judged (see below). */
+const MAX_VISIBLE_DATES = 4;
+
+export const optionsSchema = z.object({
+  tolerance_days: z
+    .number()
+    .default(1)
+    .describe(
+      "Days the visible byline date may differ from the schema document date before warning",
+    ),
+});
+
+/**
+ * Schema `@type`s that stand for a dated piece of CONTENT. These are the types a
+ * reader expects a visible date on, so they are also the only ones that can
+ * raise `visible-date-missing`.
+ */
+const ARTICLE_TYPES = new Set(
+  [
+    "Article",
+    "AdvertiserContentArticle",
+    "BlogPosting",
+    "DiscussionForumPosting",
+    "LiveBlogPosting",
+    "NewsArticle",
+    "ReportageNewsArticle",
+    "ScholarlyArticle",
+    "SocialMediaPosting",
+    "TechArticle",
+  ].map((t) => t.toLowerCase()),
+);
+
+/**
+ * Page-level `@type`s: they describe the document without being dated content in
+ * their own right. Their dates are comparable, but a page node carrying dates is
+ * usually CMS boilerplate (WordPress SEO plugins emit one on every page of a
+ * site, contact form included), so it never has to render a visible date —
+ * demanding one would warn on every page of every WordPress site, which is the
+ * noise this rule exists to avoid.
+ */
+const PAGE_TYPES = [
+  "Report",
+  "WebPage",
+  "AboutPage",
+  "CheckoutPage",
+  "CollectionPage",
+  "ContactPage",
+  "FAQPage",
+  "ItemPage",
+  "MedicalWebPage",
+  "ProfilePage",
+  "QAPage",
+  "SearchResultsPage",
+  "Recipe",
+  "HowTo",
+].map((t) => t.toLowerCase());
+
+/**
+ * Every `@type` whose node describes the DOCUMENT — the page itself or the
+ * single piece of content it exists to publish. A date on one of these is a
+ * claim about when THIS page was published or updated. Everything else
+ * (SoftwareApplication, Product, Organization, WebSite, Person, ...) describes a
+ * thing the page merely mentions, and its dates mean something else entirely.
+ */
+const DOCUMENT_TYPES = new Set([...ARTICLE_TYPES, ...PAGE_TYPES]);
+
+// ============================================================================
+// Date parsing
+// ============================================================================
+
+const MONTH_NAMES =
+  "jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t)?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?";
+
+const MONTH_INDEX: Record<string, number> = {
+  jan: 0,
+  feb: 1,
+  mar: 2,
+  apr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  aug: 7,
+  sep: 8,
+  oct: 9,
+  nov: 10,
+  dec: 11,
+};
+
+const ISO_DATE_RE = /(?<!\d)(\d{4})-(\d{2})-(\d{2})(?!\d)/;
+const MONTH_FIRST_RE = new RegExp(
+  `\\b(${MONTH_NAMES})\\.?\\s+(\\d{1,2})(?:st|nd|rd|th)?,?\\s+(\\d{4})\\b`,
+  "i",
+);
+const DAY_FIRST_RE = new RegExp(
+  `\\b(\\d{1,2})(?:st|nd|rd|th)?\\s+(${MONTH_NAMES})\\.?,?\\s+(\\d{4})\\b`,
+  "i",
+);
+
+/** A date signal, normalized to UTC midnight so two forms compare cleanly. */
+interface DateSignal {
+  /** The value exactly as the page states it — quoted back in findings. */
+  value: string;
+  /** UTC midnight of the calendar day the value names. */
+  ms: number;
+  /** Where the value came from — reported so a fix targets the right markup. */
+  source: string;
+}
+
+function utcDay(year: number, month: number, day: number): number | null {
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+  if (year < MIN_YEAR || year > MAX_YEAR) return null;
+  if (month < 0 || month > 11 || day < 1 || day > 31) return null;
+  return Date.UTC(year, month, day);
+}
+
+/**
+ * The first calendar date named in `text`, as UTC midnight. Written forms are
+ * built from their own components rather than handed to `Date.parse`, which
+ * reads "March 12, 2024" as LOCAL midnight — enough to shift the calendar day
+ * and turn an exact match into a one-day disagreement in half the world's
+ * timezones.
+ */
+export function matchDate(text: string): { text: string; ms: number } | null {
+  const iso = ISO_DATE_RE.exec(text);
+  if (iso) {
+    const ms = utcDay(Number(iso[1]), Number(iso[2]) - 1, Number(iso[3]));
+    if (ms !== null) return { text: iso[0], ms };
+  }
+
+  const monthFirst = MONTH_FIRST_RE.exec(text);
+  if (monthFirst) {
+    const month = MONTH_INDEX[monthFirst[1]!.slice(0, 3).toLowerCase()];
+    const ms =
+      month === undefined ? null : utcDay(Number(monthFirst[3]), month, Number(monthFirst[2]));
+    if (ms !== null) return { text: monthFirst[0], ms };
+  }
+
+  const dayFirst = DAY_FIRST_RE.exec(text);
+  if (dayFirst) {
+    const month = MONTH_INDEX[dayFirst[2]!.slice(0, 3).toLowerCase()];
+    const ms = month === undefined ? null : utcDay(Number(dayFirst[3]), month, Number(dayFirst[1]));
+    if (ms !== null) return { text: dayFirst[0], ms };
+  }
+
+  return null;
+}
+
+/**
+ * A machine-readable date value (schema property, `datetime` attribute,
+ * `Last-Modified` header). The written forms above are tried first so the
+ * timezone-safe path wins; `Date.parse` is the fallback for RFC-1123 and other
+ * stamps, read back in UTC.
+ */
+function parseDateValue(raw: string | null | undefined, source: string): DateSignal | null {
+  const value = (raw ?? "").trim();
+  if (!value) return null;
+
+  const matched = matchDate(value);
+  if (matched) return { value, ms: matched.ms, source };
+
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return null;
+  const date = new Date(parsed);
+  const ms = utcDay(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  return ms === null ? null : { value, ms, source };
+}
+
+function deltaDays(a: number, b: number): number {
+  return Math.round(Math.abs(a - b) / MS_PER_DAY);
+}
+
+// ============================================================================
+// Schema dates
+// ============================================================================
+
+/** Dates read off the JSON-LD, split by whether their node describes the page. */
+interface SchemaDates {
+  /** Date(s) from a document-describing node — the only ones that can warn. */
+  document: { type: string; published: DateSignal | null; modified: DateSignal | null } | null;
+  /** A date from some other node (sitewide app/product/org), source noted. */
+  fallback: { type: string; field: string; value: string } | null;
+}
+
+/** `@type` values as authored; generators array-wrap `@type` freely. */
+function typeNames(node: Record<string, unknown>): string[] {
+  const raw = node["@type"];
+  const list: unknown[] = Array.isArray(raw) ? (raw as unknown[]) : [raw];
+  return list.filter((t): t is string => typeof t === "string" && t.length > 0);
+}
+
+/** A JSON-LD date property: a plain string, or a `{"@value": ...}` wrapper. */
+function schemaDateString(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const inner = (value as Record<string, unknown>)["@value"];
+    if (typeof inner === "string") return inner.trim() || null;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = schemaDateString(entry);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Split every JSON-LD date on the page by the kind of node carrying it. An
+ * Article-family node wins over a generic page node — a Yoast-style `@graph`
+ * emits a dated `WebPage` ahead of the `BlogPosting`, and the post's own node is
+ * the one that speaks for the content. A date on any node that describes neither
+ * is kept only so the rule can NAME it (a SoftwareApplication release date looks
+ * exactly like a publish date until you ask what it is attached to).
+ */
+function collectSchemaDates(raw: string | null | undefined): SchemaDates {
+  const result: SchemaDates = { document: null, fallback: null };
+  if (!raw) return result;
+
+  let articleNode: SchemaDates["document"] = null;
+  let pageNode: SchemaDates["document"] = null;
+
+  for (const node of flattenJsonLdNodes(raw)) {
+    const published = schemaDateString(node["datePublished"]);
+    const modified = schemaDateString(node["dateModified"]);
+    if (!published && !modified) continue;
+
+    const types = typeNames(node);
+    const documentType = types.find((t) => DOCUMENT_TYPES.has(t.toLowerCase()));
+
+    if (documentType) {
+      const isArticle = ARTICLE_TYPES.has(documentType.toLowerCase());
+      if (isArticle ? articleNode !== null : pageNode !== null) continue;
+
+      const publishedSignal = parseDateValue(published, "schema:datePublished");
+      const modifiedSignal = parseDateValue(modified, "schema:dateModified");
+      if (!publishedSignal && !modifiedSignal) continue;
+
+      const entry = { type: documentType, published: publishedSignal, modified: modifiedSignal };
+      if (isArticle) articleNode = entry;
+      else pageNode = entry;
+      continue;
+    }
+
+    if (!result.fallback) {
+      const value = published ?? modified;
+      if (value) {
+        result.fallback = {
+          type: types[0] ?? "untyped node",
+          field: published ? "datePublished" : "dateModified",
+          value,
+        };
+      }
+    }
+  }
+
+  result.document = articleNode ?? pageNode;
+  return result;
+}
+
+/** Raw JSON-LD for the page: the parser's, else the document's own scripts. */
+function rawJsonLd(ctx: RuleContext, doc: Document): string | null {
+  const parsed = ctx.parsed.schema?.raw;
+  if (parsed) return parsed;
+  const blocks = [...doc.querySelectorAll('script[type="application/ld+json"]')]
+    .map((script) => (script.textContent ?? "").trim())
+    .filter(Boolean);
+  return blocks.length > 0 ? blocks.join("\n\n") : null;
+}
+
+// ============================================================================
+// Visible byline date
+// ============================================================================
+
+/** Class/id tokens that mark byline / entry-meta markup. */
+const BYLINE_CONTEXT_RE =
+  /\b(byline|by-line|dateline|entry-meta|entry-date|post-meta|post-date|article-meta|article-date|published|pubdate|posted-on|publish-date|meta-date|timestamp)\b/i;
+
+/** Words a byline line legitimately opens with. */
+const BYLINE_PREFIX_RE =
+  /^(published|posted|updated|last\s+updated|last\s+modified|last\s+reviewed|written|reviewed|revised|date)\b/i;
+
+/** Decorations that survive removing the date from a byline line. */
+const BYLINE_NOISE_RE =
+  /\b(\d+\s*min(?:ute)?s?\s*read|read\s*time|published|posted|updated|last\s+modified|on|in|at)\b/gi;
+
+/** What is left of a byline once the date and its decorations are gone. */
+const BYLINE_RESIDUE_RE = /^[\s·|•\-–—,.:;()]*(?:by\s+[^,|·•]{2,60}?)?[\s·|•\-–—,.:;()]*$/i;
+
+function cleanText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * `el`'s text with every anchor's text removed. A date-shaped string that only
+ * exists inside a link is a citation ("as measured on <a>March 12, 2024</a>"),
+ * not this page's publication date.
+ */
+function textWithoutAnchors(el: Element): string {
+  let text = "";
+  for (const node of el.childNodes) {
+    if (node.nodeType === 3) {
+      text += node.textContent ?? "";
+      continue;
+    }
+    if (node.nodeType !== 1) continue;
+    const child = node as unknown as Element;
+    if (child.tagName?.toLowerCase() === "a") continue;
+    text += textWithoutAnchors(child);
+  }
+  return text;
+}
+
+/** The region a byline can live in: the article body, else main, else the page. */
+function contentRoot(doc: Document): Element | null {
+  return (
+    (doc.querySelector("article") as Element | null) ??
+    (doc.querySelector("main") as Element | null) ??
+    (doc.querySelector("[role='main']") as Element | null) ??
+    (doc.body as Element | null)
+  );
+}
+
+/** Site chrome and non-text subtrees: never a byline, and never zone budget. */
+const SKIP_TAGS = new Set([
+  "nav",
+  "aside",
+  "footer",
+  "form",
+  "button",
+  "select",
+  "script",
+  "style",
+  "svg",
+  "noscript",
+  "template",
+]);
+const SKIP_ROLES = new Set(["navigation", "banner", "contentinfo", "search"]);
+
+function isChrome(el: Element): boolean {
+  const tag = el.tagName?.toLowerCase() ?? "";
+  if (SKIP_TAGS.has(tag)) return true;
+  const role = (el.getAttribute("role") ?? "").toLowerCase();
+  return role !== "" && SKIP_ROLES.has(role);
+}
+
+/**
+ * Elements in the top zone of main content, in document order. The zone ends
+ * once the page has produced `MAX_ZONE_CHARS` of rendered leaf text or
+ * `MAX_ZONE_ELEMENTS` elements — a byline sits above the article body, so
+ * anything past that is prose, and prose is where the false positives live.
+ *
+ * Navigation and other chrome is skipped whole rather than counted: when a page
+ * has no `<article>`/`<main>` the walk starts at `<body>`, and a long menu would
+ * otherwise spend the entire zone before reaching the byline.
+ */
+function topZoneElements(root: Element): Element[] {
+  const zone: Element[] = [];
+  let chars = 0;
+
+  const visit = (el: Element): void => {
+    for (const child of [...el.children] as Element[]) {
+      if (zone.length >= MAX_ZONE_ELEMENTS || chars >= MAX_ZONE_CHARS) return;
+      if (isChrome(child)) continue;
+      zone.push(child);
+      if (child.children.length === 0) {
+        // Only leaves add to the budget, so a wrapper's text is not counted
+        // once per level of nesting.
+        chars += cleanText(child.textContent).length;
+      } else {
+        visit(child);
+      }
+    }
+  };
+
+  visit(root);
+  return zone;
+}
+
+function hasBylineContext(el: Element): boolean {
+  const marker = `${el.getAttribute("class") ?? ""} ${el.getAttribute("id") ?? ""}`;
+  return BYLINE_CONTEXT_RE.test(marker);
+}
+
+/** True when the line says nothing beyond the date and byline decorations. */
+function isBylineLine(line: string, dateText: string): boolean {
+  if (BYLINE_PREFIX_RE.test(line)) return true;
+  const residue = line.replace(dateText, " ").replace(BYLINE_NOISE_RE, " ");
+  return BYLINE_RESIDUE_RE.test(cleanText(residue));
+}
+
+/**
+ * The dates the reader actually sees, in document order (first = the one a
+ * finding quotes). A candidate must sit in the top zone of main content and be
+ * byline-shaped: a `<time>` element, markup that names itself a byline, or a
+ * short line that says nothing but the date (plus "Published"/"by Author"-style
+ * decoration). Anchor text never qualifies unless it is wrapped in `<time>` — a
+ * permalinked post date is markup, an outbound citation is prose.
+ *
+ * Several are collected rather than just the first because pages legitimately
+ * show two ("Published … · Updated …"), and a listing page shows one per item;
+ * a disagreement is only real when NONE of them matches the schema.
+ */
+function findVisibleDates(doc: Document): DateSignal[] {
+  const root = contentRoot(doc);
+  if (!root) return [];
+
+  const found: DateSignal[] = [];
+  const seen = new Set<number>();
+  const add = (signal: DateSignal): void => {
+    if (seen.has(signal.ms)) return;
+    seen.add(signal.ms);
+    found.push(signal);
+  };
+
+  for (const el of topZoneElements(root)) {
+    if (found.length >= MAX_VISIBLE_DATES) break;
+    const tag = el.tagName?.toLowerCase();
+    if (tag === "a") continue;
+
+    if (tag === "time") {
+      // An empty `<time datetime>` renders nothing: machine-readable, invisible.
+      const shown = cleanText(el.textContent);
+      if (!shown) continue;
+      const signal =
+        parseDateValue(el.getAttribute("datetime"), "visible:time") ??
+        parseDateValue(shown, "visible:time");
+      if (signal) add({ ...signal, value: shown });
+      continue;
+    }
+
+    // Anchors are stripped so a citation's own text can never be the byline;
+    // a `<time>` nested in a permalink is reached by the branch above.
+    const line = cleanText(textWithoutAnchors(el));
+    if (!line || line.length > MAX_BYLINE_LEN) continue;
+
+    const matched = matchDate(line);
+    if (!matched) continue;
+    if (!hasBylineContext(el) && !isBylineLine(line, matched.text)) continue;
+
+    add({ value: matched.text, ms: matched.ms, source: "visible:byline" });
+  }
+
+  return found;
+}
+
+/**
+ * True when main content prints a date-shaped string ANYWHERE — byline-shaped or
+ * not, citation or prose. "This page shows the reader no date" is only worth
+ * saying when it is literally true: a date this rule declined to read as a
+ * byline is still a date on the reader's screen, and accusing a page that shows
+ * one is exactly the kind of finding that gets a rule switched off.
+ */
+function showsAnyDate(doc: Document): boolean {
+  const root = contentRoot(doc);
+  return root !== null && matchDate(cleanText(root.textContent)) !== null;
+}
+
+// ============================================================================
+// URL / title year
+// ============================================================================
+
+const YEAR_RE = /(?<!\d)(19|20)\d{2}(?!\d)/;
+
+function yearIn(text: string): number | null {
+  const match = YEAR_RE.exec(text);
+  if (!match) return null;
+  const year = Number(match[0]);
+  return year >= MIN_YEAR && year <= MAX_YEAR ? year : null;
+}
+
+// ============================================================================
+// Rule
+// ============================================================================
+
+export const dateAgreementRule: Rule = {
+  meta: {
+    id: "content/date-agreement",
+    name: "Date Agreement",
+    description: "Checks the visible date, schema dates and URL/title year agree",
+    solution:
+      "A page states its date more than once - the visible byline, schema.org datePublished/dateModified, a year in the URL or title, the sitemap lastmod, the Last-Modified header - and readers and crawlers do not all read the same one. When they disagree, at least one is wrong, and presence checks cannot tell you which: they pass as soon as any single signal exists. Drive every date on the page from ONE content timestamp. If the visible byline disagrees with the schema, fix whichever renders from the wrong field (a common cause is the template printing a build-time or hardcoded value while the schema prints the CMS field). If the schema carries dates the reader never sees, render the date in the article header - Google asks for a visible date on dated content, and a date only crawlers can see is not one. Check the schema date is attached to the node describing the page (Article/BlogPosting/WebPage): a datePublished on a sitewide SoftwareApplication or Organization node is that entity's own date and says nothing about this page.",
+    category: "content",
+    scope: "page",
+    severity: "warning",
+    weight: 4,
+    optionsSchema,
+    // A soft-404 serves the site template for a URL that does not exist; its
+    // dates describe nothing, so arguing about them is noise.
+    skipOnSoft404: true,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const opts = optionsSchema.parse(ctx.options);
+    const doc = ctx.parsed.document;
+    if (!doc) return { checks: [] };
+
+    const schema = collectSchemaDates(rawJsonLd(ctx, doc));
+    const visibleDates = findVisibleDates(doc);
+    const visible = visibleDates[0] ?? null;
+    const header = parseDateValue(ctx.page.headers["last-modified"], "header:last-modified");
+
+    // No date attached to a node that describes this page: there is nothing to
+    // hold the other signals against. Name the node the date DID come from when
+    // the page also shows a date, so "schema says 2026, the page says 2025" is
+    // traceable to the sitewide node it really belongs to — but never treat that
+    // as a disagreement, because it is not one.
+    if (!schema.document) {
+      if (schema.fallback && visible) {
+        return {
+          checks: [
+            {
+              name: SCHEMA_SOURCE_CHECK,
+              status: "info",
+              message:
+                `The only schema date on this page is ${schema.fallback.field} ` +
+                `${schema.fallback.value} on a ${schema.fallback.type} node, which describes that ` +
+                `entity rather than this page — the visible date ${visible.value} has nothing to ` +
+                "be checked against. Add datePublished/dateModified to an Article or WebPage node.",
+              value: visible.value,
+              details: {
+                visibleDate: visible.value,
+                visibleDateSource: visible.source,
+                schemaDate: schema.fallback.value,
+                schemaDateField: schema.fallback.field,
+                schemaDateNodeType: schema.fallback.type,
+                lastModified: header?.value ?? null,
+                reason: "no-document-schema-date",
+              },
+            },
+          ],
+        };
+      }
+      return { checks: [] };
+    }
+
+    const docNode = schema.document;
+    const schemaDates = [docNode.published, docNode.modified].filter(
+      (d): d is DateSignal => d !== null,
+    );
+    const checks: CheckResult[] = [];
+    const baseDetails = {
+      schemaNodeType: docNode.type,
+      schemaDatePublished: docNode.published?.value ?? null,
+      schemaDateModified: docNode.modified?.value ?? null,
+      lastModified: header?.value ?? null,
+    };
+
+    // A page-level node (WebPage, CollectionPage, ...) alongside SEVERAL visible
+    // dates is an index or archive: those dates belong to the entries it lists,
+    // not to the page, so there is nothing here to disagree with.
+    const isListing = visibleDates.length > 1 && !ARTICLE_TYPES.has(docNode.type.toLowerCase());
+
+    if (visible && !isListing) {
+      // Every visible date is measured against the CLOSEST schema date, and the
+      // best pairing decides. A page showing "Published January … Updated March"
+      // is telling the truth about both, and a listing page shows one date per
+      // item — only when NOTHING on the page matches the schema is there a real
+      // disagreement to report.
+      const best = visibleDates
+        .map((shown) => {
+          const nearest = schemaDates.reduce((closest, candidate) =>
+            deltaDays(shown.ms, candidate.ms) < deltaDays(shown.ms, closest.ms) ? candidate : closest,
+          );
+          return { shown, nearest, gap: deltaDays(shown.ms, nearest.ms) };
+        })
+        .reduce((closest, candidate) => (candidate.gap < closest.gap ? candidate : closest));
+
+      checks.push(
+        best.gap > opts.tolerance_days
+          ? {
+              name: BYLINE_CHECK,
+              status: "warn",
+              message:
+                `The visible date reads ${best.shown.value} but the ${docNode.type} schema says ` +
+                `${best.nearest.source.replace("schema:", "")} ${best.nearest.value} — ` +
+                `${best.gap} day(s) apart, so readers and crawlers are being told different things`,
+              value: best.shown.value,
+              expected: best.nearest.value,
+              details: { ...baseDetails, visibleDate: best.shown.value, gapDays: best.gap },
+            }
+          : {
+              name: BYLINE_CHECK,
+              status: "pass",
+              message: `Visible date ${best.shown.value} agrees with the ${docNode.type} schema dates`,
+              value: best.shown.value,
+              details: { ...baseDetails, visibleDate: best.shown.value, gapDays: best.gap },
+            },
+      );
+    } else if (!visible && ARTICLE_TYPES.has(docNode.type.toLowerCase()) && !showsAnyDate(doc)) {
+      // Dates in the markup and none on the page: the /learn/* half of #108.
+      // `showsAnyDate` keeps this off a page that prints a date this rule
+      // declined to read as a byline — a citation, or a format it cannot parse.
+      const stated = docNode.published ?? docNode.modified;
+      if (stated) {
+        checks.push({
+          name: VISIBLE_MISSING_CHECK,
+          status: "warn",
+          message:
+            `This ${docNode.type} states ${stated.source.replace("schema:", "")} ` +
+            `${stated.value} in its schema but shows the reader no date at all`,
+          expected: stated.value,
+          details: { ...baseDetails, reason: "no-visible-date" },
+        });
+      }
+    }
+
+    // A year in the URL or the title is a date claim too, and it is the one
+    // nobody updates when a post is re-dated.
+    const pathYear = yearIn(getPathname(ctx.page.url) || ctx.page.url);
+    const titleYear = pathYear === null ? yearIn(ctx.parsed.meta?.title ?? "") : null;
+    const claimedYear = pathYear ?? titleYear;
+    if (claimedYear !== null) {
+      const where = pathYear !== null ? "URL" : "title";
+      const schemaYears = schemaDates.map((d) => new Date(d.ms).getUTCFullYear());
+      checks.push(
+        schemaYears.includes(claimedYear)
+          ? {
+              name: URL_TITLE_CHECK,
+              status: "pass",
+              message: `The ${where} year ${claimedYear} matches the ${docNode.type} schema dates`,
+              value: claimedYear,
+              details: { ...baseDetails, claimedYear, claimedYearSource: where },
+            }
+          : {
+              name: URL_TITLE_CHECK,
+              status: "warn",
+              message:
+                `The ${where} says ${claimedYear} but the ${docNode.type} schema dates are from ` +
+                `${[...new Set(schemaYears)].join("/")}`,
+              value: claimedYear,
+              expected: schemaYears[0] ?? null,
+              details: { ...baseDetails, claimedYear, claimedYearSource: where },
+            },
+      );
+    }
+
+    return { checks };
+  },
+};

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../types";
 import { articleLinksRule } from "./article-links";
 import { authorInfoRule } from "./author-info";
 import { brokenHtmlRule } from "./broken-html";
+import { dateAgreementRule } from "./date-agreement";
 import { duplicateDescriptionRule } from "./duplicate-description";
 import { duplicateTitleRule } from "./duplicate-title";
 import { freshnessRule } from "./freshness";
@@ -40,6 +41,7 @@ export const rules: Rule[] = [
   staleCopyrightRule,
   thinVsSiteNormRule,
   titlePatternOutlierRule,
+  dateAgreementRule,
 ];
 
 export {
@@ -47,6 +49,7 @@ export {
   authorInfoRule,
   brokenHtmlRule,
   contentQualityRule,
+  dateAgreementRule,
   duplicateDescriptionRule,
   duplicateTitleRule,
   freshnessRule,

--- a/packages/rules/tests/content-date-agreement.test.ts
+++ b/packages/rules/tests/content-date-agreement.test.ts
@@ -1,0 +1,398 @@
+// content/date-agreement — the date signals on a page must agree (#108).
+//
+// content/freshness passes as soon as ANY date signal exists and eeat/content-dates
+// reports coverage, so squirrelscan.com's own site passed both while broken in two
+// opposite directions: /blog/* showed a 2025 byline against a 2026 schema date, and
+// /learn/* emitted Article dates the reader never saw.
+//
+// The must-not-fire cases below are load-bearing, not decoration: the first version
+// of this check inside an internal audit pass produced 14 findings of which 1 was
+// real, and both causes (a date read off a sitewide SoftwareApplication node, a
+// date-shaped string read out of prose or a citation link) are pinned here.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult } from "@squirrelscan/core-contracts";
+
+import { parsePage } from "@squirrelscan/parser";
+
+import { dateAgreementRule, matchDate } from "../src/content/date-agreement";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+function run(
+  html: string,
+  url = "https://example.com/blog/post",
+  headers: Record<string, string> = {},
+): CheckResult[] {
+  const ctx: RuleContext = {
+    page: { url, html, statusCode: 200, loadTime: 0, headers },
+    parsed: parsePage(html, url) as ParsedPage,
+    options: {},
+  };
+  return dateAgreementRule.run(ctx).checks as CheckResult[];
+}
+
+function check(checks: CheckResult[], name: string): CheckResult | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+function page(schema: unknown, body: string, title = "A post about caching"): string {
+  const ld = schema
+    ? `<script type="application/ld+json">${JSON.stringify(schema)}</script>`
+    : "";
+  return `<html><head><title>${title}</title>${ld}</head><body>${body}</body></html>`;
+}
+
+/** The sitewide node every page of the site carries — NOT a document date. */
+const SITEWIDE_APP = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "squirrel",
+  datePublished: "2026-01-01",
+};
+
+function article(datePublished: string, dateModified?: string): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: "A post about caching",
+    datePublished,
+    ...(dateModified ? { dateModified } : {}),
+  };
+}
+
+const PROSE =
+  "<p>Caching is the cheapest performance win available to most sites, and the headers " +
+  "that drive it are set once and then forgotten for years at a time.</p>";
+
+describe("matchDate", () => {
+  test("reads the written forms a byline actually uses", () => {
+    expect(matchDate("March 12, 2024")?.ms).toBe(Date.UTC(2024, 2, 12));
+    expect(matchDate("Mar 12, 2024")?.ms).toBe(Date.UTC(2024, 2, 12));
+    expect(matchDate("12 March 2024")?.ms).toBe(Date.UTC(2024, 2, 12));
+    expect(matchDate("2024-03-12")?.ms).toBe(Date.UTC(2024, 2, 12));
+    expect(matchDate("2024-03-12T09:30:00Z")?.ms).toBe(Date.UTC(2024, 2, 12));
+  });
+
+  test("a written date is read as the calendar day, not as local midnight", () => {
+    // Date.parse("March 12, 2024") is LOCAL midnight, which lands on the 11th in
+    // UTC for every timezone east of Greenwich — enough to turn an exact match
+    // into a one-day disagreement depending on where the audit runs.
+    expect(matchDate("March 12, 2024")?.ms).toBe(matchDate("2024-03-12")?.ms);
+  });
+
+  test("a run of digits that is not a date is not one", () => {
+    expect(matchDate("Order 20240312 shipped")).toBeNull();
+    expect(matchDate("no dates here")).toBeNull();
+  });
+});
+
+describe("content/date-agreement — must not fire", () => {
+  test("Article node beside a sitewide SoftwareApplication with a different date", () => {
+    // The trap: taking the FIRST datePublished in the document attributed the
+    // app's 2026-01-01 release date to every post on the site.
+    const html = page(
+      [SITEWIDE_APP, article("2025-11-04")],
+      `<main><article><p class="byline">Published on November 4, 2025 by Nik</p>${PROSE}</article></main>`,
+    );
+    const checks = run(html);
+
+    expect(checks.every((c) => c.status !== "warn")).toBe(true);
+    expect(check(checks, "byline-vs-schema-date")?.status).toBe("pass");
+    // The comparison used the Article node, not the app's release date.
+    expect(check(checks, "byline-vs-schema-date")?.details?.["schemaNodeType"]).toBe("Article");
+  });
+
+  test("a date in running prose is not a byline", () => {
+    const html = page(
+      article("2026-02-10"),
+      "<main><article><h1>Interaction to Next Paint</h1>" +
+        "<p>INP replaced FID on March 12, 2024, and the threshold has not moved since.</p>" +
+        `<p class="byline">Published on February 10, 2026</p>${PROSE}</article></main>`,
+    );
+    const checks = run(html);
+
+    expect(checks.every((c) => c.status !== "warn")).toBe(true);
+    expect(check(checks, "byline-vs-schema-date")?.value).toBe("February 10, 2026");
+  });
+
+  test("prose without any byline at all is still not read as a byline", () => {
+    // Same prose, no byline markup anywhere: the sentence must not become the
+    // page's visible date and produce a 2024-vs-2026 disagreement.
+    const html = page(
+      { ...article("2026-02-10"), "@type": "WebPage" },
+      "<main><h1>Interaction to Next Paint</h1>" +
+        "<p>INP replaced FID on March 12, 2024, and the threshold has not moved since.</p>" +
+        `${PROSE}</main>`,
+    );
+
+    expect(run(html).every((c) => c.status !== "warn")).toBe(true);
+  });
+
+  test("a date that only exists inside an outbound citation link", () => {
+    const html = page(
+      article("2026-02-10"),
+      "<main><article><h1>Interaction to Next Paint</h1>" +
+        '<p>Announced <a href="https://web.dev/blog/inp-cwv">March 12, 2024</a>.</p>' +
+        `${PROSE}</article></main>`,
+    );
+    const checks = run(html);
+
+    // Not a disagreement with the citation's date, and not "no date at all"
+    // either: the page does print a date, this rule just declines to read it as
+    // the byline. Accusing it of showing none would be its own false positive.
+    expect(checks.every((c) => c.status !== "warn")).toBe(true);
+    expect(check(checks, "byline-vs-schema-date")).toBeUndefined();
+    expect(check(checks, "visible-date-missing")).toBeUndefined();
+  });
+
+  test("a long nav above the content does not push the byline out of the zone", () => {
+    // With no <article>/<main> the walk starts at <body>; chrome is skipped
+    // whole so a menu cannot spend the whole byline zone before the byline.
+    const nav = Array.from({ length: 40 }, (_, i) => `<a href="/p/${i}">Section number ${i}</a>`)
+      .join("");
+    const html = page(
+      article("2026-01-08"),
+      `<header><nav>${nav}</nav></header>` +
+        '<div class="post"><h1>Caching</h1><p class="byline">Published on January 8, 2026</p>' +
+        `${PROSE}</div>`,
+    );
+
+    expect(check(run(html), "byline-vs-schema-date")?.status).toBe("pass");
+  });
+
+  test("a WebPage node with CMS boilerplate dates is not required to show a date", () => {
+    // Yoast et al. emit a dated WebPage node on every page of a site, contact
+    // form included; demanding a rendered byline there warns on everything.
+    const html = page(
+      { "@context": "https://schema.org", "@type": "WebPage", datePublished: "2026-02-10" },
+      `<main><h1>Contact us</h1>${PROSE}</main>`,
+      "Contact us",
+    );
+
+    expect(run(html, "https://example.com/contact").length).toBe(0);
+  });
+
+  test("an archive listing one date per entry is not a page-level disagreement", () => {
+    const items = ["2024-03-12", "2025-06-01", "2026-01-08"]
+      .map((d) => `<li><a href="/blog/${d}"><time datetime="${d}">${d}</time></a></li>`)
+      .join("");
+    const html = page(
+      { "@context": "https://schema.org", "@type": "CollectionPage", dateModified: "2026-06-30" },
+      `<main><h1>Archive</h1><ul>${items}</ul></main>`,
+      "Blog archive",
+    );
+
+    expect(run(html, "https://example.com/blog").every((c) => c.status !== "warn")).toBe(true);
+  });
+
+  test("a Published date and an Updated date, only one of which matches", () => {
+    const html = page(
+      article("2025-01-06", "2026-02-10"),
+      '<main><article><span class="byline">Published January 6, 2025</span>' +
+        '<span class="byline">Updated February 10, 2026</span>' +
+        `${PROSE}</article></main>`,
+    );
+
+    expect(run(html).every((c) => c.status !== "warn")).toBe(true);
+  });
+
+  test("a page with no date signals at all stays silent", () => {
+    expect(run(page(null, `<main><h1>Hello</h1>${PROSE}</main>`)).length).toBe(0);
+  });
+
+  test("a visible 'Updated' date that matches dateModified rather than datePublished", () => {
+    const html = page(
+      article("2025-01-06", "2026-02-10"),
+      '<main><article><p class="entry-meta">Updated February 10, 2026</p>' +
+        `${PROSE}</article></main>`,
+    );
+
+    expect(run(html).every((c) => c.status !== "warn")).toBe(true);
+  });
+});
+
+describe("content/date-agreement — disagreements", () => {
+  test("a visible 2025 byline against a 2026 schema date warns, naming both", () => {
+    const html = page(
+      article("2026-01-08"),
+      '<main><article><p class="byline">Published on November 4, 2025</p>' +
+        `${PROSE}</article></main>`,
+    );
+    const warn = check(run(html), "byline-vs-schema-date");
+
+    expect(warn?.status).toBe("warn");
+    expect(warn?.message).toContain("November 4, 2025");
+    expect(warn?.message).toContain("2026-01-08");
+    expect(warn?.value).toBe("November 4, 2025");
+    expect(warn?.expected).toBe("2026-01-08");
+    expect(warn?.details?.["gapDays"]).toBe(65);
+  });
+
+  test("a one-day difference is inside tolerance; two days is not", () => {
+    const body = (visible: string) =>
+      `<main><article><time datetime="${visible}">${visible}</time>${PROSE}</article></main>`;
+
+    expect(check(run(page(article("2026-01-08"), body("2026-01-09"))), "byline-vs-schema-date")
+      ?.status).toBe("pass");
+    expect(check(run(page(article("2026-01-08"), body("2026-01-10"))), "byline-vs-schema-date")
+      ?.status).toBe("warn");
+  });
+
+  test("schema dates with no visible date anywhere warns", () => {
+    const html = page(article("2026-01-08", "2026-02-01"), `<main><article>${PROSE}</article></main>`);
+    const warn = check(run(html), "visible-date-missing");
+
+    expect(warn?.status).toBe("warn");
+    expect(warn?.message).toContain("no date at all");
+    expect(warn?.expected).toBe("2026-01-08");
+  });
+
+  test("a <time> element with a datetime but nothing rendered shows the reader nothing", () => {
+    const html = page(
+      article("2026-01-08"),
+      `<main><article><time datetime="2026-01-08"></time>${PROSE}</article></main>`,
+    );
+
+    expect(check(run(html), "visible-date-missing")?.status).toBe("warn");
+  });
+
+  test("a year in the URL that disagrees with the schema date warns", () => {
+    const html = page(
+      article("2026-01-08"),
+      '<main><article><p class="byline">Published on January 8, 2026</p>' +
+        `${PROSE}</article></main>`,
+    );
+    const warn = check(run(html, "https://example.com/blog/2024/03/caching"), "url-title-year");
+
+    expect(warn?.status).toBe("warn");
+    expect(warn?.message).toContain("URL says 2024");
+    expect(warn?.value).toBe(2024);
+  });
+
+  test("a year in the title that disagrees with the schema date warns", () => {
+    const html = page(
+      article("2026-01-08"),
+      '<main><article><p class="byline">Published on January 8, 2026</p>' +
+        `${PROSE}</article></main>`,
+      "The best caching headers of 2023",
+    );
+    const warn = check(run(html), "url-title-year");
+
+    expect(warn?.status).toBe("warn");
+    expect(warn?.message).toContain("title says 2023");
+  });
+
+  test("a URL year that matches the schema date passes", () => {
+    const html = page(
+      article("2026-01-08"),
+      '<main><article><p class="byline">Published on January 8, 2026</p>' +
+        `${PROSE}</article></main>`,
+    );
+
+    expect(check(run(html, "https://example.com/blog/2026/01/caching"), "url-title-year")?.status)
+      .toBe("pass");
+  });
+});
+
+describe("content/date-agreement — schema date source", () => {
+  test("a visible date with only a non-document schema date reports the source, never a warning", () => {
+    // The /blog/* half of #108: the post's only JSON-LD was the sitewide
+    // SoftwareApplication, so there is nothing to disagree WITH.
+    const html = page(
+      SITEWIDE_APP,
+      '<main><article><p class="byline">Published on November 4, 2025</p>' +
+        `${PROSE}</article></main>`,
+    );
+    const checks = run(html);
+    const info = check(checks, "schema-date-source");
+
+    expect(checks.every((c) => c.status !== "warn")).toBe(true);
+    expect(info?.status).toBe("info");
+    expect(info?.message).toContain("SoftwareApplication");
+    expect(info?.details?.["schemaDateNodeType"]).toBe("SoftwareApplication");
+    expect(info?.details?.["schemaDate"]).toBe("2026-01-01");
+  });
+
+  test("a non-document schema date with no visible date says nothing", () => {
+    // Otherwise every page of every site carrying a sitewide dated node would
+    // report this.
+    expect(run(page(SITEWIDE_APP, `<main>${PROSE}</main>`)).length).toBe(0);
+  });
+});
+
+describe("content/date-agreement — agreement", () => {
+  test("visible, schema and Last-Modified dates that agree pass", () => {
+    const html = page(
+      article("2026-01-08", "2026-01-08"),
+      '<main><article><p class="byline">Published on January 8, 2026 by Nik</p>' +
+        `${PROSE}</article></main>`,
+    );
+    const checks = run(html, "https://example.com/blog/caching", {
+      "last-modified": "Thu, 08 Jan 2026 10:00:00 GMT",
+    });
+    const pass = check(checks, "byline-vs-schema-date");
+
+    expect(checks.every((c) => c.status !== "warn")).toBe(true);
+    expect(pass?.status).toBe("pass");
+    // All four page-side signals are extracted and reported, not just the two
+    // that can warn.
+    expect(pass?.details?.["visibleDate"]).toBe("January 8, 2026");
+    expect(pass?.details?.["schemaDatePublished"]).toBe("2026-01-08");
+    expect(pass?.details?.["lastModified"]).toBe("Thu, 08 Jan 2026 10:00:00 GMT");
+  });
+
+  test("dates inside a Yoast-style @graph are found", () => {
+    const html = page(
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          { "@type": "Organization", name: "Example", datePublished: "2019-01-01" },
+          { "@type": "BlogPosting", headline: "Caching", datePublished: "2026-01-08" },
+        ],
+      },
+      '<main><article><p class="entry-meta">January 8, 2026</p>' + `${PROSE}</article></main>`,
+    );
+    const pass = check(run(html), "byline-vs-schema-date");
+
+    expect(pass?.status).toBe("pass");
+    expect(pass?.details?.["schemaNodeType"]).toBe("BlogPosting");
+  });
+
+  test("an Article node wins over the generic WebPage node beside it", () => {
+    // Yoast-style graphs emit a dated WebPage ahead of the BlogPosting; the
+    // post's own node is the one that speaks for the content, so the byline is
+    // compared against it rather than against the page node's build stamp.
+    const html = page(
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          { "@type": "WebPage", dateModified: "2026-05-01" },
+          { "@type": "BlogPosting", headline: "Caching", datePublished: "2026-01-08" },
+        ],
+      },
+      '<main><article><p class="byline">Published on January 8, 2026</p>' +
+        `${PROSE}</article></main>`,
+    );
+    const pass = check(run(html), "byline-vs-schema-date");
+
+    expect(pass?.status).toBe("pass");
+    expect(pass?.details?.["schemaNodeType"]).toBe("BlogPosting");
+  });
+
+  test("a byline rendered as a permalinked <time> still counts as visible", () => {
+    const html = page(
+      article("2026-01-08"),
+      '<main><article><a href="/blog/caching"><time datetime="2026-01-08">January 8, 2026</time></a>' +
+        `${PROSE}</article></main>`,
+    );
+
+    expect(check(run(html), "byline-vs-schema-date")?.status).toBe("pass");
+  });
+
+  test("the rule is a page-scope content warning, not an error", () => {
+    expect(dateAgreementRule.meta.scope).toBe("page");
+    expect(dateAgreementRule.meta.category).toBe("content");
+    expect(dateAgreementRule.meta.severity).toBe("warning");
+  });
+});


### PR DESCRIPTION
Closes #108

New page-scope rule `content/date-agreement`: the disagreement BETWEEN a page's date signals is the
defect, and no rule looked for it. `content/freshness` passes as soon as any one signal exists and
`eeat/content-dates` reports coverage, so squirrelscan.com's own site passed both while broken in
two opposite directions (`/blog/*` 2025 byline vs 2026 schema; `/learn/*` Article dates the reader
never saw).

Four page-side signals are extracted and reported on every finding: visible byline date, schema
document date, URL/title year, `Last-Modified`. `Last-Modified` never raises a warning on its own —
origins stamp it at deploy time far more often than at content-change time.

### Checks

| Check | Fires when |
|---|---|
| `byline-vs-schema-date` | Visible date and schema document date more than `tolerance_days` (default 1) apart — both values named |
| `visible-date-missing` | An Article-family node states dates and main content prints no date at all |
| `url-title-year` | The URL year, else the title year, matches neither schema document date |
| `schema-date-source` | Info: the page shows a date but its only schema date sits on a node that does not describe the page |

### False-positive guards (both #108 traps are fixtures)

- Schema dates are read ONLY from document-describing `@type`s; an Article node wins over the
  generic `WebPage` beside it, and a date on a sitewide `SoftwareApplication` / `Product` /
  `Organization` is reported with its node type noted and can never raise a disagreement.
- A byline is a position: candidates must sit in the top zone of main content (chrome skipped) and
  be byline-shaped — a `<time>`, byline/entry-meta markup, or a short line saying nothing but the
  date. An anchor's own text never counts, so prose and outbound citations are not bylines.
- `visible-date-missing` only when main content prints no date-shaped string anywhere.
- A page-level node plus several visible dates is an index/archive, so nothing is compared.

### Acceptance criteria

- [x] New page-scope rule `content/date-agreement` under `packages/rules/src/content/`, registered in the rules catalog
- [x] Extracts up to four page-side signals: visible byline date, schema document date, URL/title date, `Last-Modified` header
- [x] Warns when the visible byline date and the schema document date disagree by more than 1 day, naming both values
- [x] Warns when a page emits schema document dates but shows the reader no visible date
- [x] Warns when a URL or title contains a year that disagrees with the schema document date
- [x] Schema dates are read ONLY from document-describing `@type` nodes; a date taken from any other node is reported with its source noted (`schema-date-source`, info) and never used to raise a disagreement warning on its own
- [x] Fixture: page with an `Article` node plus a sitewide `SoftwareApplication` whose `datePublished` differs — no warning
- [x] Fixture: page whose body prose contains a date unrelated to publication (`INP replaced FID on March 12, 2024`) — no warning
- [x] Fixture: page whose only date-shaped string is inside an outbound citation link — no warning
- [x] Fixture: visible 2025 byline against schema 2026 — warns
- [x] Passes on a page whose visible, schema, and header dates agree
- [x] Rule page added to `docs/` (`docs/rules/content/date-agreement.mdx`, listed in `docs.json` and the Content index)
- [x] `streaming-rules-canonical-golden.test.ts` updated with a comment line naming this rule as the cause, matching the convention used for the rules above it

### One deviation, called out

The golden pin moves `perRuleTally.length` 275 -> 276 but leaves `findings.length` at 98218, not
98219. The canonical fixture emits **no JSON-LD at all**, and this rule speaks only when a page
carries a date on a document-describing schema node — so, exactly like `schema/rating-scope` above
it, it contributes a tally key without a single finding. Writing 98219 would have pinned a number
the fixture cannot produce. The comment in the test says so.

### Verification

Local `bun` / `node` execution was blocked by this session's command policy, so tests and typecheck
were NOT run locally — CI (`bun test`, root typecheck, `docs:check`) is the gate. `bun test` at the
repo root picks up `packages/rules/tests/content-date-agreement.test.ts` (23 cases) and the
canonical golden pin.
