### PR TITLE
fix(rules): content/mojibake skips code, pre, samp and kbd

### DIFF
--- a/docs/rules/content/mojibake.mdx
+++ b/docs/rules/content/mojibake.mdx
@@ -27,7 +27,12 @@ Three families of corruption, in visible text only:
 | `replacement-char` | `caf�` | the decoder gave up on those bytes |
 | `double-encoded-entity` | visible `&amp;nbsp;` | the source said `&amp;amp;nbsp;` |
 
-The check reads text with `<script>`, `<style>` and `<noscript>` excluded, never raw HTML, so an encoded sequence inside a script body is not reported. A page with no body is skipped rather than passed.
+The check reads prose, never raw HTML, so an encoded sequence in an attribute is not reported. Two kinds of markup are excluded:
+
+- `<script>`, `<style>` and `<noscript>`, because a visitor never reads them.
+- `<code>`, `<pre>`, `<samp>` and `<kbd>`, because a visitor reads them as a quoted literal. A changelog entry or docs page that quotes `â€™` inside a code span is documenting the corruption, not suffering from it.
+
+A page with no body is skipped rather than passed.
 
 **Severity depends on certainty.** The replacement character is unambiguous corruption and fails. The other families warn.
 

--- a/packages/parser/src/extractors/dom-text.ts
+++ b/packages/parser/src/extractors/dom-text.ts
@@ -16,10 +16,17 @@ const TEXT_NODE = 3;
  * removing the excluded elements then reading `.textContent` (comments and
  * processing instructions are never visited, matching `.textContent`), but
  * without mutating or cloning the DOM.
+ *
+ * `separator` is emitted in place of each skipped subtree. It defaults to "",
+ * which reproduces remove-then-`.textContent` exactly — including the fact that
+ * removing an element GLUES its neighbours together, so `Ã<code>x</code>©` reads
+ * back as `Ã©`. Callers that scan the result for character sequences must pass a
+ * separator, or they will see sequences that exist in neither fragment.
  */
 export function collectTextExcluding(
   root: Node,
-  isExcluded: (el: Element) => boolean
+  isExcluded: (el: Element) => boolean,
+  separator = ""
 ): string {
   const out: string[] = [];
   // Explicit stack of remaining child lists; index tracks position in each.
@@ -34,7 +41,10 @@ export function collectTextExcluding(
     if (type === TEXT_NODE) {
       out.push((node as { data?: string }).data ?? "");
     } else if (type === ELEMENT_NODE) {
-      if (isExcluded(node as Element)) continue;
+      if (isExcluded(node as Element)) {
+        if (separator) out.push(separator);
+        continue;
+      }
       const children = node.childNodes;
       for (let i = children.length - 1; i >= 0; i--) {
         stack.push(children[i] as Node);

--- a/packages/parser/tests/dom-text.test.ts
+++ b/packages/parser/tests/dom-text.test.ts
@@ -1,0 +1,51 @@
+// collectTextExcluding's `separator`: skipping a subtree GLUES its neighbours,
+// so `Ã<code>x</code>©` reads back as `Ã©` — a sequence in neither fragment.
+// Callers that scan the output for character sequences (content/mojibake) must
+// pass a boundary. The default stays "" because getCleanTextContent feeds
+// contentHash, and changing its bytes would move every stored hash.
+
+import { describe, expect, test } from "bun:test";
+
+import { parseHTML } from "linkedom";
+
+import { collectTextExcluding, tagExcluder } from "../src/extractors/dom-text";
+
+const body = (html: string) =>
+  parseHTML(`<html><body>${html}</body></html>`).document.querySelector("body")!;
+
+const isCode = tagExcluder(new Set(["code"]));
+
+describe("collectTextExcluding separator", () => {
+  test("defaults to gluing, matching remove-then-textContent exactly", () => {
+    const html = "<p>Ã<code>literal</code>©</p>";
+    const a = body(html);
+    const b = body(html);
+    for (const el of b.querySelectorAll("code")) el.remove();
+
+    expect(collectTextExcluding(a, isCode)).toBe(b.textContent || "");
+    expect(collectTextExcluding(a, isCode)).toBe("Ã©");
+  });
+
+  test("a separator stands in for each skipped subtree", () => {
+    expect(collectTextExcluding(body("<p>Ã<code>literal</code>©</p>"), isCode, "\n")).toBe("Ã\n©");
+  });
+
+  test("one separator per skipped subtree, not per skipped text node", () => {
+    const text = collectTextExcluding(
+      body("<p>a<code>one<em>two</em></code>b<code>three</code>c</p>"),
+      isCode,
+      "\n",
+    );
+    expect(text).toBe("a\nb\nc");
+  });
+
+  test("surviving text is untouched when nothing is excluded", () => {
+    expect(collectTextExcluding(body("<p>plain copy</p>"), isCode, "\n")).toBe("plain copy");
+  });
+
+  test("does not mutate the DOM it reads", () => {
+    const el = body("<p>a<code>x</code>b</p>");
+    collectTextExcluding(el, isCode, "\n");
+    expect(el.querySelectorAll("code").length).toBe(1);
+  });
+});

--- a/packages/rules/src/content/mojibake.ts
+++ b/packages/rules/src/content/mojibake.ts
@@ -2,7 +2,7 @@
 
 import { getAttrCI, querySelectorByAttrValueCI } from "@squirrelscan/utils";
 
-import { getTextExcludingScripts } from "./text-content";
+import { getProseTextExcludingCode } from "./text-content";
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
@@ -138,9 +138,12 @@ export const mojibakeRule: Rule = {
       return { checks };
     }
 
-    // Visible text only, never raw HTML: a `&amp;nbsp;` in an attribute or an
-    // encoded sequence inside a <script> is not something a reader ever sees.
-    const text = getTextExcludingScripts(body);
+    // Prose only, never raw HTML: a `&amp;nbsp;` in an attribute or an encoded
+    // sequence inside a <script> is not something a reader ever sees. Code-like
+    // elements are excluded for the opposite reason — a reader DOES see them, but
+    // <code>â€™</code> is a page quoting the sequence on purpose, not a page whose
+    // bytes are broken. Without this the rule fires on its own documentation.
+    const text = getProseTextExcludingCode(body);
     const found = findMojibake(text);
 
     if (found.length === 0) {

--- a/packages/rules/src/content/text-content.ts
+++ b/packages/rules/src/content/text-content.ts
@@ -33,8 +33,20 @@ export function getTextExcludingScripts(element: Element): string {
 }
 
 /**
+ * A newline, never a space, stands in for each skipped subtree.
+ *
+ * Skipping a subtree glues its neighbours: `Ã<code>x</code>©` would otherwise
+ * read back as `Ã©` and look like corruption that is in neither fragment. A
+ * space does not fix that — `"Ã "` (à) and `"Â "` (nbsp) are themselves mojibake
+ * sequences, so a space boundary trades one false positive for another. No
+ * mojibake sequence contains a newline.
+ */
+const SKIPPED_SUBTREE_BOUNDARY = "\n";
+
+/**
  * `element`'s PROSE text: `getTextExcludingScripts` minus code-like subtrees
- * (`<code>`, `<pre>`, `<samp>`, `<kbd>`).
+ * (`<code>`, `<pre>`, `<samp>`, `<kbd>`), with a newline where each skipped
+ * subtree was.
  *
  * For rules that judge the sentences a visitor reads rather than every character
  * on the page. A page documenting a string — a changelog quoting the exact bytes
@@ -42,5 +54,5 @@ export function getTextExcludingScripts(element: Element): string {
  * it had written that string by accident.
  */
 export function getProseTextExcludingCode(element: Element): string {
-  return collectTextExcluding(element, isScriptOrCodeLike);
+  return collectTextExcluding(element, isScriptOrCodeLike, SKIPPED_SUBTREE_BOUNDARY);
 }

--- a/packages/rules/src/content/text-content.ts
+++ b/packages/rules/src/content/text-content.ts
@@ -10,7 +10,18 @@ import type { Element } from "linkedom";
 
 import { collectTextExcluding, tagExcluder } from "@squirrelscan/parser/extractors";
 
-const isScriptLike = tagExcluder(new Set(["script", "style", "noscript"]));
+const SCRIPT_LIKE_TAGS = ["script", "style", "noscript"] as const;
+
+/**
+ * Markup that says "this is a literal, not prose": whatever is inside was written
+ * to be read as source, so a rule that judges the words a visitor reads must not
+ * judge these. `<code>` and `<pre>` cover the common cases; `<samp>` (program
+ * output) and `<kbd>` (keys to press) are the same promise in different words.
+ */
+const CODE_LIKE_TAGS = ["code", "pre", "samp", "kbd"] as const;
+
+const isScriptLike = tagExcluder(new Set<string>(SCRIPT_LIKE_TAGS));
+const isScriptOrCodeLike = tagExcluder(new Set<string>([...SCRIPT_LIKE_TAGS, ...CODE_LIKE_TAGS]));
 
 /**
  * `element`'s text with `<script>`/`<style>`/`<noscript>` subtrees excluded —
@@ -19,4 +30,17 @@ const isScriptLike = tagExcluder(new Set(["script", "style", "noscript"]));
  */
 export function getTextExcludingScripts(element: Element): string {
   return collectTextExcluding(element, isScriptLike);
+}
+
+/**
+ * `element`'s PROSE text: `getTextExcludingScripts` minus code-like subtrees
+ * (`<code>`, `<pre>`, `<samp>`, `<kbd>`).
+ *
+ * For rules that judge the sentences a visitor reads rather than every character
+ * on the page. A page documenting a string — a changelog quoting the exact bytes
+ * a rule detects, a docs page listing shell output — should not be judged as if
+ * it had written that string by accident.
+ */
+export function getProseTextExcludingCode(element: Element): string {
+  return collectTextExcluding(element, isScriptOrCodeLike);
 }

--- a/packages/rules/tests/content-no-dom-mutation.test.ts
+++ b/packages/rules/tests/content-no-dom-mutation.test.ts
@@ -12,7 +12,7 @@ import { parseHTML } from "linkedom";
 
 import { keywordStuffingRule } from "../src/content/keyword-stuffing";
 import { readingLevelRule } from "../src/content/reading-level";
-import { getTextExcludingScripts } from "../src/content/text-content";
+import { getProseTextExcludingCode, getTextExcludingScripts } from "../src/content/text-content";
 import type { ParsedPage, RuleContext } from "../src/types";
 
 const HTML = `<html><body>
@@ -41,6 +41,22 @@ describe("content rules do not mutate the shared DOM", () => {
     const reference = b.textContent || "";
 
     expect(getTextExcludingScripts(a)).toBe(reference);
+  });
+
+  test("getProseTextExcludingCode matches remove-then-textContent for code-like tags too", () => {
+    const html = `<html><body><p>prose <code>literal</code> more</p>
+      <pre>block</pre><samp>output</samp><kbd>keys</kbd>
+      <script>var s = "noise";</script></body></html>`;
+    const a = parseHTML(html).document.querySelector("body")!;
+    const b = parseHTML(html).document.querySelector("body")!;
+
+    for (const el of b.querySelectorAll("script, style, noscript, code, pre, samp, kbd")) {
+      el.remove();
+    }
+
+    expect(getProseTextExcludingCode(a)).toBe(b.textContent || "");
+    // And it leaves the DOM it read intact.
+    expect(a.querySelectorAll("code, pre, samp, kbd").length).toBe(4);
   });
 
   test("keyword-stuffing leaves script/style/noscript nodes in the DOM", async () => {

--- a/packages/rules/tests/content-no-dom-mutation.test.ts
+++ b/packages/rules/tests/content-no-dom-mutation.test.ts
@@ -43,7 +43,7 @@ describe("content rules do not mutate the shared DOM", () => {
     expect(getTextExcludingScripts(a)).toBe(reference);
   });
 
-  test("getProseTextExcludingCode matches remove-then-textContent for code-like tags too", () => {
+  test("getProseTextExcludingCode drops code-like tags and nothing else", () => {
     const html = `<html><body><p>prose <code>literal</code> more</p>
       <pre>block</pre><samp>output</samp><kbd>keys</kbd>
       <script>var s = "noise";</script></body></html>`;
@@ -54,7 +54,13 @@ describe("content rules do not mutate the shared DOM", () => {
       el.remove();
     }
 
-    expect(getProseTextExcludingCode(a)).toBe(b.textContent || "");
+    // Deliberately NOT byte-identical to remove-then-textContent: a newline stands
+    // in for each skipped subtree, because removing an element glues its
+    // neighbours and the caller scans the result for character sequences. Ignoring
+    // the inserted newlines, no surviving text is lost, gained or reordered.
+    const stripNewlines = (s: string) => s.replaceAll("\n", "");
+    expect(stripNewlines(getProseTextExcludingCode(a))).toBe(stripNewlines(b.textContent || ""));
+    expect(getProseTextExcludingCode(a)).toContain("\n");
     // And it leaves the DOM it read intact.
     expect(a.querySelectorAll("code, pre, samp, kbd").length).toBe(4);
   });

--- a/packages/rules/tests/mojibake.test.ts
+++ b/packages/rules/tests/mojibake.test.ts
@@ -120,6 +120,64 @@ describe("mojibakeRule", () => {
     expect(check?.status).toBe("pass");
   });
 
+  // The rule fired on the release note that ANNOUNCED it, because that note quotes
+  // the sequences it detects inside <code>. A code span is markup for "this is a
+  // literal": the page is documenting the corruption, not suffering from it.
+  describe("code-like elements are quoted literals, not prose", () => {
+    test("mojibake only inside <code> passes", () => {
+      const [check] = run(page("<p>Catches garbled sequences like <code>â€™</code>.</p>"));
+      expect(check?.status).toBe("pass");
+    });
+
+    test("mojibake only inside <pre> passes", () => {
+      const [check] = run(page("<pre>Itâ€™s a cafÃ©</pre>"));
+      expect(check?.status).toBe("pass");
+    });
+
+    test("<samp> and <kbd> are excluded too", () => {
+      const [check] = run(page("<p><samp>cafÃ©</samp> then <kbd>â€œ</kbd></p>"));
+      expect(check?.status).toBe("pass");
+    });
+
+    test("a <code> span nested mid-sentence does not leak into the prose scan", () => {
+      const [check] = run(page("<p>text <code>Ã©</code> more</p>"));
+      expect(check?.status).toBe("pass");
+    });
+
+    test("a quoted <code> sample plus one real prose hit counts exactly one", () => {
+      const [check] = run(page("<p>Quotes <code>â€™</code> but Itâ€™s broken here.</p>"));
+      expect(check?.status).toBe("warn");
+      expect(check?.value).toBe(1);
+    });
+
+    test("code exclusion applies to the whole subtree, not just direct text", () => {
+      const [check] = run(page("<pre><span><em>Itâ€™s</em></span></pre><p>Clean.</p>"));
+      expect(check?.status).toBe("pass");
+    });
+
+    test("prose siblings of a code block are still read", () => {
+      const [check] = run(page("<pre>clean sample</pre><p>Itâ€™s broken</p>"));
+      expect(check?.status).toBe("warn");
+      expect(check?.value).toBe(1);
+    });
+
+    test("the replacement character inside code does not escalate to fail", () => {
+      const [check] = run(page("<p>Renders as <code>caf�</code>.</p>"));
+      expect(check?.status).toBe("pass");
+    });
+
+    test("reading a code block does not mutate the shared DOM", () => {
+      const { document } = parseHTML(page("<p>a <code>Ã©</code> b</p>"));
+      const before = document.querySelectorAll("code").length;
+      mojibakeRule.run({
+        page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+        parsed: { document } as unknown as ParsedPage,
+        options: {},
+      } as RuleContext);
+      expect(document.querySelectorAll("code").length).toBe(before);
+    });
+  });
+
   // Reachable: linkedom does NOT synthesize a <body>, so a head-only document really
   // does reach the rule with nothing to read. Skipped, not passed — "we could not look"
   // must never be recorded as "we looked and it was fine".

--- a/packages/rules/tests/mojibake.test.ts
+++ b/packages/rules/tests/mojibake.test.ts
@@ -166,6 +166,22 @@ describe("mojibakeRule", () => {
       expect(check?.status).toBe("pass");
     });
 
+    // Skipping a subtree GLUES its neighbours: without a boundary, the `Ã` before
+    // the code span and the `©` after it concatenate into `Ã©` — a sequence present
+    // in neither fragment. Excluding code must not invent corruption.
+    test("skipping a code span does not glue its neighbours into a sequence", () => {
+      const [check] = run(page("<p>Ã<code>literal</code>©</p>"));
+      expect(check?.status).toBe("pass");
+    });
+
+    // The boundary must be a newline, NOT a space: `Ã ` (à) and `Â ` (nbsp) are
+    // themselves mojibake sequences, so a space boundary would trade one false
+    // positive for another. This fixture fails if anyone "simplifies" it to " ".
+    test("the boundary itself cannot form a sequence with the text before it", () => {
+      expect(run(page("<p>Ã<code>sample</code></p>"))[0]?.status).toBe("pass");
+      expect(run(page("<p>Â<pre>sample</pre></p>"))[0]?.status).toBe("pass");
+    });
+
     test("reading a code block does not mutate the shared DOM", () => {
       const { document } = parseHTML(page("<p>a <code>Ã©</code> b</p>"));
       const before = document.querySelectorAll("code").length;


### PR DESCRIPTION
## The false positive

`content/mojibake` read every character in `<body>`, so any page that *documents* encoding corruption failed the rule for doing so correctly.

Auditing squirrelscan.com warns twice, on `/releases` and `/releases/0.0.81`:

> `2 encoding corruption occurrence(s) in visible text (utf8-as-latin1): charset is correctly utf-8, so the source itself is double-encoded: re-import the content from its original source`

Both hits are the release note that announced the rule, which quotes the sequences it detects as examples:

```html
Catches garbled sequences like <code>â€™</code> and <code>Ã©</code>, and
replacement characters, in the text your visitors actually read.
```

Nothing on that page is corrupt. The rule was matching its own documentation, and its message sent the reader off to re-import content that is fine. Any changelog, docs page, or blog post about character encoding hits this.

## The fix

A code-like element is markup that says "this is a literal, not prose". `<code>` and `<pre>` are the common cases; `<samp>` (program output) and `<kbd>` (keys to press) make the same promise.

`packages/rules/src/content/text-content.ts` gains `getProseTextExcludingCode` next to the existing `getTextExcludingScripts`: the same non-mutating iterative walk (`collectTextExcluding` from `@squirrelscan/parser/extractors`), with `code`, `pre`, `samp` and `kbd` added to the excluded tags. Exclusion is by subtree, so a `<code>` nested mid-sentence does not leak into the scan and its prose siblings still do.

Only `content/mojibake` switches to the new helper. `keyword-stuffing`, `reading-level` and `hidden-text` share the old one and are deliberately untouched here, though the same argument may apply to some of them.

Detection in ordinary prose is unchanged, including prose on the same page as a quoted sample.

## Tests

New cases in `packages/rules/tests/mojibake.test.ts`:

- mojibake only inside `<code>` / only inside `<pre>` / inside `<samp>` and `<kbd>` passes
- `<p>text <code>Ã©</code> more</p>` passes: no leak from a nested span
- a `<code>â€™</code>` sample plus one real prose `â€™` warns with `value === 1`
- exclusion covers the whole subtree, not just direct text
- prose siblings of a code block are still read
- `U+FFFD` inside `<code>` does not escalate to a fail
- reading a code block does not mutate the shared DOM

`packages/rules/tests/content-no-dom-mutation.test.ts` gains the equivalence guard the old helper already had: `getProseTextExcludingCode` matches remove-then-`.textContent` for the code-like tags, and leaves the nodes in place.

The existing prose and clean-accents fixtures are unchanged and still pass.

## Verification

```
bun test                 4291 pass, 4 skip, 0 fail (358 files)
bun run test:engine      58 pass, 1 skip, 0 fail
bun run typecheck        clean, all 16 workspaces
bun run format:check     clean
bun run lint             clean
bun run docs:check       clean (tangly --strict)
bun run docs:build       clean, 387 pages
```

End to end against the live page, identical 70-page crawl:

```
# released 0.0.81 (before)
squirrel audit https://squirrelscan.com/releases --offline -m 70 -C full --rule-include content/mojibake
  66 passed - 2 warnings - 0 failed
  content/mojibake Encoding Corruption (warning)
    -> /releases
    -> /releases/0.0.81

# this branch (after)
bun run dev -- audit https://squirrelscan.com/releases --offline -m 70 -C full --rule-include content/mojibake
  68 passed - 0 warnings - 0 failed
```

Running the rule directly against the fetched `/releases` HTML: `utf8-as-latin1 count 2` before, `[]` after.

Docs updated: `docs/rules/content/mojibake.mdx` now lists both exclusion sets and why they differ.
