### PR TITLE
fix(audit-engine): label first-run findings on never-rendered pages "unrendered", not "carried"

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -273,7 +273,7 @@
         "filename": "packages/report/src/output/html.tsx",
         "hashed_secret": "a9fe535612f1aff3358c2e17f1e0e50fc60a66dc",
         "is_verified": false,
-        "line_number": 1103
+        "line_number": 1109
       }
     ],
     "packages/report/tests/screenshot-section.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-27T22:28:48Z"
+  "generated_at": "2026-08-31T23:41:35Z"
 }

--- a/apps/cli/src/audit/smart-audits.ts
+++ b/apps/cli/src/audit/smart-audits.ts
@@ -47,9 +47,20 @@ export interface SmartAuditResult {
   coverage: {
     auditedPages: number;
     knownPages: number;
+    /** Findings a PREVIOUS audit observed. 0 on a first run (#1652). */
     carriedFindings: number;
+    /**
+     * Findings on pages no audit has ever rendered (#1652). OMITTED when zero so
+     * a site without any is byte-identical to a pre-#1652 report — this object is
+     * copied straight into `report.coverage`.
+     */
+    unrenderedFindings?: number;
   };
-  /** carriedKey → lastSeenAt (epoch ms) for tagging report checks as carried. */
+  /**
+   * carriedKey → lastSeenAt (epoch ms) for tagging report checks as carried.
+   * (#1652) Never-rendered findings are excluded — {@link tagCarriedCheck}
+   * preserves the `provenance: "unrendered"` the union scorer already stamped.
+   */
   carriedLastSeen: Map<string, number>;
 }
 
@@ -148,9 +159,13 @@ export function runSmartAudits(
       if (!crawledUrls.has(url)) carriedPageUrls.add(url);
     }
 
-    // Carried findings = active (open) findings on those carried pages.
+    // Carried findings = active (open) findings on those carried pages, SPLIT by
+    // whether any audit has ever rendered the page (#1652): a never-rendered
+    // page's finding was not inherited from a previous run, so it must not be
+    // counted as carried nor given a last-seen date implying an earlier look.
     const carriedFindings: CarriedFinding[] = [];
     const carriedLastSeen = new Map<string, number>();
+    let unrenderedCount = 0;
     for (const f of merged.findings) {
       if (f.provenance !== "carried") continue;
       carriedFindings.push({
@@ -162,7 +177,12 @@ export function runSmartAudits(
         value: f.value,
         expected: f.expected,
         payload: f.payload,
+        neverRendered: f.neverRendered,
       });
+      if (f.neverRendered) {
+        unrenderedCount++;
+        continue;
+      }
       carriedLastSeen.set(
         carriedKey(f.normalizedUrl, f.ruleId, f.checkName),
         f.lastSeenAt
@@ -214,14 +234,22 @@ export function runSmartAudits(
       coverage: {
         auditedPages: crawledUrls.size,
         knownPages: merged.activePageUrls.size,
-        carriedFindings: carriedFindings.length,
+        carriedFindings: carriedFindings.length - unrenderedCount,
+        ...(unrenderedCount > 0 ? { unrenderedFindings: unrenderedCount } : {}),
       },
       carriedLastSeen,
     };
   });
 }
 
-/** Tag a report check as carried (with lastSeenAt) if it matches a carried key. */
+/**
+ * Tag a report check as carried (with lastSeenAt) if it matches a carried key.
+ *
+ * (#1652) The `?? "fresh"` fallback is load-bearing, not defensive: the union
+ * scorer already stamped `provenance: "unrendered"` on findings whose page no
+ * audit has rendered, and those keys are absent from `carriedLastSeen`, so
+ * preserving an existing provenance is what keeps them out of the carried label.
+ */
 export function tagCarriedCheck(
   pageUrl: string,
   ruleId: string,

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -35,7 +35,12 @@ export interface SmartMergeOverride {
   coverage: {
     auditedPages: number;
     knownPages: number;
+    /** Findings a PREVIOUS audit observed. 0 on a first run (#1652). */
     carriedFindings: number;
+    /** Findings on pages no audit has ever rendered (#1652). Optional here (a
+     *  consumer contract) so an override built from an older coverage shape
+     *  still type-checks; `runSmartAudits` always supplies it. */
+    unrenderedFindings?: number;
   };
   carriedLastSeen: Map<string, number>;
 }

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -226,7 +226,9 @@ export interface CheckResult {
   // `carried` = re-injected from the store for a page not re-crawled this run.
   // Absent (or `fresh`) = evaluated this run. `lastSeenAt` = epoch ms of the
   // last run that observed it. Only set when `smart_audits` is enabled.
-  provenance?: "fresh" | "carried";
+  // `unrendered` (#1652) = no audit of this site has ever rendered the page, so
+  // nothing earlier observed the finding and it carries no `lastSeenAt`.
+  provenance?: "fresh" | "carried" | "unrendered";
   lastSeenAt?: number;
 }
 
@@ -481,7 +483,10 @@ export interface AuditReport {
   coverage?: {
     auditedPages: number;
     knownPages: number;
+    /** Findings a PREVIOUS audit observed. 0 on a first run (#1652). */
     carriedFindings: number;
+    /** Findings on pages no audit has ever rendered (#1652). */
+    unrenderedFindings?: number;
   };
   /**
    * Scan scope disclosure (#1180): where the audit ran and how much of the site

--- a/apps/cli/tests/audit/smart-audits.test.ts
+++ b/apps/cli/tests/audit/smart-audits.test.ts
@@ -74,6 +74,8 @@ describe("runSmartAudits end-to-end (no inflation)", () => {
     const fullScore = calculateHealthScore({
       results: full.unionRuleResults,
     }).overall;
+    // (#1652) `unrenderedFindings` is OMITTED, not 0 — a site with none must
+    // serialize byte-identically to a pre-#1652 report.
     expect(full.coverage).toEqual({
       auditedPages: 100,
       knownPages: 100,

--- a/docs/configuration/index.mdx
+++ b/docs/configuration/index.mdx
@@ -163,12 +163,17 @@ SQLite store keyed by site). On a partial re-audit:
 - **re-crawled pages** get fresh results that supersede their prior state,
 - **un-crawled pages** carry their last-known issues forward (tagged `carried`,
   with a "last seen" time) indefinitely, until you re-crawl them,
+- **pages no audit has ever rendered** (known from a sitemap or a rule's page
+  list, but never inside a run's page budget) are tagged `unrendered` instead:
+  nothing has observed them yet, so they have no "last seen" time and they are
+  counted separately from carried findings. On a first audit every such finding
+  is `unrendered` and the carried count is 0.
 - **removed pages** (404/410) have their issues closed.
 
 The health score is then computed over the **union of all known non-removed
 pages**, so re-auditing a subset never inflates the score by hiding the issues on
 the pages you skipped. Reports show a coverage line ("audited N of M known
-pages") and tag carried findings.
+pages") and tag carried and unrendered findings.
 
 ```toml
 smart_audits = true

--- a/packages/audit-engine/src/merge-core.ts
+++ b/packages/audit-engine/src/merge-core.ts
@@ -50,6 +50,19 @@ export interface MergedFinding {
   lastSeenCrawlId: string;
   lastSeenAt: number;
   provenance: FindingProvenance;
+  /**
+   * (#1652) True when this finding is carried but its page has NEVER been
+   * rendered by any audit of the site — not by an earlier run (it is absent from
+   * `priorPages`) and not by this one (absent from `crawledUrls`). Such findings
+   * are seeded from pages the crawl only KNOWS about (sitemap entries, the page
+   * lists on folded aggregates) and were never inherited from a prior audit, so
+   * surfaces must label them "unrendered", not "carried" — on a first run there
+   * is no previous audit for "carried" to refer to.
+   *
+   * DERIVED ONLY: never persisted (the store's `provenance` column is
+   * constrained to fresh|carried), always false for a fresh finding.
+   */
+  neverRendered: boolean;
   state: "open" | "resolved" | "stale";
 }
 
@@ -270,6 +283,31 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
   const activeFindings: MergedFinding[] = [];
   const handledKeys = new Set<string>();
 
+  // (#1652) The site's render history: `site_pages` rows are written only for
+  // pages a run actually crawled (step 3 below), in any lifecycle state — a
+  // "removed" page was still rendered once. A carried finding whose page is in
+  // neither this set nor rendered this run was never observed by a previous
+  // audit: it is "unrendered", not carry-over. Empty on a first run, which is
+  // exactly why a first run must report zero carried findings.
+  //
+  // `renderedThisRun` is passed in rather than re-derived from `crawledUrls`:
+  // the #1185 signal can mark a page crawled this run that never reached the
+  // payload-derived crawled set, and such a page WAS rendered.
+  //
+  // KNOWN BOUNDS — both err toward "unrendered", never toward inventing a prior
+  // audit, so the worst case is a missing "last seen" date rather than a false
+  // claim about an audit that did not happen:
+  //  - a page rendered ONLY per the #1185 signal gets no `site_pages` row (that
+  //    is deliberate — adding one would grow `carriedPageUrls` and with it the
+  //    synthetic-pass denominator, moving scores), so a later run that skips it
+  //    reads it as unrendered;
+  //  - a removed page whose `site_pages` row was pruned by retention and that is
+  //    later rediscovered loses its history the same way.
+  const everRenderedUrls = new Set<string>();
+  for (const p of priorPages) everRenderedUrls.add(p.normalizedUrl);
+  const neverRendered = (normalizedUrl: string, renderedThisRun: boolean): boolean =>
+    !renderedThisRun && !everRenderedUrls.has(normalizedUrl);
+
   // 1) FRESH — upsert findings for crawled URLs.
   for (const [key, f] of freshByKey) {
     const prior = priorByKey.get(key);
@@ -295,7 +333,8 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
       state: "open",
     };
     persisted.push(record);
-    activeFindings.push(toMerged(record));
+    // A fresh finding was evaluated on a page rendered this run, by definition.
+    activeFindings.push(toMerged(record, false));
     handledKeys.add(key);
   }
 
@@ -316,6 +355,13 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
     // sample) so it's absent from the payload-derived `crawledUrls`.
     const signalCrawled =
       !wasCrawled && (resolution?.crawledUrls.has(prior.normalizedUrl) ?? false);
+    // (#1652) Same value for every carry branch below — computed once here so a
+    // new branch can't silently forget it and default a never-rendered page back
+    // to "carried".
+    const unrendered = neverRendered(
+      prior.normalizedUrl,
+      wasCrawled || signalCrawled
+    );
 
     if (wasRemoved) {
       // Page gone — stale this finding. NOTE: site_pages state + the bulk
@@ -350,7 +396,7 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
       if (resolution?.notEvaluatedByCheck.get(checkKey)?.has(priorHash)) {
         const carried: PageFindingRecord = { ...prior, provenance: "carried" };
         persisted.push(carried);
-        activeFindings.push(toMerged(carried));
+        activeFindings.push(toMerged(carried, unrendered));
         handledKeys.add(key);
         continue;
       }
@@ -371,7 +417,7 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
             lastSeenAt: now,
           };
           persisted.push(carried);
-          activeFindings.push(toMerged(carried));
+          activeFindings.push(toMerged(carried, unrendered));
           handledKeys.add(key);
           continue;
         }
@@ -392,7 +438,7 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
         // the sampled payload — exactly today's un-crawled behavior: carry.
         const carried: PageFindingRecord = { ...prior, provenance: "carried" };
         persisted.push(carried);
-        activeFindings.push(toMerged(carried));
+        activeFindings.push(toMerged(carried, unrendered));
         handledKeys.add(key);
         continue;
       }
@@ -406,7 +452,7 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
       if (sample && !sample.has(prior.normalizedUrl)) {
         const carried: PageFindingRecord = { ...prior, provenance: "carried" };
         persisted.push(carried);
-        activeFindings.push(toMerged(carried));
+        activeFindings.push(toMerged(carried, unrendered));
         handledKeys.add(key);
         continue;
       }
@@ -425,7 +471,7 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
     // Un-crawled, still-active page: carry forward unchanged (no TTL).
     const carried: PageFindingRecord = { ...prior, provenance: "carried" };
     persisted.push(carried);
-    activeFindings.push(toMerged(carried));
+    activeFindings.push(toMerged(carried, unrendered));
     handledKeys.add(key);
   }
 
@@ -467,8 +513,12 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
   return { findings: activeFindings, persisted, sitePages, activePageUrls };
 }
 
-function toMerged(r: PageFindingRecord): MergedFinding {
+function toMerged(
+  r: PageFindingRecord,
+  neverRendered: boolean
+): MergedFinding {
   return {
+    neverRendered,
     siteKey: r.siteKey,
     normalizedUrl: r.normalizedUrl,
     ruleId: r.ruleId,

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -148,8 +148,26 @@ export interface CloudSmartAuditsResult {
   /** UNION rule results (fresh + carried) for authoritative scoring + report. */
   unionRuleResults: Map<string, RuleRunResult>;
   /** Coverage line data for surfacing. */
-  coverage: { auditedPages: number; knownPages: number; carriedFindings: number };
-  /** `${normalizedUrl}|${ruleId}|${checkName}` → lastSeenAt for tagging report checks. */
+  coverage: {
+    auditedPages: number;
+    knownPages: number;
+    /** Findings a PREVIOUS audit observed. 0 on a first run (#1652). */
+    carriedFindings: number;
+    /**
+     * Findings on pages no audit has ever rendered (#1652). OMITTED when zero so
+     * a site without any is byte-identical to a pre-#1652 report — the published
+     * report JSON feeds the publish idempotency hash and the golden fixtures.
+     */
+    unrenderedFindings?: number;
+  };
+  /**
+   * `${normalizedUrl}|${ruleId}|${checkName}` → lastSeenAt for tagging report
+   * checks as carried. (#1652) Never-rendered findings are DELIBERATELY absent:
+   * they are stamped `provenance: "unrendered"` by the union scorer, and the
+   * caller's tagging pass preserves an already-set provenance, so keeping them
+   * out here is what stops them being relabelled "carried" with a bogus
+   * last-seen date.
+   */
   carriedLastSeen: Map<string, number>;
   persistedFindings: number;
   removedPages: number;
@@ -353,9 +371,13 @@ export async function runCloudSmartAudits(
     if (!crawledUrls.has(url)) carriedPageUrls.add(url);
   }
 
-  // Carried findings = active (open) findings on those carried pages.
+  // Carried findings = active (open) findings on those carried pages, SPLIT by
+  // whether any audit has ever rendered the page (#1652): a never-rendered page's
+  // finding was not inherited from a previous run, so it must not be counted as
+  // carried nor given a last-seen date implying an earlier observation.
   const carriedFindings: CarriedFinding[] = [];
   const carriedLastSeen = new Map<string, number>();
+  let unrenderedCount = 0;
   for (const f of merged.findings) {
     if (f.provenance !== "carried") continue;
     carriedFindings.push({
@@ -367,7 +389,12 @@ export async function runCloudSmartAudits(
       value: f.value,
       expected: f.expected,
       payload: f.payload,
+      neverRendered: f.neverRendered,
     });
+    if (f.neverRendered) {
+      unrenderedCount++;
+      continue;
+    }
     carriedLastSeen.set(carriedKey(f.normalizedUrl, f.ruleId, f.checkName), f.lastSeenAt);
   }
 
@@ -407,7 +434,8 @@ export async function runCloudSmartAudits(
     coverage: {
       auditedPages: crawledUrls.size,
       knownPages: merged.activePageUrls.size,
-      carriedFindings: carriedFindings.length,
+      carriedFindings: carriedFindings.length - unrenderedCount,
+      ...(unrenderedCount > 0 ? { unrenderedFindings: unrenderedCount } : {}),
     },
     carriedLastSeen,
     persistedFindings: merged.persisted.length,

--- a/packages/audit-engine/src/scoring.ts
+++ b/packages/audit-engine/src/scoring.ts
@@ -70,6 +70,14 @@ export interface CarriedFinding {
    * the SAME per-item detail as a fresh one.
    */
   payload?: string | null;
+  /**
+   * (#1652) The finding's page has never been rendered by ANY audit of the site,
+   * so no earlier run observed it. The replayed union check is stamped
+   * `provenance: "unrendered"` here, which keeps the downstream carried-tagging
+   * pass (CLI `tagCarriedCheck` / the hosted `applyUnionToReport`) from
+   * relabelling it "carried" — both preserve an already-set provenance.
+   */
+  neverRendered?: boolean;
 }
 
 /** Minimal rule meta the union scorer needs. */
@@ -184,6 +192,12 @@ export function buildScoringResultsFromMerged(
             ...(payload.items ? { items: payload.items } : {}),
             ...(payload.details ? { details: payload.details } : {}),
             ...(payload.pages ? { pages: payload.pages } : {}),
+            // (#1652) Stamp the never-rendered case HERE, at the one place the
+            // union check is created, so every consumer of the union (report
+            // rendering, the hosted rescore, issue-sync) inherits it without a
+            // second lookup — and deliberately WITHOUT `lastSeenAt`: nothing has
+            // ever observed this finding, so there is no date to show.
+            ...(f.neverRendered ? { provenance: "unrendered" as const } : {}),
           });
         }
       }

--- a/packages/audit-engine/tests/cloud-merge.test.ts
+++ b/packages/audit-engine/tests/cloud-merge.test.ts
@@ -118,6 +118,8 @@ describe("runCloudSmartAudits — cloud parity", () => {
       ruleResults: ruleResultsFor([P2], [P1, P3]),
       pageStatuses: [P1, P2, P3].map((url) => ({ url, status: 200 })),
     });
+    // (#1652) `unrenderedFindings` is OMITTED, not 0 — a site with none must
+    // serialize byte-identically to a pre-#1652 report.
     expect(r.coverage).toEqual({ auditedPages: 3, knownPages: 3, carriedFindings: 0 });
     expect((await store.getFindings("web_1", ["open"])).length).toBe(1);
   });
@@ -622,5 +624,151 @@ describe("runCloudSmartAudits — unsampled resolution signal (#1185)", () => {
     // Never evaluated this run — stamps must stay at the seeding crawl.
     expect(unevaluated.lastSeenCrawlId).toBe("audit_1");
     expect(unevaluated.lastSeenAt).not.toBe(now);
+  });
+});
+
+// #1652: the FIRST audit of a site reported thousands of findings with
+// provenance "carried" and a non-zero coverage.carriedFindings, telling the
+// reader a previous audit had seen them when no previous audit existed. The
+// findings were on pages the crawl only KNEW about (sitemap entries / the page
+// lists on folded aggregates): the chunked publish streams a finding row for
+// every such page, and finalize's merge then reads its own ingest back as
+// "prior" state and carries anything sitting on a page outside this run's
+// crawled set.
+describe("first-run findings on never-rendered pages (#1652)", () => {
+  const DEEP = "https://x.test/deep-sitemap-only";
+
+  /** One row exactly as the chunked-publish ingest writes it, pre-finalize. */
+  function ingestedFinding(url: string, crawlId: string): PageFindingRecord {
+    return {
+      siteKey: "web_1",
+      normalizedUrl: normalizeUrl(url),
+      ruleId: "meta-description",
+      checkName: "has-meta-description",
+      locator: "",
+      status: "fail",
+      severity: "warning",
+      message: "Missing meta description",
+      value: null,
+      expected: null,
+      payload: null,
+      fingerprint: "fp",
+      firstSeenAt: 1_000,
+      lastSeenCrawlId: crawlId,
+      lastSeenAt: 1_000,
+      provenance: "fresh",
+      state: "open",
+    };
+  }
+
+  test("first run: never-rendered findings are unrendered, and carriedFindings is 0", async () => {
+    const store = new MemStore();
+    // This run's own ingest — no site_pages row for DEEP, because no audit has
+    // ever crawled it. This is the whole of the site's prior state on a first run.
+    await store.upsertFindings([ingestedFinding(DEEP, "audit_1")]);
+
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: ruleResultsFor([], [P1]),
+      pageStatuses: [{ url: P1, status: 200 }],
+    });
+
+    // AC4: nothing was inherited — there was no earlier audit to inherit from.
+    expect(r.coverage.carriedFindings).toBe(0);
+    expect(r.coverage.unrenderedFindings).toBe(1);
+    // AC1: and it is NOT tagged as carried, so no "last seen" date is invented.
+    expect(r.carriedLastSeen.size).toBe(0);
+
+    const replayed = r.unionRuleResults
+      .get("meta-description")!
+      .checks.find((c) => c.pageUrl === normalizeUrl(DEEP))!;
+    expect(replayed.provenance).toBe("unrendered");
+    expect(replayed.lastSeenAt).toBeUndefined();
+  });
+
+  test("second audit: a page an earlier run rendered still carries", async () => {
+    const store = new MemStore();
+    // Run 1 renders P1 + P2 (P2 fails) → both get site_pages rows.
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: ruleResultsFor([P2], [P1]),
+      pageStatuses: [P1, P2].map((url) => ({ url, status: 200 })),
+    });
+
+    // Run 2 re-renders only P1. P2 was rendered before → genuine carry-over.
+    const second = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_2",
+      ruleResults: ruleResultsFor([], [P1]),
+      pageStatuses: [{ url: P1, status: 200 }],
+    });
+
+    // AC2: carried keeps its meaning — an earlier audit really did see this.
+    expect(second.coverage.carriedFindings).toBe(1);
+    expect(second.coverage.unrenderedFindings).toBeUndefined();
+    expect(second.carriedLastSeen.size).toBe(1);
+    const carried = second.unionRuleResults
+      .get("meta-description")!
+      .checks.find((c) => c.pageUrl === P2)!;
+    expect(carried.provenance).toBeUndefined(); // tagged "carried" by the caller
+  });
+
+  test("a never-rendered page stays unrendered on later runs that still skip it", async () => {
+    const store = new MemStore();
+    await store.upsertFindings([ingestedFinding(DEEP, "audit_1")]);
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: ruleResultsFor([], [P1]),
+      pageStatuses: [{ url: P1, status: 200 }],
+    });
+
+    // Run 2 also never reaches DEEP — it is still a page nothing has rendered,
+    // so the label must not drift to "carried" just because time passed.
+    const second = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_2",
+      ruleResults: ruleResultsFor([], [P1]),
+      pageStatuses: [{ url: P1, status: 200 }],
+    });
+    expect(second.coverage.carriedFindings).toBe(0);
+    expect(second.coverage.unrenderedFindings).toBe(1);
+  });
+
+  test("once the page IS rendered, a later skip carries it normally", async () => {
+    const store = new MemStore();
+    await store.upsertFindings([ingestedFinding(DEEP, "audit_1")]);
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: ruleResultsFor([], [P1]),
+      pageStatuses: [{ url: P1, status: 200 }],
+    });
+    // Run 2 finally renders DEEP and still finds it failing.
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_2",
+      ruleResults: ruleResultsFor([normalizeUrl(DEEP)], [P1]),
+      pageStatuses: [P1, DEEP].map((url) => ({ url, status: 200 })),
+    });
+    // Run 3 skips it again — now there IS an earlier observation to carry.
+    const third = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_3",
+      ruleResults: ruleResultsFor([], [P1]),
+      pageStatuses: [{ url: P1, status: 200 }],
+    });
+    expect(third.coverage.carriedFindings).toBe(1);
+    expect(third.coverage.unrenderedFindings).toBeUndefined();
   });
 });

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -33,6 +33,7 @@ import type {
   AgentAccessProbe,
   CacheHitReason,
   CacheStats,
+  CheckProvenance,
   RslLicenseDoc,
   SecurityHeaders,
   WellKnownProbe,
@@ -66,8 +67,13 @@ export interface CheckResult {
    * `carried` = re-injected from the per-page store for a page not re-crawled
    * this run; absent / `fresh` = evaluated this run. `lastSeenAt` = epoch ms of
    * the last run that observed it. Only set when `smart_audits` is enabled.
+   *
+   * `unrendered` (#1652) = the page has NEVER been rendered by any audit of this
+   * site, so no earlier run observed the finding. It is not carry-over and never
+   * carries a `lastSeenAt` — labelling it `carried` claims a prior audit that may
+   * not exist (on a first run, none does).
    */
-  provenance?: "fresh" | "carried";
+  provenance?: CheckProvenance;
   lastSeenAt?: number;
 }
 
@@ -298,7 +304,18 @@ export interface AuditReport {
   coverage?: {
     auditedPages: number;
     knownPages: number;
+    /**
+     * Findings inherited from an EARLIER audit of this site. 0 on a first run —
+     * there is no earlier audit to inherit from (#1652).
+     */
     carriedFindings: number;
+    /**
+     * (#1652) Findings on pages NO audit has ever rendered — known (sitemap,
+     * aggregate page lists) but outside every run's page budget. Split out of
+     * `carriedFindings` so "carried" keeps meaning "a previous audit saw this".
+     * Optional: reports published before #1652 omit it.
+     */
+    unrenderedFindings?: number;
   };
   /**
    * Scan scope disclosure (#1180): where the audit ran and how much of the site

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -456,8 +456,27 @@ export interface CachedResourceRecord extends ResourceSizeRecord {
 /** Lifecycle state of a persisted finding. */
 export type FindingState = "open" | "resolved" | "stale";
 
-/** Provenance of a finding in a merged (union) report. */
+/**
+ * Provenance of a PERSISTED finding row. Two values only — the store's column is
+ * constrained to them, so widening this type is a schema change, not a type edit.
+ * The report-level value space is {@link CheckProvenance}, which adds
+ * "unrendered" as a purely derived distinction (#1652).
+ */
 export type FindingProvenance = "fresh" | "carried";
+
+/**
+ * Provenance of a finding as SURFACED in a report (#1652). Derived at merge
+ * time, never persisted:
+ *  - "fresh"      — evaluated on a page rendered this run.
+ *  - "carried"    — inherited from an EARLIER audit that observed it on a page
+ *                   this run did not re-render. Implies a prior audit exists.
+ *  - "unrendered" — the finding's page has never been rendered by ANY audit of
+ *                   this site (it was discovered, e.g. from a sitemap, but sat
+ *                   outside every run's page budget). Nothing earlier observed
+ *                   it, so it must never be labelled "carried" and never
+ *                   carries a `lastSeenAt`.
+ */
+export type CheckProvenance = FindingProvenance | "unrendered";
 
 /**
  * A single persisted finding, keyed by (siteKey, normalizedUrl, ruleId,

--- a/packages/report/src/coverage.ts
+++ b/packages/report/src/coverage.ts
@@ -8,17 +8,32 @@ import { checkAffectedPages } from "./affected-pages";
 
 /**
  * One-line coverage summary, e.g.
- *   "Coverage: audited 10 of 100 known pages (90 issues carried forward)."
+ *   "Coverage: audited 10 of 100 known pages (90 findings carried forward)."
+ *   "Coverage: audited 100 of 100 known pages (4925 findings on pages not yet rendered)."
  * Returns null when smart audits did not run (no `coverage` on the report).
+ *
+ * (#1652) The two counts are disjoint and read differently on purpose: "carried
+ * forward" asserts an earlier audit observed the finding, which is false for a
+ * page nothing has ever rendered — and on a first run that would be false for
+ * every one of them.
  */
 export function coverageLine(report: AuditReport): string | null {
   const c = report.coverage;
   if (!c) return null;
-  const carried =
-    c.carriedFindings > 0
-      ? ` (${c.carriedFindings} finding${c.carriedFindings === 1 ? "" : "s"} carried forward)`
-      : "";
-  return `Coverage: audited ${c.auditedPages} of ${c.knownPages} known page${c.knownPages === 1 ? "" : "s"}${carried}.`;
+  const notes: string[] = [];
+  if (c.carriedFindings > 0) {
+    notes.push(
+      `${c.carriedFindings} finding${c.carriedFindings === 1 ? "" : "s"} carried forward`
+    );
+  }
+  const unrendered = c.unrenderedFindings ?? 0;
+  if (unrendered > 0) {
+    notes.push(
+      `${unrendered} finding${unrendered === 1 ? "" : "s"} on pages not yet rendered`
+    );
+  }
+  const suffix = notes.length > 0 ? ` (${notes.join("; ")})` : "";
+  return `Coverage: audited ${c.auditedPages} of ${c.knownPages} known page${c.knownPages === 1 ? "" : "s"}${suffix}.`;
 }
 
 /**
@@ -88,11 +103,19 @@ export function timeAgo(epochMs: number, now: number = Date.now()): string {
 }
 
 /**
- * Provenance tag for a grouped check, e.g. "(carried — last seen 3 days ago)".
- * Returns "" when the check is fresh (not carried). Only fully-carried checks
- * (every merged instance carried) are tagged.
+ * Provenance tag for a grouped check, e.g. "(carried — last seen 3 days ago)"
+ * or, for a page nothing has ever rendered, "(not yet rendered)" (#1652).
+ * Returns "" when the check is fresh. Only FULLY carried / fully unrendered
+ * checks (every merged instance) are tagged.
+ *
+ * The unrendered branch comes first and never shows a "last seen" date: no run
+ * has observed the finding, so any date would be fabricated — and on a first
+ * audit "carried" itself would be.
  */
 export function carriedTag(check: GroupedCheck, now: number = Date.now()): string {
+  if (check.unrenderedCount && check.unrenderedCount >= check.count) {
+    return " (not yet rendered)";
+  }
   if (!check.carriedCount || check.carriedCount < check.count) return "";
   const seen =
     check.lastSeenAt !== undefined ? ` — last seen ${timeAgo(check.lastSeenAt, now)}` : "";
@@ -110,6 +133,19 @@ export function checkCarriedLabel(check: GroupedCheck, now: number = Date.now())
   if (!check.carriedCount || check.carriedCount < check.count) return null;
   const seen = check.lastSeenAt !== undefined ? ` — last verified ${timeAgo(check.lastSeenAt, now)}` : "";
   return `Not re-checked this run${seen}.`;
+}
+
+/**
+ * Full-sentence label for a check whose every instance sits on a page NO audit
+ * has ever rendered (#1652), e.g. "Not yet rendered in this scan."
+ *
+ * Deliberately says nothing about re-checking or last verification: there is no
+ * earlier run to have verified anything. Returns null unless every merged
+ * instance is unrendered, mirroring {@link checkCarriedLabel}.
+ */
+export function checkUnrenderedLabel(check: GroupedCheck): string | null {
+  if (!check.unrenderedCount || check.unrenderedCount < check.count) return null;
+  return "Not yet rendered in this scan.";
 }
 
 /**
@@ -160,6 +196,11 @@ export function ruleMixedProvenanceNote(
     const pages = checkAffectedPages({ pages: check.pages, items: check.items });
     if (check.pageUrl) pages.add(check.pageUrl);
     if (pages.size === 0) continue;
+    // (#1652) An "unrendered" check belongs to NEITHER bucket: its page was
+    // never rendered, so it is not a fresh result (which would suppress the
+    // note) and not carry-over from an earlier run (which would inflate
+    // "pending re-check" with pages nothing has ever checked).
+    if (check.provenance === "unrendered") continue;
     const isCarried = check.provenance === "carried";
     if (check.status === "pass") {
       if (!isCarried) for (const p of pages) freshPassPages.add(p);

--- a/packages/report/src/grouping.ts
+++ b/packages/report/src/grouping.ts
@@ -46,6 +46,12 @@ export interface GroupedCheck {
   // so a page's membership here is exact (not inferred from the
   // carriedCount/count ratio).
   carriedPages?: string[];
+  // (#1652) Merged checks on pages NO audit has ever rendered — known (sitemap,
+  // aggregate page lists) but never crawled. Deliberately NOT folded into
+  // `carriedCount`: "carried" tells the reader a previous audit saw the finding,
+  // which on these pages (and on every first run) is false. No `lastSeenAt`
+  // counterpart — there is no earlier observation to date.
+  unrenderedCount?: number;
 }
 
 export interface GroupedRule {
@@ -154,7 +160,10 @@ export function groupIssuesByCategory(
       // affected pages in `pages` instead of a single pageUrl.
       const checkPages = (check as { pages?: string[] }).pages ?? [];
       const items = (check as { items?: CheckItem[] }).items;
-      const isCarried = (check as { provenance?: string }).provenance === "carried";
+      const provenance = (check as { provenance?: string }).provenance;
+      const isCarried = provenance === "carried";
+      // (#1652) Never rendered by any audit — a separate bucket from carried.
+      const isUnrendered = provenance === "unrendered";
 
       if (status !== "fail" && status !== "warn") continue;
 
@@ -189,6 +198,9 @@ export function groupIssuesByCategory(
 
       if (existing) {
         existing.count += occurrences;
+        if (isUnrendered) {
+          existing.unrenderedCount = (existing.unrenderedCount ?? 0) + occurrences;
+        }
         if (isCarried) {
           existing.carriedCount = (existing.carriedCount ?? 0) + occurrences;
           if (checkLastSeen !== undefined) {
@@ -275,6 +287,7 @@ export function groupIssuesByCategory(
             : undefined,
           carriedCount: isCarried ? occurrences : undefined,
           lastSeenAt: isCarried ? checkLastSeen : undefined,
+          unrenderedCount: isUnrendered ? occurrences : undefined,
         });
       }
     }

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -121,6 +121,7 @@ export {
   scanScopeLine,
   fullScanHint,
   checkCarriedLabel,
+  checkUnrenderedLabel,
   ruleCarriedRollupLine,
   ruleMixedProvenanceNote,
   type MixedProvenanceCheck,

--- a/packages/report/src/output/html.tsx
+++ b/packages/report/src/output/html.tsx
@@ -33,6 +33,7 @@ import {
   fullScanHint,
   scanScopeLine,
   checkCarriedLabel,
+  checkUnrenderedLabel,
   ruleCarriedRollupLine,
 } from "../coverage";
 import { EDITOR_SUMMARY_NOTE, editorSummaryView } from "../editor-summary";
@@ -921,7 +922,12 @@ function IssuesByGroup({ categories }: { categories: GroupedCategory[] }) {
                               (item) => !isRedundantPageItem(item),
                             );
                             const hasVisibleItems = visibleItems && visibleItems.length > 0;
-                            const carriedLabel = checkCarriedLabel(check);
+                            // (#1652) A check on pages no audit has ever rendered
+                            // gets its own note FIRST — the carried notes below all
+                            // say or imply "previous crawls", which for these pages
+                            // is a claim about an audit that may never have run.
+                            const carriedLabel =
+                              checkUnrenderedLabel(check) ?? checkCarriedLabel(check);
                             // Partial carry (some but not all merged instances): a
                             // per-check fraction here would duplicate the rule-level
                             // rollup above, so only call it out when it diverges from

--- a/packages/report/src/output/json.ts
+++ b/packages/report/src/output/json.ts
@@ -23,7 +23,10 @@ interface SlimJsonReport {
     coverage?: {
       auditedPages: number;
       knownPages: number;
+      /** Findings a PREVIOUS audit observed. 0 on a first run (#1652). */
       carriedFindings: number;
+      /** Findings on pages no audit has ever rendered (#1652). */
+      unrenderedFindings?: number;
     };
   };
   /**
@@ -212,12 +215,17 @@ function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
             details: check.details,
             ...(check.value ? { legacyValue: check.value } : {}),
             // Smart audits (#110): provenance for findings carried across audits.
-            ...(check.carriedCount && check.carriedCount >= check.count
-              ? {
-                  provenance: "carried" as const,
-                  ...(check.lastSeenAt ? { lastSeenAt: check.lastSeenAt } : {}),
-                }
-              : {}),
+            // (#1652) "unrendered" is tested FIRST and emits no `lastSeenAt` —
+            // no audit has rendered the page, so there is nothing it was last
+            // seen at, and calling it "carried" would invent a prior audit.
+            ...(check.unrenderedCount && check.unrenderedCount >= check.count
+              ? { provenance: "unrendered" as const }
+              : check.carriedCount && check.carriedCount >= check.count
+                ? {
+                    provenance: "carried" as const,
+                    ...(check.lastSeenAt ? { lastSeenAt: check.lastSeenAt } : {}),
+                  }
+                : {}),
           };
       }),
     })),

--- a/packages/report/src/output/llm.ts
+++ b/packages/report/src/output/llm.ts
@@ -137,8 +137,14 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
   // findings are carried forward from prior runs (page not re-crawled this run).
   if (report.coverage) {
     const c = report.coverage;
+    // (#1652) `unrendered` is emitted only when non-zero so the attribute set is
+    // byte-identical for every report without never-rendered pages. It is NOT
+    // folded into `carried`: an agent reading carried="N" is entitled to assume
+    // a prior audit observed those N.
+    const unrendered = c.unrenderedFindings ?? 0;
+    const unrenderedAttr = unrendered > 0 ? ` unrendered="${unrendered}"` : "";
     lines.push(
-      `<coverage audited="${c.auditedPages}" known="${c.knownPages}" carried="${c.carriedFindings}"/>`,
+      `<coverage audited="${c.auditedPages}" known="${c.knownPages}" carried="${c.carriedFindings}"${unrenderedAttr}/>`,
     );
   }
 
@@ -256,12 +262,22 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
       // #1135: fully carried → provenance="carried"; some-but-not-all → a
       // "N/M" fraction attribute so an agent can tell "mixed" from "fresh"
       // without walking every check.
+      // (#1652) A rule every one of whose checks sits on a never-rendered page
+      // is `provenance="unrendered"` — checked BEFORE the carried branch so a
+      // first run can never emit provenance="carried" (nothing prior exists to
+      // have carried it). Mixed unrendered/fresh falls through to the carried
+      // logic, which correctly reports no carry.
+      const unrenderedChecks = rule.checks.filter(
+        (c) => c.unrenderedCount && c.unrenderedCount >= c.count,
+      ).length;
       const carriedAttr =
-        carriedChecks > 0 && carriedChecks === rule.checks.length
-          ? ` provenance="carried"`
-          : carriedPageCount > 0
-            ? ` carried_pages="${carriedPageCount}/${allPagesForRule.size}"`
-            : "";
+        unrenderedChecks > 0 && unrenderedChecks === rule.checks.length
+          ? ` provenance="unrendered"`
+          : carriedChecks > 0 && carriedChecks === rule.checks.length
+            ? ` provenance="carried"`
+            : carriedPageCount > 0
+              ? ` carried_pages="${carriedPageCount}/${allPagesForRule.size}"`
+              : "";
   
       const docsUrl = getDocsUrl(rule.id);
       lines.push(

--- a/packages/report/tests/carried-provenance-1135.test.ts
+++ b/packages/report/tests/carried-provenance-1135.test.ts
@@ -8,7 +8,13 @@ import type { ReportRuleResult } from "@squirrelscan/core-contracts";
 
 import { groupIssuesByCategory } from "../src/grouping";
 import { ruleAffectedPageCount, ruleCarriedPageCount } from "../src/affected-pages";
-import { checkCarriedLabel, ruleCarriedRollupLine } from "../src/coverage";
+import {
+  carriedTag,
+  checkCarriedLabel,
+  checkUnrenderedLabel,
+  coverageLine,
+  ruleCarriedRollupLine,
+} from "../src/coverage";
 
 function rule(id: string, checks: ReportRuleResult["checks"]): ReportRuleResult {
   return {
@@ -245,5 +251,86 @@ describe("carried-page provenance (#1135)", () => {
     expect(grouped[0].rules[0].mixedProvenanceNote).toBe(
       "Fixed on all 1 page checked this run; 1 page pending re-check.",
     );
+  });
+});
+
+// #1652 — a finding on a page NO audit has ever rendered is NOT carry-over.
+// Every surface that says "carried", "last seen", or "pending re-check" is
+// asserting a previous audit observed it; on a first run none did.
+describe("unrendered provenance (#1652)", () => {
+  test("unrendered checks are counted apart from carried, with no lastSeenAt", () => {
+    const grouped = groupIssuesByCategory({
+      "images/alt-text": rule("images/alt-text", [
+        {
+          name: "alt-text-missing",
+          status: "warn",
+          message: "1 image(s) missing alt text",
+          pageUrl: "https://e.com/deep",
+          provenance: "unrendered",
+        },
+      ]),
+    });
+    const check = grouped[0].rules[0].checks[0];
+    expect(check.unrenderedCount).toBe(1);
+    expect(check.carriedCount).toBeUndefined();
+    expect(check.carriedPages).toBeUndefined();
+    expect(check.lastSeenAt).toBeUndefined();
+  });
+
+  test("the label says not-yet-rendered, never re-checked/last-verified", () => {
+    const grouped = groupIssuesByCategory({
+      "images/alt-text": rule("images/alt-text", [
+        {
+          name: "alt-text-missing",
+          status: "warn",
+          message: "1 image(s) missing alt text",
+          pageUrl: "https://e.com/deep",
+          provenance: "unrendered",
+        },
+      ]),
+    });
+    const check = grouped[0].rules[0].checks[0];
+    expect(checkUnrenderedLabel(check)).toBe("Not yet rendered in this scan.");
+    // The carried label must stay silent — it implies an earlier verification.
+    expect(checkCarriedLabel(check)).toBeNull();
+    expect(carriedTag(check)).toBe(" (not yet rendered)");
+  });
+
+  test("unrendered issues never feed the 'pending re-check' note", () => {
+    const grouped = groupIssuesByCategory({
+      "images/alt-text": rule("images/alt-text", [
+        {
+          name: "alt-text-missing",
+          status: "warn",
+          message: "1 image(s) missing alt text",
+          pageUrl: "https://e.com/deep",
+          provenance: "unrendered",
+        },
+        {
+          name: "alt-text-missing",
+          status: "pass",
+          message: "ok",
+          pageUrl: "https://e.com/b",
+          provenance: "fresh",
+        },
+      ]),
+    });
+    // Nothing is pending RE-check: the deep page was never checked to begin with.
+    expect(grouped[0].rules[0].mixedProvenanceNote).toBeUndefined();
+  });
+
+  test("coverageLine reports the two counts separately", () => {
+    expect(
+      coverageLine({
+        coverage: { auditedPages: 100, knownPages: 100, carriedFindings: 0, unrenderedFindings: 4925 },
+      } as never),
+    ).toBe(
+      "Coverage: audited 100 of 100 known pages (4925 findings on pages not yet rendered).",
+    );
+    expect(
+      coverageLine({
+        coverage: { auditedPages: 10, knownPages: 100, carriedFindings: 90 },
+      } as never),
+    ).toBe("Coverage: audited 10 of 100 known pages (90 findings carried forward).");
   });
 });

--- a/packages/rules/src/fold.ts
+++ b/packages/rules/src/fold.ts
@@ -800,6 +800,11 @@ function foldGroup(group: CheckResult[], limits: FoldLimits): CheckResult {
 
   // Smart audits (#110): stay "carried" only when every folded finding was.
   const allCarried = group.every((c) => c.provenance === "carried");
+  // (#1652) Same all-or-nothing rule for never-rendered pages, kept as its own
+  // value: folding a wholly-unrendered group down to "carried" would reintroduce
+  // the claim that a previous audit saw it. The two are mutually exclusive, and
+  // an "unrendered" aggregate never gets a lastSeenAt (nothing observed it).
+  const allUnrendered = group.every((c) => c.provenance === "unrendered");
   let lastSeenAt: number | undefined;
   if (allCarried) {
     for (const c of group) {
@@ -822,8 +827,10 @@ function foldGroup(group: CheckResult[], limits: FoldLimits): CheckResult {
     ...(items.length > 0 ? { items } : {}),
     details,
     ...(first.skipReason !== undefined ? { skipReason: first.skipReason } : {}),
-    ...(allCarried
-      ? { provenance: "carried" as const, ...(lastSeenAt !== undefined ? { lastSeenAt } : {}) }
-      : {}),
+    ...(allUnrendered
+      ? { provenance: "unrendered" as const }
+      : allCarried
+        ? { provenance: "carried" as const, ...(lastSeenAt !== undefined ? { lastSeenAt } : {}) }
+        : {}),
   };
 }

--- a/packages/rules/tests/fold.test.ts
+++ b/packages/rules/tests/fold.test.ts
@@ -152,6 +152,29 @@ describe("foldOverflowChecks", () => {
     expect(notCarried!.provenance).toBeUndefined();
   });
 
+  // #1652: folding must not launder "never rendered by any audit" into
+  // "carried" — that is precisely the claim of a prior audit the aggregate
+  // would then be making on a first run.
+  test("a wholly-unrendered fold stays unrendered, with no lastSeenAt", () => {
+    const unrendered = Array.from({ length: 6 }, (_, i) =>
+      failCheck({ pageUrl: `https://example.com/p/${i}`, provenance: "unrendered" }),
+    );
+    const [aggregate] = foldOverflowChecks(unrendered, SMALL);
+    expect(aggregate!.provenance).toBe("unrendered");
+    expect(aggregate!.lastSeenAt).toBeUndefined();
+
+    // Mixed with a genuinely carried check → neither claim holds for the whole.
+    const mixed = [
+      ...unrendered.slice(0, 5),
+      failCheck({
+        pageUrl: "https://example.com/carried",
+        provenance: "carried",
+        lastSeenAt: 900,
+      }),
+    ];
+    expect(foldOverflowChecks(mixed, SMALL)[0]!.provenance).toBeUndefined();
+  });
+
   test("a pathological rule with more distinct issue classes than the cap still slices to the cap", () => {
     const checks = Array.from({ length: 10 }, (_, i) =>
       failCheck({ name: `class-${i}`, pageUrl: `https://example.com/p/${i}` }),


### PR DESCRIPTION
## What

The first audit of a site reported thousands of findings with provenance `"carried"` and a non-zero `coverage.carriedFindings`, telling the reader a previous audit had observed them when no previous audit existed.

## Why it happened

Those findings sit on pages the crawl only **knows** about: sitemap entries and the page lists on folded aggregates. The chunked publish streams a `page_findings` row for each of them, and finalize's merge then reads its own ingest back as "prior" state. For any such page outside this run's crawled set, `computeMerge` takes the un-crawled carry branch and stamps `provenance: "carried"`.

"Carried" means *a previous audit saw this and this run did not re-verify it*. On a first run there is no previous audit, so the label (and the "last seen" / "pending re-check" copy that hangs off it) is simply false.

## The fix

`computeMerge` now derives, per carried finding, whether **any** audit has ever rendered its page: absent from `site_pages` (the site's render history) **and** not rendered this run. Those findings surface as a new report-level provenance `"unrendered"` and are counted in `coverage.unrenderedFindings` instead of `carriedFindings`.

Nothing new is persisted. `page_findings.provenance` keeps its `fresh|carried` value space, which is what its DB CHECK constraint allows — the new value is derived at merge time and lives only in the report.

- `packages/audit-engine/src/merge-core.ts` — `MergedFinding.neverRendered`, computed once per prior finding so a new carry branch cannot silently forget it.
- `packages/audit-engine/src/scoring.ts` — the replayed union check is stamped `provenance: "unrendered"` at the single place it is created, and deliberately gets **no** `lastSeenAt`.
- `merge-promise.ts` + `apps/cli/src/audit/smart-audits.ts` — split the coverage counts and keep unrendered keys out of `carriedLastSeen`, which is what stops the downstream tagging pass relabelling them "carried".
- `packages/report` + `packages/rules/src/fold.ts` — surface the label (coverage line, LLM/JSON/HTML/markdown/console) and stop a wholly-unrendered fold collapsing to "carried".

## Acceptance criteria (#1652)

- [x] Findings on pages never rendered by ANY audit carry a distinct label (`"unrendered"`), not `"carried"`
- [x] `"carried"` still means inherited from a prior run
- [x] The new label's copy implies no prior audit ("Not yet rendered in this scan.", never "pending re-check" / "last verified")
- [x] `carriedFindings` on a first run is 0; the count moves to `unrenderedFindings`

## Tests

- `packages/audit-engine/tests/cloud-merge.test.ts` — first run with a sitemap-only ingest → `carriedFindings: 0`, `unrenderedFindings: 1`, check stamped `unrendered` with no `lastSeenAt`; a genuine second-audit carry-over still reports `carriedFindings: 1`; a page that stays unrendered keeps the label; once rendered, a later skip carries normally.
- `packages/report/tests/carried-provenance-1135.test.ts` — separate bucket, honest label, no "pending re-check" note, coverage line.
- `packages/rules/tests/fold.test.ts` — a wholly-unrendered fold stays unrendered.

Full suite: 4351 pass / 0 fail. Format, lint and typecheck clean.

## Back-compat

`coverage.unrenderedFindings` is **omitted** when zero, so a site with no never-rendered pages serializes byte-identically to a pre-#1652 report (the published JSON feeds the publish idempotency hash and the golden fixtures).

## Ordering

Needs the hosted publish schema to accept the new value **first** — `provenance` is validated by a zod enum, which rejects rather than clamps, so a newer CLI publishing `"unrendered"` against an older API would 400 its whole report.

## Known bounds

Both err toward "unrendered" rather than inventing a prior audit, so the worst case is a missing "last seen" date:

- a page rendered **only** per the #1185 resolution signal gets no `site_pages` row (deliberate — adding one would grow `carriedPageUrls` and with it the synthetic-pass denominator, moving scores), so a later run that skips it reads it as unrendered;
- a removed page whose `site_pages` row was pruned by retention and later rediscovered loses its history the same way.
