### PR TITLE
fix(cli): stop selling custom headers in the Pro pitch, they are free now

### DIFF
--- a/apps/cli/src/lib/upgrade.ts
+++ b/apps/cli/src/lib/upgrade.ts
@@ -49,7 +49,7 @@ export function proPitchLines(
 ): string[] {
   return [
     `  ${fmt.bold(PRO_HEADLINE)}`,
-    `  ${fmt.dim(`Also unlocks scheduled audits, custom request headers, and up to ${n(PRO.maxPagesPerAudit)} pages per audit.`)}`,
+    `  ${fmt.dim(`Also unlocks scheduled audits, faster crawls, and up to ${n(PRO.maxPagesPerAudit)} pages per audit.`)}`,
     `  Upgrade: ${fmt.cyan(upgradeUrl(src))}`,
   ];
 }


### PR DESCRIPTION
Follow-up to #137: the Pro pitch in the CLI credit wall still listed custom request headers as a Pro feature, one commit after the same PR made them free on every plan. A coding agent would relay "upgrade to get custom headers" to a user who already has them. Swapped for faster crawls (render concurrency 5 vs 1), which actually differentiates the plans.