### PR TITLE
fix(rules): images/alt-text no longer counts alt="" as missing

### DIFF
--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -300,9 +300,10 @@ export function reconstructReport(
           summary.thinContentPages.push(page.normalizedUrl);
       }
 
-      // Check missing alt text
+      // Check missing alt text. alt="" is the correct markup for a decorative
+      // image (HTML spec, WCAG H67), so only an absent attribute counts (#143).
       for (const imgAppearance of pageImageAppearances) {
-        if (!imgAppearance.alt || imgAppearance.alt.trim() === "") {
+        if (imgAppearance.alt === undefined || imgAppearance.alt === null) {
           summary.missingAltText.push({
             page: page.normalizedUrl,
             image: imgAppearance.src,

--- a/apps/cli/tests/graph/extractors/images.test.ts
+++ b/apps/cli/tests/graph/extractors/images.test.ts
@@ -1,6 +1,9 @@
 // Tests for extractors/images.ts - Image extraction
 
-import { extractImages, getImagesWithoutAlt } from "@squirrelscan/parser/extractors";
+import {
+  extractImages,
+  getImagesWithoutAlt,
+} from "@squirrelscan/parser/extractors";
 import { describe, it, expect } from "bun:test";
 import { parseHTML } from "linkedom";
 

--- a/apps/cli/tests/graph/extractors/images.test.ts
+++ b/apps/cli/tests/graph/extractors/images.test.ts
@@ -1,6 +1,6 @@
 // Tests for extractors/images.ts - Image extraction
 
-import { extractImages } from "@squirrelscan/parser/extractors";
+import { extractImages, getImagesWithoutAlt } from "@squirrelscan/parser/extractors";
 import { describe, it, expect } from "bun:test";
 import { parseHTML } from "linkedom";
 
@@ -74,6 +74,42 @@ describe("extractImages", () => {
     expect(images[0].alt).toBeNull();
     expect(images[1].alt).toBe("");
     expect(images[2].alt).toBe("Description");
+  });
+
+  it("reads alt case-insensitively, so ALT= is not an absent attribute", () => {
+    // HTML attribute names are case-insensitive, but linkedom preserves the
+    // source case. Reading only "alt" turned ALT="" into a missing attribute
+    // and made images/alt-text report it (squirrelscan/squirrelscan#143).
+    const doc = parseDoc(`
+      <html>
+        <body>
+          <img src="/upper-empty.png" ALT="">
+          <img src="/upper-described.png" ALT="Description">
+          <img src="/mixed.png" Alt="Mixed">
+        </body>
+      </html>
+    `);
+
+    const images = extractImages(doc, baseUrl);
+    expect(images[0].alt).toBe("");
+    expect(images[1].alt).toBe("Description");
+    expect(images[2].alt).toBe("Mixed");
+  });
+
+  it("getImagesWithoutAlt excludes decorative images", () => {
+    const doc = parseDoc(`
+      <html>
+        <body>
+          <img src="/no-alt.png">
+          <img src="/decorative.png" alt="">
+          <img src="/with-alt.png" alt="Description">
+        </body>
+      </html>
+    `);
+
+    expect(getImagesWithoutAlt(doc, baseUrl).map((i) => i.src)).toEqual([
+      `${baseUrl}/no-alt.png`,
+    ]);
   });
 
   it("detects lazy loaded images with loading attribute", () => {

--- a/apps/cli/tests/rules/alt-text.test.ts
+++ b/apps/cli/tests/rules/alt-text.test.ts
@@ -1,0 +1,125 @@
+// images/alt-text: alt="" is a decorative marker, not a missing attribute
+// (HTML spec, WCAG H67). Only an absent alt attribute is a defect.
+// squirrelscan/squirrelscan#143
+
+import type { CheckResult, RuleContext } from "@squirrelscan/rules";
+
+import { parsePage } from "@squirrelscan/parser";
+import { images } from "@squirrelscan/rules";
+import { describe, expect, test } from "bun:test";
+
+const { altTextRule } = images;
+
+const URL = "https://example.com/";
+
+function makeCtx(body: string): RuleContext {
+  const html = `<!DOCTYPE html><html><head><title>T</title></head><body>${body}</body></html>`;
+  const parsed = parsePage(html, URL);
+  return {
+    page: { url: URL, html, statusCode: 200, loadTime: 0, headers: {}, parsed },
+    parsed,
+    options: {},
+  } as unknown as RuleContext;
+}
+
+function run(body: string): CheckResult[] {
+  return (altTextRule.run(makeCtx(body)) as { checks: CheckResult[] }).checks;
+}
+
+function missing(body: string): CheckResult | undefined {
+  return run(body).find((c) => c.name === "alt-text-missing");
+}
+
+describe("images/alt-text", () => {
+  test('alt="" is not reported as missing', () => {
+    const checks = run(`<img src="/divider.svg" alt="">`);
+
+    expect(checks.find((c) => c.name === "alt-text-missing")).toBeUndefined();
+    expect(checks[0]?.status).toBe("pass");
+  });
+
+  test("an img with no alt attribute is still reported as missing", () => {
+    const c = missing(`<img src="/photo.jpg">`);
+
+    expect(c?.status).toBe("fail");
+    expect(c?.items?.map((i) => i.id)).toEqual([`${URL}photo.jpg`]);
+  });
+
+  test("a page with one decorative and one bare image reports exactly one", () => {
+    const c = missing(`
+      <img src="/divider.svg" alt="">
+      <img src="/photo.jpg">
+    `);
+
+    expect(c?.status).toBe("fail");
+    expect(c?.message).toBe("1 image(s) missing alt text");
+    expect(c?.items?.map((i) => i.id)).toEqual([`${URL}photo.jpg`]);
+  });
+
+  test("descriptive alt passes", () => {
+    const checks = run(`<img src="/photo.jpg" alt="A red barn at dusk">`);
+
+    expect(checks.find((c) => c.name === "alt-text-missing")).toBeUndefined();
+    expect(checks[0]?.message).toBe("All 1 image(s) have alt text");
+  });
+
+  test("a decorative image inside a link that has its own text reports nothing", () => {
+    // The squirrelscan.com case from #143: correct markup that used to fail.
+    const checks = run(
+      `<a href="/agents/claude">Claude Code<img src="/logo.svg" alt="" aria-hidden="true"></a>`
+    );
+
+    expect(checks.find((c) => c.name === "alt-text-missing")).toBeUndefined();
+    expect(checks.every((c) => c.status === "pass")).toBe(true);
+  });
+
+  test('uppercase ALT="" is an empty alt, not an absent one', () => {
+    // HTML attribute names are case-insensitive; linkedom preserves source case.
+    expect(missing(`<img src="/divider.svg" ALT="">`)).toBeUndefined();
+  });
+
+  test("uppercase ALT with a description passes too", () => {
+    expect(missing(`<img src="/photo.jpg" ALT="A red barn">`)).toBeUndefined();
+  });
+
+  test("whitespace-only alt is treated as decorative, not missing", () => {
+    expect(missing(`<img src="/divider.svg" alt="   ">`)).toBeUndefined();
+  });
+
+  test("the pass message distinguishes described from decorative images", () => {
+    const checks = run(`
+      <img src="/photo.jpg" alt="A red barn">
+      <img src="/divider.svg" alt="">
+    `);
+
+    expect(checks[0]?.message).toBe(
+      '1/2 image(s) have alt text, 1 marked decorative (alt="")'
+    );
+  });
+
+  test("a page of only decorative images passes", () => {
+    const checks = run(`
+      <img src="/a.svg" alt="">
+      <img src="/b.svg" alt="">
+    `);
+
+    expect(checks[0]?.status).toBe("pass");
+    expect(checks[0]?.message).toBe(
+      'All 2 image(s) marked decorative (alt="")'
+    );
+  });
+
+  test("no images on the page still passes", () => {
+    const checks = run(`<p>No images here.</p>`);
+
+    expect(checks[0]?.status).toBe("pass");
+    expect(checks[0]?.value).toBe(0);
+  });
+
+  test("the solution text and the behavior agree about empty alt", () => {
+    // The rule recommends alt="" for decorative images; it must not then fail
+    // a page for using it. Guards the contradiction #143 was filed about.
+    expect(altTextRule.meta.solution).toContain('alt=""');
+    expect(missing(`<img src="/divider.svg" alt="">`)).toBeUndefined();
+  });
+});

--- a/docs/rules/images/alt-text.mdx
+++ b/docs/rules/images/alt-text.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Image Alt Text"
-description: "Validates image alt attributes"
+description: "Checks that every image carries an alt attribute, counting an empty alt as a decorative marker"
 ---
 
-Validates image alt attributes
+Checks that every image carries an alt attribute, counting an empty alt as a decorative marker
 
 | | |
 |---|---|
@@ -15,7 +15,25 @@ Validates image alt attributes
 
 ## Solution
 
-Alt text describes images for screen readers and displays when images fail to load. It's essential for accessibility and helps with image search SEO. Add descriptive alt text to all meaningful images. Keep it concise (under 125 characters) but descriptive. For decorative images, use empty alt="" to indicate they should be skipped by screen readers. Avoid keyword stuffing in alt text.
+Alt text describes images for screen readers and displays when images fail to load. It is essential for accessibility and helps with image search SEO. Add descriptive alt text to every image that carries information, keeping it concise (under 125 characters) and free of keyword stuffing. An image that is purely decorative should carry an empty alt attribute (alt="") instead: that is the correct markup for "skip me" and this rule accepts it. Only an image with no alt attribute at all is reported here.
+
+## What counts as missing
+
+| Markup | Reported |
+|---|---|
+| `<img src="photo.jpg" alt="A red barn">` | No |
+| `<img src="divider.svg" alt="">` | No, this is a decorative image |
+| `<img src="photo.jpg">` | Yes, the alt attribute is absent |
+
+A decorative image is one that carries no information the surrounding text does
+not already give: a spacer, a background flourish, or an icon sitting beside a
+label that already names it. Giving such an image invented alt text makes the
+page worse for screen reader users, which is why `alt=""` is the right answer
+and why this rule accepts it.
+
+If an `alt=""` image is the only content of a link, the link itself has no
+accessible name. That is a real defect, and [`a11y/link-text`](/rules/a11y/link-text)
+reports it.
 
 ## Enable / disable
 

--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -308,14 +308,16 @@ export function buildV1Report(
             .pipe(Effect.catchAll(() => Effect.succeed([])));
       if (!hasBatchImageMethod) imageQueryCount++;
 
-      const hasAlt = appearances.some(hasAltAttribute);
-      if (!hasAlt) {
-        for (const appearance of appearances) {
-          summary.missingAltText.push({
-            page: appearance.pageUrl,
-            image: image.src,
-          });
-        }
+      // Per APPEARANCE, not per image URL: the same src can be decorative on
+      // one page and bare on another, and only the bare page is a defect. The
+      // rule and reconstruct.ts both judge per page, so grouping here would
+      // disagree with them (#143).
+      for (const appearance of appearances) {
+        if (hasAltAttribute(appearance)) continue;
+        summary.missingAltText.push({
+          page: appearance.pageUrl,
+          image: image.src,
+        });
       }
     }
     logger.traceEnd(imageAppearancesSpan, {
@@ -658,12 +660,11 @@ export function buildV2Report(
             .getImageAppearances(crawlId, image.src)
             .pipe(Effect.catchAll(() => Effect.succeed([])));
 
-      const hasAlt = appearances.some(hasAltAttribute);
-      if (!hasAlt) {
-        for (const appearance of appearances) {
-          if (summary.missingAltText.length >= maxSummaryItems) break;
-          summary.missingAltText.push({ page: appearance.pageUrl, image: image.src });
-        }
+      // Per APPEARANCE, not per image URL — see the v1 pass above (#143).
+      for (const appearance of appearances) {
+        if (summary.missingAltText.length >= maxSummaryItems) break;
+        if (hasAltAttribute(appearance)) continue;
+        summary.missingAltText.push({ page: appearance.pageUrl, image: image.src });
       }
     }
     logger.traceEnd(imageAppearancesSpan, { images: images.length });

--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -67,6 +67,16 @@ function offSiteSeedRedirect(baseUrl: string, seedUrl: string | undefined): stri
   }
 }
 
+/**
+ * Whether an image appearance carried an alt attribute at all. alt="" is the
+ * correct markup for a decorative image (HTML spec, WCAG H67), so the summary
+ * must not list it as missing alt text — only an absent attribute counts (#143).
+ * Storage maps a SQL NULL to undefined; null is accepted defensively.
+ */
+function hasAltAttribute(appearance: ImageAppearanceRecord): boolean {
+  return appearance.alt !== undefined && appearance.alt !== null;
+}
+
 export function buildRobotsData(robots: RobotsTxtRecord | null): RobotsTxtData | null {
   if (!robots) return null;
 
@@ -298,7 +308,7 @@ export function buildV1Report(
             .pipe(Effect.catchAll(() => Effect.succeed([])));
       if (!hasBatchImageMethod) imageQueryCount++;
 
-      const hasAlt = appearances.some((a) => a.alt && a.alt.trim() !== "");
+      const hasAlt = appearances.some(hasAltAttribute);
       if (!hasAlt) {
         for (const appearance of appearances) {
           summary.missingAltText.push({
@@ -648,7 +658,7 @@ export function buildV2Report(
             .getImageAppearances(crawlId, image.src)
             .pipe(Effect.catchAll(() => Effect.succeed([])));
 
-      const hasAlt = appearances.some((a) => a.alt && a.alt.trim() !== "");
+      const hasAlt = appearances.some(hasAltAttribute);
       if (!hasAlt) {
         for (const appearance of appearances) {
           if (summary.missingAltText.length >= maxSummaryItems) break;

--- a/packages/audit-engine/tests/missing-alt-summary.test.ts
+++ b/packages/audit-engine/tests/missing-alt-summary.test.ts
@@ -1,0 +1,131 @@
+// summary.missingAltText is judged per APPEARANCE, not per image URL.
+//
+// alt="" is decorative markup, not a missing attribute (HTML spec, WCAG H67),
+// so the same src can be correct on one page and a real defect on another. The
+// rule and reconstruct.ts both decide per page; grouping by src in the report
+// assembly made a single decorative appearance excuse every bare one.
+// squirrelscan/squirrelscan#143
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+
+import { generateReportFromStorage } from "../src/adapter";
+import {
+  buildV2Report,
+  emptyRuleExecutionResult,
+  type StreamingReportInput,
+} from "../src/report-stream";
+
+const EMPTY_STATS = {
+  pagesTotal: 0,
+  pagesFetched: 0,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+function streamingInput(): StreamingReportInput {
+  return { ...emptyRuleExecutionResult(), tallies: new Map() };
+}
+
+/** One src, one appearance per entry. `alt: undefined` = no alt attribute. */
+type Appearance = { pageUrl: string; alt?: string };
+
+async function summariesFor(images: Record<string, Appearance[]>) {
+  const storage = new SQLiteStorage(":memory:");
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* storage.init();
+      const crawlId = yield* storage.createCrawl({
+        baseUrl: "https://example.com",
+        originalUrl: "https://example.com",
+        startedAt: Date.now(),
+        status: "completed",
+        config: {} as never,
+        stats: EMPTY_STATS,
+      });
+
+      for (const [src, appearances] of Object.entries(images)) {
+        yield* storage.upsertImage(crawlId, { src });
+        for (const appearance of appearances) {
+          yield* storage.addImageAppearance(crawlId, {
+            src,
+            pageUrl: appearance.pageUrl,
+            ...(appearance.alt === undefined ? {} : { alt: appearance.alt }),
+            isLazyLoaded: false,
+            inFigure: false,
+          });
+        }
+      }
+
+      const v1 = yield* generateReportFromStorage(storage, crawlId, emptyRuleExecutionResult());
+      const v2 = yield* buildV2Report(storage, crawlId, streamingInput());
+      return {
+        v1: v1.summary.missingAltText,
+        v2: v2.summary.missingAltText,
+      };
+    }),
+  );
+}
+
+describe("summary.missingAltText", () => {
+  test("reports the bare page of a src that is decorative elsewhere", async () => {
+    // The regression: /logo.svg carries alt="" on page A and no alt on page B.
+    // Grouping by src let page A's correct markup hide page B's defect.
+    const { v1, v2 } = await summariesFor({
+      "https://example.com/logo.svg": [
+        { pageUrl: "https://example.com/a", alt: "" },
+        { pageUrl: "https://example.com/b" },
+      ],
+    });
+
+    for (const missing of [v1, v2]) {
+      expect(missing).toEqual([
+        { page: "https://example.com/b", image: "https://example.com/logo.svg" },
+      ]);
+    }
+  });
+
+  test("a src that is decorative everywhere is never reported", async () => {
+    const { v1, v2 } = await summariesFor({
+      "https://example.com/divider.svg": [
+        { pageUrl: "https://example.com/a", alt: "" },
+        { pageUrl: "https://example.com/b", alt: "" },
+      ],
+    });
+
+    expect(v1).toEqual([]);
+    expect(v2).toEqual([]);
+  });
+
+  test("a src with no alt attribute anywhere is reported on every page", async () => {
+    const { v1, v2 } = await summariesFor({
+      "https://example.com/photo.jpg": [
+        { pageUrl: "https://example.com/a" },
+        { pageUrl: "https://example.com/b" },
+      ],
+    });
+
+    for (const missing of [v1, v2]) {
+      expect(missing).toEqual([
+        { page: "https://example.com/a", image: "https://example.com/photo.jpg" },
+        { page: "https://example.com/b", image: "https://example.com/photo.jpg" },
+      ]);
+    }
+  });
+
+  test("a described src is never reported", async () => {
+    const { v1, v2 } = await summariesFor({
+      "https://example.com/barn.jpg": [{ pageUrl: "https://example.com/a", alt: "A red barn" }],
+    });
+
+    expect(v1).toEqual([]);
+    expect(v2).toEqual([]);
+  });
+});

--- a/packages/parser/src/extractors/images.ts
+++ b/packages/parser/src/extractors/images.ts
@@ -5,6 +5,8 @@ import type { Document, Element } from "linkedom";
 
 import { Effect } from "effect";
 
+import { getAttrCI } from "@squirrelscan/utils";
+
 import type { ExtractedImage } from "./types";
 
 /**
@@ -99,7 +101,10 @@ export function extractImages(
 
     images.push({
       src,
-      alt: element.getAttribute("alt"),
+      // Case-insensitive: HTML attribute names are, but linkedom keeps the
+      // source case, so getAttribute("alt") misses ALT="" and reads it as an
+      // absent attribute (#143).
+      alt: getAttrCI(element, "alt"),
       width: element.getAttribute("width"),
       height: element.getAttribute("height"),
       isLazyLoaded: isLazyLoaded(element),
@@ -148,15 +153,14 @@ export function getUniqueImageUrls(doc: Document, baseUrl: string): string[] {
 }
 
 /**
- * Get images missing alt text
+ * Get images with no alt attribute at all. alt="" is excluded: it is the
+ * correct markup for a decorative image, not a missing attribute (#143).
  */
 export function getImagesWithoutAlt(
   doc: Document,
   baseUrl: string
 ): ExtractedImage[] {
-  return extractImages(doc, baseUrl).filter(
-    (img) => img.alt === null || img.alt === ""
-  );
+  return extractImages(doc, baseUrl).filter((img) => img.alt === null);
 }
 
 /**

--- a/packages/parser/src/html.ts
+++ b/packages/parser/src/html.ts
@@ -4,7 +4,7 @@
 
 import { clampItemString } from "@squirrelscan/core-contracts/clamp";
 import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
-import { coerceSchemelessUrl, shouldSkipUrl } from "@squirrelscan/utils";
+import { coerceSchemelessUrl, getAttrCI, shouldSkipUrl } from "@squirrelscan/utils";
 import { parseHTML, type Document, type Element } from "linkedom";
 
 import type {
@@ -203,7 +203,10 @@ export function extractImages(doc: Document, baseUrl: string): ImageData[] {
       const absoluteSrc = new URL(src, baseUrl).toString();
       images.push({
         src: absoluteSrc,
-        alt: (img as Element).getAttribute("alt"),
+        // Case-insensitive: HTML attribute names are, but linkedom keeps the
+        // source case, so getAttribute("alt") misses ALT="" and reads it as an
+        // absent attribute (#143).
+        alt: getAttrCI(img as Element, "alt"),
         width: (img as Element).getAttribute("width"),
         height: (img as Element).getAttribute("height"),
       });

--- a/packages/rules/src/images/alt-text.ts
+++ b/packages/rules/src/images/alt-text.ts
@@ -1,4 +1,5 @@
-// images/alt-text - Validates image alt text
+// images/alt-text - Reports images with no alt attribute. alt="" is decorative
+// markup (HTML spec, WCAG H67), not a missing attribute (#143).
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
@@ -6,9 +7,10 @@ export const altTextRule: Rule = {
   meta: {
     id: "images/alt-text",
     name: "Image Alt Text",
-    description: "Validates image alt attributes",
+    description:
+      "Checks that every image carries an alt attribute, counting an empty alt as a decorative marker",
     solution:
-      'Alt text describes images for screen readers and displays when images fail to load. It\'s essential for accessibility and helps with image search SEO. Add descriptive alt text to all meaningful images. Keep it concise (under 125 characters) but descriptive. For decorative images, use empty alt="" to indicate they should be skipped by screen readers. Avoid keyword stuffing in alt text.',
+      'Alt text describes images for screen readers and displays when images fail to load. It is essential for accessibility and helps with image search SEO. Add descriptive alt text to every image that carries information, keeping it concise (under 125 characters) and free of keyword stuffing. An image that is purely decorative should carry an empty alt attribute (alt="") instead: that is the correct markup for "skip me" and this rule accepts it. Only an image with no alt attribute at all is reported here.',
     category: "images",
     scope: "page",
     severity: "warning",
@@ -29,9 +31,11 @@ export const altTextRule: Rule = {
       return { checks };
     }
 
-    const missingAlt = images.filter(
-      (img) => img.alt === null || img.alt.trim() === ""
-    );
+    // An absent alt attribute is the defect. alt="" is the spec-endorsed way to
+    // mark a decorative image (HTML spec, WCAG H67) — a positive "skip me", not
+    // a missing attribute — so it passes, or the rule would fail pages for doing
+    // exactly what its own solution text asks for (#143).
+    const missingAlt = images.filter((img) => img.alt === null);
 
     if (missingAlt.length > 0) {
       checks.push({
@@ -40,20 +44,30 @@ export const altTextRule: Rule = {
         message: `${missingAlt.length} image(s) missing alt text`,
         items: missingAlt.map((img) => ({ id: img.src })),
       });
+      return { checks };
     }
 
-    const withAlt = images.filter((img) => img.alt && img.alt.length > 0);
-    if (withAlt.length === images.length) {
+    // Whitespace-only alt is a sloppy spelling of alt="", not a description.
+    const decorative = images.filter((img) => img.alt !== null && img.alt.trim() === "");
+    const describedCount = images.length - decorative.length;
+
+    if (decorative.length === 0) {
       checks.push({
         name: "alt-text",
         status: "pass",
         message: `All ${images.length} image(s) have alt text`,
       });
-    } else if (missingAlt.length === 0) {
+    } else if (describedCount === 0) {
       checks.push({
         name: "alt-text",
         status: "pass",
-        message: `${withAlt.length}/${images.length} images have alt text`,
+        message: `All ${images.length} image(s) marked decorative (alt="")`,
+      });
+    } else {
+      checks.push({
+        name: "alt-text",
+        status: "pass",
+        message: `${describedCount}/${images.length} image(s) have alt text, ${decorative.length} marked decorative (alt="")`,
       });
     }
 

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -11,6 +11,12 @@
  */
 export function getAttrCI(el: Element, name: string): string | null {
   const lower = name.toLowerCase();
+  // Deliberately NOT short-circuiting on getAttribute(lower) first: linkedom
+  // keeps BOTH spellings of a case-variant duplicate (<img ALT="a" alt="b">
+  // yields two attributes), so an exact-match fast path would return the last
+  // one where this scan returns the first — and the first is what a browser
+  // keeps, since its parser drops the duplicate. A hash lookup is not worth
+  // disagreeing with browsers on malformed markup.
   for (const attr of el.attributes) {
     if (attr.name.toLowerCase() === lower) return attr.value;
   }


### PR DESCRIPTION
`images/alt-text` treated an empty `alt` attribute exactly like an absent one:

```ts
const missingAlt = images.filter((img) => img.alt === null || img.alt.trim() === "");
```

while the same rule's `solution` string told authors to use `alt=""` for decorative
images. The rule failed pages for doing what it asked, and printed that instruction as
the remediation.

`alt=""` is not a missing alt attribute. Per the HTML spec and WCAG technique
[H67](https://www.w3.org/WAI/WCAG22/Techniques/html/H67), it is a positive assertion
that the image carries no information and should be skipped by assistive technology.
Conflating it with an absent attribute pushed authors toward inventing alt text for
images that should be silent, which makes the page worse for screen reader users, and
buried genuinely missing attributes in the same bucket as correct markup.

## What changed

**The rule.** `images/alt-text` now reports only images whose `alt` attribute is
absent. An empty (or whitespace-only) `alt` passes and is counted separately, so the
pass message says `1/2 image(s) have alt text, 1 marked decorative (alt="")` rather
than silently folding the two together. The `description` and `solution` text were
rewritten to match the behavior.

**The parser.** HTML attribute names are case-insensitive, but linkedom preserves the
source case, so `getAttribute("alt")` returned `null` for `ALT=""` and the rule read it
as an absent attribute. Both image extractors now use the existing `getAttrCI` helper.
This also fixes `ALT="A red barn"`, which was reported as missing alt text despite
carrying a description.

**The report summary.** `summary.missingAltText` (the `N images missing alt text` list
in CLI and cloud reports) applied the same conflation in `report-stream.ts` and
`reconstruct.ts`. Both now count only an absent attribute, so the rule and the summary
agree.

`packages/parser`'s `getImagesWithoutAlt` helper had the same filter and was corrected
for consistency; it currently has no callers.

## What did not change

The issue suggests an optional info-level note for an `alt=""` image that is the only
content of a link with no other accessible name. This PR leaves that out, on the
issue's own reasoning: `a11y/link-text` already reports a link with no accessible
name, and adding a second rule for the same defect would trade one false positive for
a duplicate finding. The docs page now points at `a11y/link-text` for that case.

## Verification

- `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
- `bun test` — full CLI suite
- `bun run test:engine` — golden tests, 58 pass / 0 fail. Golden output is unchanged:
  the synthetic fixture the baseline is built from contains no `<img>` elements at all
  (`imagesTotal: 0`), so `images/alt-text` returns its unchanged "No images on page"
  pass for every page in it.
- `bun run docs:check` and `bun run docs:build`

New tests in `apps/cli/tests/rules/alt-text.test.ts` cover each acceptance criterion:
`alt=""` is not reported, a bare `<img>` still is, a fixture with one of each reports
exactly one, `<img alt="" aria-hidden="true">` inside a link with its own text reports
nothing, uppercase `ALT=""`, whitespace-only alt, and a guard that the solution text
and the behavior agree. `apps/cli/tests/graph/extractors/images.test.ts` covers the
case-insensitive attribute read.

Note for maintainers: `docs/rules/images/alt-text.mdx` looks generated from rule meta.
The title, description, and solution here match the new meta exactly, but the added
"What counts as missing" section would be lost by a regeneration.

Closes #143
