### PR TITLE
docs(agents): add Windsurf, Gemini CLI, and Copilot pages, plus Codex and geo-meta answer blocks

### DIFF
--- a/docs/developers/agents/codex.mdx
+++ b/docs/developers/agents/codex.mdx
@@ -49,6 +49,24 @@ Local audits are free and run entirely on your machine. Verify with `squirrel --
 
 <Note>Don't set `experimental_environment` for this server, it's for stdio-over-remote-executor and doesn't support streamable HTTP. More detail on the [MCP client setup](/developers/mcp-clients#codex-cli) page.</Note>
 
+## How to check which MCP servers are enabled in Codex
+
+Run `codex mcp list`. Each server is listed with a **Status** column reading `enabled` or `disabled`, so that one command tells you whether squirrelscan is registered and switched on.
+
+Remote servers like squirrelscan print in their own table, keyed by **Url** rather than **Command**, alongside the **Bearer Token Env Var** column that shows whether you configured API-key auth. Add `--json` if you want to parse the result:
+
+```bash
+codex mcp list --json
+```
+
+To inspect one server instead of all of them, pass its name to `codex mcp get`:
+
+```bash
+codex mcp get squirrelscan
+```
+
+If squirrelscan is missing from the list entirely, the `codex mcp add` step above did not write to the config file Codex is reading. Remember that `codex mcp add` only ever touches the global `~/.codex/config.toml`, so a hand-written project-level `.codex/config.toml` will not appear until that project is trusted.
+
 ## 3. Install the skills
 
 Codex reads Agent Skills from `~/.agents/skills`, so the same install works:

--- a/docs/developers/agents/copilot.mdx
+++ b/docs/developers/agents/copilot.mdx
@@ -113,7 +113,7 @@ If squirrelscan connects on your personal account but not your work one, this is
 
 ## What squirrelscan checks, and what it does not
 
-The audit covers 276 rules across 21 categories, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
+The audit covers 260+ rules, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
 
 The CLI audits anything your machine can reach, including `localhost` and private staging. The hosted MCP server crawls from squirrelscan's cloud, so it needs a publicly reachable URL, use the CLI or [`squirrel mcp`](/cli/mcp) for anything private.
 

--- a/docs/developers/agents/copilot.mdx
+++ b/docs/developers/agents/copilot.mdx
@@ -1,0 +1,139 @@
+---
+title: "squirrelscan for GitHub Copilot"
+sidebarTitle: "GitHub Copilot"
+description: "Set up squirrelscan in GitHub Copilot for VS Code: mcp.json config, agent mode, the skills, and running audits from Copilot Chat."
+icon: "github"
+---
+
+Copilot agent mode in VS Code can already run terminal commands on your behalf, so it can run `squirrel` with no configuration at all. Connecting the hosted MCP server replaces that parsed terminal output with native tools for cloud audits, the issue tracker, and the rule catalog.
+
+<Note>MCP runs through VS Code's built-in client (v1.101+), not through Copilot itself, so the config below lives in VS Code's `mcp.json`, not in a Copilot setting.</Note>
+
+## 1. Install the CLI
+
+The skills and local audits run through the `squirrel` binary.
+
+```bash
+curl -fsSL https://install.squirrelscan.com | bash
+```
+
+Local audits are free and run entirely on your machine. Verify with `squirrel --version`.
+
+## 2. Add the MCP server
+
+VS Code uses a top-level `servers` key, not `mcpServers`, and remote entries need `"type": "http"`.
+
+<Tabs>
+  <Tab title="OAuth (recommended)">
+    ```json
+    {
+      "servers": {
+        "squirrelscan": {
+          "type": "http",
+          "url": "https://mcp.squirrelscan.com/mcp"
+        }
+      }
+    }
+    ```
+
+    On first connection VS Code discovers the authorization server, registers a client, and opens a browser so you can sign in. Manage or revoke the grant later under **Accounts → Manage Trusted MCP Servers**.
+  </Tab>
+  <Tab title="API key">
+    For a config you intend to commit, use a prompted input so the key lands in VS Code's secret storage rather than in the file:
+
+    ```json
+    {
+      "inputs": [
+        {
+          "type": "promptString",
+          "id": "squirrelscan-api-key",
+          "description": "squirrelscan API key",
+          "password": true
+        }
+      ],
+      "servers": {
+        "squirrelscan": {
+          "type": "http",
+          "url": "https://mcp.squirrelscan.com/mcp",
+          "headers": {
+            "Authorization": "Bearer ${input:squirrelscan-api-key}"
+          }
+        }
+      }
+    }
+    ```
+
+    This also spares teammates an OAuth round trip just to open the project. Mint a key with `squirrel keys create --shell`.
+  </Tab>
+</Tabs>
+
+**Where it goes.** Save either block through **Command Palette → MCP: Add Server** (choose **HTTP**), or write it yourself to `.vscode/mcp.json` for this workspace (safe to commit, no token is stored in it) or to the user `mcp.json` via **Command Palette → MCP: Open User Configuration** to get it everywhere.
+
+<Warning>
+Use a top-level `headers` object. The `"requestInit": { "headers": ... }` form belongs to the separate Visual Studio IDE and silently no-ops in VS Code, you get a server that connects unauthenticated and fails on the first tool call.
+</Warning>
+
+## 3. Install the skills
+
+VS Code with Copilot supports the [Agent Skills](https://agentskills.io) standard:
+
+```bash
+npx skills add squirrelscan/squirrelscan
+```
+
+That installs `audit-website` (the fix loop) and `squirrelscan` (operating the CLI). See [`squirrel skills`](/cli/skills) for the details.
+
+## 4. Run an audit
+
+Open Copilot Chat and switch to **agent mode**. Ask mode can read your code but cannot run tools or edit files, so audits and fixes both need agent mode.
+
+```
+Audit https://example.com with squirrelscan and list the top issues by severity.
+```
+
+Then hand it the fixes. Agent mode edits across the repo the same way it acts on a failing test:
+
+```
+Fix every core/title-missing and images/alt-missing finding, then re-audit to confirm the score went up.
+```
+
+Cap the crawl on a large site so the run stays fast:
+
+```
+Audit only /blog/* on example.com, cap it at 20 pages, and fix the broken links.
+```
+
+<Tip>Copilot proposes each edit for review before applying it. On a batch of 20 image-alt fixes that gets tedious, so ask it to group the changes by file and apply them per file rather than per finding.</Tip>
+
+## Copilot Business and Enterprise
+
+Manual MCP servers are gated by org policy on paid plans, and both switches are needed. An org or enterprise owner has to enable the **MCP servers in Copilot** policy, which is off by default, and set **Restrict MCP access to registry servers** to **Allow all**, because squirrelscan is configured by hand and is not in GitHub's MCP registry.
+
+If squirrelscan connects on your personal account but not your work one, this is almost always why. The CLI path has no such restriction, so agent mode can still run `squirrel` in the integrated terminal while you wait on the policy change.
+
+## What squirrelscan checks, and what it does not
+
+The audit covers 276 rules across 21 categories, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
+
+The CLI audits anything your machine can reach, including `localhost` and private staging. The hosted MCP server crawls from squirrelscan's cloud, so it needs a publicly reachable URL, use the CLI or [`squirrel mcp`](/cli/mcp) for anything private.
+
+Copilot runs interactively in your editor, so it is the wrong tool for a per-deploy gate. Run the CLI in CI for that, it exits non-zero when a `--fail-on` threshold trips. Use Copilot for the fix loop and [CI](/guides/ci) for the gate.
+
+squirrelscan does not track keyword rankings, backlinks, or competitors. It reports what is on the page and how it is served.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Fix your site with an AI agent" icon="wand-sparkles" href="/guides/fix-your-site-with-an-ai-agent">
+    A full worked example of the audit-and-fix loop.
+  </Card>
+  <Card title="Hosted MCP server" icon="plug" href="/developers/mcp">
+    The full tool list, auth, and credits.
+  </Card>
+  <Card title="MCP client setup" icon="toy-brick" href="/developers/mcp-clients#vs-code-copilot">
+    Scopes, API-key auth, and JSON config.
+  </Card>
+  <Card title="Rules reference" icon="list-checks" href="/rules">
+    Every audit rule and how it's fixed.
+  </Card>
+</CardGroup>

--- a/docs/developers/agents/gemini-cli.mdx
+++ b/docs/developers/agents/gemini-cli.mdx
@@ -104,7 +104,7 @@ See the [CI guide](/guides/ci) for the full pattern.
 
 ## What squirrelscan checks, and what it does not
 
-The audit covers 276 rules across 21 categories, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
+The audit covers 260+ rules, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
 
 Some rules are [cloud rules](/cloud/rules), they use AI analysis, full filter lists, or live search data, so they need login and are skipped when you are signed out. The hosted MCP server crawls from squirrelscan's cloud and needs a publicly reachable URL; for `localhost` or private staging, point Gemini at the local CLI or [`squirrel mcp`](/cli/mcp) instead.
 

--- a/docs/developers/agents/gemini-cli.mdx
+++ b/docs/developers/agents/gemini-cli.mdx
@@ -1,0 +1,128 @@
+---
+title: "squirrelscan for Gemini CLI"
+sidebarTitle: "Gemini CLI"
+description: "Set up squirrelscan in Google's Gemini CLI: gemini mcp add, settings.json config, the skills, and running audits from the REPL."
+icon: "gem"
+---
+
+Gemini CLI is Google's open-source terminal agent. It speaks MCP natively, so squirrelscan's audit, report, and issue tools appear alongside Gemini's built-in tools and can be called without shelling out to the CLI each time.
+
+## 1. Install the CLI
+
+The skills and local audits run through the `squirrel` binary.
+
+```bash
+curl -fsSL https://install.squirrelscan.com | bash
+```
+
+Local audits are free and run entirely on your machine. Verify with `squirrel --version`.
+
+## 2. Add the MCP server
+
+<Tabs>
+  <Tab title="OAuth (recommended)">
+    ```bash
+    gemini mcp add --transport http --scope user \
+      squirrelscan https://mcp.squirrelscan.com/mcp
+    ```
+
+    OAuth is auto-discovered on first connect, or you can trigger it from the REPL with `/mcp auth squirrelscan`. Tokens cache in `~/.gemini/mcp-oauth-tokens.json`, never in your settings file.
+  </Tab>
+  <Tab title="API key">
+    ```bash
+    gemini mcp add --transport http --scope user \
+      --header "Authorization: Bearer $SQUIRRELSCAN_API_KEY" \
+      squirrelscan https://mcp.squirrelscan.com/mcp
+    ```
+
+    Env-var expansion (`$VAR`, `${VAR}`) works in any settings value, so export the key rather than writing it into the file. A static header stops OAuth discovery from ever firing, which is what you want in CI.
+  </Tab>
+  <Tab title="settings.json">
+    Gemini CLI writes `httpUrl` for a streamable-HTTP server. The resulting entry, in `~/.gemini/settings.json` (user) or `.gemini/settings.json` (project):
+
+    ```json
+    {
+      "mcpServers": {
+        "squirrelscan": {
+          "httpUrl": "https://mcp.squirrelscan.com/mcp"
+        }
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Warning>`gemini mcp add` defaults to **project** scope, not user scope. Without `--scope user` the server is written to `.gemini/settings.json` in the current directory and will not be there in your next project. This is the single most common Gemini CLI setup mistake.</Warning>
+
+Confirm the server registered with `gemini mcp list`, or run `/mcp` inside the REPL to see the connection state and the tools it exposes.
+
+## 3. Install the skills
+
+Gemini CLI supports the [Agent Skills](https://agentskills.io) standard, so the skills install the same way they do for every other supported agent:
+
+```bash
+npx skills add squirrelscan/squirrelscan
+```
+
+That adds `audit-website` (the fix loop) and `squirrelscan` (operating the CLI). See [`squirrel skills`](/cli/skills) for what each one does.
+
+<Note>squirrelscan is not packaged as an official Gemini CLI extension yet. Extensions can bundle MCP servers and commands, so this may change, but the `settings.json` entry above is the supported path today.</Note>
+
+## 4. Run an audit
+
+Start a REPL session and describe the task. Gemini calls `run_audit`, polls until the report is ready, then works the findings:
+
+```
+Audit https://example.com with squirrelscan and list the top 3 fixes.
+```
+
+Because Gemini CLI is a coding agent, not just a chat client, it can go straight from the report into your source:
+
+```
+Audit example.com, then fix every images/alt-missing finding in this repo and re-audit to confirm.
+```
+
+Keep runs fast on a large site by capping the crawl up front:
+
+```
+Audit only /docs/* on example.com, cap it at 20 pages, and fix the broken links.
+```
+
+<Tip>Cloud audits cost credits (50 per audit plus 2 per rendered page), and `run_audit` returns a cost estimate before anything runs. Local `squirrel audit` runs are free and unlimited, so use those for quick iteration and the cloud for browser-rendered checks.</Tip>
+
+## Headless and CI
+
+The OAuth flow needs a local browser and a reachable localhost redirect, so it fails over headless SSH or in a browser-less container. Use the API-key header there instead, exported from `SQUIRRELSCAN_API_KEY`.
+
+For a plain pass/fail deploy gate you do not need the agent at all, the free CLI exits non-zero when a threshold trips:
+
+```bash
+squirrel audit https://example.com --fail-on 'score<90'
+```
+
+See the [CI guide](/guides/ci) for the full pattern.
+
+## What squirrelscan checks, and what it does not
+
+The audit covers 276 rules across 21 categories, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
+
+Some rules are [cloud rules](/cloud/rules), they use AI analysis, full filter lists, or live search data, so they need login and are skipped when you are signed out. The hosted MCP server crawls from squirrelscan's cloud and needs a publicly reachable URL; for `localhost` or private staging, point Gemini at the local CLI or [`squirrel mcp`](/cli/mcp) instead.
+
+squirrelscan does not track keyword rankings, backlinks, or competitors. It reports what is on the page and how it is served.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Fix your site with an AI agent" icon="wand-sparkles" href="/guides/fix-your-site-with-an-ai-agent">
+    A full worked example of the audit-and-fix loop.
+  </Card>
+  <Card title="Hosted MCP server" icon="plug" href="/developers/mcp">
+    The full tool list, auth, and credits.
+  </Card>
+  <Card title="MCP client setup" icon="toy-brick" href="/developers/mcp-clients#gemini-cli">
+    Scopes, API-key auth, and JSON config.
+  </Card>
+  <Card title="Rules reference" icon="list-checks" href="/rules">
+    Every audit rule and how it's fixed.
+  </Card>
+</CardGroup>

--- a/docs/developers/agents/index.mdx
+++ b/docs/developers/agents/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Coding agents"
 sidebarTitle: "Overview"
-description: "Run squirrelscan audits from Claude Code, Cursor, Codex, ChatGPT, opencode, and any MCP client: setup, MCP, skills, and the fix loop."
+description: "Run squirrelscan audits from Claude Code, Cursor, Codex, Copilot, Gemini CLI, Windsurf, and any MCP client: setup, MCP, skills, and the fix loop."
 icon: "bot"
 ---
 
@@ -22,11 +22,20 @@ squirrelscan is built for coding agents. Point your agent at squirrelscan and it
   <Card title="ChatGPT" icon="message-square" href="/developers/agents/chatgpt">
     Add squirrelscan as a developer-mode connector.
   </Card>
+  <Card title="GitHub Copilot" icon="github" href="/developers/agents/copilot">
+    VS Code `mcp.json`, plus agent mode.
+  </Card>
+  <Card title="Gemini CLI" icon="gem" href="/developers/agents/gemini-cli">
+    `gemini mcp add`, or `settings.json`.
+  </Card>
+  <Card title="Windsurf" icon="wind" href="/developers/agents/windsurf">
+    Cascade, via `serverUrl` in `mcp_config.json`.
+  </Card>
   <Card title="opencode" icon="code" href="/developers/agents/opencode">
     Remote MCP in `opencode.json`.
   </Card>
   <Card title="Any MCP client" icon="plug" href="/developers/mcp-clients">
-    VS Code, Windsurf, Gemini CLI, and the raw endpoint.
+    Every other client, and the raw endpoint.
   </Card>
 </CardGroup>
 

--- a/docs/developers/agents/windsurf.mdx
+++ b/docs/developers/agents/windsurf.mdx
@@ -93,7 +93,7 @@ Re-auditing matters: a fix that looks right in the diff can still fail the rule,
 
 ## What squirrelscan checks, and what it does not
 
-The audit covers 276 rules across 21 categories, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
+The audit covers 260+ rules, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
 
 Two limits worth knowing before you point Cascade at a site:
 

--- a/docs/developers/agents/windsurf.mdx
+++ b/docs/developers/agents/windsurf.mdx
@@ -1,0 +1,118 @@
+---
+title: "squirrelscan for Windsurf"
+sidebarTitle: "Windsurf"
+description: "Add the squirrelscan MCP server to Windsurf (Devin Desktop): mcp_config.json setup, Cascade authorization, and the audit-and-fix loop."
+icon: "wind"
+---
+
+Windsurf's Cascade agent runs terminal commands and acts on what comes back, so it can drive the `squirrel` CLI with no setup at all. Connecting the hosted MCP server goes further: audits, rules, issues, and reports arrive as native tools instead of terminal output Cascade has to parse.
+
+<Note>Cognition rebranded Windsurf as **Devin Desktop** in 2026, and Cascade is folding into the Devin brand as Devin Local. The in-app names changed; the config file paths and JSON keys below did not.</Note>
+
+## 1. Install the CLI
+
+Run this in Windsurf's integrated terminal.
+
+```bash
+curl -fsSL https://install.squirrelscan.com | bash
+```
+
+Local audits are free, need no account, and run entirely on your machine. Verify with `squirrel --version`.
+
+## 2. Add the MCP server
+
+Windsurf uses `serverUrl` for a remote server, not `url`. Create the file if it does not exist yet, Windsurf will not create it for you.
+
+<Tabs>
+  <Tab title="OAuth (recommended)">
+    ```json
+    {
+      "mcpServers": {
+        "squirrelscan": {
+          "serverUrl": "https://mcp.squirrelscan.com/mcp"
+        }
+      }
+    }
+    ```
+
+    Save it, then open the MCP panel (the **MCPs** icon at the top right of Cascade, or **Devin Settings → Cascade → MCP Servers**), refresh, and click **Authorize** next to squirrelscan to finish the browser sign-in.
+  </Tab>
+  <Tab title="API key">
+    ```json
+    {
+      "mcpServers": {
+        "squirrelscan": {
+          "serverUrl": "https://mcp.squirrelscan.com/mcp",
+          "headers": {
+            "Authorization": "Bearer ${env:SQUIRRELSCAN_API_KEY}"
+          }
+        }
+      }
+    }
+    ```
+
+    `${env:VAR}` and `${file:/path}` interpolation both work inside `headers`, so export the key rather than hardcoding it. Mint one with `squirrel keys create --shell`.
+  </Tab>
+</Tabs>
+
+**Which file.** The standalone editor reads `~/.codeium/windsurf/mcp_config.json`. The Windsurf plugin for JetBrains or VS Code reads `~/.codeium/mcp_config.json`, with no `windsurf` segment. There is no project-scoped MCP config in Windsurf, this is a global, user-level file, so the server is available in every workspace once it is added.
+
+<Warning>Cascade caps total active MCP tools at 100 across every connected server. If you are near that ceiling, squirrelscan's tools will not load, disable unused tools or servers in the MCP panel first.</Warning>
+
+## 3. Run an audit
+
+With the MCP server connected, ask Cascade in plain language and it calls the tools directly:
+
+```
+Audit example.com with squirrelscan, then fix the high-severity SEO issues in this repo.
+```
+
+Without the MCP server, Cascade can still run the CLI for you. The `llm` output format is compact and structured, so it works from the report without you summarizing it first:
+
+```bash
+squirrel audit https://example.com --format llm
+```
+
+Scope large sites so runs stay fast and cheap:
+
+```
+Audit only /blog/* on example.com, cap it at 20 pages, and list the SEO regressions.
+```
+
+<Tip>Windsurf does not implement the [Agent Skills](https://agentskills.io) standard, so `npx skills add` has no effect here, unlike Cursor or Claude Code. The MCP tools and the CLI are the two supported paths.</Tip>
+
+## 4. The fix loop
+
+A typical pass in Cascade looks like this:
+
+1. Cascade runs the audit and groups findings by severity.
+2. It maps each finding to a file in your workspace, `core/title-missing` to a layout component, `images/alt-missing` to the templates that render them.
+3. It edits in batches, then re-audits to confirm the score moved.
+
+Re-auditing matters: a fix that looks right in the diff can still fail the rule, and the second run is what tells you.
+
+## What squirrelscan checks, and what it does not
+
+The audit covers 276 rules across 21 categories, rolling up into four scores: **SEO**, **Performance**, **Security**, and **Agents** (how well AI crawlers and agents can consume the site).
+
+Two limits worth knowing before you point Cascade at a site:
+
+- **Local versus cloud.** The CLI audits anything your machine can reach, including `localhost` and private staging. The hosted MCP server crawls from squirrelscan's cloud, so it needs a publicly reachable URL. Use the CLI or [`squirrel mcp`](/cli/mcp) for anything private.
+- **It is not a rank tracker.** squirrelscan checks what is on the page and how it is served. It does not report keyword positions, backlinks, or competitor rankings.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Fix your site with an AI agent" icon="wand-sparkles" href="/guides/fix-your-site-with-an-ai-agent">
+    A full worked example of the audit-and-fix loop.
+  </Card>
+  <Card title="Hosted MCP server" icon="plug" href="/developers/mcp">
+    The full tool list, auth, and credits.
+  </Card>
+  <Card title="MCP client setup" icon="toy-brick" href="/developers/mcp-clients#windsurf-devin-desktop">
+    Scopes, API-key auth, and JSON config.
+  </Card>
+  <Card title="Rules reference" icon="list-checks" href="/rules">
+    Every audit rule and how it's fixed.
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -98,6 +98,9 @@
                   "developers/agents/cursor",
                   "developers/agents/codex",
                   "developers/agents/chatgpt",
+                  "developers/agents/copilot",
+                  "developers/agents/gemini-cli",
+                  "developers/agents/windsurf",
                   "developers/agents/opencode"
                 ]
               },

--- a/docs/rules/local/geo-meta.mdx
+++ b/docs/rules/local/geo-meta.mdx
@@ -13,6 +13,12 @@ Checks for geographic meta tags for local targeting
 | **Severity** | info |
 | **Weight** | 2/10 |
 
+## What geo.placename is, and whether it still does anything
+
+`geo.placename` is a `<meta>` tag naming the city or locality a page targets, one of a small family alongside `geo.region` (a country-state code), `geo.position` (`latitude;longitude`), and `ICBM`. squirrelscan checks for them, but scores them in its lowest tier: severity `info`, weight 2/10.
+
+That weighting is the answer to whether they still do anything. This rule treats geo meta tags as a supplement to [LocalBusiness structured data](/rules/schema), never a substitute for it, and squirrelscan makes no claim that any particular search engine reads them. They are cheap to add to location-specific landing pages and cost nothing to keep, which is why the rule is `info` rather than a warning, but a missing `geo.placename` is not what is holding a page back in local search. Fix your LocalBusiness schema and NAP consistency first.
+
 ## Solution
 
 Geo meta tags help indicate your business location for local search. Add: geo.region (country-state code), geo.placename (city name), geo.position (latitude;longitude), and ICBM meta tag. These supplement LocalBusiness schema. Most useful for location-specific landing pages.


### PR DESCRIPTION
Adds docs setup pages for the three coding agents that have a marketing `/for` page and real search demand, but no page in the docs: **Windsurf**, **Gemini CLI**, and **GitHub Copilot**.

## Why these three

A 90-day GSC pull on `sc-domain:squirrelscan.com` (598 query rows) shows the demand here is **per-tool MCP setup intent**, and Windsurf is the biggest gap — every one of its queries is stuck on page 3 or worse:

| Query | Impressions | Position |
|---|---|---|
| windsurf mcp server | 15 | 39.7 |
| how to check enabled mcp in codex | 14 | 24.4 |
| windsurf mcp | 8 | 32.9 |
| windsurf mcp servers | 4 | 38.8 |
| windsurf mcp config | 3 | 40.0 |
| best seo mcp servers | 1 | 24.0 |
| best mcp server for seo | 1 | 25.0 |
| best seo mcp server | 1 | 28.0 |
| mcp servers for windsurf | 1 | 29.0 |
| windsurf mcp configuration | 1 | 48.0 |

That is ~32 impressions of pure Windsurf MCP-config intent, none of it ranking. On the page dimension, `/for/windsurf` absorbs 247 impressions at position 27.8, `/for/gemini-cli` 47 at 24.6, and `/for/copilot` 21 at 15.6 — the marketing pages are catching the queries, but there is no docs page behind them to convert the setup intent.

Claude Code, Cursor, and Codex were considered and **deliberately skipped**: they already have docs pages, and their queries already rank well (`cursor seo` 3.7, `cursor website audit` 6.0). Adding more pages there would have produced near-duplicates of pages that already work.

## What's in the pages

Every command, flag, key, and config snippet is lifted from `developers/mcp-clients.mdx` and the marketing tool data. Nothing is invented, and there are no benchmarks or stats.

The pages are intentionally not a template fill:

- **Windsurf** omits the skills step entirely, because Windsurf does not implement the Agent Skills standard (per `cli/skills.mdx`). It covers the `serverUrl` key, the two possible config paths, the absence of project scope, the 100-tool Cascade cap, and the Devin Desktop rebrand.
- **Gemini CLI** leads on the `--scope user` trap (`gemini mcp add` defaults to *project* scope), plus `httpUrl`, `/mcp auth`, the token cache path, and the headless-SSH OAuth limitation.
- **Copilot** covers the `servers` key (not `mcpServers`), `promptString` secret storage for committed configs, the `requestInit` no-op footgun, and the Business/Enterprise dual policy gate.

Each page ends with an honest scope section: 276 rules across 21 categories, cloud vs local URL reachability, and an explicit statement that squirrelscan is not a rank/backlink tracker.

Also wired into `docs.json` nav and the agents overview card grid.

## Duplication check

5-gram Jaccard across all agent pages. The new pages are **less** similar to each other than the existing pages already are to each other, so this does not add doorway-shaped content:

- New vs new: 0.115 – 0.147
- Existing vs existing: 0.160 – 0.268 (`codex` vs `opencode` is the highest at 0.268)
- New vs existing: max 0.120

---

## Added: two answer blocks on existing pages

Same GSC pull surfaced two queries that existing pages rank for but do not directly answer. Both got a query-phrased H2 with the answer in the first sentence, rather than a new page.

**`developers/agents/codex.mdx`** — "how to check enabled mcp in codex" is the second-largest agent query in the pull (14 impressions, position 24.4), and the page documented `add`, `login` and `logout` but never `list`. The new section answers it directly: `codex mcp list` prints a **Status** column reading `enabled` or `disabled`. It also covers the separate remote-server table, `--json`, `codex mcp get <name>`, and the usual cause of an absent server (`codex mcp add` only writes the global `~/.codex/config.toml`).

These commands were **verified by running codex-cli 0.147.0**, not taken from memory — the docs did not previously mention `codex mcp list`, so there was no in-repo ground truth to copy.

**`rules/local/geo-meta.mdx`** — 183 impressions at position 19.6, driven by:

| Query | Impressions | Position |
|---|---:|---:|
| geo placename | 146 | 17.4 |
| geo.placename | 9 | 13.6 |
| meta geo tag | 8 | 13.9 |

The page opened with a restated description and a metadata table, answering none of them. The new H2 gives what the tag is, then whether it still does anything.

On that second half I deliberately did **not** make a vendor claim. Neither the rule doc nor its source says anything about whether Google or Bing reads geo tags, so asserting either way would have been invented. Instead the answer is grounded in what squirrelscan itself asserts: severity `info`, weight 2/10 (its lowest tier), and the rule's existing framing of geo tags as a supplement to LocalBusiness schema rather than a substitute. The block says explicitly that squirrelscan makes no claim about engine support, and points readers at LocalBusiness schema and NAP consistency as the higher-value fixes.

## Also: rule-count phrasing fix

The three new pages originally cited the exact live total ("276 rules across 21 categories"). `apps/api/tests/routes/rule-count-consistency.test.ts` pins that number only in `rules/index.mdx`, `docs/index.mdx` and `rules.tsx`, so those pages would have been three new surfaces drifting silently on the next rule addition. Switched to `260+ rules`, the `PUBLIC_RULE_COUNT_FLOOR` value that is deliberately rounded down for exactly this purpose and already used in the marketing `/for` pages.

## Out of scope, noted for the separate GSC sweep

`/for/windsurf` on the marketing site is a striking-distance page — 247 impressions at position 27.8 — and is a strong answer-blocks candidate. Not touched here; marketing pages are handled by the main GSC sweep.

## Validation

`bun x tangly check --strict` passes — 380 pages, 0 orphans.

`tangly build` fails, **but it fails identically on pristine `origin/main`** with the same `UnknownContentCollectionError`, so it is a pre-existing local Tangly toolchain issue and not caused by this branch. Verified by building a detached `origin/main` worktree; clearing the stale Astro cache and the leftover `/private/tmp/squirrelscan-public-deps.*` dir did not resolve it on main either. Worth a separate look.
