### PR TITLE
fix(cli): keep reporting liveness after the crawl stops advancing

### DIFF
--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -66,6 +66,7 @@ import {
   reportProgress,
   type RegisteredRun,
   resolveRunFinalizeScore,
+  startRunHeartbeat,
 } from "@/lib/run-tracker";
 import { syncTechnologies } from "@/lib/technology-sync";
 import { getApiUrl } from "@/self/api";
@@ -1289,6 +1290,15 @@ export const audit = defineCommand({
       const onSignal = (signal: NodeJS.Signals): void => {
         // Note the cancel so the user isn't left wondering during the PATCH (stderr keeps piped stdout clean).
         if (trackedRunId) process.stderr.write("\nCancelling run…\n");
+        // #1583: the crawl is checkpointed in the project's SQLite store, so the
+        // pages fetched so far survive this exit — but nothing ever said so, and
+        // a user who has just lost a 450-page crawl reasonably assumes it is gone
+        // and starts over. Name the exact command while the context is on screen.
+        if (lastPagesFetched > 0) {
+          process.stderr.write(
+            `${lastPagesFetched} pages are saved. Resume with:\n  squirrel audit ${args.url} --resume\n`
+          );
+        }
         void finalizeTracked({
           status: "cancelled",
           completedAt: new Date().toISOString(),
@@ -1311,6 +1321,30 @@ export const audit = defineCommand({
       let lastProgressAt = 0;
       let crawlPagesFailed = 0;
       const PROGRESS_MIN_INTERVAL_MS = 1_000;
+
+      // #1583: newest counts seen from the crawl, kept OUTSIDE onProgress so the
+      // heartbeat can still report them once onProgress has moved past
+      // `crawling` (or returned entirely). They stop advancing when the crawl
+      // ends, which is correct — the beat is then asserting "still alive, still
+      // this many pages", not inventing progress.
+      let lastPagesFetched = 0;
+      let lastPagesTotal = maxPages;
+
+      // Start the liveness beat as soon as the run exists. Every phase after the
+      // crawl is silent on the wire, and the server reaps on silence, so without
+      // this a long rules/render/publish stretch reads as a dead process.
+      void registerPromise.then((run) => {
+        if (!run) return;
+        startRunHeartbeat(
+          run.runId,
+          () => ({
+            pagesFetched: lastPagesFetched,
+            pagesTotal: lastPagesTotal,
+            pagesFailed: crawlPagesFailed,
+          }),
+          run.lifecycleBase
+        );
+      });
 
       const progress = createProgress("Initializing");
       let currentPhase = "init";
@@ -1415,6 +1449,8 @@ export const audit = defineCommand({
                   }
                   // Show discovered count + the in-flight URL (live per-page
                   // progress so a slow render upgrade doesn't look frozen).
+                  lastPagesFetched = p.current;
+                  lastPagesTotal = p.total ?? maxPages;
                   const found =
                     discoveredCount > 0 ? ` [${discoveredCount} found]` : "";
                   const active = p.detail ? ` ${fmt.dim(p.detail)}` : "";

--- a/apps/cli/src/lib/run-tracker.ts
+++ b/apps/cli/src/lib/run-tracker.ts
@@ -282,6 +282,7 @@ export async function reportProgress(
   input: ProgressInput,
   base = lifecycleBase()
 ): Promise<void> {
+  lastProgressSentAtMs = Date.now();
   await cliApi.send(runPath(runId, "/progress", base), {
     method: "POST",
     auth: "required",
@@ -292,6 +293,70 @@ export async function reportProgress(
       pagesFailed: Math.max(0, Math.round(input.pagesFailed)),
     },
   });
+}
+
+// ── Liveness heartbeat (#1583) ────────────────────────────────────────────
+//
+// The server reaps a CLI run that has shown no activity for its budget, and a
+// progress POST is the ONLY activity signal a CLI run produces (it writes no
+// agent_run_events; the handler stamps config.lastProgressAtMs instead). But
+// progress was emitted from the `crawling` branch of onProgress ALONE, so every
+// post-crawl phase — external links, cloud fetch, rules, scoring, render,
+// publish — was silent. On a large site that stretch outruns the deadline and a
+// perfectly healthy run gets reaped with its work discarded: darussalam.id
+// crawled 454 pages, went quiet at its last page, and was killed 76 minutes
+// later having never stopped working.
+//
+// The heartbeat is deliberately phase-AGNOSTIC — a timer spanning markRunning →
+// finalize rather than a reportProgress call added to each of today's phases.
+// Per-phase plumbing would fix the four phases that exist now and silently
+// reintroduce the bug the next time one is added; a timer cannot miss a phase
+// it does not know about.
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+// Timestamp of the newest progress POST from any source, so a heartbeat tick
+// during the crawl (when real progress is already flowing at ≤1/s) skips its
+// redundant request instead of doubling the cadence.
+let lastProgressSentAtMs = 0;
+
+// A CLI process tracks at most one run, so one active heartbeat is the whole
+// story and module state is honest here.
+let activeHeartbeat: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the liveness heartbeat for a registered run. `snapshot` is read at each
+ * tick so the beat always carries the CURRENT counts — during the crawl that is
+ * live progress, and after it the final tally, which is what keeps the run's
+ * page total honest while the post-crawl phases work through it.
+ *
+ * Best-effort like the rest of the lifecycle: the timer is unref'd so it can
+ * never hold the process open, and a failed tick is swallowed — the next one is
+ * 30s away and the deadline is far wider than that.
+ */
+export function startRunHeartbeat(
+  runId: string,
+  snapshot: () => ProgressInput,
+  base = lifecycleBase(),
+  intervalMs = HEARTBEAT_INTERVAL_MS
+): void {
+  stopRunHeartbeat();
+  activeHeartbeat = setInterval(() => {
+    // Real progress is already keeping the run alive — don't double the cadence.
+    if (Date.now() - lastProgressSentAtMs < intervalMs) return;
+    void reportProgress(runId, snapshot(), base).catch(() => {
+      // Best-effort: a dropped beat is recoverable, a thrown one is not.
+    });
+  }, intervalMs);
+  // Never let the heartbeat be the reason the CLI does not exit.
+  activeHeartbeat.unref?.();
+}
+
+/** Stop the heartbeat. Idempotent; safe to call when none is running. */
+export function stopRunHeartbeat(): void {
+  if (activeHeartbeat) {
+    clearInterval(activeHeartbeat);
+    activeHeartbeat = null;
+  }
 }
 
 /** Close the run out at the end (after publish). Fire-and-forget. */
@@ -346,6 +411,11 @@ export function createRunFinalizer(
   return async (input: FinalizeRunInput): Promise<void> => {
     if (finalized) return;
     finalized = true;
+    // #1583: the finalizer is the one guarded path every exit funnels through
+    // (success, error, publish failure, Ctrl-C), so stopping the heartbeat here
+    // covers them all — and stopping BEFORE the terminal PATCH means a beat can
+    // never race in behind it and re-stamp activity on a finished run.
+    stopRunHeartbeat();
     const run = await registerPromise.catch(() => null);
     if (run) await finalizeRun(run.runId, input, run.lifecycleBase);
   };

--- a/apps/cli/tests/lib/run-tracker.test.ts
+++ b/apps/cli/tests/lib/run-tracker.test.ts
@@ -8,6 +8,8 @@ import {
   reportProgress,
   type RegisteredRun,
   resolveRunFinalizeScore,
+  startRunHeartbeat,
+  stopRunHeartbeat,
 } from "@/lib/run-tracker";
 
 // run-tracker resolves a credential from SQUIRREL_API_TOKEN (env path of
@@ -672,5 +674,135 @@ describe("org API key (sq_) → org-scoped lifecycle routes (#280)", () => {
 
     await finalizeRun("run_1", { status: "completed", completedAt: "t" });
     expect(url).toContain("/v1/agent-runs/org/run_1");
+  });
+});
+
+describe("run heartbeat (#1583)", () => {
+  // Collect every progress POST body so a test can assert on cadence + payload.
+  function captureProgress(): { bodies: Record<string, number>[] } {
+    const bodies: Record<string, number>[] = [];
+    globalThis.fetch = (async (
+      _input: string | URL | Request,
+      init?: RequestInit
+    ) => {
+      if (init?.body)
+        bodies.push(JSON.parse(String(init.body)) as Record<string, number>);
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    return { bodies };
+  }
+
+  const settle = (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  // Timer cadence under a loaded test runner is not exact, so every assertion
+  // below is on the SHAPE of the behaviour (beats keep arriving / stop
+  // arriving), never on a precise beat count. BEAT_MS is kept well above the
+  // runner's timer jitter for the same reason.
+  const BEAT_MS = 20;
+
+  afterEach(() => stopRunHeartbeat());
+
+  test("keeps reporting after the crawl stops advancing", async () => {
+    // The darussalam.id case: the crawl ends at N pages and the run then spends a
+    // long time in rules/render/publish. Nothing calls reportProgress in those
+    // phases, so before #1583 the server saw silence and reaped a live run.
+    const { bodies } = captureProgress();
+    const frozen = { pagesFetched: 454, pagesTotal: 454, pagesFailed: 2 };
+
+    startRunHeartbeat("run_1", () => frozen, undefined, BEAT_MS);
+    await settle(BEAT_MS * 8);
+
+    // The regression this guards: zero beats once the crawl stopped advancing.
+    expect(bodies.length).toBeGreaterThanOrEqual(2);
+    // Every beat carries the final tally — the beat asserts liveness, it does
+    // not invent progress the crawl never made.
+    for (const body of bodies) {
+      expect(body).toEqual({
+        pagesFetched: 454,
+        pagesTotal: 454,
+        pagesFailed: 2,
+      });
+    }
+  });
+
+  test("reads the snapshot at each tick, so counts stay current", async () => {
+    const { bodies } = captureProgress();
+    let fetched = 10;
+
+    startRunHeartbeat(
+      "run_1",
+      () => ({ pagesFetched: fetched, pagesTotal: 500, pagesFailed: 0 }),
+      undefined,
+      BEAT_MS
+    );
+    await settle(BEAT_MS * 3);
+    fetched = 99;
+    await settle(BEAT_MS * 4);
+
+    expect(bodies.at(0)?.pagesFetched).toBe(10);
+    expect(bodies.at(-1)?.pagesFetched).toBe(99);
+  });
+
+  test("stops on finalize, so no beat lands behind the terminal PATCH", async () => {
+    // Ordering matters: a beat arriving after the run is terminal would re-stamp
+    // activity on a finished run.
+    const { bodies } = captureProgress();
+    startRunHeartbeat(
+      "run_1",
+      () => ({ pagesFetched: 1, pagesTotal: 1, pagesFailed: 0 }),
+      undefined,
+      BEAT_MS
+    );
+    await settle(BEAT_MS * 3);
+
+    await createRunFinalizer(
+      Promise.resolve({
+        runId: "run_1",
+        websiteId: "w",
+        auditId: "a",
+        lifecycleBase: "/v1/agent-runs/org",
+        baseCharged: 0,
+        balanceAfterBase: null,
+      } as RegisteredRun)
+    )({ status: "completed", completedAt: "t" });
+
+    const afterFinalize = bodies.length;
+    await settle(BEAT_MS * 5);
+    // Only the finalize PATCH may have been recorded; no further progress beats.
+    expect(bodies.length).toBe(afterFinalize);
+  });
+
+  test("a failing beat never throws — the audit must not be affected", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    startRunHeartbeat(
+      "run_1",
+      () => ({ pagesFetched: 1, pagesTotal: 1, pagesFailed: 0 }),
+      undefined,
+      BEAT_MS
+    );
+    // An unhandled rejection here would fail the test run.
+    await settle(BEAT_MS * 4);
+    expect(true).toBe(true);
+  });
+
+  test("starting twice leaves a single timer that one stop fully clears", async () => {
+    // A stacked second timer would survive the single stop and keep beating —
+    // which on a real run means progress stamped onto an already-terminal run.
+    const { bodies } = captureProgress();
+    const snap = () => ({ pagesFetched: 1, pagesTotal: 1, pagesFailed: 0 });
+
+    startRunHeartbeat("run_1", snap, undefined, BEAT_MS);
+    startRunHeartbeat("run_1", snap, undefined, BEAT_MS);
+    await settle(BEAT_MS * 3);
+    expect(bodies.length).toBeGreaterThan(0); // it was genuinely running
+
+    stopRunHeartbeat();
+    const afterStop = bodies.length;
+    await settle(BEAT_MS * 5);
+    expect(bodies.length).toBe(afterStop);
   });
 });


### PR DESCRIPTION
A signed-in `squirrel audit` produces exactly one activity signal: the progress
POST. A CLI run writes no `agent_run_events` rows, so the server stamps
`config.lastProgressAtMs` from that POST and reaps a run that has been quiet for
its budget.

That POST was emitted from the `crawling` branch of `onProgress` **and nowhere
else**. Every phase after the crawl is silent on the wire:

| phase | reports progress |
|---|---|
| `crawling` | yes |
| `external-links` | no |
| `cloud` | no |
| `rules` | no |
| render / publish (after `onProgress` returns) | no |

On a large site that silent stretch outruns the inactivity budget and a healthy
run is killed. Confirmed in prod: `darussalam.id` crawled 454 pages, went quiet
at its last page at 13:04:31Z, and was marked `failed` / `stale` at 14:20:33Z —
76 minutes later, having never stopped working. No report was delivered, twice
in one evening.

Supporting evidence: across 14 days of prod, **all 74 `api`-trigger runs have
events (5918 of them) and all 65 `cli` runs have zero**, which is why the
progress marker is the only thing standing between a live CLI run and the reaper.

## Approach

The heartbeat is deliberately **phase-agnostic** — a timer spanning
`markRunning` → `finalize` rather than a `reportProgress` call added to each of
the four phases that exist today. Per-phase plumbing fixes today's phases and
silently reintroduces the bug the next time one is added; a timer cannot miss a
phase it does not know about.

- ticks every 30s, well under the smallest running deadline
- skips its request when real progress is already flowing, so the crawl's
  ≤1/s cadence is not doubled
- `unref()`d — it can never be the reason the CLI does not exit
- swallows failures, like the rest of the best-effort lifecycle
- stopped by the **guarded finalizer**, which every exit path funnels through
  (success, error, publish failure, Ctrl-C), and stopped *before* the terminal
  PATCH so a beat cannot land behind it and re-stamp activity on a finished run

The snapshot is read at each tick, so a beat carries the current counts. Once
the crawl ends those stop advancing — correct, because the beat asserts "still
alive, still this many pages", it does not invent progress.

## Also

On interrupt, name the resume command. The crawl is checkpointed in the
project's SQLite store, so a cancelled 450-page crawl is recoverable with
`--resume` — but nothing ever said so, and a user who just lost a long crawl
reasonably assumes it is gone and starts over.

## Testing

`tests/lib/run-tracker.test.ts` — 40 pass, run 3× for flake. Interval is
injectable so the tests drive a real timer without fake-timer support; every
assertion is on the shape of the behaviour (beats keep arriving / stop
arriving), never an exact beat count, because runner timer cadence is not exact.

Covered: beats continue once the crawl stops advancing (the regression), the
snapshot is re-read per tick, finalize stops the timer, a failing beat never
throws, and a double start leaves one timer that a single stop fully clears.

`bun run typecheck`, `lint`, `format` clean in `apps/cli`.

**Not covered:** the `audit.ts` wiring itself (that command has no test
harness), and no end-to-end run against a real 450-page site — CLI egress is
blocked in this environment. The unit tests pin the heartbeat contract; the
wiring is reviewed by eye.

Pre-existing and unrelated: `tests/audit/cloud-tech-detect-fit.test.ts`
"escape-heavy adversarial content still fits" times out at 5s (takes ~11s).
Verified it fails identically on an unmodified tree.
