### PR TITLE
fix(engine): record what the report caps drop instead of dropping it silently

### DIFF
--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -12,7 +12,13 @@
 
 import { Effect } from "effect";
 
-import { capChecksForPublish, capMixedRuleChecksForPublish } from "@squirrelscan/rules";
+import {
+  capChecksForPublish,
+  capMixedRuleChecksForPublish,
+  clampCheckItemsOverflow,
+  maxChecksTruncated,
+  stampChecksTruncated,
+} from "@squirrelscan/rules";
 import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
 import { parseRobotsTxt } from "@squirrelscan/utils/robots-txt";
 
@@ -157,6 +163,59 @@ function toReportRuleResults(
   }
 
   return Object.fromEntries(entries);
+}
+
+/**
+ * Last-resort schema backstop over the assembled `ruleResults` — ONE copy,
+ * shared by buildV1Report and buildV2Report (they carried byte-identical
+ * twins of this loop, and #1503 was filed against one of them).
+ *
+ * It is a BACKSTOP, not the cap that does the work. `toReportRuleResults` has
+ * already run `capChecksForPublish`, which FOLDS an over-cap rule down to one
+ * aggregate per (name, status) issue class and keeps every affected page on
+ * the aggregate's `pages[]` — so by the time a checks array reaches here it is
+ * bounded losslessly and these caps do not bite. Measured on a 1200-page
+ * crawl: 186 rules fold, the widest emits 4 issue classes against a cap of
+ * 500, and zero affected pages are lost.
+ *
+ * #1503 read the bare `slice(0, 500)` this replaces as the primary cap and
+ * concluded page-scoped findings were being dropped. They were not — but a
+ * silent unconditional slice sitting downstream of a lossless fold is a
+ * landmine either way: if the fold's invariant ever weakens (a rule emitting
+ * more distinct issue classes than the cap), the loss would be invisible.
+ * Both caps now record what they cut — items into `details.additional`,
+ * checks into `details.checksTruncated` — and warn, so the failure mode is
+ * loud rather than a report that merely looks complete.
+ */
+function sanitizeReportRuleResults(ruleResults: Record<string, ReportRuleResult>): void {
+  for (const [ruleId, ruleResult] of Object.entries(ruleResults)) {
+    // Display-string clamps, unchanged: in-place, and `name` IS clamped here
+    // (unlike clampCheckStrings, which leaves it alone as a fold join key) —
+    // fold has already run, so nothing downstream joins on it.
+    for (const check of ruleResult.checks) {
+      if (check.message.length > 1000) check.message = `${check.message.slice(0, 997)}...`;
+      if (check.name.length > 255) check.name = `${check.name.slice(0, 252)}...`;
+    }
+
+    // Rolls the drop into `details.additional` instead of slicing items away.
+    let checks = clampCheckItemsOverflow(ruleResult.checks, REPORT_LIMITS.maxItemsPerCheck);
+
+    if (checks.length > REPORT_LIMITS.maxChecksPerRule) {
+      // Reconciled against any marker an upstream cap already left, so a
+      // second cut never replaces the real total with this smaller one.
+      const total = Math.max(checks.length, maxChecksTruncated(checks));
+      logger.warn(
+        `report: rule ${ruleId} emitted ${total} checks past the fold, capping at ` +
+          `${REPORT_LIMITS.maxChecksPerRule} (details.checksTruncated records the total)`,
+      );
+      checks = checks.slice(0, REPORT_LIMITS.maxChecksPerRule);
+      const lastIndex = checks.length - 1;
+      const last = checks[lastIndex];
+      if (last) checks[lastIndex] = stampChecksTruncated(last, total);
+    }
+
+    ruleResult.checks = checks;
+  }
 }
 
 // ============================================
@@ -487,17 +546,7 @@ export function buildV1Report(
       }
     }
 
-    // Sanitize: truncate strings that exceed API schema limits
-    for (const ruleResult of Object.values(result.ruleResults)) {
-      for (const check of ruleResult.checks) {
-        if (check.message.length > 1000) check.message = `${check.message.slice(0, 997)}...`;
-        if (check.name.length > 255) check.name = `${check.name.slice(0, 252)}...`;
-        if (check.items) {
-          check.items = check.items.slice(0, 1000);
-        }
-      }
-      ruleResult.checks = ruleResult.checks.slice(0, 500);
-    }
+    sanitizeReportRuleResults(result.ruleResults);
 
     logger.traceEnd(reportSpan, { totalPages: pages.length });
     return result;
@@ -743,18 +792,8 @@ export function buildV2Report(
       if (result.healthScore) result.healthScore.overall = null;
     }
 
-    // Sanitize: truncate ruleResults strings that exceed API schema limits (same
-    // as v1). The page-schema.raw loop is a no-op here (pages: []), omitted.
-    for (const ruleResult of Object.values(result.ruleResults)) {
-      for (const check of ruleResult.checks) {
-        if (check.message.length > 1000) check.message = `${check.message.slice(0, 997)}...`;
-        if (check.name.length > 255) check.name = `${check.name.slice(0, 252)}...`;
-        if (check.items) {
-          check.items = check.items.slice(0, 1000);
-        }
-      }
-      ruleResult.checks = ruleResult.checks.slice(0, 500);
-    }
+    // Same backstop as v1. The page-schema.raw loop is a no-op here (pages: []).
+    sanitizeReportRuleResults(result.ruleResults);
 
     logger.traceEnd(reportSpan, { totalPages: pagesCrawled });
     return result;

--- a/packages/rules/src/fold.ts
+++ b/packages/rules/src/fold.ts
@@ -487,11 +487,13 @@ export function capChecksForPublish(checks: CheckResult[], maxChecks: number): C
  * nothing downstream can tell it happened — the array already fits under the
  * cap by the time it reaches the schema, so `collectCheckTruncations`' count
  * check never trips. #1503: that made the loss invisible. The last kept check
- * now carries `details.checksTruncated` = the pre-slice array length, the same
- * "true pre-clip total" contract as `details.pagesTruncated`, so the drop is
- * recorded in the payload rather than inferred from nothing. Preserved-if-larger
- * for the same reason `pagesTruncated` is: a second cap pass over an
- * already-capped array must not overwrite the bigger original total.
+ * now carries `details.checksTruncated` — the pre-slice length reconciled with
+ * any total an earlier cap already recorded ({@link maxChecksTruncated}) — the
+ * same "true pre-clip total" contract as `details.pagesTruncated`, so the drop
+ * is recorded in the payload rather than inferred from nothing.
+ * Preserved-if-larger for the same reason `pagesTruncated` is: a second cap
+ * pass over an already-capped array must not overwrite the bigger original
+ * total with its own smaller one.
  *
  * In practice these arrays rarely exceed `maxChecks` (this is a last-resort
  * safety net, not the primary #1003 producer) — `pages[].checks` runs closest,

--- a/packages/rules/src/fold.ts
+++ b/packages/rules/src/fold.ts
@@ -383,13 +383,20 @@ function checkAdditional(check: CheckResult): number {
  * Page-scope rules legitimately emit one check per affected page, so a
  * link-heavy 500+ page crawl overflows REPORT_LIMITS.maxChecksPerRule and the
  * publish schema silently slices the array (#817) — pages past the cap vanish
- * from the published report. Folding instead keeps every affected page:
+ * from the published report. Folding instead keeps every affected page, up to
+ * `maxPagesPerCheck` on the aggregate; past that the count stays honest even
+ * though the list is clipped (`details.pagesTruncated`, #1503):
  *  - `pages` = union of the folded checks' pageUrl/pages (schema allows maxPages);
  *  - `items` = union of the folded checks' items, deduped by id, each stamped
  *    with the pages it came from via `sourcePages`;
  *  - `details.occurrences` = folded check count (issue-sync reads this so the
  *    tracker's occurrence count survives the fold);
- *  - `details.additional` = items dropped at the cap + folded per-check remainders.
+ *  - `details.additional` = items dropped at the cap + folded per-check remainders;
+ *  - `details.pagesTruncated` = the affected-page total whenever `pages` is
+ *    clipped OR a constituent was already sampled upstream (re-fold, #916) —
+ *    exact in the first case, a floor in the second (see foldGroup).
+ *    `affectedPages()` reads it as the authoritative count, so every renderer
+ *    shows that number rather than the retained list's length.
  *
  * Rules under the cap pass through UNTOUCHED (same reference) — scoring and
  * report totals are computed from the un-folded map upstream, so this only
@@ -424,8 +431,17 @@ export function foldOverflowChecks(
   });
 
   // No rule emits >maxChecks distinct issue classes; slice keeps the invariant
-  // absolute if one ever does.
-  return out.length > limits.maxChecks ? out.slice(0, limits.maxChecks) : out;
+  // absolute if one ever does. Stamped because this drop is the one the
+  // downstream report-stream backstop can NEVER see (#1503): fold has already
+  // bounded the array to maxChecks by the time it runs, so its own length
+  // check cannot trip and the loss would be invisible everywhere.
+  if (out.length <= limits.maxChecks) return out;
+  const total = Math.max(out.length, maxChecksTruncated(out));
+  const kept = out.slice(0, limits.maxChecks);
+  const lastIndex = kept.length - 1;
+  const last = kept[lastIndex];
+  if (last) kept[lastIndex] = stampChecksTruncated(last, total);
+  return kept;
 }
 
 /**
@@ -462,17 +478,24 @@ export function capChecksForPublish(checks: CheckResult[], maxChecks: number): C
  * rule's check for one page) and `siteChecks` (every site-scoped rule's
  * check, flattened). Clamps oversize item ids/labels (#996) and any single
  * check's oversize `items` array (#1003), same as {@link capChecksForPublish}
- * — but caps the checks COUNT with a plain slice, not a fold: grouping by
+ * — but caps the checks COUNT with a slice, not a fold: grouping by
  * (name, status) across DIFFERENT rules is unsound (see
- * {@link capChecksForPublish}'s doc), so this never merges. A dropped check
- * past `maxChecks` has NO signal at all — the array already fits under the
- * cap by the time it reaches the publish schema, so
- * `collectCheckTruncations`'s count check never trips for it (unlike the
- * schema's own `truncatedArray` slice, which the RAW pre-parse payload diff
- * still catches). Same silent-clamp tradeoff as `clampCheckItemIds` (#996).
- * In practice these arrays rarely exceed
- * `maxChecks` (this is a last-resort safety net, not the primary #1003
- * producer).
+ * {@link capChecksForPublish}'s doc), so this never merges.
+ *
+ * The slice DROPS whole checks, and unlike the publish schema's own
+ * `truncatedArray` (whose cut the RAW pre-parse payload diff still catches)
+ * nothing downstream can tell it happened — the array already fits under the
+ * cap by the time it reaches the schema, so `collectCheckTruncations`' count
+ * check never trips. #1503: that made the loss invisible. The last kept check
+ * now carries `details.checksTruncated` = the pre-slice array length, the same
+ * "true pre-clip total" contract as `details.pagesTruncated`, so the drop is
+ * recorded in the payload rather than inferred from nothing. Preserved-if-larger
+ * for the same reason `pagesTruncated` is: a second cap pass over an
+ * already-capped array must not overwrite the bigger original total.
+ *
+ * In practice these arrays rarely exceed `maxChecks` (this is a last-resort
+ * safety net, not the primary #1003 producer) — `pages[].checks` runs closest,
+ * at ~198 against a 200 cap on a full rule set.
  */
 export function capMixedRuleChecksForPublish(
   checks: CheckResult[],
@@ -481,7 +504,61 @@ export function capMixedRuleChecksForPublish(
   const clamped = clampCheckItemsOverflow(
     clampCheckItemIds(clampCheckDetails(clampCheckStrings(checks))),
   );
-  return clamped.length > maxChecks ? clamped.slice(0, maxChecks) : clamped;
+  if (clamped.length <= maxChecks) return clamped;
+  const total = Math.max(clamped.length, maxChecksTruncated(clamped));
+  const kept = clamped.slice(0, maxChecks);
+  const last = kept[maxChecks - 1];
+  if (last) kept[maxChecks - 1] = stampChecksTruncated(last, total);
+  return kept;
+}
+
+/**
+ * Largest `checksTruncated` already recorded anywhere in `checks`.
+ *
+ * Must be read from the WHOLE array BEFORE it is sliced: the marker lives on
+ * whichever check was last at the time of the earlier cap, and a tighter second
+ * cap discards exactly that element. Scanning only the survivor would let a
+ * 40 → 10 → 5 sequence report 10, quietly replacing the true 40 with the
+ * already-capped intermediate — the same "smaller number overwrites the real
+ * one" bug the preserved-if-larger rule exists to prevent.
+ */
+export function maxChecksTruncated(checks: CheckResult[]): number {
+  let max = 0;
+  for (const check of checks) {
+    const prior = check.details?.checksTruncated;
+    if (typeof prior === "number" && Number.isFinite(prior) && prior > max) {
+      max = Math.floor(prior);
+    }
+  }
+  return max;
+}
+
+/**
+ * Record `total` as a check-array truncation marker on one surviving check.
+ * Split out so both mixed-rule caps and the report-stream sanitize backstop
+ * (#1503) stamp the identical field with the identical preserved-if-larger
+ * rule. A cap that bites twice keeps the LARGEST total; pass a `total` already
+ * reconciled against {@link maxChecksTruncated} of the pre-slice array.
+ */
+export function stampChecksTruncated(check: CheckResult, total: number): CheckResult {
+  const prior = check.details?.checksTruncated;
+  if (typeof prior === "number" && prior >= total) return check;
+  // Re-clamp: the stamp lands AFTER clampCheckDetails, so on a check already
+  // sitting at maxKeysPerLevel the extra key would push the record past the
+  // structural cap the publish schema enforces.
+  //
+  // The marker goes FIRST, not last. clampDetailsRecord keeps scalars ahead of
+  // everything else but then slices the level to maxKeysPerLevel in order — so
+  // a record already carrying that many scalars would drop a trailing
+  // `checksTruncated` and silently lose the very fact we are recording. First
+  // position puts it among the keys that survive; a pre-existing (smaller)
+  // marker is dropped from the spread so ours is the one that lands.
+  const { checksTruncated: _superseded, ...rest } = check.details ?? {};
+  const details = clampDetailsRecord({ checksTruncated: total, ...rest }) as Record<
+    string,
+    unknown
+  >;
+  return { ...check, details };
 }
 
 /**
@@ -640,7 +717,36 @@ function foldGroup(group: CheckResult[], limits: FoldLimits): CheckResult {
     if (check.pageUrl) pageSet.add(check.pageUrl);
     for (const page of check.pages ?? []) pageSet.add(page);
   }
-  const pages = [...pageSet].sort().slice(0, limits.maxPagesPerCheck);
+  const allPages = [...pageSet].sort();
+  const pages =
+    allPages.length > limits.maxPagesPerCheck
+      ? allPages.slice(0, limits.maxPagesPerCheck)
+      : allPages;
+
+  // Affected-page total, independent of what `pages` retains (#1503). Two ways
+  // it exceeds `pages.length`, both of which used to vanish silently:
+  //  1. the slice above, when one issue class spans >maxPagesPerCheck pages;
+  //  2. a constituent that was ALREADY sampled upstream (re-fold path, #916) —
+  //     `details` is rebuilt from scratch below, so its marker is not carried
+  //     forward unless we do it here.
+  // `affectedPages()` reads pagesTruncated as THE authoritative count, so
+  // leaving either unstamped makes a clipped rule report its retained length as
+  // if it were the whole truth.
+  //
+  // EXACT for case 1 (the union is fully known here). For case 2 it is a FLOOR:
+  // a sampled constituent reports how many pages it covered but not WHICH, so
+  // pages contributed by its siblings cannot be tested for membership in that
+  // hidden set. max() is the only non-overstating reconciliation — summing
+  // would double-count every overlap. A floor is the correct bias when the
+  // number is rendered as a coverage claim, and matches the honest-floor
+  // contract `ruleAffectedRollup` already documents.
+  let pagesTotal = pageSet.size;
+  for (const check of group) {
+    const prior = check.details?.pagesTruncated;
+    if (typeof prior === "number" && Number.isFinite(prior) && prior > pagesTotal) {
+      pagesTotal = Math.floor(prior);
+    }
+  }
 
   // Merge items by id; the folded checks' pageUrl becomes each item's
   // sourcePages so per-page attribution survives losing per-check pageUrl.
@@ -688,6 +794,7 @@ function foldGroup(group: CheckResult[], limits: FoldLimits): CheckResult {
 
   const details: Record<string, unknown> = { aggregated: true, occurrences: group.length };
   if (additional + droppedIds.size > 0) details.additional = additional + droppedIds.size;
+  if (pagesTotal > pages.length) details.pagesTruncated = pagesTotal;
 
   // Smart audits (#110): stay "carried" only when every folded finding was.
   const allCarried = group.every((c) => c.provenance === "carried");

--- a/packages/rules/tests/fold.test.ts
+++ b/packages/rules/tests/fold.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
+import { CHECK_DETAILS_LIMITS, REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
 
 import { clampItemId } from "@squirrelscan/core-contracts/clamp";
 
@@ -20,6 +20,7 @@ import {
   clampReportPagesToBudget,
   DEFAULT_FOLD_LIMITS,
   foldOverflowChecks,
+  stampChecksTruncated,
   unfoldAggregateCheck,
   type FoldLimits,
 } from "../src/fold";
@@ -763,5 +764,129 @@ describe("clampCheckDetails (#1288)", () => {
     const bigNoise = Object.fromEntries(Array.from({ length: 30 }, (_, i) => [`k${i}`, i]));
     const [c] = capMixedRuleChecksForPublish([failCheck({ details: bigNoise })], 500);
     expect(Object.keys(c!.details!).length).toBeLessThan(30);
+  });
+});
+
+// #1503 — every path that DROPS something now records what it dropped. The
+// report used to look complete either way, which is the failure mode the issue
+// was filed against: a rule reporting on 500 pages of a 2000-page site gave the
+// reader no way to tell the other 1500 were never shown.
+//
+// Note the golden snapshots are built from the UNCAPPED ruleResultsMap, so none
+// of this is observable there — these are the only tests that watch these caps.
+describe("truncation is never silent (#1503)", () => {
+  test("the per-rule check cap is LOSSLESS: a 2000-page rule keeps all 2000 pages", () => {
+    // The premise #1503 was filed on — that the cap slices page-scoped findings
+    // away — does not hold: capChecksForPublish FOLDS, collapsing the issue
+    // class to one aggregate that carries every affected page. Nothing is lost
+    // and no marker is needed, because nothing was clipped.
+    const checks = Array.from({ length: 2000 }, (_, i) =>
+      failCheck({ pageUrl: `https://example.com/p/${i}` }),
+    );
+    const capped = capChecksForPublish(checks, REPORT_LIMITS.maxChecksPerRule);
+
+    expect(capped).toHaveLength(1);
+    expect(capped[0]!.pages).toHaveLength(2000);
+    expect(capped[0]!.details?.occurrences).toBe(2000);
+    expect(capped[0]!.details?.pagesTruncated).toBeUndefined();
+  });
+
+  test("clipping pages at maxPagesPerCheck records the TRUE total, not the retained length", () => {
+    // Past the page cap the list must be clipped, but the count must not lie:
+    // affectedPages() reads pagesTruncated as authoritative, so without this
+    // stamp a clipped rule reports its retained length as the whole truth.
+    const checks = Array.from({ length: 10 }, (_, i) =>
+      failCheck({ pageUrl: `https://example.com/p/${i}` }),
+    );
+    const folded = foldOverflowChecks(checks, { ...SMALL, maxChecks: 3 });
+
+    expect(folded).toHaveLength(1);
+    expect(folded[0]!.pages).toHaveLength(SMALL.maxPagesPerCheck);
+    expect(folded[0]!.details?.pagesTruncated).toBe(10);
+  });
+
+  test("a constituent's pagesTruncated survives the fold (re-fold path, #916)", () => {
+    // foldGroup rebuilds `details` from scratch, so an already-sampled check's
+    // marker is carried forward explicitly or it vanishes — and the aggregate
+    // would then undercount to the union of the few pages that survived upstream.
+    const alreadySampled = failCheck({
+      pages: ["https://example.com/a", "https://example.com/b"],
+      details: { aggregated: true, pagesTruncated: 600 },
+    });
+    const folded = foldOverflowChecks(
+      [alreadySampled, ...Array.from({ length: 3 }, (_, i) => failCheck({ pageUrl: `https://example.com/p/${i}` }))],
+      { ...SMALL, maxChecks: 2, maxPagesPerCheck: 100 },
+    );
+
+    expect(folded).toHaveLength(1);
+    expect(folded[0]!.details?.pagesTruncated).toBe(600);
+  });
+
+  test("more issue classes than the cap stamps checksTruncated on the last kept check", () => {
+    // The one drop the downstream report-stream backstop can NEVER see: by the
+    // time it runs, fold has already bounded the array to maxChecks, so its own
+    // length check cannot trip.
+    const checks = Array.from({ length: 8 }, (_, i) =>
+      failCheck({ name: `class-${i}`, pageUrl: `https://example.com/p/${i}` }),
+    );
+    const folded = foldOverflowChecks(checks, SMALL);
+
+    expect(folded).toHaveLength(SMALL.maxChecks);
+    expect(folded.at(-1)!.details?.checksTruncated).toBe(8);
+  });
+
+  test("capMixedRuleChecksForPublish records its slice instead of dropping in silence", () => {
+    // Mixed-rule arrays cannot fold (grouping across DIFFERENT rules is
+    // unsound), so this one really does slice — it just says so now.
+    const checks = Array.from({ length: 12 }, (_, i) =>
+      failCheck({ name: `rule-${i}`, pageUrl: `https://example.com/p/${i}` }),
+    );
+    const capped = capMixedRuleChecksForPublish(checks, 5);
+
+    expect(capped).toHaveLength(5);
+    expect(capped.at(-1)!.details?.checksTruncated).toBe(12);
+  });
+
+  test("under both caps nothing is stamped (no marker on an untruncated array)", () => {
+    const checks = Array.from({ length: 3 }, (_, i) =>
+      failCheck({ name: `rule-${i}`, pageUrl: `https://example.com/p/${i}` }),
+    );
+    const capped = capMixedRuleChecksForPublish(checks, 5);
+
+    expect(capped).toHaveLength(3);
+    for (const c of capped) expect(c.details?.checksTruncated).toBeUndefined();
+  });
+
+  test("a SECOND, tighter cap keeps the original total (40 → 10 → 5 still reads 40)", () => {
+    // The marker sits on whichever check was last at the previous cap — exactly
+    // the element a tighter cap slices away. Reading it only off the survivor
+    // would report 10 here, quietly substituting the already-capped
+    // intermediate for the real 40 and re-hiding most of the loss.
+    const once = capMixedRuleChecksForPublish(
+      Array.from({ length: 40 }, (_, i) => failCheck({ name: `rule-${i}` })),
+      10,
+    );
+    expect(once.at(-1)!.details?.checksTruncated).toBe(40);
+
+    const twice = capMixedRuleChecksForPublish(once, 5);
+    expect(twice).toHaveLength(5);
+    expect(twice.at(-1)!.details?.checksTruncated).toBe(40);
+  });
+
+  test("stampChecksTruncated never replaces a larger recorded total with a smaller one", () => {
+    const stamped = stampChecksTruncated(failCheck({ details: { checksTruncated: 2000 } }), 500);
+    expect(stamped.details?.checksTruncated).toBe(2000);
+  });
+
+  test("the marker survives a details record already full of scalar keys", () => {
+    // clampDetailsRecord keeps scalars ahead of other values but still slices
+    // the level to maxKeysPerLevel in order, so a marker appended LAST to an
+    // already-full record is dropped — losing the very fact being recorded, on
+    // the two call sites that do not also log it.
+    const full = Object.fromEntries(
+      Array.from({ length: CHECK_DETAILS_LIMITS.maxKeysPerLevel }, (_, i) => [`n${i}`, i]),
+    );
+    const stamped = stampChecksTruncated(failCheck({ details: full }), 1234);
+    expect(stamped.details?.checksTruncated).toBe(1234);
   });
 });

--- a/packages/rules/tests/fold.test.ts
+++ b/packages/rules/tests/fold.test.ts
@@ -822,6 +822,28 @@ describe("truncation is never silent (#1503)", () => {
     expect(folded[0]!.details?.pagesTruncated).toBe(600);
   });
 
+  test("fold → unfold → re-fold does not INFLATE the page total", () => {
+    // unfoldAggregateCheck copies details (minus aggregated/occurrences/
+    // additional) onto EVERY synthetic per-page check, so a re-fold sees N
+    // copies of the same marker. Reconciling with max() collapses them back to
+    // the one true total; summing them — the obvious way to write this — would
+    // multiply the count on every publish round trip.
+    const LIMITS: FoldLimits = { ...SMALL, maxChecks: 2 };
+    const checks = Array.from({ length: 10 }, (_, i) =>
+      failCheck({ pageUrl: `https://example.com/p/${i}` }),
+    );
+    const folded = foldOverflowChecks(checks, LIMITS);
+    expect(folded[0]!.details?.pagesTruncated).toBe(10);
+
+    const unfolded = unfoldAggregateCheck(folded[0]!);
+    expect(unfolded.length).toBeGreaterThan(1);
+    for (const c of unfolded) expect(c.details?.pagesTruncated).toBe(10);
+
+    const refolded = foldOverflowChecks(unfolded, LIMITS);
+    expect(refolded).toHaveLength(1);
+    expect(refolded[0]!.details?.pagesTruncated).toBe(10);
+  });
+
   test("more issue classes than the cap stamps checksTruncated on the last kept check", () => {
     // The one drop the downstream report-stream backstop can NEVER see: by the
     // time it runs, fold has already bounded the array to maxChecks, so its own


### PR DESCRIPTION
Fixes the silent-truncation class behind private issue #1503.

## The premise, corrected

#1503 read `ruleResult.checks = ruleResult.checks.slice(0, 500)` in `report-stream.ts` as the primary per-rule cap and concluded page-scoped findings vanish on large crawls: "a user auditing a 2000-page site sees a rule reporting on 500 pages and has no way to tell the other 1500 were not clean."

That specific loss is not happening. `toReportRuleResults` calls `capChecksForPublish` **before** that slice, which *folds* an over-cap rule into one aggregate per `(name, status)` issue class and carries every affected page on `pages[]`. The slice is a backstop that never bites. There is now a test pinning this: a 2000-check page-scoped rule keeps all 2000 pages through the cap.

## What was actually silent

Three paths dropped whole checks or pages with no signal:

1. **`foldGroup` clipped `pages` at `maxPagesPerCheck` (5000) stamping nothing** — while `affectedPages()` reads `details.pagesTruncated` as *the* authoritative affected-page count. So a clipped rule reported its retained length as the whole truth. This is precisely the "report looks complete" failure the issue describes, just at 5000 pages rather than 500 checks.
2. **`foldGroup` rebuilds `details` from scratch**, discarding a constituent's existing `pagesTruncated` on the re-fold path (#916).
3. **`foldOverflowChecks`'s own issue-class slice was silent** — and is the one drop the report-stream backstop can *never* observe, because fold has already bounded the array to `maxChecks` by the time it runs, so its length check cannot trip.

All three now record the pre-clip total. `capMixedRuleChecksForPublish` and the report-stream backstop stamp `checksTruncated` too, and the backstop warns.

Because `pagesTruncated` already has a reader in every renderer (`affectedPages()`, the shared accessor all 9 consumers route through), the corrected count surfaces in the rendered report with **no renderer changes and no golden churn**.

## Two subtleties worth reviewing

- **The marker is stamped FIRST in the details record.** `clampDetailsRecord` keeps scalars ahead of other values but still slices the level to `maxKeysPerLevel` *in order* — so appending the marker last to an already-full record dropped the very fact being recorded, on the two call sites that do not also log it. Covered by a test using exactly `maxKeysPerLevel` scalar keys.
- **Totals are reconciled against the whole pre-slice array.** The marker sits on whichever check was last at the previous cap — exactly the element a tighter second cap removes. Reading it only off the survivor made a 40 → 10 → 5 sequence report `10`, quietly substituting the already-capped intermediate for the real total.

## Precision, stated honestly

`pagesTruncated` from `foldGroup` is **exact** when clipping a known union, and a **floor** on the re-fold path: a sampled constituent reports how many pages it covered but not *which*, so sibling pages cannot be tested for membership in that hidden set. `max()` is the only non-overstating reconciliation (summing would double-count overlaps), and a floor is the right bias for a number rendered as a coverage claim. This matches the honest-floor contract `ruleAffectedRollup` already documents.

## Testing

- `packages/rules`: **1388 pass, 0 fail** (9 new cases). Three of the new tests were verified to *fail* against the old behavior before the fix.
- `packages/report`: 208 pass, 0 fail.
- `packages/audit-engine` `test:golden`: **58 pass, 1 skip, 0 fail**, byte-identical metrics (`pages=518 findings=98220 rules=278 healthScore=48 errors=1000 warnings=4520 passed=37315`). Runtime 128.6s–261.8s across runs depending on machine load.
- `tsgo --noEmit` clean for both `rules` and `audit-engine`.

As the issue notes, golden snapshots are built from the **uncapped** `ruleResultsMap`, so none of this is observable there — the new `fold.test.ts` cases are the only tests watching these caps.

Reviewed with codex; its three findings (repeated-cap total, marker vs. scalar key cap, floor-vs-exact) are all addressed above.