### PR TITLE
docs: add Windows agent install commands

### DIFF
--- a/docs/developers/agents/copilot.mdx
+++ b/docs/developers/agents/copilot.mdx
@@ -13,9 +13,18 @@ Copilot agent mode in VS Code can already run terminal commands on your behalf, 
 
 The skills and local audits run through the `squirrel` binary.
 
-```bash
-curl -fsSL https://install.squirrelscan.com | bash
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://install.squirrelscan.com | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    iwr -useb https://install.squirrelscan.com/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
 
 Local audits are free and run entirely on your machine. Verify with `squirrel --version`.
 

--- a/docs/developers/agents/gemini-cli.mdx
+++ b/docs/developers/agents/gemini-cli.mdx
@@ -11,9 +11,18 @@ Gemini CLI is Google's open-source terminal agent. It speaks MCP natively, so sq
 
 The skills and local audits run through the `squirrel` binary.
 
-```bash
-curl -fsSL https://install.squirrelscan.com | bash
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://install.squirrelscan.com | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    iwr -useb https://install.squirrelscan.com/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
 
 Local audits are free and run entirely on your machine. Verify with `squirrel --version`.
 

--- a/docs/developers/agents/windsurf.mdx
+++ b/docs/developers/agents/windsurf.mdx
@@ -13,9 +13,18 @@ Windsurf's Cascade agent runs terminal commands and acts on what comes back, so 
 
 Run this in Windsurf's integrated terminal.
 
-```bash
-curl -fsSL https://install.squirrelscan.com | bash
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://install.squirrelscan.com | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    iwr -useb https://install.squirrelscan.com/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
 
 Local audits are free, need no account, and run entirely on your machine. Verify with `squirrel --version`.
 


### PR DESCRIPTION
## Summary

Add the Windows PowerShell installer alongside the macOS/Linux installer on the Copilot, Gemini CLI, and Windsurf agent pages. This brings all eight agent pages into the same installer-tab structure while leaving the CI guide unchanged.

Closes #133

## Verification

- `bun run docs:check` — passed (384 pages; all checks passed)
- `bun run docs:build` — passed (387 pages built)

AI disclosure: Codex prepared the scoped MDX edits and ran the documented validation commands.

## Checklist

- [x] Documentation-only change; no behavioral tests are applicable.
- [x] I did not include secrets, customer data, or incompatible third-party material.
- [x] Every commit includes a DCO `Signed-off-by` line (`git commit -s`).