### PR TITLE
chore: release v0.0.87

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "repository": "https://github.com/squirrelscan/squirrelscan",
   "license": "MIT",
   "keywords": ["seo", "audit", "website", "performance", "security", "accessibility", "crawler"],
-  "version": "0.0.86"
+  "version": "0.0.87"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "squirrelscan",
   "displayName": "squirrelscan",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "author": {
     "name": "squirrelscan"
   },

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squirrelscan/cli",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "Free CLI for SEO, performance & security audits. Built for Claude Code, Cursor, and AI workflows.",
   "bin": {
     "squirrelscan": "./build/squirrelscan"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squirrelscan",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "Website QA tool built for coding agents. 260+ rules across SEO, performance, security, accessibility & agent experience, from the CLI, cloud, or MCP.",
   "bin": {
     "squirrel": "bin/squirrel.js"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "squirrelscan",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
   "author": {
     "name": "squirrelscan",


### PR DESCRIPTION
Version bump across the five synced release manifests, ahead of cutting v0.0.87.

The release workflow's Compute-version job verifies main already carries the version before it tags, so this has to merge before the release is dispatched. Only the `version` field changes in each file.

Release contents (already on main):
- CLI liveness heartbeat, so a long audit is no longer abandoned during its post-crawl phases (#123)
- `## v0.0.87` CHANGELOG section used as the release body (#126)