### PR TITLE
docs(rules): answer the geo.placename, css file size, and llm parsability queries

### DIFF
--- a/docs/rules/ai/llm-parsability.mdx
+++ b/docs/rules/ai/llm-parsability.mdx
@@ -1,11 +1,15 @@
 ---
 title: "LLM Parsability"
-description: "Analyzes how well LLMs can parse and understand the content"
+description: "What LLM parsability means: how reliably a language model can extract a page's facts, and how squirrelscan scores it from 0 to 100 per page."
 ---
 
 <Note>**Cloud rule** - requires login (`squirrel auth login`); the analysis is **included in the audit base charge** (shared with [Page Type Match](/rules/ai/page-type-match) - both read the same analysis). Skipped when not logged in. See [Cloud rules](/cloud/rules).</Note>
 
 Analyzes how well LLMs can parse and understand the content
+
+## What LLM parsability means
+
+LLM parsability is how reliably a language model can read a page and come away with the right facts: what the page is about, what it claims, and what the reader is meant to do next. It is not the same thing as human readability, and it is not a search ranking factor. It matters because AI search answers, chat assistants, and coding agents quote the pages they parsed cleanly and quietly skip the ones where the real content is tangled up with navigation, banners, and layout text. squirrelscan scores each page from 0 to 100 with a cloud model and treats 70 as the pass mark, on the scale below.
 
 | | |
 |---|---|

--- a/docs/rules/local/geo-meta.mdx
+++ b/docs/rules/local/geo-meta.mdx
@@ -1,9 +1,32 @@
 ---
 title: "Geo Meta Tags"
-description: "Checks for geographic meta tags for local targeting"
+description: "What the geo.placename meta tag is, whether search engines still read it, and how squirrelscan checks geo meta tags on local pages."
 ---
 
 Checks for geographic meta tags for local targeting
+
+## What the geo.placename meta tag is, and whether you still need it
+
+`geo.placename` is a `<meta>` tag naming the city or locality a page is about. It travels with three others: `geo.region` (an ISO 3166-2 country and subdivision code), `geo.position` (`latitude;longitude`), and `ICBM` (the same coordinates, comma separated, named after an old joke about missile targeting). A complete set on a location page looks like this:
+
+```html
+<meta name="geo.region" content="US-CA" />
+<meta name="geo.placename" content="San Francisco" />
+<meta name="geo.position" content="37.7749;-122.4194" />
+<meta name="ICBM" content="37.7749, -122.4194" />
+```
+
+None of them is a web standard. The `geo.*` family was proposed in an [IETF Internet-Draft](https://datatracker.ietf.org/doc/html/draft-daviel-html-geo-tag-07) that expired in 2008 and never became an RFC, and all four names sit in the [WHATWG meta extensions registry](https://wiki.whatwg.org/wiki/MetaExtensions) marked "Proposal". They are a convention that stuck, not a specification any consumer is obliged to honor.
+
+Google is explicit that it does not honor them. Its guidance on [managing multi-regional and multilingual sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) says Google "ignores locational `meta` tags (like `geo.position` or `distribution`) or geotargeting HTML attributes". Adding `geo.placename` will not move a page in local search. [LocalBusiness structured data](/rules/schema/local-business), a consistent [NAP](/rules/local/nap-consistency), and a Google Business Profile will.
+
+They are still worth the four lines on a location page. They are machine readable and cost nothing to serve, so a directory crawler or an in-house tool can lift a coordinate without parsing JSON-LD, and keeping them in step with your `LocalBusiness` schema is a free consistency check: if the meta tag names one city and the JSON-LD names another, one of them is wrong.
+
+## What this rule checks
+
+squirrelscan looks for the four tags by name and passes the page as soon as it finds at least one, reporting which ones are present. It does not validate the values, so a stale city name, a bad ISO code, or coordinates in the wrong hemisphere all pass. `ICBM` is matched with that exact uppercase spelling. Severity is `info` and weight is 2/10, the lowest tier squirrelscan scores, because a missing `geo.placename` is not what holds a page back in local search.
+
+The rule is also gated on the site profile: it is skipped, with a visible reason, when a confident profile says the site is not a local business, so a global SaaS product or a blog is never marked down for it.
 
 | | |
 |---|---|
@@ -12,12 +35,6 @@ Checks for geographic meta tags for local targeting
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## What geo.placename is, and whether it still does anything
-
-`geo.placename` is a `<meta>` tag naming the city or locality a page targets, one of a small family alongside `geo.region` (a country-state code), `geo.position` (`latitude;longitude`), and `ICBM`. squirrelscan checks for them, but scores them in its lowest tier: severity `info`, weight 2/10.
-
-That weighting is the answer to whether they still do anything. This rule treats geo meta tags as a supplement to [LocalBusiness structured data](/rules/schema), never a substitute for it, and squirrelscan makes no claim that any particular search engine reads them. They are cheap to add to location-specific landing pages and cost nothing to keep, which is why the rule is `info` rather than a warning, but a missing `geo.placename` is not what is holding a page back in local search. Fix your LocalBusiness schema and NAP consistency first.
 
 ## Solution
 

--- a/docs/rules/perf/css-file-size.mdx
+++ b/docs/rules/perf/css-file-size.mdx
@@ -1,9 +1,15 @@
 ---
 title: "CSS File Size Too Large"
-description: "Checks for CSS files that exceed recommended size limits"
+description: "How large is too large for a CSS file: squirrelscan warns at 150KB per stylesheet, fails at 500KB, and both thresholds are configurable."
 ---
 
 Checks for CSS files that exceed recommended size limits
+
+## How large is too large for a CSS file
+
+squirrelscan warns on any single stylesheet over 150KB and fails the check at 500KB. The measurement is per file, not per page, and it is the size the server actually transfers (`Content-Length`), so a stylesheet served with gzip or brotli is judged on its compressed bytes and both thresholds are configurable below. Compressed CSS above 150KB is unusual outside an unpurged utility framework or a theme that ships every component's styles on every page, which is why the default sits there.
+
+Size matters here more than the download time suggests: CSS is render blocking, so the browser paints nothing until it has fetched and parsed the whole file, and one oversized stylesheet is usually loaded by every page on the site, including the pages that use a fraction of it.
 
 | | |
 |---|---|


### PR DESCRIPTION
## Why

Three rule reference pages are already ranking for informational queries they only half answer, so they sit just off page one. Search Console (docs.squirrelscan.com):

| Page | Query | Position | Impressions |
|---|---|---|---|
| `/rules/local/geo-meta` | "geo placename" | 17.3 | 199 |
| | "geo.placename" | 12.3 | |
| | "meta geo tag" | 13.9 | |
| `/rules/perf/css-file-size` | "css file size too large" | 17.8 | |
| `/rules/ai/llm-parsability` | "llm parsability" | 12.0 | |

Someone searching "geo.placename" wants to know what the tag is and whether it still does anything. The page told them the rule's severity and weight. This answers the question directly, up top, and leaves the rule reference intact below it.

## What changed

**`/rules/local/geo-meta`** (the main one). Expanded the existing short answer block into a full section, moved above the metadata table:

- what `geo.placename`, `geo.region`, `geo.position`, and `ICBM` are, with a correct four-tag example snippet
- their origin: an IETF Internet-Draft that expired in 2008 and never became an RFC, plus all four names sitting in the WHATWG meta extensions registry with status "Proposal". Not a standard, a convention that stuck.
- what Google says today, quoted and linked
- what they are still good for (machine readable, free to serve, a consistency check against `LocalBusiness` schema)
- a new "What this rule checks" section describing the rule's real behavior, read off `packages/rules/src/local/geo-meta.ts`: it passes as soon as one of the four tags is present, does not validate values, matches `ICBM` with that exact uppercase spelling, is `info` / weight 2, and is skipped with a visible reason when the site profile confidently says the site is not a local business (`appliesWhen: { requiresLocalBusiness: true }`).

No documented rule behavior changed; the `Solution` text and the config sections are untouched.

**`/rules/perf/css-file-size`**: one section stating the actual defaults (warn at 150KB, fail at 500KB, per file) and the non-obvious part, that the measurement is the transferred `Content-Length`, so a gzip or brotli stylesheet is judged compressed. Values checked against `RESOURCE_SIZE_LIMITS` in `packages/utils/src/constants.ts` and `resource-checker.ts`.

**`/rules/ai/llm-parsability`**: one paragraph defining the term and noting the 70 pass mark, matching the scoring table below it.

`description` frontmatter on all three retuned to 120 to 160 chars carrying the target query.

## Sources

- [draft-daviel-html-geo-tag-07](https://datatracker.ietf.org/doc/html/draft-daviel-html-geo-tag-07), expired Internet-Draft, "Geographic registration of HTML documents"
- [WHATWG MetaExtensions registry](https://wiki.whatwg.org/wiki/MetaExtensions), all four names listed with status "Proposal"
- [Google, Managing multi-regional and multilingual sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites): "ignores locational `meta` tags (like `geo.position` or `distribution`) or geotargeting HTML attributes"

A Bing-still-reads-them claim circulates in SEO blogs from around 2015. I could not confirm it in current Bing Webmaster documentation, so the page does not make it.

## Verification

```
cd docs && bun install && make validate   # tangly check --strict: all checks passed
cd docs && make build                     # 387 pages built, links resolve
git diff | grep '—'                  # no em-dashes
```

House style checked: sentence-case H2s, lowercase "squirrelscan", no em-dashes.
