### PR TITLE
docs(rules): correct the count in the rules index frontmatter

### DIFF
--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rules Reference"
-description: "All 275 audit rules organized by score group and category"
+description: "All 276 audit rules organized by score group and category"
 ---
 
 squirrelscan includes **276 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.


### PR DESCRIPTION
The frontmatter description states the total as prose ("All N audit rules"). The sweep in #119 missed it because its regex required "N rules" and this reads "N audit rules".

The `#483` rule-count guard in the private repo covers this surface explicitly, so the gitlink bump failed on it. Every other stated count is already at 276.

Lesson applied: the guard test is the authority on which surfaces exist, not a hand-rolled regex. Verified by running the guard itself against this tree rather than re-approximating it.