### PR TITLE
feat(plans): add the internal enterprise plan and an unmetered credit balance

### DIFF
--- a/apps/cli/src/audit/cloud.ts
+++ b/apps/cli/src/audit/cloud.ts
@@ -37,6 +37,7 @@ import { hasUnsafeUrlScheme } from "@squirrelscan/utils";
 
 import type { ExternalBulkChecker, SiteContextPage } from "@/audit/adapter";
 import type { Config } from "@/config";
+import type { PreflightBalance } from "@/lib/balance";
 
 import { buildBlocklistPayload } from "@/audit/cloud-payloads-blocklist";
 import { buildGapsPayloads } from "@/audit/cloud-payloads-gaps";
@@ -351,7 +352,10 @@ export interface RunCloudPrefetchOptions {
   auditId: string;
   /** Stage-1 gating policy (CLI-owned) threaded into the engine's prefetch. */
   gate?: (meta: SiteMetadata, service: CloudServiceId) => boolean;
-  confirm?: (estimatedCredits: number, balance: number) => Promise<boolean>;
+  confirm?: (
+    estimatedCredits: number,
+    balance: PreflightBalance
+  ) => Promise<boolean>;
   onProgress?: (message: string) => void;
   /**
    * Fires after every request payload has been built (synchronously) and
@@ -493,8 +497,11 @@ export async function resolveDeadLinksBulkChecker(opts: {
   auditId: string;
   siteContext: SiteContextPage[];
   /** Preflight balance for the confirm prompt; absent → no balance shown. */
-  getBalance?: () => Promise<number>;
-  confirm?: (estimatedCredits: number, balance: number) => Promise<boolean>;
+  getBalance?: () => Promise<PreflightBalance>;
+  confirm?: (
+    estimatedCredits: number,
+    balance: PreflightBalance
+  ) => Promise<boolean>;
   /**
    * Called after every SUCCESSFUL bulk call with the urls submitted and the
    * credits the server debited for it. Lets the audit controller account
@@ -518,7 +525,7 @@ export async function resolveDeadLinksBulkChecker(opts: {
   // when a confirm callback is available (TTY). Non-TTY/--yes proceeds silently,
   // bounded by the server-side per-url charge.
   if (confirm && estimate > config.cloud.confirm_threshold) {
-    let balance = 0;
+    let balance: PreflightBalance = 0;
     try {
       balance = (await opts.getBalance?.()) ?? 0;
     } catch (error) {
@@ -615,8 +622,11 @@ export interface RunCloudTechDetectOptions {
   /** Fetched scripts from the resource-assets phase (carries inline content). */
   scripts: FetchedScript[];
   /** Preflight balance for the confirm prompt; absent → no balance shown. */
-  getBalance?: () => Promise<number>;
-  confirm?: (estimatedCredits: number, balance: number) => Promise<boolean>;
+  getBalance?: () => Promise<PreflightBalance>;
+  confirm?: (
+    estimatedCredits: number,
+    balance: PreflightBalance
+  ) => Promise<boolean>;
   onProgress?: (message: string) => void;
   /** Called once after a SUCCESSFUL charged call with the credits debited. */
   onSpend?: (credits: number) => void;
@@ -812,8 +822,11 @@ export interface RunCloudEditorSummaryOptions {
   /** Deltas vs the previous audit, when the caller has a prior run. */
   delta?: EditorSummaryRequest["delta"];
   /** Preflight balance for the confirm prompt; absent → no balance shown. */
-  getBalance?: () => Promise<number>;
-  confirm?: (estimatedCredits: number, balance: number) => Promise<boolean>;
+  getBalance?: () => Promise<PreflightBalance>;
+  confirm?: (
+    estimatedCredits: number,
+    balance: PreflightBalance
+  ) => Promise<boolean>;
   onProgress?: (message: string) => void;
   /** Called once after a SUCCESSFUL charged call with the credits debited. */
   onSpend?: (credits: number) => void;
@@ -894,8 +907,11 @@ export interface RunCloudDomainStatsOptions {
   /** Registered website id, when this audit is tied to a tracked site. */
   websiteId?: string;
   /** Preflight balance for the confirm prompt; absent → no balance shown. */
-  getBalance?: () => Promise<number>;
-  confirm?: (estimatedCredits: number, balance: number) => Promise<boolean>;
+  getBalance?: () => Promise<PreflightBalance>;
+  confirm?: (
+    estimatedCredits: number,
+    balance: PreflightBalance
+  ) => Promise<boolean>;
   onProgress?: (message: string) => void;
   /** Called once after a SUCCESSFUL charged call with the credits debited. */
   onSpend?: (credits: number) => void;

--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -1245,7 +1245,15 @@ export const audit = defineCommand({
           outputPath: options.outputPath,
         })
       ) {
-        console.error(`${fmt.dim(tipLabel())}${pickTip()}`);
+        console.error(
+          `${fmt.dim(tipLabel())}${pickTip({
+            // A plan pitch only goes to someone who could act on it. A paid
+            // account already has the feature being sold, and an unmetered one
+            // cannot buy a plan at all — `unlimitedCredits` is checked as well as
+            // the tier because it is the flag that must never leak an upsell.
+            includeSales: accountPlan !== "paid" && !unlimitedCredits,
+          })}`
+        );
         console.error("");
       }
 

--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -216,9 +216,28 @@ export function computePreflightAffordability(opts: {
  *
  * Exported for tests. Returns plain lines; the caller does the printing.
  */
-export function registerFailureLines(failure: RegisterFailure): string[] {
+export function registerFailureLines(
+  failure: RegisterFailure,
+  /**
+   * The account's plan is not metered. An unmetered account CANNOT genuinely be
+   * out of credits, so this code can only mean the server disagrees with what
+   * the preflight told us: a stale deploy, or a plan change mid-run. Report that
+   * honestly instead of pitching Pro at someone on a contracted plan, which is
+   * both wrong and leaks an internal plan's existence into a sales pitch.
+   */
+  unlimited = false
+): string[] {
   if (failure.code !== "INSUFFICIENT_CREDITS") {
     return [`⚠ Run not tracked in your dashboard: ${failure.message}`];
+  }
+  if (unlimited) {
+    return [
+      fmt.yellow(
+        "⚠ Run not tracked in your dashboard: the server refused it as"
+      ),
+      `  ${fmt.yellow("insufficient credits, but this account is unmetered.")}`,
+      `  ${fmt.dim("The server may be running an older build. The audit itself ran locally and its results below are complete.")}`,
+    ];
   }
   const balanceLine =
     failure.balance != null
@@ -234,6 +253,32 @@ export function registerFailureLines(failure: RegisterFailure): string[] {
     `  ${fmt.dim("The audit itself ran locally and its results below are complete.")}`,
     ...proPitchLines("cli-audit"),
   ];
+}
+
+/**
+ * Can this signed-in account start a CLOUD audit, given its balance preflight?
+ *
+ * Pricing v10 (#391): every cloud audit debits a flat base at registration, so a
+ * balance below it cannot start one and the run drops to local-only (no
+ * register, no cloud calls, no publish) rather than letting the server 402 the
+ * register mid-crawl.
+ *
+ * An unmetered plan is EXEMPT. Its stored total is frozen and usually 0, and the
+ * server records the debit rather than deducting it, so comparing the number
+ * here would silently drop an enterprise org to local-only on every run: #1588's
+ * failure mode (eleven nights of anonymous audits misread as a rule regression)
+ * reproduced on a perfectly healthy account.
+ *
+ * Extracted from the command body so this branch is unit-testable. The inline
+ * version could only be reached by running a full audit, which is exactly why a
+ * missing flag check here would go unnoticed.
+ */
+export function canStartCloudAudit(balance: {
+  total: number;
+  unlimited?: boolean;
+}): boolean {
+  if (isUnlimitedBalance(balance)) return true;
+  return balance.total >= computeCost("audit_base", 1);
 }
 
 /** Warn once the balance drops below this share of the plan's monthly grant. */
@@ -958,7 +1003,7 @@ export const audit = defineCommand({
           // silently drop an enterprise org to local-only every run (#1588 is
           // the same failure mode with a real empty balance).
           const auditBase = computeCost("audit_base", 1);
-          if (!unlimitedCredits && balance.total < auditBase) {
+          if (!canStartCloudAudit(balance)) {
             kv(
               "Account",
               `${accountLabel} · ${fmt.yellow(`${balance.total.toLocaleString("en-US")} credits — below the ${auditBase}-credit audit base, running local-only`)} · upgrade: ${fmt.cyan(upgradeUrl("cli-audit"))}`
@@ -1642,7 +1687,11 @@ export const audit = defineCommand({
       // which used to be swallowed silently. Progress is stopped by now (finally
       // above), so this prints cleanly.
       if (registerWarning && !registeredRun) {
-        for (const line of registerFailureLines(registerWarning)) log(line);
+        for (const line of registerFailureLines(
+          registerWarning,
+          unlimitedCredits
+        ))
+          log(line);
       }
 
       // Handle errors

--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -13,6 +13,7 @@ import { existsSync } from "node:fs";
 import { platform } from "node:os";
 
 import type { AuditFailureDetails, CrawlerEvent } from "@/controllers/audit";
+import type { PreflightBalance } from "@/lib/balance";
 import type { UserSettings } from "@/self/types";
 import type { AuditOptions } from "@/types";
 
@@ -58,6 +59,7 @@ import {
   savePublishedReportInfo,
   type ReportVisibility,
 } from "@/controllers/report/publish";
+import { formatBalance, isUnlimitedBalance } from "@/lib/balance";
 import {
   createRunFinalizer,
   type FinalizeRunInput,
@@ -130,6 +132,8 @@ export interface CloudConsentEstimate {
   maxPages: number;
   balance: number | null;
   maxCredits: number;
+  /** Unmetered plan (enterprise): the balance sentence reads "unlimited". */
+  unlimited?: boolean;
 }
 
 /** The single up-front spend disclosure (pricing v10): flat audit base + render
@@ -140,8 +144,9 @@ export function consentEstimateLine(est: CloudConsentEstimate): string {
   const renderEst = computeCost("render", est.maxPages);
   const cap =
     est.maxCredits > 0 ? `, up to ${est.maxCredits} credits/audit` : "";
-  const bal =
-    est.balance != null
+  const bal = est.unlimited
+    ? " Balance: unlimited credits."
+    : est.balance != null
       ? ` Balance: ${est.balance.toLocaleString("en-US")} credits.`
       : "";
   const pages = est.maxPages === 1 ? "page" : "pages";
@@ -175,6 +180,12 @@ export function computePreflightAffordability(opts: {
   maxPages: number;
   cloudRendering: "http" | "browser";
   topUpUrl: string;
+  /**
+   * The plan is not metered against `balance` (enterprise). There is nothing to
+   * fall short of, so the estimate is still computed but never warned about.
+   * Absent = metered.
+   */
+  unlimited?: boolean;
 }): PreflightAffordability {
   const base = computeCost("audit_base", 1);
   const renderCost =
@@ -182,7 +193,7 @@ export function computePreflightAffordability(opts: {
       ? computeCost("render", opts.maxPages)
       : 0;
   const estimate = base + renderCost;
-  const shortfall = opts.balance < estimate;
+  const shortfall = !opts.unlimited && opts.balance < estimate;
   const warningLines = shortfall
     ? [
         `⚠ This audit may cost up to ${estimate.toLocaleString("en-US")} credits ` +
@@ -243,8 +254,15 @@ export function lowBalanceFooterLines(opts: {
   balance: number | null;
   monthlyCredits: number;
   plan: "anonymous" | "free" | "paid";
+  /**
+   * The plan is not metered (enterprise). An unmetered account can never be low
+   * on credits, so this warning — and the top-up/upgrade offer attached to it —
+   * must never fire for one. Absent = metered.
+   */
+  unlimited?: boolean;
 }): string[] {
   const { balance, monthlyCredits, plan } = opts;
+  if (opts.unlimited) return [];
   if (balance == null || plan === "anonymous") return [];
 
   const base = computeCost("audit_base", 1);
@@ -903,6 +921,9 @@ export const audit = defineCommand({
       // an unreachable API both read as signed-out, so cloud never half-runs.
       let signedIn = false;
       let startingBalance: number | null = null;
+      // Enterprise (unmetered) org: the balance numbers are frozen and must
+      // never be compared against a price or shown as a spendable figure.
+      let unlimitedCredits = false;
       // Plan tier of the signed-in account, captured from the balance preflight.
       // Drives the report's locked-rules messaging (#368): "free" → soft Pro hint,
       // "paid" → genuinely-unavailable framing, "anonymous" → free-account upsell.
@@ -923,6 +944,7 @@ export const audit = defineCommand({
         try {
           const { balance, plan, branding } = await statusClient.getBalance();
           startingBalance = balance.total;
+          unlimitedCredits = isUnlimitedBalance(balance);
           accountPlan = plan.id === "free" ? "free" : "paid";
           planMonthlyCredits = plan.monthlyCredits;
           reportBranding = branding;
@@ -930,8 +952,13 @@ export const audit = defineCommand({
           // registration. A balance below it can't start one — run local-only
           // (no register, no cloud calls, no publish) instead of letting the
           // server 402 the register mid-crawl.
+          //
+          // An unmetered plan is exempt: its stored total is frozen (often 0)
+          // and the server never refuses the debit, so comparing it here would
+          // silently drop an enterprise org to local-only every run (#1588 is
+          // the same failure mode with a real empty balance).
           const auditBase = computeCost("audit_base", 1);
-          if (balance.total < auditBase) {
+          if (!unlimitedCredits && balance.total < auditBase) {
             kv(
               "Account",
               `${accountLabel} · ${fmt.yellow(`${balance.total.toLocaleString("en-US")} credits — below the ${auditBase}-credit audit base, running local-only`)} · upgrade: ${fmt.cyan(upgradeUrl("cli-audit"))}`
@@ -940,7 +967,7 @@ export const audit = defineCommand({
             signedIn = true;
             kv(
               "Account",
-              `${accountLabel} · ${fmt.bold(balance.total.toLocaleString("en-US"))} credits`
+              `${accountLabel} · ${fmt.bold(formatBalance(balance.total, unlimitedCredits))} credits`
             );
           }
         } catch (error) {
@@ -1259,6 +1286,7 @@ export const audit = defineCommand({
             maxPages,
             balance: startingBalance,
             maxCredits: config.cloud.max_credits_per_audit,
+            unlimited: unlimitedCredits,
           },
         });
 
@@ -1276,6 +1304,7 @@ export const audit = defineCommand({
           maxPages,
           cloudRendering,
           topUpUrl: upgradeUrl("cli-audit"),
+          unlimited: unlimitedCredits,
         });
         if (preflight.shortfall) {
           log("");
@@ -1444,7 +1473,12 @@ export const audit = defineCommand({
         // controller via `cloudConsented`, not by nulling this callback.
         const confirmCloudSpend =
           process.stdout.isTTY && !args.yes
-            ? async (estimate: number, balance: number): Promise<boolean> => {
+            ? async (
+                estimate: number,
+                // An unmetered org still confirms the spend (it is accounted
+                // and invoiced), it just sees "balance: unlimited".
+                balance: PreflightBalance
+              ): Promise<boolean> => {
                 progress.stop();
                 const { createInterface } = await import("node:readline");
                 const rl = createInterface({
@@ -2019,8 +2053,11 @@ export const audit = defineCommand({
           const after =
             report.cloudSpend?.balanceAfter ??
             (spent === 0 ? startingBalance : null);
-          const balancePart =
-            after != null
+          // An unmetered org's "balance after" is meaningless (nothing was
+          // deducted) — say unlimited rather than echo a frozen number.
+          const balancePart = unlimitedCredits
+            ? " · balance unlimited"
+            : after != null
               ? ` · balance ${spent > 0 ? "~" : ""}${after.toLocaleString("en-US")}`
               : "";
           footerLines.push(
@@ -2040,6 +2077,7 @@ export const audit = defineCommand({
               balance: after,
               monthlyCredits: planMonthlyCredits,
               plan: accountPlan,
+              unlimited: unlimitedCredits,
             })
           );
         } else {

--- a/apps/cli/src/cli/commands/auth.ts
+++ b/apps/cli/src/cli/commands/auth.ts
@@ -3,6 +3,7 @@
 import { defineCommand } from "citty";
 
 import { DASHBOARD_URL, STATUS_REQUEST_TIMEOUT_MS } from "@/constants";
+import { formatBalance, isUnlimitedBalance } from "@/lib/balance";
 import {
   API_TOKEN_ENV_VAR,
   activeEnvTokenVar,
@@ -183,7 +184,9 @@ async function runStatusCommand(jsonOutput: boolean): Promise<void> {
     });
     if (client) {
       const { balance } = await client.getBalance();
-      console.log(`  Credits: ${balance.total.toLocaleString("en-US")}`);
+      console.log(
+        `  Credits: ${formatBalance(balance.total, isUnlimitedBalance(balance))}`
+      );
     }
   } catch {
     // ignore — balance is informational here; `squirrel credits` has the full view

--- a/apps/cli/src/cli/commands/credits.ts
+++ b/apps/cli/src/cli/commands/credits.ts
@@ -3,6 +3,7 @@
 import { defineCommand } from "citty";
 
 import { fmt } from "@/cli/format";
+import { isUnlimitedBalance } from "@/lib/balance";
 import { openBrowser } from "@/lib/browser";
 import { AUDIT_BASE_CREDITS, proPitchLines, upgradeUrl } from "@/lib/upgrade";
 import { warnIfSessionUnreadable } from "@/self/credentials";
@@ -60,25 +61,36 @@ export const credits = defineCommand({
       }
 
       const { balance, plan, pricing } = res;
+      const unlimited = isUnlimitedBalance(balance);
       console.log(`Plan:    ${plan.name}`);
-      console.log(
-        `Balance: ${balance.total} credits` +
-          (balance.monthly > 0
-            ? ` (${balance.monthly} monthly + ${balance.pack} purchased)`
-            : "")
-      );
-      if (balance.periodEnd) {
+      if (unlimited) {
+        // The stored numbers are frozen on an unmetered plan, so printing them
+        // (or the monthly/reset/below-base lines) would describe a balance that
+        // does not govern anything. Usage is still recorded and invoiced.
+        console.log("Balance: unlimited");
         console.log(
-          `         monthly credits reset ${balance.periodEnd.slice(0, 10)}`
+          fmt.dim("         usage is recorded on your account and invoiced")
         );
-      }
-      // A balance under the flat base can buy NOTHING, however positive it
-      // reads. Say so here rather than letting the next `squirrel audit`
-      // silently drop to local-only.
-      if (balance.total < AUDIT_BASE_CREDITS) {
+      } else {
         console.log(
-          `         ${fmt.yellow(`below the ${AUDIT_BASE_CREDITS}-credit audit base — cloud audits can't start`)}`
+          `Balance: ${balance.total} credits` +
+            (balance.monthly > 0
+              ? ` (${balance.monthly} monthly + ${balance.pack} purchased)`
+              : "")
         );
+        if (balance.periodEnd) {
+          console.log(
+            `         monthly credits reset ${balance.periodEnd.slice(0, 10)}`
+          );
+        }
+        // A balance under the flat base can buy NOTHING, however positive it
+        // reads. Say so here rather than letting the next `squirrel audit`
+        // silently drop to local-only.
+        if (balance.total < AUDIT_BASE_CREDITS) {
+          console.log(
+            `         ${fmt.yellow(`below the ${AUDIT_BASE_CREDITS}-credit audit base — cloud audits can't start`)}`
+          );
+        }
       }
       console.log("");
       console.log("Pricing:");
@@ -119,7 +131,11 @@ export const credits = defineCommand({
       console.log("");
       // The free plan is where the wall gets hit, so that is where the offer
       // goes. Paid plans get the top-up link, not a plan pitch they're on.
-      if (plan.id === "free") {
+      // An unmetered plan gets NEITHER: there is no balance to top up and no
+      // plan above it to sell (see SELF_SERVE_PLAN_IDS).
+      if (unlimited) {
+        // nothing to sell
+      } else if (plan.id === "free") {
         for (const line of proPitchLines("cli-credits")) console.log(line);
         console.log(fmt.dim("  Or run `squirrel credits --upgrade`."));
       } else {

--- a/apps/cli/src/cli/commands/credits.ts
+++ b/apps/cli/src/cli/commands/credits.ts
@@ -133,13 +133,13 @@ export const credits = defineCommand({
       // goes. Paid plans get the top-up link, not a plan pitch they're on.
       // An unmetered plan gets NEITHER: there is no balance to top up and no
       // plan above it to sell (see SELF_SERVE_PLAN_IDS).
-      if (unlimited) {
-        // nothing to sell
-      } else if (plan.id === "free") {
-        for (const line of proPitchLines("cli-credits")) console.log(line);
-        console.log(fmt.dim("  Or run `squirrel credits --upgrade`."));
-      } else {
-        console.log(`Top up: ${fmt.cyan(UPGRADE_URL)}`);
+      if (!unlimited) {
+        if (plan.id === "free") {
+          for (const line of proPitchLines("cli-credits")) console.log(line);
+          console.log(fmt.dim("  Or run `squirrel credits --upgrade`."));
+        } else {
+          console.log(`Top up: ${fmt.cyan(UPGRADE_URL)}`);
+        }
       }
     } catch (error) {
       console.error(`Could not fetch balance: ${(error as Error).message}`);

--- a/apps/cli/src/cli/tips.ts
+++ b/apps/cli/src/cli/tips.ts
@@ -3,32 +3,97 @@
 
 import { COVERAGE_FULL_MAX_PAGES } from "@/constants";
 
-export const TIPS: readonly string[] = [
-  "New rules ship all the time. `squirrel self update` gets you the latest.",
-  "Give your coding agent audit superpowers: `squirrel mcp` is a full MCP server → docs.squirrelscan.com/developers/mcp",
-  "Teach your agent to fix sites: `squirrel skills install` works with Claude Code, Cursor, Codex and friends.",
-  "Something rough? Something great? `squirrel feedback` goes straight to the team.",
-  `This scratches the surface. \`--coverage full\` goes deep: up to ${COVERAGE_FULL_MAX_PAGES} pages.`,
-  "Big site? `--incremental` only re-crawls what changed since your last audit.",
-  "Suspect stale pages? `--refresh` ignores the cache and fetches everything fresh.",
-  '`--format llm` renders the report for agents: pipe it to Claude and say "fix it".',
-  "The fix loop: audit, let your agent fix, re-audit → docs.squirrelscan.com/guides/fix-your-site-with-an-ai-agent",
-  "Client-side rendered? Browser rendering audits what browsers (and Google) actually see → docs.squirrelscan.com/guides/browser-rendering",
-  "Pro: scheduled cloud audits watch your sites while you sleep → docs.squirrelscan.com/cloud/scheduled-audits",
-  "Tweaking config? `squirrel analyze` re-runs rules on the stored crawl. No re-crawl needed.",
-  "`squirrel report list` shows every past audit. Re-render any of them in any format.",
-  "Audit this site often? `squirrel init` writes a squirrel.toml so your flags become defaults.",
-  "Run squirrel in CI: `squirrel keys create` mints an org API key → docs.squirrelscan.com/guides/ci",
-  "Weird behavior? `squirrel self doctor` checks your install, auth, and connectivity.",
-  "`squirrel credits` shows your balance and what each cloud feature costs. No surprises.",
-  "Staging behind a login or bot wall? Send custom headers with the crawl → docs.squirrelscan.com/guides/web-bot-auth",
-  "Robots read your site too. The ax rules score agent experience, not just SEO.",
-  "Signed-in audits track every issue across runs in your dashboard. Regressions get caught.",
+interface Tip {
+  text: string;
+  /**
+   * Sells a plan. Only shown to an account that could actually act on it: a
+   * paid account already has the feature, and an unmetered (enterprise) account
+   * cannot buy a plan at all — pitching one there reads as a mis-sold upsell and
+   * leaks an internal plan's existence into a promo.
+   */
+  sales?: boolean;
+}
+
+const ALL_TIPS: readonly Tip[] = [
+  {
+    text: "New rules ship all the time. `squirrel self update` gets you the latest.",
+  },
+  {
+    text: "Give your coding agent audit superpowers: `squirrel mcp` is a full MCP server → docs.squirrelscan.com/developers/mcp",
+  },
+  {
+    text: "Teach your agent to fix sites: `squirrel skills install` works with Claude Code, Cursor, Codex and friends.",
+  },
+  {
+    text: "Something rough? Something great? `squirrel feedback` goes straight to the team.",
+  },
+  {
+    text: `This scratches the surface. \`--coverage full\` goes deep: up to ${COVERAGE_FULL_MAX_PAGES} pages.`,
+  },
+  {
+    text: "Big site? `--incremental` only re-crawls what changed since your last audit.",
+  },
+  {
+    text: "Suspect stale pages? `--refresh` ignores the cache and fetches everything fresh.",
+  },
+  {
+    text: '`--format llm` renders the report for agents: pipe it to Claude and say "fix it".',
+  },
+  {
+    text: "The fix loop: audit, let your agent fix, re-audit → docs.squirrelscan.com/guides/fix-your-site-with-an-ai-agent",
+  },
+  {
+    text: "Client-side rendered? Browser rendering audits what browsers (and Google) actually see → docs.squirrelscan.com/guides/browser-rendering",
+  },
+  {
+    text: "Pro: scheduled cloud audits watch your sites while you sleep → docs.squirrelscan.com/cloud/scheduled-audits",
+    // Sells a plan a paid account already has and an unmetered one can never buy.
+    sales: true,
+  },
+  {
+    text: "Tweaking config? `squirrel analyze` re-runs rules on the stored crawl. No re-crawl needed.",
+  },
+  {
+    text: "`squirrel report list` shows every past audit. Re-render any of them in any format.",
+  },
+  {
+    text: "Audit this site often? `squirrel init` writes a squirrel.toml so your flags become defaults.",
+  },
+  {
+    text: "Run squirrel in CI: `squirrel keys create` mints an org API key → docs.squirrelscan.com/guides/ci",
+  },
+  {
+    text: "Weird behavior? `squirrel self doctor` checks your install, auth, and connectivity.",
+  },
+  {
+    text: "`squirrel credits` shows your balance and what each cloud feature costs. No surprises.",
+  },
+  {
+    text: "Staging behind a login or bot wall? Send custom headers with the crawl → docs.squirrelscan.com/guides/web-bot-auth",
+  },
+  {
+    text: "Robots read your site too. The ax rules score agent experience, not just SEO.",
+  },
+  {
+    text: "Signed-in audits track every issue across runs in your dashboard. Regressions get caught.",
+  },
 ] as const;
 
-/** Uniformly random tip. No rotation/persistence — every run is a fresh draw. */
-export function pickTip(): string {
-  return TIPS[Math.floor(Math.random() * TIPS.length)];
+/** Every tip's text, in order. The visible surface, for tests and docs. */
+export const TIPS: readonly string[] = ALL_TIPS.map((tip) => tip.text);
+
+/**
+ * Uniformly random tip. No rotation/persistence — every run is a fresh draw.
+ *
+ * `includeSales` defaults to FALSE: a plan pitch has to be opted into by a
+ * caller that knows the account can act on it, so a caller which forgets to
+ * pass the plan through shows no promo rather than the wrong one.
+ */
+export function pickTip(opts: { includeSales?: boolean } = {}): string {
+  const pool = opts.includeSales
+    ? ALL_TIPS
+    : ALL_TIPS.filter((tip) => !tip.sales);
+  return pool[Math.floor(Math.random() * pool.length)]!.text;
 }
 
 export interface TipVisibilityOptions {

--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -24,6 +24,8 @@ import {
   createFetchDocumentFetcher,
 } from "@squirrelscan/fetchers";
 
+import type { PreflightBalance } from "@/lib/balance";
+
 import {
   fetchResourceAssets,
   runRulesOnStorage,
@@ -67,6 +69,7 @@ import {
 import { createHybridDocumentFetcher } from "@/crawl/hybrid-fetcher";
 import { resolveSeedRedirect } from "@/crawler/frontier";
 import { createStorage, domainToProjectName } from "@/crawler/storage";
+import { preflightBalanceOf } from "@/lib/balance";
 import { reconstructReport } from "@/reports/reconstruct";
 import { detectRunner } from "@/self/install-meta";
 import { createCloudClientFromSettings } from "@/tools/cloud";
@@ -153,7 +156,7 @@ export interface RunAuditOptions extends AuditOptions {
    */
   confirmCloudSpend?: (
     estimatedCredits: number,
-    balance: number
+    balance: PreflightBalance
   ) => Promise<boolean>;
   /** User accepted the cost-disclosing consent prompt under a cap → skip the
    * post-crawl prefetch confirm. Uncapped spend (dead-links) is still gated. */
@@ -1137,7 +1140,8 @@ export async function runAudit(
           auditId: crawlId,
           siteContext,
           getBalance: deadLinksClient
-            ? async () => (await deadLinksClient.getBalance()).balance.total
+            ? async () =>
+                preflightBalanceOf((await deadLinksClient.getBalance()).balance)
             : undefined,
           confirm: options.confirmCloudSpend,
           onSpend: (units, credits) => {
@@ -1262,7 +1266,8 @@ export async function runAudit(
           siteContext,
           scripts: assets.scripts,
           getBalance: techClient
-            ? async () => (await techClient.getBalance()).balance.total
+            ? async () =>
+                preflightBalanceOf((await techClient.getBalance()).balance)
             : undefined,
           confirm: options.confirmCloudSpend,
           onProgress: (detail) => onProgress({ phase: "cloud", detail }),
@@ -1475,7 +1480,8 @@ export async function runAudit(
           auditId: crawlId,
           report,
           getBalance: summaryClient
-            ? async () => (await summaryClient.getBalance()).balance.total
+            ? async () =>
+                preflightBalanceOf((await summaryClient.getBalance()).balance)
             : undefined,
           confirm: options.confirmCloudSpend,
           onProgress: (detail) => onProgress({ phase: "cloud", detail }),
@@ -1509,7 +1515,8 @@ export async function runAudit(
           auditId: crawlId,
           baseUrl: url,
           getBalance: statsClient
-            ? async () => (await statsClient.getBalance()).balance.total
+            ? async () =>
+                preflightBalanceOf((await statsClient.getBalance()).balance)
             : undefined,
           confirm: options.confirmCloudSpend,
           onProgress: (detail) => onProgress({ phase: "cloud", detail }),

--- a/apps/cli/src/lib/balance.ts
+++ b/apps/cli/src/lib/balance.ts
@@ -1,0 +1,48 @@
+// One reading of "can this account afford things?" for every CLI surface that
+// used to compare `balance.total` against a cost.
+//
+// The enterprise plan (internal, 2026-08-28) is not metered against a prepaid
+// balance: `GET /v1/credits` returns `balance.unlimited: true` and the stored
+// numbers are frozen. Comparing `total` against a price there is wrong in both
+// directions — a frozen 0 would drop the run to local-only, and a frozen 5,000
+// would look like a balance that can run out. Every gate, warning and upsell in
+// the CLI must therefore ask `isUnlimitedBalance` first.
+//
+// The field is OPTIONAL on the wire: a binary already on someone's machine
+// talks to whatever server it finds, and servers predating the plan omit it.
+// Absent = metered, which is the safe reading (it keeps today's behaviour).
+
+/**
+ * Preflight balance passed to a spend-confirm prompt. `"unlimited"` renders as
+ * that word instead of a misleading frozen number.
+ */
+export type PreflightBalance = number | "unlimited";
+
+/**
+ * True when the account's plan is not metered. Deliberately takes the loose
+ * shape rather than `CreditsResponse["balance"]` so callers holding a partially
+ * typed or hand-built payload (tests, the run-tracker's register response) can
+ * pass it without a cast. `undefined`/`null` → false.
+ */
+export function isUnlimitedBalance(
+  balance: { unlimited?: boolean } | null | undefined
+): boolean {
+  return balance?.unlimited === true;
+}
+
+/** The balance as shown to a user: a grouped number, or the word "unlimited". */
+export function formatBalance(total: number, unlimited: boolean): string {
+  return unlimited ? "unlimited" : total.toLocaleString("en-US");
+}
+
+/**
+ * The balance to hand a confirm prompt. Unlimited accounts still see the
+ * estimate (the spend is real, it is just invoiced rather than deducted), so
+ * the prompt is kept — only the balance half changes.
+ */
+export function preflightBalanceOf(balance: {
+  total: number;
+  unlimited?: boolean;
+}): PreflightBalance {
+  return isUnlimitedBalance(balance) ? "unlimited" : balance.total;
+}

--- a/apps/cli/tests/cli/tips.test.ts
+++ b/apps/cli/tests/cli/tips.test.ts
@@ -44,6 +44,52 @@ describe("pickTip", () => {
     }
   });
 
+  // A tip that sells a plan is shown 1-in-20 runs regardless of who is running,
+  // so before this it pitched Pro at paying customers and at unmetered
+  // (enterprise) accounts, which cannot buy a plan at all.
+  test("omits plan-sales tips by default", () => {
+    for (let i = 0; i < 200; i++) {
+      expect(pickTip()).not.toContain("Pro:");
+    }
+  });
+
+  test("omits them for an explicitly non-sales caller", () => {
+    for (let i = 0; i < 200; i++) {
+      expect(pickTip({ includeSales: false })).not.toContain("Pro:");
+    }
+  });
+
+  // Forced index rather than sampling: with the sales tip filtered out the pool
+  // shrinks, so this pins that NO index of the filtered pool can reach it.
+  test("no random draw can reach a sales tip when they are excluded", () => {
+    const originalRandom = Math.random;
+    try {
+      for (const r of [0, 0.25, 0.5, 0.75, 0.9999999999]) {
+        Math.random = () => r;
+        const tip = pickTip();
+        expect(tip).not.toContain("Pro:");
+        expect(TIPS).toContain(tip);
+      }
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  test("a caller that opts in can still reach the sales tip", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 500; i++) seen.add(pickTip({ includeSales: true }));
+    expect([...seen].some((tip) => tip.includes("Pro:"))).toBe(true);
+  });
+
+  test("exactly one tip is tagged as plan sales", () => {
+    const salesTips = TIPS.filter((tip) => tip.includes("Pro:"));
+    expect(salesTips).toHaveLength(1);
+    // The filtered pool is the full list minus exactly that one.
+    const reachable = new Set<string>();
+    for (let i = 0; i < 2000; i++) reachable.add(pickTip());
+    expect(reachable.size).toBe(TIPS.length - 1);
+  });
+
   test("interpolates the coverage constant instead of a hardcoded page count", () => {
     const fullCoverageTip = TIPS.find((t) => t.includes("--coverage full"));
     expect(fullCoverageTip).toBeDefined();

--- a/apps/cli/tests/commands/credits-unlimited.test.ts
+++ b/apps/cli/tests/commands/credits-unlimited.test.ts
@@ -1,0 +1,173 @@
+// Command-level coverage for an UNMETERED account (the internal enterprise
+// plan), driving the real citty `run({ args })` rather than only the exported
+// formatters.
+//
+// Why command-level: the first cut of this feature made every pure helper
+// unlimited-aware and still shipped a Pro pitch, because one CALLER never passed
+// the flag through. Helper tests cannot see a caller that forgets to ask. So
+// these assert on what the command actually prints.
+//
+// Seams stubbed, following tests/commands/feedback.test.ts:
+//   - @/tools/cloud createCloudClientFromSettings — spyOn (NOT mock.module,
+//     which leaks process-wide per #1037) returning a client whose getBalance
+//     replays a scripted /v1/credits payload. No network, no credentials.
+//   - @/self/credentials warnIfSessionUnreadable — spyOn to a no-op so a real
+//     ~/.squirrel read never happens.
+//   - console.log — captured so the assertions read the actual output.
+
+import { describe, expect, spyOn, test, beforeEach, afterAll } from "bun:test";
+
+import { credits } from "@/cli/commands/credits";
+import { AUDIT_BASE_CREDITS } from "@/lib/upgrade";
+import * as credentialsModule from "@/self/credentials";
+import * as cloudModule from "@/tools/cloud";
+
+type Balance = {
+  monthly: number;
+  pack: number;
+  total: number;
+  periodEnd: string | null;
+  unlimited?: boolean;
+};
+
+let balancePayload: Balance;
+let planPayload: { id: string; name: string; monthlyCredits: number };
+
+const PRICING = {
+  audit_base: { cost: AUDIT_BASE_CREDITS, per: 1, unit: "audit" },
+  render: { cost: 2, per: 1, unit: "page" },
+};
+
+spyOn(credentialsModule, "warnIfSessionUnreadable").mockImplementation(
+  () => {}
+);
+
+spyOn(cloudModule, "createCloudClientFromSettings").mockImplementation(
+  () =>
+    ({
+      getBalance: async () => ({
+        balance: balancePayload,
+        plan: planPayload,
+        pricing: PRICING,
+        pricingVersion: 10,
+      }),
+    }) as unknown as ReturnType<
+      typeof cloudModule.createCloudClientFromSettings
+    >
+);
+
+let logged: string[] = [];
+const logSpy = spyOn(console, "log").mockImplementation(
+  (...args: unknown[]) => {
+    logged.push(args.map(String).join(" "));
+  }
+);
+
+afterAll(() => {
+  logSpy.mockRestore();
+});
+
+beforeEach(() => {
+  logged = [];
+  // The realistic enterprise shape: nothing granted, nothing deducted, so the
+  // stored total sits at 0 forever.
+  balancePayload = {
+    monthly: 0,
+    pack: 0,
+    total: 0,
+    periodEnd: null,
+    unlimited: true,
+  };
+  planPayload = { id: "enterprise", name: "Enterprise", monthlyCredits: 0 };
+});
+
+const output = () => logged.join("\n");
+
+async function runCredits(): Promise<void> {
+  await (
+    credits.run as unknown as (ctx: {
+      args: Record<string, unknown>;
+    }) => Promise<void>
+  )({ args: {} });
+}
+
+describe("`squirrel credits` on an unmetered account", () => {
+  test('prints "unlimited", never the frozen zero', async () => {
+    await runCredits();
+    expect(output()).toContain("Balance: unlimited");
+    // The frozen number would read as "you cannot afford anything".
+    expect(output()).not.toContain("Balance: 0 credits");
+  });
+
+  test("says the usage is still recorded, so it does not read as free", async () => {
+    await runCredits();
+    expect(output()).toContain("invoiced");
+  });
+
+  test("never warns about being below the audit base", async () => {
+    await runCredits();
+    expect(output()).not.toContain("audit base");
+    expect(output()).not.toContain("cloud audits can't start");
+  });
+
+  // The regression that shipped once: every helper was correct and a caller
+  // still pitched Pro.
+  test("shows NO Pro pitch, no upgrade URL and no top-up link", async () => {
+    await runCredits();
+    const text = output();
+    expect(text).not.toContain("Pro:");
+    expect(text).not.toContain("$19");
+    expect(text).not.toContain("Top up");
+    expect(text).not.toContain("squirrelscan.com/upgrade");
+    expect(text).not.toContain("credits --upgrade");
+  });
+
+  test("still prints the pricing table: the spend is real, just invoiced", async () => {
+    await runCredits();
+    expect(output()).toContain("Pricing:");
+    expect(output()).toContain(String(AUDIT_BASE_CREDITS));
+  });
+
+  test("--json passes the flag through untouched for scripts", async () => {
+    await (
+      credits.run as unknown as (ctx: {
+        args: Record<string, unknown>;
+      }) => Promise<void>
+    )({ args: { json: true } });
+    const parsed = JSON.parse(output()) as { balance: Balance };
+    expect(parsed.balance.unlimited).toBe(true);
+    expect(parsed.balance.total).toBe(0);
+  });
+});
+
+describe("`squirrel credits` on a metered account (control)", () => {
+  test("a free account still gets the Pro pitch", async () => {
+    balancePayload = { monthly: 10, pack: 0, total: 10, periodEnd: null };
+    planPayload = { id: "free", name: "Free", monthlyCredits: 500 };
+    await runCredits();
+    const text = output();
+    expect(text).toContain("Balance: 10 credits");
+    expect(text).toContain("Pro:");
+    // 10 credits cannot buy the 50-credit base, so the warning must fire.
+    expect(text).toContain("audit base");
+  });
+
+  test("a paid account still gets the top-up link", async () => {
+    balancePayload = { monthly: 3000, pack: 0, total: 3000, periodEnd: null };
+    planPayload = { id: "starter", name: "Pro", monthlyCredits: 3000 };
+    await runCredits();
+    expect(output()).toContain("Top up");
+  });
+
+  // An older server omits the field; reading absent as unlimited would hide a
+  // real empty balance.
+  test("an absent `unlimited` field is treated as metered", async () => {
+    balancePayload = { monthly: 0, pack: 0, total: 0, periodEnd: null };
+    planPayload = { id: "starter", name: "Pro", monthlyCredits: 3000 };
+    await runCredits();
+    const text = output();
+    expect(text).toContain("Balance: 0 credits");
+    expect(text).toContain("audit base");
+    expect(text).not.toContain("Balance: unlimited");
+  });
+});

--- a/apps/cli/tests/commands/credits-unlimited.test.ts
+++ b/apps/cli/tests/commands/credits-unlimited.test.ts
@@ -38,11 +38,15 @@ const PRICING = {
   render: { cost: 2, per: 1, unit: "page" },
 };
 
-spyOn(credentialsModule, "warnIfSessionUnreadable").mockImplementation(
-  () => {}
-);
+const warnSpy = spyOn(
+  credentialsModule,
+  "warnIfSessionUnreadable"
+).mockImplementation(() => {});
 
-spyOn(cloudModule, "createCloudClientFromSettings").mockImplementation(
+const cloudClientSpy = spyOn(
+  cloudModule,
+  "createCloudClientFromSettings"
+).mockImplementation(
   () =>
     ({
       getBalance: async () => ({
@@ -63,8 +67,13 @@ const logSpy = spyOn(console, "log").mockImplementation(
   }
 );
 
+// Restore EVERY top-level spy, not just console.log: these patch shared module
+// namespaces, so a leaked credential or cloud-client stub would silently serve a
+// canned balance to any later test file in the same bun process.
 afterAll(() => {
   logSpy.mockRestore();
+  warnSpy.mockRestore();
+  cloudClientSpy.mockRestore();
 });
 
 beforeEach(() => {

--- a/apps/cli/tests/lib/unlimited-balance.test.ts
+++ b/apps/cli/tests/lib/unlimited-balance.test.ts
@@ -14,9 +14,11 @@ import { computeCost } from "@squirrelscan/core-contracts/credits";
 import { describe, expect, test } from "bun:test";
 
 import {
+  canStartCloudAudit,
   computePreflightAffordability,
   consentEstimateLine,
   lowBalanceFooterLines,
+  registerFailureLines,
 } from "../../src/cli/commands/audit";
 import { renderConcurrencyUpsellHint } from "../../src/controllers/audit";
 import {
@@ -169,6 +171,81 @@ describe("consentEstimateLine on an unmetered plan", () => {
       maxCredits: 0,
     });
     expect(line).toContain("Balance: 1,234 credits.");
+  });
+});
+
+describe("canStartCloudAudit — the local-only degrade gate", () => {
+  // #1588's failure mode, reproduced on a healthy account: an unmetered org's
+  // stored total is frozen at 0, so a numeric comparison drops EVERY run to
+  // local-only (exit 0, no register, no publish) and every cloud assertion
+  // downstream fails for a reason unrelated to what it is testing.
+  test("an unmetered account can always start, at any frozen total", () => {
+    for (const total of [0, 1, AUDIT_BASE - 1]) {
+      expect(canStartCloudAudit({ total, unlimited: true })).toBe(true);
+    }
+  });
+
+  test("a metered account still needs the full audit base (control)", () => {
+    expect(canStartCloudAudit({ total: AUDIT_BASE })).toBe(true);
+    expect(canStartCloudAudit({ total: AUDIT_BASE - 1 })).toBe(false);
+    expect(canStartCloudAudit({ total: 0 })).toBe(false);
+  });
+
+  test("an absent or false flag is metered", () => {
+    expect(canStartCloudAudit({ total: 0, unlimited: false })).toBe(false);
+    expect(canStartCloudAudit({ total: 0, unlimited: undefined })).toBe(false);
+  });
+});
+
+describe("registerFailureLines on an unmetered account", () => {
+  const outOfCredits = {
+    code: "INSUFFICIENT_CREDITS" as const,
+    message: "Out of credits",
+    balance: 0,
+  };
+
+  // An unmetered account cannot genuinely run out, so this code can only mean
+  // the server disagrees with the preflight (a stale deploy, or a plan change
+  // mid-run). Pitching Pro at a contracted customer is wrong on its own, and it
+  // also leaks the existence of an internal plan into a sales pitch.
+  test("never pitches Pro, prices or an upgrade URL", () => {
+    const lines = text(registerFailureLines(outOfCredits, true));
+    expect(lines).not.toContain("Pro:");
+    expect(lines).not.toContain("$19");
+    expect(lines).not.toContain("squirrelscan.com/upgrade");
+    expect(lines).not.toContain("You have 0 credits");
+  });
+
+  test("says what actually happened, including that the server may be stale", () => {
+    const lines = text(registerFailureLines(outOfCredits, true));
+    expect(lines).toContain("unmetered");
+    expect(lines).toContain("older build");
+    // The run itself still succeeded locally; a warning that reads like a
+    // failure is the thing this copy exists to avoid.
+    expect(lines).toContain("results below are complete");
+  });
+
+  test("a metered account still gets the full offer (control)", () => {
+    const lines = text(registerFailureLines(outOfCredits));
+    expect(lines).toContain("Pro:");
+    expect(lines).toContain("You have 0 credits");
+  });
+
+  test("the flag defaults to metered when omitted", () => {
+    expect(text(registerFailureLines(outOfCredits))).toContain("Pro:");
+  });
+
+  test("a non-credit failure is unchanged on both plans", () => {
+    const limit = {
+      code: "WEBSITE_LIMIT" as const,
+      message: "at your website limit",
+      balance: null,
+    };
+    for (const unlimited of [true, false]) {
+      const lines = text(registerFailureLines(limit, unlimited));
+      expect(lines).toContain("at your website limit");
+      expect(lines).not.toContain("Pro:");
+    }
   });
 });
 

--- a/apps/cli/tests/lib/unlimited-balance.test.ts
+++ b/apps/cli/tests/lib/unlimited-balance.test.ts
@@ -1,0 +1,187 @@
+// The CLI's reading of an UNMETERED account (the internal enterprise plan).
+//
+// `GET /v1/credits` returns `balance.unlimited: true` and leaves the stored
+// numbers frozen — often 0, because nothing has ever been deducted. Every CLI
+// surface that used to compare `balance.total` against a price would therefore
+// get the wrong answer: #1588's exact failure mode (a real 5-credit balance
+// dropping every run to local-only with exit 0), except here the account can
+// actually afford everything.
+//
+// The flag is OPTIONAL on the wire: this binary talks to whatever server it
+// finds, and a server predating the plan omits it. Absent must read as metered.
+
+import { computeCost } from "@squirrelscan/core-contracts/credits";
+import { describe, expect, test } from "bun:test";
+
+import {
+  computePreflightAffordability,
+  consentEstimateLine,
+  lowBalanceFooterLines,
+} from "../../src/cli/commands/audit";
+import { renderConcurrencyUpsellHint } from "../../src/controllers/audit";
+import {
+  formatBalance,
+  isUnlimitedBalance,
+  preflightBalanceOf,
+} from "../../src/lib/balance";
+
+const AUDIT_BASE = computeCost("audit_base", 1);
+const TOP_UP = "https://squirrelscan.com/upgrade?src=cli-audit";
+const text = (lines: string[]) => lines.join("\n");
+
+describe("isUnlimitedBalance", () => {
+  test("true only for an explicit true", () => {
+    expect(isUnlimitedBalance({ unlimited: true })).toBe(true);
+  });
+
+  // An older server omits the field entirely. Reading that as "unlimited" would
+  // let a broke free org sail past every affordability gate.
+  test("an absent, null or undefined flag is metered", () => {
+    expect(isUnlimitedBalance({})).toBe(false);
+    expect(isUnlimitedBalance({ unlimited: undefined })).toBe(false);
+    expect(isUnlimitedBalance(undefined)).toBe(false);
+    expect(isUnlimitedBalance(null)).toBe(false);
+  });
+
+  test("does not coerce a truthy non-boolean", () => {
+    expect(
+      isUnlimitedBalance({ unlimited: "yes" } as unknown as {
+        unlimited?: boolean;
+      })
+    ).toBe(false);
+  });
+});
+
+describe("formatBalance", () => {
+  test('says "unlimited" instead of the frozen number', () => {
+    expect(formatBalance(0, true)).toBe("unlimited");
+    expect(formatBalance(5000, true)).toBe("unlimited");
+  });
+
+  test("groups a metered balance", () => {
+    expect(formatBalance(12345, false)).toBe("12,345");
+  });
+});
+
+describe("preflightBalanceOf", () => {
+  test("hands a confirm prompt the word, not the frozen total", () => {
+    expect(preflightBalanceOf({ total: 0, unlimited: true })).toBe("unlimited");
+  });
+
+  test("passes a metered total straight through", () => {
+    expect(preflightBalanceOf({ total: 250 })).toBe(250);
+    expect(preflightBalanceOf({ total: 250, unlimited: false })).toBe(250);
+  });
+});
+
+describe("computePreflightAffordability (#1169) on an unmetered plan", () => {
+  // A frozen 0 balance against a 500-page render estimate is the worst case:
+  // metered, that is a guaranteed shortfall warning + abort prompt.
+  test("never reports a shortfall, however low the frozen balance", () => {
+    const metered = computePreflightAffordability({
+      balance: 0,
+      maxPages: 500,
+      cloudRendering: "browser",
+      topUpUrl: TOP_UP,
+    });
+    expect(metered.shortfall).toBe(true);
+    expect(metered.warningLines.length).toBeGreaterThan(0);
+
+    const unmetered = computePreflightAffordability({
+      balance: 0,
+      maxPages: 500,
+      cloudRendering: "browser",
+      topUpUrl: TOP_UP,
+      unlimited: true,
+    });
+    expect(unmetered.shortfall).toBe(false);
+    expect(unmetered.warningLines).toEqual([]);
+    // The estimate itself is still computed — spend is accounted, just not gated.
+    expect(unmetered.estimate).toBe(metered.estimate);
+  });
+
+  test("unlimited: false is exactly today's behaviour", () => {
+    const r = computePreflightAffordability({
+      balance: 0,
+      maxPages: 10,
+      cloudRendering: "browser",
+      topUpUrl: TOP_UP,
+      unlimited: false,
+    });
+    expect(r.shortfall).toBe(true);
+  });
+});
+
+describe("lowBalanceFooterLines on an unmetered plan", () => {
+  test("never warns and never offers a top-up, at any balance", () => {
+    for (const balance of [0, 1, AUDIT_BASE - 1, 10_000]) {
+      expect(
+        lowBalanceFooterLines({
+          balance,
+          monthlyCredits: 0,
+          plan: "paid",
+          unlimited: true,
+        })
+      ).toEqual([]);
+    }
+  });
+
+  // The upsell is the part that must not leak: an enterprise org being told to
+  // upgrade is the one visible way the internal plan could surface to a user.
+  test("a metered paid plan at the same balance DOES warn (control)", () => {
+    const lines = lowBalanceFooterLines({
+      balance: 0,
+      monthlyCredits: 0,
+      plan: "paid",
+    });
+    expect(lines.length).toBeGreaterThan(0);
+    expect(text(lines)).toContain("Top up");
+  });
+
+  test("a free plan pitch is suppressed too when unmetered", () => {
+    expect(
+      lowBalanceFooterLines({
+        balance: 0,
+        monthlyCredits: 500,
+        plan: "free",
+        unlimited: true,
+      })
+    ).toEqual([]);
+  });
+});
+
+describe("consentEstimateLine on an unmetered plan", () => {
+  test('reads "unlimited credits", never the frozen number', () => {
+    const line = consentEstimateLine({
+      maxPages: 100,
+      balance: 0,
+      maxCredits: 0,
+      unlimited: true,
+    });
+    expect(line).toContain("Balance: unlimited credits.");
+    expect(line).not.toContain("Balance: 0 credits");
+  });
+
+  test("a metered account still sees its number", () => {
+    const line = consentEstimateLine({
+      maxPages: 100,
+      balance: 1234,
+      maxCredits: 0,
+    });
+    expect(line).toContain("Balance: 1,234 credits.");
+  });
+});
+
+describe("upsell hints", () => {
+  // Enterprise sits above every tier, so there is nothing to sell it — and the
+  // plan is internal, so naming it in CLI output would leak it.
+  test("no render-concurrency upsell for enterprise", () => {
+    expect(renderConcurrencyUpsellHint("enterprise")).toBe("");
+  });
+
+  test("the existing free/pro hints are unchanged", () => {
+    expect(renderConcurrencyUpsellHint("free")).toContain("upgrade to Pro");
+    expect(renderConcurrencyUpsellHint("starter")).toContain("upgrade to Team");
+    expect(renderConcurrencyUpsellHint("team")).toBe("");
+  });
+});

--- a/packages/audit-engine/src/cloud-prefetch.ts
+++ b/packages/audit-engine/src/cloud-prefetch.ts
@@ -121,7 +121,16 @@ export interface CloudPrefetchInput {
    * TTY confirmation when the estimate exceeds `confirm_threshold`.
    * Absent (non-TTY / --yes) → proceed without asking.
    */
-  confirm?: (estimatedCredits: number, balance: number) => Promise<boolean>;
+  confirm?: (
+    estimatedCredits: number,
+    /**
+     * "unlimited" on a plan that is not metered against a balance: its stored
+     * numbers are frozen (usually 0) and showing them in a spend prompt would
+     * read as "you cannot afford this". The prompt itself is still asked, since
+     * the spend is real and gets invoiced.
+     */
+    balance: number | "unlimited",
+  ) => Promise<boolean>;
   onProgress?: (message: string) => void;
 }
 
@@ -162,6 +171,10 @@ export interface CloudPrefetchResult {
    * ESTIMATED balance after the run: preflight balance minus client-side
    * spend. Concurrent usage by other sessions is not reflected — render with
    * a `~` qualifier; `getBalance()` is the authoritative read.
+   *
+   * `null` when there is no meaningful answer: the prefetch never ran, or the
+   * account's plan is not metered against a balance (its stored numbers are
+   * frozen, so subtracting spend would invent a countdown).
    */
   balanceAfter: number | null;
   /**
@@ -193,6 +206,19 @@ interface BatchOutcome {
   failedUnits: number;
   failedBatches: number;
   failure: { reason: CloudSkipReason; detail: string } | null;
+}
+
+/**
+ * Is this account's plan unmetered (not billed against a prepaid balance)?
+ *
+ * Such an account's stored balance is FROZEN, so `balance - spent` is not an
+ * "estimated balance after the run", it is a fabricated countdown of a number
+ * that never moves. `balanceAfter: null` is the existing "not known" signal and
+ * every renderer already handles it. The field is optional on the wire, so an
+ * older server omitting it correctly reads as metered.
+ */
+function unmeteredBalance(preflight: CreditsResponse): boolean {
+  return preflight.balance.unlimited === true;
 }
 
 function emptyResult(
@@ -442,7 +468,8 @@ async function fetchPageBatch(
     return new Map(results.filter((r) => !isRenderBlocked(r)).map((r) => [r.url, r]));
   }
   const req = { auditId, pages: batch };
-  const res = service === "ai-parse" ? await client.aiParse(req) : await client.authoritySignals(req);
+  const res =
+    service === "ai-parse" ? await client.aiParse(req) : await client.authoritySignals(req);
   return new Map(res.results.map((r) => [r.url, r]));
 }
 
@@ -528,7 +555,10 @@ export async function prefetchCloudData(input: CloudPrefetchInput): Promise<Clou
       metaCost +
       applyCap(stage1Specs, input.pages, stage1Cap).reduce((sum, p) => sum + p.estimate, 0);
     if (upperEstimate > input.config.confirm_threshold) {
-      const proceed = await input.confirm(upperEstimate, preflight.balance.total);
+      const proceed = await input.confirm(
+        upperEstimate,
+        preflight.balance.unlimited === true ? "unlimited" : preflight.balance.total,
+      );
       if (!proceed) {
         for (const [service, spec] of specs) {
           skipService(
@@ -544,7 +574,7 @@ export async function prefetchCloudData(input: CloudPrefetchInput): Promise<Clou
           spend,
           totalSpent,
           failures,
-          balanceAfter: preflight.balance.total,
+          balanceAfter: unmeteredBalance(preflight) ? null : preflight.balance.total,
           siteMetadata: null,
         };
       }
@@ -634,7 +664,9 @@ export async function prefetchCloudData(input: CloudPrefetchInput): Promise<Clou
       spend,
       totalSpent,
       failures,
-      balanceAfter: Math.max(0, preflight.balance.total - totalSpent),
+      balanceAfter: unmeteredBalance(preflight)
+        ? null
+        : Math.max(0, preflight.balance.total - totalSpent),
       siteMetadata,
     };
   }
@@ -870,7 +902,9 @@ export async function prefetchCloudData(input: CloudPrefetchInput): Promise<Clou
     spend,
     totalSpent,
     failures,
-    balanceAfter: Math.max(0, preflight.balance.total - totalSpent),
+    balanceAfter: unmeteredBalance(preflight)
+      ? null
+      : Math.max(0, preflight.balance.total - totalSpent),
     siteMetadata,
   };
 }

--- a/packages/audit-engine/tests/cloud-prefetch.test.ts
+++ b/packages/audit-engine/tests/cloud-prefetch.test.ts
@@ -258,6 +258,115 @@ describe("prefetchCloudData", () => {
     expect(res.store.get("keyword-gaps")?.get(CLOUD_SITE_KEY)?.skipReason).toBe("not-prefetched");
   });
 
+  describe("an unmetered plan (frozen balance)", () => {
+    const gapsRule = [
+      {
+        id: "seo/keyword-gaps",
+        cloud: {
+          service: "keyword-gaps" as const,
+          unit: "site" as const,
+          creditFeature: "keyword_gaps" as const,
+        },
+      },
+    ];
+    const gapsPayload = { "keyword-gaps": { domain: "example.com" } };
+    // The realistic enterprise shape: nothing was ever granted or deducted, so
+    // the stored total sits at 0 forever.
+    const unmetered = {
+      ...BALANCE,
+      balance: { monthly: 0, pack: 0, total: 0, periodEnd: null, unlimited: true },
+    };
+
+    test('the confirm prompt is still asked, but shows "unlimited" not the frozen 0', async () => {
+      let seen: unknown;
+      await prefetchCloudData(
+        input({
+          client: okClient({ getBalance: async () => unmetered }),
+          rules: gapsRule,
+          sitePayloads: gapsPayload,
+          config: { ...config, confirm_threshold: 1 },
+          confirm: async (_estimate, balance) => {
+            seen = balance;
+            return true;
+          },
+        }),
+      );
+      // Showing 0 here would read as "you cannot afford this" on an account
+      // that can afford everything.
+      expect(seen).toBe("unlimited");
+    });
+
+    test("balanceAfter is null, not a countdown of a number that never moves", async () => {
+      const res = await prefetchCloudData(
+        input({
+          client: okClient({ getBalance: async () => unmetered }),
+          rules: gapsRule,
+          sitePayloads: gapsPayload,
+          config: { ...config, confirm_threshold: 1 },
+          confirm: async () => true,
+        }),
+      );
+      expect(res.balanceAfter).toBeNull();
+      // The spend itself is real and still tracked — it gets invoiced.
+      expect(res.totalSpent).toBeGreaterThan(0);
+    });
+
+    test("a declined confirm also reports a null balanceAfter", async () => {
+      const res = await prefetchCloudData(
+        input({
+          client: okClient({ getBalance: async () => unmetered }),
+          rules: gapsRule,
+          sitePayloads: gapsPayload,
+          config: { ...config, confirm_threshold: 1 },
+          confirm: async () => false,
+        }),
+      );
+      expect(res.balanceAfter).toBeNull();
+      expect(res.totalSpent).toBe(0);
+    });
+
+    test("a metered account is unchanged: it sees its number and a real balanceAfter", async () => {
+      let seen: unknown;
+      const res = await prefetchCloudData(
+        input({
+          rules: gapsRule,
+          sitePayloads: gapsPayload,
+          config: { ...config, confirm_threshold: 1 },
+          confirm: async (_estimate, balance) => {
+            seen = balance;
+            return true;
+          },
+        }),
+      );
+      expect(seen).toBe(1000);
+      expect(res.balanceAfter).toBe(1000 - res.totalSpent);
+    });
+
+    // A binary already on someone's machine talks to whatever server it finds.
+    test("a response with no `unlimited` field reads as metered", async () => {
+      let seen: unknown;
+      const res = await prefetchCloudData(
+        input({
+          client: okClient({
+            getBalance: async () => ({
+              ...BALANCE,
+              balance: { monthly: 0, pack: 40, total: 40, periodEnd: null },
+            }),
+          }),
+          rules: gapsRule,
+          sitePayloads: gapsPayload,
+          config: { ...config, confirm_threshold: 1 },
+          confirm: async (_estimate, balance) => {
+            seen = balance;
+            return true;
+          },
+        }),
+      );
+      expect(seen).toBe(40);
+      expect(res.balanceAfter).not.toBeNull();
+    });
+  });
+
   test("estimate at/below threshold does not prompt", async () => {
     let prompted = false;
     // keyword-gaps estimate (25) == threshold (25): `estimate > threshold` is
@@ -427,14 +536,12 @@ describe("prefetchCloudData", () => {
   test("partial batch: pages missing from results are skipped, batch still billed", async () => {
     const client = okClient({
       aiParse: async (req) => ({
-        results: req.pages
-          .slice(1)
-          .map((p) => ({
-            url: p.url,
-            pageType: "article" as const,
-            parsabilityScore: 50,
-            confidence: 0.5,
-          })),
+        results: req.pages.slice(1).map((p) => ({
+          url: p.url,
+          pageType: "article" as const,
+          parsabilityScore: 50,
+          confidence: 0.5,
+        })),
       }),
     });
     const res = await prefetchCloudData(input({ rules: [RULES[0]], client }));
@@ -949,7 +1056,10 @@ describe("chunkPagesBySize", () => {
 
 // ── render service (#673): job-based (submit → poll), gated off on rendered crawls ──
 const RENDER_RULES: CloudPrefetchInput["rules"] = [
-  { id: "ax/content-without-js", cloud: { service: "render", unit: "page", creditFeature: "render" } },
+  {
+    id: "ax/content-without-js",
+    cloud: { service: "render", unit: "page", creditFeature: "render" },
+  },
 ];
 
 /** okClient + a render job that resolves `done` immediately, returning HTML for the requested urls. */
@@ -963,7 +1073,11 @@ function renderClient(overrides: Partial<CloudServicesClient> = {}): CloudServic
     renderResult: async () => ({
       jobId: "job-1",
       status: "done",
-      results: submitted.map((url) => ({ url, status: 200, html: `<html><body>${url}</body></html>` })),
+      results: submitted.map((url) => ({
+        url,
+        status: 200,
+        html: `<html><body>${url}</body></html>`,
+      })),
     }),
     ...overrides,
   });
@@ -1003,7 +1117,9 @@ describe("prefetchCloudData — render service (#673)", () => {
         return { jobId: "j", status: "queued" };
       },
     });
-    const res = await prefetchCloudData(input({ client, rules: RENDER_RULES, crawlRendered: true }));
+    const res = await prefetchCloudData(
+      input({ client, rules: RENDER_RULES, crawlRendered: true }),
+    );
     expect(submitted).toBe(false);
     const render = res.store.get("render");
     expect(render?.get(pages[0].url)?.status).toBe("skipped");
@@ -1017,7 +1133,9 @@ describe("prefetchCloudData — render service (#673)", () => {
         jobId: "j",
         status: "done",
         // Only the first 3 of 5 pages came back.
-        results: pages.slice(0, 3).map((p) => ({ url: p.url, status: 200, html: `<html>${p.url}</html>` })),
+        results: pages
+          .slice(0, 3)
+          .map((p) => ({ url: p.url, status: 200, html: `<html>${p.url}</html>` })),
       }),
     });
     const res = await prefetchCloudData(input({ client, rules: RENDER_RULES }));
@@ -1101,7 +1219,9 @@ describe("prefetchCloudData — render service (#673)", () => {
         results: [
           { url: pages[0].url, status: 200, html: `<html>${pages[0].url}</html>` },
           { url: pages[1].url, status: 403, html: "<html>Access denied</html>" }, // bot wall
-          ...pages.slice(2).map((p) => ({ url: p.url, status: 200, html: `<html>${p.url}</html>` })),
+          ...pages
+            .slice(2)
+            .map((p) => ({ url: p.url, status: 200, html: `<html>${p.url}</html>` })),
         ],
       }),
     });

--- a/packages/cloud-client/src/client.ts
+++ b/packages/cloud-client/src/client.ts
@@ -86,7 +86,23 @@ export interface CallOpts {
 
 /** `GET /v1/credits` response. */
 export interface CreditsResponse {
-  balance: { monthly: number; pack: number; total: number; periodEnd: string | null };
+  balance: {
+    monthly: number;
+    pack: number;
+    total: number;
+    periodEnd: string | null;
+    /**
+     * The org's plan is not metered against this balance: usage is recorded in
+     * the ledger and invoiced out of band, and no debit is ever refused. The
+     * raw numbers above stay whatever the frozen balance holds — read this
+     * flag, never `total`, to decide whether the org can afford something.
+     *
+     * OPTIONAL on purpose: servers older than the enterprise plan omit it, and
+     * an absent value must read as `false` (metered). Use `isUnlimitedBalance`
+     * rather than testing it directly.
+     */
+    unlimited?: boolean;
+  };
   plan: PlanDefinition;
   pricing: Record<CreditFeature, CreditPrice>;
   pricingVersion: number;

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -1309,7 +1309,13 @@ export interface RunSyncDelta {
 
 // ── Organization & Plan types ──────────────────────────────────────
 
-export type PlanId = "free" | "starter" | "team";
+/**
+ * `enterprise` is INTERNAL / invite-only (2026-08-28): it has no price, no
+ * checkout, and never appears on pricing, marketing, docs, dashboard plan
+ * pickers or CLI upsells. An admin assigns it from the admin dashboard. Public
+ * surfaces must enumerate `SELF_SERVE_PLAN_IDS`, never `Object.keys(PLANS)`.
+ */
+export type PlanId = "free" | "starter" | "team" | "enterprise";
 export type OrgRole = "owner" | "admin" | "editor" | "viewer" | "billing";
 
 /** Stripe subscription billing interval. Annual prepays 12 months at the
@@ -1356,6 +1362,26 @@ export interface PlanDefinition {
    * forwards stored headers for a non-capable plan (defense in depth).
    */
   customHeaders: boolean;
+  /**
+   * Credits are not metered for this plan: no debit is ever rejected for
+   * insufficient funds and `credit_balances` is never mutated. Every debit,
+   * credit, refund and grant is still WRITTEN to `credit_ledger` exactly as it
+   * would be on a metered plan (same entry_type/amount/feature/units/
+   * idempotency key) with `metadata.accounting = "unlimited"`, so usage stays
+   * fully accounted for later invoicing. The stored balance is therefore FROZEN
+   * while the org is on such a plan and resumes from that frozen value if the
+   * org moves back to a metered plan.
+   *
+   * `false`/absent = normal metered billing.
+   */
+  unlimitedCredits: boolean;
+  /**
+   * The plan can be bought by the customer without talking to us. Public
+   * surfaces (pricing page, dashboard plan comparison / upgrade funnel, CLI
+   * upsells, checkout) must enumerate only self-serve plans; a non-self-serve
+   * plan is admin-assigned and invisible to end users.
+   */
+  selfServe: boolean;
   /**
    * Per-seat pricing for seat-based plans (Team, #625). Only seat-based plans
    * set it; `undefined` means flat subscription pricing (free/starter). At

--- a/packages/core-contracts/src/plans.ts
+++ b/packages/core-contracts/src/plans.ts
@@ -44,6 +44,8 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     // #1020 ladder: matches Screaming Frog's free-tier crawl cap and today's
     // `full` coverage preset ceiling.
     maxPagesPerAudit: 500,
+    unlimitedCredits: false,
+    selfServe: true,
   },
   starter: {
     id: "starter",
@@ -69,6 +71,8 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     customHeaders: true,
     // #1020 ladder: today's cloud REPORT_LIMITS.maxPages ceiling.
     maxPagesPerAudit: 2000,
+    unlimitedCredits: false,
+    selfServe: true,
   },
   team: {
     id: "team",
@@ -97,6 +101,8 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     // once the report/publish ingest ceiling is raised separately (see the
     // maxPagesPerAudit doc comment on PlanDefinition in index.ts).
     maxPagesPerAudit: 5000,
+    unlimitedCredits: false,
+    selfServe: true,
     perSeat: {
       priceMonthUsd: 29,
       // Annual per-seat = 12 months prepaid at the cost of 10.
@@ -105,7 +111,54 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
       minSeats: 2,
     },
   },
+  /**
+   * INTERNAL / invite-only (decided 2026-08-28). This is how enterprise billing
+   * will work: usage is not metered against a prepaid balance, it is ACCOUNTED
+   * in `credit_ledger` and invoiced out of band.
+   *
+   * Deliberately absent: `priceMonthUsd` / `priceYearUsd` / `perSeat` — there is
+   * no price and no Stripe checkout for it. `selfServe: false` keeps it out of
+   * every public surface (pricing page, dashboard plan comparison and upgrade
+   * funnel, CLI/MCP upsells). The only way into it is an admin moving the org
+   * from the admin dashboard; the only way out is an admin moving it back.
+   *
+   * `monthlyCredits: 0` because there is nothing to grant — `unlimitedCredits`
+   * means the balance is never consulted or mutated. The recurring-grant
+   * scheduler tasks skip the plan for the same reason.
+   */
+  enterprise: {
+    id: "enterprise",
+    name: "Enterprise",
+    // No recurring grant: unlimitedCredits makes the balance irrelevant, and
+    // granting into a frozen balance would corrupt the value the org resumes
+    // from if it is ever moved back to a metered plan.
+    monthlyCredits: 0,
+    maxOrgs: 1,
+    // -1 = uncapped (same sentinel Team uses for maxMembers). The 100-website
+    // abuse cap is a hosted-tier guard; a contracted org is not that risk.
+    maxWebsites: -1,
+    maxMembers: -1,
+    renderConcurrency: 10,
+    scheduledCrawls: true,
+    customHeaders: true,
+    // NOT subject to TEAM_MAX_PAGES_UNLOCKED — that flag gates Team's ladder
+    // step specifically (#1274). Enterprise carries its own allowance, still
+    // clamped at dispatch by `REPORT_LIMITS.maxPages` like every other plan.
+    maxPagesPerAudit: 5000,
+    unlimitedCredits: true,
+    selfServe: false,
+  },
 } as const;
+
+/**
+ * The plans a customer can reach on their own. Every public/marketing/upgrade
+ * surface must enumerate THIS, never `Object.keys(PLANS)` — otherwise an
+ * internal plan leaks into pricing or a plan picker the moment it is added.
+ * Ordered low → high tier.
+ */
+export const SELF_SERVE_PLAN_IDS: readonly PlanId[] = (Object.keys(PLANS) as PlanId[]).filter(
+  (id) => PLANS[id].selfServe,
+);
 
 // Accepts a raw string (DB columns are plain text) and falls back to the free
 // plan for any unknown id — callers never need to cast or null-check.
@@ -113,23 +166,42 @@ export function getPlan(planId: string): PlanDefinition {
   return PLANS[planId as PlanId] ?? PLANS.free;
 }
 
-// Tier hierarchy: free < starter < team. Keep in sync with PlanId — a new tier
-// must be ranked here (an unranked id resolves to 0 = free, matching getPlan).
+// Tier hierarchy: free < starter < team < enterprise. Keep in sync with PlanId —
+// a new tier must be ranked here (an unranked id resolves to 0 = free, matching
+// getPlan). Enterprise ranks top so it inherits every `planAtLeast` entitlement.
 const PLAN_RANK: Record<PlanId, number> = {
   free: 0,
   starter: 1,
   team: 2,
+  enterprise: 3,
 };
 
 /**
  * True when `planId` sits at or above `floor` in the tier hierarchy
- * (free < starter < team). Accepts a raw string; an unknown id ranks as free.
+ * (free < starter < team < enterprise). Accepts a raw string; an unknown id ranks as free.
  * Use for "at least this tier" entitlement gates (e.g. `planAtLeast(id,
  * "starter")` = "any paid plan") instead of a binary `id !== "free"` so a
  * higher tier inherits every entitlement of the tiers below it.
  */
 export function planAtLeast(planId: string, floor: PlanId): boolean {
   return (PLAN_RANK[planId as PlanId] ?? 0) >= PLAN_RANK[floor];
+}
+
+/**
+ * True when the plan is not metered against a prepaid credit balance: debits are
+ * recorded in the ledger but never rejected and never mutate `credit_balances`.
+ * Accepts a raw string (DB columns are plain text); unknown ids are metered.
+ */
+export function planHasUnlimitedCredits(planId: string): boolean {
+  return getPlan(planId).unlimitedCredits;
+}
+
+/**
+ * True when the customer can reach this plan themselves. Gate every upgrade CTA,
+ * plan card and checkout on this rather than on an id denylist.
+ */
+export function isSelfServePlan(planId: string): boolean {
+  return getPlan(planId).selfServe;
 }
 
 /**

--- a/packages/core-contracts/tests/plans.test.ts
+++ b/packages/core-contracts/tests/plans.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PlanId } from "../src/index";
+
+import {
+  getPlan,
+  isSelfServePlan,
+  PLANS,
+  planAtLeast,
+  planHasUnlimitedCredits,
+  SELF_SERVE_PLAN_IDS,
+} from "../src/plans";
+
+const ALL_PLAN_IDS = Object.keys(PLANS) as PlanId[];
+
+describe("plan definitions", () => {
+  test("every plan declares the unlimitedCredits and selfServe flags", () => {
+    for (const id of ALL_PLAN_IDS) {
+      expect(typeof PLANS[id].unlimitedCredits).toBe("boolean");
+      expect(typeof PLANS[id].selfServe).toBe("boolean");
+    }
+  });
+
+  test("enterprise is the only unmetered plan", () => {
+    const unmetered = ALL_PLAN_IDS.filter((id) => PLANS[id].unlimitedCredits);
+    expect(unmetered).toEqual(["enterprise"]);
+  });
+
+  test("enterprise has no price and no per-seat pricing", () => {
+    const plan = PLANS.enterprise;
+    expect(plan.priceMonthUsd).toBeUndefined();
+    expect(plan.priceYearUsd).toBeUndefined();
+    expect(plan.perSeat).toBeUndefined();
+    // Nothing to grant: the balance is frozen while unmetered.
+    expect(plan.monthlyCredits).toBe(0);
+  });
+
+  test("enterprise carries the uncapped/top-tier entitlements", () => {
+    const plan = PLANS.enterprise;
+    expect(plan.maxWebsites).toBe(-1);
+    expect(plan.maxMembers).toBe(-1);
+    expect(plan.renderConcurrency).toBe(10);
+    expect(plan.scheduledCrawls).toBe(true);
+    expect(plan.customHeaders).toBe(true);
+    expect(plan.maxPagesPerAudit).toBe(5000);
+  });
+});
+
+describe("SELF_SERVE_PLAN_IDS", () => {
+  test("lists exactly the plans a customer can buy themselves", () => {
+    expect([...SELF_SERVE_PLAN_IDS]).toEqual(["free", "starter", "team"]);
+  });
+
+  // The whole point of the constant: an internal plan added later must not
+  // silently appear on pricing, plan pickers or upgrade funnels.
+  test("excludes every non-self-serve plan", () => {
+    for (const id of ALL_PLAN_IDS) {
+      expect(SELF_SERVE_PLAN_IDS.includes(id)).toBe(PLANS[id].selfServe);
+    }
+    expect(SELF_SERVE_PLAN_IDS).not.toContain("enterprise");
+  });
+
+  test("isSelfServePlan agrees, and an unknown id falls back to free", () => {
+    expect(isSelfServePlan("team")).toBe(true);
+    expect(isSelfServePlan("enterprise")).toBe(false);
+    expect(isSelfServePlan("nope")).toBe(true); // → free, which is self-serve
+  });
+});
+
+describe("getPlan", () => {
+  test("resolves enterprise", () => {
+    expect(getPlan("enterprise").id).toBe("enterprise");
+    expect(getPlan("enterprise").name).toBe("Enterprise");
+  });
+
+  test("still falls back to free for an unknown id", () => {
+    expect(getPlan("platinum").id).toBe("free");
+  });
+});
+
+describe("planAtLeast", () => {
+  test("enterprise ranks above team, so it inherits every entitlement gate", () => {
+    for (const floor of ALL_PLAN_IDS) {
+      expect(planAtLeast("enterprise", floor)).toBe(true);
+    }
+  });
+
+  test("no lower tier reaches the enterprise floor", () => {
+    expect(planAtLeast("free", "enterprise")).toBe(false);
+    expect(planAtLeast("starter", "enterprise")).toBe(false);
+    expect(planAtLeast("team", "enterprise")).toBe(false);
+    expect(planAtLeast("bogus", "enterprise")).toBe(false);
+  });
+
+  test("the existing ordering is unchanged", () => {
+    expect(planAtLeast("team", "starter")).toBe(true);
+    expect(planAtLeast("starter", "team")).toBe(false);
+    expect(planAtLeast("free", "starter")).toBe(false);
+  });
+});
+
+describe("planHasUnlimitedCredits", () => {
+  test("true only for enterprise", () => {
+    expect(planHasUnlimitedCredits("enterprise")).toBe(true);
+    expect(planHasUnlimitedCredits("team")).toBe(false);
+    expect(planHasUnlimitedCredits("starter")).toBe(false);
+    expect(planHasUnlimitedCredits("free")).toBe(false);
+  });
+
+  // A typo'd or future plan id must never accidentally read as unmetered.
+  test("an unknown id is metered", () => {
+    expect(planHasUnlimitedCredits("")).toBe(false);
+    expect(planHasUnlimitedCredits("enterprize")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Internal-only plan, not a customer-facing launch

Adds an `enterprise` plan tier. It is **invite-only and invisible**: no price, no
Stripe checkout, and no appearance on pricing, the marketing site, docs, dashboard
plan pickers, upgrade funnels, or CLI/MCP upsells. The only way in or out is an
admin moving the org from the admin dashboard (that half lives in the private
monorepo). This is how enterprise billing will work later: usage is **accounted,
not metered**.

Decided by Nik on 2026-08-28.

### `PlanDefinition` gains two fields

- **`unlimitedCredits`** (true only for enterprise) — no debit is ever refused and
  `credit_balances` is never mutated, but every debit/credit/refund/grant is still
  written to `credit_ledger` with the same entry type, amount, feature, units and
  idempotency key. The stored balance is frozen while the org is on the plan and
  resumes from that value if it moves back to a metered plan.
- **`selfServe`** (false only for enterprise) — plus the new `SELF_SERVE_PLAN_IDS`
  export. Public surfaces must enumerate that, never `Object.keys(PLANS)`, so the
  next internal plan cannot leak into a pricing card by default.

`PLAN_RANK` ranks enterprise 3 so it inherits every `planAtLeast` entitlement.
Leaving it unranked would have silently resolved to 0 (= free), which is the
quiet failure this repo's `?? 0` fallback invites.

### CLI

`GET /v1/credits` gains `balance.unlimited`. It is **additive and optional**: a
binary already on someone's machine talks to whatever server it finds, so an
absent value reads as metered and today's behaviour is unchanged.

Every CLI surface that compared `balance.total` against a price now asks
`isUnlimitedBalance` first. A frozen (often zero) enterprise balance would
otherwise reproduce #1588 on every run: the audit silently drops to local-only
with exit 0.

| surface | before | with `unlimited` |
|---|---|---|
| sub-audit-base local-only degrade | `balance.total < 50` → local-only | never degrades |
| `Account` preamble | `0 credits` | `unlimited credits` |
| #1169 preflight shortfall | warn + abort prompt | no shortfall, estimate still computed |
| cloud-consent estimate | `Balance: 0 credits.` | `Balance: unlimited credits.` |
| spend-confirm prompts | `(balance: 0)` | `(balance: unlimited)` — the prompt stays, the spend is real |
| footer low-balance warning + top-up/upgrade offer | fires | never fires |
| footer `balance ~N` | frozen number | `balance unlimited` |
| `squirrel credits` | balance/monthly/reset/below-base lines + top-up or Pro pitch | `unlimited`, no pitch, no top-up |
| `squirrel auth status` | `Credits: 0` | `Credits: unlimited` |
| `renderConcurrencyUpsellHint` | — | already empty above Pro; asserted for enterprise |

### Tests

30 new assertions across two files: `packages/core-contracts/tests/plans.test.ts`
(enterprise is the only unmetered plan, has no price/perSeat, `SELF_SERVE_PLAN_IDS`
excludes it and tracks the flag for every plan, rank ordering, unknown ids stay
metered) and `apps/cli/tests/lib/unlimited-balance.test.ts` (absent/null/truthy-
non-boolean `unlimited` all read as metered; each gate above, each with a metered
control case).

Full suite: 4341 pass, 0 fail. Typecheck, oxfmt, oxlint and detect-secrets clean.

### Follow-up (private monorepo)

The API half — ledger-only debits, `getBalance().unlimited`, the admin plan
control and its guard against moving a live Stripe subscriber to enterprise — is
a companion PR that consumes this via the submodule gitlink.
