### PR TITLE
fix(rules): count comments with a string-aware scanner #142

### DIFF
--- a/docs/rules/perf/unminified-js.mdx
+++ b/docs/rules/perf/unminified-js.mdx
@@ -17,7 +17,9 @@ Detects unminified JavaScript that could be optimized
 
 Unminified JavaScript, based on newline ratio, comment volume, identifier length, indentation, and whitespace. Preserved `/*! ... */` and `//!` license banners (the standard "keep on minify" convention used by Terser, esbuild, Vite, and Webpack) are stripped before analysis, so a fully minified bundle that legitimately retains license comments is not flagged.
 
-Comment counting is string aware. The `//` in a URL such as `"https://example.com"`, and comment openers inside template literals and regular expressions, are not counted as comments, so a minified bundle that ships URLs is not reported as unminified with an inflated savings estimate.
+Comment counting is string aware. The `//` in a URL such as `"https://example.com"`, and comment openers inside single-quoted, double-quoted and template literals, are not counted as comments, so a minified bundle that ships URLs is not reported as unminified with an inflated savings estimate.
+
+Regular expression literals are recognised heuristically rather than parsed. A `/` is read as the start of a regex after an operator, after a keyword such as `return` or `typeof`, and after the `)` of an `if`, `while` or `for` head. In rarer positions, such as directly after another `)` or `]`, it is read as division instead, and the regex body is scanned as ordinary code. A regex used directly as the left operand of `/` or `*`, as in `/a/*2`, is also read as division, since dividing or multiplying by a regular expression is not something real code does. Both cases are rare, and neither affects whether ordinary minified output is flagged. Shebang lines (`#!`) and Annex B `<!--` comments are not counted.
 
 ## Solution
 

--- a/docs/rules/perf/unminified-js.mdx
+++ b/docs/rules/perf/unminified-js.mdx
@@ -17,6 +17,8 @@ Detects unminified JavaScript that could be optimized
 
 Unminified JavaScript, based on newline ratio, comment volume, identifier length, indentation, and whitespace. Preserved `/*! ... */` and `//!` license banners (the standard "keep on minify" convention used by Terser, esbuild, Vite, and Webpack) are stripped before analysis, so a fully minified bundle that legitimately retains license comments is not flagged.
 
+Comment counting is string aware. The `//` in a URL such as `"https://example.com"`, and comment openers inside template literals and regular expressions, are not counted as comments, so a minified bundle that ships URLs is not reported as unminified with an inflated savings estimate.
+
 ## Solution
 
 Minify JavaScript to reduce file size and improve load times. Use build tools like Terser, esbuild, or UglifyJS. Most bundlers (Webpack, Vite, Rollup) minify automatically in production. Minification shortens variable names, removes whitespace, and dead code.

--- a/packages/rules/src/performance/unminified-css.ts
+++ b/packages/rules/src/performance/unminified-css.ts
@@ -3,6 +3,7 @@
 
 import { z } from "zod";
 
+import { scanCssComments } from "../shared/comment-scan";
 import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
 
 export const optionsSchema = z.object({
@@ -48,12 +49,12 @@ function analyzeCss(css: string): {
     potentialSavings += newlines; // Each newline could be removed
   }
 
-  // Count comments
-  const comments = css.match(/\/\*[\s\S]*?\*\//g) || [];
-  const commentBytes = comments.reduce((sum, c) => sum + c.length, 0);
-  if (comments.length > COMMENT_COUNT_THRESHOLD) {
-    issues.push(`${comments.length} comments`);
-    potentialSavings += commentBytes;
+  // Count comments. #142: string-aware, so a `/*` inside `content: "..."` or a
+  // data URI does not open a comment that swallows to the next `*/`.
+  const comments = scanCssComments(css);
+  if (comments.blockComments > COMMENT_COUNT_THRESHOLD) {
+    issues.push(`${comments.blockComments} comments`);
+    potentialSavings += comments.commentBytes;
   }
 
   // Count whitespace

--- a/packages/rules/src/performance/unminified-js.ts
+++ b/packages/rules/src/performance/unminified-js.ts
@@ -3,6 +3,7 @@
 
 import { z } from "zod";
 
+import { scanJsComments } from "../shared/comment-scan";
 import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
 
 export const optionsSchema = z.object({
@@ -62,17 +63,14 @@ function analyzeJs(rawJs: string): {
     potentialSavings += newlines;
   }
 
-  // Count comments
-  const singleLineComments = js.match(/\/\/[^\n]*/g) || [];
-  const multiLineComments = js.match(/\/\*[\s\S]*?\*\//g) || [];
-  const totalCommentCount = singleLineComments.length + multiLineComments.length;
-  const commentBytes =
-    singleLineComments.reduce((sum, c) => sum + c.length, 0) +
-    multiLineComments.reduce((sum, c) => sum + c.length, 0);
+  // Count comments. #142: string-aware, because a plain /\/\/[^\n]*/ match counts
+  // every `"https://..."` in the bundle as a comment running to end of line.
+  const comments = scanJsComments(js);
+  const totalCommentCount = comments.lineComments + comments.blockComments;
 
   if (totalCommentCount > COMMENT_COUNT_THRESHOLD) {
     issues.push(`${totalCommentCount} comments`);
-    potentialSavings += commentBytes;
+    potentialSavings += comments.commentBytes;
   }
 
   // Check for readable variable names (minified typically has single-char vars)

--- a/packages/rules/src/shared/comment-scan.ts
+++ b/packages/rules/src/shared/comment-scan.ts
@@ -17,11 +17,6 @@ export interface CommentScan {
 }
 
 // A `/` after one of these keywords opens a regex literal rather than dividing.
-// After an identifier, a literal, `)` or `]` it is treated as division, which is
-// the conservative choice: mistaking a regex for division at worst scans its
-// body as code, while mistaking division for a regex swallows real comments.
-// `if(x)/re/.test(y)` is therefore read as division; that is legal JavaScript but
-// rare enough not to be worth a backwards paren match.
 const REGEX_KEYWORDS = new Set([
   "await",
   "case",
@@ -57,6 +52,24 @@ function isSchemeChar(ch: string): boolean {
   return isIdentPart(ch) || ch === "+" || ch === "-" || ch === ".";
 }
 
+/**
+ * A URL authority starts right after `//`. Testing for a host character rather
+ * than for "not whitespace" avoids depending on an ASCII-only whitespace test,
+ * so `http:// text` is still read as a comment.
+ */
+function isUrlHostStart(ch: string | undefined): boolean {
+  if (ch === undefined) return false;
+  return (
+    (ch >= "a" && ch <= "z") ||
+    (ch >= "A" && ch <= "Z") ||
+    (ch >= "0" && ch <= "9") ||
+    ch === "-" ||
+    ch === "_" ||
+    ch === "[" ||
+    ch === "%"
+  );
+}
+
 // Only these make the `x://` guard fire, so a JS label really named `foo` still
 // gets its `foo:// comment` counted.
 const URL_SCHEMES = new Set(["blob", "data", "file", "ftp", "http", "https", "ws", "wss"]);
@@ -69,17 +82,46 @@ function endsUrlScheme(src: string, colon: number): boolean {
   return URL_SCHEMES.has(src.slice(start + 1, colon).toLowerCase());
 }
 
-function regexCanStartAfter(src: string, lastCode: number): boolean {
+// A `)` closing one of these heads is followed by a statement, so a `/` there
+// opens a regex (`if(ok)/re/.test(s)`). After any other `)` the `/` divides.
+const CONTROL_FLOW_HEADS = new Set(["catch", "for", "if", "while", "with"]);
+// Caps the memory the open-paren stack can be made to hold. Far beyond any real
+// nesting depth, so reaching it means the input is not ordinary JavaScript.
+const PAREN_STACK_LIMIT = 4096;
+
+/** True when the `(` at `open` is the one belonging to an `if`/`while`/`for` head. */
+function opensControlFlowHead(src: string, open: number): boolean {
+  let end = open - 1;
+  while (end >= 0 && isWhitespace(src[end] as string)) end--;
+  let start = end;
+  while (start >= 0 && isIdentPart(src[start] as string)) start--;
+  return CONTROL_FLOW_HEADS.has(src.slice(start + 1, end + 1));
+}
+
+/**
+ * @param controlFlowClose index of the most recent `)` that closed a control
+ * flow head, or -1. Matched forward by the scanner, so parens inside strings,
+ * comments and regex literals never enter the count.
+ */
+function regexCanStartAfter(src: string, lastCode: number, controlFlowClose: number): boolean {
   if (lastCode < 0) return true;
   const ch = src[lastCode] as string;
-  if (ch === ")" || ch === "]" || ch === '"' || ch === "'" || ch === "`") return false;
+  if (ch === '"' || ch === "'" || ch === "`" || ch === "]") return false;
+  // `/` here is the closing delimiter of a regex literal with no flags, or a
+  // division sign; either way the operand is complete, so this `/` divides.
+  if (ch === "/") return false;
+  // `x++ / n` and `x-- / n` divide. A single `+` or `-` is a sign, not a suffix.
+  if ((ch === "+" || ch === "-") && src[lastCode - 1] === ch) return false;
+  if (ch === ")") return lastCode === controlFlowClose;
   if (isIdentPart(ch)) {
     let start = lastCode;
     while (start >= 0 && isIdentPart(src[start] as string)) start--;
     return REGEX_KEYWORDS.has(src.slice(start + 1, lastCode + 1));
   }
   // `}` closes a block far more often than it closes an object literal being
-  // divided, so a `/` after it is read as a regex at statement position.
+  // divided, so a `/` after it is read as a regex at statement position. When
+  // that guess is wrong, skipRegex refuses to close a regex on a comment
+  // opener, so the comment behind it is still counted.
   return true;
 }
 
@@ -119,6 +161,12 @@ function skipRegex(src: string, start: number): number {
     } else if (ch === "[") {
       inClass = true;
     } else if (ch === "/") {
+      // A regex whose closing delimiter is immediately followed by `/` or `*`
+      // would be a regex being divided or multiplied, which is never real code.
+      // `i++ / n // real` is division followed by a comment, so refusing here
+      // keeps the comment countable instead of swallowing it as a regex body.
+      const after = src[i + 1];
+      if (after === "/" || after === "*") return -1;
       return i + 1;
     }
     i++;
@@ -146,6 +194,15 @@ export function scanJsComments(src: string): CommentScan {
   // quadratic on a multi-MB bundle. If nothing could close a regex opened at i,
   // treat the rest of that line as division rather than probing again.
   let noRegexBefore = -1;
+  // Open `(` positions, pushed only in code context, and the index of the most
+  // recent `)` that closed a control flow head. Matching parens forward keeps
+  // this O(1) per paren; walking backwards from each `)` was quadratic. Script
+  // bodies come from crawled pages, so the stack is capped: 5MB of `(` grew RSS
+  // by 131MB unbounded. Past the cap only the depth is tracked, which can lose
+  // one control flow head far past any real nesting.
+  const parens: number[] = [];
+  let parenOverflow = 0;
+  let controlFlowClose = -1;
   let i = 0;
 
   while (i < src.length) {
@@ -181,8 +238,14 @@ export function scanJsComments(src: string): CommentScan {
       if (next === "/") {
         // Backstop for a URL that reached code context anyway, e.g. inside a
         // regex this scanner read as division. A real comment never abuts the
-        // colon of a URL scheme.
-        if (i > 0 && src[i - 1] === ":" && endsUrlScheme(src, i - 1)) {
+        // colon of a URL scheme, and a URL always has a host right after the
+        // slashes, so `http:// text` stays a comment on a label named `http`.
+        if (
+          i > 0 &&
+          src[i - 1] === ":" &&
+          isUrlHostStart(src[i + 2]) &&
+          endsUrlScheme(src, i - 1)
+        ) {
           lastCode = i + 1;
           i += 2;
           continue;
@@ -206,7 +269,7 @@ export function scanJsComments(src: string): CommentScan {
         i = close + 2;
         continue;
       }
-      if (i >= noRegexBefore && regexCanStartAfter(src, lastCode)) {
+      if (i >= noRegexBefore && regexCanStartAfter(src, lastCode, controlFlowClose)) {
         const end = skipRegex(src, i);
         if (end !== -1) {
           lastCode = end - 1;
@@ -231,6 +294,26 @@ export function scanJsComments(src: string): CommentScan {
     if (ch === "`") {
       frames.push({ mode: "code", braceDepth });
       mode = "template";
+      i++;
+      continue;
+    }
+
+    if (ch === "(") {
+      if (parens.length < PAREN_STACK_LIMIT) parens.push(i);
+      else parenOverflow++;
+      lastCode = i;
+      i++;
+      continue;
+    }
+
+    if (ch === ")") {
+      if (parenOverflow > 0) {
+        parenOverflow--;
+      } else {
+        const open = parens.pop();
+        if (open !== undefined && opensControlFlowHead(src, open)) controlFlowClose = i;
+      }
+      lastCode = i;
       i++;
       continue;
     }

--- a/packages/rules/src/shared/comment-scan.ts
+++ b/packages/rules/src/shared/comment-scan.ts
@@ -407,7 +407,12 @@ export function scanJsComments(src: string): CommentScan {
         ident.prevIsProperty = ident.isProperty;
         ident.prevAdjacent = ident.end >= 0 && lastCode + 1 === ident.end;
         ident.start = i;
-        ident.isProperty = lastCode >= 0 && src[lastCode] === ".";
+        // `.` makes it a member name. `#` makes it a private name, which only
+        // ever appears as `this.#x`, `#x in o` or a `#x = 1` field. Neither
+        // form can be a keyword, and testing `#` on its own also covers
+        // `this. #x`, where a space sits between the dot and the hash.
+        const prev = lastCode >= 0 ? src[lastCode] : "";
+        ident.isProperty = prev === "." || prev === "#";
       }
       lastCode = i;
       ident.end = i + 1;

--- a/packages/rules/src/shared/comment-scan.ts
+++ b/packages/rules/src/shared/comment-scan.ts
@@ -69,7 +69,7 @@ function isSchemeChar(ch: string): boolean {
 /**
  * A URL authority starts right after `//`. Testing for a host character rather
  * than for "not whitespace" avoids depending on an ASCII-only whitespace test,
- * so `http:// text` is still read as a comment.
+ * so `http://<NBSP>text` is still read as a comment.
  */
 function isUrlHostStart(ch: string | undefined): boolean {
   if (ch === undefined) return false;
@@ -104,18 +104,51 @@ const CONTROL_FLOW_HEADS = new Set(["catch", "for", "if", "while", "with"]);
 const PAREN_STACK_LIMIT = 4096;
 
 /**
- * The identifier token ending at `identEnd`, but only when it is still the most
- * recent significant token, i.e. nothing but whitespace and comments has been
- * consumed since. Reading this from the scanner's own token state rather than
- * walking backwards over raw source is what lets `if /*c*\/ (x)` and
- * `if (x)` be recognised: the scanner has already stepped over the comment,
- * and every flavour of whitespace is skipped in one place.
+ * The last two identifier tokens seen in code context. Keeping this as the
+ * scanner walks forward is what lets a comment or any flavour of whitespace sit
+ * between a keyword and what follows it: the scanner has already stepped over
+ * both, so nothing ever re-reads raw source behind the cursor.
  */
-function precedingIdent(src: string, lastCode: number, identEnd: number): string {
-  if (identEnd < 0 || lastCode + 1 !== identEnd) return "";
-  let start = identEnd - 1;
-  while (start >= 0 && isIdentPart(src[start] as string)) start--;
-  return src.slice(start + 1, identEnd);
+interface IdentState {
+  /** Bounds of the most recent identifier token, or -1 when there is none. */
+  start: number;
+  end: number;
+  /** The token is a property name (`obj.if`), so it is never a keyword. */
+  isProperty: boolean;
+  /** The same, for the identifier before it. */
+  prevStart: number;
+  prevEnd: number;
+  prevIsProperty: boolean;
+  /** Only whitespace and comments separated those two identifiers. */
+  prevAdjacent: boolean;
+}
+
+function newIdentState(): IdentState {
+  return {
+    start: -1,
+    end: -1,
+    isProperty: false,
+    prevStart: -1,
+    prevEnd: -1,
+    prevIsProperty: false,
+    prevAdjacent: false,
+  };
+}
+
+/** The keyword immediately before the cursor, or "" when there is not one. */
+function precedingKeyword(src: string, lastCode: number, ident: IdentState): string {
+  if (ident.isProperty || ident.end < 0 || lastCode + 1 !== ident.end) return "";
+  return src.slice(ident.start, ident.end);
+}
+
+/** True when the `(` about to be pushed opens an `if`/`while`/`for`/`for await` head. */
+function opensControlFlowHead(src: string, lastCode: number, ident: IdentState): boolean {
+  const word = precedingKeyword(src, lastCode, ident);
+  if (CONTROL_FLOW_HEADS.has(word)) return true;
+  // `for await (` puts the head keyword one token further back. Plain `await (`
+  // is grouping, so only a preceding `for` promotes it.
+  if (word !== "await" || !ident.prevAdjacent || ident.prevIsProperty) return false;
+  return src.slice(ident.prevStart, ident.prevEnd) === "for";
 }
 
 /**
@@ -123,7 +156,12 @@ function precedingIdent(src: string, lastCode: number, identEnd: number): string
  * flow head, or -1. Matched forward by the scanner, so parens inside strings,
  * comments and regex literals never enter the count.
  */
-function regexCanStartAfter(src: string, lastCode: number, controlFlowClose: number): boolean {
+function regexCanStartAfter(
+  src: string,
+  lastCode: number,
+  controlFlowClose: number,
+  ident: IdentState,
+): boolean {
   if (lastCode < 0) return true;
   const ch = src[lastCode] as string;
   if (ch === '"' || ch === "'" || ch === "`" || ch === "]") return false;
@@ -133,11 +171,8 @@ function regexCanStartAfter(src: string, lastCode: number, controlFlowClose: num
   // `x++ / n` and `x-- / n` divide. A single `+` or `-` is a sign, not a suffix.
   if ((ch === "+" || ch === "-") && src[lastCode - 1] === ch) return false;
   if (ch === ")") return lastCode === controlFlowClose;
-  if (isIdentPart(ch)) {
-    let start = lastCode;
-    while (start >= 0 && isIdentPart(src[start] as string)) start--;
-    return REGEX_KEYWORDS.has(src.slice(start + 1, lastCode + 1));
-  }
+  // A property name is never a keyword, so `obj.return /re/` divides.
+  if (isIdentPart(ch)) return REGEX_KEYWORDS.has(precedingKeyword(src, lastCode, ident));
   // `}` closes a block far more often than it closes an object literal being
   // divided, so a `/` after it is read as a regex at statement position. When
   // that guess is wrong, skipRegex refuses to close a regex on a comment
@@ -210,7 +245,7 @@ export function scanJsComments(src: string): CommentScan {
   // transparent, so they never update it.
   let lastCode = -1;
   // A failed regex probe scans to end of line. Without remembering the failure,
-  // a line such as `x=/\/\/\/…` re-probes at every slash and the scan goes
+  // a line such as `x=/\/\/\/...` re-probes at every slash and the scan goes
   // quadratic on a multi-MB bundle. If nothing could close a regex opened at i,
   // treat the rest of that line as division rather than probing again.
   let noRegexBefore = -1;
@@ -225,8 +260,7 @@ export function scanJsComments(src: string): CommentScan {
   const parens: boolean[] = [];
   let parenOverflow = 0;
   let controlFlowClose = -1;
-  // Index just past the most recent identifier token consumed in code context.
-  let identEnd = -1;
+  const ident = newIdentState();
   let i = 0;
 
   while (i < src.length) {
@@ -293,7 +327,7 @@ export function scanJsComments(src: string): CommentScan {
         i = close + 2;
         continue;
       }
-      if (i >= noRegexBefore && regexCanStartAfter(src, lastCode, controlFlowClose)) {
+      if (i >= noRegexBefore && regexCanStartAfter(src, lastCode, controlFlowClose, ident)) {
         const end = skipRegex(src, i);
         if (end !== -1) {
           lastCode = end - 1;
@@ -323,7 +357,7 @@ export function scanJsComments(src: string): CommentScan {
     }
 
     if (ch === "(") {
-      const head = CONTROL_FLOW_HEADS.has(precedingIdent(src, lastCode, identEnd));
+      const head = opensControlFlowHead(src, lastCode, ident);
       if (parens.length < PAREN_STACK_LIMIT) parens.push(head);
       else parenOverflow++;
       lastCode = i;
@@ -365,8 +399,18 @@ export function scanJsComments(src: string): CommentScan {
     }
 
     if (isIdentPart(ch)) {
+      // `ident.end !== i` means this character opens a new identifier token
+      // rather than continuing the one already being consumed.
+      if (ident.end !== i) {
+        ident.prevStart = ident.start;
+        ident.prevEnd = ident.end;
+        ident.prevIsProperty = ident.isProperty;
+        ident.prevAdjacent = ident.end >= 0 && lastCode + 1 === ident.end;
+        ident.start = i;
+        ident.isProperty = lastCode >= 0 && src[lastCode] === ".";
+      }
       lastCode = i;
-      identEnd = i + 1;
+      ident.end = i + 1;
     } else if (!isWhitespace(ch)) {
       lastCode = i;
     }

--- a/packages/rules/src/shared/comment-scan.ts
+++ b/packages/rules/src/shared/comment-scan.ts
@@ -1,0 +1,296 @@
+// shared/comment-scan - string-aware comment counting for the minification heuristics
+//
+// #142: `js.match(/\/\/[^\n]*/g)` has no notion of string context, so every
+// `"https://..."` in a bundle scored as a line comment running to the end of the
+// line. In a minified bundle "the end of the line" is most of the file, so a
+// handful of URLs produced both a bogus "27 comments" reason and a
+// potentialSavingsBytes figure close to the whole bundle size. Counting comments
+// needs an actual scanner, not a regex.
+
+export interface CommentScan {
+  /** `//` comments found outside strings, templates, regex literals and comments. */
+  lineComments: number;
+  /** Terminated block comments found outside strings and templates. */
+  blockComments: number;
+  /** Bytes spanned by every counted comment, delimiters included. */
+  commentBytes: number;
+}
+
+// A `/` after one of these keywords opens a regex literal rather than dividing.
+// After an identifier, a literal, `)` or `]` it is treated as division, which is
+// the conservative choice: mistaking a regex for division at worst scans its
+// body as code, while mistaking division for a regex swallows real comments.
+// `if(x)/re/.test(y)` is therefore read as division; that is legal JavaScript but
+// rare enough not to be worth a backwards paren match.
+const REGEX_KEYWORDS = new Set([
+  "await",
+  "case",
+  "delete",
+  "do",
+  "else",
+  "in",
+  "instanceof",
+  "new",
+  "of",
+  "return",
+  "throw",
+  "typeof",
+  "void",
+  "yield",
+]);
+
+function isIdentPart(ch: string): boolean {
+  return (
+    (ch >= "a" && ch <= "z") ||
+    (ch >= "A" && ch <= "Z") ||
+    (ch >= "0" && ch <= "9") ||
+    ch === "_" ||
+    ch === "$"
+  );
+}
+
+function isWhitespace(ch: string): boolean {
+  return ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "\f" || ch === "\v";
+}
+
+function isSchemeChar(ch: string): boolean {
+  return isIdentPart(ch) || ch === "+" || ch === "-" || ch === ".";
+}
+
+// Only these make the `x://` guard fire, so a JS label really named `foo` still
+// gets its `foo:// comment` counted.
+const URL_SCHEMES = new Set(["blob", "data", "file", "ftp", "http", "https", "ws", "wss"]);
+
+/** True when `colon` closes a URL scheme, i.e. the `//` after it is part of a URL. */
+function endsUrlScheme(src: string, colon: number): boolean {
+  let start = colon - 1;
+  while (start >= 0 && isSchemeChar(src[start] as string)) start--;
+  if (start === colon - 1) return false;
+  return URL_SCHEMES.has(src.slice(start + 1, colon).toLowerCase());
+}
+
+function regexCanStartAfter(src: string, lastCode: number): boolean {
+  if (lastCode < 0) return true;
+  const ch = src[lastCode] as string;
+  if (ch === ")" || ch === "]" || ch === '"' || ch === "'" || ch === "`") return false;
+  if (isIdentPart(ch)) {
+    let start = lastCode;
+    while (start >= 0 && isIdentPart(src[start] as string)) start--;
+    return REGEX_KEYWORDS.has(src.slice(start + 1, lastCode + 1));
+  }
+  // `}` closes a block far more often than it closes an object literal being
+  // divided, so a `/` after it is read as a regex at statement position.
+  return true;
+}
+
+/** Index just past the closing quote, or at the line terminator that ended it. */
+function skipQuoted(src: string, start: number, quote: string): number {
+  let i = start + 1;
+  while (i < src.length) {
+    const ch = src[i] as string;
+    if (ch === "\\") {
+      // A backslash before CRLF is a single line continuation. Stepping over
+      // only two characters would land on the `\n` and end the string early.
+      i += src[i + 1] === "\r" && src[i + 2] === "\n" ? 3 : 2;
+      continue;
+    }
+    if (ch === quote) return i + 1;
+    // An unterminated string must not swallow the rest of the file, and an
+    // unescaped line terminator ends a quoted string anyway.
+    if (ch === "\n" || ch === "\r" || ch === "\u2028" || ch === "\u2029") return i;
+    i++;
+  }
+  return src.length;
+}
+
+/** Index just past the closing `/`, or -1 when this `/` did not open a regex. */
+function skipRegex(src: string, start: number): number {
+  let i = start + 1;
+  let inClass = false;
+  while (i < src.length) {
+    const ch = src[i] as string;
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (ch === "\n") return -1; // regex literals cannot span lines
+    if (inClass) {
+      if (ch === "]") inClass = false;
+    } else if (ch === "[") {
+      inClass = true;
+    } else if (ch === "/") {
+      return i + 1;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Count JavaScript comments while tracking string, template literal and regex
+ * context, so `//` and block-comment openers inside literals are not counted.
+ */
+export function scanJsComments(src: string): CommentScan {
+  const scan: CommentScan = { lineComments: 0, blockComments: 0, commentBytes: 0 };
+
+  // Frames record the mode to return to; template interpolations (`${ ... }`)
+  // put us back into code, so brace depth has to be tracked per frame.
+  const frames: Array<{ mode: "code" | "template"; braceDepth: number }> = [];
+  let mode: "code" | "template" = "code";
+  let braceDepth = 0;
+  // Last non-whitespace character consumed in code context. Comments are
+  // transparent, so they never update it.
+  let lastCode = -1;
+  // A failed regex probe scans to end of line. Without remembering the failure,
+  // a line such as `x=/\/\/\/…` re-probes at every slash and the scan goes
+  // quadratic on a multi-MB bundle. If nothing could close a regex opened at i,
+  // treat the rest of that line as division rather than probing again.
+  let noRegexBefore = -1;
+  let i = 0;
+
+  while (i < src.length) {
+    const ch = src[i] as string;
+
+    if (mode === "template") {
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      if (ch === "`") {
+        const frame = frames.pop();
+        mode = frame?.mode ?? "code";
+        braceDepth = frame?.braceDepth ?? 0;
+        lastCode = i;
+        i++;
+        continue;
+      }
+      if (ch === "$" && src[i + 1] === "{") {
+        frames.push({ mode: "template", braceDepth });
+        mode = "code";
+        braceDepth = 0;
+        lastCode = i + 1;
+        i += 2;
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === "/") {
+      const next = src[i + 1];
+      if (next === "/") {
+        // Backstop for a URL that reached code context anyway, e.g. inside a
+        // regex this scanner read as division. A real comment never abuts the
+        // colon of a URL scheme.
+        if (i > 0 && src[i - 1] === ":" && endsUrlScheme(src, i - 1)) {
+          lastCode = i + 1;
+          i += 2;
+          continue;
+        }
+        let end = i + 2;
+        while (end < src.length && src[end] !== "\n") end++;
+        scan.lineComments++;
+        scan.commentBytes += end - i;
+        i = end;
+        continue;
+      }
+      if (next === "*") {
+        const close = src.indexOf("*/", i + 2);
+        if (close === -1) {
+          // Unterminated: the old regex did not match it either, so it is not
+          // counted, but the rest of the file is still comment text.
+          break;
+        }
+        scan.blockComments++;
+        scan.commentBytes += close + 2 - i;
+        i = close + 2;
+        continue;
+      }
+      if (i >= noRegexBefore && regexCanStartAfter(src, lastCode)) {
+        const end = skipRegex(src, i);
+        if (end !== -1) {
+          lastCode = end - 1;
+          i = end;
+          continue;
+        }
+        const lineEnd = src.indexOf("\n", i);
+        noRegexBefore = lineEnd === -1 ? src.length : lineEnd;
+      }
+      lastCode = i;
+      i++;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      const end = skipQuoted(src, i, ch);
+      lastCode = end - 1;
+      i = end;
+      continue;
+    }
+
+    if (ch === "`") {
+      frames.push({ mode: "code", braceDepth });
+      mode = "template";
+      i++;
+      continue;
+    }
+
+    if (ch === "{") {
+      braceDepth++;
+      lastCode = i;
+      i++;
+      continue;
+    }
+
+    if (ch === "}") {
+      const frame = frames[frames.length - 1];
+      if (braceDepth === 0 && frame?.mode === "template") {
+        frames.pop();
+        mode = "template";
+        braceDepth = frame.braceDepth;
+        i++;
+        continue;
+      }
+      if (braceDepth > 0) braceDepth--;
+      lastCode = i;
+      i++;
+      continue;
+    }
+
+    if (!isWhitespace(ch)) lastCode = i;
+    i++;
+  }
+
+  return scan;
+}
+
+/**
+ * Count CSS block comments while skipping quoted strings, so a `/*` inside
+ * `content: "..."` or a data URI is not read as a comment opener (#142).
+ */
+export function scanCssComments(src: string): CommentScan {
+  const scan: CommentScan = { lineComments: 0, blockComments: 0, commentBytes: 0 };
+  let i = 0;
+
+  while (i < src.length) {
+    const ch = src[i] as string;
+
+    if (ch === '"' || ch === "'") {
+      i = skipQuoted(src, i, ch);
+      continue;
+    }
+
+    if (ch === "/" && src[i + 1] === "*") {
+      const close = src.indexOf("*/", i + 2);
+      if (close === -1) break;
+      scan.blockComments++;
+      scan.commentBytes += close + 2 - i;
+      i = close + 2;
+      continue;
+    }
+
+    i++;
+  }
+
+  return scan;
+}

--- a/packages/rules/src/shared/comment-scan.ts
+++ b/packages/rules/src/shared/comment-scan.ts
@@ -44,8 +44,22 @@ function isIdentPart(ch: string): boolean {
   );
 }
 
+// Non-ASCII ECMAScript WhiteSpace and LineTerminator code points: NBSP, OGHAM
+// SPACE MARK, EN QUAD through HAIR SPACE, LINE and PARAGRAPH SEPARATOR, NARROW
+// NO-BREAK SPACE, MEDIUM MATHEMATICAL SPACE, IDEOGRAPHIC SPACE and the BOM.
+// Anything omitted reads as a significant token, which would wrongly separate a
+// keyword from the `(` after it.
+const NON_ASCII_SPACES = new Set([
+  0x00a0, 0x1680, 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008, 0x2009,
+  0x200a, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000, 0xfeff,
+]);
+
 function isWhitespace(ch: string): boolean {
-  return ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "\f" || ch === "\v";
+  if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "\f" || ch === "\v") {
+    return true;
+  }
+  const code = ch.charCodeAt(0);
+  return code > 0x7f && NON_ASCII_SPACES.has(code);
 }
 
 function isSchemeChar(ch: string): boolean {
@@ -89,13 +103,19 @@ const CONTROL_FLOW_HEADS = new Set(["catch", "for", "if", "while", "with"]);
 // nesting depth, so reaching it means the input is not ordinary JavaScript.
 const PAREN_STACK_LIMIT = 4096;
 
-/** True when the `(` at `open` is the one belonging to an `if`/`while`/`for` head. */
-function opensControlFlowHead(src: string, open: number): boolean {
-  let end = open - 1;
-  while (end >= 0 && isWhitespace(src[end] as string)) end--;
-  let start = end;
+/**
+ * The identifier token ending at `identEnd`, but only when it is still the most
+ * recent significant token, i.e. nothing but whitespace and comments has been
+ * consumed since. Reading this from the scanner's own token state rather than
+ * walking backwards over raw source is what lets `if /*c*\/ (x)` and
+ * `if (x)` be recognised: the scanner has already stepped over the comment,
+ * and every flavour of whitespace is skipped in one place.
+ */
+function precedingIdent(src: string, lastCode: number, identEnd: number): string {
+  if (identEnd < 0 || lastCode + 1 !== identEnd) return "";
+  let start = identEnd - 1;
   while (start >= 0 && isIdentPart(src[start] as string)) start--;
-  return CONTROL_FLOW_HEADS.has(src.slice(start + 1, end + 1));
+  return src.slice(start + 1, identEnd);
 }
 
 /**
@@ -200,9 +220,13 @@ export function scanJsComments(src: string): CommentScan {
   // bodies come from crawled pages, so the stack is capped: 5MB of `(` grew RSS
   // by 131MB unbounded. Past the cap only the depth is tracked, which can lose
   // one control flow head far past any real nesting.
-  const parens: number[] = [];
+  // Each entry says whether that `(` opened a control flow head, decided from
+  // token state at push time rather than by re-reading the source behind it.
+  const parens: boolean[] = [];
   let parenOverflow = 0;
   let controlFlowClose = -1;
+  // Index just past the most recent identifier token consumed in code context.
+  let identEnd = -1;
   let i = 0;
 
   while (i < src.length) {
@@ -299,7 +323,8 @@ export function scanJsComments(src: string): CommentScan {
     }
 
     if (ch === "(") {
-      if (parens.length < PAREN_STACK_LIMIT) parens.push(i);
+      const head = CONTROL_FLOW_HEADS.has(precedingIdent(src, lastCode, identEnd));
+      if (parens.length < PAREN_STACK_LIMIT) parens.push(head);
       else parenOverflow++;
       lastCode = i;
       i++;
@@ -309,9 +334,8 @@ export function scanJsComments(src: string): CommentScan {
     if (ch === ")") {
       if (parenOverflow > 0) {
         parenOverflow--;
-      } else {
-        const open = parens.pop();
-        if (open !== undefined && opensControlFlowHead(src, open)) controlFlowClose = i;
+      } else if (parens.pop() === true) {
+        controlFlowClose = i;
       }
       lastCode = i;
       i++;
@@ -340,7 +364,12 @@ export function scanJsComments(src: string): CommentScan {
       continue;
     }
 
-    if (!isWhitespace(ch)) lastCode = i;
+    if (isIdentPart(ch)) {
+      lastCode = i;
+      identEnd = i + 1;
+    } else if (!isWhitespace(ch)) {
+      lastCode = i;
+    }
     i++;
   }
 

--- a/packages/rules/tests/comment-scan.test.ts
+++ b/packages/rules/tests/comment-scan.test.ts
@@ -243,6 +243,25 @@ describe("scanJsComments — keyword lookup", () => {
     expect(count("obj.typeof /[//]/;")).toBe(1);
   });
 
+  test("a private name is never a keyword", () => {
+    const src = "class C { #return = 1; m() { return this.#return /[/* c */ 1] / 2; } }";
+    const r = scanJsComments(src);
+    expect(r.blockComments).toBe(1);
+    expect(r.commentBytes).toBe("/* c */".length);
+    // A space may sit between the dot and the hash, so the hash alone decides.
+    expect(count("class C { m() { this. #return /[/* c */ 1] / 2; } }")).toBe(1);
+    expect(count("class C { m() { this.#if(x) /[/* c */ 1] / 2; } }")).toBe(1);
+  });
+
+  test("a `#` name outside a class body does not inflate or throw", () => {
+    // Invalid JavaScript, but crawled input is not required to be valid. It is
+    // still a private name shape, so it is not a keyword, and the count matches
+    // what the old regex produced.
+    expect(count("#if(x)/[//]/.test(s);")).toBe(1);
+    expect(count("#x in o;")).toBe(0);
+    expect(count("class C { #count = 0; }")).toBe(0);
+  });
+
   test("real keywords still work after the property fix", () => {
     expect(count(x4("if(x)/[//]/.test(s);"))).toBe(4);
     expect(count("function f(){return /[//]/;}")).toBe(0);

--- a/packages/rules/tests/comment-scan.test.ts
+++ b/packages/rules/tests/comment-scan.test.ts
@@ -152,6 +152,28 @@ describe("scanJsComments — division is not a regex opener", () => {
     expect(count('if(t("(")) /[//]/.test(s);')).toBe(0);
   });
 
+  test("a comment between the keyword and its `(` does not hide the head", () => {
+    // The head is decided from the scanner's own token state, so the comment is
+    // already stepped over. Reading the raw source backwards could not cross it,
+    // and counted the `//` inside the character class as a second comment.
+    expect(count("if/*c*/(ok)/[//]/.test(s);")).toBe(1);
+    expect(count("while /*c*/ (x) /[//]/.test(s);")).toBe(1);
+    expect(count("for/*c*/(;;)/[//]/.test(s);")).toBe(1);
+  });
+
+  test.each([
+    ["NBSP", "\u00a0"],
+    ["LINE SEPARATOR", "\u2028"],
+    ["PARAGRAPH SEPARATOR", "\u2029"],
+    ["IDEOGRAPHIC SPACE", "\u3000"],
+    ["BOM", "\ufeff"],
+    ["NARROW NO-BREAK SPACE", "\u202f"],
+  ])("%s between the keyword and its `(` is whitespace, not a token", (_label, space) => {
+    const src = Array.from({ length: 4 }, (_, i) => `if${space}(ok)/[//]/.test(s${i});`).join("\n");
+    // Four of these crossed COMMENT_COUNT_THRESHOLD and flagged comment-free code.
+    expect(count(src)).toBe(0);
+  });
+
   test("the open-paren stack is capped, so unmatched `(` cannot grow memory", () => {
     const before = process.memoryUsage().heapUsed;
     expect(count("(".repeat(2_000_000))).toBe(0);
@@ -172,6 +194,13 @@ describe("scanJsComments — accepted misreadings", () => {
 
   test("a regex directly after a non control flow `)` is read as division", () => {
     expect(count("f(a)/[//]/.test(s);")).toBe(1);
+  });
+
+  test("a regex as the right operand of `/` after `}` is read as division", () => {
+    // `{}` is treated as a closed block, so the `/` after it opens a regex, and
+    // that regex probe stops at the second `/`. More regex arithmetic, and the
+    // same trade as above: `}` at statement position is the common case.
+    expect(count("const x = {} / /[//]/;")).toBe(1);
   });
 });
 

--- a/packages/rules/tests/comment-scan.test.ts
+++ b/packages/rules/tests/comment-scan.test.ts
@@ -204,6 +204,52 @@ describe("scanJsComments — accepted misreadings", () => {
   });
 });
 
+// Review round 4: the preceding-keyword lookup answered from one identifier
+// token, so a two-word head went unrecognised and a property name was mistaken
+// for a keyword. Both misread the `/` that follows and swallowed or invented a
+// comment. Byte totals are checked against the old regex, which was right here.
+describe("scanJsComments — keyword lookup", () => {
+  const x4 = (line: string) => Array.from({ length: 4 }, (_, i) => `${line} // ${i}`).join("\n");
+
+  test("`for await (` is a control flow head", () => {
+    expect(count("async function f(){for await(const x of xs)/[//]/.test(x);}")).toBe(0);
+    expect(count("async function f(){for await (const x of xs)/[//]/.test(x);}")).toBe(0);
+    // The comment between the two keywords is stepped over, and is the only one.
+    expect(count("async function f(){for/*c*/await(const x of xs)/[//]/.test(x);}")).toBe(1);
+  });
+
+  test("plain `await (` is grouping, so the `/` after it divides", () => {
+    const src = "async function f(){await (x) / 2 // real\n}";
+    const r = scanJsComments(src);
+    expect(r.lineComments).toBe(1);
+    expect(r.commentBytes).toBe("// real".length);
+    expect(count("async function f(){await(x)/[//]/;}")).toBe(1);
+  });
+
+  test.each([
+    ["obj.if", "obj.if(x) /[/* c */ 1] / 2"],
+    ["a?.if", "a?.if(x) /[/* c */ 1] / 2"],
+    ["x.while", "x.while(y) /[/* c */ 1] / 2"],
+  ])("a keyword used as a property name (%s) is not a head", (_label, line) => {
+    const r = scanJsComments(line);
+    expect(r.blockComments).toBe(1);
+    expect(r.commentBytes).toBe("/* c */".length);
+  });
+
+  test("a keyword used as a property name does not open a regex either", () => {
+    // `obj.return` is a member access, so the `/` after it divides and the
+    // `//` inside what follows is a comment, exactly as the old regex had it.
+    expect(count("obj.return /[//]/;")).toBe(1);
+    expect(count("obj.typeof /[//]/;")).toBe(1);
+  });
+
+  test("real keywords still work after the property fix", () => {
+    expect(count(x4("if(x)/[//]/.test(s);"))).toBe(4);
+    expect(count("function f(){return /[//]/;}")).toBe(0);
+    expect(count("var t = typeof /[//]/;")).toBe(0);
+  });
+});
+
 describe("scanJsComments — deliberately not counted", () => {
   test("a `#!` shebang is not a comment, matching the old regex", () => {
     expect(count("#!/usr/bin/env node\nvar a=1;")).toBe(0);

--- a/packages/rules/tests/comment-scan.test.ts
+++ b/packages/rules/tests/comment-scan.test.ts
@@ -1,0 +1,118 @@
+// shared/comment-scan — the scanner behind perf/unminified-js and
+// perf/unminified-css (#142). These are unit tests for the state machine
+// itself; the rule-level behaviour lives in unminified-{js,css}.test.ts.
+
+import { describe, expect, test } from "bun:test";
+
+import { scanCssComments, scanJsComments } from "../src/shared/comment-scan";
+
+function count(src: string) {
+  const r = scanJsComments(src);
+  return r.lineComments + r.blockComments;
+}
+
+describe("scanJsComments — literals are not comments", () => {
+  test("`//` inside single, double and template quotes is ignored", () => {
+    expect(count(`var a="https://a.example/x";`)).toBe(0);
+    expect(count(`var a='https://a.example/x';`)).toBe(0);
+    expect(count("var a=`https://a.example/x`;")).toBe(0);
+  });
+
+  test("`/*` inside a string is not a block comment opener", () => {
+    expect(count(`var a="/* not a comment */",b="also /* not */";`)).toBe(0);
+  });
+
+  test("an escaped quote does not end the string early", () => {
+    expect(count(`var a="he said \\"https://a.example\\" loudly";`)).toBe(0);
+  });
+
+  test("a backslash before CRLF continues the string instead of ending it", () => {
+    // `i += 2` over `\` + CR would land on the LF and end the string early,
+    // turning the next line into code and its `//` into a comment.
+    expect(count('var a="x\\\r\n// still string";')).toBe(0);
+  });
+
+  test("an unterminated string stops at the line terminator, not at end of file", () => {
+    expect(count("var a='oops\n// a real comment\n")).toBe(1);
+    expect(count("var a='oops\r// a real comment\n")).toBe(1);
+  });
+
+  test("template interpolation returns to code, and nests", () => {
+    // The `${...}` below are fixture text, not interpolations of this file.
+    // oxlint-disable no-template-curly-in-string
+    expect(count("var a=`x${b}y`;")).toBe(0);
+    expect(count("var a=`x${ {p:1} }y//z`;")).toBe(0);
+    expect(count("var a=`x${`inner//u`}y`;")).toBe(0);
+    // A genuine comment inside an interpolation is still code, so still counted.
+    expect(count("var a=`x${ b // note\n }y`;")).toBe(1);
+    // oxlint-enable no-template-curly-in-string
+  });
+});
+
+describe("scanJsComments — regex literals", () => {
+  test("slashes inside a regex are not comments", () => {
+    expect(count("var a=/https?:\\/\\//;")).toBe(0);
+    expect(count("var a=/[/]/;")).toBe(0);
+    expect(count('var a="x".replace(/\\/\\//g,"");')).toBe(0);
+  });
+
+  test("a regex at statement position after `}` is not read as division", () => {
+    expect(count("function f(){}\n/a\\/\\/b/.test(q);")).toBe(0);
+  });
+
+  test("division is not mistaken for a regex", () => {
+    expect(count("var a=1/2/3;\n// real\n")).toBe(1);
+  });
+
+  test("a pathological run of escaped slashes stays linear", () => {
+    // Each `/` used to re-probe to end of line: O(n^2) on a multi-MB bundle.
+    const src = `x=/${"\\/".repeat(500_000)}`;
+    const started = performance.now();
+    expect(count(src)).toBe(0);
+    expect(performance.now() - started).toBeLessThan(5_000);
+  });
+});
+
+describe("scanJsComments — genuine comments are still counted", () => {
+  test("line and block comments, with byte totals matching the delimiters", () => {
+    const r = scanJsComments("// one\nvar a=1;/* two */\n");
+    expect(r.lineComments).toBe(1);
+    expect(r.blockComments).toBe(1);
+    expect(r.commentBytes).toBe("// one".length + "/* two */".length);
+  });
+
+  test("a comment after a string on the same line is counted, and only the comment", () => {
+    const r = scanJsComments('var u="https://a.example/x"; // note\n');
+    expect(r.lineComments).toBe(1);
+    expect(r.commentBytes).toBe("// note".length);
+  });
+
+  test("the URL-scheme guard does not swallow a comment after a label", () => {
+    expect(count("outer:// genuine comment\nfor(;;)break outer;")).toBe(1);
+  });
+
+  test("a sourceMappingURL comment is a comment", () => {
+    expect(count("var a=1;\n//# sourceMappingURL=index.js.map")).toBe(1);
+  });
+
+  test("an unterminated block comment is not counted, matching the previous regex", () => {
+    expect(count("var a=1;/* never closed")).toBe(0);
+  });
+});
+
+describe("scanCssComments", () => {
+  test("`/* */` inside a CSS string is not a comment", () => {
+    expect(scanCssComments('a::before{content:"/* x */"}').blockComments).toBe(0);
+    expect(scanCssComments("a::before{content:'/* x */'}").blockComments).toBe(0);
+  });
+
+  test("real comments are counted with their delimiters", () => {
+    const r = scanCssComments('/* one */a{color:red}b::after{content:"/* no */"}/* two */');
+    expect(r.blockComments).toBe(2);
+    expect(r.commentBytes).toBe("/* one */".length + "/* two */".length);
+  });
+
+  test("a backslash before CRLF continues a CSS string", () => {
+    expect(scanCssComments('a{content:"x\\\r\n/* still string */"}').blockComments).toBe(0);
+  });
+});

--- a/packages/rules/tests/comment-scan.test.ts
+++ b/packages/rules/tests/comment-scan.test.ts
@@ -89,6 +89,16 @@ describe("scanJsComments — genuine comments are still counted", () => {
 
   test("the URL-scheme guard does not swallow a comment after a label", () => {
     expect(count("outer:// genuine comment\nfor(;;)break outer;")).toBe(1);
+    // Even a label named after a scheme: a URL has a host right after the
+    // slashes, so anything else there means this is a comment.
+    const src = Array.from({ length: 4 }, (_, i) => `http:// real comment ${i}`).join("\n");
+    const r = scanJsComments(src);
+    expect(r.lineComments).toBe(4);
+    expect(r.commentBytes).toBe((src.match(/\/\/[^\n]*/g) ?? []).join("").length);
+    // The host check must not depend on an ASCII-only whitespace test.
+    expect(count("http:// real comment\n0;")).toBe(1);
+    // A real URL still suppresses the guard.
+    expect(count("var u=x;https://example.com/a\n")).toBe(0);
   });
 
   test("a sourceMappingURL comment is a comment", () => {
@@ -97,6 +107,81 @@ describe("scanJsComments — genuine comments are still counted", () => {
 
   test("an unterminated block comment is not counted, matching the previous regex", () => {
     expect(count("var a=1;/* never closed")).toBe(0);
+  });
+});
+
+// Review round 2 found the regex/division classifier swallowing comments: a `/`
+// read as a regex opener scans forward for a closing `/` and can consume the
+// `//` of a real comment. Each case below is checked against the byte total the
+// old `/\/\/[^\n]*/g` produced, which was correct for these inputs.
+describe("scanJsComments — division is not a regex opener", () => {
+  const x4 = (line: string) => Array.from({ length: 4 }, (_, i) => `${line} ${i}`).join("\n");
+
+  test.each([
+    ["postfix increment", "i++ / n // real"],
+    ["postfix decrement", "i-- / n // real"],
+    ["object literal", "const q = {} / n // real"],
+    ["regex literal with no flags", "var r=/a/ / n // real"],
+  ])("`/` after %s divides, so the comment behind it is still counted", (_label, line) => {
+    const src = x4(line);
+    const r = scanJsComments(src);
+    expect(r.lineComments).toBe(4);
+    expect(r.commentBytes).toBe((src.match(/\/\/[^\n]*/g) ?? []).join("").length);
+  });
+
+  test("a regex is never closed on a comment opener", () => {
+    // `/ n //` is division then a comment, not a regex body ending at the `//`.
+    // A regex being divided or multiplied is not real code, so `//` and `/*`
+    // immediately after a candidate closing slash reject the whole probe.
+    expect(count("x = y / n /* real */ z")).toBe(1);
+  });
+
+  test("`/` after the `)` of a control flow head opens a regex", () => {
+    // The `//` here sits inside a character class, so it is not a comment.
+    for (const head of ["if(ok)", "while(ok)", "for(;;)"]) {
+      expect(count(x4(`${head}/[//]/.test(s);`))).toBe(0);
+    }
+  });
+
+  test("`/` after any other `)` divides", () => {
+    expect(count(x4("var v = f(a) / n // real"))).toBe(4);
+  });
+
+  test("parens inside strings and comments never enter the paren matching", () => {
+    // The `(` lives in a string, so the `)` below belongs to `if(`, not to it.
+    expect(count('if(t("(")) /[//]/.test(s);')).toBe(0);
+  });
+
+  test("the open-paren stack is capped, so unmatched `(` cannot grow memory", () => {
+    const before = process.memoryUsage().heapUsed;
+    expect(count("(".repeat(2_000_000))).toBe(0);
+    // Unbounded, this held one array slot per `(`: ~45MB of heap for 5M parens.
+    expect(process.memoryUsage().heapUsed - before).toBeLessThan(8_000_000);
+  });
+});
+
+// Known, deliberate residuals of treating `/` heuristically instead of parsing.
+// Pinned so a future change makes a considered decision rather than an accident.
+describe("scanJsComments — accepted misreadings", () => {
+  test("a regex used as the left operand of `*` or `/` is read as division", () => {
+    // `/a/*2` is valid JavaScript, and multiplying by a regex is not real code,
+    // so the scanner prefers to keep `/*` and `//` countable as comments.
+    expect(count("const x=/a/*2;// real")).toBe(0);
+    expect(count("const x=/[//]//2;")).toBe(1);
+  });
+
+  test("a regex directly after a non control flow `)` is read as division", () => {
+    expect(count("f(a)/[//]/.test(s);")).toBe(1);
+  });
+});
+
+describe("scanJsComments — deliberately not counted", () => {
+  test("a `#!` shebang is not a comment, matching the old regex", () => {
+    expect(count("#!/usr/bin/env node\nvar a=1;")).toBe(0);
+  });
+
+  test("an Annex B `<!--` HTML-style comment is not counted, matching the old regex", () => {
+    expect(count("<!-- not counted\nvar a=1;")).toBe(0);
   });
 });
 

--- a/packages/rules/tests/unminified-css.test.ts
+++ b/packages/rules/tests/unminified-css.test.ts
@@ -1,0 +1,63 @@
+// perf/unminified-css — #142 counted `/* ... */` with a plain regex, so a
+// comment opener sitting inside a string literal (`content: "..."`, a data URI)
+// started a "comment" that ran to the next `*/`. Same shape as the JS rule's
+// `//`-in-a-URL bug, so comment counting here is string-aware too.
+
+import { describe, expect, test } from "bun:test";
+
+import { parsePage } from "@squirrelscan/parser";
+
+import { unminifiedCssRule } from "../src/performance/unminified-css";
+import type { RuleContext } from "../src/types";
+
+function ctx(css: string): RuleContext {
+  const url = "https://example.com/";
+  const html = `<!DOCTYPE html><html><head><title>t</title><style>${css}</style></head><body></body></html>`;
+  return {
+    page: { url, html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: parsePage(html, url),
+    site: { baseUrl: "https://example.com", pages: [], robotsTxt: null, sitemaps: null },
+    options: {},
+  } as unknown as RuleContext;
+}
+
+function checkNamed(checks: ReturnType<typeof unminifiedCssRule.run>["checks"], name: string) {
+  return checks.find((c) => c.name === name);
+}
+
+// Minified filler: one line, no comments, well over min_size_bytes.
+const PADDING = Array.from(
+  { length: 60 },
+  (_, i) => `.p${i}{color:#abcdef;margin:0;padding:0;border:0}`,
+).join("");
+
+describe("perf/unminified-css — string-aware comment detection (#142)", () => {
+  test("#142: `/* */` inside a string literal is not counted as a comment", () => {
+    const strings = Array.from(
+      { length: 5 },
+      (_, i) => `.s${i}::before{content:"/* not a comment ${i} */"}`,
+    ).join("");
+    const { checks } = unminifiedCssRule.run(ctx(`${strings}${PADDING}`));
+    expect(checkNamed(checks, "unminified-css")).toBeUndefined();
+    expect(checkNamed(checks, "minified-css")?.status).toBe("pass");
+  });
+
+  test("true positive preserved: real CSS comments are still counted and flagged", () => {
+    const comments = Array.from({ length: 5 }, (_, i) => `/* section ${i} */`).join("");
+    const { checks } = unminifiedCssRule.run(ctx(`${comments}${PADDING}`));
+    const warn = checkNamed(checks, "unminified-css");
+    expect(warn?.status).toBe("warn");
+    expect(warn?.items?.[0]?.meta?.reason).toBe("5 comments");
+  });
+
+  test("a real comment following a string on the same line is still counted", () => {
+    const mixed = Array.from(
+      { length: 5 },
+      (_, i) => `.m${i}::after{content:"/* x */"}/* real ${i} */`,
+    ).join("");
+    const { checks } = unminifiedCssRule.run(ctx(`${mixed}${PADDING}`));
+    const warn = checkNamed(checks, "unminified-css");
+    expect(warn?.status).toBe("warn");
+    expect(warn?.items?.[0]?.meta?.reason).toBe("5 comments");
+  });
+});

--- a/packages/rules/tests/unminified-js.test.ts
+++ b/packages/rules/tests/unminified-js.test.ts
@@ -119,3 +119,123 @@ describe("perf/unminified-js — license banner handling", () => {
     expect(checkNamed(checks, "unminified-js")?.status).toBe("warn");
   });
 });
+
+// #142: `//` was counted with /\/\/[^\n]*/g, which has no notion of string
+// context. Every `"https://..."` in a bundle scored as a comment running to the
+// end of the line, and in a minified bundle that is most of the file — hence a
+// 330KB already-minified bundle reported as "27 comments, ~295KB savings".
+
+// Six protocol slashes, none of them a comment.
+const URLS = [
+  "https://github.com/squirrelscan/squirrelscan",
+  "https://example.com/api/v1/items",
+  "https://cdn.example.com/assets/main.css",
+  "https://docs.example.com/guide/getting-started",
+  "https://api.example.com/v2/search?q=1",
+  "//cdn.example.com/protocol-relative.js",
+];
+
+// A minified bundle the way esbuild actually emits one: a few very long lines,
+// each carrying a URL. Short identifiers, no whitespace runs, zero comments, and
+// a newline ratio (~0.2%) well under NEWLINE_RATIO_THRESHOLD. One URL per line
+// matters — the old regex consumed to end of line, so same-line URLs hid behind
+// the first match; spread across lines they each scored as a separate comment.
+const MINIFIED_WITH_URLS = `${URLS.map(
+  (u, i) => `var a${i}=[${JSON.stringify(u)},"${"y".repeat(400)}"];`,
+).join("\n")}\nwindow.__u=[a0,a1,a2,a3,a4,a5];`;
+
+describe("perf/unminified-js — string-aware comment detection (#142)", () => {
+  test("#142: a minified bundle whose only slashes are URLs in string literals is NOT flagged", () => {
+    const { checks } = unminifiedJsRule.run(
+      ctx([scriptEntry("https://example.com/assets/index-DAwQ9g4m.js", MINIFIED_WITH_URLS)]),
+    );
+    expect(checkNamed(checks, "unminified-js")).toBeUndefined();
+    expect(checkNamed(checks, "minified-js")?.status).toBe("pass");
+  });
+
+  test("#142: savings never include the URL tails when the file is flagged for another reason", () => {
+    // The URL-bearing minified lines, then enough short lines to trip the
+    // newline ratio. Only the newlines are recoverable; before the fix the six
+    // URLs each contributed their ~400-byte line tail to the savings (~2.4KB on
+    // a 2.8KB file, the same nonsense as "295KB savings" on a 330KB bundle).
+    const padding = Array.from({ length: 20 }, (_, i) => `x${i}=${i};`).join("\n");
+    const content = `${MINIFIED_WITH_URLS}\n${padding}`;
+    const { checks } = unminifiedJsRule.run(
+      ctx([scriptEntry("https://example.com/assets/index-newlines.js", content)]),
+    );
+    const warn = checkNamed(checks, "unminified-js");
+    expect(warn?.status).toBe("warn");
+    expect(warn?.items?.[0]?.meta?.reason).toContain("high newlines");
+    expect(warn?.items?.[0]?.meta?.reason).not.toContain("comments");
+    // 20 newlines is ~0.02KB. The old regex reported thousands of bytes here.
+    expect(warn?.details?.totalPotentialSavingsKb).toBe("0.0");
+  });
+
+  test("#142: `//` inside a template literal is not a comment", () => {
+    // The `${...}` here are fixture text, not interpolations of this test file:
+    // the scanner has to re-enter code mode inside a template's interpolation
+    // and come back out, without losing the surrounding template context.
+    // oxlint-disable no-template-curly-in-string
+    const templates = [
+      "var b=`see https://example.com/docs and //cdn.example.com/x`;",
+      "var c=`${b} https://example.com/one`;",
+      "var e=`https://example.com/two ${b} https://example.com/three`;",
+      "var f=`https://example.com/four`;",
+      "var g=`//cdn.example.com/five`;",
+    ];
+    // oxlint-enable no-template-curly-in-string
+    const content = `${templates
+      .map((t, i) => `${t}var p${i}="${"z".repeat(400)}";`)
+      .join("\n")}\nwindow.__t=[b,c,e,f,g];`;
+    const { checks } = unminifiedJsRule.run(
+      ctx([scriptEntry("https://example.com/assets/index-template.js", content)]),
+    );
+    expect(checkNamed(checks, "unminified-js")).toBeUndefined();
+    expect(checkNamed(checks, "minified-js")?.status).toBe("pass");
+  });
+
+  test("true positive preserved: real `//` comments are still counted and flagged", () => {
+    // Six genuine line comments over a body that is otherwise minified-looking,
+    // so "comments" is the only reason the rule can fire.
+    const comments = Array.from({ length: 6 }, (_, i) => `// step ${i}`).join("\n");
+    const content = `${comments}\nvar a=1,b="${"q".repeat(2400)}";window.__c=[a,b];`;
+    const { checks } = unminifiedJsRule.run(
+      ctx([scriptEntry("https://example.com/assets/app-commented.js", content)]),
+    );
+    const warn = checkNamed(checks, "unminified-js");
+    expect(warn?.status).toBe("warn");
+    expect(warn?.items?.[0]?.meta?.reason).toBe("6 comments");
+  });
+
+  test("true positive preserved: a `//` comment after a string on the same line is still counted", () => {
+    const lines = Array.from(
+      { length: 6 },
+      (_, i) => `var u${i}="https://example.com/page/${i}"; // note ${i}`,
+    ).join("\n");
+    const content = `${lines}\nvar z="${"w".repeat(2400)}";window.__z=z;`;
+    const { checks } = unminifiedJsRule.run(
+      ctx([scriptEntry("https://example.com/assets/app-trailing.js", content)]),
+    );
+    const warn = checkNamed(checks, "unminified-js");
+    expect(warn?.status).toBe("warn");
+    expect(warn?.items?.[0]?.meta?.reason).toContain("6 comments");
+  });
+
+  test("a regex literal containing slashes is not read as a comment", () => {
+    const patterns = [
+      "var a=/https?:\\/\\//;",
+      "var b=/[/]/;",
+      'var c="x".replace(/\\/\\//g,"");',
+      "var d=1/2/1;",
+      "var e=/a\\/\\/b/.source;",
+    ];
+    const content = `${patterns
+      .map((p, i) => `${p}var q${i}="${"r".repeat(400)}";`)
+      .join("\n")}\nwindow.__r=[a,b,c,d,e];`;
+    const { checks } = unminifiedJsRule.run(
+      ctx([scriptEntry("https://example.com/assets/index-regex.js", content)]),
+    );
+    expect(checkNamed(checks, "unminified-js")).toBeUndefined();
+    expect(checkNamed(checks, "minified-js")?.status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## The false positive

`analyzeJs` in `packages/rules/src/performance/unminified-js.ts` counted single-line comments with:

```ts
const singleLineComments = js.match(/\/\/[^\n]*/g) || [];
```

That regex has no notion of string context, so every URL in a bundle scored as a comment:

```js
Ps="https://github.com/squirrelscan/squirrelscan"
//                  ^ matched here, then to end of line
```

In a minified bundle "to end of line" is most of the file. squirrelscan.com's own 330KB bundle, with zero comments and a 0.058% newline ratio, came back as `27 comments, ~295.1KB savings`: the rule was reporting that minifying an already minified bundle would recover almost all of it. `https://` inside a string is about as common as JavaScript gets, so this fired on a large share of real bundles, and `potentialSavingsBytes` was meaningless whenever it did.

## The fix

`packages/rules/src/shared/comment-scan.ts` is a new linear scanner that both minification rules now use instead of their comment regexes. It tracks:

- single-quoted, double-quoted and template-literal state, with escape handling (including a backslash before CRLF, which is one line continuation rather than an escaped CR plus a string-ending newline)
- template `${ ... }` interpolation, which returns to code context and nests, via a frame stack with per-frame brace depth
- regex literals, including character classes where `/` does not terminate
- block comments, string-aware in the same pass

Only `//` and `/*` reached in code context are counted. Byte accounting matches the old regexes for genuine comments: a line comment spans `//` to the newline, a block comment spans its delimiters, and an unterminated block comment is not counted (the old `/\/\*[\s\S]*?\*\//g` did not match one either).

Two deliberately conservative choices, both documented at the call site:

- A `/` after `)` or `]` is read as division rather than a regex. `if(x)/re/.test(y)` is legal but rare, and mistaking a regex for division only scans its body as code, whereas mistaking division for a regex would swallow real comments.
- A failed regex probe records the line it failed on, so the rest of that line is treated as division instead of re-probing. Without it, a line like `x=/\/\/\/…` probes to end of line at every slash and the scan goes quadratic; a 2MB pathological input now scans in ~57ms.

`//` immediately preceded by the colon of a known URL scheme (`http`, `https`, `ws`, `data`, ...) is skipped as a backstop for a URL that reaches code context anyway. It is scheme-checked rather than a bare `:` test so a JS label followed by a real comment, `outer:// note`, is still counted.

`unminified-css.ts` had the same shape: a `/*` inside `content: "..."` or a data URI opened a "comment" that ran to the next `*/`. It now uses `scanCssComments`.

Thresholds and scoring semantics are unchanged.

## Tests

`packages/rules/tests/comment-scan.test.ts` (new) unit-tests the scanner: quotes and escapes, the CRLF continuation, unterminated literals, template interpolation and nesting, regex literals and division, the pathological-input time bound, and byte totals for genuine comments.

`packages/rules/tests/unminified-js.test.ts` adds rule-level fixtures:

- a minified bundle whose only slashes are URLs in string literals, one per line, is not flagged
- the same bundle padded to trip the newline ratio reports `0.0KB` savings, not the URL line tails
- `//` inside template literals, including interpolations, is not a comment
- six real `//` comments over an otherwise minified body are still flagged as `6 comments`
- a real `//` comment after a string on the same line is still counted
- regex literals containing slashes are not read as comments

Three of these fail against the current `main` code and pass with the fix. The other new tests, and the existing `#698` license-banner tests, pass either way and are there to pin the behaviour that must not change.

`packages/rules/tests/unminified-css.test.ts` (new) covers the CSS equivalent: `/* */` inside a string is not a comment, real comments are still flagged, and a real comment following a string on the same line is still counted.

## Verification

```
bun test packages/rules          # 1432 pass, 0 fail
bun run test:engine              # 58 pass, golden baseline byte-identical
bun run typecheck                # clean, all workspaces
bun run format:check / lint      # clean
bun run docs:check               # clean
oxfmt / oxlint on the changed files under packages/rules   # clean
```

The engine golden baseline is unchanged: `pages=518 findings=98220 rules=278 healthScore=48 errors=1000 warnings=4520 passed=37315`, identical to before the change.

Ran old regexes against the new scanner over 714 minified-looking bundles (>50KB, newline ratio under the rule's threshold) in `node_modules`. Files flagged on comment count drop from 240 to 34. The scanner never counts more comments than the old regexes on any of them, and the 34 that remain carry genuine comments (`//#region` markers, preserved mid-file license blocks). Worst false positive fixed: `workerd/worker.mjs`, 4.9MB, previously credited with 2,850,212 bytes of "comments", now 906.

## Review rounds

The scanner went through four rounds of adversarial review after the first commit. Each round is a separate commit, and each reproducer is pinned as a test.

- **Division misread as a regex.** A `/` treated as a regex opener scans forward for a closing `/` and could "close" on the first slash of a real `//` comment, so `i++ / n // real` counted no comments. `skipRegex` now refuses to close on a candidate slash immediately followed by `/` or `*`, since a regex being divided or multiplied is not real code.
- **Control flow heads.** `if(ok)/re/.test(s)` needs the `)` to be recognised as closing a head. Heads are matched with a forward paren stack built in code context, so parens inside string literals never enter the count.
- **Keyword lookup.** The preceding keyword is read from the scanner's own token state, which lets a comment or any ECMAScript whitespace sit between the keyword and its `(`. `for await (` is recognised from the last two identifier tokens, and an identifier introduced by `.` or `#` is a member or private name and never a keyword.
- **Bounds.** The open-paren stack is capped, and a failed regex probe is remembered per line. Nine 2MB adversarial inputs (all-one-character, unterminated string, unterminated template, deep nesting, repeated two-character motifs) each scan in under 45ms, and 5MB of `(` no longer grows the heap.

On scan direction: there is **no backward scan for identifier or keyword lookup** anywhere in the scanner. `endsUrlScheme` still walks backwards over scheme characters to recognise `https:` before `//`; that walk is pre-existing, bounded by the scheme token, and unchanged by this PR.

### Accepted misreadings

Three shapes are deliberately misread, pinned as tests under `accepted misreadings` so a future change is a decision rather than an accident. All three are regex arithmetic, which real code does not contain:

- `/a/*2` and `/[//]//2`, a regex as the left operand of `*` or `/`.
- `{} / /[//]/`, a regex as the right operand after `}`.
- A regex directly after a `)` that does not close an `if`/`while`/`for` head.

Closes #142

