### PR TITLE
fix(cli): survive a 2xx editor-summary response that is missing prose

### DIFF
--- a/apps/cli/src/audit/cloud.ts
+++ b/apps/cli/src/audit/cloud.ts
@@ -27,7 +27,10 @@ import {
 } from "@squirrelscan/audit-engine";
 import { computeCost } from "@squirrelscan/core-contracts";
 import { SERVICE_LIMITS } from "@squirrelscan/core-contracts/limits";
-import { buildEditorSummaryRequest } from "@squirrelscan/report";
+import {
+  buildEditorSummaryRequest,
+  toEditorSummary,
+} from "@squirrelscan/report";
 import {
   filterRules,
   loadAllRules,
@@ -861,20 +864,22 @@ export async function runCloudEditorSummary(
 
     opts.onProgress?.("cloud: editor's summary");
     const res = await client.editorSummary(request);
+    // A 2xx is not proof of a usable body: the client casts JSON to the response
+    // type without validating it, so a partial rollout / proxy JSON envelope /
+    // truncated body types as valid while missing `prose`. Degrade exactly like
+    // a 5xx (and don't report spend for a summary we're not rendering) rather
+    // than let it through to throw in a renderer after the crawl is paid for.
+    const editorSummary = toEditorSummary(res);
+    if (!editorSummary) {
+      opts.onProgress?.("cloud: editor's summary skipped");
+      logger.debug("editor-summary skipped", "unusable response body");
+      return null;
+    }
     // A digest-cache hit (#1012) is served free — never bill it or report it
     // as spend (same contract as the domain-stats 30-day cache below).
     const credits = res.cached ? 0 : estimate;
     if (credits > 0) opts.onSpend?.(credits);
-    return {
-      editorSummary: {
-        prose: res.prose,
-        bigTicket: res.bigTicket,
-        verdict: res.verdict,
-        model: res.model,
-        generatedAt: res.generatedAt,
-      },
-      credits,
-    };
+    return { editorSummary, credits };
   } catch (error) {
     // Any failure (402 out of credits / auth / network / 5xx / build) →
     // degrade silently (no editor-summary section). Never fails the audit.

--- a/apps/cli/src/reports/output/console.ts
+++ b/apps/cli/src/reports/output/console.ts
@@ -1,5 +1,7 @@
 // Console report output
 
+import type { EditorSummaryView } from "@squirrelscan/report";
+
 import { stripControlCharsPreservingSgr } from "@squirrelscan/core-contracts/control-chars";
 import {
   carriedTag,
@@ -13,6 +15,7 @@ import {
   domainStatRows,
   positionBands,
   EDITOR_SUMMARY_NOTE,
+  editorSummaryView,
   SITE_PROFILE_NOTE,
   siteProfileFlags,
   siteProfileRows,
@@ -21,7 +24,6 @@ import {
 import type {
   AuditReport,
   DomainStats,
-  EditorSummary,
   GroupScore,
   HealthScore,
   ReportTechnologies,
@@ -118,9 +120,10 @@ export function generateConsoleReport(
   log(divider());
 
   // Editor's summary — report-only Pro exec narrative, surfaced at the top.
-  if (report.editorSummary) {
+  const editorSummary = editorSummaryView(report.editorSummary);
+  if (editorSummary) {
     log("");
-    printEditorSummary(report.editorSummary);
+    printEditorSummary(editorSummary);
   }
 
   // Category breakdown
@@ -323,14 +326,12 @@ function partialAuditLine(
   return `partial audit: ${parts.join("; ")}${scored}`;
 }
 
-function printEditorSummary(es: EditorSummary): void {
+function printEditorSummary(es: EditorSummaryView): void {
   log(fmt.bold("EDITOR'S SUMMARY"));
   log(fmt.dim(EDITOR_SUMMARY_NOTE));
   log("");
-  for (const para of es.prose.split(/\n{2,}/)) {
-    const trimmed = para.trim();
-    if (!trimmed) continue;
-    log(trimmed);
+  for (const para of es.paragraphs) {
+    log(para);
     log("");
   }
   if (es.bigTicket.length > 0) {

--- a/apps/cli/tests/audit/cloud-spend.test.ts
+++ b/apps/cli/tests/audit/cloud-spend.test.ts
@@ -4,6 +4,7 @@
 
 import type { PageRecord } from "@squirrelscan/core-contracts/storage";
 
+import { createCloudClient } from "@squirrelscan/cloud-client";
 import { computeCost } from "@squirrelscan/core-contracts";
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
@@ -226,6 +227,70 @@ describe("editor-summary spend accounting", () => {
     });
     expect(result?.credits).toBe(0);
     expect(result?.editorSummary.prose).toBe("All good.");
+    expect(reported).toBe(false);
+  });
+});
+
+/**
+ * A 2xx is not proof of a usable body. The cloud client casts its JSON to the
+ * response type without validating it, so a partial rollout / proxy JSON
+ * envelope / truncated body arrives typed as valid while missing `prose`. That
+ * used to sail past the try/catch here and throw far away, in a renderer
+ * ("undefined is not an object (evaluating 'es.prose.split')") — after the crawl
+ * had already been paid for, discarding the whole audit. It must degrade exactly
+ * like a 5xx: no summary, no spend, no throw.
+ */
+describe("editor-summary malformed 2xx", () => {
+  test("a real 200 whose body is missing prose degrades like a 5xx", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ ok: true }),
+    });
+    try {
+      const config = getDefaultConfig();
+      config.cloud.enabled = true;
+      let reported = false;
+      const result = await runCloudEditorSummary({
+        client: createCloudClient({
+          apiUrl: server.url.origin,
+          token: "sqcli_x",
+          maxAttempts: 1,
+        }),
+        config,
+        auditId: "audit-1",
+        report: makeSummaryReport(),
+        onSpend: () => {
+          reported = true;
+        },
+      });
+      expect(result).toBeNull();
+      expect(reported).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a 200 whose prose is the wrong type degrades the same way", async () => {
+    const config = getDefaultConfig();
+    config.cloud.enabled = true;
+    let reported = false;
+    const result = await runCloudEditorSummary({
+      client: {
+        editorSummary: async () => ({
+          prose: 42,
+          bigTicket: null,
+          verdict: "",
+          model: "",
+        }),
+      } as never,
+      config,
+      auditId: "audit-1",
+      report: makeSummaryReport(),
+      onSpend: () => {
+        reported = true;
+      },
+    });
+    expect(result).toBeNull();
     expect(reported).toBe(false);
   });
 });

--- a/apps/cli/tests/reports/output/console-editor-summary.test.ts
+++ b/apps/cli/tests/reports/output/console-editor-summary.test.ts
@@ -1,0 +1,100 @@
+// The console renderer is where the original crash landed: a stored editor's
+// summary whose `prose` is not a usable string reached `es.prose.split(...)`
+// and killed a finished audit with "undefined is not an object". It must render
+// as "no editor-summary section" instead, never as a throw.
+//
+// Sibling of packages/report/tests/editor-summary-malformed.test.ts, which
+// covers the other five formats; console lives here, in the CLI.
+
+import { describe, expect, test, spyOn } from "bun:test";
+
+import type { AuditReport, EditorSummary } from "@/types";
+
+import { generateConsoleReport } from "@/reports/output/console";
+
+import { createMinimalReport } from "../fixtures";
+
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+function capture(report: AuditReport): string {
+  const lines: string[] = [];
+  const spy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.join(" "));
+  });
+  try {
+    generateConsoleReport(report);
+  } finally {
+    spy.mockRestore();
+  }
+  return lines.join("\n").replace(ANSI, "");
+}
+
+function reportWith(editorSummary: unknown): AuditReport {
+  const report = createMinimalReport();
+  report.editorSummary = editorSummary as EditorSummary;
+  return report;
+}
+
+/** Same body shapes the report-package renderer matrix pins. */
+const MALFORMED: Array<[string, unknown]> = [
+  [
+    "missing prose",
+    { bigTicket: [], verdict: "v", model: "m", generatedAt: "t" },
+  ],
+  ["the whole body replaced by an envelope", { ok: true }],
+  [
+    "prose is not a string",
+    { prose: 42, bigTicket: [], verdict: "", model: "", generatedAt: "" },
+  ],
+  [
+    "prose is blank",
+    {
+      prose: "   \n\n  ",
+      bigTicket: [],
+      verdict: "",
+      model: "",
+      generatedAt: "",
+    },
+  ],
+  [
+    "prose is null",
+    { prose: null, bigTicket: [], verdict: "", model: "", generatedAt: "" },
+  ],
+];
+
+describe("console editor's summary", () => {
+  test.each(MALFORMED)(
+    "renders without the section and without throwing: %s",
+    (_label, body) => {
+      const out = capture(reportWith(body));
+      expect(out).not.toContain("EDITOR'S SUMMARY");
+      // The rest of the report still renders — the audit is not discarded.
+      expect(out).toContain("85");
+    }
+  );
+
+  test("renders a well-formed summary in full", () => {
+    const out = capture(
+      reportWith({
+        prose: "First paragraph.\n\nSecond paragraph.",
+        bigTicket: ["Fix the titles"],
+        verdict: "Ship it",
+        model: "test-model",
+        generatedAt: "2026-06-16T14:30:00.000Z",
+      })
+    );
+    expect(out).toContain("EDITOR'S SUMMARY");
+    expect(out).toContain("First paragraph.");
+    expect(out).toContain("Second paragraph.");
+    expect(out).toContain("Fix the titles");
+    expect(out).toContain("Verdict: Ship it");
+  });
+
+  test("a summary carrying only prose renders it with no bullet list", () => {
+    // `bigTicket.length` was the second unguarded dereference here.
+    const out = capture(reportWith({ prose: "Body text." }));
+    expect(out).toContain("EDITOR'S SUMMARY");
+    expect(out).toContain("Body text.");
+    expect(out).not.toContain("Big-ticket items:");
+  });
+});

--- a/packages/audit-engine/src/cloud-prefetch-run.ts
+++ b/packages/audit-engine/src/cloud-prefetch-run.ts
@@ -19,7 +19,7 @@ import type {
 import { computeCost } from "@squirrelscan/core-contracts/credits";
 import { SERVICE_LIMITS } from "@squirrelscan/core-contracts/limits";
 import type { Config } from "@squirrelscan/config";
-import { buildEditorSummaryRequest } from "@squirrelscan/report/editor-summary";
+import { buildEditorSummaryRequest, toEditorSummary } from "@squirrelscan/report/editor-summary";
 import { filterRules, loadAllRules, type RuleCloudSpec } from "@squirrelscan/rules";
 import { getHostname, getOrigin, getPathname, hasUnsafeUrlScheme } from "@squirrelscan/utils/url";
 
@@ -503,16 +503,11 @@ export async function runContainerEditorSummary(input: {
   if (input.remainingBudget < credits) return null;
   try {
     const res = await client.editorSummary(buildEditorSummaryRequest(report, { auditId }));
-    return {
-      editorSummary: {
-        prose: res.prose,
-        bigTicket: res.bigTicket,
-        verdict: res.verdict,
-        model: res.model,
-        generatedAt: res.generatedAt,
-      },
-      credits,
-    };
+    // Same guard as the CLI path: a 2xx body is cast, not validated, so one that
+    // is missing `prose` has to degrade here instead of throwing in a renderer.
+    const editorSummary = toEditorSummary(res);
+    if (!editorSummary) return null;
+    return { editorSummary, credits };
   } catch {
     return null;
   }

--- a/packages/report/src/editor-summary.ts
+++ b/packages/report/src/editor-summary.ts
@@ -9,6 +9,7 @@
 
 import type {
   AuditReport,
+  EditorSummary,
   EditorSummaryCategoryInput,
   EditorSummaryIssueInput,
   EditorSummaryRequest,
@@ -129,5 +130,68 @@ export function buildEditorSummaryRequest(
     topIssues: buildTopIssues(report, SERVICE_LIMITS.editorSummaryMaxIssues),
     ...(opts.delta ? { delta: opts.delta } : {}),
     ...(report.siteMetadata ? { siteProfile: toSiteProfile(report.siteMetadata) } : {}),
+  };
+}
+
+/**
+ * Coerce a cloud editor-summary response body into the report-stored shape, or
+ * null when the body is unusable.
+ *
+ * The cloud client CASTS its JSON to the declared response type without
+ * validating it. That is additive-safe (an unknown extra field is harmless) but
+ * not subtractive-safe: a 2xx body missing `prose` still types as `string` while
+ * being `undefined` at runtime, and the failure then lands far from the fetch,
+ * inside a renderer, after the crawl has already been paid for. Callers treat
+ * null exactly like a 5xx: no editor-summary section, never a throw.
+ *
+ * `prose` IS the section, so a missing or blank one rejects the whole body; the
+ * remaining fields are decorative and are defaulted rather than rejected.
+ */
+export function toEditorSummary(res: unknown): EditorSummary | null {
+  if (!res || typeof res !== "object") return null;
+  const r = res as Partial<Record<keyof EditorSummary, unknown>>;
+  if (typeof r.prose !== "string" || r.prose.trim() === "") return null;
+  return {
+    prose: r.prose,
+    bigTicket: Array.isArray(r.bigTicket)
+      ? r.bigTicket.filter((item): item is string => typeof item === "string")
+      : [],
+    verdict: typeof r.verdict === "string" ? r.verdict : "",
+    model: typeof r.model === "string" ? r.model : "",
+    generatedAt: typeof r.generatedAt === "string" ? r.generatedAt : "",
+  };
+}
+
+/** The already-validated slice every output format renders. */
+export interface EditorSummaryView {
+  /** Prose split on blank lines, trimmed, empties dropped; never empty. */
+  paragraphs: string[];
+  bigTicket: string[];
+  verdict: string;
+  model: string;
+}
+
+/**
+ * Renderer-side guard: normalize a report's stored editor summary into what the
+ * output formats need, or null when there is nothing safe to render.
+ *
+ * Every format goes through here so that none of them dereferences `prose` (or
+ * `bigTicket`) directly. Reports are persisted and re-rendered later, so a
+ * report stored before the fetch-side guard existed can still carry a malformed
+ * summary: the guard has to live at render time too, not only at fetch time.
+ */
+export function editorSummaryView(
+  es: EditorSummary | undefined | null,
+): EditorSummaryView | null {
+  const summary = toEditorSummary(es);
+  if (!summary) return null;
+  return {
+    paragraphs: summary.prose
+      .split(/\n{2,}/)
+      .map((para) => para.trim())
+      .filter(Boolean),
+    bigTicket: summary.bigTicket,
+    verdict: summary.verdict,
+    model: summary.model,
   };
 }

--- a/packages/report/src/editor-summary.ts
+++ b/packages/report/src/editor-summary.ts
@@ -162,13 +162,15 @@ export function toEditorSummary(res: unknown): EditorSummary | null {
   };
 }
 
-/** The already-validated slice every output format renders. */
-export interface EditorSummaryView {
+/**
+ * The validated summary every output format renders, plus the paragraph split
+ * they all used to do for themselves. The raw fields ride along so the formats
+ * that persist the summary verbatim (json) go through this same guard instead
+ * of a second one.
+ */
+export interface EditorSummaryView extends EditorSummary {
   /** Prose split on blank lines, trimmed, empties dropped; never empty. */
   paragraphs: string[];
-  bigTicket: string[];
-  verdict: string;
-  model: string;
 }
 
 /**
@@ -186,12 +188,10 @@ export function editorSummaryView(
   const summary = toEditorSummary(es);
   if (!summary) return null;
   return {
+    ...summary,
     paragraphs: summary.prose
       .split(/\n{2,}/)
       .map((para) => para.trim())
       .filter(Boolean),
-    bigTicket: summary.bigTicket,
-    verdict: summary.verdict,
-    model: summary.model,
   };
 }

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -130,7 +130,10 @@ export {
 export {
   EDITOR_SUMMARY_NOTE,
   buildEditorSummaryRequest,
+  editorSummaryView,
+  toEditorSummary,
   type BuildEditorSummaryRequestOptions,
+  type EditorSummaryView,
 } from "./editor-summary";
 
 // Re-export the persisted editor-summary report type for renderers + consumers.

--- a/packages/report/src/output/html.tsx
+++ b/packages/report/src/output/html.tsx
@@ -35,7 +35,7 @@ import {
   checkCarriedLabel,
   ruleCarriedRollupLine,
 } from "../coverage";
-import { EDITOR_SUMMARY_NOTE } from "../editor-summary";
+import { EDITOR_SUMMARY_NOTE, editorSummaryView } from "../editor-summary";
 import { DOMAIN_STATS_NOTE, domainStatRows, allPositionBands } from "../domain-stats";
 import { CACHE_STATS_NOTE, cacheHitRatePercent, cacheReasonsLabel } from "../cache-stats";
 import { formatBytes, formatHumanDateTime, sanitizeUrl } from "../utils";
@@ -1118,12 +1118,9 @@ function screenshotImgSrc(report: AuditReport): string | null {
 }
 
 function EditorSummarySection({ report }: { report: AuditReport }) {
-  const es = report.editorSummary;
+  const es = editorSummaryView(report.editorSummary);
   if (!es) return null;
-  const paragraphs = es.prose
-    .split(/\n{2,}/)
-    .map((p) => p.trim())
-    .filter(Boolean);
+  const paragraphs = es.paragraphs;
   return (
     <div className="editor-summary-section">
       <h2>Editor&apos;s summary</h2>

--- a/packages/report/src/output/json.ts
+++ b/packages/report/src/output/json.ts
@@ -7,7 +7,7 @@ import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { affectedPages } from "../affected-pages";
 import { techIconUrl } from "../technologies";
 import { domainAgeYears, siteProfileRows } from "../site-metadata";
-import { toEditorSummary } from "../editor-summary";
+import { editorSummaryView } from "../editor-summary";
 
 export interface JsonRenderOptions {
   version?: string;
@@ -137,7 +137,7 @@ interface SlimJsonReport {
 
 function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
   const categoryIssues = groupIssuesByCategory(report.ruleResults);
-  const editorSummary = toEditorSummary(report.editorSummary);
+  const es = editorSummaryView(report.editorSummary);
   return {
     meta: {
       version,
@@ -172,10 +172,22 @@ function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
       warnings: report.warnings,
       failed: report.failed,
     },
-    // Validated, not just cast: the declared shape promises string fields, so a
-    // malformed stored summary omits the whole section rather than emitting a
-    // half-built one into the user-facing JSON.
-    ...(editorSummary ? { editorSummary } : {}),
+    // Same guard as every other format, validated rather than just cast: the
+    // declared shape promises string fields, so a malformed stored summary omits
+    // the whole section rather than emitting a half-built one into the
+    // user-facing JSON. Fields are listed out (not spread) to keep `paragraphs`,
+    // which is a rendering aid, out of the persisted shape.
+    ...(es
+      ? {
+          editorSummary: {
+            prose: es.prose,
+            bigTicket: es.bigTicket,
+            verdict: es.verdict,
+            model: es.model,
+            generatedAt: es.generatedAt,
+          },
+        }
+      : {}),
     // Severity-first across the whole report (#1536), not category-by-category.
     issues: flattenIssuesBySeverity(categoryIssues).map((rule) => ({
       ruleId: rule.id,

--- a/packages/report/src/output/json.ts
+++ b/packages/report/src/output/json.ts
@@ -7,6 +7,7 @@ import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { affectedPages } from "../affected-pages";
 import { techIconUrl } from "../technologies";
 import { domainAgeYears, siteProfileRows } from "../site-metadata";
+import { toEditorSummary } from "../editor-summary";
 
 export interface JsonRenderOptions {
   version?: string;
@@ -136,6 +137,7 @@ interface SlimJsonReport {
 
 function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
   const categoryIssues = groupIssuesByCategory(report.ruleResults);
+  const editorSummary = toEditorSummary(report.editorSummary);
   return {
     meta: {
       version,
@@ -170,17 +172,10 @@ function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
       warnings: report.warnings,
       failed: report.failed,
     },
-    ...(report.editorSummary
-      ? {
-          editorSummary: {
-            prose: report.editorSummary.prose,
-            bigTicket: report.editorSummary.bigTicket,
-            verdict: report.editorSummary.verdict,
-            model: report.editorSummary.model,
-            generatedAt: report.editorSummary.generatedAt,
-          },
-        }
-      : {}),
+    // Validated, not just cast: the declared shape promises string fields, so a
+    // malformed stored summary omits the whole section rather than emitting a
+    // half-built one into the user-facing JSON.
+    ...(editorSummary ? { editorSummary } : {}),
     // Severity-first across the whole report (#1536), not category-by-category.
     issues: flattenIssuesBySeverity(categoryIssues).map((rule) => ({
       ruleId: rule.id,

--- a/packages/report/src/output/llm.ts
+++ b/packages/report/src/output/llm.ts
@@ -8,6 +8,7 @@ import { ruleAffectedPages, ruleAffectedRollup, ruleCarriedPageCount } from "../
 import { getDocsUrl } from "../docs";
 import { domainAgeYears } from "../site-metadata";
 import { lockedRulesMessage } from "../locked-rules";
+import { editorSummaryView } from "../editor-summary";
 import { LLM_REPORT } from "@squirrelscan/core-contracts/limits";
 import { stripControlChars } from "@squirrelscan/core-contracts/control-chars";
 
@@ -152,12 +153,11 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
   }
 
   // Editor's summary — report-only exec narrative for the agent (does not affect the score).
-  if (report.editorSummary) {
-    const es = report.editorSummary;
+  const es = editorSummaryView(report.editorSummary);
+  if (es) {
     lines.push(`<editor-summary model="${escapeXml(es.model)}">`);
-    for (const para of es.prose.split(/\n{2,}/)) {
-      const trimmed = para.trim();
-      if (trimmed) lines.push(`${indent(1)}<para>${escapeXml(trimmed)}</para>`);
+    for (const para of es.paragraphs) {
+      lines.push(`${indent(1)}<para>${escapeXml(para)}</para>`);
     }
     if (es.bigTicket.length > 0) {
       lines.push(`${indent(1)}<big-ticket>`);

--- a/packages/report/src/output/markdown.ts
+++ b/packages/report/src/output/markdown.ts
@@ -8,7 +8,7 @@ import { REPORT_SOURCE_PAGES_PREVIEW, REPORT_PAGES_HARD_CAP } from "../constants
 import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { groupTechnologies, techChangeSummary, techIconUrl } from "../technologies";
 import { SITE_PROFILE_NOTE, siteProfileFlags, siteProfileRows } from "../site-metadata";
-import { EDITOR_SUMMARY_NOTE } from "../editor-summary";
+import { EDITOR_SUMMARY_NOTE, editorSummaryView } from "../editor-summary";
 import { getGroupName, getSubcategoryName, severityLabel } from "../categories";
 import {
   carriedTag,
@@ -101,16 +101,14 @@ export function renderMarkdown(report: AuditReport, options?: MarkdownRenderOpti
   lines.push("");
 
   // Editor's summary — report-only (Pro exec-email narrative), surfaced first.
-  if (report.editorSummary) {
-    const es = report.editorSummary;
+  const es = editorSummaryView(report.editorSummary);
+  if (es) {
     lines.push("## Editor's Summary");
     lines.push("");
     lines.push(`_${EDITOR_SUMMARY_NOTE}_`);
     lines.push("");
-    for (const para of es.prose.split(/\n{2,}/)) {
-      const trimmed = para.trim();
-      if (!trimmed) continue;
-      lines.push(trimmed);
+    for (const para of es.paragraphs) {
+      lines.push(para);
       lines.push("");
     }
     if (es.bigTicket.length > 0) {

--- a/packages/report/src/output/text.ts
+++ b/packages/report/src/output/text.ts
@@ -9,7 +9,7 @@ import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { affectedPages } from "../affected-pages";
 import { groupTechnologies, techChangeSummary } from "../technologies";
 import { SITE_PROFILE_NOTE, siteProfileFlags, siteProfileRows } from "../site-metadata";
-import { EDITOR_SUMMARY_NOTE } from "../editor-summary";
+import { EDITOR_SUMMARY_NOTE, editorSummaryView } from "../editor-summary";
 import { getGroupName, getSubcategoryName, severityLabel } from "../categories";
 import {
   carriedTag,
@@ -104,16 +104,14 @@ export function renderText(report: AuditReport, options?: TextRenderOptions): st
 
   // Editor's summary — report-only (Pro exec-email narrative; not part of the score).
   // Surfaced at the very top of the report, before the health score.
-  if (report.editorSummary) {
-    const es = report.editorSummary;
+  const es = editorSummaryView(report.editorSummary);
+  if (es) {
     write("EDITOR'S SUMMARY");
     write("-".repeat(40));
     write(EDITOR_SUMMARY_NOTE);
     write("");
-    for (const para of es.prose.split(/\n{2,}/)) {
-      const trimmed = para.trim();
-      if (!trimmed) continue;
-      for (const line of wrapText(trimmed, REPORT_TEXT_WRAP_WIDTH)) write(line);
+    for (const para of es.paragraphs) {
+      for (const line of wrapText(para, REPORT_TEXT_WRAP_WIDTH)) write(line);
       write("");
     }
     if (es.bigTicket.length > 0) {

--- a/packages/report/src/output/xml.ts
+++ b/packages/report/src/output/xml.ts
@@ -7,6 +7,7 @@ import { getGroupName } from "../categories";
 import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { affectedPages } from "../affected-pages";
 import { domainAgeYears } from "../site-metadata";
+import { editorSummaryView } from "../editor-summary";
 
 export interface XmlRenderOptions {
   version?: string;
@@ -60,12 +61,11 @@ export function renderXml(report: AuditReport, options?: XmlRenderOptions): stri
   lines.push(`${indent(1)}<summary passed="${report.passed}" warnings="${report.warnings}" failed="${report.failed}"/>`);
 
   // Editor's summary — report-only exec narrative (does not affect the health score).
-  if (report.editorSummary) {
-    const es = report.editorSummary;
+  const es = editorSummaryView(report.editorSummary);
+  if (es) {
     lines.push(`${indent(1)}<editor-summary model="${escapeXml(es.model)}">`);
-    for (const para of es.prose.split(/\n{2,}/)) {
-      const trimmed = para.trim();
-      if (trimmed) lines.push(`${indent(2)}<para>${escapeXml(trimmed)}</para>`);
+    for (const para of es.paragraphs) {
+      lines.push(`${indent(2)}<para>${escapeXml(para)}</para>`);
     }
     if (es.bigTicket.length > 0) {
       lines.push(`${indent(2)}<big-ticket>`);

--- a/packages/report/tests/editor-summary-malformed.test.ts
+++ b/packages/report/tests/editor-summary-malformed.test.ts
@@ -1,0 +1,153 @@
+// A stored editor's summary whose `prose` is not a usable string must render as
+// "no editor-summary section" in EVERY output format, never as a throw.
+//
+// The cloud client casts its JSON to the response type without validating it, so
+// a 2xx body missing `prose` reaches the report typed as `string` while being
+// `undefined` at runtime. Reports are also persisted and re-rendered later, so a
+// report written before the fetch-side guard existed can still carry one. The
+// old renderers called `es.prose.split(...)` unguarded and died with
+// "undefined is not an object", discarding an audit that had already finished.
+
+import { describe, expect, test } from "bun:test";
+
+import type { AuditReport, EditorSummary } from "../src/types";
+import { editorSummaryView, toEditorSummary } from "../src/editor-summary";
+import { renderHtml } from "../src/output/html";
+import { renderJson } from "../src/output/json";
+import { renderLlm } from "../src/output/llm";
+import { renderMarkdown } from "../src/output/markdown";
+import { renderText } from "../src/output/text";
+import { renderXml } from "../src/output/xml";
+
+function baseReport(editorSummary: unknown): AuditReport {
+  return {
+    baseUrl: "https://acme.example",
+    timestamp: "2026-06-16T14:30:00.000Z",
+    totalPages: 1,
+    passed: 0,
+    warnings: 0,
+    failed: 0,
+    ruleResults: {},
+    generatorVersion: "1.2.3",
+    editorSummary: editorSummary as EditorSummary,
+  } as AuditReport;
+}
+
+const GOOD: EditorSummary = {
+  prose: "First paragraph.\n\nSecond paragraph.",
+  bigTicket: ["Fix the titles"],
+  verdict: "Ship it",
+  model: "test-model",
+  generatedAt: "2026-06-16T14:30:00.000Z",
+};
+
+/** Every malformed body a 2xx can plausibly hand us (issue repro: `{"ok":true}`). */
+const MALFORMED: Array<[string, unknown]> = [
+  ["missing prose", { bigTicket: [], verdict: "v", model: "m", generatedAt: "t" }],
+  ["the whole body replaced by an envelope", { ok: true }],
+  ["prose is not a string", { prose: 42, bigTicket: [], verdict: "", model: "", generatedAt: "" }],
+  ["prose is blank", { prose: "   \n\n  ", bigTicket: [], verdict: "", model: "", generatedAt: "" }],
+  ["prose is null", { prose: null, bigTicket: [], verdict: "", model: "", generatedAt: "" }],
+];
+
+describe("toEditorSummary", () => {
+  test("accepts a well-formed body unchanged", () => {
+    expect(toEditorSummary(GOOD)).toEqual(GOOD);
+  });
+
+  test.each(MALFORMED)("rejects a 2xx body with %s", (_label, body) => {
+    expect(toEditorSummary(body)).toBeNull();
+  });
+
+  test("rejects non-objects", () => {
+    expect(toEditorSummary(undefined)).toBeNull();
+    expect(toEditorSummary(null)).toBeNull();
+    expect(toEditorSummary("prose")).toBeNull();
+  });
+
+  test("defaults the decorative fields rather than rejecting the body", () => {
+    // Only `prose` is the section; a missing verdict/model must still render.
+    expect(toEditorSummary({ prose: "Body." })).toEqual({
+      prose: "Body.",
+      bigTicket: [],
+      verdict: "",
+      model: "",
+      generatedAt: "",
+    });
+  });
+
+  test("drops non-string big-ticket entries instead of rendering them", () => {
+    const summary = toEditorSummary({ prose: "Body.", bigTicket: ["keep", 7, null, "also"] });
+    expect(summary?.bigTicket).toEqual(["keep", "also"]);
+  });
+});
+
+describe("editorSummaryView", () => {
+  test("splits prose on blank lines and trims", () => {
+    expect(editorSummaryView(GOOD)?.paragraphs).toEqual(["First paragraph.", "Second paragraph."]);
+  });
+
+  test("returns null for an absent or malformed summary", () => {
+    expect(editorSummaryView(undefined)).toBeNull();
+    expect(editorSummaryView({ prose: undefined } as unknown as EditorSummary)).toBeNull();
+  });
+});
+
+describe.each(MALFORMED)("renderers with %s", (_label, body) => {
+  const report = baseReport(body);
+
+  test("markdown renders without the section and without throwing", () => {
+    const out = renderMarkdown(report);
+    expect(out).not.toContain("Editor's Summary");
+  });
+
+  test("text renders without the section and without throwing", () => {
+    const out = renderText(report);
+    expect(out).not.toContain("EDITOR'S SUMMARY");
+  });
+
+  test("llm renders without the section and without throwing", () => {
+    const out = renderLlm(report);
+    expect(out).not.toContain("<editor-summary");
+  });
+
+  test("xml renders without the section and without throwing", () => {
+    const out = renderXml(report);
+    expect(out).not.toContain("<editor-summary");
+  });
+
+  test("html renders without the section and without throwing", () => {
+    // Match the attribute, not the class name: the stylesheet always ships the rule.
+    const out = renderHtml(report);
+    expect(out).not.toContain('class="editor-summary-section"');
+  });
+
+  test("json omits the section rather than emitting a half-built one", () => {
+    const parsed = JSON.parse(renderJson(report)) as Record<string, unknown>;
+    expect(parsed.editorSummary).toBeUndefined();
+  });
+});
+
+describe("renderers with a well-formed summary still render it", () => {
+  const report = baseReport(GOOD);
+
+  test("every format keeps the section", () => {
+    expect(renderMarkdown(report)).toContain("First paragraph.");
+    expect(renderText(report)).toContain("First paragraph.");
+    expect(renderLlm(report)).toContain("<para>First paragraph.</para>");
+    expect(renderXml(report)).toContain("<para>First paragraph.</para>");
+    expect(renderHtml(report)).toContain('class="editor-summary-section"');
+    const parsed = JSON.parse(renderJson(report)) as { editorSummary?: EditorSummary };
+    expect(parsed.editorSummary?.prose).toBe(GOOD.prose);
+  });
+
+  test("a summary missing only bigTicket renders the prose and no bullet list", () => {
+    // `bigTicket.length` was the second unguarded dereference in every format.
+    const partial = baseReport({ prose: "Body text." });
+    expect(renderMarkdown(partial)).toContain("Body text.");
+    expect(renderText(partial)).toContain("Body text.");
+    expect(renderLlm(partial)).toContain("<para>Body text.</para>");
+    expect(renderXml(partial)).toContain("<para>Body text.</para>");
+    expect(renderHtml(partial)).toContain('class="editor-summary-section"');
+  });
+});

--- a/packages/report/tests/editor-summary-malformed.test.ts
+++ b/packages/report/tests/editor-summary-malformed.test.ts
@@ -137,8 +137,38 @@ describe("renderers with a well-formed summary still render it", () => {
     expect(renderLlm(report)).toContain("<para>First paragraph.</para>");
     expect(renderXml(report)).toContain("<para>First paragraph.</para>");
     expect(renderHtml(report)).toContain('class="editor-summary-section"');
+  });
+
+  test("json emits the section byte-for-byte unchanged", () => {
+    // --format json is a user-facing shape, and routing it through the guard
+    // must not perturb a single byte of a well-formed summary: not the field
+    // set, not the key ORDER, not the two-space indentation, not the prose
+    // (which the guard splits into paragraphs for the other formats but must
+    // persist verbatim, blank lines and all). A field-by-field toEqual would
+    // pass on reordered keys or re-joined prose; this pins the actual output.
+    const JSON_FIXTURE = [
+      '  "editorSummary": {',
+      '    "prose": "First paragraph.\\n\\nSecond paragraph.",',
+      '    "bigTicket": [',
+      '      "Fix the titles"',
+      "    ],",
+      '    "verdict": "Ship it",',
+      '    "model": "test-model",',
+      '    "generatedAt": "2026-06-16T14:30:00.000Z"',
+      "  },",
+    ].join("\n");
+    expect(renderJson(report)).toContain(JSON_FIXTURE);
+
     const parsed = JSON.parse(renderJson(report)) as { editorSummary?: EditorSummary };
-    expect(parsed.editorSummary?.prose).toBe(GOOD.prose);
+    expect(parsed.editorSummary).toEqual(GOOD);
+    // `paragraphs` is a rendering aid on the view; it must never reach the shape.
+    expect(Object.keys(parsed.editorSummary as object)).toEqual([
+      "prose",
+      "bigTicket",
+      "verdict",
+      "model",
+      "generatedAt",
+    ]);
   });
 
   test("a summary missing only bigTicket renders the prose and no bullet list", () => {


### PR DESCRIPTION
## The crash

A cloud editor-summary response that answers **200 with a body missing `prose`** killed the CLI *after* the crawl had finished, throwing away the entire audit. It surfaced as a raw TypeError, not a degraded report:

```
error audit exception {"error":"undefined is not an object (evaluating 'es.prose.split')"}
 ERROR  undefined is not an object (evaluating 'es.prose.split')
```

The editor's summary is one optional enrichment fetched at the very end of a run, so the whole cost of the audit (crawl, render, rules) had already been paid when a partial 200 discarded it.

## Why the existing guard missed it

`runCloudEditorSummary` is written to never fail the audit, but its `try`/`catch` only covers throws and non-2xx. The cloud client casts its JSON to the declared response type without validating it. That is additive-safe (an unknown extra field is harmless) but not subtractive-safe: a missing `prose` types as `string` while being `undefined` at runtime, sails past the guard, and throws far away, inside a renderer.

Anything that can produce a 2xx with an unexpected body triggers it: a partial rollout, an edge or proxy returning a JSON error envelope with 200, a truncated response, or a future field rename.

## The fix, in two layers

**1. Validate the body at the fetch.** New `toEditorSummary` in `packages/report/src/editor-summary.ts`: `prose` must be a non-empty string or the whole body is rejected; the decorative fields (`bigTicket`, `verdict`, `model`, `generatedAt`) are defaulted rather than rejected, and non-string big-ticket entries are dropped. An unusable body now degrades exactly like a 5xx: no editor-summary section, a debug log, no spend reported, never a throw. Applied to both call sites, the CLI path in `apps/cli/src/audit/cloud.ts` and the container path in `packages/audit-engine/src/cloud-prefetch-run.ts`.

A tiny shape guard rather than a schema, matching how the rest of the cloud responses are handled.

**2. Guard every renderer.** New `editorSummaryView` is the single point every output format goes through, so none of them dereferences `prose` (or `bigTicket`) directly. This layer is not redundant: reports are persisted and re-rendered later, so a report stored before the fetch-side guard existed can still carry a malformed summary. Covers `console`, `markdown`, `text`, `llm`, `xml`, `html`, and `json` (which now omits the section rather than emitting a half-built one into the user-facing JSON shape).

Splitting the prose into paragraphs was duplicated in all six renderers; it now lives in the view helper.

## Tests

- `apps/cli/tests/audit/cloud-spend.test.ts`: a real local server answering 200 `{"ok":true}` for the editor-summary endpoint, driven through the actual cloud client, must yield no summary, no reported spend, and no throw. Plus a wrong-typed `prose`.
- `packages/report/tests/editor-summary-malformed.test.ts`: five malformed body shapes (missing `prose`, the body replaced by an envelope, `prose` non-string / blank / null) rendered through all six formats, asserting the section is absent and nothing throws, plus the well-formed summary still rendering in every format.

Both were confirmed to fail against the unfixed code before the guards landed.

## Verification

```
bun run format:check   # clean
bun run lint           # clean
bun run typecheck      # clean, all 16 workspaces
bun test               # 4325 pass, 4 skip
```

The only failure in the full run was `packages/audit-engine/tests/golden-baseline.test.ts` hitting its 60s timeout on a loaded machine; it passes on its own (6 pass) and is untouched by this change.
