### PR TITLE
fix(rules): stop reporting SHA-256 checksums as leaked secrets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -291,42 +291,42 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 369
+        "line_number": 385
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "daefe0b4345a654580dcad25c7c11ff4c944a8c0",
         "is_verified": false,
-        "line_number": 374
+        "line_number": 390
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "f0778f3e140a61d5bbbed5430773e52af2f5fba4",
         "is_verified": false,
-        "line_number": 379
+        "line_number": 395
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
         "is_verified": false,
-        "line_number": 384
+        "line_number": 400
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
         "is_verified": false,
-        "line_number": 389
+        "line_number": 405
       },
       {
         "type": "Secret Keyword",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 704
+        "line_number": 829
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T00:24:48Z"
+  "generated_at": "2026-08-27T21:30:07Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -291,42 +291,42 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 385
+        "line_number": 386
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "daefe0b4345a654580dcad25c7c11ff4c944a8c0",
         "is_verified": false,
-        "line_number": 390
+        "line_number": 391
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "f0778f3e140a61d5bbbed5430773e52af2f5fba4",
         "is_verified": false,
-        "line_number": 395
+        "line_number": 396
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 401
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
         "is_verified": false,
-        "line_number": 405
+        "line_number": 406
       },
       {
         "type": "Secret Keyword",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 829
+        "line_number": 915
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-27T21:30:07Z"
+  "generated_at": "2026-08-27T22:01:41Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -326,7 +326,7 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 915
+        "line_number": 950
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-27T22:01:41Z"
+  "generated_at": "2026-08-27T22:28:48Z"
 }

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -724,12 +724,40 @@ function keyWords(key: string): string[] {
   return words;
 }
 
-// A minifier's key carries no meaning: `t.a = "…"`, `e.x2 = "…"`. Suppressing
-// on those would blind the rule to every minified bundle, so they are treated
-// as "no key at all" rather than as a key that failed to say "credential".
-function isUninformativeKey(key: string): boolean {
+/**
+ * A minifier's member access carries no meaning: `t.a = "…"`, `e.x2 = "…"`,
+ * `n["a"] = "…"`. Suppressing on those would blind the rule to every bundled
+ * script, so they count as "no key at all" rather than as a key that failed to
+ * say "credential".
+ *
+ * Being short is not enough — it has to be a member access on an object. A
+ * query parameter (`?v=<hex>`), a JSON key (`"id":"<hex>"`) and a plain
+ * property (`id: "<hex>"`) are short but they do name their value, and what
+ * they name is not a credential.
+ */
+function isMinifiedMemberKey(key: string, viaBracket: boolean): boolean {
   const last = key.split(".").pop() ?? key;
-  return last.replace(/[^A-Za-z0-9]/g, "").length <= 2;
+  if (last.replace(/[^A-Za-z0-9]/g, "").length > 2) return false;
+  return viaBracket || key.includes(".");
+}
+
+// Characters that can be part of a key, so cutting the look-back in the middle
+// of a run of them would hand classifyKeyContext a truncated key.
+const KEY_CHAR_RE = /[A-Za-z0-9_$.-]/;
+
+/**
+ * The text immediately before a match, for reading the key off.
+ *
+ * SECRET_KEY_LOOKBEHIND_SIZE is a budget, not a hard cut: slicing at exactly
+ * that offset can land inside the key itself, and `redential="` classifies as
+ * nothing at all. So the slice walks back to the nearest non-key character,
+ * spending at most the same budget again before giving up.
+ */
+export function lookBehind(text: string, index: number): string {
+  const floor = Math.max(0, index - SECRET_KEY_LOOKBEHIND_SIZE * 2);
+  let start = Math.max(0, index - SECRET_KEY_LOOKBEHIND_SIZE);
+  while (start > floor && KEY_CHAR_RE.test(text[start - 1] ?? "")) start--;
+  return text.slice(start, index);
 }
 
 // The key an assignment puts immediately in front of a value:
@@ -824,7 +852,8 @@ export function classifyKeyContext(
     return "digest";
   }
 
-  const match = BRACKET_KEY_RE.exec(before) ?? PRECEDING_KEY_RE.exec(before);
+  const bracket = BRACKET_KEY_RE.exec(before);
+  const match = bracket ?? PRECEDING_KEY_RE.exec(before);
   const key = match?.[1];
 
   if (key) {
@@ -838,7 +867,9 @@ export function classifyKeyContext(
     if (fromTag !== "unknown") return fromTag;
   }
 
-  if (key) return isUninformativeKey(key) ? "assigned" : "none";
+  if (key) {
+    return isMinifiedMemberKey(key, bracket !== null) ? "assigned" : "none";
+  }
 
   if (AUTH_SCHEME_RE.test(before)) return "credential";
 
@@ -870,12 +901,16 @@ function maskSecret(value: string): string {
 }
 
 /**
- * A window around one keyword occurrence. `text` carries an extra
- * SECRET_KEY_LOOKBEHIND_SIZE characters of lead-in so a value sitting at the
- * very start of the scanned region still has its key visible; `scanFrom` marks
- * where matching begins, keeping the scanned span exactly as wide as before.
+ * A window around one keyword occurrence. `text` carries a lead-in — the full
+ * budget lookBehind can spend — so a value sitting at the very start of the
+ * scanned region still has its key visible. `scanFrom` marks where the region
+ * proper begins: a match must reach into it to count, which keeps the scanned
+ * span exactly as wide as it was before the lead-in existed.
  */
 type KeywordWindow = { text: string; scanFrom: number };
+
+// How much lead-in a window carries: whatever lookBehind is allowed to spend.
+const WINDOW_LEAD_IN = SECRET_KEY_LOOKBEHIND_SIZE * 2;
 
 // Extract windows around all keyword occurrences
 function extractKeywordWindows(
@@ -888,7 +923,7 @@ function extractKeywordWindows(
 
   while ((pos = contentLower.indexOf(keyword, pos)) !== -1) {
     const start = Math.max(0, pos - SECRET_CONTEXT_WINDOW_SIZE);
-    const leadIn = Math.max(0, start - SECRET_KEY_LOOKBEHIND_SIZE);
+    const leadIn = Math.max(0, start - WINDOW_LEAD_IN);
     const end = Math.min(
       content.length,
       pos + keyword.length + SECRET_CONTEXT_WINDOW_SIZE
@@ -976,12 +1011,19 @@ export function scanContent(
 
     // Only scan the windows, not the entire content
     for (const { text: window, scanFrom } of windows) {
-      // Start matching past the lead-in, which is context for the key only
-      pattern.lastIndex = scanFrom;
+      // Match across the lead-in too: a value can START there and run into the
+      // region proper, and skipping those loses the leak at a window boundary.
+      pattern.lastIndex = 0;
 
       let match: RegExpExecArray | null;
       while ((match = pattern.exec(window)) !== null) {
         const value = match[0];
+
+        // A match that both starts and ends inside the lead-in belongs to the
+        // previous window, which already scanned it. The lead-in is context.
+        if (match.index + value.length <= scanFrom) {
+          continue;
+        }
 
         // Skip duplicates, overlapping rematches, and false positives
         if (
@@ -1006,12 +1048,8 @@ export function scanContent(
         // Bare-shape patterns are the shape of a SHA-256 digest, so the key in
         // front of the value decides: never report under sha256/integrity/
         // checksum/commit/cache, or with no assignment context at all.
-        const before = window.slice(
-          Math.max(0, match.index - SECRET_KEY_LOOKBEHIND_SIZE),
-          match.index
-        );
         const keyContext = classifyKeyContext(
-          before,
+          lookBehind(window, match.index),
           keyword,
           enclosingTag(window, match.index)
         );

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -31,8 +31,9 @@ type FastPattern = {
 // characters with no distinctive prefix, which is also the shape of a SHA-256
 // digest, an SRI hash, a git object id, an ETag and a UUID. The brand keyword
 // ("together", "datadog"…) is the only thing separating them from ordinary page
-// content, and brand words show up in ordinary prose. So a match here must also
-// sit under a key that says the value is a credential — see classifyKeyContext.
+// content, and brand words show up in ordinary prose. So a match here is also
+// read against the key it is assigned to: never reported under a digest key or
+// with no assignment at all — see classifyKeyContext.
 type ContextPattern = {
   name: string;
   keyword: string; // Lowercase keyword to check via includes() first
@@ -660,9 +661,10 @@ function isInValuePosition(
   return false;
 }
 
-// Keys whose value is a digest, hash or object id — never a credential. A
-// release page publishing `sha256:"01e4fbb0…"` next to a download is doing the
-// right thing, and so is an SRI `integrity=` attribute or a git commit id.
+// Keys whose value is a digest, hash, cache entry or object id — never a
+// credential. A release page publishing `sha256:"01e4fbb0…"` next to a download
+// is doing the right thing, and so is an SRI `integrity=` attribute, a git
+// commit id, or a cache key built by hashing its inputs.
 const DIGEST_KEY_WORDS = new Set([
   "sha",
   "sha1",
@@ -680,12 +682,16 @@ const DIGEST_KEY_WORDS = new Set([
   "commit",
   "revision",
   "fingerprint",
+  "cache",
+  "cachekey",
 ]);
 
-// Keys that say the value is meant to be secret.
-const SECRET_KEY_WORDS = new Set([
+// Keys that say the value is meant to be secret. Bare `api` is deliberately
+// absent — `api:"…"` names a service, not a credential — while bare `key` is
+// deliberately present: `key:"…"` is a weak signal, but these are all
+// medium-confidence findings and dropping it costs real detections.
+const CREDENTIAL_KEY_WORDS = new Set([
   "apikey",
-  "api",
   "key",
   "keys",
   "token",
@@ -701,18 +707,41 @@ const SECRET_KEY_WORDS = new Set([
 ]);
 
 // `x-api-key`, `apiKey`, `SHA256`, `"sha256"` -> the words a key is made of.
+// A one-letter word is also glued to its successor so lower-camel `eTagKey`
+// yields `etag`, not `e` + `tag`.
 function keyWords(key: string): string[] {
-  return key
+  const parts = key
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .split(/[^A-Za-z0-9]+/)
     .filter(Boolean)
     .map((word) => word.toLowerCase());
+
+  const words = [...parts];
+  for (const [index, part] of parts.entries()) {
+    const next = parts[index + 1];
+    if (part.length === 1 && next) words.push(part + next);
+  }
+  return words;
+}
+
+// A minifier's key carries no meaning: `t.a = "…"`, `e.x2 = "…"`. Suppressing
+// on those would blind the rule to every minified bundle, so they are treated
+// as "no key at all" rather than as a key that failed to say "credential".
+function isUninformativeKey(key: string): boolean {
+  const last = key.split(".").pop() ?? key;
+  return last.replace(/[^A-Za-z0-9]/g, "").length <= 2;
 }
 
 // The key an assignment puts immediately in front of a value:
 // `sha256:"`, `api_key = "`, `"x-api-key":`, `apiKey:`
 const PRECEDING_KEY_RE =
   /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*[:=]\s*["'`]?\s*$/;
+
+// The same, written as a bracket access: `cfg["apiKey"] = "`, `cfg['sha256'] =`
+const BRACKET_KEY_RE = /\[\s*["'`]([^"'`\]]{1,64})["'`]\s*\]\s*[:=]\s*["'`]?\s*$/;
+
+// Anything at all in value position, whatever the key turned out to be
+const ASSIGNMENT_RE = /[:=]\s*["'`]?\s*$/;
 
 // SRI and prefixed-digest values: integrity="sha384-…", `sha256-…`, `md5:…`
 const DIGEST_PREFIX_RE = /(?:sha-?(?:1|256|384|512)|md5)\s*[-:]\s*[\w+/=-]*$/i;
@@ -723,52 +752,97 @@ const INTEGRITY_ATTR_RE = /\bintegrity\s*=\s*["'][^"']*$/i;
 // Header-style credentials: `Authorization: Bearer <value>`, `Basic <value>`
 const AUTH_SCHEME_RE = /\b(?:bearer|basic)\s+$/i;
 
-// Attributes that only carry a value; the key naming it sits on a sibling
-// attribute (`<meta name="algolia-api-key" content="…">`).
-const CARRIER_KEYS = new Set(["content", "value", "data", "text"]);
-const NAMED_ATTR_RE =
-  /\b(?:name|id|property|itemprop)\s*=\s*["']([^"']{1,64})["'][^<>]{0,40}$/i;
+// Attributes that name the value carried by a sibling attribute of the same
+// tag, in either order: `<meta name="algolia-api-key" content="…">` and
+// `<meta content="…" name="algolia-api-key">` say the same thing.
+const TAG_NAMING_ATTR_RE =
+  /\b(?:name|id|itemprop|property)\s*=\s*["']([^"']{1,64})["']/gi;
+const TAG_DATA_ATTR_RE = /\b(data-[A-Za-z0-9_-]{1,64})\s*=/g;
 
-type KeyContext = "digest" | "secret" | "unknown";
+type KeyContext = "digest" | "credential" | "assigned" | "none";
 
-function classifyKeyName(key: string, keyword: string): KeyContext {
+function classifyKeyName(key: string, keyword: string): KeyContext | "unknown" {
   const words = keyWords(key);
   if (words.some((word) => DIGEST_KEY_WORDS.has(word))) return "digest";
-  if (words.some((word) => SECRET_KEY_WORDS.has(word) || word === keyword)) {
-    return "secret";
+  if (
+    words.some((word) => CREDENTIAL_KEY_WORDS.has(word) || word === keyword)
+  ) {
+    return "credential";
   }
   return "unknown";
 }
 
+/** The whole tag a value sits inside, or undefined if it sits between tags. */
+export function enclosingTag(text: string, index: number): string | undefined {
+  const open = text.lastIndexOf("<", index);
+  if (open === -1) return undefined;
+  // A `>` between the tag opener and the value means the value is text content.
+  if (text.slice(open, index).includes(">")) return undefined;
+  const close = text.indexOf(">", index);
+  return close === -1 ? undefined : text.slice(open, close + 1);
+}
+
+/** Every key a tag names, whichever attribute order it wrote them in. */
+function classifyTagKeys(tag: string, keyword: string): KeyContext | "unknown" {
+  let verdict: KeyContext | "unknown" = "unknown";
+
+  const consider = (key: string) => {
+    const cls = classifyKeyName(key, keyword);
+    // Digest wins outright; a credential hit still yields to a later digest.
+    if (cls === "digest") verdict = "digest";
+    else if (cls === "credential" && verdict === "unknown") verdict = cls;
+  };
+
+  for (const attr of tag.matchAll(TAG_NAMING_ATTR_RE)) {
+    if (attr[1]) consider(attr[1]);
+  }
+  for (const attr of tag.matchAll(TAG_DATA_ATTR_RE)) {
+    if (attr[1]) consider(attr[1]);
+  }
+  return verdict;
+}
+
 /**
- * Classify the text immediately before a bare-shape match by the key it is
- * assigned to. Digest keys win over secret ones (`sha256Key` is a checksum),
- * and anything we cannot name is "unknown" — bare shapes only report under a
- * key that positively says "credential".
+ * Classify a bare-shape match by the key it is assigned to.
+ *
+ * - `digest` — a checksum, SRI hash, cache key or object id. Never reported.
+ * - `credential` — a key that says "secret". Reported.
+ * - `assigned` — in value position under a key that means nothing either way,
+ *   including a minifier's `t.a`. Reported: suppressing here would blind the
+ *   rule to every minified bundle, which is where leaks actually hide.
+ * - `none` — no assignment at all (a hex run in prose or a table cell).
+ *   Not reported.
+ *
+ * Digest beats credential when a key claims both, so `sha256Key` is a checksum.
  */
 export function classifyKeyContext(
   before: string,
-  keyword: string
+  keyword: string,
+  tag?: string
 ): KeyContext {
   if (DIGEST_PREFIX_RE.test(before) || INTEGRITY_ATTR_RE.test(before)) {
     return "digest";
   }
 
-  const match = PRECEDING_KEY_RE.exec(before);
-  if (match?.[1]) {
-    const direct = classifyKeyName(match[1], keyword);
-    if (direct !== "unknown") return direct;
+  const match = BRACKET_KEY_RE.exec(before) ?? PRECEDING_KEY_RE.exec(before);
+  const key = match?.[1];
 
-    if (CARRIER_KEYS.has(match[1].toLowerCase())) {
-      const named = NAMED_ATTR_RE.exec(before);
-      if (named?.[1]) return classifyKeyName(named[1], keyword);
-    }
-    return "unknown";
+  if (key) {
+    const direct = classifyKeyName(key, keyword);
+    if (direct !== "unknown") return direct;
   }
 
-  if (AUTH_SCHEME_RE.test(before)) return "secret";
+  // The naming attribute may sit on either side of the one holding the value.
+  if (tag) {
+    const fromTag = classifyTagKeys(tag, keyword);
+    if (fromTag !== "unknown") return fromTag;
+  }
 
-  return "unknown";
+  if (key) return isUninformativeKey(key) ? "assigned" : "none";
+
+  if (AUTH_SCHEME_RE.test(before)) return "credential";
+
+  return ASSIGNMENT_RE.test(before) ? "assigned" : "none";
 }
 
 export interface LeakedSecret {
@@ -795,22 +869,34 @@ function maskSecret(value: string): string {
   );
 }
 
+/**
+ * A window around one keyword occurrence. `text` carries an extra
+ * SECRET_KEY_LOOKBEHIND_SIZE characters of lead-in so a value sitting at the
+ * very start of the scanned region still has its key visible; `scanFrom` marks
+ * where matching begins, keeping the scanned span exactly as wide as before.
+ */
+type KeywordWindow = { text: string; scanFrom: number };
+
 // Extract windows around all keyword occurrences
 function extractKeywordWindows(
   content: string,
   contentLower: string,
   keyword: string
-): string[] {
-  const windows: string[] = [];
+): KeywordWindow[] {
+  const windows: KeywordWindow[] = [];
   let pos = 0;
 
   while ((pos = contentLower.indexOf(keyword, pos)) !== -1) {
     const start = Math.max(0, pos - SECRET_CONTEXT_WINDOW_SIZE);
+    const leadIn = Math.max(0, start - SECRET_KEY_LOOKBEHIND_SIZE);
     const end = Math.min(
       content.length,
       pos + keyword.length + SECRET_CONTEXT_WINDOW_SIZE
     );
-    windows.push(content.slice(start, end));
+    windows.push({
+      text: content.slice(leadIn, end),
+      scanFrom: start - leadIn,
+    });
     pos += keyword.length;
   }
 
@@ -889,9 +975,9 @@ export function scanContent(
     if (windows.length === 0) continue;
 
     // Only scan the windows, not the entire content
-    for (const window of windows) {
-      // Reset pattern state for global regex
-      pattern.lastIndex = 0;
+    for (const { text: window, scanFrom } of windows) {
+      // Start matching past the lead-in, which is context for the key only
+      pattern.lastIndex = scanFrom;
 
       let match: RegExpExecArray | null;
       while ((match = pattern.exec(window)) !== null) {
@@ -918,13 +1004,18 @@ export function scanContent(
         }
 
         // Bare-shape patterns are the shape of a SHA-256 digest, so the key in
-        // front of the value decides: report only under a key that says
-        // "credential", never under sha256/integrity/checksum/commit.
+        // front of the value decides: never report under sha256/integrity/
+        // checksum/commit/cache, or with no assignment context at all.
         const before = window.slice(
           Math.max(0, match.index - SECRET_KEY_LOOKBEHIND_SIZE),
           match.index
         );
-        if (classifyKeyContext(before, keyword) !== "secret") {
+        const keyContext = classifyKeyContext(
+          before,
+          keyword,
+          enclosingTag(window, match.index)
+        );
+        if (keyContext === "digest" || keyContext === "none") {
           continue;
         }
 

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -2,7 +2,10 @@
 
 import type { Rule, RuleContext, RuleResult, CheckResult, ParsedPage } from "../types";
 
-import { SECRET_CONTEXT_WINDOW_SIZE } from "@squirrelscan/utils/constants";
+import {
+  SECRET_CONTEXT_WINDOW_SIZE,
+  SECRET_KEY_LOOKBEHIND_SIZE,
+} from "@squirrelscan/utils/constants";
 
 // Secret detection patterns with service names
 // Sources: secrets-patterns-db, secret-regex-list, gitleaks patterns
@@ -23,6 +26,13 @@ type FastPattern = {
 
 // Type for context patterns (generic patterns, only run if keyword present)
 // These avoid catastrophic backtracking from (?=.*keyword) lookaheads
+//
+// Every pattern in this tier is BARE-SHAPE: a run of hex/base64/alphanumeric
+// characters with no distinctive prefix, which is also the shape of a SHA-256
+// digest, an SRI hash, a git object id, an ETag and a UUID. The brand keyword
+// ("together", "datadog"…) is the only thing separating them from ordinary page
+// content, and brand words show up in ordinary prose. So a match here must also
+// sit under a key that says the value is a credential — see classifyKeyContext.
 type ContextPattern = {
   name: string;
   keyword: string; // Lowercase keyword to check via includes() first
@@ -31,6 +41,12 @@ type ContextPattern = {
 };
 
 // Fast patterns - have distinctive prefixes, safe to run on all content
+//
+// Every entry here carries its own literal marker — a prefix (`sk-`, `ghp_`,
+// `AKIA`, `pk_live_`), a suffix (`NRAL`, `-us1`), a URL host, a PEM header, or a
+// required keyword in the pattern itself (AWS secret key, the generic
+// assignments, `Bearer`). None of them match a bare digest, so none of them
+// needs the key-context gate the CONTEXT_PATTERNS tier uses.
 const FAST_PATTERNS: FastPattern[] = [
   // AI/ML Services
   {
@@ -517,12 +533,10 @@ const CONTEXT_PATTERNS: ContextPattern[] = [
     pattern: /[a-f0-9]{32}/gi,
     confidence: "medium",
   },
-  {
-    name: "LogRocket App ID",
-    keyword: "logrocket",
-    pattern: /[a-z0-9]{6}\/[a-z0-9-]+/gi,
-    confidence: "medium",
-  },
+  // "LogRocket App ID" (/[a-z0-9]{6}\/[a-z0-9-]+/) was dropped: it matches any
+  // short path segment ("assets/logo-dark"), and a LogRocket app id is a public
+  // client-side identifier anyway — LogRocket.init() ships it to the browser by
+  // design. No amount of key context makes a path shape mean "credential".
 
   // Auth Services (need context)
   {
@@ -644,6 +658,117 @@ function isInValuePosition(
   }
 
   return false;
+}
+
+// Keys whose value is a digest, hash or object id — never a credential. A
+// release page publishing `sha256:"01e4fbb0…"` next to a download is doing the
+// right thing, and so is an SRI `integrity=` attribute or a git commit id.
+const DIGEST_KEY_WORDS = new Set([
+  "sha",
+  "sha1",
+  "sha256",
+  "sha384",
+  "sha512",
+  "md5",
+  "hash",
+  "hashes",
+  "digest",
+  "checksum",
+  "checksums",
+  "integrity",
+  "etag",
+  "commit",
+  "revision",
+  "fingerprint",
+]);
+
+// Keys that say the value is meant to be secret.
+const SECRET_KEY_WORDS = new Set([
+  "apikey",
+  "api",
+  "key",
+  "keys",
+  "token",
+  "secret",
+  "password",
+  "passwd",
+  "pwd",
+  "auth",
+  "authorization",
+  "bearer",
+  "credential",
+  "credentials",
+]);
+
+// `x-api-key`, `apiKey`, `SHA256`, `"sha256"` -> the words a key is made of.
+function keyWords(key: string): string[] {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((word) => word.toLowerCase());
+}
+
+// The key an assignment puts immediately in front of a value:
+// `sha256:"`, `api_key = "`, `"x-api-key":`, `apiKey:`
+const PRECEDING_KEY_RE =
+  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*[:=]\s*["'`]?\s*$/;
+
+// SRI and prefixed-digest values: integrity="sha384-…", `sha256-…`, `md5:…`
+const DIGEST_PREFIX_RE = /(?:sha-?(?:1|256|384|512)|md5)\s*[-:]\s*[\w+/=-]*$/i;
+
+// An HTML integrity attribute, whatever the algorithm prefix looks like
+const INTEGRITY_ATTR_RE = /\bintegrity\s*=\s*["'][^"']*$/i;
+
+// Header-style credentials: `Authorization: Bearer <value>`, `Basic <value>`
+const AUTH_SCHEME_RE = /\b(?:bearer|basic)\s+$/i;
+
+// Attributes that only carry a value; the key naming it sits on a sibling
+// attribute (`<meta name="algolia-api-key" content="…">`).
+const CARRIER_KEYS = new Set(["content", "value", "data", "text"]);
+const NAMED_ATTR_RE =
+  /\b(?:name|id|property|itemprop)\s*=\s*["']([^"']{1,64})["'][^<>]{0,40}$/i;
+
+type KeyContext = "digest" | "secret" | "unknown";
+
+function classifyKeyName(key: string, keyword: string): KeyContext {
+  const words = keyWords(key);
+  if (words.some((word) => DIGEST_KEY_WORDS.has(word))) return "digest";
+  if (words.some((word) => SECRET_KEY_WORDS.has(word) || word === keyword)) {
+    return "secret";
+  }
+  return "unknown";
+}
+
+/**
+ * Classify the text immediately before a bare-shape match by the key it is
+ * assigned to. Digest keys win over secret ones (`sha256Key` is a checksum),
+ * and anything we cannot name is "unknown" — bare shapes only report under a
+ * key that positively says "credential".
+ */
+export function classifyKeyContext(
+  before: string,
+  keyword: string
+): KeyContext {
+  if (DIGEST_PREFIX_RE.test(before) || INTEGRITY_ATTR_RE.test(before)) {
+    return "digest";
+  }
+
+  const match = PRECEDING_KEY_RE.exec(before);
+  if (match?.[1]) {
+    const direct = classifyKeyName(match[1], keyword);
+    if (direct !== "unknown") return direct;
+
+    if (CARRIER_KEYS.has(match[1].toLowerCase())) {
+      const named = NAMED_ATTR_RE.exec(before);
+      if (named?.[1]) return classifyKeyName(named[1], keyword);
+    }
+    return "unknown";
+  }
+
+  if (AUTH_SCHEME_RE.test(before)) return "secret";
+
+  return "unknown";
 }
 
 export interface LeakedSecret {
@@ -789,6 +914,17 @@ export function scanContent(
         // For context patterns, require the value to be in a value position
         // (assigned via = or :) to reduce false positives from array elements
         if (!isInValuePosition(window, value, match.index)) {
+          continue;
+        }
+
+        // Bare-shape patterns are the shape of a SHA-256 digest, so the key in
+        // front of the value decides: report only under a key that says
+        // "credential", never under sha256/integrity/checksum/commit.
+        const before = window.slice(
+          Math.max(0, match.index - SECRET_KEY_LOOKBEHIND_SIZE),
+          match.index
+        );
+        if (classifyKeyContext(before, keyword) !== "secret") {
           continue;
         }
 

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -17,9 +17,17 @@
 import { describe, expect, test } from "bun:test";
 
 import { parsePage } from "@squirrelscan/parser";
-import { SECRET_CONTEXT_WINDOW_SIZE } from "@squirrelscan/utils/constants";
+import {
+  SECRET_CONTEXT_WINDOW_SIZE,
+  SECRET_KEY_LOOKBEHIND_SIZE,
+} from "@squirrelscan/utils/constants";
 
-import { classifyKeyContext, leakedSecretsRule, scanContent } from "../src/security/leaked-secrets";
+import {
+  classifyKeyContext,
+  leakedSecretsRule,
+  lookBehind,
+  scanContent,
+} from "../src/security/leaked-secrets";
 import type { RuleContext } from "../src/types";
 
 // A real SHA-256 of a release artifact: 64 hex characters, which is also the
@@ -140,6 +148,20 @@ describe("security/leaked-secrets: hex digests are not secrets", () => {
     const content = `<p>together</p><meta content="${DIGEST}" name="release-sha256">`;
     expect(scanContent(content, "html")).toEqual([]);
   });
+
+  test("a short key that names something is not a minified member access", () => {
+    // A cache-busting query param and a JSON id are short but they do name
+    // their value, and it is not a credential.
+    const cases = [
+      `<a href="/bundle.js?v=${DIGEST}">built together</a>`,
+      `<script>x={"id":"${DIGEST}",vendor:"together"}</script>`,
+      `<script>x={id:"${DIGEST}",vendor:"together"}</script>`,
+      `<script>x={a:"${DIGEST}",vendor:"together"}</script>`,
+    ];
+    for (const content of cases) {
+      expect(scanContent(content, "html")).toEqual([]);
+    }
+  });
 });
 
 describe("security/leaked-secrets: real credentials still report", () => {
@@ -228,6 +250,36 @@ describe("security/leaked-secrets: real credentials still report", () => {
     expect(found.map((f) => f.value)).toContain(TOGETHER_KEY);
   });
 
+  test("a long key beginning past the look-back budget still reports", () => {
+    // End to end version of the look-back test: silent from N+1 before the fix.
+    const N = SECRET_KEY_LOOKBEHIND_SIZE;
+    for (const distance of [N, N + 1, N + 2]) {
+      const key = `key${"Z".padEnd(distance - 2 - "key".length, "z")}`;
+      const content = `;${key}="${TOGETHER_KEY}" // together.ai`; // pragma: allowlist secret
+      expect(scanContent(content, "inline-script").map((f) => f.value)).toContain(
+        TOGETHER_KEY
+      );
+    }
+  });
+
+  test("a value straddling the start of the window is still reported once", () => {
+    // The value begins in the lead-in and runs into the scanned region. Cutting
+    // matching at the region boundary drops it entirely; scanning the lead-in
+    // and requiring the match to reach the region keeps it, exactly once.
+    const straddle = 32;
+    const key = `credential="`;
+    const lead = `${"x".repeat(199)};`;
+    const valueStart = lead.length + key.length;
+    // Put the brand word so the window opens partway through the value.
+    const keywordAt = valueStart + straddle + SECRET_CONTEXT_WINDOW_SIZE;
+    const upto = valueStart + TOGETHER_KEY.length + 1;
+    const filler = "x".repeat(keywordAt - upto);
+    const content = `${lead}${key}${TOGETHER_KEY}"${filler}together.ai`; // pragma: allowlist secret
+
+    const found = scanContent(content, "inline-script");
+    expect(found.map((f) => f.value)).toEqual([TOGETHER_KEY]);
+  });
+
   test("public-by-design client keys stay informational, not leaks", () => {
     const page = html(
       `<script>const cfg={apiKey:"AIzaSyD3mQ8xR2vT7pLnK4hW9cB1sE6yU0zJfXa"};</script>`, // pragma: allowlist secret
@@ -264,13 +316,37 @@ describe("classifyKeyContext", () => {
     expect(classifyKeyContext(`cfg["filename"] = "`, "together")).toBe("none");
   });
 
-  test("a minifier's key is treated as no key, not as a key that failed", () => {
+  test("a minifier's member access is treated as no key at all", () => {
     expect(classifyKeyContext(`t.a = "`, "together")).toBe("assigned");
     expect(classifyKeyContext(`e.x2="`, "together")).toBe("assigned");
-    expect(classifyKeyContext(`n={a:"`, "together")).toBe("assigned");
+    expect(classifyKeyContext(`n["a"]="`, "together")).toBe("assigned");
     // A key long enough to mean something still has to say "credential".
     expect(classifyKeyContext(`filename: "`, "together")).toBe("none");
     expect(classifyKeyContext(`description = "`, "together")).toBe("none");
+  });
+
+  test("a short key that is not a member access still names its value", () => {
+    // Short is not the same as meaningless: these all name something, and what
+    // they name is not a credential.
+    expect(classifyKeyContext(`?v=`, "together")).toBe("none");
+    expect(classifyKeyContext(`&v="`, "together")).toBe("none");
+    expect(classifyKeyContext(`{"id":"`, "together")).toBe("none");
+    expect(classifyKeyContext(`id: "`, "together")).toBe("none");
+    expect(classifyKeyContext(`n={a:"`, "together")).toBe("none");
+  });
+
+  test("a long key is read whole, never cut in half by the look-back", () => {
+    // The credential word sits at the FRONT of the key, so a slice landing one
+    // character inside it decapitates `keyZzz…` into `eyZzz…` and the key stops
+    // meaning anything. Distances N, N+1 and N+2 all have to survive that.
+    const N = SECRET_KEY_LOOKBEHIND_SIZE;
+    for (const distance of [N, N + 1, N + 2]) {
+      const key = `key${"Z".padEnd(distance - 2 - "key".length, "z")}`;
+      const text = `;${key}="`;
+      expect(classifyKeyContext(lookBehind(text, text.length), "together")).toBe(
+        "credential"
+      );
+    }
   });
 
   test("cache keys are digests; bare api is not a credential, bare key still is", () => {

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { parsePage } from "@squirrelscan/parser";
+import { SECRET_CONTEXT_WINDOW_SIZE } from "@squirrelscan/utils/constants";
 
 import { classifyKeyContext, leakedSecretsRule, scanContent } from "../src/security/leaked-secrets";
 import type { RuleContext } from "../src/types";
@@ -127,6 +128,18 @@ describe("security/leaked-secrets: hex digests are not secrets", () => {
     const content = `<p>bundled together</p>${SRI_TAG}`;
     expect(scanContent(content, "html")).toEqual([]);
   });
+
+  test("a cache key built by hashing its inputs reports nothing", () => {
+    for (const key of ["cacheKey", "cache_key", "cachekey", "cache", "eTag", "eTagKey"]) {
+      const content = `{together:true,${key}:"${DIGEST}"}`;
+      expect(scanContent(content, "inline-script")).toEqual([]);
+    }
+  });
+
+  test("a naming attribute after the value still suppresses a digest", () => {
+    const content = `<p>together</p><meta content="${DIGEST}" name="release-sha256">`;
+    expect(scanContent(content, "html")).toEqual([]);
+  });
 });
 
 describe("security/leaked-secrets: real credentials still report", () => {
@@ -172,6 +185,49 @@ describe("security/leaked-secrets: real credentials still report", () => {
     }
   });
 
+  test("a key written as a bracket access is still read", () => {
+    for (const assignment of [
+      `cfg["apiKey"] = "${TOGETHER_KEY}"; // together`, // pragma: allowlist secret
+      `cfg['x-api-key'] = "${TOGETHER_KEY}"; // together`, // pragma: allowlist secret
+      `cfg["together"] = "${TOGETHER_KEY}"`, // pragma: allowlist secret
+    ]) {
+      const found = scanContent(assignment, "inline-script");
+      expect(found.map((f) => f.value)).toContain(TOGETHER_KEY);
+    }
+  });
+
+  test("a minified assignment is still scanned", () => {
+    // `t.a = "…"` is what a bundler leaves behind, and it is exactly where a
+    // leaked key hides. The brand word is elsewhere in the window.
+    const content = `var t={};t.a="${TOGETHER_KEY}";/* together.ai client */`; // pragma: allowlist secret
+    const found = scanContent(content, "inline-script");
+    expect(found.map((f) => f.value)).toContain(TOGETHER_KEY);
+  });
+
+  test("a naming attribute after the value is still read", () => {
+    const content = `<meta content="${TOGETHER_KEY}" name="algolia-api-key">`; // pragma: allowlist secret
+    const found = scanContent(content, "html");
+    // Algolia's 32-hex pattern claims the leading half of the value first, so
+    // assert the report, not which pattern's slice of it won.
+    expect(found).not.toEqual([]);
+    expect(TOGETHER_KEY.startsWith(found[0]?.value ?? "\0")).toBe(true);
+  });
+
+  test("a brand word at the far edge of the window still sees the key", () => {
+    // The window opens on the value itself and the key sits in the lead-in, so
+    // this only reports if the extracted window carries look-back context.
+    // No FAST pattern matches `credential=`, so the context tier is on its own.
+    const lead = `${"x".repeat(199)};`;
+    const assignment = `credential="${TOGETHER_KEY}"`; // pragma: allowlist secret
+    const valueStart = lead.length + `credential="`.length;
+    const keywordAt = valueStart + SECRET_CONTEXT_WINDOW_SIZE;
+    const filler = "x".repeat(keywordAt - (lead.length + assignment.length));
+    const content = `${lead}${assignment}${filler}together.ai`;
+
+    const found = scanContent(content, "inline-script");
+    expect(found.map((f) => f.value)).toContain(TOGETHER_KEY);
+  });
+
   test("public-by-design client keys stay informational, not leaks", () => {
     const page = html(
       `<script>const cfg={apiKey:"AIzaSyD3mQ8xR2vT7pLnK4hW9cB1sE6yU0zJfXa"};</script>`, // pragma: allowlist secret
@@ -188,28 +244,79 @@ describe("classifyKeyContext", () => {
     expect(classifyKeyContext(`{filename:"x",sha256:"`, "together")).toBe("digest");
     expect(classifyKeyContext(`<code>sha256: `, "together")).toBe("digest");
     expect(classifyKeyContext(`integrity="sha384-`, "together")).toBe("digest");
-    expect(classifyKeyContext(`"x-api-key": "`, "together")).toBe("secret");
-    expect(classifyKeyContext(`api_key = "`, "together")).toBe("secret");
-    expect(classifyKeyContext(`Authorization: Bearer `, "together")).toBe("secret");
-    expect(classifyKeyContext(`together: "`, "together")).toBe("secret");
-    expect(classifyKeyContext(`<td>`, "together")).toBe("unknown");
-    expect(classifyKeyContext(`monkey: "`, "together")).toBe("unknown");
+    expect(classifyKeyContext(`"x-api-key": "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`api_key = "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`Authorization: Bearer `, "together")).toBe("credential");
+    expect(classifyKeyContext(`together: "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`<td>`, "together")).toBe("none");
+    expect(classifyKeyContext(`monkey: "`, "together")).toBe("none");
   });
 
   test("a digest key wins over a credential word in the same key", () => {
     expect(classifyKeyContext(`sha256Key: "`, "together")).toBe("digest");
   });
 
-  test("reads through a value-carrier attribute to the sibling that names it", () => {
-    // <meta name="algolia-api-key" content="…"> keeps the key one attribute back.
-    expect(classifyKeyContext(`<meta name="algolia-api-key" content="`, "algolia")).toBe(
-      "secret",
-    );
-    expect(classifyKeyContext(`<meta name="release-sha256" content="`, "together")).toBe(
-      "digest",
-    );
-    expect(classifyKeyContext(`<meta name="description" content="`, "together")).toBe(
-      "unknown",
-    );
+  test("parses a bracket access as the preceding key", () => {
+    expect(classifyKeyContext(`cfg["apiKey"] = "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`cfg['x-api-key'] = "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`cfg["together"] = "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`cfg["sha256"] = "`, "together")).toBe("digest");
+    expect(classifyKeyContext(`cfg["filename"] = "`, "together")).toBe("none");
+  });
+
+  test("a minifier's key is treated as no key, not as a key that failed", () => {
+    expect(classifyKeyContext(`t.a = "`, "together")).toBe("assigned");
+    expect(classifyKeyContext(`e.x2="`, "together")).toBe("assigned");
+    expect(classifyKeyContext(`n={a:"`, "together")).toBe("assigned");
+    // A key long enough to mean something still has to say "credential".
+    expect(classifyKeyContext(`filename: "`, "together")).toBe("none");
+    expect(classifyKeyContext(`description = "`, "together")).toBe("none");
+  });
+
+  test("cache keys are digests; bare api is not a credential, bare key still is", () => {
+    expect(classifyKeyContext(`cacheKey: "`, "together")).toBe("digest");
+    expect(classifyKeyContext(`cache_key: "`, "together")).toBe("digest");
+    expect(classifyKeyContext(`cachekey: "`, "together")).toBe("digest");
+    expect(classifyKeyContext(`cache: "`, "together")).toBe("digest");
+    expect(classifyKeyContext(`api: "`, "together")).toBe("none");
+    // Deliberate: `key:"…"` is a weak signal but these are medium-confidence
+    // findings, and dropping it costs real detections.
+    expect(classifyKeyContext(`key: "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`api_key: "`, "together")).toBe("credential");
+  });
+
+  test("etag is recognised in lower-camel form", () => {
+    expect(classifyKeyContext(`eTag: "`, "together")).toBe("digest");
+    expect(classifyKeyContext(`eTagKey: "`, "together")).toBe("digest");
+  });
+
+  test("reads the naming attribute of the same tag in either order", () => {
+    const tag = (attrs: string) => `<meta ${attrs}>`;
+    expect(
+      classifyKeyContext(
+        `<meta name="algolia-api-key" content="`,
+        "algolia",
+        tag(`name="algolia-api-key" content="x"`)
+      )
+    ).toBe("credential");
+    // content first, name second — the old look-back could never see this.
+    expect(
+      classifyKeyContext(
+        `<meta content="`,
+        "algolia",
+        tag(`content="x" name="algolia-api-key"`)
+      )
+    ).toBe("credential");
+    expect(
+      classifyKeyContext(`<meta content="`, "together", tag(`content="x" name="release-sha256"`))
+    ).toBe("digest");
+    // Intervening attributes past the 64-char look-back no longer break it.
+    expect(
+      classifyKeyContext(
+        `" data-testid="release-row" content="`,
+        "algolia",
+        tag(`name="algolia-api-key" lang="en" dir="ltr" data-testid="release-row" content="x"`)
+      )
+    ).toBe("credential");
   });
 });

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -1,0 +1,215 @@
+// security/leaked-secrets — a bare hex run is a SHA-256 digest far more often
+// than it is a credential.
+//
+// The context-pattern tier ("Together AI Key" = /[a-f0-9]{64}/ near the word
+// "together", "Datadog API Key" = /[a-f0-9]{32}/ near "datadog", …) matches on
+// shape alone. That shape is also a release checksum, an SRI hash, a git object
+// id and an ETag, and the brand keyword that is supposed to make the pattern
+// specific shows up in ordinary prose ("we ship the crawler and the renderer
+// together"). Auditing squirrelscan.com's own release pages produced 19
+// findings, every one of them a published download checksum.
+//
+// So these fixtures defend the silence: a bare-shape match reports only under a
+// key that says the value is a credential, and never under sha256 / integrity /
+// checksum / commit. The prefixed patterns (sk-, ghp_, AKIA, pk_live_…) carry
+// their own marker and are untouched — the last block pins that.
+
+import { describe, expect, test } from "bun:test";
+
+import { parsePage } from "@squirrelscan/parser";
+
+import { classifyKeyContext, leakedSecretsRule, scanContent } from "../src/security/leaked-secrets";
+import type { RuleContext } from "../src/types";
+
+// A real SHA-256 of a release artifact: 64 hex characters, which is also the
+// exact shape of a Together AI key.
+const DIGEST = "01e4fbb0227e0f575e245eb0d8a4fc9b1d3a7e6c2f80b41d95ea7cd3f0b62a18"; // pragma: allowlist secret
+const DIGEST_2 = "7b2c40e91af38d605c7e1b94a2f6d083e5c19b7a4d0f38e6215ca9b70d4f8e32"; // pragma: allowlist secret
+// A second 64-hex value, this one actually assigned to an api_key.
+const TOGETHER_KEY = "9f3c1d7ba24e08f65c1b93d0e47af215c806b3e9d24f71a5c0938e6b1df42a70"; // pragma: allowlist secret
+const COMMIT = "3f9a1c5d7e2b48061a9c3d5f7e8b2a4c6d0e1f93"; // pragma: allowlist secret
+
+function html(body: string): string {
+  return `<!DOCTYPE html><html><head><title>Releases</title></head><body>${body}</body></html>`;
+}
+
+function ctx(pageHtml: string, url = "https://squirrelscan.com/releases"): RuleContext {
+  return {
+    site: {
+      baseUrl: "https://squirrelscan.com",
+      pages: [{ url, statusCode: 200, parsed: parsePage(pageHtml, url) }],
+      robotsTxt: null,
+      sitemaps: null,
+    },
+    options: {},
+  } as unknown as RuleContext;
+}
+
+function findings(checks: ReturnType<typeof leakedSecretsRule.run>["checks"]) {
+  return checks
+    .filter((c) => c.name === "leaked-secrets-high" || c.name === "leaked-secrets-medium")
+    .flatMap((c) => c.items ?? []);
+}
+
+// The shape squirrelscan.com/releases embeds in its SSR payload, verbatim: an
+// asset list where every entry carries the artifact's published checksum. The
+// release notes mention shipping things "together", which is all the Together AI
+// pattern ever needed to fire.
+const RELEASE_PAYLOAD = `<script>window.__RELEASES__={"version":"0.0.86","notes":"The crawler and the renderer now ship together.","assets":[{filename:"squirrel-0.0.86-darwin-x64",sha256:"${DIGEST}"},{filename:"squirrel-0.0.86-linux-x64",sha256:"${DIGEST_2}"}]}</script>`;
+
+const CHECKSUM_TABLE = `
+  <h2>Checksums</h2>
+  <table>
+    <tr><td>squirrel-0.0.86-darwin-x64</td><td><code>${DIGEST}</code></td></tr>
+    <tr><td>squirrel-0.0.86-linux-x64</td><td><code>${DIGEST_2}</code></td></tr>
+  </table>
+  <pre><code>sha256: ${DIGEST}</code></pre>
+`;
+
+const SRI_TAG = `<script src="https://cdn.example.net/lib.js" integrity="sha256-${DIGEST}" crossorigin="anonymous"></script>`;
+
+const COMMIT_ID = `<p>Built from commit <code data-commit="${COMMIT}">${COMMIT}</code> on Cloudflare.</p>`;
+
+describe("security/leaked-secrets: hex digests are not secrets", () => {
+  test("a release page of checksums, an SRI hash and a commit id reports nothing", () => {
+    const page = html(`${RELEASE_PAYLOAD}${CHECKSUM_TABLE}${SRI_TAG}${COMMIT_ID}`);
+    const { checks } = leakedSecretsRule.run(ctx(page));
+
+    expect(findings(checks)).toEqual([]);
+    expect(checks.find((c) => c.name === "leaked-secrets")?.status).toBe("pass");
+  });
+
+  test("the same page plus a real Together key reports exactly one finding", () => {
+    const leak = `<script>const api_key = "${TOGETHER_KEY}";</script>`; // pragma: allowlist secret
+    const page = html(`${RELEASE_PAYLOAD}${CHECKSUM_TABLE}${SRI_TAG}${COMMIT_ID}${leak}`);
+    const { checks } = leakedSecretsRule.run(ctx(page));
+
+    const items = findings(checks);
+    expect(items).toHaveLength(1);
+    // Reported values are masked, so match on the tail the mask keeps: the
+    // finding is the api_key assignment, not one of the four digests.
+    expect(items[0]?.id).toContain("API Key");
+    expect(items[0]?.id).toContain(TOGETHER_KEY.slice(-3));
+    for (const digest of [DIGEST, DIGEST_2, COMMIT]) {
+      expect(items[0]?.id).not.toContain(digest.slice(-4));
+    }
+  });
+
+  test("the exact squirrelscan.com/releases asset shape reports nothing", () => {
+    expect(scanContent(RELEASE_PAYLOAD, "inline-script")).toEqual([]);
+  });
+
+  test("digest keys suppress a 64-hex value even with the brand keyword nearby", () => {
+    for (const key of [
+      "sha256",
+      "SHA256",
+      "sha384",
+      "sha512",
+      "hash",
+      "digest",
+      "checksum",
+      "etag",
+      "commit",
+      "integrity",
+    ]) {
+      const content = `{together:true,${key}:"${DIGEST}"}`;
+      expect(scanContent(content, "inline-script")).toEqual([]);
+    }
+  });
+
+  test("a bare hex run with no key in front of it reports nothing", () => {
+    // Prose + a checksum in a table cell: no assignment, no key, no finding.
+    const content = `<p>Everything together.</p><td>${DIGEST}</td>`;
+    expect(scanContent(content, "html")).toEqual([]);
+  });
+
+  test("an SRI integrity attribute reports nothing", () => {
+    const content = `<p>bundled together</p>${SRI_TAG}`;
+    expect(scanContent(content, "html")).toEqual([]);
+  });
+});
+
+describe("security/leaked-secrets: real credentials still report", () => {
+  test("a Together key under a credential key is still reported as one", () => {
+    for (const assignment of [
+      `const togetherKey = "${TOGETHER_KEY}"`, // pragma: allowlist secret
+      `{"together_secret":"${TOGETHER_KEY}"}`, // pragma: allowlist secret
+      `window.TOGETHER_TOKEN = "${TOGETHER_KEY}"`, // pragma: allowlist secret
+    ]) {
+      const found = scanContent(assignment, "inline-script");
+      expect(found.map((f) => f.type)).toEqual(["Together AI Key"]);
+      expect(found[0]?.value).toBe(TOGETHER_KEY);
+    }
+  });
+
+  test("an Authorization: Bearer header is still reported", () => {
+    const content = `together\nAuthorization: Bearer ${TOGETHER_KEY}`; // pragma: allowlist secret
+    const found = scanContent(content, "html");
+    expect(found.map((f) => f.type)).toContain("Bearer Token");
+  });
+
+  test("prefixed keys are untouched by the key-context gate", () => {
+    // Each fixture joins its prefix at runtime: a whole token shape written as
+    // one literal trips GitHub push protection, which rejects the push before
+    // CI ever runs. The scanner sees the same string either way.
+    const PREFIX = {
+      github: "ghp_",
+      stripe: "sk_live_",
+      aws: "AKIA",
+      slack: "xoxb-",
+    };
+    const fixtures: Array<[string, string]> = [
+      ["GitHub Personal Access Token", `${PREFIX.github}016b3f2c9d4e7a815c0b2d6f39ea47c1b5d8`], // pragma: allowlist secret
+      ["Stripe Live Key", `${PREFIX.stripe}51HxQ2mKz9pLvA3nR7dTfJw8Y`], // pragma: allowlist secret
+      ["AWS Access Key ID", `${PREFIX.aws}2XJQ7LP4RNVD3KEB`], // pragma: allowlist secret
+      ["Slack Token", `${PREFIX.slack}2094857361-3948572610-Kj8dPqR2mTvX5nB7wLcH1sZa`], // pragma: allowlist secret
+      ["Private Key (RSA)", "-----BEGIN RSA PRIVATE KEY-----"], // pragma: allowlist secret
+    ];
+
+    for (const [type, value] of fixtures) {
+      const found = scanContent(`<script>const v = "${value}";</script>`, "html");
+      expect(found.map((f) => f.type)).toContain(type);
+    }
+  });
+
+  test("public-by-design client keys stay informational, not leaks", () => {
+    const page = html(
+      `<script>const cfg={apiKey:"AIzaSyD3mQ8xR2vT7pLnK4hW9cB1sE6yU0zJfXa"};</script>`, // pragma: allowlist secret
+    );
+    const { checks } = leakedSecretsRule.run(ctx(page));
+
+    expect(findings(checks)).toEqual([]);
+    expect(checks.find((c) => c.name === "leaked-secrets-public")?.status).toBe("info");
+  });
+});
+
+describe("classifyKeyContext", () => {
+  test("names the key in front of a value", () => {
+    expect(classifyKeyContext(`{filename:"x",sha256:"`, "together")).toBe("digest");
+    expect(classifyKeyContext(`<code>sha256: `, "together")).toBe("digest");
+    expect(classifyKeyContext(`integrity="sha384-`, "together")).toBe("digest");
+    expect(classifyKeyContext(`"x-api-key": "`, "together")).toBe("secret");
+    expect(classifyKeyContext(`api_key = "`, "together")).toBe("secret");
+    expect(classifyKeyContext(`Authorization: Bearer `, "together")).toBe("secret");
+    expect(classifyKeyContext(`together: "`, "together")).toBe("secret");
+    expect(classifyKeyContext(`<td>`, "together")).toBe("unknown");
+    expect(classifyKeyContext(`monkey: "`, "together")).toBe("unknown");
+  });
+
+  test("a digest key wins over a credential word in the same key", () => {
+    expect(classifyKeyContext(`sha256Key: "`, "together")).toBe("digest");
+  });
+
+  test("reads through a value-carrier attribute to the sibling that names it", () => {
+    // <meta name="algolia-api-key" content="…"> keeps the key one attribute back.
+    expect(classifyKeyContext(`<meta name="algolia-api-key" content="`, "algolia")).toBe(
+      "secret",
+    );
+    expect(classifyKeyContext(`<meta name="release-sha256" content="`, "together")).toBe(
+      "digest",
+    );
+    expect(classifyKeyContext(`<meta name="description" content="`, "together")).toBe(
+      "unknown",
+    );
+  });
+});

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -54,6 +54,12 @@ export const DEFAULT_CLOUD_AUDIT_MODEL = "google/gemini-3.1-flash-lite";
 // Leaked secrets scanning window
 export const SECRET_CONTEXT_WINDOW_SIZE = 500;
 
+// How far back a bare-shape secret pattern looks for the key it is assigned to.
+// Short on purpose: only the key immediately in front of the value says what the
+// value is (`sha256:"…"` vs `api_key:"…"`), and a wider look-back just picks up
+// an unrelated key from earlier in the payload.
+export const SECRET_KEY_LOOKBEHIND_SIZE = 64;
+
 // Shared marker for a cloud audit blocked by a per-website credit cap (#319):
 // the /cloud route's 402 typed-envelope `error.code`, the scheduler's skip
 // reason, and the dashboard's error check all key off this single string (#562).


### PR DESCRIPTION
## The false positive

`security/leaked-secrets` reported every bare 64 hex character run as a "Together AI Key". That is also exactly the shape of a SHA-256 digest, so publishing a download checksum next to a release, an SRI hash, a git object id or an ETag all came back as "potential secret(s) detected".

A 20 page crawl of squirrelscan.com produced 4 findings, every one of them a published checksum on `/releases` and `/download`. Publishing checksums beside a download is the correct thing to do, and it is common, so a secrets rule that fires on all of them trains people to ignore the `security` category.

## What changed

I audited every pattern in the rule and split them into two classes.

**Prefixed patterns (unchanged).** Everything in `FAST_PATTERNS` carries its own literal marker: a prefix (`sk-`, `ghp_`, `AKIA`, `pk_live_`, `xox[baprs]-`), a suffix (`NRAL`, `-us1`), a URL host, a PEM header, or a keyword required inside the pattern itself (AWS secret key, the generic assignments, `Bearer`). None of them can match a bare digest, so none of them needed touching. Severity is unchanged.

**Bare-shape patterns (narrowed).** Every pattern in `CONTEXT_PATTERNS` is a run of hex, base64 or alphanumeric characters gated only by a brand keyword appearing somewhere within 500 characters. Brand words show up in ordinary prose: release notes saying two things now ship "together" are enough to arm the Together AI pattern over a checksum table.

A match in that tier is now read against the key it is assigned to, which lands in one of four states:

- **`digest`, never reported.** The key is `sha`, `sha1`, `sha256`, `sha384`, `sha512`, `md5`, `hash`, `digest`, `checksum`, `integrity`, `etag`, `commit`, `revision`, `fingerprint`, `cache` or `cachekey`; or the value sits in an SRI `integrity="sha256-..."` attribute or behind any `sha256-` / `md5:` algorithm prefix. A digest key beats a credential word in the same key, so `sha256Key` is a checksum.
- **`credential`, reported.** The key names a secret (`api_key`, `apikey`, `x-api-key`, `token`, `secret`, `password`, `auth`, `authorization`, `credential`, `key`, or the pattern's own brand word), or the value follows an `Authorization: Bearer` / `Basic` scheme.
- **`assigned`, reported.** In value position under a minifier's member access (`t.a`, `e.x2`, `n["a"]`), which names nothing. Short is not enough on its own: `?v=`, `"id":` and `id:` all name their value, so they suppress.
- **`none`, not reported.** No assignment at all: a hex run in prose, or a checksum in a `<td>`.

Keys are read from plain assignments (`sha256:"..."`), bracket access (`cfg["apiKey"] = "..."`), and from the enclosing tag when the naming attribute is a sibling of the one holding the value, in either attribute order, so `<meta name="algolia-api-key" content="...">` and `<meta content="..." name="algolia-api-key">` both report while `<meta content="..." name="release-sha256">` does not.

The look-back is short by design (64 characters, `SECRET_KEY_LOOKBEHIND_SIZE`): only the key immediately in front of a value says what the value is. That is a budget rather than a hard cut, because slicing at a fixed offset can land inside the key and `keyZzz...` truncated to `eyZzz...` stops meaning anything, so the slice walks back to the nearest non-key character before giving up. The context window carries a matching lead-in so a value at the very edge of the window still has its key visible; matching runs across the lead-in and a match must reach the region proper to count, which keeps the scanned span exactly as wide as before while still catching a value that straddles the boundary.

**One pattern dropped: "LogRocket App ID"** (`/[a-z0-9]{6}\/[a-z0-9-]+/`). It matches any short path segment such as `assets/logo-dark`, and a LogRocket app id is a public client-side identifier that `LogRocket.init()` ships to the browser by design. No amount of key context makes a path shape mean "credential", so it is gone rather than narrowed.

### Three deliberate calls

- Bare `key` stays on the credential list. `key:"..."` is a weak signal, but these are medium-confidence findings and dropping it costs real detections.
- Bare `api` was removed from it. `api:"..."` names a service, not a credential.
- A minified object-literal property with no dot or bracket, `n={a:"<hex>"}`, is now suppressed, while the member-access forms `n.a="<hex>"` and `n["a"]="<hex>"` still report. That is a real if narrow true-positive loss, accepted because the alternative is treating every short key as meaningless, which is what made `?v=<hex>` and `{"id":"<hex>"}` report as leaked keys.

## Known gaps, not introduced here

Three shapes carrying a real credential are missed. All three reproduce on `main` unchanged, so they are pre-existing rather than a cost of this PR, and they are filed as #150 rather than fixed here: a quoted JSON key (`{"apiKey":"..."}`, including inside `<script type="application/json">`), a hardcoded fallback behind an env var (`process.env.SECRET_KEY || "..."`), and a standard-base64 Bearer token whose first 20 characters contain `+` or `/`.

A short key after a dot is a member access, so `x.id="<hex>"` and `cfg["id"]` report. Both did at the previous head too, so this is not new, but an `id` exception applied across property syntaxes would be a reasonable follow-up.

The tag lookup reads the context window, not the whole page, so a credential buried deep inside one enormous tag is out of its reach, as it was before this PR. On an adversarial 2MB single-tag input with a repeated service keyword, this branch scans in 89ms against 96ms (unclosed) and 102ms (closed) on `main`, so the lookup costs nothing measurable.

## Verification

Before and after on the live site, same command both ways:

```
bun run dev -- audit https://squirrelscan.com --offline -m 20 -C full
```

- before: `leaked-secrets-medium: 4 potential secret(s) detected` on `/download` and `/releases`
- after: no `security/leaked-secrets` findings

23 tests in `packages/rules/tests/leaked-secrets.test.ts`. The suppression fixtures use a release page carrying the SSR asset shape this site actually publishes (`{filename:"squirrel-0.0.86-darwin-x64",sha256:"..."}`), a checksum table in `<code>` blocks, an SRI integrity attribute and a git commit id:

- that page alone reports nothing and the rule passes
- that page plus one real-shaped key in `api_key = "..."` context reports exactly one finding, and it is the key, not any of the digests
- cache keys and `eTag` / `eTagKey` report nothing

The detection fixtures pin what must still fire, each of which fails against the first commit of this branch:

- a Together key under `togetherKey` / `together_secret` / `TOGETHER_TOKEN`, still typed "Together AI Key"
- a bracket access: `cfg["apiKey"]`, `cfg['x-api-key']`, `cfg["together"]`
- a minified assignment: `t.a = "<hex>"`, while `?v=`, `"id":`, `id:` and `{a:` stay silent
- a naming attribute written after the value
- a brand word at the far edge of the context window
- a key beginning 64, 65 and 66 characters before the value, with its credential word at the front
- a value straddling the start of the scanned region, reported exactly once
- the prefixed fixtures (`ghp_`, `sk_live_`, `AKIA`, `xoxb-`, RSA PEM header), and public-by-design keys staying informational

Also run: `bun test` (root, 4304 pass / 0 fail), `bun run test:engine` (58 pass, 0 fail; the streaming and legacy paths still produce byte-identical results over the 518 page fixture), `bun run typecheck`, `bun run lint`, `bun run format:check`, and the detect-secrets baseline check.

The prefixed fixtures assemble their prefix at runtime because a whole token shape written as one literal trips GitHub push protection and the push is rejected before CI runs.
