### PR TITLE
fix(rules): require observed evidence before canonical-chain reports a redirect

### DIFF
--- a/packages/rules/src/crawl/canonical-chain.ts
+++ b/packages/rules/src/crawl/canonical-chain.ts
@@ -6,11 +6,7 @@ import { formatRedirectHop } from "@squirrelscan/core-contracts";
 
 import { normalizeUrl } from "@squirrelscan/utils";
 
-import {
-  contradictsItself,
-  didRedirect,
-  hasObservedRedirect,
-} from "../shared/redirect-evidence";
+import { didRedirect } from "../shared/redirect-evidence";
 
 export const canonicalChainRule: Rule = {
   meta: {
@@ -153,8 +149,7 @@ export const canonicalChainRule: Rule = {
         normalizedCanonical === normalizeUrl(pageUrl) &&
         normalizedFinal !== normalizedCanonical &&
         redirectChain &&
-        hasObservedRedirect(redirectChain) &&
-        !contradictsItself(redirectChain)
+        didRedirect(pageUrl, finalUrl, redirectChain)
       ) {
         checks.push({
           name: "canonical-redirects",

--- a/packages/rules/src/crawl/canonical-chain.ts
+++ b/packages/rules/src/crawl/canonical-chain.ts
@@ -6,6 +6,12 @@ import { formatRedirectHop } from "@squirrelscan/core-contracts";
 
 import { normalizeUrl } from "@squirrelscan/utils";
 
+import {
+  contradictsItself,
+  didRedirect,
+  hasObservedRedirect,
+} from "../shared/redirect-evidence";
+
 export const canonicalChainRule: Rule = {
   meta: {
     id: "crawl/canonical-chain",
@@ -28,11 +34,10 @@ export const canonicalChainRule: Rule = {
     const finalUrl = ctx.page.finalUrl ?? pageUrl;
     const redirectChain = ctx.page.redirectChain;
 
-    // If the page itself redirected, surface the chain context
-    if (
-      redirectChain &&
-      (redirectChain.chainLength > 0 || pageUrl !== finalUrl)
-    ) {
+    // If the page itself redirected, surface the chain context. A chain exists
+    // whenever a fetcher recorded hops; it is evidence of a redirect only when
+    // we watched one happen or the request landed on a different resource.
+    if (redirectChain && didRedirect(pageUrl, finalUrl, redirectChain)) {
       const chainLabel =
         redirectChain.hops.length > 1
           ? redirectChain.hops.map((hop) => formatRedirectHop(hop)).join(" → ")
@@ -148,7 +153,8 @@ export const canonicalChainRule: Rule = {
         normalizedCanonical === normalizeUrl(pageUrl) &&
         normalizedFinal !== normalizedCanonical &&
         redirectChain &&
-        redirectChain.chainLength > 0
+        hasObservedRedirect(redirectChain) &&
+        !contradictsItself(redirectChain)
       ) {
         checks.push({
           name: "canonical-redirects",

--- a/packages/rules/src/crawl/canonical-chain.ts
+++ b/packages/rules/src/crawl/canonical-chain.ts
@@ -4,9 +4,7 @@ import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
 import { formatRedirectHop } from "@squirrelscan/core-contracts";
 
-import { normalizeUrl } from "@squirrelscan/utils";
-
-import { didRedirect } from "../shared/redirect-evidence";
+import { didRedirect, requestTarget } from "../shared/redirect-evidence";
 
 export const canonicalChainRule: Rule = {
   meta: {
@@ -141,31 +139,30 @@ export const canonicalChainRule: Rule = {
       }
     }
 
-    // If canonical points to a URL that ultimately redirects, flag it
-    try {
-      const normalizedCanonical = normalizeUrl(absoluteCanonical);
-      const normalizedFinal = normalizeUrl(finalUrl);
-      if (
-        normalizedCanonical === normalizeUrl(pageUrl) &&
-        normalizedFinal !== normalizedCanonical &&
-        redirectChain &&
-        didRedirect(pageUrl, finalUrl, redirectChain)
-      ) {
-        checks.push({
-          name: "canonical-redirects",
-          status: "warn",
-          message: "Canonical URL resolves through a redirect chain",
-          items: [
-            {
-              id: absoluteCanonical,
-              label: redirectChain.hops.map((hop) => formatRedirectHop(hop)).join(" → "),
-              meta: { chain: redirectChain, finalUrl },
-            },
-          ],
-        });
-      }
-    } catch {
-      // Normalization failed; already handled above
+    // If the canonical names the very URL we watched redirect, flag it. Identity
+    // is the request target, not a normalized form: `/page`, `/page/` and
+    // `/page?x=1` are different requests, and only the one we actually fetched
+    // is the one whose chain we hold. Folding them together hands this page's
+    // chain to a canonical that never redirected (#1510).
+    const canonicalTarget = requestTarget(absoluteCanonical);
+    if (
+      canonicalTarget === requestTarget(pageUrl) &&
+      requestTarget(finalUrl) !== canonicalTarget &&
+      redirectChain &&
+      didRedirect(pageUrl, finalUrl, redirectChain)
+    ) {
+      checks.push({
+        name: "canonical-redirects",
+        status: "warn",
+        message: "Canonical URL resolves through a redirect chain",
+        items: [
+          {
+            id: absoluteCanonical,
+            label: redirectChain.hops.map((hop) => formatRedirectHop(hop)).join(" → "),
+            meta: { chain: redirectChain, finalUrl },
+          },
+        ],
+      });
     }
 
     return { checks };

--- a/packages/rules/src/links/redirect-chains.ts
+++ b/packages/rules/src/links/redirect-chains.ts
@@ -3,59 +3,7 @@
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 import { formatRedirectHop, type RedirectChain } from "@squirrelscan/core-contracts";
 
-/**
- * Identity of the resource a URL names, for deciding whether a request LANDED
- * somewhere else and for joining links to redirect targets.
- *
- * This is `@squirrelscan/utils`' `normalizeUrl` with the trailing slash KEPT.
- * `/about` and `/about/` are different request targets, and telling them apart
- * is the entire point of this rule: folding them together both hides a genuine
- * `/about → /about/` move and lets a page that links the canonical form get
- * blamed for the other form's redirect (#1510).
- */
-function targetKey(url: string): string {
-  try {
-    const parsed = new URL(url);
-    return `${parsed.protocol.toLowerCase()}//${parsed.host.toLowerCase()}${parsed.pathname}`;
-  } catch {
-    return url;
-  }
-}
-
-/**
- * A NON-final hop we watched actually redirect: an HTTP hop carrying a 3xx, or
- * any client-side hop at all — a `javascript` / `meta-refresh` hop IS the
- * redirect, whatever status the document that performed it returned.
- */
-function hasObservedRedirect(chain: RedirectChain | undefined): boolean {
-  if (!chain || chain.hops.length < 2) return false;
-  return chain.hops
-    .slice(0, -1)
-    .some((hop) => hop.type !== "http" || (hop.statusCode >= 300 && hop.statusCode < 400));
-}
-
-/**
- * True when the chain contradicts itself: an HTTP hop it says was followed by
- * another hop reports a 2xx, and an HTTP response that returned 200 did not
- * redirect.
- *
- * Such a chain was assembled from a source URL and a landing URL by something
- * that never watched the responses in between, and it is what made every
- * trailing-slash-canonical site report its own pages as redirecting,
- * `(200) → (200)`, blaming every page that linked them (#1510). The producers
- * are fixed to record an unobserved hop as `0` rather than borrowing the landing
- * status; this is the rule refusing to accuse on that shape even if one regresses.
- *
- * Client-side hops are exempt: a `javascript` / `meta-refresh` redirect is by
- * definition a document that returned 200 and then sent the visitor elsewhere,
- * so a 2xx there is the truth, not a borrowed status.
- */
-function contradictsItself(chain: RedirectChain | undefined): boolean {
-  if (!chain || chain.hops.length < 2) return false;
-  return chain.hops
-    .slice(0, -1)
-    .some((hop) => hop.type === "http" && hop.statusCode >= 200 && hop.statusCode < 300);
-}
+import { didRedirect, targetKey } from "../shared/redirect-evidence";
 
 export const redirectChainsRule: Rule = {
   meta: {
@@ -98,15 +46,8 @@ export const redirectChainsRule: Rule = {
 
       const chain = page.redirectChain;
       const original = targetKey(page.url);
-      const final = targetKey(page.finalUrl);
 
-      // Two independent kinds of evidence: the request landed on a different
-      // resource, or we watched a hop return a 3xx. Either is a redirect — the
-      // first covers the render path, which reports the landing page but never
-      // the statuses that led to it. A self-contradicting chain is neither.
-      const redirected = original !== final || hasObservedRedirect(chain);
-
-      if (redirected && !contradictsItself(chain)) {
+      if (didRedirect(page.url, page.finalUrl, chain)) {
         const chainLabel =
           chain && chain.hops.length > 1
             ? chain.hops.map((hop) => formatRedirectHop(hop)).join(" → ")

--- a/packages/rules/src/shared/redirect-evidence.ts
+++ b/packages/rules/src/shared/redirect-evidence.ts
@@ -66,10 +66,29 @@ export function contradictsItself(chain: RedirectChain | undefined): boolean {
 }
 
 /**
+ * The request target a URL names: everything the server is asked for, query
+ * INCLUDED, fragment excluded because it never leaves the browser.
+ *
+ * Deliberately not `targetKey`. This one answers "did the request land
+ * somewhere else", and a redirect that only rewrites the query string still
+ * redirected. `targetKey` is a join key for matching links to the redirect they
+ * hit, where folding the query in would stop a link carrying a tracking
+ * parameter from matching the path-level redirect it lands on.
+ */
+function requestTarget(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol.toLowerCase()}//${parsed.host.toLowerCase()}${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Did this request redirect? Two independent kinds of evidence: it landed on a
- * different resource, or we watched a hop return a 3xx. The first covers the
- * render path, which reports the landing page but never the statuses that led
- * to it. A self-contradicting chain is neither, whatever the URLs say.
+ * different request target, or we watched a hop return a 3xx. The first covers
+ * the render path, which reports the landing page but never the statuses that
+ * led to it. A self-contradicting chain is neither, whatever the URLs say.
  */
 export function didRedirect(
   url: string,
@@ -77,6 +96,7 @@ export function didRedirect(
   chain: RedirectChain | undefined
 ): boolean {
   if (contradictsItself(chain)) return false;
-  const landedElsewhere = finalUrl !== undefined && targetKey(url) !== targetKey(finalUrl);
+  const landedElsewhere =
+    finalUrl !== undefined && requestTarget(url) !== requestTarget(finalUrl);
   return landedElsewhere || hasObservedRedirect(chain);
 }

--- a/packages/rules/src/shared/redirect-evidence.ts
+++ b/packages/rules/src/shared/redirect-evidence.ts
@@ -66,16 +66,19 @@ export function contradictsItself(chain: RedirectChain | undefined): boolean {
 }
 
 /**
- * The request target a URL names: everything the server is asked for, query
- * INCLUDED, fragment excluded because it never leaves the browser.
+ * The request target a URL names: path AND query, fragment excluded because it
+ * never leaves the browser. Which URL a request was aimed at, and which one it
+ * landed on, are both this.
  *
- * Deliberately not `targetKey`. This one answers "did the request land
- * somewhere else", and a redirect that only rewrites the query string still
- * redirected. `targetKey` is a join key for matching links to the redirect they
- * hit, where folding the query in would stop a link carrying a tracking
- * parameter from matching the path-level redirect it lands on.
+ * Deliberately not `targetKey`. This one decides whether two URLs are the same
+ * resource, and `/page`, `/page/` and `/page?x=1` are three different requests:
+ * a redirect that only rewrites the query still redirected, and only one of the
+ * slash forms is the one that moved (#1510, #1524). `targetKey` is a join key
+ * for matching links to the redirect they hit, where folding the query in would
+ * stop a link carrying a tracking parameter from matching the path-level
+ * redirect it lands on.
  */
-function requestTarget(url: string): string {
+export function requestTarget(url: string): string {
   try {
     const parsed = new URL(url);
     return `${parsed.protocol.toLowerCase()}//${parsed.host.toLowerCase()}${parsed.pathname}${parsed.search}`;

--- a/packages/rules/src/shared/redirect-evidence.ts
+++ b/packages/rules/src/shared/redirect-evidence.ts
@@ -1,0 +1,82 @@
+// shared/redirect-evidence - what counts as proof that a request redirected
+//
+// A `RedirectChain` is a record of hops, not a promise that any of them
+// redirected. Producers that only ever saw the landing response still emit a
+// chain, and a rule that reads `chainLength > 0` or `url !== finalUrl` as proof
+// accuses sites of redirects they never performed: every trailing-slash-
+// canonical site reported its own pages as `(200) → (200)` moves (#1510).
+//
+// These predicates are the shared answer to "did we actually watch this
+// redirect happen", so every rule that reports a chain asks the same question.
+
+import type { RedirectChain } from "@squirrelscan/core-contracts";
+
+/**
+ * Identity of the resource a URL names, for deciding whether a request LANDED
+ * somewhere else and for joining links to redirect targets.
+ *
+ * This is `@squirrelscan/utils`' `normalizeUrl` with the trailing slash KEPT.
+ * `/about` and `/about/` are different request targets, and telling them apart
+ * is the entire point: folding them together both hides a genuine
+ * `/about → /about/` move and lets a page that links the canonical form get
+ * blamed for the other form's redirect (#1510).
+ */
+export function targetKey(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol.toLowerCase()}//${parsed.host.toLowerCase()}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * A NON-final hop we watched actually redirect: an HTTP hop carrying a 3xx, or
+ * any client-side hop at all — a `javascript` / `meta-refresh` hop IS the
+ * redirect, whatever status the document that performed it returned.
+ */
+export function hasObservedRedirect(chain: RedirectChain | undefined): boolean {
+  if (!chain || chain.hops.length < 2) return false;
+  return chain.hops
+    .slice(0, -1)
+    .some((hop) => hop.type !== "http" || (hop.statusCode >= 300 && hop.statusCode < 400));
+}
+
+/**
+ * True when the chain contradicts itself: an HTTP hop it says was followed by
+ * another hop reports a 2xx, and an HTTP response that returned 200 did not
+ * redirect.
+ *
+ * Such a chain was assembled from a source URL and a landing URL by something
+ * that never watched the responses in between, and it is what made every
+ * trailing-slash-canonical site report its own pages as redirecting,
+ * `(200) → (200)`, blaming every page that linked them (#1510). The producers
+ * are fixed to record an unobserved hop as `0` rather than borrowing the landing
+ * status; this is the rules refusing to accuse on that shape even if one regresses.
+ *
+ * Client-side hops are exempt: a `javascript` / `meta-refresh` redirect is by
+ * definition a document that returned 200 and then sent the visitor elsewhere,
+ * so a 2xx there is the truth, not a borrowed status.
+ */
+export function contradictsItself(chain: RedirectChain | undefined): boolean {
+  if (!chain || chain.hops.length < 2) return false;
+  return chain.hops
+    .slice(0, -1)
+    .some((hop) => hop.type === "http" && hop.statusCode >= 200 && hop.statusCode < 300);
+}
+
+/**
+ * Did this request redirect? Two independent kinds of evidence: it landed on a
+ * different resource, or we watched a hop return a 3xx. The first covers the
+ * render path, which reports the landing page but never the statuses that led
+ * to it. A self-contradicting chain is neither, whatever the URLs say.
+ */
+export function didRedirect(
+  url: string,
+  finalUrl: string | undefined,
+  chain: RedirectChain | undefined
+): boolean {
+  if (contradictsItself(chain)) return false;
+  const landedElsewhere = finalUrl !== undefined && targetKey(url) !== targetKey(finalUrl);
+  return landedElsewhere || hasObservedRedirect(chain);
+}

--- a/packages/rules/tests/canonical-chain-redirect-evidence.test.ts
+++ b/packages/rules/tests/canonical-chain-redirect-evidence.test.ts
@@ -250,6 +250,52 @@ describe("crawl/canonical-chain — canonical-redirects needs the same evidence"
     );
   });
 
+  test.each([
+    ["a trailing slash", "https://example.com/page/"],
+    ["a query string", "https://example.com/page?ref=nav"],
+  ])(
+    "a canonical differing by %s is not blamed for the fetched URL's redirect",
+    (_label, canonical) => {
+      // `/page`, `/page/` and `/page?ref=nav` are three different requests. We
+      // fetched one of them and hold its chain; handing that chain to a
+      // canonical naming another is the misattribution of #1510, one rule over.
+      const check = run(
+        {
+          url: "https://example.com/page",
+          finalUrl: "https://example.com/elsewhere",
+          canonical,
+          redirectChain: chain("https://example.com/page", "https://example.com/elsewhere", [
+            hop("https://example.com/page", 301),
+            hop("https://example.com/elsewhere", 200),
+          ]),
+        },
+        "canonical-redirects"
+      );
+
+      expect(check).toBeUndefined();
+    }
+  );
+
+  test("an observed redirect landing back on the same target does not flag the canonical", () => {
+    // Deliberate, and not a gap in the shared evidence rule: this check exists
+    // to say "point the canonical at the final URL instead", and there is no
+    // other URL to point it at. Following that advice here would mean
+    // canonicalizing to a fragment. A redirect loop is links/redirects' finding.
+    const page = {
+      url: "https://example.com/page",
+      finalUrl: "https://example.com/page#top",
+      canonical: "https://example.com/page",
+      redirectChain: chain("https://example.com/page", "https://example.com/page#top", [
+        hop("https://example.com/page", 302),
+        hop("https://example.com/page#top", 200),
+      ]),
+    };
+
+    expect(run(page, "canonical-redirects")).toBeUndefined();
+    // The redirect itself is still reported, on the same evidence.
+    expect(run(page, "page-redirect-chain")?.status).toBe("warn");
+  });
+
   test("an unobserved chain to a different destination still flags the canonical", () => {
     // Both checks must ask the same question. Demanding a recorded 3xx here
     // while page-redirect-chain accepts a different destination would drop

--- a/packages/rules/tests/canonical-chain-redirect-evidence.test.ts
+++ b/packages/rules/tests/canonical-chain-redirect-evidence.test.ts
@@ -1,0 +1,192 @@
+// crawl/canonical-chain accepted the SHAPE of a redirect chain as proof one
+// happened — `chainLength > 0 || pageUrl !== finalUrl`, with no check that any
+// hop returned a 3xx — and then labelled the result `url (200) → url (200)`.
+// That is the defect #1510 fixed in links/redirect-chains, still latent here:
+// it went quiet only because the producers stopped fabricating chains, so any
+// producer regression or a chain persisted from an older crawl brings it back.
+//
+// These tests pin the rule to observed redirect evidence, on the exact shapes
+// from the field report.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "linkedom";
+
+import type { RedirectChain, RedirectHop } from "@squirrelscan/core-contracts";
+import type { RuleContext } from "../src/types";
+
+import { canonicalChainRule } from "../src/crawl/canonical-chain";
+
+function hop(url: string, statusCode: number, type: RedirectHop["type"] = "http"): RedirectHop {
+  return { url, statusCode, type };
+}
+
+function chain(sourceUrl: string, finalUrl: string, hops: RedirectHop[]): RedirectChain {
+  return {
+    sourceUrl,
+    finalUrl,
+    hops,
+    chainLength: Math.max(0, hops.length - 1),
+    isLoop: false,
+    endsInError: false,
+    httpsToHttp: false,
+    httpToHttps: false,
+  };
+}
+
+/**
+ * A document is required — the rule returns no checks without one — but the
+ * page-redirect-chain check reads nothing from it, so a bare canonical is
+ * enough for every case here.
+ */
+function ctx(page: {
+  url: string;
+  finalUrl?: string;
+  redirectChain?: RedirectChain;
+  canonical?: string;
+}): RuleContext {
+  const canonical = page.canonical ?? page.url;
+  const html = `<html><head><link rel="canonical" href="${canonical}"></head><body></body></html>`;
+  return {
+    page: {
+      url: page.url,
+      finalUrl: page.finalUrl,
+      redirectChain: page.redirectChain,
+      html,
+      statusCode: 200,
+    },
+    parsed: { document: parseHTML(html).document },
+    options: {},
+  } as unknown as RuleContext;
+}
+
+const run = (page: Parameters<typeof ctx>[0], name: string) =>
+  canonicalChainRule.run(ctx(page)).checks.find((c) => c.name === name);
+
+describe("crawl/canonical-chain — chain shape is not redirect evidence", () => {
+  test("the fabricated 200 → 200 chain no longer reports a redirect", () => {
+    // Verbatim from the #1524 report: a slash-canonical page whose chain claims
+    // two hops, both 200. An HTTP response that returned 200 did not redirect.
+    const check = run(
+      {
+        url: "https://example.com/o-mnie",
+        finalUrl: "https://example.com/o-mnie/",
+        redirectChain: chain("https://example.com/o-mnie", "https://example.com/o-mnie/", [
+          hop("https://example.com/o-mnie", 200),
+          hop("https://example.com/o-mnie/", 200),
+        ]),
+      },
+      "page-redirect-chain"
+    );
+
+    expect(check).toBeUndefined();
+  });
+
+  test("a genuine 301 → 200 chain still fires, labelled with the observed statuses", () => {
+    const check = run(
+      {
+        url: "https://example.com/o-mnie",
+        finalUrl: "https://example.com/o-mnie/",
+        redirectChain: chain("https://example.com/o-mnie", "https://example.com/o-mnie/", [
+          hop("https://example.com/o-mnie", 301),
+          hop("https://example.com/o-mnie/", 200),
+        ]),
+      },
+      "page-redirect-chain"
+    );
+
+    expect(check?.status).toBe("warn");
+    expect(check?.items?.[0]?.label).toBe(
+      "https://example.com/o-mnie (301) → https://example.com/o-mnie/ (200)"
+    );
+  });
+
+  test("a chain with no hop statuses still fires when the request landed elsewhere", () => {
+    // The render path reports the landing URL but never the statuses that led
+    // to it, so unobserved hops are recorded as 0. Landing on a different
+    // resource is evidence in its own right, and the label must not invent a
+    // status for a hop nobody watched.
+    const check = run(
+      {
+        url: "https://example.com/old",
+        finalUrl: "https://example.com/new",
+        redirectChain: chain("https://example.com/old", "https://example.com/new", [
+          hop("https://example.com/old", 0),
+          hop("https://example.com/new", 200),
+        ]),
+      },
+      "page-redirect-chain"
+    );
+
+    expect(check?.status).toBe("warn");
+    expect(check?.items?.[0]?.label).toBe("https://example.com/old → https://example.com/new (200)");
+  });
+
+  test("a client-side hop returning 200 is a real redirect, not a contradiction", () => {
+    // A meta-refresh redirect IS a document that returned 200 and then sent the
+    // visitor elsewhere, so its 2xx is the truth rather than a borrowed status.
+    const check = run(
+      {
+        url: "https://example.com/splash",
+        finalUrl: "https://example.com/home",
+        redirectChain: chain("https://example.com/splash", "https://example.com/home", [
+          hop("https://example.com/splash", 200, "meta-refresh"),
+          hop("https://example.com/home", 200),
+        ]),
+      },
+      "page-redirect-chain"
+    );
+
+    expect(check?.status).toBe("warn");
+  });
+
+  test("a page that never redirected stays silent", () => {
+    const check = run(
+      {
+        url: "https://example.com/about/",
+        finalUrl: "https://example.com/about/",
+        redirectChain: chain("https://example.com/about/", "https://example.com/about/", [
+          hop("https://example.com/about/", 200),
+        ]),
+      },
+      "page-redirect-chain"
+    );
+
+    expect(check).toBeUndefined();
+  });
+});
+
+describe("crawl/canonical-chain — canonical-redirects needs the same evidence", () => {
+  const selfCanonicalThroughChain = (hops: RedirectHop[]) => ({
+    url: "https://example.com/page",
+    finalUrl: "https://example.com/elsewhere",
+    canonical: "https://example.com/page",
+    redirectChain: chain("https://example.com/page", "https://example.com/elsewhere", hops),
+  });
+
+  test("a fabricated chain does not accuse the canonical of resolving through redirects", () => {
+    const check = run(
+      selfCanonicalThroughChain([
+        hop("https://example.com/page", 200),
+        hop("https://example.com/elsewhere", 200),
+      ]),
+      "canonical-redirects"
+    );
+
+    expect(check).toBeUndefined();
+  });
+
+  test("an observed 301 still flags the canonical", () => {
+    const check = run(
+      selfCanonicalThroughChain([
+        hop("https://example.com/page", 301),
+        hop("https://example.com/elsewhere", 200),
+      ]),
+      "canonical-redirects"
+    );
+
+    expect(check?.status).toBe("warn");
+    expect(check?.items?.[0]?.label).toBe(
+      "https://example.com/page (301) → https://example.com/elsewhere (200)"
+    );
+  });
+});

--- a/packages/rules/tests/canonical-chain-redirect-evidence.test.ts
+++ b/packages/rules/tests/canonical-chain-redirect-evidence.test.ts
@@ -121,22 +121,82 @@ describe("crawl/canonical-chain — chain shape is not redirect evidence", () =>
     expect(check?.items?.[0]?.label).toBe("https://example.com/old → https://example.com/new (200)");
   });
 
-  test("a client-side hop returning 200 is a real redirect, not a contradiction", () => {
-    // A meta-refresh redirect IS a document that returned 200 and then sent the
-    // visitor elsewhere, so its 2xx is the truth rather than a borrowed status.
+  test.each([["meta-refresh"], ["javascript"]] as const)(
+    "a %s hop returning 200 is a real redirect, not a contradiction",
+    (type) => {
+      // A client-side redirect IS a document that returned 200 and then sent
+      // the visitor elsewhere, so its 2xx is the truth rather than a borrowed
+      // status.
+      const check = run(
+        {
+          url: "https://example.com/splash",
+          finalUrl: "https://example.com/home",
+          redirectChain: chain("https://example.com/splash", "https://example.com/home", [
+            hop("https://example.com/splash", 200, type),
+            hop("https://example.com/home", 200),
+          ]),
+        },
+        "page-redirect-chain"
+      );
+
+      expect(check?.status).toBe("warn");
+    }
+  );
+
+  test("one contradictory hop suppresses the chain even beside an observed 301", () => {
+    // A 200 on a hop the chain says was followed is proof the chain was
+    // assembled rather than watched, and that taints every status in it.
     const check = run(
       {
-        url: "https://example.com/splash",
-        finalUrl: "https://example.com/home",
-        redirectChain: chain("https://example.com/splash", "https://example.com/home", [
-          hop("https://example.com/splash", 200, "meta-refresh"),
-          hop("https://example.com/home", 200),
+        url: "https://example.com/a",
+        finalUrl: "https://example.com/c",
+        redirectChain: chain("https://example.com/a", "https://example.com/c", [
+          hop("https://example.com/a", 301),
+          hop("https://example.com/b", 200),
+          hop("https://example.com/c", 200),
+        ]),
+      },
+      "page-redirect-chain"
+    );
+
+    expect(check).toBeUndefined();
+  });
+
+  test("a redirect that only rewrites the query string still counts as landing elsewhere", () => {
+    // The query is part of the request target: `/search` and `/search?page=1`
+    // are different resources, so a request aimed at one that landed on the
+    // other redirected, even with no status to prove it.
+    const check = run(
+      {
+        url: "https://example.com/search",
+        finalUrl: "https://example.com/search?page=1",
+        redirectChain: chain("https://example.com/search", "https://example.com/search?page=1", [
+          hop("https://example.com/search", 0),
+          hop("https://example.com/search?page=1", 200),
         ]),
       },
       "page-redirect-chain"
     );
 
     expect(check?.status).toBe("warn");
+  });
+
+  test("a fragment-only difference is not a redirect", () => {
+    // The fragment never leaves the browser, so it cannot differ across an
+    // HTTP request and must not be read as a destination change.
+    const check = run(
+      {
+        url: "https://example.com/docs",
+        finalUrl: "https://example.com/docs#install",
+        redirectChain: chain("https://example.com/docs", "https://example.com/docs#install", [
+          hop("https://example.com/docs", 0),
+          hop("https://example.com/docs#install", 200),
+        ]),
+      },
+      "page-redirect-chain"
+    );
+
+    expect(check).toBeUndefined();
   });
 
   test("a page that never redirected stays silent", () => {
@@ -187,6 +247,25 @@ describe("crawl/canonical-chain — canonical-redirects needs the same evidence"
     expect(check?.status).toBe("warn");
     expect(check?.items?.[0]?.label).toBe(
       "https://example.com/page (301) → https://example.com/elsewhere (200)"
+    );
+  });
+
+  test("an unobserved chain to a different destination still flags the canonical", () => {
+    // Both checks must ask the same question. Demanding a recorded 3xx here
+    // while page-redirect-chain accepts a different destination would drop
+    // every render-path redirect, which reports where the request landed but
+    // never the statuses that led there.
+    const check = run(
+      selfCanonicalThroughChain([
+        hop("https://example.com/page", 0),
+        hop("https://example.com/elsewhere", 200),
+      ]),
+      "canonical-redirects"
+    );
+
+    expect(check?.status).toBe("warn");
+    expect(check?.items?.[0]?.label).toBe(
+      "https://example.com/page → https://example.com/elsewhere (200)"
     );
   });
 });


### PR DESCRIPTION
`crawl/canonical-chain` treated the *shape* of a redirect chain as proof a redirect happened:

```ts
if (redirectChain && (redirectChain.chainLength > 0 || pageUrl !== finalUrl))
```

Nothing here checks that any hop returned a 3xx, and the rule then labels every hop `${hop.url} (${hop.statusCode})`. Fed a chain assembled from a source URL and a landing URL by a producer that never watched the responses in between, it reports:

```
https://example.com/o-mnie (200) → https://example.com/o-mnie/ (200)
```

An HTTP response that returned 200 did not redirect. This is the same defect fixed in `links/redirect-chains` earlier, still present one rule over.

It is latent rather than live: the rule went quiet when the producers stopped fabricating chains, not on its own merits. It was reporting 14 items per site on every trailing-slash-canonical site in the smoke sample and now reports 0. Any producer regression, or a chain persisted from an older crawl, brings the false positive straight back, and this rule has none of the defence `links/redirect-chains` gained.

## What changed

**1. Evidence before accusation.** The predicates move out of `links/redirect-chains` into `shared/redirect-evidence.ts`, and both `canonical-chain` checks now gate on them, so every rule that reports a chain asks the same question:

- a hop that returned 2xx did not redirect
- a client-side hop (`javascript` / `meta-refresh`) *is* the redirect, whatever status the document that performed it carried
- a chain that contradicts itself (a 2xx on a hop it also says was followed) is not evidence of anything
- an unobserved hop stays unlabelled rather than borrowing the landing status

The extraction is behaviour-preserving for `links/redirect-chains`; only `canonical-chain` changes behaviour.

**2. Two false negatives the first pass introduced,** both caught in review:

- `canonical-redirects` required a recorded 3xx while `page-redirect-chain` also accepted a different destination, so the two checks disagreed about what a redirect is. A render-path chain reports where a request landed but never the statuses that led there, and every one of those was dropped. Both now ask `didRedirect`.
- The landing comparison borrowed `targetKey`, which discards the query, so a redirect that only rewrote the query string read as no redirect at all. The comparison gets its own `requestTarget`, keeping the query and dropping only the fragment, which never leaves the browser. `targetKey` is untouched: it joins links to the redirect they hit, and folding the query in there would stop a link carrying a tracking parameter from matching a path-level redirect.

**3. One adjacent misattribution** (last commit, separable from the rest). `canonical-redirects` decided whether a canonical was self-referencing with `normalizeUrl`, which discards the query *and* the trailing slash. `/page`, `/page/` and `/page?ref=nav` all counted as the URL we fetched, so the check handed this page's chain to whichever of them the canonical named: a page at `/page` that redirects reported `/page/` as resolving through a redirect, on the evidence of a request to `/page/` that was never made. It now compares request targets, the same identity `didRedirect` uses.

## A deliberate asymmetry

`canonical-redirects` keeps its own requirement that the request landed on a *different* target, on top of the shared evidence rule. That is not the two checks disagreeing again: this one exists to say "point the canonical at the final URL instead", and a redirect that lands back where it started offers no other URL to point at, only advice to canonicalize a fragment. A loop is `links/redirects`' finding. There is a test pinning it so it is not later read as an oversight.

## Tests

`packages/rules/tests/canonical-chain-redirect-evidence.test.ts`, on the exact shapes from the field report: the fabricated `200 → 200` chain stays silent, the genuine `301 → 200` still fires with its observed statuses, an unobserved `0 → 200` to a different destination fires and is labelled without inventing a status, client-side hops are exempt, one contradictory hop suppresses a chain that also carries a real 301, a query-only redirect counts and a fragment-only one does not, and a canonical differing by slash or query is not blamed for the fetched URL's redirect.

Each fix was checked for vacuity by reverting it alone and confirming exactly the intended tests fail.

`cd packages/rules && bun test` → 1394 pass, 0 fail. `bun run typecheck` clean.

> Note, unrelated to this change: the root `test` script is `cd apps/cli && bun test`, so the `packages/rules` suite these tests join does not run in CI. The regression cover added here only binds locally until that is wired up.
