### PR TITLE
fix(rules): stop holding index sitemaps to the per-file 50,000-URL limit

### DIFF
--- a/packages/rules/src/crawl/sitemap-valid.ts
+++ b/packages/rules/src/crawl/sitemap-valid.ts
@@ -3,6 +3,8 @@
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
 const MAX_URLS_PER_SITEMAP = 50000;
+// The protocol limit for an index file counts CHILD SITEMAPS, not URLs.
+const MAX_CHILDREN_PER_INDEX = 50000;
 
 export const sitemapValidRule: Rule = {
   meta: {
@@ -62,8 +64,16 @@ export const sitemapValidRule: Rule = {
         sitemapsWithErrors.push({ url: sitemap.url, errors: sitemap.errors });
       }
 
-      // Check URL count limit
-      if (sitemap.urlCount > MAX_URLS_PER_SITEMAP) {
+      // Size limits. The crawler stores the AGGREGATED child URL total as
+      // urlCount on a top-level index (coverage math needs it), so an index
+      // must never be held to the per-file URL limit — a healthy sharded site
+      // with >50k total URLs would fail on its index file (#1651). Indexes
+      // have their own protocol limit: 50,000 child sitemaps.
+      if (sitemap.type === "index") {
+        if (sitemap.childSitemaps.length > MAX_CHILDREN_PER_INDEX) {
+          oversizedSitemaps.push(`${sitemap.url} (${sitemap.childSitemaps.length} child sitemaps)`);
+        }
+      } else if (sitemap.urlCount > MAX_URLS_PER_SITEMAP) {
         oversizedSitemaps.push(`${sitemap.url} (${sitemap.urlCount} URLs)`);
       }
     }
@@ -93,7 +103,7 @@ export const sitemapValidRule: Rule = {
       checks.push({
         name: "sitemap-size",
         status: "warn",
-        message: `${oversizedSitemaps.length} sitemap(s) exceed 50,000 URL limit`,
+        message: `${oversizedSitemaps.length} sitemap(s) exceed the 50,000-entry protocol limit`,
         items: oversizedSitemaps.map((s) => ({ id: s })),
       });
     } else {

--- a/packages/rules/tests/sitemap-valid.test.ts
+++ b/packages/rules/tests/sitemap-valid.test.ts
@@ -1,0 +1,107 @@
+// crawl/sitemap-valid — index files must not be held to the per-file URL
+// limit (#1651). The crawler stores the AGGREGATED child URL total as
+// urlCount on a top-level index sitemap, so comparing that against the
+// 50,000-URL per-file cap flagged every healthy sharded site on its index
+// file ("/sitemap.xml exceeds 50,000 URL limit (121613 URLs)" while every
+// shard was ≤40k). Indexes have their own protocol limit: 50,000 children.
+
+import { describe, expect, test } from "bun:test";
+
+import type { SitemapData } from "@squirrelscan/core-contracts";
+
+import { sitemapValidRule } from "../src/crawl/sitemap-valid";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+function ctx(discovered: SitemapData[]): RuleContext {
+  return {
+    page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+    parsed: {} as ParsedPage,
+    site: {
+      baseUrl: "https://example.com",
+      pages: [],
+      robotsTxt: null,
+      sitemaps: {
+        discovered,
+        sources: { robotsTxt: [], commonLocations: [] },
+        totalUrls: discovered.reduce((sum, s) => sum + s.urlCount, 0),
+        orphanPages: [],
+        missingPages: [],
+        failed: [],
+      },
+    },
+    options: {},
+  } as unknown as RuleContext;
+}
+
+function sitemap(over: Partial<SitemapData>): SitemapData {
+  return {
+    url: "https://example.com/sitemap.xml",
+    type: "urlset",
+    urls: [],
+    childSitemaps: [],
+    errors: [],
+    urlCount: 0,
+    ...over,
+  };
+}
+
+function sizeCheck(result: ReturnType<typeof sitemapValidRule.run>) {
+  const checks = (result as { checks: Array<{ name: string; status: string; items?: Array<{ id: string }> }> })
+    .checks;
+  const check = checks.find((c) => c.name === "sitemap-size");
+  expect(check).toBeDefined();
+  return check as { name: string; status: string; items?: Array<{ id: string }> };
+}
+
+describe("crawl/sitemap-valid index vs per-file limits (#1651)", () => {
+  test("an index whose aggregated urlCount exceeds 50k passes when shards are within limits", () => {
+    const shards = Array.from({ length: 4 }, (_, i) =>
+      sitemap({
+        url: `https://example.com/sitemap-${i}.xml`,
+        urlCount: 40000,
+      }),
+    );
+    const index = sitemap({
+      url: "https://example.com/sitemap.xml",
+      type: "index",
+      childSitemaps: shards.map((s) => s.url),
+      urlCount: 160000, // crawler-aggregated child total
+    });
+
+    const check = sizeCheck(sitemapValidRule.run(ctx([index, ...shards])));
+    expect(check.status).toBe("pass");
+  });
+
+  test("a urlset shard over 50k URLs fails and the finding names the shard, not the index", () => {
+    const shard = sitemap({ url: "https://example.com/sitemap-big.xml", urlCount: 60000 });
+    const index = sitemap({
+      url: "https://example.com/sitemap.xml",
+      type: "index",
+      childSitemaps: [shard.url],
+      urlCount: 60000,
+    });
+
+    const check = sizeCheck(sitemapValidRule.run(ctx([index, shard])));
+    expect(check.status).toBe("warn");
+    expect(check.items).toHaveLength(1);
+    expect(check.items?.[0]?.id).toContain("sitemap-big.xml");
+  });
+
+  test("an index listing more than 50k child sitemaps fails on the child limit", () => {
+    const index = sitemap({
+      url: "https://example.com/sitemap.xml",
+      type: "index",
+      childSitemaps: Array.from({ length: 50001 }, (_, i) => `https://example.com/s-${i}.xml`),
+      urlCount: 0,
+    });
+
+    const check = sizeCheck(sitemapValidRule.run(ctx([index])));
+    expect(check.status).toBe("warn");
+    expect(check.items?.[0]?.id).toContain("50001 child sitemaps");
+  });
+
+  test("a plain oversized urlset still fails", () => {
+    const check = sizeCheck(sitemapValidRule.run(ctx([sitemap({ urlCount: 50001 })])));
+    expect(check.status).toBe("warn");
+  });
+});


### PR DESCRIPTION
crawl/sitemap-valid compared every discovered sitemap's `urlCount` against the 50,000-URL per-file cap, but the crawler stores the **aggregated child total** as `urlCount` on a top-level `type: "index"` sitemap. Any healthy sharded site with >50k total URLs got an error-severity false positive attributed to its index file (field report: `/sitemap.xml exceeds 50,000 URL limit (121613 URLs)` while all 10 shards were ≤40k).

- `type: "index"` sitemaps are now checked against the limit that actually applies to them: 50,000 **child sitemaps**
- `type: "urlset"` files (shards included) keep the 50,000-URL check on their own count, and the finding names the shard
- check message updated to "exceed the 50,000-entry protocol limit" since it can now name either kind
- new `tests/sitemap-valid.test.ts` covering: big-aggregate index passes, oversized shard fails and is named, >50k-children index fails, plain oversized urlset still fails

Tracked in the monorepo as squirrelscan/repo#1651.