### PR TITLE
fix(parser): HTML attribute lookup is case-insensitive, as in a browser

### DIFF
--- a/apps/cli/scripts/debug-alt-text.ts
+++ b/apps/cli/scripts/debug-alt-text.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // Debug script to diagnose alt-text detection issues
 
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { extractImages } from "../src/parse/extractors/images";
 

--- a/apps/cli/src/links/index.ts
+++ b/apps/cli/src/links/index.ts
@@ -1,8 +1,8 @@
 // Internal link analysis - crawl depth, orphan pages, link equity
 // Phase 4 enhancement for comprehensive link analysis
 
+import { parseHTML } from "@squirrelscan/parser/dom";
 import { shouldSkipUrl } from "@squirrelscan/utils";
-import { parseHTML } from "linkedom";
 
 import type {
   CheckResult,

--- a/apps/cli/src/parse/document.ts
+++ b/apps/cli/src/parse/document.ts
@@ -1,6 +1,9 @@
 // Parse page processor - single DOM parse, concurrent extractors
 // This is the main entry point for parsing a page
 
+import type { Document } from "linkedom";
+
+import { parseHTML } from "@squirrelscan/parser/dom";
 import {
   extractMeta,
   extractOG,
@@ -16,7 +19,6 @@ import {
   type ExtractedImage,
 } from "@squirrelscan/parser/extractors";
 import { Effect } from "effect";
-import { parseHTML, type Document } from "linkedom";
 
 import type {
   ContextRef,

--- a/apps/cli/tests/audit/cloud-prefetch-parity.test.ts
+++ b/apps/cli/tests/audit/cloud-prefetch-parity.test.ts
@@ -12,8 +12,8 @@ import {
   computeCost,
   estimateAuditCap,
 } from "@squirrelscan/core-contracts/credits";
+import { parseHTML } from "@squirrelscan/parser/dom";
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
 
 import {
   selectCloudRules as cliSelectCloudRules,

--- a/apps/cli/tests/graph/extractors/content.test.ts
+++ b/apps/cli/tests/graph/extractors/content.test.ts
@@ -5,13 +5,13 @@
 // tests pin the exact exclusion semantics (tags, aria-hidden, sr-only classes),
 // comment handling, and whitespace preservation.
 
+import { parseHTML } from "@squirrelscan/parser/dom";
 import {
   extractContent,
   getCleanTextContent,
   getMainContent,
 } from "@squirrelscan/parser/extractors";
 import { describe, it, expect } from "bun:test";
-import { parseHTML } from "linkedom";
 
 function parseDoc(html: string) {
   return parseHTML(html).document;

--- a/apps/cli/tests/graph/extractors/images.test.ts
+++ b/apps/cli/tests/graph/extractors/images.test.ts
@@ -1,11 +1,11 @@
 // Tests for extractors/images.ts - Image extraction
 
+import { parseHTML } from "@squirrelscan/parser/dom";
 import {
   extractImages,
   getImagesWithoutAlt,
 } from "@squirrelscan/parser/extractors";
 import { describe, it, expect } from "bun:test";
-import { parseHTML } from "linkedom";
 
 function parseDoc(html: string) {
   return parseHTML(html).document;

--- a/apps/cli/tests/graph/extractors/links.test.ts
+++ b/apps/cli/tests/graph/extractors/links.test.ts
@@ -1,11 +1,11 @@
 // Tests for extractors/links.ts - Link extraction with position detection
 
+import { parseHTML } from "@squirrelscan/parser/dom";
 import {
   extractLinks,
   extractCrawlableUrls,
 } from "@squirrelscan/parser/extractors";
 import { describe, it, expect } from "bun:test";
-import { parseHTML } from "linkedom";
 
 function parseDoc(html: string) {
   return parseHTML(html).document;

--- a/apps/cli/tests/graph/extractors/meta.test.ts
+++ b/apps/cli/tests/graph/extractors/meta.test.ts
@@ -1,5 +1,6 @@
 // Tests for extractors/meta.ts - Meta tag extraction
 
+import { parseHTML } from "@squirrelscan/parser/dom";
 import {
   extractMeta,
   extractOG,
@@ -7,7 +8,6 @@ import {
   extractH1,
 } from "@squirrelscan/parser/extractors";
 import { describe, it, expect } from "bun:test";
-import { parseHTML } from "linkedom";
 
 function parseDoc(html: string) {
   return parseHTML(html).document;

--- a/apps/cli/tests/graph/extractors/schema.test.ts
+++ b/apps/cli/tests/graph/extractors/schema.test.ts
@@ -4,9 +4,9 @@ import {
   SchemaCollection,
   schemaCollectionFromJSON,
 } from "@squirrelscan/parser";
+import { parseHTML } from "@squirrelscan/parser/dom";
 import { extractSchema } from "@squirrelscan/parser/extractors";
 import { describe, it, expect } from "bun:test";
-import { parseHTML } from "linkedom";
 
 function parseDoc(html: string) {
   return parseHTML(html).document;

--- a/apps/cli/tests/rules/lcp-hints.test.ts
+++ b/apps/cli/tests/rules/lcp-hints.test.ts
@@ -2,9 +2,9 @@
 
 import type { RuleContext } from "@squirrelscan/rules";
 
+import { parseHTML } from "@squirrelscan/parser/dom";
 import { perf } from "@squirrelscan/rules";
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
 
 const { lcpHintsRule } = perf;
 

--- a/apps/cli/tests/utils/dom.test.ts
+++ b/apps/cli/tests/utils/dom.test.ts
@@ -1,5 +1,5 @@
+import { parseHTML } from "@squirrelscan/parser/dom";
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
 
 import {
   getAttrCI,

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./dom": "./src/dom.ts",
     "./extractors": "./src/extractors/index.ts"
   },
   "dependencies": {

--- a/packages/parser/src/dom.ts
+++ b/packages/parser/src/dom.ts
@@ -1,0 +1,288 @@
+// The HTML parsing entry point: parse through `parseHTML` from here, never
+// straight from linkedom, so attribute lookups follow the HTML case rules.
+//
+// A browser ASCII-lowercases attribute names while parsing HTML, and
+// `getAttribute` lowercases its argument for any element in the HTML namespace.
+// linkedom does neither: it stores the source spelling and compares it exactly,
+// so `getAttribute("inputmode")` misses `inputMode="url"` and, on a page that
+// spells it in lowercase, `getAttribute("inputMode")` misses it too (#1507).
+// React-adjacent SSR passes unknown props straight through, so camelCase
+// attributes are ordinary valid markup, and every rule reading an attribute by
+// name had the exposure in both directions.
+//
+// Reading is where the fix lives: parsing never renames an attribute, so
+// serialisation is byte-identical and anything walking `el.attributes` still
+// sees the author's spelling. Writing through `setAttribute` does lowercase the
+// name, because that is what a browser does and because linkedom recognises
+// only the literal name `class` when it keeps `classList` in step.
+//
+// SVG is left alone, because there attribute names really are case-sensitive in
+// a browser: `viewBox` and `preserveAspectRatio` keep matching only their exact
+// spelling.
+//
+// The patch is on a prototype linkedom exports, so it reaches every linkedom
+// element in the process, not only documents parsed here. Scoping it to those
+// was tried and dropped: linkedom does not repoint `ownerDocument` when a node
+// moves between documents, and `Document.cloneNode()` produces an unregistered
+// one, so the scope check turned the fix silently OFF on exactly the paths it
+// was meant to make precise — the failure mode of #1507 itself. Nothing in this
+// repo parses XML (the guard test in tests/attribute-case.test.ts keeps
+// linkedom reachable only through this module); anyone adding an XML parser
+// should add it here and give it back its case-sensitive names.
+//
+// NOT covered, both deliberately:
+//
+// - MathML. linkedom's parser specialises SVG but not MathML, so a `<math>`
+//   subtree reports the XHTML namespace and gets the HTML rules. Telling which
+//   of its elements are really MathML needs the tree-construction context —
+//   integration points, breakout tags — that linkedom never recorded, so every
+//   approximation of it is wrong somewhere. The single attribute at stake is
+//   `definitionURL`, the only camelCase name the HTML parser produces for
+//   MathML, and no rule reads it.
+// - `el.dataset`. linkedom builds its DOMStringMap by walking `el.attributes`
+//   for a literal `data-` prefix, so `<div DATA-Foo="v">` is
+//   `getAttribute("data-foo") === "v"` but `dataset.foo === undefined`. Nothing
+//   in the engine reads `dataset`; read attributes by name instead.
+
+import { Element as ElementFacade } from "linkedom";
+
+export { parseHTML } from "linkedom";
+
+const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+
+// Minimal structural views of the linkedom internals touched here. linkedom's
+// own types describe `attributes` as a NamedNodeMap that is not iterable, which
+// it is at runtime.
+interface AttrNode {
+  name: string;
+  value: string;
+}
+
+interface AttrElement {
+  namespaceURI: string;
+  className: string;
+  attributes: Iterable<AttrNode>;
+  classList: { clear(): void };
+  getAttributeNode(name: string): AttrNode | null;
+}
+
+interface SharedState {
+  installed: boolean;
+  /**
+   * Lowercased name -> attribute node, for the attributes of one element whose
+   * names are NOT already lowercase. `null` records the overwhelmingly common
+   * answer, "this element has none", so a repeat miss costs one WeakMap read
+   * rather than a walk over `el.attributes` (which allocates a NamedNodeMap and
+   * a Proxy per access, and a rule pass asks about absent attributes ~10^5
+   * times a page).
+   *
+   * Keyed on the attribute SET, so every method that adds or removes one drops
+   * the entry. linkedom leaves `Attr.name` writable, unlike the DOM, and
+   * renaming one in place would go unnoticed here; nothing writes it.
+   */
+  mixedCaseAttrs: WeakMap<object, Map<string, AttrNode> | null>;
+}
+
+// State lives on the global, not in this module's closure, so that two
+// evaluations of this file (a bundler emitting two copies) share one cache and
+// one install flag rather than the second quietly shadowing the first.
+const STATE_KEY = Symbol.for("squirrelscan.parser.html-attribute-case");
+const globalScope = globalThis as unknown as Record<symbol, SharedState | undefined>;
+
+const state: SharedState = (globalScope[STATE_KEY] ??= {
+  installed: false,
+  mixedCaseAttrs: new WeakMap<object, Map<string, AttrNode> | null>(),
+});
+
+const { mixedCaseAttrs } = state;
+
+const NON_ASCII = /[^\u0000-\u007f]/;
+
+/**
+ * ASCII lowercase, which is all "case-insensitive" means in HTML.
+ * `toLowerCase()` also folds non-ASCII — U+212A KELVIN SIGN becomes "k" — which
+ * would let an authored `K="…"` answer to `getAttribute("k")` where a browser
+ * says null, and would rewrite the name `getAttributeNames()` reports.
+ */
+function asciiLowerCase(value: string): string {
+  if (!NON_ASCII.test(value)) return value.toLowerCase();
+  return value.replace(/[A-Z]/g, (c) => String.fromCharCode(c.charCodeAt(0) + 32));
+}
+
+/** An element the HTML case rules apply to. */
+function isHtmlElement(el: AttrElement): boolean {
+  return el.namespaceURI === HTML_NAMESPACE;
+}
+
+/** A name that means `class` to a browser but not to linkedom. */
+function isMixedCaseClass(name: string): boolean {
+  return name !== "class" && asciiLowerCase(name) === "class";
+}
+
+/**
+ * Rebuild the cached class list from whatever `class` attribute the element has
+ * now. linkedom does this itself for the literal name `class` only, so any
+ * write that reaches the attribute under another spelling would leave
+ * `className` and every class selector answering the old value.
+ */
+function resyncClassList(el: AttrElement): void {
+  const stored = el.getAttributeNode("class");
+  el.classList.clear();
+  if (!stored) return;
+  // Rebuilding the token list writes its own joined spelling back to the
+  // attribute; a browser leaves the value exactly as given, so put it back.
+  const authored = stored.value;
+  el.className = authored;
+  stored.value = authored;
+}
+
+function mixedCaseIndexOf(el: AttrElement): Map<string, AttrNode> | null {
+  const cached = mixedCaseAttrs.get(el);
+  if (cached !== undefined) return cached;
+
+  let index: Map<string, AttrNode> | null = null;
+  for (const attr of el.attributes) {
+    const lower = asciiLowerCase(attr.name);
+    if (lower === attr.name) continue;
+    index ??= new Map();
+    // First spelling wins, as in a browser, where the second of two attributes
+    // that differ only in case is dropped at parse time. Only among the
+    // mixed-case ones, though: an exact match is tried before this index, so a
+    // later lowercase twin still beats an earlier `DATA-Foo`. Being exact about
+    // that would mean indexing every attribute of every element on every
+    // lookup, to settle markup that is invalid either way.
+    if (!index.has(lower)) index.set(lower, attr);
+  }
+
+  mixedCaseAttrs.set(el, index);
+  return index;
+}
+
+/**
+ * Make attribute lookup ASCII case-insensitive for HTML elements. Idempotent,
+ * and run on import of this module, so importing `parseHTML` from here is
+ * enough.
+ *
+ * Patching `getAttributeNode` covers the whole read surface in one place:
+ * `getAttribute`, `hasAttribute`, `getAttributeNS`, `classList`/`className`,
+ * and — because linkedom's css-select adapter routes selector matching through
+ * it — `querySelector("[inputmode]")` too.
+ */
+export function installHtmlAttributeCaseInsensitivity(): void {
+  if (state.installed) return;
+  state.installed = true;
+
+  const proto = (ElementFacade as unknown as { prototype: Record<PropertyKey, unknown> })
+    .prototype;
+
+  const getAttributeNode = proto.getAttributeNode as (
+    this: AttrElement,
+    name: string,
+  ) => AttrNode | null;
+
+  proto.getAttributeNode = function (this: AttrElement, name: string): AttrNode | null {
+    const exact = getAttributeNode.call(this, name);
+    if (exact) return exact;
+    if (!isHtmlElement(this)) return null;
+
+    const lower = asciiLowerCase(name);
+    // The caller spelled it in mixed case; the document spells it plainly.
+    if (lower !== name) {
+      const lowered = getAttributeNode.call(this, lower);
+      if (lowered) return lowered;
+    }
+    // The document spells it in mixed case.
+    return mixedCaseIndexOf(this)?.get(lower) ?? null;
+  };
+
+  const getAttributeNames = proto.getAttributeNames as (this: AttrElement) => string[];
+
+  proto.getAttributeNames = function (this: AttrElement): string[] {
+    const names = getAttributeNames.call(this);
+    if (!isHtmlElement(this)) return names;
+    for (let i = 0; i < names.length; i++) {
+      const name = names[i];
+      if (name !== undefined) names[i] = asciiLowerCase(name);
+    }
+    return names;
+  };
+
+  const setAttribute = proto.setAttribute as (
+    this: AttrElement,
+    name: string,
+    value: string,
+  ) => void;
+
+  proto.setAttribute = function (this: AttrElement, name: string, value: string): void {
+    try {
+      // A browser lowercases the name here, which matters beyond tidiness:
+      // linkedom keeps its cached class list in step only for the literal name
+      // `class`, so `setAttribute("CLASS", …)` would otherwise write the value
+      // and leave `className` and every class selector on the old one. An
+      // existing mixed-case twin is still updated in place rather than
+      // duplicated, because linkedom resolves it through getAttributeNode.
+      setAttribute.call(this, isHtmlElement(this) ? asciiLowerCase(name) : name, value);
+    } finally {
+      mixedCaseAttrs.delete(this);
+    }
+  };
+
+  // `setAttributeNS` does NOT lowercase in a browser, and linkedom implements
+  // it by delegating to `setAttribute` — which would now lowercase for it.
+  proto.setAttributeNS = function (
+    this: AttrElement,
+    _namespace: string | null,
+    name: string,
+    value: string,
+  ): void {
+    try {
+      setAttribute.call(this, name, value);
+    } finally {
+      mixedCaseAttrs.delete(this);
+      // Without the lowercasing above, a `CLASS` written here reaches the
+      // `class` attribute through getAttributeNode but not the class list.
+      if (isHtmlElement(this) && isMixedCaseClass(name)) resyncClassList(this);
+    }
+  };
+
+  const removeAttribute = proto.removeAttribute as (this: AttrElement, name: string) => void;
+
+  proto.removeAttribute = function (this: AttrElement, name: string): void {
+    // linkedom compares names exactly here and does not route through
+    // getAttributeNode, so resolve the stored spelling first: otherwise an
+    // attribute `hasAttribute` reports would refuse to be removed.
+    const stored = this.getAttributeNode(name);
+    const target = stored ? stored.name : name;
+    try {
+      if (isHtmlElement(this) && isMixedCaseClass(target)) this.classList.clear();
+      removeAttribute.call(this, target);
+    } finally {
+      mixedCaseAttrs.delete(this);
+    }
+  };
+
+  // These two take an Attr node, so they can install a name `setAttribute`
+  // would have lowercased. linkedom rebuilds its cached class list for the
+  // literal name `class` only, which leaves the mixed-case spelling stale;
+  // and both change the attribute SET the index above is built from.
+  //
+  // Invalidate AFTER the call, never before: linkedom's own `setAttribute`
+  // asks `getAttributeNode` whether the attribute already exists, which would
+  // rebuild and re-cache the index from the pre-insert state and leave the new
+  // attribute permanently invisible. Nothing in the audit engine mutates a
+  // parsed document, but a cache that silently goes stale if something ever
+  // does is a trap.
+  for (const method of ["setAttributeNode", "removeAttributeNode"] as const) {
+    const original = proto[method] as (this: AttrElement, attr: AttrNode) => unknown;
+    proto[method] = function (this: AttrElement, attr: AttrNode): unknown {
+      try {
+        return original.call(this, attr);
+      } finally {
+        mixedCaseAttrs.delete(this);
+        if (isHtmlElement(this) && isMixedCaseClass(attr.name)) resyncClassList(this);
+      }
+    };
+  }
+}
+
+installHtmlAttributeCaseInsensitivity();

--- a/packages/parser/src/html.ts
+++ b/packages/parser/src/html.ts
@@ -5,7 +5,9 @@
 import { clampItemString } from "@squirrelscan/core-contracts/clamp";
 import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
 import { coerceSchemelessUrl, getAttrCI, shouldSkipUrl } from "@squirrelscan/utils";
-import { parseHTML, type Document, type Element } from "linkedom";
+import type { Document, Element } from "linkedom";
+
+import { parseHTML } from "./dom";
 
 import type {
   ContactLinkData,

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,6 +1,6 @@
 // @squirrelscan/parser - HTML parsing and extraction
 
-import { parseHTML } from "linkedom";
+import { parseHTML } from "./dom";
 
 export {
   parsePage,

--- a/packages/parser/tests/attribute-case.test.ts
+++ b/packages/parser/tests/attribute-case.test.ts
@@ -1,0 +1,435 @@
+// HTML attribute names are ASCII case-insensitive; linkedom compares them
+// exactly. Every rule that reads an attribute by name was exposed in both
+// directions: `getAttribute("inputmode")` missed `inputMode="url"` (React-style
+// SSR emits camelCase), and on a lowercase page `getAttribute("inputMode")`
+// missed it too. #1507.
+//
+// These tests pin three things together: HTML lookups ignore case, SVG does
+// NOT, and parsing never rewrites what the document said. Writing is the one
+// place a name changes, because a browser's setAttribute lowercases too. The
+// two gaps left open on purpose, MathML and `dataset`, are pinned as well.
+
+import { Glob } from "bun";
+import { describe, expect, test } from "bun:test";
+
+import { installHtmlAttributeCaseInsensitivity, parseHTML } from "../src/dom";
+
+function parse(body: string) {
+  return parseHTML(`<!DOCTYPE html><html><body>${body}</body></html>`).document;
+}
+
+describe("HTML attribute lookup ignores case (#1507)", () => {
+  test("a camelCase-authored attribute is found by its lowercase name", () => {
+    const el = parse(`<input id="a" inputMode="url">`).getElementById("a")!;
+
+    expect(el.getAttribute("inputmode")).toBe("url");
+    expect(el.hasAttribute("inputmode")).toBe(true);
+  });
+
+  test("a lowercase attribute is found when the caller spells it in camelCase", () => {
+    const el = parse(`<input id="b" inputmode="url">`).getElementById("b")!;
+
+    expect(el.getAttribute("inputMode")).toBe("url");
+    expect(el.hasAttribute("inputMode")).toBe(true);
+  });
+
+  test("the issue's reproduction now agrees with a browser", () => {
+    const doc = parse(`
+      <input id="a" inputMode="url">
+      <input id="b" inputmode="url">
+      <div id="c" DATA-Foo="1" aria-LABEL="hi"></div>
+    `);
+    const c = doc.getElementById("c")!;
+
+    expect(doc.getElementById("a")!.getAttribute("inputmode")).toBe("url");
+    expect(doc.getElementById("b")!.getAttribute("inputmode")).toBe("url");
+    expect(c.getAttributeNames()).toEqual(["id", "data-foo", "aria-label"]);
+    expect(c.getAttribute("data-foo")).toBe("1");
+    expect(c.getAttribute("aria-label")).toBe("hi");
+  });
+
+  test("installing twice does not wrap the prototype twice", () => {
+    // The install runs on import; a second call must be a no-op, or each extra
+    // one adds a frame to every attribute read in the process.
+    const el = parse(`<input id="a" inputMode="url">`).getElementById("a")!;
+    const before = el.getAttributeNode;
+
+    installHtmlAttributeCaseInsensitivity();
+    installHtmlAttributeCaseInsensitivity();
+
+    expect(el.getAttributeNode).toBe(before);
+    expect(el.getAttribute("inputmode")).toBe("url");
+  });
+
+  test("case folding is ASCII, not Unicode", () => {
+    // KELVIN SIGN lowercases to "k" under toLowerCase(), but HTML case
+    // insensitivity is ASCII only, so a browser leaves this name as authored.
+    // Spelled as a code point: as a literal it is indistinguishable from "K".
+    const kelvin = "\u212A";
+    const el = parse(`<div id="a" ${kelvin}="kelvin" ASCII-K="plain"></div>`).getElementById(
+      "a",
+    )!;
+
+    expect(el.getAttribute("k")).toBeNull();
+    expect(el.getAttribute(kelvin)).toBe("kelvin");
+    expect(el.getAttributeNames()).toEqual(["id", kelvin, "ascii-k"]);
+  });
+
+  test("an absent attribute is still absent", () => {
+    const el = parse(`<div id="a" data-foo="1"></div>`).getElementById("a")!;
+
+    expect(el.getAttribute("data-bar")).toBeNull();
+    expect(el.hasAttribute("data-bar")).toBe(false);
+    expect(el.getAttributeNode("data-bar")).toBeNull();
+  });
+
+  test("an attribute selector matches whichever case either side spells", () => {
+    const doc = parse(`
+      <input id="a" inputMode="url">
+      <input id="b" inputmode="url">
+    `);
+
+    expect(doc.querySelectorAll("[inputmode]")).toHaveLength(2);
+    expect(doc.querySelectorAll("[inputMode]")).toHaveLength(2);
+    expect(doc.querySelectorAll('[inputmode="url"]')).toHaveLength(2);
+    expect(doc.getElementById("a")!.matches("[inputmode]")).toBe(true);
+  });
+
+  test("an uppercase CLASS reaches className, classList and class selectors", () => {
+    // linkedom builds its DOMTokenList from getAttributeNode("class"), so
+    // before the fix an uppercase CLASS was invisible to all three.
+    const doc = parse(`<div id="a" CLASS="alpha beta"></div>`);
+    const el = doc.getElementById("a")!;
+
+    expect(el.className).toBe("alpha beta");
+    expect(el.classList.contains("alpha")).toBe(true);
+    expect(el.getAttribute("class")).toBe("alpha beta");
+    expect(doc.querySelectorAll(".alpha")).toHaveLength(1);
+  });
+
+  test("the first spelling wins when a document repeats an attribute in two cases", () => {
+    const el = parse(`<div id="a" DATA-Foo="1" DATA-FOO="2"></div>`).getElementById("a")!;
+
+    expect(el.getAttribute("data-foo")).toBe("1");
+  });
+
+  test("an exact match still wins over an earlier mixed-case one", () => {
+    // Documented divergence: a browser drops the second of two attributes that
+    // differ only in case, so it would answer "1". Resolving that here would
+    // mean indexing every attribute of every element on every lookup, to be
+    // exact about markup that is invalid to begin with.
+    const el = parse(`<div id="a" DATA-Foo="1" data-foo="2"></div>`).getElementById("a")!;
+
+    expect(el.getAttribute("data-foo")).toBe("2");
+  });
+});
+
+describe("SVG keeps case-sensitive attribute names", () => {
+  const svg = () =>
+    parse(
+      `<svg id="s" viewBox="0 0 10 10" preserveAspectRatio="xMidYMid"><path d="M0 0"/></svg>`,
+    ).getElementById("s")!;
+
+  test("viewBox and preserveAspectRatio match only their exact spelling", () => {
+    const s = svg();
+
+    expect(s.getAttribute("viewBox")).toBe("0 0 10 10");
+    expect(s.getAttribute("viewbox")).toBeNull();
+    expect(s.getAttribute("preserveAspectRatio")).toBe("xMidYMid");
+    expect(s.getAttribute("preserveaspectratio")).toBeNull();
+    expect(s.hasAttribute("viewbox")).toBe(false);
+  });
+
+  test("getAttributeNames leaves foreign names alone", () => {
+    expect(svg().getAttributeNames()).toEqual(["id", "viewBox", "preserveAspectRatio"]);
+  });
+
+  test("known gap: MathML gets the HTML rules, because linkedom has no MathML", () => {
+    // linkedom specialises SVG but not MathML, so <math> reports the XHTML
+    // namespace and definitionURL is reachable in lowercase, where a browser
+    // would say null. Telling MathML elements from the HTML ones a <math>
+    // subtree legitimately contains (integration points, breakout tags) needs
+    // tree-construction context linkedom never recorded. definitionURL is the
+    // only camelCase name the HTML parser produces for MathML, and no rule
+    // reads it. Pinned so the gap is visible if that changes.
+    const math = parse(`<math id="m" definitionURL="http://x"></math>`).getElementById("m")!;
+
+    expect(math.namespaceURI).toBe("http://www.w3.org/1999/xhtml");
+    expect(math.getAttribute("definitionurl")).toBe("http://x");
+  });
+});
+
+describe("no attribute is ever renamed", () => {
+  const SOURCE = [
+    `<input id="a" inputMode="url">`,
+    `<div id="c" DATA-Foo="1" aria-LABEL="hi"></div>`,
+    `<svg id="s" viewBox="0 0 10 10"><path d="M0 0" /></svg>`,
+  ].join("");
+
+  test("serialisation keeps the source spelling byte for byte", () => {
+    const doc = parse(SOURCE);
+    // Read every attribute first: a lookup must not disturb what is stored.
+    doc.getElementById("c")!.getAttribute("data-foo");
+    doc.getElementById("s")!.getAttribute("viewbox");
+
+    expect(doc.body.innerHTML).toBe(SOURCE);
+  });
+
+  test("known gap: el.dataset does not see a mixed-case data- attribute", () => {
+    // linkedom builds its DOMStringMap by walking el.attributes for a literal
+    // "data-" prefix, without going through getAttributeNode. A browser would
+    // answer "v" here. Pinned rather than fixed: nothing in the engine reads
+    // dataset, and covering it means reimplementing the whole proxy.
+    const el = parse(`<div id="c" DATA-Foo="v"></div>`).getElementById("c")!;
+
+    expect(el.getAttribute("data-foo")).toBe("v");
+    expect(el.dataset.foo).toBeUndefined();
+  });
+
+  test("el.attributes still reports the author's spelling", () => {
+    const el = parse(SOURCE).getElementById("c")!;
+
+    expect([...el.attributes].map((a) => a.name)).toEqual(["id", "DATA-Foo", "aria-LABEL"]);
+    expect(el.getAttributeNode("data-foo")!.name).toBe("DATA-Foo");
+  });
+});
+
+describe("mutation keeps the lookup index honest", () => {
+  test("setAttribute lowercases the name, as a browser does", () => {
+    const el = parse(`<div id="a"></div>`).getElementById("a")!;
+    // linkedom's setAttribute asks getAttributeNode first, so an index rebuilt
+    // during the call would cache the pre-insert state and hide this forever.
+    el.getAttribute("data-bar");
+    el.setAttribute("DATA-Bar", "2");
+
+    expect(el.getAttribute("data-bar")).toBe("2");
+    expect([...el.attributes].map((a) => a.name).sort()).toEqual(["data-bar", "id"]);
+  });
+
+  test("writing a mixed-case class keeps className and class selectors in step", () => {
+    // linkedom refreshes its cached class list only for the literal name
+    // "class", so writing CLASS wrote the value and left className, classList
+    // and every class selector answering the old one.
+    const doc = parse(`<div id="a" CLASS="alpha"></div>`);
+    const el = doc.getElementById("a")!;
+    expect(el.className).toBe("alpha");
+
+    el.setAttribute("CLASS", "beta");
+
+    expect(el.className).toBe("beta");
+    expect(el.getAttribute("class")).toBe("beta");
+    expect(doc.querySelectorAll(".beta")).toHaveLength(1);
+    expect(doc.querySelectorAll(".alpha")).toHaveLength(0);
+  });
+
+  test("a foreign attribute is still written with the case given", () => {
+    const el = parse(`<svg id="s"></svg>`).getElementById("s")!;
+    el.setAttribute("viewBox", "0 0 2 2");
+
+    expect(el.getAttribute("viewBox")).toBe("0 0 2 2");
+    expect(el.outerHTML).toContain(`viewBox="0 0 2 2"`);
+  });
+
+  test("setAttributeNS does not lowercase, because a browser's does not", () => {
+    // linkedom implements setAttributeNS by delegating to setAttribute, which
+    // now lowercases; the namespaced form has to keep the name it was given.
+    const el = parse(`<div id="a"></div>`).getElementById("a")!;
+    el.setAttributeNS(null, "DATA-X", "v");
+
+    expect([...el.attributes].map((a) => a.name).sort()).toEqual(["DATA-X", "id"]);
+    expect(el.getAttribute("DATA-X")).toBe("v");
+    // A browser would answer null here, having lowercased the argument and
+    // found no `data-x`. Reaching a mixed-case stored name by its lowercase
+    // spelling is the whole point of the fix, and there is nothing to tell a
+    // name set this way apart from one an author wrote.
+    expect(el.getAttribute("data-x")).toBe("v");
+  });
+
+  test("setAttributeNode keeps a mixed-case class in step with className", () => {
+    // These take an Attr node, so they can install a name setAttribute would
+    // have lowercased. linkedom rebuilds its cached class list for the literal
+    // name "class" only.
+    const doc = parse(`<div id="a" class="alpha"></div>`);
+    const el = doc.getElementById("a")!;
+    expect(el.className).toBe("alpha");
+
+    const attr = doc.createAttribute("CLASS");
+    attr.value = "beta";
+    el.removeAttribute("class");
+    el.setAttributeNode(attr);
+
+    expect(el.className).toBe("beta");
+    expect(doc.querySelectorAll(".beta")).toHaveLength(1);
+    expect(doc.querySelectorAll(".alpha")).toHaveLength(0);
+  });
+
+  test("and leaves the value it was handed exactly as given", () => {
+    // Rebuilding the token list writes back its own joined spelling; a browser
+    // stores what setAttributeNode was given, whitespace and all.
+    const doc = parse(`<div id="a"></div>`);
+    const el = doc.getElementById("a")!;
+    const attr = doc.createAttribute("CLASS");
+    attr.value = "  alpha   beta  ";
+    el.setAttributeNode(attr);
+
+    expect(el.getAttributeNode("class")!.value).toBe("  alpha   beta  ");
+    expect(el.classList.contains("alpha")).toBe(true);
+    expect(el.classList.contains("beta")).toBe(true);
+  });
+
+  test("setAttributeNS keeps a mixed-case class in step too", () => {
+    // It skips the lowercasing, so a CLASS written this way reaches the class
+    // attribute through getAttributeNode but would miss the class list.
+    const doc = parse(`<div id="a" class="alpha"></div>`);
+    const el = doc.getElementById("a")!;
+    expect(el.className).toBe("alpha");
+
+    el.setAttributeNS(null, "CLASS", "beta");
+
+    expect(el.getAttribute("class")).toBe("beta");
+    expect(el.className).toBe("beta");
+    expect(doc.querySelectorAll(".beta")).toHaveLength(1);
+  });
+
+  test("setting a lowercase attribute in mixed case updates it in place", () => {
+    const el = parse(`<div id="a" data-foo="1"></div>`).getElementById("a")!;
+    el.setAttribute("DATA-Foo", "2");
+
+    expect(el.getAttribute("data-foo")).toBe("2");
+    expect([...el.attributes].map((a) => a.name)).toEqual(["id", "data-foo"]);
+  });
+
+  test("removeAttribute removes a mixed-case attribute named in lowercase", () => {
+    const el = parse(`<div id="a" DATA-Foo="1"></div>`).getElementById("a")!;
+    el.removeAttribute("data-foo");
+
+    expect(el.hasAttribute("data-foo")).toBe(false);
+    expect(el.outerHTML).toBe(`<div id="a"></div>`);
+  });
+
+  test("removing an uppercase CLASS clears the class list with it", () => {
+    const el = parse(`<div id="a" CLASS="alpha"></div>`).getElementById("a")!;
+    expect(el.classList.contains("alpha")).toBe(true);
+
+    el.removeAttribute("class");
+
+    expect(el.classList.contains("alpha")).toBe(false);
+    expect(el.outerHTML).toBe(`<div id="a"></div>`);
+  });
+
+  test("toggleAttribute round-trips a mixed-case attribute", () => {
+    const el = parse(`<div id="a" DATA-Foo="1"></div>`).getElementById("a")!;
+
+    expect(el.toggleAttribute("data-foo")).toBe(false);
+    expect(el.hasAttribute("data-foo")).toBe(false);
+
+    el.toggleAttribute("data-foo");
+    expect(el.getAttribute("data-foo")).toBe("");
+  });
+
+  test("removing a foreign attribute still needs its exact spelling", () => {
+    const el = parse(`<svg id="s" viewBox="0 0 10 10"></svg>`).getElementById("s")!;
+    el.removeAttribute("viewbox");
+
+    expect(el.getAttribute("viewBox")).toBe("0 0 10 10");
+  });
+});
+
+// Every way a module specifier can be named: static, side-effect, dynamic and
+// require, in either quote, bare or with a subpath.
+const SPECIFIER_RE = /(?:from|import|require)\s*\(?\s*(['"])linkedom(?:\/[\w./-]+)?\1/g;
+
+// Everything a type-only statement may hold between its keyword and `from`.
+// Only the `import type` / `export type` form counts: `import { type X }`
+// still emits a runtime import under verbatimModuleSyntax.
+const TYPE_IMPORT_PREFIX_RE = /^(?:import|export)\s+type\s[^;]*$/;
+
+// As whole words, so the `import` inside an identifier like `important` is not
+// mistaken for the start of a statement.
+const KEYWORD_RE = /\b(?:import|export)\b/g;
+
+/**
+ * Whether the specifier at `match` belongs to a type-only statement, which
+ * erases at compile time and pulls in no runtime module. A heuristic, not a
+ * parser: it reads back to the nearest preceding import/export keyword, so a
+ * keyword sitting inside a comment mid-statement would fool it. It errs toward
+ * flagging, and a false positive is a loud test failure rather than a silent
+ * regression.
+ */
+function isTypeOnlyImport(source: string, match: RegExpExecArray): boolean {
+  // Only a `from` clause can belong to one. A bare `import "linkedom"`,
+  // `import(…)` or `require(…)` is a runtime load whatever precedes it, which
+  // is what keeps a preceding semicolonless type import from covering for it.
+  if (!match[0].startsWith("from")) return false;
+
+  const head = source.slice(0, match.index);
+  KEYWORD_RE.lastIndex = 0;
+  let start = -1;
+  for (const keyword of head.matchAll(KEYWORD_RE)) start = keyword.index;
+
+  return start >= 0 && TYPE_IMPORT_PREFIX_RE.test(head.slice(start));
+}
+
+function importsLinkedomAtRuntime(source: string): boolean {
+  SPECIFIER_RE.lastIndex = 0;
+  for (const match of source.matchAll(SPECIFIER_RE)) {
+    if (!isTypeOnlyImport(source, match)) return true;
+  }
+  return false;
+}
+
+// Bun.Glob brace expansion silently matches nothing, so scan one at a time.
+const SOURCE_GLOBS = ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts", "**/*.js", "**/*.mjs", "**/*.cjs"];
+
+// dom.ts is the door. This file describes the patterns it looks for, in
+// comments and in the two regexes above, so it cannot scan itself.
+const EXEMPT = new Set([
+  "packages/parser/src/dom.ts",
+  "packages/parser/tests/attribute-case.test.ts",
+]);
+
+describe("linkedom is reachable through one door", () => {
+  test.each([
+    [true, "a value import", `import { parseHTML } from "linkedom";`],
+    [true, "single quotes", `import { parseHTML } from 'linkedom';`],
+    [true, "a side-effect import", `import "linkedom";`],
+    [true, "a dynamic import", `const m = await import("linkedom");`],
+    [true, "require", `const l = require("linkedom");`],
+    [true, "a subpath", `import { DOMParser } from "linkedom/worker";`],
+    [true, "a re-export", `export { parseHTML } from "linkedom";`],
+    [true, "a value import after a semicolonless type import", `import type { X } from "other"\nimport { parseHTML } from "linkedom"`],
+    [true, "require after a semicolonless type import", `import type { Y } from "other"\nconst l = require("linkedom")`],
+    [true, "an inline type specifier, which still emits the import", `import { type Document } from "linkedom";`],
+    [false, "a type import", `import type { Document } from "linkedom";`],
+    [false, "a multiline type import", `import type {\n  Document,\n  Element,\n} from "linkedom";`],
+    [false, "a type import after another import", `import { a } from "b";\nimport type { Document } from "linkedom";`],
+    [false, "a type re-export", `export type { Document } from "linkedom";`],
+    [false, "a type import whose binding contains the word import", `import type { important } from "linkedom";`],
+  ])("flags %p: %s", (flagged, _label, source) => {
+    expect(importsLinkedomAtRuntime(source)).toBe(flagged);
+  });
+
+  // The patch makes every linkedom element in the process case-insensitive, but
+  // only once src/dom.ts has been loaded. A file reaching linkedom directly is
+  // a coin flip on module load order, and in a build that never loads dom.ts it
+  // is simply the old case-sensitive behaviour back.
+  test("nothing but src/dom.ts pulls linkedom in at runtime", async () => {
+    const root = `${import.meta.dir}/../../..`;
+    const offenders: string[] = [];
+    const seen = new Set<string>();
+
+    for (const pattern of SOURCE_GLOBS) {
+      for await (const rel of new Glob(pattern).scan({ cwd: root })) {
+        if (rel.includes("node_modules") || EXEMPT.has(rel) || seen.has(rel)) continue;
+        seen.add(rel);
+
+        const source = await Bun.file(`${root}/${rel}`).text();
+        if (importsLinkedomAtRuntime(source)) offenders.push(rel);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+    // The scan is only as good as its reach: prove it saw the tree.
+    expect(seen.size).toBeGreaterThan(500);
+  });
+});

--- a/packages/parser/tests/dom-text.test.ts
+++ b/packages/parser/tests/dom-text.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { parseHTML } from "linkedom";
+import { parseHTML } from "../src/dom";
 
 import { collectTextExcluding, tagExcluder } from "../src/extractors/dom-text";
 

--- a/packages/parser/tests/headings.test.ts
+++ b/packages/parser/tests/headings.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "../src/dom";
 
 import { parsePage } from "../src/index";
 import { extractHeadings } from "../src/extractors/headings";

--- a/packages/rules/src/content/broken-html.ts
+++ b/packages/rules/src/content/broken-html.ts
@@ -1,5 +1,5 @@
 // content/broken-html - Malformed HTML detection
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 

--- a/packages/rules/src/performance/cwv.ts
+++ b/packages/rules/src/performance/cwv.ts
@@ -1,6 +1,8 @@
 // Core Web Vitals static hints checker
-import { parseHTML, type Document } from "linkedom";
 // Analyzes HTML for performance indicators without runtime measurement
+import type { Document } from "linkedom";
+
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import type { CheckResult, CWVHints } from "@squirrelscan/core-contracts";
 

--- a/packages/rules/tests/anchor-text.test.ts
+++ b/packages/rules/tests/anchor-text.test.ts
@@ -3,7 +3,7 @@
 // not three findings.
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { anchorTextRule } from "../src/links/anchor-text";
 import type { ParsedPage, RuleContext } from "../src/types";

--- a/packages/rules/tests/asset-divergence.test.ts
+++ b/packages/rules/tests/asset-divergence.test.ts
@@ -11,7 +11,7 @@
 // the two must be byte-identical.
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import type { CheckResult, PageFeatureRow, SiteQuery } from "@squirrelscan/core-contracts";
 

--- a/packages/rules/tests/broken-html-reuse.test.ts
+++ b/packages/rules/tests/broken-html-reuse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 import { content } from "@squirrelscan/rules";
 import type { RuleContext } from "@squirrelscan/rules";
 

--- a/packages/rules/tests/canonical-chain-redirect-evidence.test.ts
+++ b/packages/rules/tests/canonical-chain-redirect-evidence.test.ts
@@ -9,7 +9,7 @@
 // from the field report.
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import type { RedirectChain, RedirectHop } from "@squirrelscan/core-contracts";
 import type { RuleContext } from "../src/types";

--- a/packages/rules/tests/content-no-dom-mutation.test.ts
+++ b/packages/rules/tests/content-no-dom-mutation.test.ts
@@ -8,7 +8,7 @@
 // that the helper output matches the old "remove then read textContent".
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { keywordStuffingRule } from "../src/content/keyword-stuffing";
 import { readingLevelRule } from "../src/content/reading-level";

--- a/packages/rules/tests/cwv-reuse.test.ts
+++ b/packages/rules/tests/cwv-reuse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 import { getCWVHints } from "../src/performance/cwv";
 
 const HTML = `<!doctype html><html><head>

--- a/packages/rules/tests/forms-ux.test.ts
+++ b/packages/rules/tests/forms-ux.test.ts
@@ -231,6 +231,16 @@ describe("a11y/input-types — the right type", () => {
     expect(check(inputTypesRule.run(ctx(html)).checks, "input-types")?.status).toBe("pass");
   });
 
+  test("the escape hatch survives a camelCase inputMode (#1507)", () => {
+    // squirrelscan.com's own tools pages: React passes inputMode straight
+    // through, the exemption read "inputmode", missed it, and the rule warned
+    // on correct markup across five pages.
+    const html = page(
+      `<form action="/x"><label for="u">Site URL</label><input id="u" name="websiteUrl" type="text" inputMode="url"></form>`,
+    );
+    expect(check(inputTypesRule.run(ctx(html)).checks, "input-types")?.status).toBe("pass");
+  });
+
   test("skipped: no input on the page implies a particular type", () => {
     const html = page(
       `<form action="/x"><label for="m">Message</label><textarea id="m" name="message"></textarea><input id="n" name="fullName" type="text" autocomplete="name"></form>`,

--- a/packages/rules/tests/hidden-text.test.ts
+++ b/packages/rules/tests/hidden-text.test.ts
@@ -6,7 +6,7 @@
 // replacement) must come back clean, or the rule libels the sites using them.
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { hiddenTextRule, parseColor, parseLengthPx } from "../src/content/hidden-text";
 import type { ParsedPage, RuleContext } from "../src/types";

--- a/packages/rules/tests/keyword-stuffing.test.ts
+++ b/packages/rules/tests/keyword-stuffing.test.ts
@@ -4,7 +4,7 @@
 // density check on ordinary pages. Real prose stuffing must still flag.
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { keywordStuffingRule } from "../src/content/keyword-stuffing";
 import type { ParsedPage, RuleContext } from "../src/types";

--- a/packages/rules/tests/lazy-above-fold.test.ts
+++ b/packages/rules/tests/lazy-above-fold.test.ts
@@ -5,7 +5,7 @@
 // genuinely visible images must still flag.
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { lazyAboveFoldRule } from "../src/performance/lazy-above-fold";
 import type { ParsedPage, RuleContext } from "../src/types";

--- a/packages/rules/tests/mojibake.test.ts
+++ b/packages/rules/tests/mojibake.test.ts
@@ -4,7 +4,7 @@
 // clean-accents fixture matters more than any of the detection cases.
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { declaredCharset, findMojibake, mojibakeRule } from "../src/content/mojibake";
 import type { ParsedPage, RuleContext } from "../src/types";

--- a/packages/rules/tests/noai-signals.test.ts
+++ b/packages/rules/tests/noai-signals.test.ts
@@ -1,7 +1,7 @@
 // ax/noai-signals — noai / noimageai / snippet-limit reporting (page scope).
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import type { CheckResult } from "@squirrelscan/core-contracts";
 

--- a/packages/rules/tests/sitemap-lastmod-drift.test.ts
+++ b/packages/rules/tests/sitemap-lastmod-drift.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { sitemapLastmodDriftRule } from "../src/crawl/sitemap-lastmod-drift";
 import type { ParsedPage, RuleContext, SiteData } from "../src/types";

--- a/packages/rules/tests/stale-copyright.test.ts
+++ b/packages/rules/tests/stale-copyright.test.ts
@@ -4,7 +4,7 @@
 // year and fail every 1 January, which is the worst possible time to learn about it.
 
 import { describe, expect, test } from "bun:test";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "@squirrelscan/parser/dom";
 
 import { latestCopyrightYear, staleCopyrightRule } from "../src/content/stale-copyright";
 import type { ParsedPage, RuleContext } from "../src/types";


### PR DESCRIPTION
`packages/parser` uses linkedom, which stores the source spelling of an attribute name and compares it exactly. A browser ASCII-lowercases attribute names while parsing HTML, and `getAttribute` lowercases its argument for any element in the HTML namespace. Neither happened here, so every rule that reads an attribute by name was exposed in **both** directions:

```
a  getAttribute('inputmode') => null   | getAttribute('inputMode') => "url"
b  getAttribute('inputmode') => "url"  | getAttribute('inputMode') => null
c  attrs: [ "id", "DATA-Foo", "aria-LABEL" ]
```

A browser answers `"url"` for both `a` and `b`, and reports `c`'s attributes as `id`, `data-foo`, `aria-label`.

Mostly latent, because most sites emit lowercase. React-adjacent SSR does not: it passes unknown props straight through, and camelCase attributes are ordinary valid markup. The visible symptom was `a11y/input-types`, whose `inputmode` escape hatch missed squirrelscan.com's own `inputMode="url"` and warned on correct markup across five pages.

## What changed

**`packages/parser/src/dom.ts`** is new, and is now the single `parseHTML` entry point. On import it wraps the `Element` prototype linkedom exports so that `getAttributeNode` resolves names ASCII case-insensitively for HTML elements. That one method covers the whole read surface: `getAttribute`, `hasAttribute`, `getAttributeNS`, `className`/`classList`, and — because linkedom's css-select adapter routes selector matching through it — `querySelector("[inputmode]")` too.

Design notes, in the order they will be questioned:

- **Lookup, not renaming.** Parsing never rewrites a name, so serialisation stays byte-identical and anything walking `el.attributes` still sees what the author wrote. A per-element index of the mixed-case names, built lazily and cached in a WeakMap, keeps a miss to one WeakMap read rather than a walk that allocates a NamedNodeMap and a Proxy.
- **SVG is untouched.** There attribute names really are case-sensitive: `viewBox` and `preserveAspectRatio` still match only their exact spelling, in reads and in writes.
- **`setAttribute` does lowercase**, for HTML elements only, because a browser's does. This is also what fixes a class of desync: linkedom keeps its cached class list in step only for the literal name `class`, so `setAttribute("CLASS", …)` used to write the value and leave `className` and every class selector on the old one. `setAttributeNS` is patched not to lowercase, since a browser's does not either.
- **An uppercase `CLASS` attribute now works at all.** Before this, `<div CLASS="alpha">` gave `className === ""`, an empty `classList` and no `.alpha` match, because linkedom builds its DOMTokenList through `getAttributeNode("class")`.
- **The patch is global, not scoped to documents parsed here.** Scoping it was implemented and then removed: linkedom does not repoint `ownerDocument` when a node moves between documents, and `Document.cloneNode()` produces an unregistered one, so the scope check turned the fix silently *off* on exactly those paths — the failure mode of this bug itself. Nothing in this repo parses XML, and the guard test below keeps linkedom reachable only through this module.
- **State lives under a `Symbol.for` on the global**, so two evaluations of the module (a bundler emitting two copies) share one cache and one install flag instead of the second shadowing the first.

**Every `parseHTML` callsite** now imports from `@squirrelscan/parser/dom` — production and tests alike, so tests exercise the semantics production has. A guard test fails if anything else pulls linkedom in at runtime; it covers static, side-effect, dynamic and `require` forms, both quote styles and subpaths, allows type-only imports, and has its own table test because the classifier is subtle.

## Known gaps, deliberate and pinned by tests

- **MathML** gets the HTML rules. linkedom specialises SVG but not MathML, so a `<math>` subtree reports the XHTML namespace. Two approximations of "which of these elements are really MathML" were tried and both were wrong: doing it correctly needs the tree-construction context (integration points, breakout tags) that linkedom never recorded. The only attribute at stake is `definitionURL`, the sole camelCase name the HTML parser produces for MathML, and no rule reads it.
- **`el.dataset`** does not see a mixed-case `data-` attribute. linkedom builds its DOMStringMap by walking `el.attributes` for a literal `data-` prefix. `getAttribute("data-foo")` works; nothing in the engine reads `dataset`.
- **Two attributes differing only in case.** A browser drops the second at parse time; here an exact match is tried before the mixed-case index, so a later lowercase twin beats an earlier `DATA-Foo`. Being exact would mean indexing every attribute of every element on every lookup, to settle markup that is invalid either way.

## Acceptance criteria

- [x] `getAttribute("inputmode")` returns the value for markup authored as `inputMode`
- [x] `getAttributeNames()` reports lowercased names (ASCII-only: U+212A KELVIN SIGN is left alone, as in a browser)
- [x] Golden baseline re-pinned if any verdict moves — **nothing moved**, so nothing to re-pin. The synthetic fixture is authored entirely in lowercase, so the fix is a no-op on it: `pages=518 findings=98220 rules=278 healthScore=48 errors=1000 warnings=4520 passed=37315`, byte-identical to `main`.
- [x] squirrelscan.com's tools pages no longer warn on `a11y/input-types` — covered by a new test in `packages/rules/tests/forms-ux.test.ts` reproducing the exact markup (`type="text" inputMode="url"` on a URL field). Verified it fails without the fix and passes with it.

## Tests changed

No existing test encoded the old case-sensitive behaviour, so none had to be rewritten to accommodate the fix. The only test edits are the 23 one-line import rewires onto `@squirrelscan/parser/dom`, plus two additions: `packages/parser/tests/attribute-case.test.ts` (new, 44 tests) and one case in `packages/rules/tests/forms-ux.test.ts`.

## Verification

- `packages/parser` 106 pass, `packages/rules` 1518 pass, `apps/cli` 1814 pass + 1 skip, all 0 fail
- `bun run test:engine` — 63 pass, golden baseline unchanged (numbers above)
- `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
- The compiled standalone binary, run against a page with `type="text" inputMode="url"`, reports no `a11y/input-types` finding while still reporting `a11y/autocomplete-tokens` for the same form, so the form was analysed and the exemption fired rather than the rule being skipped.
- Four rounds of adversarial review (OpenAI Codex). It found, and this branch fixes: a WeakMap invalidated *before* the mutation (linkedom's own `setAttribute` calls `getAttributeNode` first, so the index was rebuilt from the pre-insert state and the new attribute became permanently invisible); Unicode rather than ASCII case folding; the mixed-case `CLASS` desync; `setAttributeNS` inheriting the lowercasing; a split-brain between two module copies; a guard regex whose `[^;]` crossed newlines and could swallow a real runtime import in semicolonless code; and a class-list resync that normalised the whitespace of the value it was handed. One more of that last family was found by re-reading the finished code rather than by the reviewer: `setAttributeNS`, which deliberately skips the lowercasing, could reach the `class` attribute without refreshing the class list. All three write paths now share one resync helper. Its remaining objection was to an earlier attempt to classify MathML elements, which is why that attempt was removed rather than refined.

## Rebased onto #147

#147 has merged and this branch is rebased on top of it. The two overlapping import blocks were resolved as the union, keeping both changes:

- `packages/parser/src/html.ts` keeps `getAttrCI` (still used at the `alt` read #147 added) and routes `parseHTML` through `./dom`.
- `apps/cli/tests/graph/extractors/images.test.ts` keeps #147's `getImagesWithoutAlt` import and takes `parseHTML` from `@squirrelscan/parser/dom`.

No semantic conflict: `getAttrCI` walks `el.attributes` directly, so it is unaffected by this change and keeps working. This PR makes it redundant for HTML elements, but nothing in #147 needed to change and the helper is left in place with its dozen rule callers.

The rebase also surfaced three test files that landed on main from other PRs and reach linkedom directly — `packages/parser/tests/dom-text.test.ts`, `packages/rules/tests/canonical-chain-redirect-evidence.test.ts` (#157) and `packages/rules/tests/sitemap-lastmod-drift.test.ts` (#161). The single-door guard flagged all three. They are rewired onto `@squirrelscan/parser/dom` rather than exempted: each builds a document and hands it to production code (an extractor, two rules), so leaving them on raw linkedom would test that code against a DOM whose attribute semantics depend on which other test file loaded first. That load-order coin flip is the thing the guard exists to prevent, and exempting ordinary test files would hollow it out for exactly the file class it was written for. All three pass unchanged after the rewire.
