### PR TITLE
fix(docs): correct per-category rule counts on group overview pages

### DIFF
--- a/docs/rules/seo/index.mdx
+++ b/docs/rules/seo/index.mdx
@@ -16,34 +16,34 @@ are skipped when you're not logged in.
 
 <CardGroup cols={2}>
   <Card title="Crawlability" icon="folder" href="/rules/crawl">
-    Robots.txt, sitemaps, and crawl directives (18 rules)
+    Robots.txt, sitemaps, and crawl directives (20 rules)
   </Card>
   <Card title="Core SEO" icon="folder" href="/rules/core">
-    Essential meta tags and page structure for search engines (13 rules)
+    Essential meta tags and page structure for search engines (14 rules)
   </Card>
   <Card title="Links" icon="folder" href="/rules/links">
-    Internal and external link health and structure (14 rules)
+    Internal and external link health and structure (15 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (12 rules)
+    Text quality, readability, and content structure (18 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
-    Structured data and rich snippet eligibility (10 rules)
+    Structured data and rich snippet eligibility (12 rules)
   </Card>
   <Card title="Images" icon="folder" href="/rules/images">
     Image optimization and accessibility (15 rules)
   </Card>
   <Card title="Social Media" icon="folder" href="/rules/social">
-    Open Graph and social sharing metadata (4 rules)
+    Open Graph and social sharing metadata (5 rules)
   </Card>
   <Card title="Accessibility" icon="folder" href="/rules/a11y">
-    Accessibility for users with disabilities (59 rules)
+    Accessibility for users with disabilities (61 rules)
   </Card>
   <Card title="Mobile" icon="folder" href="/rules/mobile">
     Mobile-friendliness and responsive design (6 rules)
   </Card>
   <Card title="URL Structure" icon="folder" href="/rules/url">
-    URL structure, length, and formatting (8 rules)
+    URL structure, length, and formatting (9 rules)
   </Card>
   <Card title="Internationalization" icon="folder" href="/rules/i18n">
     Language declarations and multi-region support (2 rules)


### PR DESCRIPTION
## What

`docs/rules/seo/index.mdx` is a *group overview* page: it repeats each category's
rule count in its own cards. Only the canonical index (`docs/rules/index.mdx`) is
covered by the count guard, so this second copy drifted silently. Eight cards were
stale against the live catalog:

| category | doc said | live |
|---|---:|---:|
| crawl | 18 | 20 |
| core | 13 | 14 |
| links | 14 | 15 |
| content | 12 | 18 |
| schema | 10 | 12 |
| social | 4 | 5 |
| a11y | 59 | 61 |
| url | 8 | 9 |

## How the numbers were derived

Recomputed from this repo, not copied from anywhere: `loadAllRules()` in
`packages/rules`, tallied by `rule.meta.category`. At this commit that is
**278 rules across 21 categories**.

## Also checked, no change needed

- `docs/rules/agents/index.mdx` (ax 17), `docs/rules/performance/index.mdx`
  (perf 29, card and prose), `docs/rules/security/index.mdx` (integrity 9,
  legal 4, blocking 3, security 16) are all current.
- The exact totals on `docs/index.mdx` (278 / 21, including the per-category
  table, which sums to 278) and `docs/agent-setup/index.mdx` (278) are current.
- "spanning 16 categories" on the SEO page is correct: 15 live categories map to
  the SEO group in `packages/report/src/categories.ts`, plus the docs-only
  Gap Analysis card.

## Validation

`make validate` in `docs/`: `Pages: 384  Orphans: 1  ✓ All checks passed`.
`make build`: 387 pages built, clean.

## Follow-up (not in this PR)

`docs/configuration/rules.mdx` is stale in the same way but needs a content
rewrite rather than a numeric fix: it claims "All 18 audit rule categories",
lists 20 sections (Site Integrity is missing entirely), documents the legacy
`ai/*` alias instead of the canonical `ax/*`, and has 14 stale `**Rules:** N`
values. Tracked separately so this fix stays reviewable.

Refs squirrelscan/repo#1661, which adds the guard that stops these pages
drifting again.
