### PR TITLE
fix(installer): diagnose a self install killed by the OOM killer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,8 +48,16 @@ fi
 
 log() { echo -e "${GREEN}==>${NC} $1" >&2; }
 warn() { echo -e "${YELLOW}Warning:${NC} $1" >&2; }
+# error <message> [detail]
+# `message` is shown to the user AND carried in the failure report, where it is
+# clamped to ERROR_LINE_MAX. `detail` is remediation text shown to the user
+# only: a long guidance block passed as `message` would push the actual error
+# out of the report's `error_line`.
 error() {
   echo -e "${RED}Error:${NC} $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo -e "$2" >&2
+  fi
   LAST_ERROR_MSG="$1"
   # Also persist to a file: error() often runs inside a command-substitution
   # subshell (e.g. version=$(get_latest_version)), where the LAST_ERROR_MSG
@@ -146,6 +154,271 @@ report_error() {
   ( curl -fsS -m 3 --connect-timeout 2 -X POST \
       -H 'Content-Type: application/json' \
       --data "$payload" "$ERROR_ENDPOINT" >/dev/null 2>&1 & ) 2>/dev/null || true
+}
+
+# --- Killed-process diagnosis ---------------------------------------------
+# A shell reports a signal-killed child as 128+signal: 137 is SIGKILL, 143 is
+# SIGTERM. In the field 137 is the kernel OOM-killer taking out the bun
+# standalone binary on a small VPS or a memory-capped container. It leaves
+# NOTHING on stdout/stderr, so the exit code is the only evidence there is, and
+# a generic "failed with exit code 137" sent users back to retry it unchanged.
+SELF_INSTALL_KILL_CODES="137 143"
+# Reported instead of `self_install` for these codes. The Sentry fingerprint is
+# (script, step) with the exit code only in event data, so without a distinct
+# step every OOM kill groups into the same issue as a real self-install bug.
+SELF_INSTALL_KILLED_STEP="self_install_killed"
+
+# Indirected so the tests can point the probe at fixtures instead of the real
+# kernel interfaces; SQUIRREL_ERROR_ENDPOINT above is seamed the same way.
+CGROUP_ROOT="${SQUIRREL_CGROUP_ROOT:-/sys/fs/cgroup}"
+PROC_SELF_CGROUP="${SQUIRREL_PROC_SELF_CGROUP:-/proc/self/cgroup}"
+PROC_MEMINFO="${SQUIRREL_PROC_MEMINFO:-/proc/meminfo}"
+# Above this, a "limit" is a not-configured sentinel rather than a real cap:
+# cgroup v1 parks an uncapped controller at PAGE_COUNTER_MAX (~8 EiB).
+CGROUP_LIMIT_SANITY_MAX=1099511627776 # 1TiB
+
+is_uint() {
+  case "${1:-}" in
+    "" | *[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# True when digit-string $1 exceeds digit-string $2, compared WITHOUT bash
+# arithmetic: cgroup limits routinely exceed a signed 64-bit integer (v1 writes
+# UINT64_MAX for "unlimited" on many kernels), and `[ "$v" -gt ... ]` wraps on
+# those, so an unlimited controller would read as a real 16-exabyte cap. Equal
+# length digit strings compare correctly lexically.
+uint_gt() {
+  # Digits collate out of order in a handful of locales, and this decides
+  # whether a cap is real, so pin the comparison.
+  local LC_ALL=C
+  local a="${1#"${1%%[!0]*}"}" b="${2#"${2%%[!0]*}"}"
+  a="${a:-0}"
+  b="${b:-0}"
+  if [ "${#a}" -ne "${#b}" ]; then
+    [ "${#a}" -gt "${#b}" ]
+    return
+  fi
+  [[ "$a" > "$b" ]]
+}
+
+# This process's path within a cgroup hierarchy, selected by an awk program
+# over /proc/self/cgroup. Empty when the hierarchy isn't in use.
+cgroup_rel_path() {
+  local program="$1"
+  if [ -r "$PROC_SELF_CGROUP" ]; then
+    awk -F: "$program" "$PROC_SELF_CGROUP" 2>/dev/null || true
+  fi
+}
+
+# The kernel only ever writes an absolute, traversal-free path here, but this
+# string is about to be concatenated into a filesystem read and fed to a loop
+# that shortens it, so anything else is refused rather than followed.
+is_safe_cgroup_rel() {
+  case "${1:-}" in
+    "") return 0 ;;
+    *//* | */../* | */.. | */./* | */.) return 1 ;;
+    /*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Headroom under one cgroup memory cap, in MiB.
+#   prints a number, returns 0 -> a real cap, and this is what's left under it
+#   prints nothing, returns 0 -> no cap here; the caller may look elsewhere
+#   returns 1                 -> a cap exists but can't be read; the caller must
+#                                stay SILENT rather than quote the host's memory
+cgroup_headroom_mib() {
+  local limit_file="$1" usage_file="$2" limit usage
+  if [ ! -f "$limit_file" ]; then
+    return 0
+  fi
+  limit=$(cat "$limit_file" 2>/dev/null || true)
+  if ! is_uint "$limit" || uint_gt "$limit" "$CGROUP_LIMIT_SANITY_MAX"; then
+    # A literal "max" (v2) or a sentinel (v1) is a genuine "uncapped"; anything
+    # else here is a value we failed to understand, which is not the same thing.
+    if [ "$limit" = "max" ] || is_uint "$limit"; then
+      return 0
+    fi
+    return 1
+  fi
+  usage=$(cat "$usage_file" 2>/dev/null || true)
+  if ! is_uint "$usage"; then
+    return 1
+  fi
+  # Clamp rather than underflow: usage sits at or above the limit at the moment
+  # of an OOM kill, and "0" is the true answer there. Compared without
+  # arithmetic for the same overflow reason as the limit above; past this point
+  # both values are under the sanity bound, so the subtraction is safe.
+  if ! uint_gt "$limit" "$usage"; then
+    printf '0'
+  else
+    printf '%s' "$(((limit - usage) / 1048576))"
+  fi
+}
+
+# Walks from this process's own cgroup up to the mount root: a limit on an
+# ancestor (a systemd slice's MemoryMax, typically) binds exactly as hard as one
+# on the leaf, and the leaf is very often uncapped underneath it. The tightest
+# headroom wins, and a cap anywhere in the chain that we cannot read makes the
+# whole answer unknown rather than optimistic.
+cgroup_tree_headroom_mib() {
+  local base="$1" limit_name="$2" usage_name="$3" rel="$4"
+  local best="" headroom dir previous
+  while :; do
+    dir="${base}${rel}"
+    if headroom=$(cgroup_headroom_mib "$dir/$limit_name" "$dir/$usage_name"); then
+      if [ -n "$headroom" ] && { [ -z "$best" ] || [ "$headroom" -lt "$best" ]; }; then
+        best="$headroom"
+      fi
+    else
+      return 1
+    fi
+    if [ -z "$rel" ]; then
+      break
+    fi
+    # is_safe_cgroup_rel guarantees this shortens, but a loop that walks a
+    # string from a file gets an explicit termination guard regardless: hanging
+    # the installer would be a worse bug than the one being fixed here.
+    previous="$rel"
+    rel="${rel%/*}"
+    if [ "$rel" = "$previous" ]; then
+      break
+    fi
+  done
+  printf '%s' "$best"
+}
+
+# Memory this process could still get, in MiB, or empty when we can't say --
+# every caller must handle empty. cgroups are consulted FIRST, and a cap we can
+# see but not read suppresses the answer entirely, because /proc/meminfo
+# describes the HOST inside a container: it would cheerfully report gigabytes
+# free moments after the kernel killed us for passing a 256MB cap.
+available_memory_mib() {
+  local rel headroom kib
+
+  # cgroup v2: a single "0::<path>" line, relative to the v2 mount.
+  rel=$(cgroup_rel_path '$1 == "0" { print $3; exit }')
+  if [ -n "$rel" ] && is_safe_cgroup_rel "$rel"; then
+    if headroom=$(cgroup_tree_headroom_mib \
+      "$CGROUP_ROOT" memory.max memory.current "${rel%/}"); then
+      if [ -n "$headroom" ]; then
+        printf '%s' "$headroom"
+        return 0
+      fi
+    else
+      return 0
+    fi
+  fi
+
+  # cgroup v1: "<n>:memory:<path>", under the memory controller's own mount.
+  rel=$(cgroup_rel_path '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }')
+  if [ -n "$rel" ] && is_safe_cgroup_rel "$rel"; then
+    if headroom=$(cgroup_tree_headroom_mib \
+      "$CGROUP_ROOT/memory" memory.limit_in_bytes memory.usage_in_bytes "${rel%/}"); then
+      if [ -n "$headroom" ]; then
+        printf '%s' "$headroom"
+        return 0
+      fi
+    else
+      return 0
+    fi
+  fi
+
+  # Demonstrably uncapped, so the host figure is the honest one. MemAvailable,
+  # not MemFree: MemFree ignores reclaimable page cache and reads far too low.
+  if [ -r "$PROC_MEMINFO" ]; then
+    kib=$(awk '/^MemAvailable:/ { print $2; exit }' "$PROC_MEMINFO" 2>/dev/null || true)
+    if is_uint "$kib"; then
+      printf '%s' "$((kib / 1024))"
+    fi
+  fi
+  return 0
+}
+
+# The step name reported for a self-install exit code: signal deaths get their
+# own bucket, everything else keeps reporting as `self_install` (#1654).
+self_install_step_for_code() {
+  local code="$1" kill_code
+  for kill_code in $SELF_INSTALL_KILL_CODES; do
+    if [ "$code" = "$kill_code" ]; then
+      printf '%s' "$SELF_INSTALL_KILLED_STEP"
+      return 0
+    fi
+  done
+  printf 'self_install'
+}
+
+# Names the signal behind a 128+n exit code, for the error line.
+signal_name_for_code() {
+  case "${1:-}" in
+    137) printf 'SIGKILL' ;;
+    143) printf 'SIGTERM' ;;
+    *) printf 'signal %s' "$((${1:-128} - 128))" ;;
+  esac
+}
+
+# The headline for a signal death. Only SIGKILL gets to assert memory: SIGTERM
+# arrives from `timeout` wrappers and cancelled CI jobs too, and this whole fix
+# exists because a confidently wrong diagnosis wastes the user's time.
+self_install_kill_headline() {
+  local code="$1" signal
+  signal=$(signal_name_for_code "$code")
+  if [ "$code" = 137 ]; then
+    printf 'Self install was killed by the system (exit %s, %s), most likely out of memory' \
+      "$code" "$signal"
+  else
+    printf 'Self install was stopped by a signal before it finished (exit %s, %s)' \
+      "$code" "$signal"
+  fi
+}
+
+# Remediation block for a signal-killed self install. Printed as error()'s
+# `detail`, so it never crowds the reported error_line. Only SIGKILL gets the
+# out-of-memory diagnosis and the swap recipe: SIGTERM arrives from `timeout`
+# wrappers, supervisors and cancelled CI jobs at least as often, and telling
+# those users to add swap would send them off fixing the wrong machine.
+self_install_kill_guidance() {
+  local code="$1" mib="" cause=""
+  # Contained: this only ever runs on an already-failing path, so a probe that
+  # trips must cost the user a memory figure, never the guidance itself.
+  mib=$( (available_memory_mib) 2>/dev/null || true)
+
+  if [ "$code" = 137 ]; then
+    cause="  The download itself was fine: the binary passed its checksum, then the
+  system killed it partway through installing. On a small VPS or a
+  memory-capped container that is almost always the out-of-memory killer."
+    if [ -n "$mib" ]; then
+      cause="${cause}
+  Memory available right now: ${mib} MB"
+    fi
+    printf '%s' "${cause}
+
+  Give the machine more memory, then re-run this installer:
+    Add 1GB of swap (usually the quickest fix on a VPS):
+      sudo fallocate -l 1G /swapfile && sudo chmod 600 /swapfile
+      sudo mkswap /swapfile && sudo swapon /swapfile
+    Or resize the machine, or raise the container memory limit, to 1GB or more.
+
+  If you cannot add memory, download the binary directly and put it on your
+  PATH by hand:
+    https://github.com/${REPO}/releases"
+    return 0
+  fi
+
+  cause="  The download itself was fine: the binary passed its checksum, then
+  something outside the installer stopped it partway through. Usually that is a
+  timeout wrapper, a process supervisor, a cancelled job, or a memory limit."
+  if [ -n "$mib" ]; then
+    cause="${cause}
+  Memory available right now: ${mib} MB"
+  fi
+  printf '%s' "${cause}
+
+  Re-run the installer without a timeout or job limit around it. If it keeps
+  happening, download the binary directly and put it on your PATH by hand:
+    https://github.com/${REPO}/releases"
 }
 
 # Single EXIT trap: cleans the temp dir and reports genuine failures. Replaces
@@ -552,6 +825,13 @@ download_and_install() {
     # is where the failure is; report_error scrubs and clamps what we pass.
     LAST_ERROR_OUTPUT=$(tail -n 40 "$self_install_log" 2>/dev/null || true)
     LAST_ERROR_CODE="$rc"
+    # A signal death is not a self-install bug: the binary never got to fail on
+    # its own terms. Move it to its own step so it reports, and fingerprints,
+    # apart from real failures, and say what to actually do about it (#1654).
+    CURRENT_STEP=$(self_install_step_for_code "$rc")
+    if [ "$CURRENT_STEP" = "$SELF_INSTALL_KILLED_STEP" ]; then
+      error "$(self_install_kill_headline "$rc")" "$(self_install_kill_guidance "$rc")"
+    fi
     error "Self install failed with exit code $rc"
   fi
 }

--- a/scripts/install-contract.test.ts
+++ b/scripts/install-contract.test.ts
@@ -62,6 +62,377 @@ describe("self install failure reporting", () => {
   });
 });
 
+// A self install killed by the kernel (137 = SIGKILL, in the field the OOM
+// killer on a small VPS) produces no output at all, so it used to surface as a
+// bare "failed with exit code 137" and report under the same step as a genuine
+// self-install bug (#1654).
+describe("self install killed by a signal", () => {
+  // Everything under test lives in the sourceable preamble, above the EXIT trap.
+  const sourcePreamble = async (script: string, env: Record<string, string> = {}) => {
+    const preambleEnd = shellInstaller.indexOf("trap report_on_exit EXIT");
+    expect(preambleEnd).toBeGreaterThan(0);
+    const preamble = join(tmpdir(), `install-kill-${process.pid}-${Math.random()}.sh`);
+    await Bun.write(preamble, shellInstaller.slice(0, preambleEnd));
+    try {
+      const proc = Bun.spawn(["bash", "-c", `source "$1"; ${script}`, "--", preamble], {
+        env: { ...process.env, NO_TELEMETRY: "1", ...env } as Record<string, string>,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      return { stdout, stderr, code: await proc.exited };
+    } finally {
+      rmSync(preamble, { force: true });
+    }
+  };
+
+  test("137 and 143 report under their own step; every other code does not", async () => {
+    const { stdout } = await sourcePreamble(
+      'for c in 137 143 0 1 2 126 127 255; do printf "%s=%s\\n" "$c" "$(self_install_step_for_code "$c")"; done',
+    );
+    expect(stdout.trim().split("\n")).toEqual([
+      "137=self_install_killed",
+      "143=self_install_killed",
+      // Criterion: non-signal failures keep reporting exactly as before.
+      "0=self_install",
+      "1=self_install",
+      "2=self_install",
+      "126=self_install",
+      "127=self_install",
+      "255=self_install",
+    ]);
+  });
+
+  test("the killed step is what report_error actually POSTs", async () => {
+    const preambleEnd = shellInstaller.indexOf("trap report_on_exit EXIT");
+    const preamble = join(tmpdir(), `install-kill-report-${process.pid}.sh`);
+    await Bun.write(preamble, shellInstaller.slice(0, preambleEnd));
+
+    const received: Record<string, unknown>[] = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        received.push((await request.json()) as Record<string, unknown>);
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    try {
+      const proc = Bun.spawn(
+        [
+          "bash",
+          "-c",
+          'source "$1"; report_error "$(self_install_step_for_code 137)" 137 "killed" ""; sleep 1',
+          "--",
+          preamble,
+        ],
+        {
+          env: {
+            ...process.env,
+            NO_TELEMETRY: undefined,
+            SQUIRREL_ERROR_ENDPOINT: `http://127.0.0.1:${server.port}/error`,
+          } as Record<string, string>,
+        },
+      );
+      await proc.exited;
+      for (let i = 0; i < 100 && received.length === 0; i++) await Bun.sleep(50);
+
+      expect(received).toHaveLength(1);
+      // Distinct from "self_install", which is what makes Sentry fingerprint
+      // OOM kills apart from real self-install failures.
+      expect(received[0].step).toBe("self_install_killed");
+      expect(received[0].exit_code).toBe(137);
+    } finally {
+      server.stop(true);
+      rmSync(preamble, { force: true });
+    }
+  }, 15_000);
+
+  test("only SIGKILL claims memory; SIGTERM stays non-committal", async () => {
+    const { stdout } = await sourcePreamble(
+      'self_install_kill_headline 137; printf "\\n"; self_install_kill_headline 143',
+    );
+    const [sigkill, sigterm] = stdout.split("\n");
+    expect(sigkill).toBe(
+      "Self install was killed by the system (exit 137, SIGKILL), most likely out of memory",
+    );
+    // SIGTERM also arrives from timeout wrappers and cancelled CI jobs.
+    expect(sigterm).toBe(
+      "Self install was stopped by a signal before it finished (exit 143, SIGTERM)",
+    );
+    expect(sigterm).not.toContain("memory");
+  });
+
+  test("SIGKILL guidance names the cause and the ways out of it", async () => {
+    const { stdout } = await sourcePreamble("self_install_kill_guidance 137");
+    expect(stdout).toContain("out-of-memory killer");
+    expect(stdout).toContain("mkswap /swapfile");
+    // The direct-download escape hatch for a machine that cannot grow.
+    expect(stdout).toContain("https://github.com/squirrelscan/squirrelscan/releases");
+    // No em-dashes in user-facing copy.
+    expect(stdout).not.toContain("—");
+  });
+
+  test("SIGTERM guidance does not send the user off to add swap", async () => {
+    const { stdout } = await sourcePreamble("self_install_kill_guidance 143");
+    // The headline already declines to blame memory; the detail must agree.
+    expect(stdout).not.toContain("out-of-memory killer");
+    expect(stdout).not.toContain("swapon");
+    expect(stdout).toContain("timeout wrapper");
+    expect(stdout).toContain("https://github.com/squirrelscan/squirrelscan/releases");
+    expect(stdout).not.toContain("—");
+  });
+
+  test("error() prints detail to the user but keeps it out of the report line", async () => {
+    // error() exits, so it runs in a subshell here and the message is read back
+    // from the file it persists to for exactly that reason.
+    const { stderr, stdout } = await sourcePreamble(
+      '( error "short line" "long detail block" ) || true; cat "$ERROR_MSG_FILE"',
+    );
+    expect(stderr).toContain("short line");
+    expect(stderr).toContain("long detail block");
+    // Only the short line rides along in the report.
+    expect(stdout).toBe("short line");
+  });
+
+  // Cap sizes are compared as digit strings because a cgroup limit routinely
+  // exceeds what bash arithmetic can hold.
+  describe("uint_gt", () => {
+    const compare = async (pairs: [string, string][]) => {
+      const script = pairs
+        .map(([a, b]) => `if uint_gt "${a}" "${b}"; then echo true; else echo false; fi`)
+        .join("; ");
+      const { stdout } = await sourcePreamble(script);
+      return stdout.trim().split("\n");
+    };
+
+    test("orders equal-length values, the branch that needs the locale pin", async () => {
+      expect(
+        await compare([
+          ["268435456", "234881024"],
+          ["234881024", "268435456"],
+          ["268435456", "268435456"],
+          ["1099511627777", "1099511627776"],
+        ]),
+      ).toEqual(["true", "false", "false", "true"]);
+    });
+
+    test("orders values too large for bash arithmetic", async () => {
+      expect(
+        await compare([
+          // UINT64_MAX and PAGE_COUNTER_MAX: both wrap a signed compare.
+          ["18446744073709551615", "1099511627776"],
+          ["9223372036854771712", "1099511627776"],
+          ["99999999999999999999999999", "1099511627776"],
+          ["268435456", "1099511627776"],
+        ]),
+      ).toEqual(["true", "true", "true", "false"]);
+    });
+
+    test("normalizes leading zeros instead of comparing them as length", async () => {
+      expect(
+        await compare([
+          ["0000000009", "10"],
+          ["010", "9"],
+          ["000", "0"],
+        ]),
+      ).toEqual(["false", "true", "false"]);
+    });
+  });
+
+  describe("memory probe", () => {
+    // The probe reads the kernel through indirected paths, so the container
+    // cases it exists for are testable against fixtures.
+    const withFixture = async (files: Record<string, string>) => {
+      const root = join(tmpdir(), `install-cg-${process.pid}-${Math.random()}`);
+      for (const [path, body] of Object.entries(files)) {
+        await Bun.write(join(root, path), body);
+      }
+      try {
+        return await sourcePreamble("available_memory_mib", {
+          SQUIRREL_CGROUP_ROOT: join(root, "cgroup"),
+          SQUIRREL_PROC_SELF_CGROUP: join(root, "self-cgroup"),
+          SQUIRREL_PROC_MEMINFO: join(root, "meminfo"),
+        });
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    };
+
+    // 8GB free on the host. Inside a capped container this must never win.
+    const HOST_MEMINFO = "MemTotal: 16000000 kB\nMemAvailable: 8388608 kB\n";
+
+    test("reports headroom under a cgroup v2 cap, not the host's memory", async () => {
+      const { stdout } = await withFixture({
+        "self-cgroup": "0::/\n",
+        "cgroup/memory.max": "268435456\n", // 256MB cap
+        "cgroup/memory.current": "234881024\n", // 224MB used
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("32");
+    });
+
+    test("resolves a nested v2 cgroup rather than the hierarchy root", async () => {
+      const { stdout } = await withFixture({
+        "self-cgroup": "0::/docker/abc123\n",
+        "cgroup/memory.max": "max\n", // the root is uncapped
+        "cgroup/docker/abc123/memory.max": "134217728\n", // 128MB
+        "cgroup/docker/abc123/memory.current": "67108864\n", // 64MB
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("64");
+    });
+
+    test("reports zero, not a negative, when usage is at the cap", async () => {
+      const { stdout } = await withFixture({
+        "self-cgroup": "0::/\n",
+        "cgroup/memory.max": "268435456",
+        "cgroup/memory.current": "300000000", // over the cap, as at an OOM kill
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("0");
+    });
+
+    test("reads a cgroup v1 memory controller", async () => {
+      const { stdout } = await withFixture({
+        "self-cgroup": "9:memory:/docker/abc123\n8:cpu:/docker/abc123\n",
+        "cgroup/memory/docker/abc123/memory.limit_in_bytes": "268435456\n",
+        "cgroup/memory/docker/abc123/memory.usage_in_bytes": "134217728\n",
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("128");
+    });
+
+    test("honours a capped ancestor when the leaf itself is uncapped", async () => {
+      // systemd sets MemoryMax on a slice and leaves the unit below it at
+      // "max"; the ancestor's limit binds just as hard.
+      const { stdout } = await withFixture({
+        "self-cgroup": "0::/system.slice/squirrel.service\n",
+        "cgroup/system.slice/squirrel.service/memory.max": "max\n",
+        "cgroup/system.slice/memory.max": "268435456\n", // 256MB on the slice
+        "cgroup/system.slice/memory.current": "234881024\n", // 224MB used
+        "cgroup/memory.max": "max\n",
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("32");
+    });
+
+    test("takes the tightest cap when several ancestors are capped", async () => {
+      const { stdout } = await withFixture({
+        "self-cgroup": "0::/a/b\n",
+        "cgroup/a/b/memory.max": "1073741824\n", // 1GB, 512MB free
+        "cgroup/a/b/memory.current": "536870912\n",
+        "cgroup/a/memory.max": "268435456\n", // 256MB, 32MB free: tighter
+        "cgroup/a/memory.current": "234881024\n",
+        "cgroup/memory.max": "max\n",
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("32");
+    });
+
+    test("a UINT64_MAX limit reads as uncapped, not an exabyte cap", async () => {
+      // Bash compares signed, so this value wraps: without a string-wise guard
+      // it passes the sanity bound and yields a garbage headroom figure.
+      const { stdout } = await withFixture({
+        "self-cgroup": "9:memory:/\n",
+        "cgroup/memory/memory.limit_in_bytes": "18446744073709551615\n",
+        "cgroup/memory/memory.usage_in_bytes": "134217728\n",
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("8192");
+    });
+
+    test("treats a v1 PAGE_COUNTER_MAX sentinel as uncapped", async () => {
+      const { stdout } = await withFixture({
+        "self-cgroup": "9:memory:/\n",
+        "cgroup/memory/memory.limit_in_bytes": "9223372036854771712\n",
+        "cgroup/memory/memory.usage_in_bytes": "134217728\n",
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("8192"); // the host figure is the honest one here
+    });
+
+    test("stays silent when a cap exists but its usage cannot be read", async () => {
+      const { stdout } = await withFixture({
+        "self-cgroup": "0::/\n",
+        "cgroup/memory.max": "268435456\n",
+        // memory.current missing: quoting the host's 8GB here would be a lie.
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("");
+    });
+
+    test("falls back to the host only when demonstrably uncapped", async () => {
+      const { stdout } = await withFixture({
+        "self-cgroup": "0::/\n",
+        "cgroup/memory.max": "max\n",
+        meminfo: HOST_MEMINFO,
+      });
+      expect(stdout).toBe("8192");
+    });
+
+    test.each([
+      ["a", "relative, and never shortens under ${rel%/*}"],
+      ["a/b", "relative, shortens to a then stalls"],
+      ["/../../etc", "escapes the cgroup root"],
+      ["/a/./b", "un-normalized"],
+      ["//a", "empty component"],
+    ])("refuses the malformed cgroup path %p (%s)", async (rel) => {
+      // The old walk had no termination guard: a path that never shortens hung
+      // the installer on the failure path, which is worse than the bug it is
+      // there to explain. The suite timeout is the real assertion.
+      const { stdout } = await withFixture({
+        "self-cgroup": `0::${rel}\n`,
+        "cgroup/memory.max": "268435456\n",
+        "cgroup/memory.current": "234881024\n",
+        meminfo: HOST_MEMINFO,
+      });
+      // Falls through to the host figure rather than following the path.
+      expect(stdout).toBe("8192");
+    }, 10_000);
+
+    // The cases above are refused by is_safe_cgroup_rel before they reach the
+    // walk, so they would still pass with the loop guard removed. Drive the
+    // walk directly to cover the guard on its own.
+    test.each(["a", "a/b", "", "/", "/a", "/a/b/c"])(
+      "the walk itself terminates on rel %p",
+      async (rel) => {
+        const { stdout, code } = await sourcePreamble(
+          `cgroup_tree_headroom_mib /nonexistent memory.max memory.current "${rel}"`,
+        );
+        expect(code).toBe(0);
+        expect(stdout).toBe("");
+      },
+      10_000,
+    );
+
+    test("emits nothing rather than a guess when no interface is readable", async () => {
+      const { stdout } = await withFixture({ "self-cgroup": "" });
+      expect(stdout).toBe("");
+    });
+
+    test("never emits a non-numeric figure on the real machine", async () => {
+      // Empty when it cannot tell (macOS has no /proc); digits only otherwise.
+      const { stdout } = await sourcePreamble("available_memory_mib");
+      expect(stdout).toMatch(/^\d*$/);
+    });
+  });
+
+  test("the self install branch routes the killed codes through both helpers", () => {
+    // The branch itself sits below the sourceable preamble, so pin the wiring.
+    expect(shellInstaller).toContain('CURRENT_STEP=$(self_install_step_for_code "$rc")');
+    expect(shellInstaller).toContain('if [ "$CURRENT_STEP" = "$SELF_INSTALL_KILLED_STEP" ]; then');
+    expect(shellInstaller).toContain(
+      'error "$(self_install_kill_headline "$rc")" "$(self_install_kill_guidance "$rc")"',
+    );
+    // Unchanged fallback for every non-signal failure.
+    expect(shellInstaller).toContain('error "Self install failed with exit code $rc"');
+  });
+});
+
 // Behavioural, not textual: source the shell installer's reporting preamble and
 // watch what report_error actually POSTs.
 describe("install.sh report_error payload", () => {


### PR DESCRIPTION
## What

`curl | sh` installs on small VPSes have been dying at the `self_install` step with a bare `Self install failed with exit code 137`. Exit 137 is 128+9, i.e. the process was SIGKILLed, and in practice that is the kernel out-of-memory killer taking out the `squirrel` binary partway through installing.

SIGKILL leaves nothing on stdout or stderr, so the captured `error_output` from #95/#132 comes back empty and the exit code is the only evidence there is. The message named a number and offered nothing to do about it, so the obvious next move was to retry, which failed identically. One reporter retried across four separate days.

## Changes

**Exit 137 now explains itself and offers a way out** — add swap (with the actual commands), grow the machine or raise the container memory limit, or download the binary directly and place it by hand.

**Exit 143 gets its own wording.** SIGTERM comes from `timeout` wrappers, process supervisors and cancelled CI jobs at least as often as from memory pressure, so it does not claim an OOM or tell anyone to add swap. Only SIGKILL asserts memory.

**A memory figure is included when it can be established honestly.** This turned out to be the fiddly part: `/proc/meminfo` describes the *host* inside a container, so it would happily report gigabytes free moments after the kernel killed the process for passing a 256MB cap. The probe therefore reads cgroups first, resolved through `/proc/self/cgroup` so a nested container cgroup is found rather than just the hierarchy root, walks up to the mount root because a limit on a parent slice binds just as hard as one on the leaf, supports v1 and v2, and prints **nothing at all** when it can see a cap it cannot read. Comparisons use digit strings rather than bash arithmetic, since an "unlimited" v1 controller reports `UINT64_MAX` and wraps a signed compare into looking like a real 16-exabyte cap. The whole probe is contained, so a failure inside it costs the memory figure and never the guidance.

**Both codes report under a distinct step, `self_install_killed`.** The error report's Sentry fingerprint is `(script, step)` with the exit code only in event data, so every OOM kill was grouping into the same issue as a genuine self-install bug.

Non-signal exit codes keep their existing step, message and behaviour, untouched.

## Testing

`scripts/install-contract.test.ts` gains 26 tests (40 in the file, all passing). They source the installer's preamble and run the real functions rather than asserting on its text where behaviour is testable:

- exit-code classification across `137 143 0 1 2 126 127 255`
- the killed step is what `report_error` actually POSTs, verified against a local HTTP server
- 137 vs 143 wording, and that the SIGTERM detail agrees with its own headline
- the memory probe against cgroup fixtures: a v2 cap beating the host figure, a nested cgroup, a capped ancestor under an uncapped leaf, the tightest of several caps, usage at the cap clamping to `0`, v1, the `PAGE_COUNTER_MAX` and `UINT64_MAX` sentinels reading as uncapped, and silence when a cap is unreadable
- malformed cgroup paths, plus direct coverage that the walk terminates on every path shape (two of them previously looped forever)
- `uint_gt` on equal-length values, values too large for bash arithmetic, and leading zeros

Also: `bash -n`, ShellCheck clean, and the full root suite (4375 pass, 0 fail). A real SIGKILL through the `tee` pipeline was confirmed to surface as `PIPESTATUS[0] = 137`.

## Note

`install.sh` is served from R2 and release-gated, so this reaches users at the next release, not at merge.