### PR TITLE
fix(installer): dangling-symlink EEXIST on reinstall, and `| sh` dying under dash

### DIFF
--- a/apps/cli/src/controllers/self/install.ts
+++ b/apps/cli/src/controllers/self/install.ts
@@ -1,16 +1,10 @@
-import {
-  existsSync,
-  mkdirSync,
-  copyFileSync,
-  unlinkSync,
-  chmodSync,
-} from "node:fs";
+import { mkdirSync, copyFileSync, chmodSync } from "node:fs";
 import { dirname } from "node:path";
 
 import type { InstallResult } from "@/self/types";
 
 import { type Result, ok, err, commandError } from "@/controllers/types";
-import { linkBinary } from "@/self/link-binary";
+import { linkBinary, unlinkIfPresent } from "@/self/link-binary";
 import {
   getSquirrelPaths,
   getReleasePath,
@@ -55,10 +49,10 @@ export async function runSelfInstall(
       chmodSync(binaryPath, 0o755);
     }
 
-    // Create/update symlink (a copy on Windows, where symlinks need privilege)
-    if (existsSync(symlinkPath)) {
-      unlinkSync(symlinkPath);
-    }
+    // Create/update symlink (a copy on Windows, where symlinks need privilege).
+    // unlinkIfPresent, not an existsSync guard: existsSync follows the link, so
+    // a dangling one survived the guard and made linkBinary throw EEXIST.
+    unlinkIfPresent(symlinkPath);
     linkBinary(binaryPath, symlinkPath);
 
     // Initialize settings — preserve anything already there (auth, telemetry

--- a/apps/cli/src/self/link-binary.ts
+++ b/apps/cli/src/self/link-binary.ts
@@ -1,5 +1,36 @@
-import { copyFileSync, symlinkSync } from "node:fs";
+import { copyFileSync, symlinkSync, unlinkSync } from "node:fs";
 import { platform } from "node:os";
+
+export interface UnlinkIfPresentDeps {
+  unlink?: (path: string) => void;
+}
+
+/**
+ * Remove whatever currently sits at `path` — file, live symlink, or dangling
+ * symlink — and do nothing if there is genuinely nothing there.
+ *
+ * Callers used to guard the unlink with `existsSync(path)`, which FOLLOWS
+ * symlinks: a link whose release directory has been cleaned up reads as
+ * missing, the unlink is skipped, and the symlink/copy that follows dies with
+ * `EEXIST: file already exists`. That is the whole of the "Self install failed
+ * with exit code 1" the installer has been reporting on reinstall.
+ *
+ * Unlinking unconditionally and swallowing only ENOENT is the fix: unlink
+ * operates on the link itself, so every case above collapses to one call. Any
+ * other errno (EACCES on an unwritable bin dir, EBUSY on a running Windows
+ * .exe) still surfaces, because those are real problems.
+ */
+export function unlinkIfPresent(
+  path: string,
+  deps: UnlinkIfPresentDeps = {}
+): void {
+  const unlink = deps.unlink ?? unlinkSync;
+  try {
+    unlink(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
 
 export interface LinkBinaryDeps {
   symlink?: (target: string, path: string) => void;

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -21,7 +21,7 @@ import type { ReleaseManifest, UpdateResult, UserSettings } from "./types";
 
 import { version } from "../../package.json";
 import { updateSuppressedReason } from "./install-meta";
-import { linkBinary } from "./link-binary";
+import { linkBinary, unlinkIfPresent } from "./link-binary";
 import {
   getReleasePath,
   getBinaryPath,
@@ -856,7 +856,7 @@ export function updateSymlink(
       // Some filesystems/Windows policies refuse rename-over-existing for
       // links — fall back to the old swap and clean up the tmp link.
       try {
-        if (existsSync(symlinkPath)) unlinkSync(symlinkPath);
+        unlinkIfPresent(symlinkPath);
         linkBinary(binaryPath, symlinkPath);
       } finally {
         try {

--- a/apps/cli/tests/self/link-binary.test.ts
+++ b/apps/cli/tests/self/link-binary.test.ts
@@ -4,6 +4,7 @@ import {
   lstatSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -89,23 +90,36 @@ describe("linkBinary", () => {
 });
 
 describe("unlinkIfPresent", () => {
+  // Why the bug existed: the old code guarded its unlink with existsSync.
+  test("existsSync reports a dangling symlink as absent, lstat does not", () => {
+    const dir = mkdtempSync(join(tmpdir(), "squirrel-unlink-"));
+    try {
+      const link = join(dir, "squirrel");
+      // An older release directory was cleaned up, leaving the bin symlink
+      // pointing at nothing — the shape of the reported failure.
+      symlinkSync(join(dir, "releases", "0.0.86", "squirrel"), link);
+
+      expect(existsSync(link)).toBe(false); // follows the link to a missing file
+      expect(lstatSync(link).isSymbolicLink()).toBe(true); // the link is right there
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("removes a dangling symlink so the relink can't hit EEXIST", () => {
     const dir = mkdtempSync(join(tmpdir(), "squirrel-unlink-"));
     try {
       const link = join(dir, "squirrel");
-      const gone = join(dir, "releases", "0.0.86", "squirrel");
-      // The exact shape of the reported failure: an older release directory
-      // was cleaned up, leaving the bin symlink pointing at nothing.
-      symlinkSync(gone, link);
-      expect(existsSync(link)).toBe(false); // existsSync follows the link
-      expect(lstatSync(link).isSymbolicLink()).toBe(true); // ...but it is there
+      const target = join(dir, "new-squirrel");
+      symlinkSync(join(dir, "releases", "0.0.86", "squirrel"), link);
+      writeFileSync(target, "binary");
 
       unlinkIfPresent(link);
-
-      const target = join(dir, "new-squirrel");
-      writeFileSync(target, "binary");
       linkBinary(target, link, { isWindows: false });
-      expect(readFileSync(link, "utf-8")).toBe("binary");
+
+      // readlink, not readFileSync: assert the link was repointed, which is
+      // what the fix is about, rather than reading through it.
+      expect(readlinkSync(link)).toBe(target);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/apps/cli/tests/self/link-binary.test.ts
+++ b/apps/cli/tests/self/link-binary.test.ts
@@ -1,15 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import {
+  existsSync,
   lstatSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { linkBinary } from "../../src/self/link-binary";
+import { linkBinary, unlinkIfPresent } from "../../src/self/link-binary";
 
 // Windows refuses symlinks to unprivileged users, which is what made
 // `self install` exit 1 on stock Windows boxes (#1538). The deps are injected
@@ -83,5 +85,74 @@ describe("linkBinary", () => {
     ).toThrow("EPERM");
     // A copy here would leave an install `self update` can't swap.
     expect(copied).toBe(false);
+  });
+});
+
+describe("unlinkIfPresent", () => {
+  test("removes a dangling symlink so the relink can't hit EEXIST", () => {
+    const dir = mkdtempSync(join(tmpdir(), "squirrel-unlink-"));
+    try {
+      const link = join(dir, "squirrel");
+      const gone = join(dir, "releases", "0.0.86", "squirrel");
+      // The exact shape of the reported failure: an older release directory
+      // was cleaned up, leaving the bin symlink pointing at nothing.
+      symlinkSync(gone, link);
+      expect(existsSync(link)).toBe(false); // existsSync follows the link
+      expect(lstatSync(link).isSymbolicLink()).toBe(true); // ...but it is there
+
+      unlinkIfPresent(link);
+
+      const target = join(dir, "new-squirrel");
+      writeFileSync(target, "binary");
+      linkBinary(target, link, { isWindows: false });
+      expect(readFileSync(link, "utf-8")).toBe("binary");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("removes a live symlink and a regular file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "squirrel-unlink-"));
+    try {
+      const target = join(dir, "target");
+      const link = join(dir, "link");
+      const plain = join(dir, "plain");
+      writeFileSync(target, "binary");
+      symlinkSync(target, link);
+      writeFileSync(plain, "not a link");
+
+      unlinkIfPresent(link);
+      unlinkIfPresent(plain);
+
+      expect(existsSync(link)).toBe(false);
+      expect(existsSync(plain)).toBe(false);
+      expect(existsSync(target)).toBe(true); // unlink the link, never its target
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("is a no-op when nothing is there", () => {
+    const dir = mkdtempSync(join(tmpdir(), "squirrel-unlink-"));
+    try {
+      expect(() => unlinkIfPresent(join(dir, "absent"))).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("surfaces a non-ENOENT errno instead of swallowing it", () => {
+    // EACCES on an unwritable bin dir is a real problem, not a missing file.
+    expect(() =>
+      unlinkIfPresent("/bin/squirrel", {
+        unlink: () => {
+          const error = new Error(
+            "EACCES: permission denied, unlink"
+          ) as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        },
+      })
+    ).toThrow("EACCES");
   });
 });

--- a/docs/developers/agents/claude-code.mdx
+++ b/docs/developers/agents/claude-code.mdx
@@ -11,9 +11,18 @@ squirrelscan plugs straight into Claude Code. The plugin bundles both skills and
 
 The skills and local audits run through the `squirrel` binary.
 
-```bash
-curl -fsSL https://install.squirrelscan.com | bash
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://install.squirrelscan.com | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    iwr -useb https://install.squirrelscan.com/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
 
 Local audits are free and run entirely on your machine. Verify with `squirrel --version`.
 

--- a/docs/developers/agents/codex.mdx
+++ b/docs/developers/agents/codex.mdx
@@ -11,9 +11,18 @@ Codex connects to squirrelscan over the hosted MCP server and reads Agent Skills
 
 The skills and local audits run through the `squirrel` binary.
 
-```bash
-curl -fsSL https://install.squirrelscan.com | bash
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://install.squirrelscan.com | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    iwr -useb https://install.squirrelscan.com/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
 
 Local audits are free and run entirely on your machine. Verify with `squirrel --version`.
 

--- a/docs/developers/agents/cursor.mdx
+++ b/docs/developers/agents/cursor.mdx
@@ -11,9 +11,18 @@ Cursor gets squirrelscan as a one-click MCP install plus the audit skills. Curso
 
 The skills and local audits run through the `squirrel` binary.
 
-```bash
-curl -fsSL https://install.squirrelscan.com | bash
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://install.squirrelscan.com | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    iwr -useb https://install.squirrelscan.com/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
 
 Local audits are free and run entirely on your machine. Verify with `squirrel --version`.
 

--- a/docs/developers/agents/opencode.mdx
+++ b/docs/developers/agents/opencode.mdx
@@ -11,9 +11,18 @@ opencode connects to squirrelscan over the hosted MCP server, so it can run audi
 
 Local audits and the skills run through the `squirrel` binary.
 
-```bash
-curl -fsSL https://install.squirrelscan.com | bash
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://install.squirrelscan.com | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    iwr -useb https://install.squirrelscan.com/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
 
 Local audits are free and run entirely on your machine. Verify with `squirrel --version`.
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,26 @@
 #!/bin/bash
+
+# Everything below needs bash: `local`, `[[ ]]`, and the `set -o pipefail` on
+# the next line. Piped into a POSIX shell — `curl ... | sh`, and /bin/sh is
+# dash on Debian/Ubuntu — that `set` aborts on line 1 with
+#   sh: set: Illegal option -o pipefail
+# before the error reporting below is even defined, so the failure is opaque
+# to the user and invisible to us. `| sh` one-liners are published in places we
+# can't edit, so hand over to bash rather than trusting the shebang.
+if [ -z "${BASH_VERSION:-}" ]; then
+  if command -v bash > /dev/null 2>&1; then
+    # Saved to a file: just re-run it. Piped: this script has already been
+    # consumed from stdin and cannot be rewound, so refetch it under bash.
+    case "$0" in
+      */install.sh | install.sh) exec bash "$0" "$@" ;;
+    esac
+    exec bash -c 'curl -fsSL https://install.squirrelscan.com/install.sh | bash'
+  fi
+  echo "Error: the squirrelscan installer requires bash, and none was found." >&2
+  echo "  Install bash, or grab a binary from https://github.com/squirrelscan/squirrelscan/releases" >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 # squirrelscan installer


### PR DESCRIPTION
Three installer failures found while reviewing what Sentry has been recording. All are live right now.

## 1. `self install` dies on a dangling symlink (8 events, still firing)

`self install` guarded its unlink with `existsSync(symlinkPath)`. **`existsSync` follows symlinks**, so a link whose release directory had been cleaned up reads as *missing*, the unlink is skipped, and `linkBinary` then throws:

```
EEXIST: file already exists, symlink '~/.squirrel/releases/0.0.87/squirrel' -> '~/.local/bin/squirrel'
```

Users see `Self install failed with exit code 1`. This hits **existing** installs re-running the installer, so it silently blocks upgrades and repairs.

Fix: `unlinkIfPresent()` — unlink unconditionally, swallow only `ENOENT`. `unlink` acts on the link itself, so regular file / live link / dangling link all collapse to one call, while `EACCES` (unwritable bin dir) and `EBUSY` (running Windows .exe) still surface. `updateSymlink`'s rename fallback had the same guard and is switched over too.

Reproduction, before the fix:

```
link exists on disk (lstat): true
existsSync(link)           : false   <-- follows the link, so a dangling link reads as MISSING
RESULT: FAILED -> EEXIST
```

## 2. `curl ... | sh` aborts on line 1 under dash (invisible in telemetry)

`install.sh` is bash (`local`, `[[ ]]`, `set -o pipefail`) but is published in several places as `| sh`. On Debian/Ubuntu `/bin/sh` is dash:

```
$ printf 'set -euo pipefail\n' | dash
dash: 1: set: Illegal option -o pipefail   (exit 2)
```

That happens **before** the error-reporting helpers are defined, so the user gets an opaque message and we record nothing. This drop-off does not appear in Sentry at all.

Fix: re-exec under bash before `set` runs. A saved file is re-run directly; a piped script has already been consumed from stdin and cannot be rewound, so it is refetched. With no bash present, print what to do instead of dying on syntax. Verified against dash for all three paths (piped, `dash install.sh`, `bash install.sh`).

The companion change that stops publishing `| sh` in the first place is in the private monorepo (the `/learn/*` pages).

## 3. Windows readers were only offered the curl command (20 events, the largest single failure)

The four agent setup pages showed only the macOS/Linux one-liner, so Windows readers ran it and hit the installer's "this installer is for macOS/Linux" exit. Now uses the same `<Tabs>` pattern as `quickstart.mdx`.

## Verification

- `bun test tests/self/` — 245 pass, 0 fail (4 new regression tests for `unlinkIfPresent`, including the dangling-link case and that a non-ENOENT errno still throws)
- `oxfmt --check`, `oxlint`, `tsgo --noEmit` — all clean
- `make validate` in `docs/` — 382 pages, 0 orphans, all checks passed

Signed off per DCO on all three commits.
