### PR TITLE
fix(crawler): self-heal sitemaps.is_news_sitemap like the pages columns

### DIFF
--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -340,6 +340,15 @@ const PAGES_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: string }> = [
   { name: "source_hash", type: "TEXT" },
 ];
 
+// Same guard for `sitemaps`. Migration 21 added is_news_sitemap; a DB stamped
+// past 21 by a build that numbered its own migration 21 skips it forever, and
+// then the first sitemap write throws "no column named is_news_sitemap" and the
+// whole audit fails at the crawl's first step. Seen on DBs recorded at 22 with
+// the column absent. Any new ALTER-added `sitemaps` column MUST be listed here.
+const SITEMAPS_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: string }> = [
+  { name: "is_news_sitemap", type: "INTEGER" },
+];
+
 const SCHEMA = `
 -- Crawl sessions
 CREATE TABLE IF NOT EXISTS crawls (
@@ -915,12 +924,13 @@ export class SQLiteStorage implements CrawlStorage {
       }
     }
 
-    // Self-heal: re-add any `pages` column a version-number collision skipped.
-    // Runs unconditionally (PRAGMA table_info is the source of truth, not the
-    // schema_version counter), so a DB stuck at the current version with a
-    // missing column recovers instead of throwing on every upsertPage. See
-    // PAGES_ALTER_COLUMNS.
+    // Self-heal: re-add any ALTER-added column a version-number collision
+    // skipped. Runs unconditionally (PRAGMA table_info is the source of truth,
+    // not the schema_version counter), so a DB stuck at the current version
+    // with a missing column recovers instead of throwing on every write. See
+    // PAGES_ALTER_COLUMNS and SITEMAPS_ALTER_COLUMNS.
     this.reconcilePagesColumns();
+    this.reconcileColumns("sitemaps", SITEMAPS_ALTER_COLUMNS);
   }
 
   /**
@@ -931,20 +941,27 @@ export class SQLiteStorage implements CrawlStorage {
    * (one PRAGMA read + at most one ALTER per missing column).
    */
   private reconcilePagesColumns(): void {
+    this.reconcileColumns("pages", PAGES_ALTER_COLUMNS);
+  }
+
+  private reconcileColumns(
+    table: "pages" | "sitemaps",
+    columns: ReadonlyArray<{ name: string; type: string }>
+  ): void {
     const db = this.getDb();
     const existing = new Set(
-      (db.prepare("PRAGMA table_info(pages)").all() as Array<{ name: string }>).map(
+      (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map(
         (c) => c.name
       )
     );
-    // No pages table yet (shouldn't happen — SCHEMA creates it first) → nothing
-    // to reconcile; a fresh CREATE TABLE already has every column.
+    // No table yet (shouldn't happen — SCHEMA creates it first) → nothing to
+    // reconcile; a fresh CREATE TABLE already has every column.
     if (existing.size === 0) return;
 
-    for (const col of PAGES_ALTER_COLUMNS) {
+    for (const col of columns) {
       if (existing.has(col.name)) continue;
       try {
-        db.exec(`ALTER TABLE pages ADD COLUMN ${col.name} ${col.type}`);
+        db.exec(`ALTER TABLE ${table} ADD COLUMN ${col.name} ${col.type}`);
       } catch (e) {
         // Idempotent: tolerate a concurrent add; surface anything else.
         const msg = e instanceof Error ? e.message : String(e);

--- a/packages/crawler/tests/pages-alter-columns-guard.test.ts
+++ b/packages/crawler/tests/pages-alter-columns-guard.test.ts
@@ -33,4 +33,26 @@ describe("PAGES_ALTER_COLUMNS drift guard (#921)", () => {
     const missing = [...migrationCols].filter((c) => !reconciledCols.has(c));
     expect(missing).toEqual([]);
   });
+
+  // The same gap bit `sitemaps`: DBs recorded at 22 without is_news_sitemap
+  // (migration 21) failed every audit at the first sitemap write.
+  test("every 'ALTER TABLE sitemaps ADD COLUMN' in MIGRATIONS is in SITEMAPS_ALTER_COLUMNS", () => {
+    const src = readFileSync(new URL("../src/storage/sqlite.ts", import.meta.url), "utf8");
+
+    const migrationCols = new Set<string>();
+    for (const m of src.matchAll(/ALTER TABLE sitemaps ADD COLUMN\s+(\w+)/g)) {
+      migrationCols.add(m[1]!);
+    }
+
+    const listBlock = src.match(/SITEMAPS_ALTER_COLUMNS[^[]*\[([\s\S]*?)\];/);
+    expect(listBlock).not.toBeNull();
+    const reconciledCols = new Set<string>();
+    for (const m of listBlock![1]!.matchAll(/name:\s*"(\w+)"/g)) {
+      reconciledCols.add(m[1]!);
+    }
+
+    expect(migrationCols.size).toBeGreaterThan(0);
+    const missing = [...migrationCols].filter((c) => !reconciledCols.has(c));
+    expect(missing).toEqual([]);
+  });
 });

--- a/packages/crawler/tests/sitemaps-column-collision.test.ts
+++ b/packages/crawler/tests/sitemaps-column-collision.test.ts
@@ -1,0 +1,111 @@
+// Regression: the same migration renumbering gap that once dropped
+// `pages.source_hash` (#839) also dropped `sitemaps.is_news_sitemap`. Migration
+// 21 adds the column; a DB stamped past 21 by a build that numbered its own
+// migration 21 never runs it, and `runMigrations` only runs when
+// currentVersion < SCHEMA_VERSION. The first sitemap write then threw
+// "table sitemaps has no column named is_news_sitemap" and the whole audit
+// failed at the crawl's first step. The reconciler now covers `sitemaps` too.
+
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "crypto";
+import { tmpdir } from "os";
+import { join } from "path";
+import { unlinkSync } from "fs";
+import { Effect } from "effect";
+
+import { SCHEMA_VERSION, SQLiteStorage } from "../src/storage/sqlite";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const tmpFiles: string[] = [];
+function tmpDbPath(): string {
+  const p = join(tmpdir(), `squirrel-sitemaps-${randomUUID()}.db`);
+  tmpFiles.push(p);
+  return p;
+}
+
+afterEach(() => {
+  for (const p of tmpFiles.splice(0)) {
+    try {
+      unlinkSync(p);
+    } catch {
+      // ignore missing temp files
+    }
+  }
+});
+
+function sitemapColumns(path: string): string[] {
+  const db = new Database(path);
+  const cols = (db.prepare("PRAGMA table_info(sitemaps)").all() as Array<{ name: string }>).map(
+    (c) => c.name
+  );
+  db.close();
+  return cols;
+}
+
+// The exact broken state seen on real DBs: `sitemaps` as it was before
+// migration 21, and schema_version already at the current version, so the
+// version-gated runner will never add the column.
+function buildCollisionDb(path: string): void {
+  const legacy = new Database(path);
+  legacy.exec(`
+    CREATE TABLE crawls (
+      id TEXT PRIMARY KEY, base_url TEXT NOT NULL, seed_url TEXT, original_url TEXT,
+      started_at INTEGER NOT NULL, completed_at INTEGER, status TEXT NOT NULL,
+      config TEXT NOT NULL, stats TEXT NOT NULL
+    );
+    CREATE TABLE pages (
+      crawl_id TEXT NOT NULL, url TEXT NOT NULL, normalized_url TEXT NOT NULL,
+      final_url TEXT, depth INTEGER NOT NULL, parent_url TEXT, redirect_chain TEXT,
+      status INTEGER NOT NULL, content_type TEXT, size_bytes INTEGER NOT NULL,
+      load_time_ms INTEGER NOT NULL, ttfb INTEGER, download_time INTEGER,
+      fetched_at INTEGER NOT NULL, etag TEXT, last_modified TEXT,
+      content_hash TEXT NOT NULL, html TEXT, parsed_data TEXT, headers TEXT NOT NULL,
+      security_headers TEXT NOT NULL, request_headers TEXT,
+      fetcher_id TEXT, fallback_reason TEXT, source_hash TEXT,
+      PRIMARY KEY (crawl_id, normalized_url)
+    );
+    CREATE TABLE sitemaps (
+      crawl_id TEXT NOT NULL, url TEXT NOT NULL, type TEXT NOT NULL,
+      url_count INTEGER NOT NULL, child_sitemaps TEXT NOT NULL, errors TEXT NOT NULL,
+      fetched_at INTEGER NOT NULL,
+      PRIMARY KEY (crawl_id, url)
+    );
+    CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+    INSERT INTO schema_version (version) VALUES (${SCHEMA_VERSION});
+  `);
+  legacy.close();
+}
+
+describe("sitemaps.is_news_sitemap migration collision self-heal", () => {
+  test("opening a current-version DB that skipped migration 21 adds the column", async () => {
+    const path = tmpDbPath();
+    buildCollisionDb(path);
+    expect(sitemapColumns(path)).not.toContain("is_news_sitemap");
+
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    await run(store.close());
+
+    expect(sitemapColumns(path)).toContain("is_news_sitemap");
+  });
+
+  test("reconcile is idempotent: re-opening a healthy DB leaves sitemaps columns unchanged", async () => {
+    const path = tmpDbPath();
+
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    await run(store.close());
+    const first = sitemapColumns(path);
+    expect(first).toContain("is_news_sitemap");
+
+    const store2 = new SQLiteStorage(path);
+    await run(store2.init());
+    await run(store2.close());
+
+    expect(sitemapColumns(path)).toEqual(first);
+  });
+});


### PR DESCRIPTION
Found during the v0.0.88 pre-release smoke: two project DBs on a dev machine sat at `schema_version=22` with no `is_news_sitemap` column on `sitemaps`, so every audit of those sites failed at the first sitemap write with `SQLiteError: table sitemaps has no column named is_news_sitemap`. That is the migration-renumbering collision the `pages` table already self-heals via `PAGES_ALTER_COLUMNS`; `sitemaps` had no equivalent.

No shipped tag collided on 21 (v0.0.85 was at 20, v0.0.86/87 at 21 with this column), so released users are not in this state. The failure class is real though, and the guard is the same cheap PRAGMA-and-ALTER on open.

- `reconcileColumns(table, cols)` generalises the existing `pages` reconciler; `SITEMAPS_ALTER_COLUMNS` lists `is_news_sitemap`.
- Drift guard extended: any `ALTER TABLE sitemaps ADD COLUMN` in MIGRATIONS must appear in the list.
- New test builds the exact broken DB (current version, column absent) and asserts open heals it, plus idempotency.