### PR TITLE
build(deps): bump codeql-action to v4.37.7 and attest-build-provenance to v4.2.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript-typescript
           build-mode: none
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
           name: release-binaries
           path: release-assets
       - name: Attest release artifacts
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: release-assets/*
       - name: Resolve release notes


### PR DESCRIPTION
Supersedes #125, #124 and #102.

`codeql-action/init` and `codeql-action/analyze` are pinned to the same SHA and must move together. Dependabot split them into two PRs, so **neither can go green alone** - whichever lands first leaves the two steps on different versions and the analyze step fails:

```
Loaded a configuration file for version '4.37.7', but running version '4.37.3'
```

That is exactly what #125 is showing right now ([job log](https://github.com/squirrelscan/squirrelscan/actions/runs/32676888760/job/97286564591)). Bumping both in one commit is the only way either lands.

#102 (`attest-build-provenance` v4.1.1 -> v4.2.2) is folded in rather than left as the last stray dependabot PR against these pinned actions.

Note `release.yml` is touched, so this affects the release path - the attest step runs only during a release, and the version move is a straight patch bump of a pinned action.