### PR TITLE
ci(dco): key the dependabot exemption off the PR author, not the run actor

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -17,7 +17,11 @@ jobs:
           fetch-depth: 0
       - name: Check DCO sign-offs
         env:
-          ACTOR: ${{ github.actor }}
+          # The PR's author, NOT github.actor. github.actor is whoever
+          # triggered *this run*, so it flips to a human the moment anyone
+          # rebases, updates, or re-runs a dependabot PR, silently revoking
+          # the exemption below and failing a PR that passed when opened.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -31,7 +35,7 @@ jobs:
             author=$(git show -s --format='%an <%ae>' "$commit")
             committer=$(git show -s --format='%cn <%ce>' "$commit")
             message=$(git show -s --format=%B "$commit")
-            if [ "$ACTOR" = "dependabot[bot]" ] && \
+            if [ "$PR_AUTHOR" = "dependabot[bot]" ] && \
                [ "$author" = "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>" ]; then
               continue
             fi


### PR DESCRIPTION
## Problem

The DCO dependabot exemption tests `github.actor`:

```yaml
ACTOR: ${{ github.actor }}
...
if [ "$ACTOR" = "dependabot[bot]" ] && [ "$author" = "dependabot[bot] <...>" ]; then
```

`github.actor` is **whoever triggered the current run**, not whoever opened the PR. So any human action on a dependabot PR - a rebase, an "Update branch", even a plain re-run - makes `github.actor` a human, revokes the exemption, and fails DCO on commits that passed when the PR was opened.

This is not hypothetical. I hit it today: #102, #124 and #125 were all passing DCO, I clicked Update branch on each to refresh their month-old CI, and all three immediately went to `Verify commit sign-offs FAILURE` with no change to their commits.

The failure mode is nasty because it looks like the bot did something wrong, when the check simply stopped applying.

## Fix

Use `github.event.pull_request.user.login`, which is a property of the PR itself and does not change with who triggers the run.

The author-identity check is deliberately left in place, so the exemption still requires the commit to genuinely be authored by dependabot - this only stops the exemption evaporating on re-runs.

## Acceptance Criteria
- [ ] A dependabot PR passes DCO after a human clicks "Update branch" or re-runs the job
- [ ] A human-authored commit with no sign-off still fails DCO
- [ ] A commit forged to claim dependabot authorship in a human-opened PR still fails DCO