### PR TITLE
fix(rules): scope sitemap-lastmod-drift to the document's own JSON-LD node

### DIFF
--- a/docs/rules/crawl/sitemap-lastmod-drift.mdx
+++ b/docs/rules/crawl/sitemap-lastmod-drift.mdx
@@ -21,6 +21,25 @@ For every crawled page that appears in a sitemap with a `lastmod`, the rule comp
 published date. Pages with no date signal at all are skipped: that is
 [Content Freshness](/rules/content/freshness) territory, not drift.
 
+### Which JSON-LD node the date comes from
+
+Only the node that describes the **document** is read: an `Article`, `BlogPosting`,
+`NewsArticle` or similar, else a page-level node such as `WebPage`, `FAQPage` or `Recipe`. A
+sitewide `WebSite`, `Organization`, `Product` or `SoftwareApplication` node carries its own
+`dateModified` that has nothing to do with when this page changed, and Yoast and Rank Math emit
+one *first* in `@graph`, ahead of the article. Those nodes are ignored, and an article node is
+preferred over a page-level one wherever the two sit, so moving a sitewide node around the
+`@graph` cannot change the verdict.
+
+Types may be written bare (`Article`), as a full IRI (`https://schema.org/Article`) or against
+the `schema:` prefix, and a node may claim several at once (`["WebPage", "BlogPosting"]` counts
+as the article). The date itself may be a plain string, a `{"@value": "..."}` wrapper, or a
+list of either, in which case the first entry that parses as a date is used.
+
+If no document-describing node carries a usable `dateModified`, the rule falls through to the
+page's own markup and visible date rather than borrowing the sitewide one. The same scoping is
+applied by [Date Agreement](/rules/content/date-agreement).
+
 The two directions are reported as separate checks, because they point at different code:
 
 | Check | Fires when | Usual cause |

--- a/docs/rules/crawl/sitemap-lastmod-drift.mdx
+++ b/docs/rules/crawl/sitemap-lastmod-drift.mdx
@@ -47,8 +47,10 @@ The two directions are reported as separate checks, because they point at differ
 | `sitemap-lastmod-behind-page` | `lastmod` is older than the page's `dateModified` by more than 7 days | Stale cached sitemap, or a generator resolving `publishedAt ?? updatedAt` while the page renders `updatedAt ?? publishedAt` |
 | `sitemap-lastmod-ahead-of-page` | `lastmod` is newer than the page's `dateModified` by more than 30 days | `lastmod` stamped at build/deploy time instead of on content change |
 
-Each finding reports both dates and the gap in days. Same-day and within-threshold differences
-never warn.
+Each finding reports both dates and the gap in days. The gap is counted in whole elapsed days,
+so a difference has to reach the next whole day past the threshold before it warns: with the
+default `behind_days = 7`, a 7.5-day gap passes and an 8-day gap warns. Same-day and
+within-threshold differences never warn.
 
 Lastmod being *older* than the page's own `dateModified` is the more clearly wrong of the two:
 it tells crawlers not to bother re-fetching a page that has in fact changed.

--- a/packages/rules/src/content/date-agreement.ts
+++ b/packages/rules/src/content/date-agreement.ts
@@ -46,6 +46,13 @@ import { flattenJsonLdNodes, getPathname } from "@squirrelscan/utils";
 
 import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
 
+import {
+  documentTypes,
+  isArticleType,
+  schemaDateString,
+  typeNames,
+} from "../shared/schema-document";
+
 const BYLINE_CHECK = "byline-vs-schema-date";
 const VISIBLE_MISSING_CHECK = "visible-date-missing";
 const URL_TITLE_CHECK = "url-title-year";
@@ -73,60 +80,6 @@ export const optionsSchema = z.object({
       "Days the visible byline date may differ from the schema document date before warning",
     ),
 });
-
-/**
- * Schema `@type`s that stand for a dated piece of CONTENT. These are the types a
- * reader expects a visible date on, so they are also the only ones that can
- * raise `visible-date-missing`.
- */
-const ARTICLE_TYPES = new Set(
-  [
-    "Article",
-    "AdvertiserContentArticle",
-    "BlogPosting",
-    "DiscussionForumPosting",
-    "LiveBlogPosting",
-    "NewsArticle",
-    "ReportageNewsArticle",
-    "ScholarlyArticle",
-    "SocialMediaPosting",
-    "TechArticle",
-  ].map((t) => t.toLowerCase()),
-);
-
-/**
- * Page-level `@type`s: they describe the document without being dated content in
- * their own right. Their dates are comparable, but a page node carrying dates is
- * usually CMS boilerplate (WordPress SEO plugins emit one on every page of a
- * site, contact form included), so it never has to render a visible date —
- * demanding one would warn on every page of every WordPress site, which is the
- * noise this rule exists to avoid.
- */
-const PAGE_TYPES = [
-  "Report",
-  "WebPage",
-  "AboutPage",
-  "CheckoutPage",
-  "CollectionPage",
-  "ContactPage",
-  "FAQPage",
-  "ItemPage",
-  "MedicalWebPage",
-  "ProfilePage",
-  "QAPage",
-  "SearchResultsPage",
-  "Recipe",
-  "HowTo",
-].map((t) => t.toLowerCase());
-
-/**
- * Every `@type` whose node describes the DOCUMENT — the page itself or the
- * single piece of content it exists to publish. A date on one of these is a
- * claim about when THIS page was published or updated. Everything else
- * (SoftwareApplication, Product, Organization, WebSite, Person, ...) describes a
- * thing the page merely mentions, and its dates mean something else entirely.
- */
-const DOCUMENT_TYPES = new Set([...ARTICLE_TYPES, ...PAGE_TYPES]);
 
 // ============================================================================
 // Date parsing
@@ -245,29 +198,6 @@ interface SchemaDates {
   fallback: { type: string; field: string; value: string } | null;
 }
 
-/** `@type` values as authored; generators array-wrap `@type` freely. */
-function typeNames(node: Record<string, unknown>): string[] {
-  const raw = node["@type"];
-  const list: unknown[] = Array.isArray(raw) ? (raw as unknown[]) : [raw];
-  return list.filter((t): t is string => typeof t === "string" && t.length > 0);
-}
-
-/** A JSON-LD date property: a plain string, or a `{"@value": ...}` wrapper. */
-function schemaDateString(value: unknown): string | null {
-  if (typeof value === "string") return value.trim() || null;
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    const inner = (value as Record<string, unknown>)["@value"];
-    if (typeof inner === "string") return inner.trim() || null;
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const found = schemaDateString(entry);
-      if (found) return found;
-    }
-  }
-  return null;
-}
-
 /**
  * Split every JSON-LD date on the page by the kind of node carrying it. An
  * Article-family node wins over a generic page node — a Yoast-style `@graph`
@@ -289,17 +219,18 @@ function collectSchemaDates(raw: string | null | undefined): SchemaDates {
     if (!published && !modified) continue;
 
     const types = typeNames(node);
-    const documentType = types.find((t) => DOCUMENT_TYPES.has(t.toLowerCase()));
+    // First document type wins, as it always has here.
+    const docType = documentTypes(node)[0] ?? null;
 
-    if (documentType) {
-      const isArticle = ARTICLE_TYPES.has(documentType.toLowerCase());
+    if (docType) {
+      const isArticle = isArticleType(docType);
       if (isArticle ? articleNode !== null : pageNode !== null) continue;
 
       const publishedSignal = parseDateValue(published, "schema:datePublished");
       const modifiedSignal = parseDateValue(modified, "schema:dateModified");
       if (!publishedSignal && !modifiedSignal) continue;
 
-      const entry = { type: documentType, published: publishedSignal, modified: modifiedSignal };
+      const entry = { type: docType, published: publishedSignal, modified: modifiedSignal };
       if (isArticle) articleNode = entry;
       else pageNode = entry;
       continue;
@@ -612,7 +543,7 @@ export const dateAgreementRule: Rule = {
     // A page-level node (WebPage, CollectionPage, ...) alongside SEVERAL visible
     // dates is an index or archive: those dates belong to the entries it lists,
     // not to the page, so there is nothing here to disagree with.
-    const isListing = visibleDates.length > 1 && !ARTICLE_TYPES.has(docNode.type.toLowerCase());
+    const isListing = visibleDates.length > 1 && !isArticleType(docNode.type);
 
     if (visible && !isListing) {
       // Every visible date is measured against the CLOSEST schema date, and the
@@ -650,7 +581,7 @@ export const dateAgreementRule: Rule = {
               details: { ...baseDetails, visibleDate: best.shown.value, gapDays: best.gap },
             },
       );
-    } else if (!visible && ARTICLE_TYPES.has(docNode.type.toLowerCase()) && !showsAnyDate(doc)) {
+    } else if (!visible && isArticleType(docNode.type) && !showsAnyDate(doc)) {
       // Dates in the markup and none on the page: the /learn/* half of #108.
       // `showsAnyDate` keeps this off a page that prints a date this rule
       // declined to read as a byline — a citation, or a format it cannot parse.

--- a/packages/rules/src/crawl/sitemap-lastmod-drift.ts
+++ b/packages/rules/src/crawl/sitemap-lastmod-drift.ts
@@ -7,6 +7,8 @@ import type { SitemapData } from "@squirrelscan/core-contracts";
 
 import { flattenJsonLdNodes, normalizeUrl } from "@squirrelscan/utils";
 
+import { documentTypes, isArticleType, schemaDateString } from "../shared/schema-document";
+
 const MS_PER_DAY = 86_400_000;
 
 // Findings are capped so a site whose whole sitemap is build-stamped reports a
@@ -41,22 +43,48 @@ function parseDate(value: string | null | undefined): number | null {
   return Number.isNaN(ms) ? null : ms;
 }
 
-/** The `dateModified` carried by any JSON-LD node (including `@graph` children). */
+const isUsableDate = (value: string): boolean => parseDate(value) !== null;
+
+/**
+ * The `dateModified` of the JSON-LD node that describes THIS DOCUMENT.
+ *
+ * Nodes for things the page merely mentions are ignored: a sitewide
+ * `WebSite`/`Organization` node carries its own stale `dateModified`, and Yoast
+ * and Rank Math emit it FIRST in `@graph`, ahead of the `Article`. Reading the
+ * first dated node made the verdict depend on `@graph` order — the same trap
+ * `content/date-agreement` guards with the shared `documentTypes` (#1570).
+ *
+ * Selection is position-independent: an Article-family node wins wherever it
+ * sits, since the post's own node speaks for the content, and a node claiming
+ * both (`["WebPage", "BlogPosting"]`) counts as the article whichever half was
+ * written first. Among nodes of one kind the first with a USABLE `dateModified`
+ * wins; unparseable values are skipped while scanning rather than returned, so a
+ * malformed date cannot hide a good one later in the graph or later in the same
+ * node's date list. When no document node carries a usable date the answer is
+ * null, and the caller falls through to the page's own visible date signals
+ * rather than borrowing a sitewide one.
+ */
 function schemaDateModified(parsed: ParsedPage): string | null {
   if (!parsed.schema?.raw) return null;
+  let pageLevel: string | null = null;
   // Flattened nodes include @graph children — a top-level-only read misses every
   // date on Yoast-style sites (same reason eeat/content-dates flattens).
   for (const node of flattenJsonLdNodes(parsed.schema.raw)) {
-    const value = node["dateModified"];
-    if (typeof value === "string" && value.trim()) return value.trim();
+    const types = documentTypes(node);
+    if (types.length === 0) continue;
+    const value = schemaDateString(node["dateModified"], isUsableDate);
+    if (!value) continue;
+    if (types.some(isArticleType)) return value;
+    pageLevel ??= value;
   }
-  return null;
+  return pageLevel;
 }
 
 /**
- * The page's strongest own date signal: schema `dateModified`, else the
- * `dateModified`-equivalent markup the parser lifts from `[itemprop=dateModified]`
- * meta/`<time>` (`visibleDateModified`), else the visible published date.
+ * The page's strongest own date signal: the document node's schema
+ * `dateModified`, else the `dateModified`-equivalent markup the parser lifts from
+ * `[itemprop=dateModified]` meta/`<time>` (`visibleDateModified`), else the
+ * visible published date.
  *
  * Only parsed-page SCALARS are read — never `parsed.document` — so the rule sees
  * the same input on the legacy `site.pages` path and on the streaming path, where

--- a/packages/rules/src/crawl/sitemap-lastmod-drift.ts
+++ b/packages/rules/src/crawl/sitemap-lastmod-drift.ts
@@ -222,9 +222,11 @@ export const sitemapLastmodDriftRule: Rule = {
 
       comparedPages++;
 
-      // Magnitude only — direction is read off the comparison below. Whole days,
-      // so a same-day (and any sub-threshold) difference can never warn.
-      const deltaDays = Math.round(Math.abs(pageDate.ms - lastmodMs) / MS_PER_DAY);
+      // Magnitude only — direction is read off the comparison below. Truncated,
+      // not rounded: rounding moved the real thresholds half a day past the
+      // documented ones (a 7.5-day gap warned, and was quoted back to the user
+      // as "8 day(s)" under a message reading "more than 7 day(s)").
+      const deltaDays = Math.floor(Math.abs(pageDate.ms - lastmodMs) / MS_PER_DAY);
       const drift: Drift = {
         url: page.url,
         lastmod,

--- a/packages/rules/src/shared/schema-document.ts
+++ b/packages/rules/src/shared/schema-document.ts
@@ -1,0 +1,135 @@
+// Shared JSON-LD vocabulary for the rules that read a DATE off a page's schema
+// (content/date-agreement, crawl/sitemap-lastmod-drift).
+//
+// The trap both rules exist to avoid: a date belongs to the node that describes
+// the DOCUMENT. A sitewide SoftwareApplication / Product / Organization / WebSite
+// node carries its own datePublished or dateModified (a release date, a founding
+// date, a template's build date) and WordPress SEO plugins emit one on every page
+// of the site — Yoast and Rank Math put it FIRST in `@graph`, ahead of the
+// Article. Taking the first dated node in the document therefore attributes one
+// sitewide date to every post, and makes a verdict depend on `@graph` node order.
+//
+// Both rules pick their own node once classified — they want different fields —
+// but the classification itself lives here so the two can never drift apart.
+
+/**
+ * Schema `@type`s that stand for a dated piece of CONTENT. These are the types a
+ * reader expects a visible date on, so `content/date-agreement` also treats them
+ * as the only ones that can raise `visible-date-missing`.
+ */
+const ARTICLE_TYPES = new Set(
+  [
+    "Article",
+    "AdvertiserContentArticle",
+    "BlogPosting",
+    "DiscussionForumPosting",
+    "LiveBlogPosting",
+    "NewsArticle",
+    "ReportageNewsArticle",
+    "ScholarlyArticle",
+    "SocialMediaPosting",
+    "TechArticle",
+  ].map((t) => t.toLowerCase()),
+);
+
+/**
+ * Page-level `@type`s: they describe the document without being dated content in
+ * their own right. Their dates are comparable, but a page node carrying dates is
+ * usually CMS boilerplate (emitted on every page of a site, contact form
+ * included), so it never has to render a visible date — demanding one would warn
+ * on every page of every WordPress site.
+ */
+const PAGE_TYPES = new Set(
+  [
+    "Report",
+    "WebPage",
+    "AboutPage",
+    "CheckoutPage",
+    "CollectionPage",
+    "ContactPage",
+    "FAQPage",
+    "ItemPage",
+    "MedicalWebPage",
+    "ProfilePage",
+    "QAPage",
+    "SearchResultsPage",
+    "Recipe",
+    "HowTo",
+  ].map((t) => t.toLowerCase()),
+);
+
+/** `@type` values as authored; generators array-wrap `@type` freely. */
+export function typeNames(node: Record<string, unknown>): string[] {
+  const raw = node["@type"];
+  const list: unknown[] = Array.isArray(raw) ? (raw as unknown[]) : [raw];
+  return list.filter((t): t is string => typeof t === "string" && t.length > 0);
+}
+
+/**
+ * A `@type` reduced to the bare term the sets are keyed on. JSON-LD lets a type
+ * be written as the full IRI (`https://schema.org/Article`) or against a compact
+ * prefix (`schema:Article`); both name the same type as the bare `Article` most
+ * generators emit.
+ */
+function typeTerm(type: string): string {
+  // One alternation, not two passes: stripping in sequence would reduce the
+  // nonsense `https://schema.org/schema:Article` to a type it does not name.
+  return type.trim().replace(/^(?:https?:\/\/schema\.org\/|schema:)/i, "").toLowerCase();
+}
+
+/** Whether a `@type` (as authored) is a dated piece of content rather than a page shell. */
+export function isArticleType(type: string): boolean {
+  return ARTICLE_TYPES.has(typeTerm(type));
+}
+
+/**
+ * The node's document-describing `@type`s as authored, in the order written — the
+ * page itself or the single piece of content it exists to publish. Empty when the
+ * node describes something the page merely mentions. A date on a document node is
+ * a claim about when THIS page was published or updated; everything else
+ * (SoftwareApplication, Product, Organization, WebSite, Person, ...) dates a
+ * different thing entirely.
+ *
+ * A list rather than one winner because callers disagree about what to do with a
+ * node claiming several (`["WebPage", "BlogPosting"]`): whether the Article half
+ * outranks the page half is a per-rule policy, not part of the vocabulary.
+ */
+export function documentTypes(node: Record<string, unknown>): string[] {
+  return typeNames(node).filter((t) => {
+    const term = typeTerm(t);
+    return ARTICLE_TYPES.has(term) || PAGE_TYPES.has(term);
+  });
+}
+
+/**
+ * A JSON-LD date property: a plain string, a `{"@value": ...}` wrapper, or a list
+ * of either.
+ *
+ * `accept` narrows what counts as a hit, so a caller that can only use a
+ * parseable date skips a malformed entry and keeps looking instead of taking it
+ * and failing later. It defaults to accepting any non-empty string, which is
+ * what a caller that validates downstream wants.
+ */
+export function schemaDateString(
+  value: unknown,
+  accept: (date: string) => boolean = () => true,
+): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed && accept(trimmed) ? trimmed : null;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const inner = (value as Record<string, unknown>)["@value"];
+    if (typeof inner === "string") {
+      const trimmed = inner.trim();
+      return trimmed && accept(trimmed) ? trimmed : null;
+    }
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = schemaDateString(entry, accept);
+      if (found) return found;
+    }
+  }
+  return null;
+}

--- a/packages/rules/tests/sitemap-lastmod-drift.test.ts
+++ b/packages/rules/tests/sitemap-lastmod-drift.test.ts
@@ -222,6 +222,45 @@ describe("crawl/sitemap-lastmod-drift", () => {
     expect(warned.checks[0]?.name).toBe("sitemap-lastmod-behind-page");
   });
 
+  test("a gap between the threshold and the next whole day never warns", () => {
+    // Rounding used to push the effective thresholds half a day out: a 7.5-day
+    // gap warned and was reported as "8 day(s)" under a "more than 7 day(s)"
+    // message, overstating both the verdict and the number.
+    const lastmod = "2024-03-01T00:00:00Z";
+    const behindBy = (hours: number) =>
+      sitemapLastmodDriftRule.run(
+        ctx(
+          [
+            {
+              url: "https://example.com/a",
+              schemaDateModified: new Date(
+                new Date(lastmod).getTime() + hours * 3_600_000
+              ).toISOString(),
+            },
+          ],
+          [{ loc: "https://example.com/a", lastmod }]
+        )
+      );
+
+    expect(behindBy(7 * 24).checks[0]?.status).toBe("pass"); // exactly 7 days
+    expect(behindBy(7 * 24 + 12).checks[0]?.status).toBe("pass"); // 7.5 days
+    expect(behindBy(8 * 24 - 1).checks[0]?.status).toBe("pass"); // just under 8
+    const warned = behindBy(8 * 24);
+    expect(warned.checks[0]?.status).toBe("warn");
+    expect(warned.checks[0]?.items?.[0]?.meta?.deltaDays).toBe(8);
+  });
+
+  test("a same-day difference cannot warn even with the threshold at zero", () => {
+    const { checks } = sitemapLastmodDriftRule.run(
+      ctx(
+        [{ url: "https://example.com/a", schemaDateModified: "2024-03-01T22:00:00Z" }],
+        [{ loc: "https://example.com/a", lastmod: "2024-03-01T02:00:00Z" }],
+        { behind_days: 0 }
+      )
+    );
+    expect(checks[0]?.status).toBe("pass");
+  });
+
   test("both directions on one site → two separate checks", () => {
     const { checks } = sitemapLastmodDriftRule.run(
       ctx(

--- a/packages/rules/tests/sitemap-lastmod-drift.test.ts
+++ b/packages/rules/tests/sitemap-lastmod-drift.test.ts
@@ -2,6 +2,8 @@
 
 import { describe, expect, test } from "bun:test";
 
+import { parseHTML } from "linkedom";
+
 import { sitemapLastmodDriftRule } from "../src/crawl/sitemap-lastmod-drift";
 import type { ParsedPage, RuleContext, SiteData } from "../src/types";
 
@@ -15,24 +17,34 @@ function plusDays(base: string, days: number): string {
 interface PageSpec {
   url: string;
   schemaDateModified?: string;
+  /** Raw JSON-LD, for the multi-node shapes a single `schemaDateModified` cannot express. */
+  schemaRaw?: string;
   visibleDateModified?: string;
   visibleDatePublished?: string;
 }
 
+/** A `@graph` document, in the order the nodes are written — the ordering is the fixture. */
+function graph(...nodes: Record<string, unknown>[]): string {
+  return JSON.stringify({ "@context": "https://schema.org", "@graph": nodes });
+}
+
+/** A bare top-level array of nodes: the other shape generators emit. */
+function flatArray(...nodes: Record<string, unknown>[]): string {
+  return JSON.stringify(nodes.map((node) => ({ "@context": "https://schema.org", ...node })));
+}
+
 function parsed(spec: PageSpec): ParsedPage {
+  const raw =
+    spec.schemaRaw ??
+    (spec.schemaDateModified
+      ? JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "BlogPosting",
+          dateModified: spec.schemaDateModified,
+        })
+      : null);
   return {
-    schema: {
-      types: [],
-      valid: true,
-      errors: [],
-      raw: spec.schemaDateModified
-        ? JSON.stringify({
-            "@context": "https://schema.org",
-            "@type": "BlogPosting",
-            dateModified: spec.schemaDateModified,
-          })
-        : null,
-    },
+    schema: { types: [], valid: true, errors: [], raw },
     visibleDateModified: spec.visibleDateModified ?? null,
     visibleDatePublished: spec.visibleDatePublished ?? null,
   } as unknown as ParsedPage;
@@ -324,7 +336,195 @@ describe("crawl/sitemap-lastmod-drift", () => {
     ]);
   });
 
-  test("a siteQuery on the context does not change the output (dual-path parity)", () => {
+  // ==========================================================================
+  // Only the node that describes the DOCUMENT carries the page's date (#1570).
+  //
+  // Yoast, Rank Math and most WordPress stacks emit a sitewide WebSite /
+  // Organization node FIRST in `@graph`, ahead of the Article. Reading the first
+  // dated node made the verdict depend on that ordering, so every fixture below
+  // is asserted in both orders.
+  // ==========================================================================
+  describe("document-typed nodes only", () => {
+    const AGREES = "2024-06-01T00:00:00.000Z";
+    const LASTMOD = "2024-06-01";
+    const SITEWIDE = { "@type": "WebSite", name: "Example", dateModified: "2020-01-01" };
+    const ARTICLE = { "@type": "Article", headline: "Post", dateModified: AGREES };
+
+    const URL = "https://example.com/post";
+
+    /** One page whose only date signals are the given JSON-LD, against an agreeing lastmod. */
+    function runOn(raw: string, spec: Partial<PageSpec> = {}) {
+      return sitemapLastmodDriftRule.run(
+        ctx([{ url: URL, schemaRaw: raw, ...spec }], [{ loc: URL, lastmod: LASTMOD }])
+      );
+    }
+
+    /** Same nodes, both orders — the verdict must not move. */
+    function bothOrders(sitewide: Record<string, unknown>, article: Record<string, unknown>) {
+      return {
+        sitewideFirst: runOn(graph(sitewide, article)),
+        articleFirst: runOn(graph(article, sitewide)),
+      };
+    }
+
+    test("sitewide WebSite dated 2020 ahead of an agreeing Article → pass, in either order", () => {
+      const { sitewideFirst, articleFirst } = bothOrders(SITEWIDE, ARTICLE);
+
+      expect(sitewideFirst.checks[0]?.status).toBe("pass");
+      expect(articleFirst.checks[0]?.status).toBe("pass");
+      // Not just the same status: the same finding, byte for byte.
+      expect(JSON.stringify(sitewideFirst)).toBe(JSON.stringify(articleFirst));
+    });
+
+    test("real drift on the Article still warns, with the sitewide node present", () => {
+      const drifted = { "@type": "Article", dateModified: "2011-04-02T00:00:00.000Z" };
+      const { sitewideFirst, articleFirst } = bothOrders(SITEWIDE, drifted);
+
+      for (const result of [sitewideFirst, articleFirst]) {
+        expect(result.checks[0]?.status).toBe("warn");
+        expect(result.checks[0]?.name).toBe("sitemap-lastmod-ahead-of-page");
+        // The Article's 2011 date, never the WebSite's 2020 one.
+        expect(result.checks[0]?.items?.[0]?.meta?.pageDate).toBe("2011-04-02T00:00:00.000Z");
+      }
+      expect(JSON.stringify(sitewideFirst)).toBe(JSON.stringify(articleFirst));
+    });
+
+    test("the same trap in a flat top-level array, not just @graph", () => {
+      expect(runOn(flatArray(SITEWIDE, ARTICLE)).checks[0]?.status).toBe("pass");
+      expect(runOn(flatArray(ARTICLE, SITEWIDE)).checks[0]?.status).toBe("pass");
+    });
+
+    test("sitewide nodes carrying dates raise no drift claim of their own", () => {
+      // Every one of these describes a thing the page mentions, not the page.
+      // With no document node and no visible date, there is nothing to compare.
+      const { checks } = runOn(
+        graph(
+          SITEWIDE,
+          { "@type": "Organization", dateModified: "2019-05-05" },
+          { "@type": "SoftwareApplication", datePublished: "2026-01-01" },
+          { "@type": "Person", name: "Author" }
+        )
+      );
+      expect(checks).toHaveLength(1);
+      expect(checks[0]?.status).toBe("skipped");
+      expect(checks[0]?.skipReason).toBe("No comparable dates");
+    });
+
+    test("with no document-typed date the page's own visible date is used, not the sitewide one", () => {
+      // The WebSite's 2020 date would have warned by 1,613 days.
+      const { checks } = runOn(graph(SITEWIDE), { visibleDateModified: AGREES });
+      expect(checks[0]?.status).toBe("pass");
+    });
+
+    test("a WebPage node speaks for the document when there is no Article", () => {
+      const { checks } = runOn(graph(SITEWIDE, { "@type": "WebPage", dateModified: AGREES }));
+      expect(checks[0]?.status).toBe("pass");
+    });
+
+    test("an Article wins over a dated WebPage regardless of position", () => {
+      const webPage = { "@type": "WebPage", dateModified: "2011-04-02T00:00:00.000Z" };
+      // The WebPage's 2011 date would warn; the Article agrees with lastmod.
+      expect(runOn(graph(webPage, ARTICLE)).checks[0]?.status).toBe("pass");
+      expect(runOn(graph(ARTICLE, webPage)).checks[0]?.status).toBe("pass");
+    });
+
+    test("array-wrapped @type and a {@value} date are still read", () => {
+      const { checks } = runOn(
+        graph(SITEWIDE, {
+          "@type": ["WebPage", "BlogPosting"],
+          dateModified: { "@value": "2011-04-02T00:00:00.000Z" },
+        })
+      );
+      expect(checks[0]?.status).toBe("warn");
+      expect(checks[0]?.items?.[0]?.meta?.pageDate).toBe("2011-04-02T00:00:00.000Z");
+    });
+
+    test("a node claiming both a page and an article type counts as the article", () => {
+      // `["WebPage","BlogPosting"]` and its reverse are the same claim, so the
+      // dated WebPage must lose to this node either way round.
+      const stalePage = { "@type": "WebPage", dateModified: "2011-04-02T00:00:00.000Z" };
+      for (const types of [["WebPage", "BlogPosting"], ["BlogPosting", "WebPage"]]) {
+        const { checks } = runOn(graph(stalePage, { "@type": types, dateModified: AGREES }));
+        expect(checks[0]?.status).toBe("pass");
+      }
+    });
+
+    test("full-IRI and schema:-prefixed @types are recognised", () => {
+      for (const type of ["https://schema.org/Article", "http://schema.org/Article", "schema:Article"]) {
+        // Recognised as the document node, so its agreeing date beats the sitewide one.
+        expect(runOn(graph(SITEWIDE, { "@type": type, dateModified: AGREES })).checks[0]?.status).toBe(
+          "pass"
+        );
+      }
+    });
+
+    test("an unparseable date on one document node does not hide a later usable one", () => {
+      const { checks } = runOn(
+        graph(
+          SITEWIDE,
+          { "@type": "Article", dateModified: "last tuesday" },
+          { "@type": "BlogPosting", dateModified: AGREES }
+        )
+      );
+      // Returning "last tuesday" would have failed to parse and dropped the page
+      // to "no comparable dates", losing a comparison the page could support.
+      expect(checks[0]?.status).toBe("pass");
+      expect(checks[0]?.details?.comparedPages).toBe(1);
+    });
+
+    test("an unparseable entry does not hide a later one in the same date list", () => {
+      const { checks } = runOn(
+        graph(SITEWIDE, { "@type": "Article", dateModified: ["last tuesday", AGREES] })
+      );
+      expect(checks[0]?.status).toBe("pass");
+      expect(checks[0]?.details?.comparedPages).toBe(1);
+    });
+
+    test("a crafted IRI is not normalised twice into a type it does not name", () => {
+      // Stripping the IRI and then the prefix in sequence would reduce this to
+      // `Article`; it names no schema.org type, so the node is not the document.
+      const { checks } = runOn(
+        graph({ "@type": "https://schema.org/schema:Article", dateModified: AGREES })
+      );
+      expect(checks[0]?.status).toBe("skipped");
+      expect(checks[0]?.skipReason).toBe("No comparable dates");
+    });
+  });
+
+  // The rule reads only parsed-page SCALARS — never `parsed.document` — so the
+  // streaming site pass (every DOM dropped before site rules run) must reach the
+  // same verdict as the legacy `site.pages` pass. Probed by feeding a DOM that
+  // CONTRADICTS the scalars: if the rule ever started falling back to the
+  // document's own JSON-LD, the two paths would diverge here.
+  test("dropping the page DOM does not change the output (dual-path parity)", () => {
+    const page = {
+      url: "https://example.com/post",
+      // Scalars say the page agrees with lastmod...
+      schemaDateModified: "2026-08-01T00:00:00.000Z",
+    };
+    const urls = [{ loc: "https://example.com/post", lastmod: "2026-08-01T00:00:00.000Z" }];
+
+    const streaming = sitemapLastmodDriftRule.run(ctx([page], urls));
+
+    // ...while the DOM the legacy path still carries says it drifted by years.
+    const legacyCtx = ctx([page], urls);
+    const document = parseHTML(
+      `<html><head><script type="application/ld+json">${JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "Article",
+        dateModified: "2011-04-02T00:00:00.000Z",
+      })}</script></head><body><time datetime="2011-04-02">2 April 2011</time></body></html>`
+    ).document;
+    for (const sitePage of legacyCtx.site!.pages) {
+      (sitePage.parsed as unknown as { document: unknown }).document = document;
+    }
+    const legacy = sitemapLastmodDriftRule.run(legacyCtx);
+
+    expect(streaming.checks[0]?.status).toBe("pass");
+    expect(JSON.stringify(legacy)).toBe(JSON.stringify(streaming));
+  });
+
+  test("a siteQuery on the context does not change the output", () => {
     const base = ctx(
       [{ url: "https://example.com/post", schemaDateModified: "2011-04-02T00:00:00Z" }],
       [{ loc: "https://example.com/post", lastmod: "2026-08-01T00:00:00Z" }]
@@ -332,8 +532,6 @@ describe("crawl/sitemap-lastmod-drift", () => {
     const legacy = sitemapLastmodDriftRule.run(base);
     const streaming = sitemapLastmodDriftRule.run({
       ...base,
-      // The rule reads only parsed-page scalars, never a DOM — so the streaming
-      // site pass (documents dropped, siteQuery threaded) sees identical input.
       siteQuery: { pageCount: () => 1 },
     } as unknown as RuleContext);
     expect(JSON.stringify(streaming)).toBe(JSON.stringify(legacy));


### PR DESCRIPTION
`crawl/sitemap-lastmod-drift` compares a sitemap's `lastmod` against the page's own `dateModified`. Its `schemaDateModified()` took the **first** flattened JSON-LD node carrying any `dateModified`, with no `@type` filter.

So a page whose `Article.dateModified` agreed with its sitemap **exactly** still warned, as long as a sitewide node carried a stale date and happened to be written first:

```
A: @graph = [ {"@type":"WebSite", dateModified:"2020-01-01"},
              {"@type":"Article", dateModified:"2024-06-01"} ]   lastmod 2024-06-01
   -> [warn] sitemap-lastmod-ahead-of-page ... (1613 day(s))

B: same two nodes, Article first
   -> [pass]
```

Yoast and Rank Math emit the sitewide node ahead of the `Article` in `@graph`, so that is the common ordering, not the exotic one. The verdict should never have turned on it.

## What changed

**Only document-describing nodes feed the comparison** — the guard the sibling rule `content/date-agreement` already shipped with. Rather than a second copy, the type vocabulary, the `@type` reader and the `{"@value"}` date unwrapper move to `packages/rules/src/shared/schema-document.ts` and both rules use it.

`documentTypes(node)` returns the node's document types **in the order written**, leaving the selection policy to each rule:

- `content/date-agreement` takes `[0]` — its previous first-one-wins behaviour, unchanged.
- `crawl/sitemap-lastmod-drift` prefers an Article-family node wherever it sits, and treats a node claiming both (`["WebPage","BlogPosting"]`) as the article either way round. No part of its verdict depends on node order now.

Unparseable values are skipped **while scanning** rather than returned, so a malformed date cannot hide a good one later in the graph or later in the same node's date list. With no document node carrying a usable `dateModified` the answer is nothing, and the rule falls through to the page's own meta/visible dates rather than borrowing a sitewide one. A page with no signal at all stays skipped, as before.

Second commit, separable: `deltaDays` used `Math.round`, putting the effective thresholds half a day past the documented ones. A 7.5-day gap warned and was quoted back as `8 day(s)` under a message reading *"older ... by more than 7 day(s)"* — both the verdict and the number overstated. `Math.floor` makes the rule agree with its own copy, and makes the comment above it true (with `behind_days: 0`, a 20-hour same-day difference no longer warns with `deltaDays: 1`).

## Behaviour changes a user could notice

- Pages carrying a dated sitewide node ahead of their article node stop warning. That is the bug.
- Pages whose **only** dated JSON-LD is sitewide no longer produce a drift finding from it. They fall to meta/visible dates, or are skipped as before.
- The vocabulary now also recognises a `@type` written as a full IRI (`https://schema.org/Article`) or against the `schema:` prefix, and a whitespace-padded one. Neither rule read those before; `content/date-agreement` is affected by this widening too (such a node is now the document node rather than a reported fallback).
- The drift rule now accepts a `{"@value": ...}` wrapper and a list of dates, which it previously ignored in favour of weaker signals.

All four are documented on the rule's docs page.

## Tests

`packages/rules/tests/sitemap-lastmod-drift.test.ts`, 31 tests (was 20). The traps are asserted in **both node orders**, and in `@graph` and flat-array shapes, so none can pass on ordering luck. **8 of the new tests fail against the pre-fix rule**, verified by checking out `origin/main`'s copy of the rule under the new test file.

The old "dual-path parity" test called the same rule twice on the same object and could not fail. It is replaced with one that feeds a DOM contradicting the parsed scalars: verified falsifiable by mutating the rule to consult `parsed.document`, which the old test did not catch.

Green: 1,395 rules tests, 1,791 CLI tests, `tsgo --noEmit` across all packages, `bun run format:check`, `make validate` in `docs/`.

Reviewed with Codex over two rounds; every finding is addressed in the branch rather than deferred.

Refs squirrelscan/repo#1570