### PR TITLE
feat(rules): add links/no-contextual-inbound (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **276 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **277 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler 
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more 
@@ -42,7 +42,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Agent Experience | 17 | How ready you are for AI agents to read, discover and act on the site: whether GPTBot and Claude-User get the same content a browser does, AGENTS.md, llms.txt, Markdown responses, API and MCP discovery, licensing and noai signals, pay-per-crawl, response token weight |
 | Site Integrity | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | Security | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
-| Links | 14 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, HTTPS downgrades |
+| Links | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
 | Content | 18 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | Performance | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | Images | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 276 rules across 21 categories**
+**Total: 277 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/apps/cli/src/audit/adapter.ts
+++ b/apps/cli/src/audit/adapter.ts
@@ -245,6 +245,7 @@ export function parsePageRecord(page: PageRecord): ParsedPage | null {
           isInternal: l.isInternal,
           rel: l.rel,
           isNofollow: l.isNofollow,
+          isChrome: l.isChrome,
         })),
         // tel:/mailto: anchors, which `extractLinks` drops as non-crawlable.
         // This is the THIRD ParsedPage producer (see @squirrelscan/parser's

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -268,6 +268,8 @@ export interface LinkData {
   error?: string;
   rel?: string[];
   isNofollow?: boolean;
+  /** Anchor sat in a `nav`/`header`/`footer`/`aside` landmark (#109). */
+  isChrome?: boolean;
 }
 
 export interface ResourceSizeData {

--- a/apps/cli/tests/audit/parsed-page-producer-parity.test.ts
+++ b/apps/cli/tests/audit/parsed-page-producer-parity.test.ts
@@ -103,3 +103,34 @@ describe("ParsedPage producer parity — contactLinks", () => {
     }
   });
 });
+
+// #109 — `links/no-contextual-inbound` reads `LinkData.isChrome`, and which
+// producer ran depends on whether the crawl stored `parsedData`. A flag set in
+// only some of them would make the rule silently pass on half the audit paths.
+const CHROME_HTML = `<!DOCTYPE html><html><head><title>t</title></head><body>
+<nav><a href="/nav">nav</a></nav>
+<main><p><a href="/body">body</a></p></main>
+<footer><a href="/legal">legal</a></footer>
+</body></html>`;
+
+function chromeRecord(): PageRecord {
+  return { ...pageRecord(), html: CHROME_HTML } as PageRecord;
+}
+
+describe("ParsedPage producer parity — isChrome", () => {
+  test("all three producers classify nav/footer as chrome and body copy as not", () => {
+    const produced = [
+      parsePage(CHROME_HTML, URL),
+      parseHtmlForRules(CHROME_HTML, URL),
+      parsePageRecord(chromeRecord())!,
+    ];
+
+    for (const parsed of produced) {
+      expect(parsed.links.map((l) => [l.url, l.isChrome])).toEqual([
+        ["https://example.com/nav", true],
+        ["https://example.com/body", false],
+        ["https://example.com/legal", true],
+      ]);
+    }
+  });
+});

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -221,6 +221,7 @@
                   "rules/links/nofollow-internal",
                   "rules/links/orphan-pages",
                   "rules/links/weak-internal-links",
+                  "rules/links/no-contextual-inbound",
                   "rules/links/dead-end-pages",
                   "rules/links/anchor-text",
                   "rules/links/https-downgrade",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule Categories
 
-squirrelscan runs **276 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **277 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -225,8 +225,8 @@ squirrelscan runs **276 rules** across **21 categories**, plus opt-in cloud gap 
 | **Agent Experience** | 17 | How ready you are for AI agents to read, discover and act on the site: whether GPTBot and Claude-User get the same content a browser does, AGENTS.md, llms.txt, Markdown responses, API and MCP discovery, licensing and noai signals, pay-per-crawl, response token weight |
 | **Site Integrity** | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | **Security** | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
-| **Links** | 14 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, HTTPS downgrades |
-| **Content** | 17 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| **Links** | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
+| **Content** | 18 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | **Performance** | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | **Structured Data** | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have and rating markup that is not about the page it sits on |
@@ -242,7 +242,7 @@ squirrelscan runs **276 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 276 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 277 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules Reference"
-description: "All 276 audit rules organized by score group and category"
+description: "All 277 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **276 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **277 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 

--- a/docs/rules/links/index.mdx
+++ b/docs/rules/links/index.mdx
@@ -35,6 +35,9 @@ Internal and external link health and structure
   <Card title="Invalid Links" icon="triangle-exclamation" href="/rules/links/invalid-links">
     Detects invalid link formats on the page
   </Card>
+  <Card title="No Contextual Inbound Links" icon="triangle-exclamation" href="/rules/links/no-contextual-inbound">
+    Detects pages whose only internal inbound links come from sitewide chrome (nav, header, footer, sidebar)
+  </Card>
   <Card title="Nofollow Internal" icon="triangle-exclamation" href="/rules/links/nofollow-internal">
     Flags internal links with rel=nofollow
   </Card>

--- a/docs/rules/links/no-contextual-inbound.mdx
+++ b/docs/rules/links/no-contextual-inbound.mdx
@@ -1,0 +1,91 @@
+---
+title: "No Contextual Inbound Links"
+description: "Detects pages whose only internal inbound links come from sitewide chrome"
+---
+
+Detects pages whose only internal inbound links come from sitewide chrome (nav, header, footer, sidebar)
+
+| | |
+|---|---|
+| **Rule ID** | `links/no-contextual-inbound` |
+| **Category** | [Links](/rules/links) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 4/10 |
+
+## What it checks
+
+Every internal link the crawl finds is recorded with whether its anchor sat inside site
+chrome - an ancestor `<nav>`, `<header>`, `<footer>` or `<aside>`. A link from any of those
+is repeated verbatim on every page of the site, so it carries no signal about what the
+target page is about or how important it is. A link from body copy does.
+
+This rule counts only the **contextual** (non-chrome) inbound links per page and warns when
+that count is zero.
+
+Chrome detection is deliberately strict: only those four landmark elements count. A wrapper
+named `class="post-nav"` is *not* treated as chrome, because misclassifying body copy would
+turn a genuinely well-linked page into a false warning.
+
+## Why the existing link rules miss this
+
+[Orphan Pages](/rules/links/orphan-pages) and [Weak Internal Links](/rules/links/weak-internal-links)
+both count **raw** inbound links, with no distinction by container. A page linked from the
+sitewide footer of a 200-page site has 200 inbound links and passes both - while receiving no
+editorial support at all.
+
+To keep the three rules from reporting the same page twice, this rule speaks only about the
+gap the other two cannot see: a page is flagged when it has **zero** contextual inbound links
+**and** a raw inbound count at or above the orphan threshold (`minInboundLinks`, default `2`).
+Below that threshold the page is already reported as an orphan.
+
+The homepage is always skipped - it is reached from every page's header and footer by design.
+
+## Solution
+
+These pages look well-linked but receive no editorial support: every link pointing at them is repeated on every page of the site, so it carries no signal about what the page is about or how important it is. Add links from the body copy of related articles, hub pages, or category descriptions using descriptive anchor text. Sitewide navigation links help discovery, but contextual links are what pass topical relevance and internal link equity.
+
+## Options
+
+This rule supports the following configuration options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `minInboundLinks` | number | `2` | Raw inbound-link threshold from links/orphan-pages; only pages at or above it are considered here (below it they are already reported as orphans) |
+| `excludePatterns` | array | `[]` | URL patterns to exclude from contextual inbound link detection |
+
+Keep `minInboundLinks` in sync with the same option on
+[Orphan Pages](/rules/links/orphan-pages) - the two are the same threshold viewed from
+either side.
+
+### Configuration Example
+
+```toml squirrel.toml
+[rule_options."links/no-contextual-inbound"]
+minInboundLinks = 2
+excludePatterns = ["/tags/", "/authors/"]
+```
+
+## Enable / Disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["links/no-contextual-inbound"]
+```
+
+### Disable all Links rules
+
+```toml squirrel.toml
+[rules]
+disable = ["links/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["links/no-contextual-inbound"]
+disable = ["*"]
+```

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -360,6 +360,7 @@ export function parseHtmlForRules(html: string, baseUrl: string): ParsedPage {
       isInternal: l.isInternal,
       rel: l.rel,
       isNofollow: l.isNofollow,
+      isChrome: l.isChrome,
     })),
     // tel:/mailto: anchors, which `extractLinks` drops as non-crawlable. This is
     // the parse path production actually runs (parsePageRecord + the #263 page-rule

--- a/packages/audit-engine/src/site-query.ts
+++ b/packages/audit-engine/src/site-query.ts
@@ -77,7 +77,8 @@ export function createSiteQuery(
 
     return {
       pageCount: () => pageCount,
-      incomingLinkCounts: () => incoming,
+      incomingLinkCounts: () => incoming.all,
+      contextualIncomingLinkCounts: () => incoming.contextual,
       homepage: () => homepageRow,
       duplicateGroups: (field) => duplicates[field] ?? [],
       templateClusters: () => templateGroups,
@@ -104,6 +105,14 @@ export function createSiteQuery(
  * the count for its normalized URL, so pages that collapse to one normalized URL
  * (e.g. query-string variants) share a count exactly as the legacy Map does.
  *
+ * CONTEXTUAL VARIANT (#109): the same pass also accumulates a second bucket that
+ * skips links flagged `isChrome` (anchor sat in a `nav`/`header`/`footer`/`aside`
+ * landmark). Both maps are built in ONE scan and share every other filter, key
+ * and iteration order, so `contextual <= all` holds per page by construction.
+ * `isChrome === undefined` (a crawl stored before the flag existed) counts as
+ * contextual — an old DB degrades to the pre-#109 numbers rather than reporting
+ * every page as chrome-only.
+ *
  * PAGE-UNIVERSE RECONCILIATION (#1021 E-E2 (b)): when `universe` is supplied (the
  * streaming loop passes v1's assembled `site.pages` URLs), Pass A projects onto
  * exactly that set/order (HTML + appended 4xx/5xx, WAF/non-HTML/redirect pages
@@ -117,11 +126,17 @@ function buildIncomingLinkCounts(
   storage: SQLiteStorage,
   crawlId: string,
   universe?: readonly string[]
-): Effect.Effect<Map<string, number>, StorageError, never> {
+): Effect.Effect<
+  { all: Map<string, number>; contextual: Map<string, number> },
+  StorageError,
+  never
+> {
   return Effect.gen(function* () {
     const orderedUrls: string[] = [];
     // Keyed by normalizeUrl(page.url) — the legacy incoming-count bucket key.
     const bucket = new Map<string, number>();
+    // Same keys; counts only links that did NOT sit in site chrome (#109).
+    const contextualBucket = new Map<string, number>();
     // Link SOURCES are restricted to the universe so a WAF-challenge page's links
     // (its parsedData is populated but v1 excludes it from site.pages) never inflate
     // a target's incoming count. Undefined → count from every stored page (legacy).
@@ -134,11 +149,13 @@ function buildIncomingLinkCounts(
       for (const url of universe) {
         orderedUrls.push(url);
         bucket.set(normalizeUrl(url), 0);
+        contextualBucket.set(normalizeUrl(url), 0);
       }
     } else {
       yield* streamPages(storage, crawlId, (page) => {
         orderedUrls.push(page.normalizedUrl);
         bucket.set(normalizeUrl(page.normalizedUrl), 0);
+        contextualBucket.set(normalizeUrl(page.normalizedUrl), 0);
       });
     }
 
@@ -152,7 +169,12 @@ function buildIncomingLinkCounts(
           try {
             const target = normalizeUrl(new URL(link.url, page.normalizedUrl).href);
             const current = bucket.get(target);
-            if (current !== undefined) bucket.set(target, current + 1);
+            if (current !== undefined) {
+              bucket.set(target, current + 1);
+              if (!link.isChrome) {
+                contextualBucket.set(target, (contextualBucket.get(target) ?? 0) + 1);
+              }
+            }
           } catch {
             // Invalid link URL — ignored, matching the legacy rules' try/catch.
           }
@@ -162,11 +184,14 @@ function buildIncomingLinkCounts(
 
     // Project normalized-URL buckets onto each page's stored identity URL, in
     // crawl order — mirrors the legacy `incomingLinkCount.get(normalizeUrl(page.url))`.
-    const incoming = new Map<string, number>();
+    const all = new Map<string, number>();
+    const contextual = new Map<string, number>();
     for (const url of orderedUrls) {
-      incoming.set(url, bucket.get(normalizeUrl(url)) ?? 0);
+      const key = normalizeUrl(url);
+      all.set(url, bucket.get(key) ?? 0);
+      contextual.set(url, contextualBucket.get(key) ?? 0);
     }
-    return incoming;
+    return { all, contextual };
   });
 }
 

--- a/packages/audit-engine/tests/site-query-link-rules-golden.test.ts
+++ b/packages/audit-engine/tests/site-query-link-rules-golden.test.ts
@@ -16,6 +16,7 @@ import { Effect } from "effect";
 
 import { SQLiteStorage } from "@squirrelscan/crawler";
 import { loadAllRules } from "@squirrelscan/rules";
+import { normalizeUrl } from "@squirrelscan/utils";
 import type { ParsedPage, Rule, RuleContext } from "@squirrelscan/rules";
 import type { LinkData, PageFeatureRow, PageRecord } from "@squirrelscan/core-contracts";
 
@@ -37,6 +38,7 @@ const BASE = "https://example.com/";
 const rules = loadAllRules();
 const orphanRule = rules.get("links/orphan-pages")!;
 const weakRule = rules.get("links/weak-internal-links")!;
+const contextualRule = rules.get("links/no-contextual-inbound")!;
 
 // ── fixture builders ──────────────────────────────────────────────────────────
 
@@ -48,6 +50,10 @@ function nofollow(url: string): LinkData {
 }
 function external(url: string): LinkData {
   return { url, text: "ext", isInternal: false };
+}
+/** A sitewide-chrome link — counted by incomingLinkCounts, NOT by the contextual map (#109). */
+function chrome(url: string): LinkData {
+  return { url, text: "chrome", isInternal: true, isChrome: true };
 }
 
 function pageRow(normalizedUrl: string, links: LinkData[]): PageRecord {
@@ -262,6 +268,163 @@ describe("SiteQuery dual-path — links/weak-internal-links", () => {
   });
 });
 
+// ── #109: contextual (non-chrome) inbound links ───────────────────────────────
+
+// Every page carries the same footer link to /legal, so /legal has a HEALTHY raw
+// inbound count (4) and zero contextual support — the exact case orphan-pages and
+// weak-internal-links cannot see. /deep is linked once, from body copy.
+const CHROME_FIXTURE: PageRecord[] = [
+  pageRow(BASE, [link("/a"), link("/b"), chrome("/legal")]),
+  pageRow("https://example.com/a", [link("/b"), link("/deep"), chrome("/legal")]),
+  pageRow("https://example.com/b", [link("/a"), chrome("/legal")]),
+  pageRow("https://example.com/deep", [link("/a")]),
+  pageRow("https://example.com/legal", [chrome("/legal")]),
+];
+
+async function seedChromeFixture(store: SQLiteStorage): Promise<void> {
+  for (const p of CHROME_FIXTURE) await run(store.upsertPage(CRAWL, p));
+}
+
+/** Rebuild both inbound counts the way the LEGACY `site.pages` path does. */
+function legacyCounts(pages: PageRecord[]): {
+  all: Map<string, number>;
+  contextual: Map<string, number>;
+} {
+  const all = new Map<string, number>();
+  const contextual = new Map<string, number>();
+  for (const p of pages) {
+    all.set(normalizeUrl(p.normalizedUrl), 0);
+    contextual.set(normalizeUrl(p.normalizedUrl), 0);
+  }
+  for (const p of pages) {
+    for (const l of parseLinks(p.parsedData)) {
+      if (!l.isInternal || !l.url || l.isNofollow) continue;
+      const target = normalizeUrl(new URL(l.url, p.normalizedUrl).href);
+      if (!all.has(target)) continue;
+      all.set(target, all.get(target)! + 1);
+      if (!l.isChrome) contextual.set(target, contextual.get(target)! + 1);
+    }
+  }
+  // Project back onto each page's stored identity URL, in crawl order.
+  return {
+    all: new Map(pages.map((p) => [p.normalizedUrl, all.get(normalizeUrl(p.normalizedUrl))!])),
+    contextual: new Map(
+      pages.map((p) => [p.normalizedUrl, contextual.get(normalizeUrl(p.normalizedUrl))!])
+    ),
+  };
+}
+
+describe("SiteQuery — contextual inbound link counts (#109)", () => {
+  test("chrome links count toward the raw map but not the contextual one", async () => {
+    const store = await freshStore();
+    await seedChromeFixture(store);
+
+    const sq = await run(createSiteQuery(store, CRAWL));
+    const all = sq.incomingLinkCounts();
+    const contextual = sq.contextualIncomingLinkCounts();
+
+    // Same keys, same order — the two maps are built in one pass.
+    expect([...contextual.keys()]).toEqual([...all.keys()]);
+
+    // /legal: four footer links, zero contextual → healthy on paper, unsupported.
+    expect(all.get("https://example.com/legal")).toBe(4);
+    expect(contextual.get("https://example.com/legal")).toBe(0);
+    // /deep: one body-copy link.
+    expect(all.get("https://example.com/deep")).toBe(1);
+    expect(contextual.get("https://example.com/deep")).toBe(1);
+    // contextual <= all holds for every page.
+    for (const [url, count] of contextual) {
+      expect(count).toBeLessThanOrEqual(all.get(url)!);
+    }
+
+    await run(store.close());
+  });
+
+  test("the legacy site.pages rebuild produces IDENTICAL counts to the accumulator", async () => {
+    const store = await freshStore();
+    await seedChromeFixture(store);
+
+    const sq = await run(createSiteQuery(store, CRAWL));
+    const legacy = legacyCounts(await run(store.getPages(CRAWL)));
+
+    expect([...sq.incomingLinkCounts()]).toEqual([...legacy.all]);
+    expect([...sq.contextualIncomingLinkCounts()]).toEqual([...legacy.contextual]);
+
+    await run(store.close());
+  });
+});
+
+describe("SiteQuery dual-path — links/no-contextual-inbound", () => {
+  test("streaming path is deep-equal to legacy AND flags the chrome-only page", async () => {
+    const store = await freshStore();
+    await seedChromeFixture(store);
+
+    const { legacy, streamed } = await runBothWays(store, contextualRule, {
+      minInboundLinks: 2,
+      excludePatterns: [],
+    });
+
+    expect(streamed).toEqual(legacy);
+    expect(legacy).toEqual([
+      {
+        name: "no-contextual-inbound",
+        status: "warn",
+        message: "1 page(s) are linked only from sitewide chrome",
+        items: [{ id: "https://example.com/legal" }],
+        details: { total: 1 },
+        value: "/legal",
+      },
+    ]);
+    await run(store.close());
+  });
+
+  test("links/orphan-pages does NOT report that page — the blind spot is real", async () => {
+    const store = await freshStore();
+    await seedChromeFixture(store);
+
+    const { legacy, streamed } = await runBothWays(store, orphanRule, {
+      minInboundLinks: 2,
+      excludePatterns: [],
+    });
+
+    expect(streamed).toEqual(legacy);
+    // Only /deep (one inbound link) is an orphan; /legal's four footer links
+    // keep it comfortably above the threshold on both paths.
+    expect(legacy[0]!.items).toEqual([{ id: "https://example.com/deep" }]);
+    await run(store.close());
+  });
+
+  test("a page linked once from body copy is not flagged, on either path", async () => {
+    const store = await freshStore();
+    // Raise the threshold so /deep's single body-copy link clears it and the rule
+    // is forced to judge it on contextual support alone.
+    await seedChromeFixture(store);
+
+    const { legacy, streamed } = await runBothWays(store, contextualRule, {
+      minInboundLinks: 1,
+      excludePatterns: [],
+    });
+
+    expect(streamed).toEqual(legacy);
+    expect(legacy[0]!.items).toEqual([{ id: "https://example.com/legal" }]);
+    await run(store.close());
+  });
+
+  test("excludePatterns are honoured identically on both paths", async () => {
+    const store = await freshStore();
+    await seedChromeFixture(store);
+
+    const { legacy, streamed } = await runBothWays(store, contextualRule, {
+      minInboundLinks: 2,
+      excludePatterns: ["/legal"],
+    });
+
+    expect(streamed).toEqual(legacy);
+    expect(legacy[0]!.status).toBe("pass");
+    await run(store.close());
+  });
+});
+
 describe("SiteQuery dual-path — edge cases parity", () => {
   test("a crawl with <2 pages skips identically on both paths", async () => {
     const store = await freshStore();
@@ -376,6 +539,7 @@ describe("createSiteQuery — page_features-backed aggregates", () => {
     const sq = await run(createSiteQuery(store, CRAWL));
     expect(sq.pageCount()).toBe(0);
     expect(sq.incomingLinkCounts().size).toBe(0);
+    expect(sq.contextualIncomingLinkCounts().size).toBe(0);
     expect(sq.homepage()).toBeNull();
     expect(sq.duplicateGroups("content")).toEqual([]);
     expect(sq.templateClusters()).toEqual([]);

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -89,7 +89,12 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // page-scoped but speaks ONLY when a page carries a date on a
       // document-describing schema node, and the fixture emits no JSON-LD at all —
       // so it contributes a tally key below without a single finding.
-      expect(v1.findings.length).toBe(98218);
+      // 98218 -> 98219: links/no-contextual-inbound, likewise site-scoped, adds
+      // its own single whole-crawl check (#109). It PASSES on this fixture: the
+      // only chrome link the renderer emits is the header nav's link to `/`, and
+      // the homepage is exempt, so every other page's contextual count equals its
+      // raw count.
+      expect(v1.findings.length).toBe(98219);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
@@ -97,9 +102,10 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // core/canonical-form-drift, 271 -> 272 content/title-pattern-outlier,
       // 272 -> 273 schema/rating-scope, 273 -> 274 crawl/sitemap-lastmod-churn,
       // 274 -> 275 crawl/sitemap-lastmod-drift, 275 -> 276
-      // content/date-agreement; anything else means a rule id
+      // content/date-agreement, 276 -> 277 links/no-contextual-inbound;
+      // anything else means a rule id
       // leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(276);
+      expect(v1.perRuleTally.length).toBe(277);
     },
     180_000,
   );

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -1045,6 +1045,14 @@ export interface LinkData {
   error?: string;
   rel?: string[];
   isNofollow?: boolean;
+  /**
+   * The anchor sat inside a `nav`/`header`/`footer`/`aside` landmark, i.e. in
+   * sitewide chrome rather than editorial body copy (#109). Optional because
+   * crawls stored before this field existed simply omit it; readers MUST treat
+   * `undefined` as "not chrome" so an old crawl degrades to the previous
+   * behaviour (every link contextual) instead of flagging the whole site.
+   */
+  isChrome?: boolean;
 }
 
 /**

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -661,6 +661,15 @@ export interface SiteQuery {
    * cannot answer internal orphan / weak-internal-link questions.
    */
   incomingLinkCounts(): Map<string, number>;
+  /**
+   * Incoming internal-link counts restricted to CONTEXTUAL links — those that
+   * did NOT sit in sitewide chrome (`LinkData.isChrome`); see #109. Same keys,
+   * same order, same filtering as {@link incomingLinkCounts}, so a page's value
+   * here is always <= its value there. A page with a healthy raw count but zero
+   * here is reachable only through chrome and receives no editorial support —
+   * the case `links/orphan-pages` and `links/weak-internal-links` cannot see.
+   */
+  contextualIncomingLinkCounts(): Map<string, number>;
   /** Normalized URLs of pages classified as `type`. */
   pagesByType(type: string): string[];
   /** URL sets sharing one template fingerprint (count > 1). */

--- a/packages/parser/src/extractors/chrome.ts
+++ b/packages/parser/src/extractors/chrome.ts
@@ -1,0 +1,38 @@
+// Site-chrome detection for anchors (#109).
+//
+// A link that sits in sitewide chrome — the header, the footer, the primary nav,
+// a sidebar — is repeated verbatim on every page of the site. It contributes to a
+// page's RAW inbound-link count but carries no editorial signal: it says nothing
+// about which page is relevant to which. `links/no-contextual-inbound` needs to
+// tell the two apart, so every link in the graph records where it sat.
+//
+// Deliberately STRICTER than `detectLinkPosition` in ./links.ts. That function
+// falls back to class/id substring heuristics (`class="post-nav"` → "nav",
+// `id="main-content"` → "content") which are fine for a descriptive position
+// label but far too loose to drive a warning: a single blog post whose wrapper is
+// `<div class="nav-post">` would have its body links silently reclassified as
+// chrome. Here only the four SEMANTIC landmark elements count — `nav`, `header`,
+// `footer`, `aside` — matching the acceptance criteria exactly. False negatives
+// (a div-soup footer) cost a missed warning; false positives cost a wrong one.
+
+import type { Element } from "linkedom";
+
+/** Landmark elements whose subtree is treated as sitewide chrome. */
+const CHROME_TAGS = new Set(["nav", "header", "footer", "aside"]);
+
+/**
+ * True when `element` has an ancestor (or is itself) one of {@link CHROME_TAGS}.
+ *
+ * Walks to the root rather than stopping at the first landmark, so a link inside
+ * `<footer><div class="content">…` is still chrome — nesting a content wrapper
+ * inside the footer does not make a sitewide link editorial.
+ */
+export function isInSiteChrome(element: Element): boolean {
+  let current: Element | null = element;
+  while (current) {
+    const tagName = current.tagName?.toLowerCase();
+    if (tagName && CHROME_TAGS.has(tagName)) return true;
+    current = current.parentElement;
+  }
+  return false;
+}

--- a/packages/parser/src/extractors/index.ts
+++ b/packages/parser/src/extractors/index.ts
@@ -7,6 +7,7 @@ export * from "./types";
 export * from "./dom-text";
 export * from "./meta";
 export * from "./links";
+export * from "./chrome";
 export * from "./images";
 export * from "./stylesheets";
 export * from "./scripts";

--- a/packages/parser/src/extractors/links.ts
+++ b/packages/parser/src/extractors/links.ts
@@ -14,6 +14,8 @@ const logger = {
 
 import type { ExtractedLink, LinkPosition } from "./types";
 
+import { isInSiteChrome } from "./chrome";
+
 /**
  * Detect link position in document structure.
  *
@@ -137,6 +139,8 @@ export function extractLinks(doc: Document, baseUrl: string): ExtractedLink[] {
         position,
         rel,
         isNofollow: hasNofollow(rel),
+        // Landmark-strict, unlike `position` above (#109) — see ./chrome.ts.
+        isChrome: isInSiteChrome(element),
       });
     } catch {
       // Skip invalid URLs

--- a/packages/parser/src/extractors/types.ts
+++ b/packages/parser/src/extractors/types.ts
@@ -42,6 +42,12 @@ export interface ExtractedLink {
   position: LinkPosition;
   rel?: string[];
   isNofollow: boolean;
+  /**
+   * The anchor sat inside a `nav`/`header`/`footer`/`aside` landmark — sitewide
+   * chrome, not editorial body copy (#109). Stricter than {@link position},
+   * which also matches on class/id substrings.
+   */
+  isChrome: boolean;
 }
 
 // Extended image data

--- a/packages/parser/src/html.ts
+++ b/packages/parser/src/html.ts
@@ -21,6 +21,8 @@ import type {
   TwitterData,
 } from "@squirrelscan/core-contracts";
 
+import { isInSiteChrome } from "./extractors/chrome";
+
 import type { AuthorInfo } from "./schema";
 import type { PageType } from "./page-type";
 import type { SchemaCollection } from "./schema/collection";
@@ -122,8 +124,14 @@ export function extractLinks(doc: Document, baseUrl: string): LinkData[] {
       const url = new URL(normalizedHref, baseUrl).toString();
       const text = (anchor as Element).textContent?.trim() ?? "";
       const isInternal = new URL(url).hostname === baseUrlObj.hostname;
+      // Whether the anchor sat in sitewide chrome (#109). This extractor is the
+      // one whose output the crawler SERIALIZES into `parsedData`, which both the
+      // legacy `site.pages` path and `createSiteQuery` re-read — so a flag set
+      // only in the extractors/links.ts variant would be absent everywhere it
+      // matters. Cheap: an ancestor tagName walk, no attribute reads.
+      const isChrome = isInSiteChrome(anchor as Element);
 
-      links.push({ url, text, isInternal });
+      links.push({ url, text, isInternal, isChrome });
     } catch {
       // Skip invalid URLs
       links.push({

--- a/packages/parser/tests/link-chrome.test.ts
+++ b/packages/parser/tests/link-chrome.test.ts
@@ -78,8 +78,10 @@ describe("extractLinks — isChrome agrees with parsePage", () => {
       ["c", false],
       ["a", false],
     ]);
-    // The looser `position` label keeps its previous behaviour: class/id
-    // heuristics still apply there, which is exactly why isChrome is separate.
-    expect(links.map((l) => l.position)).toEqual(["header", "content", "nav"]);
+    // The looser `position` label keeps its previous behaviour: it resolves on
+    // the *closest* ancestor, so the `<header><nav>` link is "nav" rather than
+    // "header", and class/id heuristics still apply (`post-nav` → "nav"). That
+    // looseness is exactly why isChrome is a separate, landmark-strict signal.
+    expect(links.map((l) => l.position)).toEqual(["nav", "content", "nav"]);
   });
 });

--- a/packages/parser/tests/link-chrome.test.ts
+++ b/packages/parser/tests/link-chrome.test.ts
@@ -1,0 +1,85 @@
+// LinkData.isChrome — did the anchor sit in sitewide chrome? (#109)
+//
+// Two producers must agree, because the two rule paths read different ones:
+// `parsePage` (html.ts) is what the crawler SERIALIZES into `parsedData`, which
+// both `site.pages` and `createSiteQuery` re-read, while `extractLinks`
+// (extractors/links.ts) is what `parseHtmlForRules` uses. A flag set by only one
+// of them is silently absent wherever it matters, so both are covered here.
+
+import { describe, expect, test } from "bun:test";
+
+import { extractLinks } from "../src/extractors/links";
+import { parsePage } from "../src/html";
+import { parseDocument } from "../src/index";
+
+const URL = "https://example.com/post";
+
+function page(body: string): string {
+  return `<!DOCTYPE html><html><head><title>t</title></head><body>${body}</body></html>`;
+}
+
+/** `isChrome` by link text, from the parsePage (stored-parsedData) producer. */
+function chromeByText(body: string): Record<string, boolean | undefined> {
+  const out: Record<string, boolean | undefined> = {};
+  for (const l of parsePage(page(body), URL).links) out[l.text] = l.isChrome;
+  return out;
+}
+
+describe("parsePage — isChrome", () => {
+  test("nav, header, footer and aside anchors are chrome; body copy is not", () => {
+    expect(
+      chromeByText(
+        `<header><a href="/h">h</a></header>` +
+          `<nav><a href="/n">n</a></nav>` +
+          `<aside><a href="/s">s</a></aside>` +
+          `<footer><a href="/f">f</a></footer>` +
+          `<main><p><a href="/c">c</a></p></main>`,
+      ),
+    ).toEqual({ h: true, n: true, s: true, f: true, c: false });
+  });
+
+  test("a wrapper nested inside a landmark is still chrome", () => {
+    // The whole subtree of a landmark is chrome — a content-ish wrapper inside
+    // the footer does not make a sitewide link editorial.
+    expect(chromeByText(`<footer><div class="content"><a href="/f">f</a></div></footer>`)).toEqual({
+      f: true,
+    });
+  });
+
+  test("class/id names alone are NOT chrome", () => {
+    // Deliberately stricter than `detectLinkPosition`'s class/id heuristics: a
+    // post wrapper called "nav" must not silently reclassify body links.
+    expect(
+      chromeByText(
+        `<div class="post-nav"><a href="/a">a</a></div>` +
+          `<div id="sidebar"><a href="/b">b</a></div>`,
+      ),
+    ).toEqual({ a: false, b: false });
+  });
+
+  test("a page with no landmarks at all marks every link contextual", () => {
+    expect(chromeByText(`<p><a href="/a">a</a></p><div><a href="/b">b</a></div>`)).toEqual({
+      a: false,
+      b: false,
+    });
+  });
+});
+
+describe("extractLinks — isChrome agrees with parsePage", () => {
+  test("same classification, and `position` is unchanged by it", () => {
+    const body =
+      `<header><nav><a href="/n">n</a></nav></header>` +
+      `<main><p><a href="/c">c</a></p></main>` +
+      `<div class="post-nav"><a href="/a">a</a></div>`;
+    const links = extractLinks(parseDocument(page(body)), URL);
+
+    expect(links.map((l) => [l.text, l.isChrome])).toEqual([
+      ["n", true],
+      ["c", false],
+      ["a", false],
+    ]);
+    // The looser `position` label keeps its previous behaviour: class/id
+    // heuristics still apply there, which is exactly why isChrome is separate.
+    expect(links.map((l) => l.position)).toEqual(["header", "content", "nav"]);
+  });
+});

--- a/packages/rules/src/links/index.ts
+++ b/packages/rules/src/links/index.ts
@@ -11,6 +11,7 @@ import { externalLinksRule } from "./external-links";
 import { httpsDowngradeRule } from "./https-downgrade";
 import { internalLinksRule } from "./internal-links";
 import { invalidLinksRule } from "./invalid-links";
+import { noContextualInboundRule } from "./no-contextual-inbound";
 import { nofollowInternalRule } from "./nofollow-internal";
 import { orphanPagesRule } from "./orphan-pages";
 import { redirectChainsRule } from "./redirect-chains";
@@ -30,6 +31,7 @@ export const rules: Rule[] = [
   nofollowInternalRule,
   orphanPagesRule,
   weakInternalLinksRule,
+  noContextualInboundRule,
   deadEndPages,
   anchorTextRule,
   httpsDowngradeRule,
@@ -46,6 +48,7 @@ export {
   httpsDowngradeRule,
   internalLinksRule,
   invalidLinksRule,
+  noContextualInboundRule,
   nofollowInternalRule,
   orphanPagesRule,
   redirectChainsRule,

--- a/packages/rules/src/links/no-contextual-inbound.ts
+++ b/packages/rules/src/links/no-contextual-inbound.ts
@@ -1,0 +1,249 @@
+// links/no-contextual-inbound - Pages whose only inbound links are sitewide chrome
+//
+// The blind spot this closes (#109). `links/orphan-pages` and
+// `links/weak-internal-links` both count RAW inbound links: a link from the
+// footer that every page on the site carries scores exactly the same as a link
+// from the middle of a related article. So a page reachable only through the
+// header nav, the footer, or a sidebar widget shows a healthy inbound count and
+// passes both rules while receiving no editorial support at all.
+//
+// This rule counts only CONTEXTUAL inbound links — those whose anchor did NOT sit
+// in a `nav`/`header`/`footer`/`aside` landmark (`LinkData.isChrome`, set by the
+// parser) — and warns when that count is zero.
+//
+// FALSE-POSITIVE TRAPS, and why each is handled the way it is:
+//
+//   * OVERLAP WITH orphan-pages. A page with zero contextual AND zero raw inbound
+//     links is already an orphan; reporting it twice is noise. So a page is
+//     flagged only when its RAW count is at or above the orphan threshold
+//     (`minInboundLinks`, the same default 2) — i.e. exactly when orphan-pages
+//     stays silent. Keep the two thresholds in sync when tuning.
+//   * THE HOMEPAGE. Reached from every page's header/footer by design; it has no
+//     contextual-equity problem. Skipped, exactly as orphan-pages skips it.
+//   * A CHROME-ONLY CRAWL. Not special-cased: if a whole site links only through
+//     chrome, every one of its pages genuinely lacks contextual support. The
+//     `value` sample is capped so the finding stays readable; `details.total`
+//     and `items` carry the full picture, exactly as orphan-pages does.
+//   * OLD CRAWLS. `isChrome` is optional on `LinkData` (crawls stored before
+//     #109 omit it). `undefined` counts as contextual on BOTH paths, so an old DB
+//     produces contextual == raw and this rule simply passes — never a site-wide
+//     false alarm.
+//
+// Both paths (legacy `site.pages`, streaming `siteQuery`) feed the SAME
+// `collectChromeOnlyPages` helper the same `(url, {all, contextual})` pairs, so
+// the emitted check is byte-identical regardless of how the counts were sourced
+// (`site-query-link-rules-golden.test.ts` is the gate).
+
+import { z } from "zod";
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+import type { LinkData } from "@squirrelscan/core-contracts";
+
+import { matchesExcludePattern } from "@squirrelscan/utils";
+import { getPathname, normalizeUrl } from "@squirrelscan/utils";
+
+import { logger } from "../logger";
+
+const SKIP_CHECK: CheckResult = {
+  name: "no-contextual-inbound",
+  status: "skipped",
+  message: "Insufficient pages for contextual inbound link analysis",
+};
+
+// Sampled paths shown in `value`; `details.total` always carries the real count.
+const MAX_SAMPLE = 5;
+
+/** One page's raw and contextual (non-chrome) inbound dofollow-internal counts. */
+interface InboundCounts {
+  all: number;
+  contextual: number;
+}
+
+// Shared result builder — both paths feed it the SAME `pages` list.
+function buildCheck(pages: string[]): CheckResult {
+  if (pages.length > 0) {
+    const pathList = pages
+      .slice(0, MAX_SAMPLE)
+      .map((url) => getPathname(url))
+      .join("\n");
+
+    const suffix =
+      pages.length > MAX_SAMPLE ? `\n+${pages.length - MAX_SAMPLE} more` : "";
+
+    return {
+      name: "no-contextual-inbound",
+      status: "warn",
+      message: `${pages.length} page(s) are linked only from sitewide chrome`,
+      items: pages.map((url) => ({ id: url })),
+      details: { total: pages.length },
+      value: pathList + suffix,
+    };
+  }
+  return {
+    name: "no-contextual-inbound",
+    status: "pass",
+    message: "All pages have at least one contextual inbound link",
+  };
+}
+
+// Given per-page counts in the crawl's stable order, flag the pages that are
+// neither the homepage nor excluded, have NO contextual inbound link, and carry
+// enough raw inbound links that `links/orphan-pages` stays silent about them.
+function collectChromeOnlyPages(
+  entries: Iterable<[string, InboundCounts]>,
+  minInboundLinks: number,
+  excludePatterns: string[],
+  baseUrl: string
+): string[] {
+  const normalizedBase = normalizeUrl(baseUrl);
+  const flagged: string[] = [];
+  for (const [url, counts] of entries) {
+    const normalizedUrl = normalizeUrl(url);
+
+    // Skip homepage — same test orphan-pages uses.
+    const isHomepage = normalizedUrl === normalizedBase || getPathname(url) === "/";
+    const isExcluded = matchesExcludePattern(url, excludePatterns);
+
+    if (isHomepage || isExcluded) {
+      continue;
+    }
+
+    // Only the orphan rules' blind spot: well-linked on paper, chrome-only in fact.
+    if (counts.contextual === 0 && counts.all >= minInboundLinks) {
+      flagged.push(url);
+    }
+  }
+  return flagged;
+}
+
+/** A link that participates in the internal link graph (mirrors the orphan rules). */
+function isGraphLink(link: LinkData): boolean {
+  return Boolean(link.isInternal && link.url && !link.isNofollow);
+}
+
+export const noContextualInboundRule: Rule = {
+  meta: {
+    id: "links/no-contextual-inbound",
+    name: "No Contextual Inbound Links",
+    description:
+      "Detects pages whose only internal inbound links come from sitewide chrome (nav, header, footer, sidebar)",
+    solution:
+      "These pages look well-linked but receive no editorial support: every link pointing at them is repeated on every page of the site, so it carries no signal about what the page is about or how important it is. Add links from the body copy of related articles, hub pages, or category descriptions using descriptive anchor text. Sitewide navigation links help discovery, but contextual links are what pass topical relevance and internal link equity.",
+    category: "links",
+    scope: "site",
+    severity: "warning",
+    weight: 4,
+    optionsSchema: z.object({
+      minInboundLinks: z
+        .number()
+        .int()
+        .min(0)
+        .default(2)
+        .describe(
+          "Raw inbound-link threshold from links/orphan-pages; only pages at or above it are considered here (below it they are already reported as orphans)"
+        ),
+      excludePatterns: z
+        .array(z.string())
+        .default([])
+        .describe("URL patterns to exclude from contextual inbound link detection"),
+    }),
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const checks: CheckResult[] = [];
+    const options = ctx.options;
+    const minInboundLinks = options.minInboundLinks as number;
+    const excludePatterns = options.excludePatterns as string[];
+
+    // Streaming path — read the pre-materialized counts. Both maps are built by
+    // one pass over the same links with the same key/order, so zipping them by
+    // key is safe.
+    if (ctx.siteQuery) {
+      const all = ctx.siteQuery.incomingLinkCounts();
+      if (all.size < 2) {
+        checks.push(SKIP_CHECK);
+        return { checks };
+      }
+      const contextual = ctx.siteQuery.contextualIncomingLinkCounts();
+      const entries: Array<[string, InboundCounts]> = [];
+      for (const [url, count] of all) {
+        entries.push([url, { all: count, contextual: contextual.get(url) ?? 0 }]);
+      }
+      checks.push(
+        buildCheck(
+          collectChromeOnlyPages(
+            entries,
+            minInboundLinks,
+            excludePatterns,
+            ctx.site?.baseUrl || ""
+          )
+        )
+      );
+      return { checks };
+    }
+
+    // Legacy path — rebuild both counts from every page's parsed links.
+    const pages = ctx.site?.pages;
+
+    if (!pages || pages.length < 2) {
+      checks.push(SKIP_CHECK);
+      return { checks };
+    }
+
+    const counts = new Map<string, InboundCounts>();
+    const normalizedCache = new Map<string, string>();
+
+    // Phase 1: initialize every crawled page at zero and cache normalized URLs.
+    for (const page of pages) {
+      const normalized = normalizeUrl(page.url);
+      normalizedCache.set(page.url, normalized);
+      counts.set(normalized, { all: 0, contextual: 0 });
+    }
+
+    // Phase 2: count dofollow internal links whose target is a crawled page,
+    // splitting chrome from contextual.
+    let invalidUrlCount = 0;
+    for (const page of pages) {
+      for (const link of page.parsed.links) {
+        if (!isGraphLink(link)) continue;
+        try {
+          const linkUrl = new URL(link.url, page.url);
+          const current = counts.get(normalizeUrl(linkUrl.href));
+          if (current !== undefined) {
+            current.all += 1;
+            if (!link.isChrome) current.contextual += 1;
+          }
+        } catch {
+          invalidUrlCount++;
+          logger.debug(
+            `[no-contextual-inbound] Invalid internal link URL: "${link.url}" on page ${getPathname(page.url)}`
+          );
+        }
+      }
+    }
+
+    if (invalidUrlCount > 0) {
+      logger.debug(
+        `[no-contextual-inbound] Found ${invalidUrlCount} invalid internal link URL(s) during link counting`
+      );
+    }
+
+    // Phase 3: flag the chrome-only pages (use cached normalized URLs).
+    const flagged = collectChromeOnlyPages(
+      pages.map(
+        (page) =>
+          [
+            page.url,
+            counts.get(normalizedCache.get(page.url)!) ?? { all: 0, contextual: 0 },
+          ] as [string, InboundCounts]
+      ),
+      minInboundLinks,
+      excludePatterns,
+      ctx.site?.baseUrl || ""
+    );
+
+    checks.push(buildCheck(flagged));
+
+    return { checks };
+  },
+};

--- a/packages/rules/tests/core-canonical-form-drift.test.ts
+++ b/packages/rules/tests/core-canonical-form-drift.test.ts
@@ -112,6 +112,7 @@ function siteQueryCtx(specs: PageSpec[]): RuleContext {
     pageCount: () => rows.length,
     duplicateGroups: unused,
     incomingLinkCounts: unused,
+    contextualIncomingLinkCounts: unused,
     pagesByType: unused,
     templateClusters: unused,
     sumTransferBytes: unused,

--- a/packages/rules/tests/no-contextual-inbound.test.ts
+++ b/packages/rules/tests/no-contextual-inbound.test.ts
@@ -1,0 +1,195 @@
+// links/no-contextual-inbound — pages linked only from sitewide chrome (#109).
+//
+// The two fixtures the acceptance criteria name are the first two tests: a page
+// linked ONLY from the sitewide footer must warn here and must NOT be reported by
+// links/orphan-pages, and a page linked once from body copy must not warn.
+// links/orphan-pages runs over the SAME fixtures throughout, so any drift in the
+// two rules' division of labour fails here rather than in production.
+
+import { describe, expect, test } from "bun:test";
+
+import { noContextualInboundRule } from "../src/links/no-contextual-inbound";
+import { orphanPagesRule } from "../src/links/orphan-pages";
+import { weakInternalLinksRule } from "../src/links/weak-internal-links";
+import type { CheckResult, ParsedPage, Rule, RuleContext, RuleResult } from "../src/types";
+import type { LinkData } from "@squirrelscan/core-contracts";
+
+const BASE = "https://example.com/";
+
+/** A body-copy (contextual) internal link. */
+function body(url: string): LinkData {
+  return { url, text: "read more", isInternal: true, isChrome: false };
+}
+/** A sitewide-chrome internal link (nav/header/footer/aside anchor). */
+function chrome(url: string): LinkData {
+  return { url, text: "nav", isInternal: true, isChrome: true };
+}
+/** A link from a crawl stored before `isChrome` existed. */
+function legacyLink(url: string): LinkData {
+  return { url, text: "old", isInternal: true };
+}
+
+interface PageSpec {
+  url: string;
+  links: LinkData[];
+}
+
+function ctx(pages: PageSpec[], options: Record<string, unknown> = {}): RuleContext {
+  return {
+    page: { url: BASE, html: "", statusCode: 200, loadTime: 0, headers: {} },
+    parsed: {} as ParsedPage,
+    site: {
+      baseUrl: BASE,
+      pages: pages.map((p) => ({
+        url: p.url,
+        finalUrl: p.url,
+        statusCode: 200,
+        parsed: { links: p.links } as ParsedPage,
+      })),
+      robotsTxt: null,
+      sitemaps: null,
+    },
+    options: { minInboundLinks: 2, excludePatterns: [], ...options },
+  } as unknown as RuleContext;
+}
+
+/** All three rules under test are synchronous on the legacy path. */
+function check(rule: Rule, c: RuleContext): CheckResult {
+  return (rule.run(c) as RuleResult).checks[0]!;
+}
+
+function ids(c: CheckResult): string[] {
+  return (c.items ?? []).map((i) => String(i.id));
+}
+
+// Three content pages all cross-link each other in body copy; /legal is reached
+// ONLY through the sitewide footer that every page carries.
+const FOOTER_ONLY: PageSpec[] = [
+  { url: BASE, links: [body("/a"), body("/b"), chrome("/legal")] },
+  { url: "https://example.com/a", links: [body("/b"), chrome("/legal")] },
+  { url: "https://example.com/b", links: [body("/a"), chrome("/legal")] },
+  { url: "https://example.com/legal", links: [chrome("/legal")] },
+];
+
+describe("links/no-contextual-inbound — the acceptance fixtures", () => {
+  test("a page linked only from the sitewide footer warns", () => {
+    const result = check(noContextualInboundRule, ctx(FOOTER_ONLY));
+
+    expect(result.status).toBe("warn");
+    expect(ids(result)).toEqual(["https://example.com/legal"]);
+    expect(result.details).toEqual({ total: 1 });
+    expect(result.value).toBe("/legal");
+    expect(result.message).toBe("1 page(s) are linked only from sitewide chrome");
+  });
+
+  test("…and links/orphan-pages does NOT report it (the blind spot)", () => {
+    // 4 footer links (one per page) put /legal well above the orphan threshold.
+    const orphans = check(orphanPagesRule, ctx(FOOTER_ONLY));
+    expect(orphans.status).toBe("pass");
+    // Nor does weak-internal-links: its raw count is 4, not 1.
+    expect(check(weakInternalLinksRule, ctx(FOOTER_ONLY)).status).toBe("pass");
+  });
+
+  test("a page linked once from body copy does not warn", () => {
+    // /deep has exactly ONE inbound link, and it is contextual.
+    const pages: PageSpec[] = [
+      { url: BASE, links: [body("/a"), body("/b")] },
+      { url: "https://example.com/a", links: [body("/b"), body("/deep")] },
+      { url: "https://example.com/b", links: [body("/a")] },
+      { url: "https://example.com/deep", links: [] },
+    ];
+
+    const result = check(noContextualInboundRule, ctx(pages));
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("All pages have at least one contextual inbound link");
+
+    // It IS an orphan though — that page belongs to orphan-pages, not to us.
+    expect(ids(check(orphanPagesRule, ctx(pages)))).toContain("https://example.com/deep");
+  });
+});
+
+describe("links/no-contextual-inbound — scoping", () => {
+  test("the homepage is never flagged even when only chrome links to it", () => {
+    const pages: PageSpec[] = [
+      { url: BASE, links: [body("/a"), body("/b")] },
+      { url: "https://example.com/a", links: [chrome(BASE), body("/b")] },
+      { url: "https://example.com/b", links: [chrome(BASE), body("/a")] },
+    ];
+    expect(check(noContextualInboundRule, ctx(pages)).status).toBe("pass");
+  });
+
+  test("excludePatterns are honoured, same as links/orphan-pages", () => {
+    const excluded = ctx(FOOTER_ONLY, { excludePatterns: ["/legal"] });
+    expect(check(noContextualInboundRule, excluded).status).toBe("pass");
+  });
+
+  test("a chrome-only page BELOW the orphan threshold is left to orphan-pages", () => {
+    // Only one page carries the footer link, so /legal's raw count is 1 (< 2).
+    const pages: PageSpec[] = [
+      { url: BASE, links: [body("/a"), chrome("/legal")] },
+      { url: "https://example.com/a", links: [body(BASE)] },
+      { url: "https://example.com/legal", links: [] },
+    ];
+
+    expect(check(noContextualInboundRule, ctx(pages)).status).toBe("pass");
+    expect(ids(check(orphanPagesRule, ctx(pages)))).toContain("https://example.com/legal");
+  });
+
+  test("minInboundLinks moves the handoff point in step with orphan-pages", () => {
+    const pages: PageSpec[] = [
+      { url: BASE, links: [body("/a"), chrome("/legal")] },
+      { url: "https://example.com/a", links: [body(BASE)] },
+      { url: "https://example.com/legal", links: [] },
+    ];
+    // At a threshold of 1, /legal (raw 1) is no longer an orphan — so it becomes
+    // ours. Neither rule may drop it.
+    const opts = { minInboundLinks: 1 };
+    expect(check(orphanPagesRule, ctx(pages, opts)).status).toBe("pass");
+    expect(ids(check(noContextualInboundRule, ctx(pages, opts)))).toEqual([
+      "https://example.com/legal",
+    ]);
+  });
+
+  test("nofollow chrome links do not count on either side of the comparison", () => {
+    // /legal's only inbound links are nofollowed chrome → raw 0 → an orphan,
+    // not our case.
+    const pages: PageSpec[] = [
+      { url: BASE, links: [body("/a"), { ...chrome("/legal"), isNofollow: true }] },
+      { url: "https://example.com/a", links: [body(BASE), { ...chrome("/legal"), isNofollow: true }] },
+      { url: "https://example.com/legal", links: [] },
+    ];
+    expect(check(noContextualInboundRule, ctx(pages)).status).toBe("pass");
+  });
+
+  test("a crawl with <2 pages is skipped", () => {
+    const result = check(noContextualInboundRule, ctx([{ url: BASE, links: [] }]));
+    expect(result.status).toBe("skipped");
+  });
+
+  test("links stored without isChrome (pre-#109 crawls) count as contextual", () => {
+    const pages: PageSpec[] = [
+      { url: BASE, links: [legacyLink("/a"), legacyLink("/legal")] },
+      { url: "https://example.com/a", links: [legacyLink("/legal")] },
+      { url: "https://example.com/legal", links: [] },
+    ];
+    // Degrades to the pre-#109 behaviour: no site-wide false alarm.
+    expect(check(noContextualInboundRule, ctx(pages)).status).toBe("pass");
+  });
+
+  test("the reported sample is capped at 5 while details.total stays exact", () => {
+    // Home links to 7 chrome-only pages; each of the 7 also carries the chrome
+    // link, so every one has a raw count of 8 — comfortably above the threshold.
+    const targets = Array.from({ length: 7 }, (_, i) => `/c${i}`);
+    const chromeLinks = targets.map((t) => chrome(t));
+    const pages: PageSpec[] = [
+      { url: BASE, links: chromeLinks },
+      ...targets.map((t) => ({ url: `https://example.com${t}`, links: chromeLinks })),
+    ];
+
+    const result = check(noContextualInboundRule, ctx(pages));
+    expect(result.status).toBe("warn");
+    expect(result.details).toEqual({ total: 7 });
+    expect(ids(result)).toHaveLength(7);
+    expect(result.value).toBe("/c0\n/c1\n/c2\n/c3\n/c4\n+2 more");
+  });
+});

--- a/packages/rules/tests/schema-coverage-outlier.test.ts
+++ b/packages/rules/tests/schema-coverage-outlier.test.ts
@@ -111,6 +111,7 @@ function siteQueryCtx(specs: PageSpec[]): RuleContext {
     pageCount: () => rows.length,
     duplicateGroups: unused,
     incomingLinkCounts: unused,
+    contextualIncomingLinkCounts: unused,
     pagesByType: unused,
     templateClusters: unused,
     sumTransferBytes: unused,

--- a/packages/rules/tests/slug-convention.test.ts
+++ b/packages/rules/tests/slug-convention.test.ts
@@ -110,6 +110,7 @@ function siteQueryCtx(specs: PageSpec[]): RuleContext {
     pageCount: () => rows.length,
     duplicateGroups: unused,
     incomingLinkCounts: unused,
+    contextualIncomingLinkCounts: unused,
     pagesByType: unused,
     templateClusters: unused,
     sumTransferBytes: unused,

--- a/packages/rules/tests/thin-vs-site-norm.test.ts
+++ b/packages/rules/tests/thin-vs-site-norm.test.ts
@@ -106,6 +106,7 @@ function siteQueryCtx(specs: PageSpec[]): RuleContext {
     pageCount: () => rows.length,
     duplicateGroups: unused,
     incomingLinkCounts: unused,
+    contextualIncomingLinkCounts: unused,
     pagesByType: unused,
     templateClusters: unused,
     sumTransferBytes: unused,

--- a/packages/rules/tests/title-pattern-outlier.test.ts
+++ b/packages/rules/tests/title-pattern-outlier.test.ts
@@ -110,6 +110,7 @@ function siteQueryCtx(specs: PageSpec[]): RuleContext {
     pageCount: () => rows.length,
     duplicateGroups: unused,
     incomingLinkCounts: unused,
+    contextualIncomingLinkCounts: unused,
     pagesByType: unused,
     templateClusters: unused,
     sumTransferBytes: unused,


### PR DESCRIPTION
Closes #109

Part of #103 (V-04).

`links/orphan-pages` and `links/weak-internal-links` count RAW inbound links, with no container distinction — a link repeated in the sitewide footer of a 200-page site scores the same as a link from body copy. A page reachable only through chrome therefore has a healthy count and passes both while receiving no editorial support.

## What changed

**Link graph.** `LinkData.isChrome` records whether the anchor sat inside a `nav`/`header`/`footer`/`aside` landmark (`packages/parser/src/extractors/chrome.ts`). Deliberately stricter than the existing `detectLinkPosition`, which also matches class/id substrings — too loose to drive a warning (`class="post-nav"` would reclassify a post's body links). Set by **all three** ParsedPage producers, including the parser's `html.ts` extractor, which is the one the crawler serialises into `parsedData` and which *both* rule paths re-read.

**Bounded per-page scalar.** `SiteQuery.contextualIncomingLinkCounts()` is accumulated in the SAME scan as `incomingLinkCounts()` — identical keys, order, universe handling and filters — so `contextual <= all` holds by construction. The legacy `site.pages` path rebuilds both counts in one pass.

**The rule.** Warns on `contextual === 0 && raw >= minInboundLinks` — exactly the band where `orphan-pages` stays silent, so the two never report the same page. Homepage exempt, same exclude handling as `orphan-pages`.

**Backwards compatible:** `isChrome` is optional; `undefined` counts as contextual on both paths, so a crawl DB stored before this change degrades to the pre-change numbers rather than flagging every page.

## Acceptance criteria

- [x] The link graph records, per link, whether it sat inside site chrome (ancestor `nav`/`header`/`footer`/`aside`)
- [x] A bounded per-page scalar for contextual (non-chrome) inbound link count is available to rules from both the legacy `site.pages` path and the `siteQuery` accumulator
- [x] Both paths produce identical counts for the same crawl, covered by a test (`site-query-link-rules-golden.test.ts`: an explicit count-level parity assertion plus deep-equal rule output)
- [x] New site-scope rule `links/no-contextual-inbound`, registered in the rules catalog
- [x] Warns on pages whose contextual inbound count is 0 while their raw inbound count is above the orphan threshold
- [x] Excludes the homepage and honours the same exclude patterns as `links/orphan-pages`
- [x] Fixture: a page linked from the sitewide footer only — warns, and is NOT reported by `links/orphan-pages`
- [x] Fixture: a page linked once from body copy — no warning
- [x] Existing `links/orphan-pages` and `links/weak-internal-links` output is unchanged (their fixtures and expectations are untouched; the new cases use a separate fixture)
- [x] Rule page added to `docs/`, listed in `docs/rules/links/index.mdx` and `docs/docs.json`
- [x] `streaming-rules-canonical-golden.test.ts`: `findings.length` 98218 → 98219 and `perRuleTally.length` 276 → 277, each with a comment line naming this rule

## Tests added

- `packages/rules/tests/no-contextual-inbound.test.ts` — the two named fixtures plus homepage exemption, exclude patterns, threshold handoff with `orphan-pages`, nofollow chrome, pre-change crawls, sample cap.
- `packages/audit-engine/tests/site-query-link-rules-golden.test.ts` — count-level parity, dual-path deep-equality, and the `orphan-pages`-stays-silent assertion on the same crawl.
- `packages/parser/tests/link-chrome.test.ts` — landmark detection, nested wrappers, class/id names are not chrome.
- `apps/cli/tests/audit/parsed-page-producer-parity.test.ts` — all three producers agree on `isChrome`.

## Also

Docs rule counts were stale (README said 273 in one place and 275 in another; catalog was 276 — `content/date-agreement`'s +1 was missed in #108). All brought to 277.

## Not verified locally

Local `bun`/`tsgo` execution was blocked by this environment's command policy, so the typecheck and test suite were not run here — CI is the first execution. The golden-pin reasoning is spelled out in the test comment: the rule is site-scoped (one check, always) and passes on the 518-page fixture, whose only chrome link is the header nav's link to `/`, which is exempt.