### PR TITLE
feat(cli): sell Pro at the credit wall, and fix the dead top-up URL

### DIFF
--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -215,7 +215,7 @@ export function registerFailureLines(failure: RegisterFailure): string[] {
       : AUDIT_PRICING_LINE;
   return [
     fmt.yellow(
-      "⚠ Out of cloud credits — this run is not tracked in your dashboard."
+      "⚠ Out of cloud credits. This run is not tracked in your dashboard."
     ),
     `  ${balanceLine}`,
     // Say plainly that nothing was lost. A warning that reads like a failure is
@@ -259,7 +259,7 @@ export function lowBalanceFooterLines(opts: {
 
   const headline = spent
     ? fmt.yellow(
-        `${balance.toLocaleString("en-US")} credits left — below the ${base}-credit audit base, so the next cloud audit can't start.`
+        `${balance.toLocaleString("en-US")} credits left, below the ${base}-credit audit base: the next cloud audit can't start.`
       )
     : fmt.yellow(
         `${balance.toLocaleString("en-US")} credits left. ${AUDIT_PRICING_LINE}`

--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -65,10 +65,12 @@ import {
   registerRun,
   reportProgress,
   type RegisteredRun,
+  type RegisterFailure,
   resolveRunFinalizeScore,
   startRunHeartbeat,
 } from "@/lib/run-tracker";
 import { syncTechnologies } from "@/lib/technology-sync";
+import { AUDIT_PRICING_LINE, proPitchLines, upgradeUrl } from "@/lib/upgrade";
 import { getApiUrl } from "@/self/api";
 import {
   API_TOKEN_ENV_VAR,
@@ -190,6 +192,81 @@ export function computePreflightAffordability(opts: {
       ]
     : [];
   return { base, renderCost, estimate, shortfall, warningLines };
+}
+
+/**
+ * Lines printed when register failed definitively and the run went untracked.
+ *
+ * Out of credits gets the full offer rather than the server's one sentence: the
+ * CLI is the surface most of these users live in, and 12 of the 13 orgs that
+ * ever ran out of credits never came back, having never been shown a price. The
+ * other definitive codes (website limit, org locked) are not a plan problem, so
+ * they keep the plain one-liner.
+ *
+ * Exported for tests. Returns plain lines; the caller does the printing.
+ */
+export function registerFailureLines(failure: RegisterFailure): string[] {
+  if (failure.code !== "INSUFFICIENT_CREDITS") {
+    return [`⚠ Run not tracked in your dashboard: ${failure.message}`];
+  }
+  const balanceLine =
+    failure.balance != null
+      ? `You have ${failure.balance.toLocaleString("en-US")} credits. ${AUDIT_PRICING_LINE}`
+      : AUDIT_PRICING_LINE;
+  return [
+    fmt.yellow(
+      "⚠ Out of cloud credits — this run is not tracked in your dashboard."
+    ),
+    `  ${balanceLine}`,
+    // Say plainly that nothing was lost. A warning that reads like a failure is
+    // why "the audit still ran" never landed.
+    `  ${fmt.dim("The audit itself ran locally and its results below are complete.")}`,
+    ...proPitchLines("cli-audit"),
+  ];
+}
+
+/** Warn once the balance drops below this share of the plan's monthly grant. */
+const LOW_BALANCE_FRACTION = 0.2;
+
+/**
+ * End-of-run low-balance warning, mirroring the dashboard's banner for people
+ * who never open the dashboard.
+ *
+ * Fires at 20% of the plan's monthly grant — while there are still credits to
+ * spend and a decision to make — and again, more sharply, once the balance is
+ * under the flat base and can buy nothing. Free plans get the Pro offer; paid
+ * plans get a top-up link, not a pitch for the plan they're already on.
+ *
+ * Exported for tests.
+ */
+export function lowBalanceFooterLines(opts: {
+  balance: number | null;
+  monthlyCredits: number;
+  plan: "anonymous" | "free" | "paid";
+}): string[] {
+  const { balance, monthlyCredits, plan } = opts;
+  if (balance == null || plan === "anonymous") return [];
+
+  const base = computeCost("audit_base", 1);
+  const spent = balance < base;
+  // A plan with no monthly grant (Team pools per seat) has no share to measure
+  // against, so it only warns once the balance can't buy an audit.
+  const threshold =
+    monthlyCredits > 0
+      ? Math.floor(monthlyCredits * LOW_BALANCE_FRACTION)
+      : base;
+  if (!spent && balance >= threshold) return [];
+
+  const headline = spent
+    ? fmt.yellow(
+        `${balance.toLocaleString("en-US")} credits left — below the ${base}-credit audit base, so the next cloud audit can't start.`
+      )
+    : fmt.yellow(
+        `${balance.toLocaleString("en-US")} credits left. ${AUDIT_PRICING_LINE}`
+      );
+
+  if (plan === "free") return [headline, ...proPitchLines("cli-audit")];
+  return [headline, `  Top up: ${fmt.cyan(upgradeUrl("cli-audit"))}`];
 }
 
 /**
@@ -831,6 +908,9 @@ export const audit = defineCommand({
       // "paid" → genuinely-unavailable framing, "anonymous" → free-account upsell.
       // Also picks the default coverage mode below (signed-in → surface).
       let accountPlan: "anonymous" | "free" | "paid" = "anonymous";
+      // Monthly grant for the signed-in plan, so the footer can warn at a
+      // share of it rather than only once the balance is already spent.
+      let planMonthlyCredits = 0;
       // White-label branding for local html/markdown/text/xml exports (#810).
       // Present only when the signed-in org is on the Team plan (API decides).
       let reportBranding: ReportBranding | undefined;
@@ -844,6 +924,7 @@ export const audit = defineCommand({
           const { balance, plan, branding } = await statusClient.getBalance();
           startingBalance = balance.total;
           accountPlan = plan.id === "free" ? "free" : "paid";
+          planMonthlyCredits = plan.monthlyCredits;
           reportBranding = branding;
           // Pricing v10 (#391): every cloud audit debits a flat base at
           // registration. A balance below it can't start one — run local-only
@@ -853,7 +934,7 @@ export const audit = defineCommand({
           if (balance.total < auditBase) {
             kv(
               "Account",
-              `${accountLabel} · ${fmt.yellow(`${balance.total.toLocaleString("en-US")} credits — below the ${auditBase}-credit audit base, running local-only`)} · top up: ${fmt.cyan(DASHBOARD_URL)}`
+              `${accountLabel} · ${fmt.yellow(`${balance.total.toLocaleString("en-US")} credits — below the ${auditBase}-credit audit base, running local-only`)} · upgrade: ${fmt.cyan(upgradeUrl("cli-audit"))}`
             );
           } else {
             signedIn = true;
@@ -1194,7 +1275,7 @@ export const audit = defineCommand({
           balance: startingBalance,
           maxPages,
           cloudRendering,
-          topUpUrl: DASHBOARD_URL,
+          topUpUrl: upgradeUrl("cli-audit"),
         });
         if (preflight.shortfall) {
           log("");
@@ -1244,7 +1325,7 @@ export const audit = defineCommand({
       // Captures a loud, actionable register failure (#816) — e.g. at the
       // website limit — surfaced once after the crawl (progress stopped) so it
       // isn't clobbered mid-crawl. Only set for definitive 4xx, not transient.
-      let registerWarning: string | null = null;
+      let registerWarning: RegisterFailure | null = null;
       const registerPromise: Promise<RegisteredRun | null> =
         signedIn && !args.offline
           ? registerRun(
@@ -1260,8 +1341,8 @@ export const audit = defineCommand({
                   runner: runnerInfo,
                 },
               },
-              (msg) => {
-                registerWarning = msg;
+              (failure) => {
+                registerWarning = failure;
               }
             )
           : Promise.resolve(null);
@@ -1527,7 +1608,7 @@ export const audit = defineCommand({
       // which used to be swallowed silently. Progress is stopped by now (finally
       // above), so this prints cleanly.
       if (registerWarning && !registeredRun) {
-        log(`⚠ Run not tracked in your dashboard: ${registerWarning}`);
+        for (const line of registerFailureLines(registerWarning)) log(line);
       }
 
       // Handle errors
@@ -1951,6 +2032,16 @@ export const audit = defineCommand({
           // CTA below, so skip this line there to avoid printing two.
           const lockedLine = lockedRulesFooterLine(report);
           if (lockedLine) footerLines.push(lockedLine);
+          // The advance warning the dashboard now shows as a banner, in the
+          // one place a CLI-only user will actually read it. Fires while there
+          // are still credits left, not at zero.
+          footerLines.push(
+            ...lowBalanceFooterLines({
+              balance: after,
+              monthlyCredits: planMonthlyCredits,
+              plan: accountPlan,
+            })
+          );
         } else {
           footerLines.push(
             `${fmt.dim("Unlock cloud features:")} squirrel auth login  •  ${fmt.cyan(DASHBOARD_URL)}`

--- a/apps/cli/src/cli/commands/credits.ts
+++ b/apps/cli/src/cli/commands/credits.ts
@@ -1,11 +1,14 @@
-// squirrel credits - cloud credit balance + pricing
+// squirrelscan credits - cloud credit balance + pricing
 
 import { defineCommand } from "citty";
 
+import { fmt } from "@/cli/format";
+import { openBrowser } from "@/lib/browser";
+import { AUDIT_BASE_CREDITS, proPitchLines, upgradeUrl } from "@/lib/upgrade";
 import { warnIfSessionUnreadable } from "@/self/credentials";
 import { safeExit } from "@/self/updater";
 
-const TOP_UP_URL = "https://squirrelscan.com/account/credits";
+const UPGRADE_URL = upgradeUrl("cli-credits");
 
 export const credits = defineCommand({
   meta: {
@@ -17,8 +20,26 @@ export const credits = defineCommand({
       type: "boolean",
       description: "Output as JSON",
     },
+    upgrade: {
+      type: "boolean",
+      description: "Open the upgrade page in your browser",
+    },
   },
   async run({ args }) {
+    // --upgrade is deliberately answered BEFORE the credential check: someone
+    // who wants to pay should not have to log in to the CLI first to be told
+    // where. It is also the whole point of the flag for users who never open
+    // the dashboard.
+    if (args.upgrade) {
+      console.log(`Upgrade: ${fmt.cyan(UPGRADE_URL)}`);
+      // Best-effort: a headless box, WSL without a handler, or no DESKTOP
+      // session just leaves the printed URL above as the answer.
+      await openBrowser(UPGRADE_URL).catch(() => {
+        console.log(fmt.dim("Couldn't open a browser. Copy the URL above."));
+      });
+      return;
+    }
+
     warnIfSessionUnreadable();
     const { createCloudClientFromSettings } = await import("@/tools/cloud");
 
@@ -49,6 +70,14 @@ export const credits = defineCommand({
       if (balance.periodEnd) {
         console.log(
           `         monthly credits reset ${balance.periodEnd.slice(0, 10)}`
+        );
+      }
+      // A balance under the flat base can buy NOTHING, however positive it
+      // reads. Say so here rather than letting the next `squirrel audit`
+      // silently drop to local-only.
+      if (balance.total < AUDIT_BASE_CREDITS) {
+        console.log(
+          `         ${fmt.yellow(`below the ${AUDIT_BASE_CREDITS}-credit audit base — cloud audits can't start`)}`
         );
       }
       console.log("");
@@ -88,7 +117,14 @@ export const credits = defineCommand({
         );
       }
       console.log("");
-      console.log(`Top up: ${TOP_UP_URL}`);
+      // The free plan is where the wall gets hit, so that is where the offer
+      // goes. Paid plans get the top-up link, not a plan pitch they're on.
+      if (plan.id === "free") {
+        for (const line of proPitchLines("cli-credits")) console.log(line);
+        console.log(fmt.dim("  Or run `squirrel credits --upgrade`."));
+      } else {
+        console.log(`Top up: ${fmt.cyan(UPGRADE_URL)}`);
+      }
     } catch (error) {
       console.error(`Could not fetch balance: ${(error as Error).message}`);
       return safeExit(1);

--- a/apps/cli/src/controllers/auth/login.ts
+++ b/apps/cli/src/controllers/auth/login.ts
@@ -10,6 +10,7 @@ import { hostname } from "node:os";
 
 import { type Result, ok, err, commandError } from "@/controllers/types";
 import { cliApi } from "@/lib/api-client";
+import { openBrowser } from "@/lib/browser";
 import { DEFAULT_API_URL, getApiUrl } from "@/self/api";
 import { loadUserSettings, updateSettings } from "@/self/settings";
 
@@ -115,51 +116,10 @@ async function findAvailablePort(): Promise<number> {
   });
 }
 
-/**
- * Open a URL in the default browser
- */
-async function openBrowser(url: string): Promise<void> {
-  const safeUrl = normalizeBrowserUrl(url);
-  const { platform } = process;
-
-  let command: string;
-  let args: string[];
-
-  if (platform === "darwin") {
-    command = "open";
-    args = [safeUrl];
-  } else if (platform === "win32") {
-    // Do not pass the API-provided URL through cmd.exe: shell metacharacters in
-    // the URL would otherwise be interpreted as commands. Explorer delegates
-    // HTTP(S) URLs to the default browser without invoking a command shell.
-    command = "explorer.exe";
-    args = [safeUrl];
-  } else {
-    // Linux
-    command = "xdg-open";
-    args = [safeUrl];
-  }
-
-  const { spawn } = await import("node:child_process");
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      detached: true,
-      stdio: "ignore",
-    });
-    child.unref();
-    child.on("error", reject);
-    // Don't wait for close - browser stays open
-    setTimeout(resolve, 500);
-  });
-}
-
-export function normalizeBrowserUrl(rawUrl: string): string {
-  const url = new URL(rawUrl);
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error("Authentication URL must use HTTP or HTTPS");
-  }
-  return url.toString();
-}
+// Moved to lib/browser.ts so non-auth commands can open a URL without pulling
+// in this module's callback server. Re-exported: existing callers and tests
+// import normalizeBrowserUrl from here.
+export { normalizeBrowserUrl } from "@/lib/browser";
 
 export function fetchSessionStatus(
   apiUrl: string,

--- a/apps/cli/src/lib/browser.ts
+++ b/apps/cli/src/lib/browser.ts
@@ -1,0 +1,53 @@
+// Opening a URL in the user's default browser.
+//
+// Lifted out of controllers/auth/login.ts so `squirrel credits --upgrade` can
+// reuse it: importing it from the login controller would drag the whole OAuth
+// callback server into an unrelated command.
+
+/**
+ * Reject anything that isn't http(s) before it reaches a platform opener —
+ * `open`/`xdg-open` will happily launch other schemes and their handlers.
+ */
+export function normalizeBrowserUrl(rawUrl: string): string {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Authentication URL must use HTTP or HTTPS");
+  }
+  return url.toString();
+}
+
+/** Open a URL in the default browser. */
+export async function openBrowser(url: string): Promise<void> {
+  const safeUrl = normalizeBrowserUrl(url);
+  const { platform } = process;
+
+  let command: string;
+  let args: string[];
+
+  if (platform === "darwin") {
+    command = "open";
+    args = [safeUrl];
+  } else if (platform === "win32") {
+    // Do not pass the API-provided URL through cmd.exe: shell metacharacters in
+    // the URL would otherwise be interpreted as commands. Explorer delegates
+    // HTTP(S) URLs to the default browser without invoking a command shell.
+    command = "explorer.exe";
+    args = [safeUrl];
+  } else {
+    // Linux
+    command = "xdg-open";
+    args = [safeUrl];
+  }
+
+  const { spawn } = await import("node:child_process");
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    child.on("error", reject);
+    // Don't wait for close - browser stays open
+    setTimeout(resolve, 500);
+  });
+}

--- a/apps/cli/src/lib/run-tracker.ts
+++ b/apps/cli/src/lib/run-tracker.ts
@@ -171,6 +171,20 @@ const DEFINITIVE_REGISTER_FAILURE_CODES = new Set([
 ]);
 
 /**
+ * What the caller is told about a definitive register failure. The `code` is
+ * carried, not just the message, because the three failures need three
+ * different answers: out of credits is an upgrade, at the website limit is a
+ * cleanup, locked is a billing fix. Collapsing them to one string left the CLI
+ * printing the server's sentence and nothing the user could act on.
+ */
+export interface RegisterFailure {
+  code: string;
+  message: string;
+  /** Balance at the time of the failure; null when the server didn't say. */
+  balance: number | null;
+}
+
+/**
  * Register the run at audit START. Returns the ids the dashboard needs to track
  * it live, or null on ANY failure (no credential, network error, non-2xx, bad
  * body) — the audit then simply proceeds untracked.
@@ -181,16 +195,16 @@ const DEFINITIVE_REGISTER_FAILURE_CODES = new Set([
  * run row and its 50cr base debit, and an untracked audit then gets reaped as an
  * orphan pending run and refunded — a delivered audit, for free.
  *
- * `onWarn` is invoked with the server message ONLY on a DEFINITIVE, actionable
- * failure (see DEFINITIVE_REGISTER_FAILURE_CODES) so the caller can surface it
- * loudly (#816): at the website limit / out of credits / org locked means the
- * run runs untracked and unpublished-to-dashboard and the user should know why.
+ * `onWarn` is invoked ONLY on a DEFINITIVE, actionable failure (see
+ * DEFINITIVE_REGISTER_FAILURE_CODES) so the caller can surface it loudly
+ * (#816): at the website limit / out of credits / org locked means the run runs
+ * untracked and unpublished-to-dashboard and the user should know why.
  * Everything else — transient network/5xx, rate limits, generic 400s — stays
  * silent: best-effort tracking must not spam noise on a flaky connection.
  */
 export async function registerRun(
   input: RegisterRunInput,
-  onWarn?: (message: string) => void
+  onWarn?: (failure: RegisterFailure) => void
 ): Promise<RegisteredRun | null> {
   // Resolve the base ONCE here; thread it through the returned RegisteredRun.
   const base = lifecycleBase();
@@ -238,9 +252,15 @@ export async function registerRun(
       // string `error` body (e.g. rate-limit) has no `.code` → stays silent.
       const code = data?.error?.code;
       if (onWarn && code && DEFINITIVE_REGISTER_FAILURE_CODES.has(code)) {
-        onWarn(
-          data?.error?.message ?? "the run won't appear in your dashboard"
-        );
+        onWarn({
+          code,
+          message:
+            data?.error?.message ?? "the run won't appear in your dashboard",
+          balance:
+            typeof data?.balance?.total === "number"
+              ? data.balance.total
+              : null,
+        });
       }
     }
     return null;

--- a/apps/cli/src/lib/upgrade.ts
+++ b/apps/cli/src/lib/upgrade.ts
@@ -1,0 +1,58 @@
+// The upgrade offer, in one place, for every surface that can hit the credit
+// wall: `squirrel credits`, the preflight balance line, and a register failure
+// mid-audit.
+//
+// Before this, the CLI had three different "where to pay" URLs and only one of
+// them worked. `squirrel credits` printed https://squirrelscan.com/account/credits,
+// which has never been a route on the marketing site, so the single most direct
+// question a paying-curious user can ask the CLI answered with a 404.
+//
+// The URL is squirrelscan.com/upgrade, not an app.squirrelscan.com deep link.
+// Billing lives under /$org/settings/billing and the CLI does not reliably know
+// the org slug (an API key acts for an org the user never named), and a binary
+// already on someone's machine can never be corrected — so the CLI points at a
+// stable marketing URL and lets the site own the mapping.
+
+import { computeCost } from "@squirrelscan/core-contracts/credits";
+import { getPlan } from "@squirrelscan/core-contracts/plans";
+
+import { fmt } from "@/cli/format";
+
+/** planId stays "starter" in the DB and Stripe; users only ever see "Pro". */
+const PRO = getPlan("starter");
+
+/** Cheapest possible audit: a balance under this can buy no cloud audit at all. */
+export const AUDIT_BASE_CREDITS = computeCost("audit_base", 1);
+export const RENDER_PAGE_CREDITS = computeCost("render", 1);
+
+const UPGRADE_BASE = "https://squirrelscan.com/upgrade";
+
+/**
+ * The one public upgrade URL. `src` is attribution only, so the surface that
+ * sold the upgrade can be told apart from the ones that didn't.
+ */
+export function upgradeUrl(src: "cli" | "cli-audit" | "cli-credits"): string {
+  return `${UPGRADE_BASE}?src=${src}`;
+}
+
+const n = (value: number) => value.toLocaleString("en-US");
+
+/** One line naming the price and the grant. Safe to embed anywhere. */
+export const PRO_HEADLINE = `Pro: $${PRO.priceMonthUsd}/month (or $${PRO.priceYearUsd}/year) for ${n(PRO.monthlyCredits)} credits a month`;
+
+/**
+ * The full pitch, as lines ready to `log()`. Used verbatim by every CLI surface
+ * so the price and the feature list can never drift between them.
+ */
+export function proPitchLines(
+  src: "cli" | "cli-audit" | "cli-credits"
+): string[] {
+  return [
+    `  ${fmt.bold(PRO_HEADLINE)}`,
+    `  ${fmt.dim(`Also unlocks scheduled audits, custom request headers, and up to ${n(PRO.maxPagesPerAudit)} pages per audit.`)}`,
+    `  Upgrade: ${fmt.cyan(upgradeUrl(src))}`,
+  ];
+}
+
+/** What an audit costs, stated in the same words everywhere. */
+export const AUDIT_PRICING_LINE = `Every cloud audit costs ${AUDIT_BASE_CREDITS} credits base plus ${RENDER_PAGE_CREDITS} per rendered page.`;

--- a/apps/cli/src/self/completion.ts
+++ b/apps/cli/src/self/completion.ts
@@ -200,6 +200,10 @@ _squirrel_completions() {
       COMPREPLY=( $(compgen -W "--max-pages -m --concurrency --per-host --coverage -C --refresh -r --fresh-ua --resume --help" -- "\${cur}") )
       return 0
       ;;
+    credits)
+      COMPREPLY=( $(compgen -W "--json --upgrade --help" -- "\${cur}") )
+      return 0
+      ;;
     analyze)
       COMPREPLY=( $(compgen -W "--id --help" -- "\${cur}") )
       return 0
@@ -469,6 +473,11 @@ _squirrel() {
             '--fresh-ua[Re-roll the pinned random user-agent]' \\
             '--resume[Resume interrupted crawl]'
           ;;
+        credits)
+          _arguments \\
+            '--json[Output as JSON]' \\
+            '--upgrade[Open the upgrade page in your browser]'
+          ;;
         analyze)
           _arguments \\
             '--id[Crawl ID to analyze]:crawl-id:'
@@ -645,7 +654,10 @@ complete -c squirrel -n "__fish_seen_subcommand_from audit" -s H -l header -d "C
 complete -c squirrel -n "__fish_seen_subcommand_from audit" -l rule-include -d "Only run these rule categories or rules"
 complete -c squirrel -n "__fish_seen_subcommand_from audit" -l rule-exclude -d "Skip these rule categories or rules"
 complete -c squirrel -n "__fish_seen_subcommand_from audit" -l summary -d "Print score, category breakdown, and issue counts only"
+
+# Credits options
 complete -c squirrel -n "__fish_seen_subcommand_from credits" -l json -d "Output as JSON"
+complete -c squirrel -n "__fish_seen_subcommand_from credits" -l upgrade -d "Open the upgrade page in your browser"
 
 # Crawl options
 complete -c squirrel -n "__fish_seen_subcommand_from crawl" -s m -l max-pages -d "Maximum pages to crawl"

--- a/apps/cli/tests/commands/credit-wall-copy.test.ts
+++ b/apps/cli/tests/commands/credit-wall-copy.test.ts
@@ -1,0 +1,171 @@
+// What the CLI says when credits run out.
+//
+// Measured on prod 2026-08-26: 12 of the 13 orgs that ever ran their balance
+// below the cost of one audit never ran another audit. The CLI's answer at that
+// moment was the server's bare sentence, and `squirrel credits` pointed at
+// https://squirrelscan.com/account/credits — a URL that has never been a route.
+// So these assert the two things that were missing: a working URL, and a price.
+
+import { computeCost } from "@squirrelscan/core-contracts/credits";
+import { getPlan } from "@squirrelscan/core-contracts/plans";
+import { describe, expect, test } from "bun:test";
+
+import {
+  lowBalanceFooterLines,
+  registerFailureLines,
+} from "../../src/cli/commands/audit";
+import {
+  AUDIT_BASE_CREDITS,
+  PRO_HEADLINE,
+  proPitchLines,
+  upgradeUrl,
+} from "../../src/lib/upgrade";
+
+const PRO = getPlan("starter");
+const UPGRADE = "https://squirrelscan.com/upgrade?src=cli-audit";
+const text = (lines: string[]) => lines.join("\n");
+
+describe("the upgrade offer", () => {
+  test("names the price, the term price and the monthly grant", () => {
+    expect(PRO_HEADLINE).toContain(`$${PRO.priceMonthUsd}`);
+    expect(PRO_HEADLINE).toContain(`$${PRO.priceYearUsd}`);
+    expect(PRO_HEADLINE).toContain(PRO.monthlyCredits.toLocaleString("en-US"));
+  });
+
+  test('says "Pro", never the internal plan id', () => {
+    const pitch = text(proPitchLines("cli-credits"));
+    expect(pitch).toContain("Pro");
+    expect(pitch).not.toContain("starter");
+  });
+
+  test("carries a squirrelscan.com/upgrade URL, not the dead /account/credits", () => {
+    const pitch = text(proPitchLines("cli-credits"));
+    expect(pitch).toContain("https://squirrelscan.com/upgrade?src=cli-credits");
+    expect(pitch).not.toContain("/account/credits");
+    expect(upgradeUrl("cli")).toBe("https://squirrelscan.com/upgrade?src=cli");
+  });
+
+  test("the audit base tracks the shared pricing source", () => {
+    expect(AUDIT_BASE_CREDITS).toBe(computeCost("audit_base", 1));
+  });
+});
+
+describe("registerFailureLines", () => {
+  const insufficient = {
+    code: "INSUFFICIENT_CREDITS",
+    message: "Insufficient credits for the audit base",
+    balance: 12,
+  };
+
+  test("out of credits gets the balance, the price and a working upgrade URL", () => {
+    const out = text(registerFailureLines(insufficient));
+    expect(out).toContain("12 credits");
+    expect(out).toContain(String(AUDIT_BASE_CREDITS));
+    expect(out).toContain(`$${PRO.priceMonthUsd}`);
+    expect(out).toContain(UPGRADE);
+  });
+
+  test("says the audit itself still ran, so the warning isn't read as a failure", () => {
+    expect(text(registerFailureLines(insufficient)).toLowerCase()).toContain(
+      "ran locally"
+    );
+  });
+
+  test("degrades without a balance rather than printing null", () => {
+    const out = text(registerFailureLines({ ...insufficient, balance: null }));
+    expect(out).not.toContain("null");
+    expect(out).toContain(UPGRADE);
+  });
+
+  test("other definitive failures are not turned into a plan pitch", () => {
+    for (const code of ["WEBSITE_LIMIT", "ORG_LOCKED"]) {
+      const out = text(
+        registerFailureLines({
+          code,
+          message: "Website limit reached.",
+          balance: null,
+        })
+      );
+      expect(out).toContain("Website limit reached.");
+      expect(out).not.toContain(UPGRADE);
+      expect(out).not.toContain(`$${PRO.priceMonthUsd}`);
+    }
+  });
+});
+
+describe("lowBalanceFooterLines", () => {
+  const free = getPlan("free").monthlyCredits;
+
+  test("warns at 20% of the grant, while credits remain to spend", () => {
+    const out = text(
+      lowBalanceFooterLines({ balance: 80, monthlyCredits: free, plan: "free" })
+    );
+    expect(out).toContain("80 credits left");
+    expect(out).toContain(UPGRADE);
+  });
+
+  test("stays quiet on a healthy balance", () => {
+    expect(
+      lowBalanceFooterLines({
+        balance: 100,
+        monthlyCredits: free,
+        plan: "free",
+      })
+    ).toEqual([]);
+    expect(
+      lowBalanceFooterLines({
+        balance: free,
+        monthlyCredits: free,
+        plan: "free",
+      })
+    ).toEqual([]);
+  });
+
+  test("a stranded sub-base balance says the next audit can't start", () => {
+    const out = text(
+      lowBalanceFooterLines({ balance: 12, monthlyCredits: free, plan: "free" })
+    );
+    expect(out).toContain(`below the ${AUDIT_BASE_CREDITS}-credit audit base`);
+    expect(out).toContain(UPGRADE);
+  });
+
+  test("paid plans get a top-up link, not a pitch for the plan they're on", () => {
+    const out = text(
+      lowBalanceFooterLines({ balance: 12, monthlyCredits: 3000, plan: "paid" })
+    );
+    expect(out).toContain(UPGRADE);
+    expect(out).not.toContain(`$${PRO.priceMonthUsd}`);
+  });
+
+  test("anonymous and unknown balances print nothing", () => {
+    expect(
+      lowBalanceFooterLines({
+        balance: 0,
+        monthlyCredits: free,
+        plan: "anonymous",
+      })
+    ).toEqual([]);
+    expect(
+      lowBalanceFooterLines({
+        balance: null,
+        monthlyCredits: free,
+        plan: "free",
+      })
+    ).toEqual([]);
+  });
+
+  test("a plan with no monthly grant warns only once it can't buy an audit", () => {
+    // Team pools credits per seat, so there is no share to measure against.
+    expect(
+      lowBalanceFooterLines({
+        balance: AUDIT_BASE_CREDITS,
+        monthlyCredits: 0,
+        plan: "paid",
+      })
+    ).toEqual([]);
+    expect(
+      lowBalanceFooterLines({ balance: 10, monthlyCredits: 0, plan: "paid" })
+        .length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/apps/cli/tests/lib/run-tracker.test.ts
+++ b/apps/cli/tests/lib/run-tracker.test.ts
@@ -7,6 +7,7 @@ import {
   registerRun,
   reportProgress,
   type RegisteredRun,
+  type RegisterFailure,
   resolveRunFinalizeScore,
   startRunHeartbeat,
   stopRunHeartbeat,
@@ -306,14 +307,18 @@ describe("registerRun", () => {
         { status: 402 }
       )) as unknown as typeof fetch;
 
-    const warnings: string[] = [];
-    const result = await registerRun({ url: "https://newsite.com" }, (m) =>
-      warnings.push(m)
+    const warnings: RegisterFailure[] = [];
+    const result = await registerRun({ url: "https://newsite.com" }, (f) =>
+      warnings.push(f)
     );
 
     expect(result).toBeNull();
     expect(warnings).toEqual([
-      "Website limit reached. Contact support if you need more.",
+      {
+        code: "WEBSITE_LIMIT",
+        message: "Website limit reached. Contact support if you need more.",
+        balance: null,
+      },
     ]);
   });
 
@@ -329,9 +334,17 @@ describe("registerRun", () => {
         { status: 402 }
       )) as unknown as typeof fetch;
 
-    const warnings: string[] = [];
-    await registerRun({ url: "https://example.com" }, (m) => warnings.push(m));
-    expect(warnings).toEqual(["Not enough credits"]);
+    const warnings: RegisterFailure[] = [];
+    await registerRun({ url: "https://example.com" }, (f) => warnings.push(f));
+    // The CODE, not just the sentence: audit.ts needs it to tell "out of
+    // credits" (an upgrade) from "website limit" (a cleanup).
+    expect(warnings).toEqual([
+      {
+        code: "INSUFFICIENT_CREDITS",
+        message: "Not enough credits",
+        balance: null,
+      },
+    ]);
   });
 
   test("does NOT warn on a transient 5xx — best-effort tracking stays quiet (#816)", async () => {
@@ -340,9 +353,9 @@ describe("registerRun", () => {
         status: 503,
       })) as unknown as typeof fetch;
 
-    const warnings: string[] = [];
+    const warnings: RegisterFailure[] = [];
     expect(
-      await registerRun({ url: "https://example.com" }, (m) => warnings.push(m))
+      await registerRun({ url: "https://example.com" }, (f) => warnings.push(f))
     ).toBeNull();
     expect(warnings).toEqual([]);
   });
@@ -352,9 +365,9 @@ describe("registerRun", () => {
       throw new Error("ECONNREFUSED");
     }) as unknown as typeof fetch;
 
-    const warnings: string[] = [];
+    const warnings: RegisterFailure[] = [];
     expect(
-      await registerRun({ url: "https://example.com" }, (m) => warnings.push(m))
+      await registerRun({ url: "https://example.com" }, (f) => warnings.push(f))
     ).toBeNull();
     expect(warnings).toEqual([]);
   });
@@ -370,9 +383,9 @@ describe("registerRun", () => {
         }
       )) as unknown as typeof fetch;
 
-    const warnings: string[] = [];
+    const warnings: RegisterFailure[] = [];
     expect(
-      await registerRun({ url: "https://example.com" }, (m) => warnings.push(m))
+      await registerRun({ url: "https://example.com" }, (f) => warnings.push(f))
     ).toBeNull();
     expect(warnings).toEqual([]);
   });
@@ -391,8 +404,8 @@ describe("registerRun", () => {
         { status: 400 }
       )) as unknown as typeof fetch;
 
-    const warnings: string[] = [];
-    await registerRun({ url: "https://example.com" }, (m) => warnings.push(m));
+    const warnings: RegisterFailure[] = [];
+    await registerRun({ url: "https://example.com" }, (f) => warnings.push(f));
     expect(warnings).toEqual([]);
   });
 });

--- a/apps/cli/tests/self/completion.test.ts
+++ b/apps/cli/tests/self/completion.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { audit } from "@/cli/commands/audit";
+import { credits } from "@/cli/commands/credits";
 import { report } from "@/cli/commands/report";
 import { skills } from "@/cli/commands/skills";
 import { OUTPUT_FORMATS } from "@/constants";
@@ -41,12 +42,15 @@ function commandFlags(cmd: { args?: unknown }): {
 
 const auditDef = commandFlags(audit);
 const reportDef = commandFlags(report);
+const creditsDef = commandFlags(credits);
 
 // Flags completion may offer beyond the def: citty's built-in --help, and
 // auto-negation of boolean args (--no-incremental).
 const ALLOWED_EXTRAS: Record<string, string[]> = {
   audit: ["help", "no-incremental"],
   report: ["help"],
+  // citty auto-negates booleans, and bash/zsh offer --help.
+  credits: ["help", "no-json", "no-upgrade"],
 };
 
 const shells: Shell[] = ["bash", "zsh", "fish"];
@@ -62,6 +66,7 @@ function script(shell: Shell): string {
 const BASH_BLOCK_END: Record<string, string> = {
   audit: "crawl)",
   report: "feedback)",
+  credits: "analyze)",
 };
 
 /** Slice out the completion block for one command in a shell script. */
@@ -150,6 +155,30 @@ describe.each(shells)("%s completion", (shell) => {
 
     test("format list matches OUTPUT_FORMATS exactly", () => {
       expect(formatListIn(shell, block)).toEqual([...OUTPUT_FORMATS]);
+    });
+  });
+
+  // credits had NO bash or zsh arm at all before #1604 — `squirrel credits
+  // --<TAB>` fell through to the global default and offered only --config-file,
+  // so --json had been invisible in two of three shells since it shipped.
+  describe("credits", () => {
+    const block = commandBlock(shell, text, "credits");
+
+    test("every citty flag is offered", () => {
+      expect(creditsDef.flags).toContain("upgrade");
+      for (const flag of creditsDef.flags) {
+        expectOffersFlag(shell, block, flag);
+      }
+    });
+
+    test("every offered flag exists on the citty def", () => {
+      const allowed = new Set([
+        ...creditsDef.flags,
+        ...ALLOWED_EXTRAS.credits!,
+      ]);
+      for (const offered of longFlagsIn(shell, block)) {
+        expect(allowed).toContain(offered);
+      }
     });
   });
 

--- a/docs/cli/credits.mdx
+++ b/docs/cli/credits.mdx
@@ -19,6 +19,14 @@ Requires login - run [`squirrel auth login`](/cli/auth) first.
 | Option | Description |
 |--------|-------------|
 | `--json` | Output as JSON |
+| `--upgrade` | Print the upgrade URL and open it in your browser |
+
+`--upgrade` does not require login, so you can go straight to the upgrade page
+from any machine:
+
+```bash
+squirrel credits --upgrade
+```
 
 ## Example
 
@@ -38,8 +46,21 @@ Pricing:
   issue_enrich           3 per issue
   keyword_gaps          25 per run
 
-Top up: https://squirrelscan.com/account/credits
+Top up: https://squirrelscan.com/upgrade?src=cli-credits
 ```
+
+On the free plan the output ends with the Pro offer instead:
+
+```text
+  Pro: $19/month (or $190/year) for 3,000 credits a month
+  Also unlocks scheduled audits, custom request headers, and up to 2,000 pages per audit.
+  Upgrade: https://squirrelscan.com/upgrade?src=cli-credits
+  Or run `squirrel credits --upgrade`.
+```
+
+A balance below 50 credits cannot start any cloud audit, since every audit
+charges a flat 50 credit base before a page renders. `squirrel credits` calls
+that out rather than showing a positive number you cannot spend.
 
 JSON output:
 

--- a/docs/cloud/credits.mdx
+++ b/docs/cloud/credits.mdx
@@ -53,7 +53,7 @@ Pricing:
   issue_enrich           3 per issue
   keyword_gaps          25 per run
 
-Top up: https://squirrelscan.com/account/credits
+Top up: https://squirrelscan.com/upgrade?src=cli-credits
 ```
 
 `squirrel auth status` also shows your balance, and the start banner of every audit shows the estimated spend against it.

--- a/packages/core-contracts/src/plans.ts
+++ b/packages/core-contracts/src/plans.ts
@@ -38,7 +38,9 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     maxMembers: 1,
     renderConcurrency: 1,
     scheduledCrawls: false,
-    customHeaders: false,
+    // Free on purpose: custom headers are how you audit a staging site behind
+    // auth, which is evaluation, not a paid job.
+    customHeaders: true,
     // #1020 ladder: matches Screaming Frog's free-tier crawl cap and today's
     // `full` coverage preset ceiling.
     maxPagesPerAudit: 500,


### PR DESCRIPTION
## Why

Measured on prod, 2026-08-26: **13 orgs** have ever run their credit balance below the cost of one audit. **12 are still on free and never ran another audit** — most stopped the same day. **8 of those 12** had spent their whole free tier on ONE website, i.e. they were in the audit → fix → re-audit loop the CLI exists for, paying the 50-credit base every lap.

The wall is not priced wrong, it is **unsold**. And the CLI was the worst surface for it, because `squirrel credits` ended with:

```
Top up: https://squirrelscan.com/account/credits
```

There is no `/account` route on squirrelscan.com and there never has been. **The single most direct question a paying-curious user can ask the CLI answered with a 404**, in every released binary.

## What changed

**`src/lib/upgrade.ts` (new)** — one URL, one price, one feature list, so the surfaces below can't drift. The CLI had three different "where to pay" URLs and only one of them worked.

The URL is `squirrelscan.com/upgrade?src=…`, not an `app.squirrelscan.com` deep link: billing lives under `/$org/settings/billing`, the CLI often can't name the org (an API key acts for an org the user never typed), and a binary already on someone's machine can never be corrected. The marketing site owns the mapping (companion PR squirrelscan/repo#1609 adds the route).

**`squirrel credits`** (`src/cli/commands/credits.ts`)
- free plans now end with the offer rather than a dead link:
  ```
    Pro: $19/month (or $190/year) for 3,000 credits a month
    Also unlocks scheduled audits, custom request headers, and up to 2,000 pages per audit.
    Upgrade: https://squirrelscan.com/upgrade?src=cli-credits
    Or run `squirrel credits --upgrade`.
  ```
- calls out a balance under the 50-credit audit base, which can buy **nothing** however positive it reads, instead of letting the next `squirrel audit` silently drop to local-only.
- **`--upgrade`** prints the URL and opens it, deliberately *before* the credential check — someone who wants to pay shouldn't have to log into the CLI first to be told where. Completions updated for bash, zsh and fish; `credits` had **no bash or zsh arm at all**, so even `--json` had been invisible in two of three shells since it shipped.

**`squirrel audit`**
- `registerRun`'s `onWarn` now carries the failure **code**, not just the server's sentence, so `audit.ts` can tell "out of credits" (an upgrade) from "website limit" (a cleanup) from "org locked" (a billing fix) — it previously could not. Out of credits gets the balance, the pricing, the offer, and says plainly that **the audit itself still ran locally and its results are complete**; the other codes keep the plain one-liner.
- the footer warns at 20% of the monthly grant, *before* the wall, and more sharply once the balance can't start another audit. This is the advance warning the dashboard now shows as a banner, in the one place a CLI-only user will read it.
- the preflight local-only line and `topUpUrl` now point at the working URL.

`openBrowser` lifted from `controllers/auth/login.ts` into `src/lib/browser.ts` so `credits` can reuse it without dragging the OAuth callback server into an unrelated command; `normalizeBrowserUrl` is re-exported from its old home for existing callers and tests.

**Behaviour preserved:** a local audit still runs when credits are out, just untracked. No warning became a hard failure. No pricing values and no change to the free grant.

## Tests

`tests/commands/credit-wall-copy.test.ts` (14 new) covers the two things that were missing — a working URL and a price:
- the pitch names `$19`, `$190` and `3,000`, says "Pro" and never the internal id `starter`, and carries `squirrelscan.com/upgrade`, not `/account/credits`;
- `registerFailureLines` gives out-of-credits the balance + price + URL, says the audit still ran, degrades without a balance rather than printing `null`, and does **not** turn `WEBSITE_LIMIT`/`ORG_LOCKED` into a plan pitch;
- `lowBalanceFooterLines` warns at 20% while credits remain, stays quiet on a healthy balance, is sharper below the base, gives paid plans a top-up link rather than a pitch for the plan they're on, and is silent for anonymous/unknown balances.

`tests/self/completion.test.ts` reconciles `credits`' flags against the real citty def in all three shells. `tests/lib/run-tracker.test.ts` updated for the widened `onWarn`, and now asserts the **code** is carried, not just the message.

Verified each bites by breaking what it covers: restoring the dead `/account/credits` base (6 fails), dropping the price from the pitch (2), removing the advance-warning threshold (1), pitching every register failure instead of only the credit one (1).

Full suite: **1753 pass, 1 skip, 0 fail**. `tsgo --noEmit`, `oxlint` and `oxfmt` clean. `docs/` updated (`cli/credits.mdx`, `cloud/credits.mdx` — both showed the 404 URL in their sample output); `tangly check --strict` passes.

## Shipping note

**Merging this ships nothing to CLI users.** `install.sh` is served from R2 and is release-gated, so these changes only reach anyone when a release is cut. The dead `/account/credits` link is fixed for already-installed binaries by the redirect in the companion PR, not by this one.

Companion PR (dashboard, web, MCP): squirrelscan/repo#1609.
