### PR TITLE
feat(cli): apply a known pending auto-update before running the command #170

### DIFF
--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -102,7 +102,6 @@ import {
   printAutoUpdateDisabledReminder,
   promptForUpdate,
   printFooter,
-  printAutoUpdateAppliedNotice,
   lockedRulesFooterLine,
 } from "../banner";
 import {
@@ -876,7 +875,9 @@ export const audit = defineCommand({
       }
       printHeader(settings.ok ? settings.data.channel : "stable");
       if (settings.ok && !args.offline) {
-        await printAutoUpdateAppliedNotice(settings.data);
+        // The "✓ auto-updated" notice is printed once per RUN by cli/index.ts,
+        // not per command — every command has to announce an update applied
+        // before it, not just this one (#170).
         printUpdateNotification(settings.data);
         if (shouldShowAutoUpdateDisabledReminder(settings.data)) {
           updateSettings({

--- a/apps/cli/src/cli/commands/crawl.ts
+++ b/apps/cli/src/cli/commands/crawl.ts
@@ -24,7 +24,6 @@ import {
   printAutoUpdateDisabledReminder,
   promptForUpdate,
   printFooter,
-  printAutoUpdateAppliedNotice,
 } from "../banner";
 import { printDatabaseLockWarningIfNeeded } from "../db-lock-warning";
 import { fmt, pageLimitHint } from "../format";
@@ -158,7 +157,7 @@ export const crawl = defineCommand({
 
       printHeader(channel);
       if (settings.ok) {
-        await printAutoUpdateAppliedNotice(settings.data);
+        // See audit.ts: the auto-updated notice belongs to the run (#170).
         printUpdateNotification(settings.data);
         if (shouldShowAutoUpdateDisabledReminder(settings.data)) {
           updateSettings({

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -4,6 +4,7 @@ import { defineCommand, runMain } from "citty";
 
 import type { UserSettings } from "@/self/types";
 
+import { printAutoUpdateAppliedNotice } from "@/cli/banner";
 import { setGlobalConfigPath } from "@/config";
 import { registerInstall } from "@/self/register-install";
 import { loadSettings } from "@/self/settings";
@@ -72,30 +73,8 @@ export function run(): void {
     setLogLevel(settings.data.log_level);
   }
 
-  // Skip background tasks for simple commands and self install/update/uninstall
-  // (self install resets settings, causing race condition with registerInstall;
-  // self update is itself the updater — including the detached --auto child —
-  // and must not spawn further checks or installs)
-  const args = process.argv.slice(2);
-  const isSelfInstallCommand =
-    args[0] === "self" &&
-    (args[1] === "install" || args[1] === "update" || args[1] === "uninstall");
-  // mcp speaks JSON-RPC on stdout — skip background tasks so nothing pollutes the stream.
-  const isMcpCommand = args[0] === "mcp";
-  const isSimpleCommand =
-    args.length === 0 ||
-    args.includes("--version") ||
-    args.includes("-v") ||
-    args.includes("--help") ||
-    args.includes("-h") ||
-    isSelfInstallCommand ||
-    isMcpCommand;
-
-  // --offline promises zero network: skip update check + install registration
-  const isOffline = args.includes("--offline");
-
   const effectiveSettings = settings.ok ? settings.data : undefined;
-  const withBackgroundTasks = !isSimpleCommand && !isOffline;
+  const withBackgroundTasks = shouldRunBackgroundTasks(process.argv.slice(2));
 
   // An update a previous run already discovered is applied BEFORE the command,
   // and the original argv re-executed on the new binary, so a fresh run always
@@ -118,6 +97,35 @@ export function run(): void {
   startCommand(effectiveSettings, withBackgroundTasks);
 }
 
+/**
+ * Whether this invocation gets the startup extras: the telemetry notice, the
+ * update check/apply, install registration and log rotation.
+ *
+ * Skipped for simple commands and self install/update/uninstall (self install
+ * resets settings, racing registerInstall; self update IS the updater —
+ * including the detached --auto child — and must not spawn further checks or
+ * installs), for `mcp` (JSON-RPC on stdout, nothing may pollute the stream),
+ * and for --offline, which promises zero network.
+ *
+ * Exported for tests: it decides, among other things, which commands can print
+ * the auto-updated notice.
+ */
+export function shouldRunBackgroundTasks(args: string[]): boolean {
+  const isSelfInstallCommand =
+    args[0] === "self" &&
+    (args[1] === "install" || args[1] === "update" || args[1] === "uninstall");
+  const isSimpleCommand =
+    args.length === 0 ||
+    args.includes("--version") ||
+    args.includes("-v") ||
+    args.includes("--help") ||
+    args.includes("-h") ||
+    isSelfInstallCommand ||
+    args[0] === "mcp";
+
+  return !isSimpleCommand && !args.includes("--offline");
+}
+
 function startCommand(
   settings: UserSettings | undefined,
   withBackgroundTasks: boolean
@@ -130,6 +138,21 @@ function startCommand(
     rotateLogsIfNeeded().catch(() => {}); // Best effort, silent fail
   }
 
+  // The one-time "✓ auto-updated" confirmation belongs to the RUN, not to any
+  // one command: an update applied before `squirrel config` must be announced
+  // by `squirrel config` (#170). Gated synchronously on the marker so the
+  // ordinary run stays free of the await. printAutoUpdateAppliedNotice itself
+  // only prints when this process IS the new version, and clears the marker.
+  if (withBackgroundTasks && settings?.auto_update_applied) {
+    void printAutoUpdateAppliedNotice(settings)
+      .catch(() => {})
+      .then(runCommand);
+    return;
+  }
+  runCommand();
+}
+
+function runCommand(): void {
   // After the command settles, bound any in-process (Windows) auto-update so
   // a still-downloading binary can't hold the CLI open indefinitely (#1074).
   void runMain(main).finally(() => void finishInlineAutoUpdate());

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -2,12 +2,16 @@
 
 import { defineCommand, runMain } from "citty";
 
+import type { UserSettings } from "@/self/types";
+
 import { setGlobalConfigPath } from "@/config";
 import { registerInstall } from "@/self/register-install";
 import { loadSettings } from "@/self/settings";
 import { showTelemetryNotice } from "@/self/telemetry";
 import {
+  applyPendingUpdateInForeground,
   finishInlineAutoUpdate,
+  foregroundUpdateTarget,
   runBackgroundUpdateCheck,
 } from "@/self/updater";
 import { rotateLogsIfNeeded } from "@/utils/log-rotation";
@@ -90,12 +94,39 @@ export function run(): void {
   // --offline promises zero network: skip update check + install registration
   const isOffline = args.includes("--offline");
 
-  if (!isSimpleCommand && !isOffline) {
+  const effectiveSettings = settings.ok ? settings.data : undefined;
+  const withBackgroundTasks = !isSimpleCommand && !isOffline;
+
+  // An update a previous run already discovered is applied BEFORE the command,
+  // and the original argv re-executed on the new binary, so a fresh run always
+  // gets the newest version the CLI knows about (#170). The decision is
+  // synchronous and settings-only: with nothing pending — the overwhelmingly
+  // common case — this is a null check and startup is byte-for-byte the old
+  // path, no await and no network.
+  if (
+    withBackgroundTasks &&
+    effectiveSettings &&
+    foregroundUpdateTarget(effectiveSettings)
+  ) {
+    void applyPendingUpdateInForeground(effectiveSettings)
+      // Failure-safe: a broken update must never break the user's command.
+      .catch(() => {})
+      .then(() => startCommand(effectiveSettings, withBackgroundTasks));
+    return;
+  }
+
+  startCommand(effectiveSettings, withBackgroundTasks);
+}
+
+function startCommand(
+  settings: UserSettings | undefined,
+  withBackgroundTasks: boolean
+): void {
+  if (withBackgroundTasks) {
     // Non-blocking background tasks
-    const effectiveSettings = settings.ok ? settings.data : undefined;
-    if (effectiveSettings) showTelemetryNotice(effectiveSettings);
-    runBackgroundUpdateCheck(effectiveSettings);
-    registerInstall(effectiveSettings);
+    if (settings) showTelemetryNotice(settings);
+    runBackgroundUpdateCheck(settings);
+    registerInstall(settings);
     rotateLogsIfNeeded().catch(() => {}); // Best effort, silent fail
   }
 

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -386,6 +386,15 @@ function spawnDetachedAutoUpdate(): boolean {
       detached: true,
       stdio: "ignore",
     });
+    // spawn() only throws for bad arguments; a real failure to start (ENOENT,
+    // EAGAIN, EMFILE) arrives later as an 'error' event, and an unhandled
+    // 'error' on an EventEmitter takes the whole CLI down with it. Attach the
+    // listener BEFORE unref so a failed background dispatch stays background.
+    child.once("error", (error: Error) => {
+      logger.debug("update-check: background auto-update failed to start", {
+        error: error.message,
+      });
+    });
     child.unref();
     return true;
   } catch (error) {
@@ -499,11 +508,20 @@ export async function applyPendingUpdateInForeground(
   if (!target) return "skipped";
 
   // Narrow the window between the startup settings snapshot and the install:
-  // another run may already have applied this exact update while this one was
-  // starting. Re-exec into what it installed instead of downloading it twice.
+  // the notification may have been consumed while this run was starting.
   const current = loadSettings();
   if (current.ok && !current.data.pending_update_notification) {
-    const alreadyInstalled = releaseBinaryIfPresent(target);
+    // Only a completed install may be re-executed. A release binary on disk is
+    // NOT evidence of one — old releases are kept for rollback, and
+    // `self update --dismiss` clears the notification without installing
+    // anything — so require the applied marker for this exact target, and take
+    // a dismissal recorded since the snapshot as a veto.
+    const applied = current.data.auto_update_applied;
+    const alreadyInstalled =
+      applied?.to_version === target &&
+      current.data.dismissed_update_version !== target
+        ? releaseBinaryIfPresent(target)
+        : null;
     if (alreadyInstalled) {
       logger.debug("foreground-update: already installed by another run", {
         to_version: target,

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -70,6 +70,8 @@ const REEXEC_FORWARDED_SIGNALS = [
   "SIGTERM",
   "SIGHUP",
   "SIGQUIT",
+  "SIGUSR1",
+  "SIGUSR2",
 ] as const;
 // How long to wait for a re-raised signal to actually kill this process before
 // falling back to exiting with the shell's encoding for it.
@@ -453,7 +455,15 @@ function bumpAutoUpdateAttempts(
  */
 export function foregroundUpdateTarget(settings: UserSettings): string | null {
   // Loop guard first: cheapest check, and the one that must never be bypassed.
-  if (process.env[FOREGROUND_UPDATE_ENV]) return null;
+  if (process.env[FOREGROUND_UPDATE_ENV]) {
+    // CONSUME it. The marker's job is to stop THIS process from updating a
+    // second time; leaving it set would also mute every squirrel the command
+    // goes on to spawn, and a nested invocation is a separate run entitled to
+    // its own update. Children spawned before this point are vanishingly
+    // unlikely (nothing runs before the startup gate).
+    delete process.env[FOREGROUND_UPDATE_ENV];
+    return null;
+  }
 
   const notification = settings.pending_update_notification;
   // Fast path — nothing recorded, so nothing to do and nothing to fetch.
@@ -474,8 +484,28 @@ export function foregroundUpdateTarget(settings: UserSettings): string | null {
   if (settings.dismissed_update_version === notification.to_version)
     return null;
   if (isAutoUpdateAttemptThrottled(settings)) return null;
+  // Another updater already owns the install. Gate on it HERE, not by letting
+  // runAutoUpdate fail on the lock: reaching that point would already have
+  // announced an update to the user and burnt the hourly throttle for work
+  // someone else is doing.
+  if (isUpdateLockHeld()) return null;
 
   return notification.to_version;
+}
+
+/**
+ * Whether a live update lock exists, WITHOUT taking it — a read-only preview of
+ * acquireUpdateLock's verdict for gating. A lock past the staleness bound is
+ * treated as abandoned, exactly as the acquire does. Unreadable/absent reads as
+ * free: the real acquire still runs and is the authority.
+ */
+function isUpdateLockHeld(): boolean {
+  try {
+    const stat = statSync(getUpdateLockPath());
+    return Date.now() - stat.mtimeMs <= UPDATE_LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
 }
 
 /** What a foreground update attempt did. Success never returns — see below. */
@@ -912,7 +942,10 @@ export async function runAutoUpdate(options?: {
     const manifest = updateResult.data.manifest;
     if (settings.dismissed_update_version === manifest.version) return null;
 
-    const applyResult = await performUpdate(manifest, settings, options);
+    const applyResult = await performUpdate(manifest, settings, {
+      ...options,
+      abortIfDismissed: true,
+    });
     if (!applyResult.ok) {
       if (options?.signal?.aborted) {
         // Expected when the command finished before the download — not an
@@ -962,13 +995,30 @@ export async function runAutoUpdate(options?: {
 async function performUpdate(
   manifest: ReleaseManifest,
   settings: UserSettings,
-  options?: { signal?: AbortSignal }
+  options?: { signal?: AbortSignal; abortIfDismissed?: boolean }
 ): Promise<Result<void>> {
   const platformArch = detectPlatformArch();
   const downloadResult = await downloadBinary(manifest, platformArch, {
     signal: options?.signal,
   });
   if (!downloadResult.ok) return downloadResult;
+
+  // A download takes long enough for `self update --dismiss` to land in the
+  // middle of one. Re-read immediately before the swap so an unattended update
+  // never installs a version the user has just refused. Explicit
+  // `squirrel self update` deliberately does NOT pass this: asking for an
+  // update outranks an earlier dismissal.
+  if (options?.abortIfDismissed) {
+    const fresh = loadSettings();
+    if (fresh.ok && fresh.data.dismissed_update_version === manifest.version) {
+      return err(
+        commandError(
+          "UPDATE_DISMISSED",
+          `v${manifest.version} was dismissed while it was downloading`
+        )
+      );
+    }
+  }
 
   const installResult = await installVersion(
     manifest.version,

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -10,7 +10,7 @@ import {
   unlinkSync,
   chmodSync,
 } from "node:fs";
-import { platform } from "node:os";
+import { constants as osConstants, platform } from "node:os";
 import { basename, dirname, join } from "node:path";
 
 import { AUTO_UPDATE_FALLBACK_THRESHOLD } from "@/constants";
@@ -51,6 +51,21 @@ const INLINE_UPDATE_EXIT_GRACE_MS = 10_000;
 // GitHub retries must finish well inside it, or a second updater could
 // take over mid-install.
 const UPDATE_LOCK_STALE_MS = 30 * 60 * 1000;
+
+/**
+ * Set on the process re-executed after a foreground update (#170). Its only
+ * job is loop-proofing: the new binary must never itself try to apply another
+ * update at startup, no matter what the settings on disk say. Inherited by
+ * everything the re-executed run spawns, which is what we want — a squirrel
+ * invoked from inside that run is part of the same already-updated session.
+ */
+export const FOREGROUND_UPDATE_ENV = "SQUIRREL_UPDATE_REEXEC";
+
+// Signals to hold while the re-executed child owns the terminal. Ctrl-C at a
+// tty is delivered to the whole foreground process group, so the child gets it
+// too; without these the waiting parent would die on the spot, hand the shell
+// its prompt back and leave the child writing over it.
+const REEXEC_HELD_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
 
 /**
  * Whether this install can silently self-update: the user hasn't turned
@@ -309,14 +324,9 @@ export function maybeSpawnAutoUpdate(settings: UserSettings): void {
     return;
   }
 
-  if (settings.last_auto_update_attempt) {
-    const hoursSinceAttempt =
-      (Date.now() - new Date(settings.last_auto_update_attempt).getTime()) /
-      (1000 * 60 * 60);
-    // Silent: fires on every run inside the window; the attempt it throttles
-    // against was already reported.
-    if (hoursSinceAttempt < AUTO_UPDATE_ATTEMPT_INTERVAL_HOURS) return;
-  }
+  // Silent: fires on every run inside the window; the attempt it throttles
+  // against was already reported.
+  if (isAutoUpdateAttemptThrottled(settings)) return;
 
   // Record intent-to-attempt before dispatch — a crashing/killed updater must
   // not retry on every subsequent run. This is the THROTTLE only; it does not
@@ -329,21 +339,8 @@ export function maybeSpawnAutoUpdate(settings: UserSettings): void {
     return;
   }
 
-  // Advance the per-version failed-attempt counter ONLY when an update
-  // genuinely starts (#1085): an inline start deferred by commandSettled, or a
-  // spawn that throws, never runs — counting it would trip the loud fallback
-  // ("didn't complete on this system") for an attempt the updater never got to
-  // make. Bumping at genuine start still counts #1074's killed-mid-update runs
-  // (the updater started, then died). Increment for the same target, reset to 1
-  // when the pending version changed; performUpdate clears it on success.
-  const bumpAttemptCounter = () => {
-    const prev = settings.auto_update_attempts;
-    const count =
-      prev && prev.version === notification.to_version ? prev.count + 1 : 1;
-    updateSettings({
-      auto_update_attempts: { version: notification.to_version, count },
-    });
-  };
+  const bumpAttemptCounter = () =>
+    bumpAutoUpdateAttempts(settings, notification.to_version);
 
   if (platform() === "win32") {
     if (startInlineAutoUpdate()) {
@@ -371,6 +368,193 @@ export function maybeSpawnAutoUpdate(settings: UserSettings): void {
       error: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+/**
+ * Hourly throttle shared by every auto-install dispatch path (background spawn,
+ * Windows inline, foreground apply): one download attempt per hour, however
+ * often the CLI runs. A corrupt timestamp parses to NaN and every comparison
+ * with NaN is false, so it reads as "not throttled" — the safe direction.
+ */
+function isAutoUpdateAttemptThrottled(settings: UserSettings): boolean {
+  if (!settings.last_auto_update_attempt) return false;
+  const hoursSinceAttempt =
+    (Date.now() - Date.parse(settings.last_auto_update_attempt)) /
+    (1000 * 60 * 60);
+  return hoursSinceAttempt < AUTO_UPDATE_ATTEMPT_INTERVAL_HOURS;
+}
+
+/**
+ * Advance the per-version failed-attempt counter, but ONLY when an update
+ * genuinely starts (#1085): an inline start deferred by commandSettled, or a
+ * spawn that throws, never runs — counting it would trip the loud fallback
+ * ("didn't complete on this system") for an attempt the updater never got to
+ * make. Bumping at genuine start still counts #1074's killed-mid-update runs
+ * (the updater started, then died). Increment for the same target, reset to 1
+ * when the pending version changed; performUpdate clears it on success.
+ */
+function bumpAutoUpdateAttempts(
+  settings: UserSettings,
+  toVersion: string
+): void {
+  const prev = settings.auto_update_attempts;
+  const count = prev && prev.version === toVersion ? prev.count + 1 : 1;
+  updateSettings({ auto_update_attempts: { version: toVersion, count } });
+}
+
+/**
+ * The version this run should install BEFORE executing the user's command, or
+ * null to leave startup exactly as it was (#170).
+ *
+ * Cheap and synchronous on purpose: the overwhelmingly common answer is null,
+ * and the caller must be able to decide without awaiting anything or touching
+ * the network. It acts only on a notification an earlier background check
+ * already stored — it never performs a check of its own, so the
+ * `update_check_interval_hours` cadence is untouched.
+ *
+ * Deliberately silent about its skips: the very same settings go through
+ * maybeSpawnAutoUpdate later in this run, which owns the update_auto_skipped
+ * telemetry. Emitting here would double-count every skip reason.
+ */
+export function foregroundUpdateTarget(settings: UserSettings): string | null {
+  // Loop guard first: cheapest check, and the one that must never be bypassed.
+  if (process.env[FOREGROUND_UPDATE_ENV]) return null;
+
+  const notification = settings.pending_update_notification;
+  // Fast path — nothing recorded, so nothing to do and nothing to fetch.
+  if (!notification) return null;
+  // Belt-and-braces: a notification pointing at the running version would
+  // re-exec into an identical binary forever if it somehow survived an install.
+  if (notification.to_version === version) return null;
+
+  // Windows keeps the existing in-process background updater: the running exe
+  // is the thing being replaced there (a copy, not a symlink — see
+  // link-binary.ts), so a synchronous swap-then-re-exec has to reason about a
+  // loaded image being renamed out from under the process that is about to
+  // spawn from it. Not worth the #1538 class of breakage for the win.
+  if (platform() === "win32") return null;
+
+  if (updateSuppressedReason()) return null; // CI / SQUIRREL_NO_UPDATE
+  if (!isAutoUpdateEligible(settings)) return null; // opted out / unmanaged
+  if (settings.dismissed_update_version === notification.to_version)
+    return null;
+  if (isAutoUpdateAttemptThrottled(settings)) return null;
+
+  return notification.to_version;
+}
+
+/** What a foreground update attempt did. Success never returns — see below. */
+export type ForegroundUpdateOutcome = "skipped" | "failed";
+
+/**
+ * Apply an already-known pending update, then run the original command on the
+ * new binary (#170). On success this never returns: spawnSync runs the new
+ * binary with this run's argv and stdio, and the process exits with the child's
+ * status.
+ *
+ * Every other path returns, and the caller runs the command on the current
+ * binary exactly as before — a failed update must never be a failed command.
+ *
+ * `deps` exists so the orchestration (order, fallbacks, loop guard) is testable
+ * without a network or a real binary swap.
+ */
+export async function applyPendingUpdateInForeground(
+  settings: UserSettings,
+  deps: {
+    update?: () => Promise<string | null>;
+    reexec?: (binaryPath: string) => void;
+  } = {}
+): Promise<ForegroundUpdateOutcome> {
+  const target = foregroundUpdateTarget(settings);
+  if (!target) return "skipped";
+
+  // Record the attempt BEFORE downloading anything, exactly as the background
+  // dispatch does: an update that keeps failing must not re-download on every
+  // single run, and the per-version counter still drives the loud
+  // manual-update fallback (#1085).
+  const recorded = updateSettings({
+    last_auto_update_attempt: new Date().toISOString(),
+  });
+  if (!recorded.ok) return "skipped";
+  bumpAutoUpdateAttempts(settings, target);
+
+  // The download is the one part of startup that can take real seconds; say so
+  // rather than stalling silently. The "✓ auto-updated" confirmation is still
+  // printed once, by the re-executed run (banner.ts).
+  if (settings.notifications) {
+    console.error(`Updating squirrel v${version} → v${target}...`);
+  }
+
+  const installed = await (deps.update ?? runAutoUpdate)();
+  if (!installed) {
+    // runAutoUpdate already logged and reported the reason (no network, bad
+    // checksum, install failure, another updater holding the lock).
+    logger.debug("foreground-update: not applied, running current version");
+    return "failed";
+  }
+
+  let binaryPath: string;
+  try {
+    binaryPath = getBinaryPath(installed);
+  } catch {
+    return "failed";
+  }
+  if (!existsSync(binaryPath)) {
+    logger.debug("foreground-update: installed binary missing", { binaryPath });
+    return "failed";
+  }
+
+  (deps.reexec ?? reexecIntoUpdatedBinary)(binaryPath);
+
+  // Reached only when the re-exec itself failed to take over.
+  trackTelemetryEvent("update_auto_error", settings, {
+    error_type: "REEXEC_FAILED",
+  });
+  return "failed";
+}
+
+/**
+ * Run `binaryPath` with this process's argv, environment, cwd and stdio, then
+ * exit with whatever it exited with — the closest thing to execve() available
+ * on both Node and Bun. Returns (instead of exiting) only when the child could
+ * not be started at all, so the caller can fall back to the current binary.
+ *
+ * The freshly installed release path is used rather than the symlink: it is
+ * the exact version just verified and installed, and it cannot be flipped out
+ * from under us by a concurrent updater between the install and the spawn.
+ *
+ * `argv` is a seam for tests only — production always re-runs this process's
+ * own arguments.
+ * @internal
+ */
+export function reexecIntoUpdatedBinary(
+  binaryPath: string,
+  argv: string[] = process.argv.slice(2)
+): void {
+  const hold = () => {};
+  for (const signal of REEXEC_HELD_SIGNALS) process.on(signal, hold);
+
+  const result = spawnSync(binaryPath, argv, {
+    stdio: "inherit",
+    env: { ...process.env, [FOREGROUND_UPDATE_ENV]: "1" },
+  });
+
+  if (result.error) {
+    // Hand the terminal signals back before returning to the normal command.
+    for (const signal of REEXEC_HELD_SIGNALS) process.off(signal, hold);
+    logger.debug("foreground-update: re-exec failed", {
+      error: result.error.message,
+    });
+    return;
+  }
+
+  if (result.signal) {
+    // Same encoding a shell reports for a signal-killed child, so `$?` reads
+    // the same as it would have without the update in the middle.
+    const signalNumber = osConstants.signals[result.signal];
+    process.exit(typeof signalNumber === "number" ? 128 + signalNumber : 1);
+  }
+  process.exit(result.status ?? 1);
 }
 
 // Single-flight state for the in-process (Windows) updater. The pending
@@ -408,8 +592,9 @@ export function resetUpdaterStateForTests(): void {
  * @internal
  */
 export function startInlineAutoUpdate(
-  runner: (signal: AbortSignal) => Promise<void> = (signal) =>
-    runAutoUpdate({ signal })
+  runner: (signal: AbortSignal) => Promise<void> = async (signal) => {
+    await runAutoUpdate({ signal });
+  }
 ): boolean {
   if (inlineUpdate) return false;
   if (commandSettled) {
@@ -496,21 +681,26 @@ function raceAbort<T>(
 
 /**
  * Silent auto-update — the body of a detached `self update --auto` child
- * (POSIX) or the in-process runner (Windows). No console output — outcomes
- * surface via telemetry and the auto_update_applied notice on the next run.
+ * (POSIX), the in-process runner (Windows), or the foreground apply that
+ * precedes a command (#170). No console output — outcomes surface via
+ * telemetry and the auto_update_applied notice on the next run.
+ *
+ * Returns the version it installed, or null when nothing was installed for any
+ * reason. Callers that need to act on the new binary (the foreground path)
+ * depend on that distinction; the fire-and-forget callers ignore it.
  */
 export async function runAutoUpdate(options?: {
   signal?: AbortSignal;
-}): Promise<void> {
+}): Promise<string | null> {
   const settingsResult = loadSettings();
-  if (!settingsResult.ok) return;
+  if (!settingsResult.ok) return null;
 
   const settings = settingsResult.data;
-  if (!isAutoUpdateEligible(settings)) return;
+  if (!isAutoUpdateEligible(settings)) return null;
   // Belt-and-braces: the detached `self update --auto` child re-validates the
   // environment so a CI / opted-out machine never downloads or flips a binary,
   // even if it was somehow invoked directly.
-  if (updateSuppressedReason()) return;
+  if (updateSuppressedReason()) return null;
 
   // Before any slow work: a started-with-no-outcome install is one whose
   // updater was killed mid-flight — #1074's field signature, previously
@@ -519,7 +709,7 @@ export async function runAutoUpdate(options?: {
 
   if (!acquireUpdateLock()) {
     logger.debug("auto-update: another update is in progress");
-    return;
+    return null;
   }
 
   try {
@@ -534,17 +724,17 @@ export async function runAutoUpdate(options?: {
     );
     if (updateResult === ABORTED) {
       logger.debug("auto-update: aborted during update check");
-      return;
+      return null;
     }
     if (!updateResult.ok) {
       if (options?.signal?.aborted) {
         logger.debug("auto-update: aborted at command exit");
-        return;
+        return null;
       }
       trackTelemetryEvent("update_auto_error", settings, {
         error_type: updateResult.error.code,
       });
-      return;
+      return null;
     }
 
     if (!updateResult.data.available || !updateResult.data.manifest) {
@@ -552,11 +742,11 @@ export async function runAutoUpdate(options?: {
       // (release pulled, or we already updated) — clear it so we stop
       // nagging and respawning.
       updateSettings({ pending_update_notification: undefined });
-      return;
+      return null;
     }
 
     const manifest = updateResult.data.manifest;
-    if (settings.dismissed_update_version === manifest.version) return;
+    if (settings.dismissed_update_version === manifest.version) return null;
 
     const applyResult = await performUpdate(manifest, settings, options);
     if (!applyResult.ok) {
@@ -564,13 +754,13 @@ export async function runAutoUpdate(options?: {
         // Expected when the command finished before the download — not an
         // error; the attempt retries on a later run.
         logger.debug("auto-update: aborted at command exit");
-        return;
+        return null;
       }
       trackTelemetryEvent("update_auto_error", settings, {
         error_type: applyResult.error.code,
       });
       logger.debug("auto-update: failed", { error: applyResult.error.message });
-      return;
+      return null;
     }
 
     updateSettings({
@@ -582,10 +772,11 @@ export async function runAutoUpdate(options?: {
     });
     trackTelemetryEvent("update_auto", settings);
     logger.debug("auto-update: installed", { version: manifest.version });
+    return manifest.version;
   } catch (error) {
     if (options?.signal?.aborted) {
       logger.debug("auto-update: aborted at command exit");
-      return;
+      return null;
     }
     trackTelemetryEvent("update_auto_error", settings, {
       error_type: error instanceof Error ? error.name : "Error",
@@ -593,6 +784,7 @@ export async function runAutoUpdate(options?: {
     logger.debug("auto-update: error", {
       error: error instanceof Error ? error.message : String(error),
     });
+    return null;
   } finally {
     releaseUpdateLock();
   }

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -61,11 +61,23 @@ const UPDATE_LOCK_STALE_MS = 30 * 60 * 1000;
  */
 export const FOREGROUND_UPDATE_ENV = "SQUIRREL_UPDATE_REEXEC";
 
-// Signals to hold while the re-executed child owns the terminal. Ctrl-C at a
-// tty is delivered to the whole foreground process group, so the child gets it
-// too; without these the waiting parent would die on the spot, hand the shell
-// its prompt back and leave the child writing over it.
-const REEXEC_HELD_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+// Terminal signals forwarded to the re-executed child instead of killing this
+// waiting parent — a dead parent would hand the shell its prompt back and leave
+// the child writing over it, and a supervisor's SIGTERM would never reach the
+// command the user asked for.
+const REEXEC_FORWARDED_SIGNALS = [
+  "SIGINT",
+  "SIGTERM",
+  "SIGHUP",
+  "SIGQUIT",
+] as const;
+// How long to wait for a re-raised signal to actually kill this process before
+// falling back to exiting with the shell's encoding for it.
+const REEXEC_SIGNAL_RERAISE_GRACE_MS = 50;
+// Ceiling on how long a user's command may wait for a foreground install.
+// Past it the download is handed to the detached updater and the command runs
+// now on the current binary: slow links still get updated, just not in-line.
+const FOREGROUND_UPDATE_TIMEOUT_MS = 120_000;
 
 /**
  * Whether this install can silently self-update: the user hasn't turned
@@ -352,21 +364,35 @@ export function maybeSpawnAutoUpdate(settings: UserSettings): void {
     return;
   }
 
+  if (spawnDetachedAutoUpdate()) {
+    bumpAttemptCounter();
+    logger.debug("update-check: spawned background auto-update", {
+      to_version: notification.to_version,
+    });
+  } else {
+    skip("spawn_failed");
+  }
+}
+
+/**
+ * Start the detached `self update --auto` child that installs out of band —
+ * a new session, so it survives this process exiting. Returns whether it
+ * started. Used both as the ordinary POSIX dispatch and as the foreground
+ * path's escape hatch when the download outlasts the user's patience.
+ */
+function spawnDetachedAutoUpdate(): boolean {
   try {
     const child = spawn(process.execPath, ["self", "update", "--auto"], {
       detached: true,
       stdio: "ignore",
     });
     child.unref();
-    bumpAttemptCounter();
-    logger.debug("update-check: spawned background auto-update", {
-      to_version: notification.to_version,
-    });
+    return true;
   } catch (error) {
-    skip("spawn_failed");
     logger.debug("update-check: failed to spawn auto-update", {
       error: error instanceof Error ? error.message : String(error),
     });
+    return false;
   }
 }
 
@@ -448,9 +474,8 @@ export type ForegroundUpdateOutcome = "skipped" | "failed";
 
 /**
  * Apply an already-known pending update, then run the original command on the
- * new binary (#170). On success this never returns: spawnSync runs the new
- * binary with this run's argv and stdio, and the process exits with the child's
- * status.
+ * new binary (#170). On success this never returns: the new binary runs with
+ * this run's argv and stdio, and the process exits with its status.
  *
  * Every other path returns, and the caller runs the command on the current
  * binary exactly as before — a failed update must never be a failed command.
@@ -461,22 +486,44 @@ export type ForegroundUpdateOutcome = "skipped" | "failed";
 export async function applyPendingUpdateInForeground(
   settings: UserSettings,
   deps: {
-    update?: () => Promise<string | null>;
-    reexec?: (binaryPath: string) => void;
+    update?: (
+      signal: AbortSignal,
+      onStart: () => void
+    ) => Promise<string | null>;
+    reexec?: (binaryPath: string) => void | Promise<void>;
+    /** Override the wait ceiling. Tests only. */
+    timeoutMs?: number;
   } = {}
 ): Promise<ForegroundUpdateOutcome> {
   const target = foregroundUpdateTarget(settings);
   if (!target) return "skipped";
 
+  // Narrow the window between the startup settings snapshot and the install:
+  // another run may already have applied this exact update while this one was
+  // starting. Re-exec into what it installed instead of downloading it twice.
+  const current = loadSettings();
+  if (current.ok && !current.data.pending_update_notification) {
+    const alreadyInstalled = releaseBinaryIfPresent(target);
+    if (alreadyInstalled) {
+      logger.debug("foreground-update: already installed by another run", {
+        to_version: target,
+      });
+      await (deps.reexec ?? reexecIntoUpdatedBinary)(alreadyInstalled);
+      return "failed"; // only reached when the re-exec did not take over
+    }
+    logger.debug("foreground-update: notification consumed by another run");
+    return "skipped";
+  }
+
   // Record the attempt BEFORE downloading anything, exactly as the background
   // dispatch does: an update that keeps failing must not re-download on every
-  // single run, and the per-version counter still drives the loud
-  // manual-update fallback (#1085).
+  // single run. The per-version FAILURE counter that drives the loud
+  // manual-update fallback (#1085) is advanced separately, via onStart, so an
+  // attempt that never gets past the update lock is not counted as one.
   const recorded = updateSettings({
     last_auto_update_attempt: new Date().toISOString(),
   });
   if (!recorded.ok) return "skipped";
-  bumpAutoUpdateAttempts(settings, target);
 
   // The download is the one part of startup that can take real seconds; say so
   // rather than stalling silently. The "✓ auto-updated" confirmation is still
@@ -485,26 +532,44 @@ export async function applyPendingUpdateInForeground(
     console.error(`Updating squirrel v${version} → v${target}...`);
   }
 
-  const installed = await (deps.update ?? runAutoUpdate)();
+  // Hard ceiling on how long a user's command may wait. The download timeout in
+  // releases.ts only covers response headers, so without this a server that
+  // stalls the body would hang the CLI forever — a risk the detached updater
+  // never carried, because nothing waited on it.
+  const controller = new AbortController();
+  let timedOut = false;
+  const deadline = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, deps.timeoutMs ?? FOREGROUND_UPDATE_TIMEOUT_MS);
+
+  let installed: string | null;
+  try {
+    installed = await (deps.update ?? runForegroundAutoUpdate)(
+      controller.signal,
+      () => bumpAutoUpdateAttempts(settings, target)
+    );
+  } finally {
+    clearTimeout(deadline);
+  }
+
   if (!installed) {
     // runAutoUpdate already logged and reported the reason (no network, bad
     // checksum, install failure, another updater holding the lock).
     logger.debug("foreground-update: not applied, running current version");
+    if (timedOut) {
+      // Out of patience, not out of luck: hand the download to the detached
+      // updater so a slow link still lands the update, exactly as before #170.
+      logger.debug("foreground-update: deadline reached, finishing detached");
+      spawnDetachedAutoUpdate();
+    }
     return "failed";
   }
 
-  let binaryPath: string;
-  try {
-    binaryPath = getBinaryPath(installed);
-  } catch {
-    return "failed";
-  }
-  if (!existsSync(binaryPath)) {
-    logger.debug("foreground-update: installed binary missing", { binaryPath });
-    return "failed";
-  }
+  const binaryPath = releaseBinaryIfPresent(installed);
+  if (!binaryPath) return "failed";
 
-  (deps.reexec ?? reexecIntoUpdatedBinary)(binaryPath);
+  await (deps.reexec ?? reexecIntoUpdatedBinary)(binaryPath);
 
   // Reached only when the re-exec itself failed to take over.
   trackTelemetryEvent("update_auto_error", settings, {
@@ -513,15 +578,43 @@ export async function applyPendingUpdateInForeground(
   return "failed";
 }
 
+/** runAutoUpdate bound to the foreground path's signal + start callback. */
+function runForegroundAutoUpdate(
+  signal: AbortSignal,
+  onStart: () => void
+): Promise<string | null> {
+  return runAutoUpdate({ signal, onStart });
+}
+
+/** The installed binary for `version`, or null when it isn't on disk. */
+function releaseBinaryIfPresent(version: string): string | null {
+  let binaryPath: string;
+  try {
+    binaryPath = getBinaryPath(version);
+  } catch {
+    return null; // version failed the release-path validation
+  }
+  if (existsSync(binaryPath)) return binaryPath;
+  logger.debug("foreground-update: installed binary missing", { binaryPath });
+  return null;
+}
+
 /**
  * Run `binaryPath` with this process's argv, environment, cwd and stdio, then
- * exit with whatever it exited with — the closest thing to execve() available
- * on both Node and Bun. Returns (instead of exiting) only when the child could
- * not be started at all, so the caller can fall back to the current binary.
+ * exit the way it exited — the closest thing to execve() available on both Node
+ * and Bun. Resolves (instead of exiting) only when the child could not be
+ * started, so the caller can fall back to the current binary.
  *
  * The freshly installed release path is used rather than the symlink: it is
  * the exact version just verified and installed, and it cannot be flipped out
  * from under us by a concurrent updater between the install and the spawn.
+ *
+ * Terminal signals are FORWARDED rather than held: a supervisor (or `timeout`,
+ * or a harness) signalling this pid must still reach the command the user
+ * actually asked for. A synchronous spawn cannot do that — it blocks the loop
+ * for the whole run, so the CLI would ignore cancellation for as long as an
+ * audit takes. At a tty the child already receives the process-group signal;
+ * the forwarded duplicate is harmless.
  *
  * `argv` is a seam for tests only — production always re-runs this process's
  * own arguments.
@@ -530,31 +623,76 @@ export async function applyPendingUpdateInForeground(
 export function reexecIntoUpdatedBinary(
   binaryPath: string,
   argv: string[] = process.argv.slice(2)
-): void {
-  const hold = () => {};
-  for (const signal of REEXEC_HELD_SIGNALS) process.on(signal, hold);
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = spawn(binaryPath, argv, {
+        stdio: "inherit",
+        env: { ...process.env, [FOREGROUND_UPDATE_ENV]: "1" },
+      });
+    } catch (error) {
+      logger.debug("foreground-update: re-exec could not start", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      resolve();
+      return;
+    }
 
-  const result = spawnSync(binaryPath, argv, {
-    stdio: "inherit",
-    env: { ...process.env, [FOREGROUND_UPDATE_ENV]: "1" },
-  });
-
-  if (result.error) {
-    // Hand the terminal signals back before returning to the normal command.
-    for (const signal of REEXEC_HELD_SIGNALS) process.off(signal, hold);
-    logger.debug("foreground-update: re-exec failed", {
-      error: result.error.message,
+    const handlers = REEXEC_FORWARDED_SIGNALS.map((signal) => {
+      const handler = () => {
+        try {
+          child.kill(signal);
+        } catch {
+          // already gone — nothing to forward to
+        }
+      };
+      process.on(signal, handler);
+      return [signal, handler] as const;
     });
-    return;
-  }
+    // Always restore the previous disposition: a leaked handler would leave
+    // the fallback command (or a test process) ignoring Ctrl-C.
+    const release = () => {
+      for (const [signal, handler] of handlers) process.off(signal, handler);
+    };
 
-  if (result.signal) {
-    // Same encoding a shell reports for a signal-killed child, so `$?` reads
-    // the same as it would have without the update in the middle.
-    const signalNumber = osConstants.signals[result.signal];
-    process.exit(typeof signalNumber === "number" ? 128 + signalNumber : 1);
-  }
-  process.exit(result.status ?? 1);
+    let settled = false;
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      release();
+      logger.debug("foreground-update: re-exec failed", {
+        error: error.message,
+      });
+      resolve();
+    });
+
+    child.once("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      release();
+      if (signal) {
+        // Die the way the child died, so a supervisor sees the signal and not
+        // just a number. Delivery is asynchronous, so if this runtime keeps the
+        // signal handled anyway, fall back to the shell's 128+n encoding.
+        const signalNumber = osConstants.signals[signal];
+        try {
+          process.kill(process.pid, signal);
+        } catch {
+          // signal unsupported here — the timer below still exits
+        }
+        setTimeout(
+          () =>
+            process.exit(
+              typeof signalNumber === "number" ? 128 + signalNumber : 1
+            ),
+          REEXEC_SIGNAL_RERAISE_GRACE_MS
+        );
+        return;
+      }
+      process.exit(code ?? 1);
+    });
+  });
 }
 
 // Single-flight state for the in-process (Windows) updater. The pending
@@ -691,6 +829,13 @@ function raceAbort<T>(
  */
 export async function runAutoUpdate(options?: {
   signal?: AbortSignal;
+  /**
+   * Called once the updater OWNS the update lock and real work is about to
+   * begin. The foreground path advances its failed-attempt counter here rather
+   * than at dispatch, so an attempt that lost the lock to a concurrent updater
+   * (which is doing the work) never counts toward the #1085 fallback box.
+   */
+  onStart?: () => void;
 }): Promise<string | null> {
   const settingsResult = loadSettings();
   if (!settingsResult.ok) return null;
@@ -711,6 +856,7 @@ export async function runAutoUpdate(options?: {
     logger.debug("auto-update: another update is in progress");
     return null;
   }
+  options?.onStart?.();
 
   try {
     // Inline (signal-bearing) runs skip the 3x retry so an abort at command

--- a/apps/cli/tests/cli/banner.test.ts
+++ b/apps/cli/tests/cli/banner.test.ts
@@ -10,16 +10,26 @@ import {
   spyOn,
   test,
 } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import type { UserSettings } from "@/self/types";
 
 import {
+  printAutoUpdateAppliedNotice,
   printEndOfRunUpdateReminder,
   printUpdateNotification,
 } from "@/cli/banner";
 import * as pathsModule from "@/self/paths";
-import { DEFAULT_SETTINGS } from "@/self/settings";
+import {
+  DEFAULT_SETTINGS,
+  loadUserSettings,
+  updateSettings,
+} from "@/self/settings";
 import * as telemetryModule from "@/self/telemetry";
+
+import { version } from "../../package.json";
 
 function settingsWith(overrides: Partial<UserSettings>): UserSettings {
   return { ...DEFAULT_SETTINGS, ...overrides } as UserSettings;
@@ -155,6 +165,69 @@ describe("printEndOfRunUpdateReminder (#1085)", () => {
         auto_update: true,
         pending_update_notification: pendingV2,
         auto_update_attempts: { version: "0.0.2", count: 5 },
+      })
+    );
+    out.spy.mockRestore();
+    expect(out.text()).toBe("");
+  });
+});
+
+// #170: after a foreground update the re-executed run is the one on the new
+// binary, and it is the only place the confirmation may appear.
+describe("printAutoUpdateAppliedNotice (#170)", () => {
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "squirrelscan-banner-"));
+    // The notice CLEARS the marker, so the write must not reach the real
+    // ~/.squirrel/settings.json (homedir() ignores $HOME).
+    spyOn(pathsModule, "getSettingsPath").mockReturnValue(
+      join(tempHome, "settings.json")
+    );
+  });
+
+  afterEach(() => {
+    mock.restore();
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  test("prints once for the running version, then clears the marker", async () => {
+    const applied = {
+      from_version: "0.0.1",
+      to_version: version,
+      at: new Date().toISOString(),
+    };
+    updateSettings({ auto_update_applied: applied });
+
+    const first = captureStderr();
+    await printAutoUpdateAppliedNotice(
+      settingsWith({ auto_update_applied: applied })
+    );
+    first.spy.mockRestore();
+    expect(first.text()).toContain(`auto-updated v0.0.1 → v${version}`);
+
+    const saved = loadUserSettings();
+    expect(saved.ok).toBe(true);
+    if (saved.ok) expect(saved.data.auto_update_applied ?? null).toBeNull();
+
+    // A later run reads the cleared settings and says nothing.
+    const second = captureStderr();
+    await printAutoUpdateAppliedNotice(
+      saved.ok ? saved.data : settingsWith({})
+    );
+    second.spy.mockRestore();
+    expect(second.text()).toBe("");
+  });
+
+  test("silent in the process that applied the update (still the old version)", async () => {
+    const out = captureStderr();
+    await printAutoUpdateAppliedNotice(
+      settingsWith({
+        auto_update_applied: {
+          from_version: version,
+          to_version: "99.99.99",
+          at: new Date().toISOString(),
+        },
       })
     );
     out.spy.mockRestore();

--- a/apps/cli/tests/cli/startup.test.ts
+++ b/apps/cli/tests/cli/startup.test.ts
@@ -1,0 +1,44 @@
+// #170: the startup extras — including the one-time "✓ auto-updated" notice —
+// belong to the RUN, not to `audit`/`crawl`. This pins which invocations get
+// them, since that is what decides whether an applied update is ever announced.
+
+import { describe, expect, test } from "bun:test";
+
+import { shouldRunBackgroundTasks } from "@/cli/index";
+
+describe("shouldRunBackgroundTasks (#170)", () => {
+  test.each([
+    ["audit", ["audit", "https://example.com"]],
+    ["crawl", ["crawl", "https://example.com"]],
+    // The commands the notice used to be invisible for.
+    ["analyze", ["analyze"]],
+    ["auth", ["auth", "status"]],
+    ["config", ["config", "get", "channel"]],
+    ["credits", ["credits"]],
+    ["report", ["report"]],
+    ["keys", ["keys", "list"]],
+    ["skills", ["skills", "install"]],
+    ["self doctor", ["self", "doctor"]],
+    ["self version", ["self", "version"]],
+  ])("%s runs them (so an applied update is announced)", (_name, args) => {
+    expect(shouldRunBackgroundTasks(args)).toBe(true);
+  });
+
+  test.each([
+    ["no arguments", []],
+    ["--version", ["--version"]],
+    ["-v", ["-v"]],
+    ["--help", ["--help"]],
+    ["-h", ["audit", "-h"]],
+    // JSON-RPC on stdout: nothing may pollute the stream.
+    ["mcp", ["mcp"]],
+    // self install resets settings; self update IS the updater.
+    ["self install", ["self", "install"]],
+    ["self update", ["self", "update", "--auto"]],
+    ["self uninstall", ["self", "uninstall"]],
+    // --offline promises zero network.
+    ["--offline", ["audit", "https://example.com", "--offline"]],
+  ])("%s skips them", (_name, args) => {
+    expect(shouldRunBackgroundTasks(args)).toBe(false);
+  });
+});

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -15,6 +15,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import * as os from "node:os";
@@ -668,6 +669,51 @@ describe("updater", () => {
         expect(foregroundUpdateTarget(eligible())).toBeNull();
       });
 
+      // The marker must not outlive the gate: a squirrel the command goes on to
+      // spawn is a separate run entitled to its own foreground update.
+      test("the loop marker is consumed, not inherited by nested runs", () => {
+        managedPosix();
+        process.env[FOREGROUND_UPDATE_ENV] = "1";
+
+        expect(foregroundUpdateTarget(eligible())).toBeNull();
+
+        expect(process.env[FOREGROUND_UPDATE_ENV]).toBeUndefined();
+      });
+
+      // Deliberate semantic (#170): update_check_interval_hours governs how
+      // often we CHECK, not whether an already-recorded update gets applied.
+      // Applying it on the next run is the entire feature.
+      test("a long update_check_interval_hours does not veto applying a stored update", () => {
+        managedPosix();
+        expect(
+          foregroundUpdateTarget(
+            eligible({
+              update_check_interval_hours: 744,
+              last_update_check: new Date().toISOString(),
+            })
+          )
+        ).toBe("9.9.9");
+      });
+
+      test("a live update lock skips the foreground path entirely", () => {
+        managedPosix();
+        writeFileSync(
+          join(tempHome, "update.lock"),
+          JSON.stringify({ pid: process.pid + 1, at: new Date().toISOString() })
+        );
+        expect(foregroundUpdateTarget(eligible())).toBeNull();
+      });
+
+      test("a STALE update lock does not skip (the acquire decides)", () => {
+        managedPosix();
+        const lock = join(tempHome, "update.lock");
+        writeFileSync(lock, JSON.stringify({ pid: process.pid + 1 }));
+        // Older than the 30-minute staleness bound.
+        const old = new Date(Date.now() - 60 * 60 * 1000);
+        utimesSync(lock, old, old);
+        expect(foregroundUpdateTarget(eligible())).toBe("9.9.9");
+      });
+
       test("CI skips the foreground path", () => {
         managedPosix();
         process.env.CI = "true";
@@ -1070,9 +1116,9 @@ describe("updater", () => {
       });
 
       // Real contention, not a stubbed updater: another process owns the lock
-      // file, so runAutoUpdate bails before any network work and onStart never
-      // fires — the #1085 counter must stay untouched.
-      test("real update-lock contention: no download, no failure counted", async () => {
+      // file, so the foreground path skips BEFORE announcing anything or
+      // burning the hourly throttle on work someone else is doing.
+      test("real update-lock contention: silent skip, nothing recorded", async () => {
         managedPosix();
         captureTelemetry();
         // Record HOSTS, not URLs: an exact hostname comparison is the only
@@ -1094,13 +1140,17 @@ describe("updater", () => {
           reexec,
         });
 
-        expect(outcome).toBe("failed");
+        expect(outcome).toBe("skipped");
         expect(reexec).not.toHaveBeenCalled();
-        // Only telemetry may have gone out; no release metadata was fetched.
+        // Nothing announced, nothing fetched.
+        expect(stderr).toHaveLength(0);
         expect(fetchedHosts).not.toContain("install.squirrelscan.com");
         const saved = loadUserSettings();
         if (saved.ok) {
           expect(saved.data.auto_update_attempts ?? null).toBeNull();
+          // The hourly throttle is NOT burnt: the next run, once the other
+          // updater is done, is free to try.
+          expect(saved.data.last_auto_update_attempt ?? null).toBeNull();
         }
         // The other process's lock is left alone.
         expect(existsSync(join(tempHome, "update.lock"))).toBe(true);
@@ -1163,6 +1213,53 @@ describe("updater", () => {
         ]);
         // The lock must not be left behind for the detached updater to trip on.
         expect(existsSync(join(tempHome, "update.lock"))).toBe(false);
+      });
+
+      // A download takes long enough for `self update --dismiss` to land in the
+      // middle of one; the swap must not happen after that.
+      test("a dismissal DURING the download aborts before the binary swap", async () => {
+        managedPosix();
+        captureTelemetry();
+        spyOn(pathsModule, "getReleasePath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v)
+        );
+        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v, "squirrel")
+        );
+        spyOn(pathsModule, "getSymlinkPath").mockReturnValue(
+          join(tempHome, "bin", "squirrel")
+        );
+        spyOn(releasesModule, "checkForUpdates").mockResolvedValue({
+          ok: true,
+          data: {
+            available: true,
+            current_version: "0.0.1",
+            latest_version: "9.9.9",
+            release_url: null,
+            manifest: { version: "9.9.9", binaries: {} } as ReleaseManifest,
+          },
+        } as Awaited<ReturnType<typeof releasesModule.checkForUpdates>>);
+        spyOn(releasesModule, "downloadBinary").mockImplementation(async () => {
+          // The user dismisses while the bytes are in flight.
+          updateSettings({ dismissed_update_version: "9.9.9" });
+          return {
+            ok: true,
+            data: new TextEncoder().encode("bin").buffer as ArrayBuffer,
+          };
+        });
+
+        const reexec = mock(() => {});
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          reexec,
+        });
+
+        expect(outcome).toBe("failed");
+        expect(reexec).not.toHaveBeenCalled();
+        // Nothing was written into the releases dir, and no symlink was flipped.
+        expect(
+          existsSync(join(tempHome, "releases", "9.9.9", "squirrel"))
+        ).toBe(false);
+        expect(existsSync(join(tempHome, "bin", "squirrel"))).toBe(false);
       });
 
       test("end to end: downloads, installs, flips the symlink, re-execs the release binary", async () => {

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -1075,9 +1075,12 @@ describe("updater", () => {
       test("real update-lock contention: no download, no failure counted", async () => {
         managedPosix();
         captureTelemetry();
-        const fetches: string[] = [];
+        // Record HOSTS, not URLs: an exact hostname comparison is the only
+        // sound way to ask "did we hit the release endpoint".
+        const fetchedHosts: string[] = [];
         globalThis.fetch = (async (url: string | URL | Request) => {
-          fetches.push(String(url));
+          const href = url instanceof Request ? url.url : String(url);
+          fetchedHosts.push(new URL(href).hostname);
           return new Response("{}", { status: 200 });
         }) as unknown as typeof fetch;
         // A fresh lock held by some other pid.
@@ -1094,9 +1097,7 @@ describe("updater", () => {
         expect(outcome).toBe("failed");
         expect(reexec).not.toHaveBeenCalled();
         // Only telemetry may have gone out; no release metadata was fetched.
-        expect(
-          fetches.filter((u) => u.includes("install.squirrelscan.com"))
-        ).toEqual([]);
+        expect(fetchedHosts).not.toContain("install.squirrelscan.com");
         const saved = loadUserSettings();
         if (saved.ok) {
           expect(saved.data.auto_update_attempts ?? null).toBeNull();

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -376,6 +376,7 @@ describe("updater", () => {
     function stubSpawn() {
       spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
       spyOn(childProcess, "spawn").mockReturnValue({
+        once() {},
         unref() {},
       } as unknown as ReturnType<typeof childProcess.spawn>);
     }
@@ -483,6 +484,7 @@ describe("updater", () => {
       spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
       spyOn(os, "platform").mockReturnValue("linux");
       const spawnSpy = spyOn(childProcess, "spawn").mockReturnValue({
+        once() {},
         unref() {},
       } as unknown as ReturnType<typeof childProcess.spawn>);
 
@@ -934,6 +936,7 @@ describe("updater", () => {
         managedPosix();
         captureTelemetry();
         const spawnSpy = spyOn(childProcess, "spawn").mockReturnValue({
+          once() {},
           unref() {},
         } as unknown as ReturnType<typeof childProcess.spawn>);
         let sawAbort = false;
@@ -970,6 +973,7 @@ describe("updater", () => {
         managedPosix();
         captureTelemetry();
         const spawnSpy = spyOn(childProcess, "spawn").mockReturnValue({
+          once() {},
           unref() {},
         } as unknown as ReturnType<typeof childProcess.spawn>);
 
@@ -984,17 +988,31 @@ describe("updater", () => {
         expect(spawnSpy).not.toHaveBeenCalled();
       });
 
+      /** A release binary on disk for `v`, as a rollback copy would be. */
+      function stageRelease(v: string): string {
+        spyOn(pathsModule, "getBinaryPath").mockImplementation((x: string) =>
+          join(tempHome, "releases", x, "squirrel")
+        );
+        mkdirSync(join(tempHome, "releases", v), { recursive: true });
+        writeFileSync(join(tempHome, "releases", v, "squirrel"), "bin");
+        return join(tempHome, "releases", v, "squirrel");
+      }
+
       test("another run having already applied the update re-execs without downloading", async () => {
         managedPosix();
         captureTelemetry();
-        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
-          join(tempHome, "releases", v, "squirrel")
-        );
-        mkdirSync(join(tempHome, "releases", "9.9.9"), { recursive: true });
-        writeFileSync(join(tempHome, "releases", "9.9.9", "squirrel"), "bin");
-        // On disk the notification is already consumed; the caller's snapshot
-        // still has it (it was read at startup).
-        updateSettings({ pending_update_notification: undefined });
+        const binary = stageRelease("9.9.9");
+        // On disk the notification is consumed and the applied marker records
+        // the install; the caller's snapshot still has the notification (it was
+        // read at startup).
+        updateSettings({
+          pending_update_notification: undefined,
+          auto_update_applied: {
+            from_version: "0.0.1",
+            to_version: "9.9.9",
+            at: new Date().toISOString(),
+          },
+        });
 
         const update = mock(async () => null);
         const reexeced: string[] = [];
@@ -1007,18 +1025,20 @@ describe("updater", () => {
         });
 
         expect(update).not.toHaveBeenCalled();
-        expect(reexeced).toEqual([
-          join(tempHome, "releases", "9.9.9", "squirrel"),
-        ]);
+        expect(reexeced).toEqual([binary]);
       });
 
-      test("notification consumed and nothing installed: skip, run the command", async () => {
+      // `self update --dismiss` clears the notification WITHOUT installing, and
+      // old releases are kept on disk for rollback — so a binary being present
+      // must never on its own be read as "another run applied it".
+      test("a dismissed version is never re-execed just because its binary exists", async () => {
         managedPosix();
         captureTelemetry();
-        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
-          join(tempHome, "releases", v, "squirrel")
-        );
-        updateSettings({ pending_update_notification: undefined });
+        stageRelease("9.9.9");
+        updateSettings({
+          pending_update_notification: undefined,
+          dismissed_update_version: "9.9.9",
+        });
 
         const update = mock(async () => null);
         const reexec = mock(() => {});
@@ -1031,6 +1051,117 @@ describe("updater", () => {
         expect(outcome).toBe("skipped");
         expect(update).not.toHaveBeenCalled();
         expect(reexec).not.toHaveBeenCalled();
+      });
+
+      test("a stale rollback copy with no applied marker is not re-execed", async () => {
+        managedPosix();
+        captureTelemetry();
+        stageRelease("9.9.9");
+        updateSettings({ pending_update_notification: undefined });
+
+        const reexec = mock(() => {});
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          update: async () => null,
+          reexec,
+        });
+
+        expect(outcome).toBe("skipped");
+        expect(reexec).not.toHaveBeenCalled();
+      });
+
+      // Real contention, not a stubbed updater: another process owns the lock
+      // file, so runAutoUpdate bails before any network work and onStart never
+      // fires — the #1085 counter must stay untouched.
+      test("real update-lock contention: no download, no failure counted", async () => {
+        managedPosix();
+        captureTelemetry();
+        const fetches: string[] = [];
+        globalThis.fetch = (async (url: string | URL | Request) => {
+          fetches.push(String(url));
+          return new Response("{}", { status: 200 });
+        }) as unknown as typeof fetch;
+        // A fresh lock held by some other pid.
+        writeFileSync(
+          join(tempHome, "update.lock"),
+          JSON.stringify({ pid: process.pid + 1, at: new Date().toISOString() })
+        );
+
+        const reexec = mock(() => {});
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          reexec,
+        });
+
+        expect(outcome).toBe("failed");
+        expect(reexec).not.toHaveBeenCalled();
+        // Only telemetry may have gone out; no release metadata was fetched.
+        expect(
+          fetches.filter((u) => u.includes("install.squirrelscan.com"))
+        ).toEqual([]);
+        const saved = loadUserSettings();
+        if (saved.ok) {
+          expect(saved.data.auto_update_attempts ?? null).toBeNull();
+        }
+        // The other process's lock is left alone.
+        expect(existsSync(join(tempHome, "update.lock"))).toBe(true);
+      });
+
+      // The whole deadline chain with the real runAutoUpdate: abort reaches the
+      // download, the lock is released, and the install is handed off detached.
+      test("deadline through the real updater: aborts the download, releases the lock, hands off", async () => {
+        managedPosix();
+        captureTelemetry();
+        const spawnSpy = spyOn(childProcess, "spawn").mockReturnValue({
+          once() {},
+          unref() {},
+        } as unknown as ReturnType<typeof childProcess.spawn>);
+        spyOn(releasesModule, "checkForUpdates").mockResolvedValue({
+          ok: true,
+          data: {
+            available: true,
+            current_version: "0.0.1",
+            latest_version: "9.9.9",
+            release_url: null,
+            manifest: { version: "9.9.9", binaries: {} } as ReleaseManifest,
+          },
+        } as Awaited<ReturnType<typeof releasesModule.checkForUpdates>>);
+        let downloadAborted = false;
+        spyOn(releasesModule, "downloadBinary").mockImplementation(
+          (_manifest, _arch, options) =>
+            new Promise((resolve) => {
+              options?.signal?.addEventListener(
+                "abort",
+                () => {
+                  downloadAborted = true;
+                  resolve({
+                    ok: false,
+                    error: {
+                      code: "DOWNLOAD_ABORTED",
+                      message: "aborted",
+                    },
+                  } as Awaited<
+                    ReturnType<typeof releasesModule.downloadBinary>
+                  >);
+                },
+                { once: true }
+              );
+            })
+        );
+
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          timeoutMs: 20,
+          reexec: () => {},
+        });
+
+        expect(downloadAborted).toBe(true);
+        expect(outcome).toBe("failed");
+        expect(spawnSpy).toHaveBeenCalledTimes(1);
+        expect(spawnSpy.mock.calls[0]?.[1]).toEqual([
+          "self",
+          "update",
+          "--auto",
+        ]);
+        // The lock must not be left behind for the detached updater to trip on.
+        expect(existsSync(join(tempHome, "update.lock"))).toBe(false);
       });
 
       test("end to end: downloads, installs, flips the symlink, re-execs the release binary", async () => {
@@ -1190,6 +1321,29 @@ describe("updater", () => {
 
           expect(exits).toEqual([7]);
           // The forwarding handlers must not outlive the child.
+          expect(process.listenerCount("SIGTERM")).toBe(0);
+        });
+
+        // A child killed BY a signal must make this process die the same way,
+        // so a supervisor sees the signal and not just a number. process.kill
+        // is spied because the real re-raise would kill the test runner.
+        test("re-raises the child's death signal, with a 128+n fallback", async () => {
+          const killed: Array<[number, string | number | undefined]> = [];
+          spyOn(process, "kill").mockImplementation(((
+            pid: number,
+            signal?: string | number
+          ) => {
+            killed.push([pid, signal]);
+            return true;
+          }) as never);
+          const script = writeScript("suicidal-squirrel", "kill -9 $$");
+
+          void reexecIntoUpdatedBinary(script, []);
+          await waitFor(() => exits.length > 0, "the signal fallback to fire");
+
+          expect(killed).toEqual([[process.pid, "SIGKILL"]]);
+          // 128 + SIGKILL(9): what a shell reports for the same death.
+          expect(exits).toEqual([137]);
           expect(process.listenerCount("SIGTERM")).toBe(0);
         });
 

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -8,7 +8,15 @@ import {
   test,
 } from "bun:test";
 import * as childProcess from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import * as os from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -24,9 +32,13 @@ import {
   updateSettings,
 } from "@/self/settings";
 import {
+  applyPendingUpdateInForeground,
   finishInlineAutoUpdate,
+  FOREGROUND_UPDATE_ENV,
+  foregroundUpdateTarget,
   isAutoUpdateFallbackActive,
   maybeSpawnAutoUpdate,
+  reexecIntoUpdatedBinary,
   resetUpdaterStateForTests,
   runAutoUpdate,
   safeExit,
@@ -47,6 +59,7 @@ const CI_VARS = [
   "TEAMCITY_VERSION",
   "TF_BUILD",
   "SQUIRREL_NO_UPDATE",
+  FOREGROUND_UPDATE_ENV,
 ];
 
 let tempHome: string;
@@ -605,5 +618,405 @@ describe("updater", () => {
 
       expect(Date.now() - start).toBeLessThan(1000);
     });
+  });
+
+  // #170: a pending update recorded by an earlier background check is applied
+  // BEFORE the command runs, and the original argv re-executed on the new
+  // binary — so a fresh run never executes on a version the CLI already knows
+  // is stale.
+  describe("foreground update before the command (#170)", () => {
+    const PENDING = {
+      from_version: "0.0.1",
+      to_version: "9.9.9",
+      release_url: null,
+    } as const;
+
+    function eligible(overrides: Partial<UserSettings> = {}): UserSettings {
+      return settingsWith({
+        auto_update: true,
+        pending_update_notification: { ...PENDING },
+        ...overrides,
+      });
+    }
+
+    /** Managed, non-Windows install — the only shape that takes this path. */
+    function managedPosix(): void {
+      spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
+      spyOn(os, "platform").mockReturnValue("linux");
+    }
+
+    describe("foregroundUpdateTarget gates", () => {
+      test("returns the pending version for an eligible managed install", () => {
+        managedPosix();
+        expect(foregroundUpdateTarget(eligible())).toBe("9.9.9");
+      });
+
+      test("no pending notification → null (the untouched fast path)", () => {
+        managedPosix();
+        expect(
+          foregroundUpdateTarget(
+            settingsWith({ pending_update_notification: undefined })
+          )
+        ).toBeNull();
+      });
+
+      test("re-executed process never updates again (loop guard)", () => {
+        managedPosix();
+        process.env[FOREGROUND_UPDATE_ENV] = "1";
+        expect(foregroundUpdateTarget(eligible())).toBeNull();
+      });
+
+      test("CI skips the foreground path", () => {
+        managedPosix();
+        process.env.CI = "true";
+        expect(foregroundUpdateTarget(eligible())).toBeNull();
+      });
+
+      test("SQUIRREL_NO_UPDATE skips the foreground path", () => {
+        managedPosix();
+        process.env.SQUIRREL_NO_UPDATE = "1";
+        expect(foregroundUpdateTarget(eligible())).toBeNull();
+      });
+
+      test("auto_update=false skips the foreground path", () => {
+        managedPosix();
+        expect(
+          foregroundUpdateTarget(eligible({ auto_update: false }))
+        ).toBeNull();
+      });
+
+      test("unmanaged install skips the foreground path", () => {
+        spyOn(pathsModule, "isManagedInstall").mockReturnValue(false);
+        spyOn(os, "platform").mockReturnValue("linux");
+        expect(foregroundUpdateTarget(eligible())).toBeNull();
+      });
+
+      test("a dismissed version skips the foreground path", () => {
+        managedPosix();
+        expect(
+          foregroundUpdateTarget(
+            eligible({ dismissed_update_version: "9.9.9" })
+          )
+        ).toBeNull();
+      });
+
+      test("an attempt inside the hourly throttle skips", () => {
+        managedPosix();
+        expect(
+          foregroundUpdateTarget(
+            eligible({
+              last_auto_update_attempt: new Date(
+                Date.now() - 10 * 60 * 1000
+              ).toISOString(),
+            })
+          )
+        ).toBeNull();
+      });
+
+      test("an attempt older than the throttle window is allowed", () => {
+        managedPosix();
+        expect(
+          foregroundUpdateTarget(
+            eligible({
+              last_auto_update_attempt: new Date(
+                Date.now() - 3 * 60 * 60 * 1000
+              ).toISOString(),
+            })
+          )
+        ).toBe("9.9.9");
+      });
+
+      test("win32 keeps the existing background/inline updater", () => {
+        spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
+        spyOn(os, "platform").mockReturnValue("win32");
+        expect(foregroundUpdateTarget(eligible())).toBeNull();
+      });
+    });
+
+    describe("applyPendingUpdateInForeground", () => {
+      let stderr: string[];
+
+      beforeEach(() => {
+        stderr = [];
+        spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+          stderr.push(args.map(String).join(" "));
+        });
+      });
+
+      test("announces the update rather than stalling silently", async () => {
+        managedPosix();
+        captureTelemetry();
+
+        await applyPendingUpdateInForeground(eligible(), {
+          update: async () => null,
+          reexec: () => {},
+        });
+
+        expect(stderr.join("\n")).toContain("→ v9.9.9");
+      });
+
+      test("notifications=false stays silent", async () => {
+        managedPosix();
+        captureTelemetry();
+
+        await applyPendingUpdateInForeground(
+          eligible({ notifications: false }),
+          {
+            update: async () => null,
+            reexec: () => {},
+          }
+        );
+
+        expect(stderr).toHaveLength(0);
+      });
+
+      test("no pending update: no network, no settings write, no update call", async () => {
+        managedPosix();
+        let fetched = false;
+        globalThis.fetch = (async () => {
+          fetched = true;
+          return new Response("{}", { status: 200 });
+        }) as unknown as typeof fetch;
+        const update = mock(async () => null);
+        const reexec = mock(() => {});
+
+        const outcome = await applyPendingUpdateInForeground(
+          settingsWith({ pending_update_notification: undefined }),
+          { update, reexec }
+        );
+
+        expect(outcome).toBe("skipped");
+        expect(update).not.toHaveBeenCalled();
+        expect(reexec).not.toHaveBeenCalled();
+        expect(fetched).toBe(false);
+        // Nothing was attempted, so nothing throttles the next run either.
+        expect(existsSync(join(tempHome, "settings.json"))).toBe(false);
+      });
+
+      test("installs first, then re-execs into the new binary", async () => {
+        managedPosix();
+        captureTelemetry();
+        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v, "squirrel")
+        );
+        // The installed binary must exist before the re-exec is attempted.
+        const order: string[] = [];
+        const update = mock(async () => {
+          order.push("update");
+          mkdirSync(join(tempHome, "releases", "9.9.9"), { recursive: true });
+          writeFileSync(join(tempHome, "releases", "9.9.9", "squirrel"), "bin");
+          return "9.9.9";
+        });
+        const reexec = mock((path: string) => {
+          order.push(`reexec:${path}`);
+        });
+
+        await applyPendingUpdateInForeground(eligible(), { update, reexec });
+
+        expect(order).toEqual([
+          "update",
+          `reexec:${join(tempHome, "releases", "9.9.9", "squirrel")}`,
+        ]);
+      });
+
+      test("a failed update falls back to the current binary, never re-execs", async () => {
+        managedPosix();
+        captureTelemetry();
+        const reexec = mock(() => {});
+
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          update: async () => null,
+          reexec,
+        });
+
+        expect(outcome).toBe("failed");
+        expect(reexec).not.toHaveBeenCalled();
+      });
+
+      test("an installed-but-missing binary falls back instead of re-execing", async () => {
+        managedPosix();
+        captureTelemetry();
+        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v, "squirrel")
+        );
+        const reexec = mock(() => {});
+
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          update: async () => "9.9.9",
+          reexec,
+        });
+
+        expect(outcome).toBe("failed");
+        expect(reexec).not.toHaveBeenCalled();
+      });
+
+      test("a re-exec that fails to take over still runs the command here", async () => {
+        managedPosix();
+        captureTelemetry();
+        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v, "squirrel")
+        );
+        mkdirSync(join(tempHome, "releases", "9.9.9"), { recursive: true });
+        writeFileSync(join(tempHome, "releases", "9.9.9", "squirrel"), "bin");
+
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          update: async () => "9.9.9",
+          // Returning models spawnSync failing to start the child; the real
+          // implementation exits the process instead of returning.
+          reexec: () => {},
+        });
+
+        expect(outcome).toBe("failed");
+      });
+
+      test("records the attempt before downloading so a failing update can't retry every run", async () => {
+        managedPosix();
+        captureTelemetry();
+
+        await applyPendingUpdateInForeground(eligible(), {
+          update: async () => null,
+          reexec: () => {},
+        });
+
+        const saved = loadUserSettings();
+        expect(saved.ok).toBe(true);
+        if (saved.ok) {
+          expect(saved.data.last_auto_update_attempt).toBeTruthy();
+          expect(saved.data.auto_update_attempts).toEqual({
+            version: "9.9.9",
+            count: 1,
+          });
+          // And the recorded attempt now throttles this run's own background
+          // dispatch, so the two paths can't both download.
+          expect(foregroundUpdateTarget(saved.data)).toBeNull();
+        }
+      });
+
+      test("end to end: downloads, installs, flips the symlink, re-execs the release binary", async () => {
+        managedPosix();
+        captureTelemetry();
+        spyOn(pathsModule, "getReleasePath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v)
+        );
+        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v, "squirrel")
+        );
+        spyOn(pathsModule, "getSymlinkPath").mockReturnValue(
+          join(tempHome, "bin", "squirrel")
+        );
+        spyOn(releasesModule, "checkForUpdates").mockResolvedValue({
+          ok: true,
+          data: {
+            available: true,
+            current_version: "0.0.1",
+            latest_version: "9.9.9",
+            release_url: null,
+            manifest: {
+              version: "9.9.9",
+              binaries: {
+                "darwin-arm64": {
+                  filename: "squirrel",
+                  sha256: "0".repeat(64),
+                  size: 3,
+                },
+                "darwin-x64": {
+                  filename: "squirrel",
+                  sha256: "0".repeat(64),
+                  size: 3,
+                },
+                "linux-x64": {
+                  filename: "squirrel",
+                  sha256: "0".repeat(64),
+                  size: 3,
+                },
+                "linux-arm64": {
+                  filename: "squirrel",
+                  sha256: "0".repeat(64),
+                  size: 3,
+                },
+                "windows-x64": {
+                  filename: "squirrel",
+                  sha256: "0".repeat(64),
+                  size: 3,
+                },
+              },
+            } as ReleaseManifest,
+          },
+        } as Awaited<ReturnType<typeof releasesModule.checkForUpdates>>);
+        spyOn(releasesModule, "downloadBinary").mockResolvedValue({
+          ok: true,
+          data: new TextEncoder().encode("bin").buffer as ArrayBuffer,
+        });
+
+        // The settings runAutoUpdate reloads from disk must be eligible too.
+        updateSettings({
+          auto_update: true,
+          pending_update_notification: { ...PENDING },
+        });
+
+        const reexeced: string[] = [];
+        await applyPendingUpdateInForeground(eligible(), {
+          reexec: (path) => reexeced.push(path),
+        });
+
+        expect(reexeced).toEqual([
+          join(tempHome, "releases", "9.9.9", "squirrel"),
+        ]);
+        expect(existsSync(join(tempHome, "bin", "squirrel"))).toBe(true);
+
+        const saved = loadUserSettings();
+        expect(saved.ok).toBe(true);
+        if (saved.ok) {
+          // The pending notification is consumed, and the marker that makes the
+          // re-executed run print "✓ auto-updated" exactly once is set.
+          expect(saved.data.pending_update_notification).toBeUndefined();
+          expect(saved.data.auto_update_applied?.to_version).toBe("9.9.9");
+          expect(saved.data.auto_update_attempts ?? null).toBeNull();
+        }
+      });
+    });
+
+    // The re-exec is the part that has to behave like execve: same arguments,
+    // same exit status, and the loop marker set for the process that takes over.
+    // Exercised against a real child process, not a stub.
+    describe.skipIf(process.platform === "win32")(
+      "reexecIntoUpdatedBinary",
+      () => {
+        test("passes argv through, sets the loop marker, propagates the exit code", () => {
+          const script = join(tempHome, "fake-squirrel");
+          const out = join(tempHome, "argv.txt");
+          writeFileSync(
+            script,
+            `#!/bin/sh\nprintf '%s|' "$@" > ${out}\nprintf 'marker=%s' "$${FOREGROUND_UPDATE_ENV}" >> ${out}\nexit 42\n`
+          );
+          chmodSync(script, 0o755);
+
+          spyOn(process, "exit").mockImplementation(((code?: number) => {
+            throw new Error(`__exit__:${code}`);
+          }) as never);
+
+          expect(() =>
+            reexecIntoUpdatedBinary(script, ["audit", "https://example.com"])
+          ).toThrow("__exit__:42");
+          expect(readFileSync(out, "utf-8")).toBe(
+            "audit|https://example.com|marker=1"
+          );
+        });
+
+        test("a child that cannot start returns (so the caller falls back) and restores signals", () => {
+          const before = process.listenerCount("SIGINT");
+          const exitSpy = spyOn(process, "exit").mockImplementation(((
+            code?: number
+          ) => {
+            throw new Error(`__exit__:${code}`);
+          }) as never);
+
+          reexecIntoUpdatedBinary(join(tempHome, "does-not-exist"), []);
+
+          expect(exitSpy).not.toHaveBeenCalled();
+          expect(process.listenerCount("SIGINT")).toBe(before);
+        });
+      }
+    );
   });
 });

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -741,6 +741,12 @@ describe("updater", () => {
         spyOn(console, "error").mockImplementation((...args: unknown[]) => {
           stderr.push(args.map(String).join(" "));
         });
+        // Production reads the same notification the caller snapshotted; the
+        // apply path re-reads it to detect a concurrent run consuming it.
+        updateSettings({
+          auto_update: true,
+          pending_update_notification: { ...PENDING },
+        });
       });
 
       test("announces the update rather than stalling silently", async () => {
@@ -790,7 +796,10 @@ describe("updater", () => {
         expect(reexec).not.toHaveBeenCalled();
         expect(fetched).toBe(false);
         // Nothing was attempted, so nothing throttles the next run either.
-        expect(existsSync(join(tempHome, "settings.json"))).toBe(false);
+        const saved = loadUserSettings();
+        if (saved.ok) {
+          expect(saved.data.last_auto_update_attempt ?? null).toBeNull();
+        }
       });
 
       test("installs first, then re-execs into the new binary", async () => {
@@ -874,7 +883,10 @@ describe("updater", () => {
         captureTelemetry();
 
         await applyPendingUpdateInForeground(eligible(), {
-          update: async () => null,
+          update: async (_signal, onStart) => {
+            onStart();
+            return null;
+          },
           reexec: () => {},
         });
 
@@ -890,6 +902,135 @@ describe("updater", () => {
           // dispatch, so the two paths can't both download.
           expect(foregroundUpdateTarget(saved.data)).toBeNull();
         }
+      });
+
+      // #1085: the loud "didn't complete on this system" box must not be armed
+      // by an attempt that never got past the update lock — the other updater
+      // is doing the work.
+      test("an update that never starts (lock held) does not count as a failure", async () => {
+        managedPosix();
+        captureTelemetry();
+
+        await applyPendingUpdateInForeground(eligible(), {
+          // Never calls onStart: this is what losing the lock looks like.
+          update: async () => null,
+          reexec: () => {},
+        });
+
+        const saved = loadUserSettings();
+        expect(saved.ok).toBe(true);
+        if (saved.ok) {
+          expect(saved.data.auto_update_attempts ?? null).toBeNull();
+          // The hourly throttle is still recorded, so this run's own background
+          // dispatch can't pile a second download onto the one in flight.
+          expect(saved.data.last_auto_update_attempt).toBeTruthy();
+        }
+      });
+
+      // The user's command must never wait forever on a stalled download: past
+      // the ceiling the install is handed to the detached updater (pre-#170
+      // behaviour) and the command runs now.
+      test("a deadline abort aborts the download and hands it to the detached updater", async () => {
+        managedPosix();
+        captureTelemetry();
+        const spawnSpy = spyOn(childProcess, "spawn").mockReturnValue({
+          unref() {},
+        } as unknown as ReturnType<typeof childProcess.spawn>);
+        let sawAbort = false;
+
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          timeoutMs: 10,
+          update: (signal, onStart) => {
+            onStart();
+            return new Promise<string | null>((resolve) => {
+              signal.addEventListener(
+                "abort",
+                () => {
+                  sawAbort = true;
+                  resolve(null);
+                },
+                { once: true }
+              );
+            });
+          },
+          reexec: () => {},
+        });
+
+        expect(sawAbort).toBe(true);
+        expect(outcome).toBe("failed");
+        expect(spawnSpy).toHaveBeenCalledTimes(1);
+        expect(spawnSpy.mock.calls[0]?.[1]).toEqual([
+          "self",
+          "update",
+          "--auto",
+        ]);
+      });
+
+      test("an ordinary failure does NOT spawn a detached updater", async () => {
+        managedPosix();
+        captureTelemetry();
+        const spawnSpy = spyOn(childProcess, "spawn").mockReturnValue({
+          unref() {},
+        } as unknown as ReturnType<typeof childProcess.spawn>);
+
+        await applyPendingUpdateInForeground(eligible(), {
+          update: async (_signal, onStart) => {
+            onStart();
+            return null;
+          },
+          reexec: () => {},
+        });
+
+        expect(spawnSpy).not.toHaveBeenCalled();
+      });
+
+      test("another run having already applied the update re-execs without downloading", async () => {
+        managedPosix();
+        captureTelemetry();
+        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v, "squirrel")
+        );
+        mkdirSync(join(tempHome, "releases", "9.9.9"), { recursive: true });
+        writeFileSync(join(tempHome, "releases", "9.9.9", "squirrel"), "bin");
+        // On disk the notification is already consumed; the caller's snapshot
+        // still has it (it was read at startup).
+        updateSettings({ pending_update_notification: undefined });
+
+        const update = mock(async () => null);
+        const reexeced: string[] = [];
+
+        await applyPendingUpdateInForeground(eligible(), {
+          update,
+          reexec: (path) => {
+            reexeced.push(path);
+          },
+        });
+
+        expect(update).not.toHaveBeenCalled();
+        expect(reexeced).toEqual([
+          join(tempHome, "releases", "9.9.9", "squirrel"),
+        ]);
+      });
+
+      test("notification consumed and nothing installed: skip, run the command", async () => {
+        managedPosix();
+        captureTelemetry();
+        spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+          join(tempHome, "releases", v, "squirrel")
+        );
+        updateSettings({ pending_update_notification: undefined });
+
+        const update = mock(async () => null);
+        const reexec = mock(() => {});
+
+        const outcome = await applyPendingUpdateInForeground(eligible(), {
+          update,
+          reexec,
+        });
+
+        expect(outcome).toBe("skipped");
+        expect(update).not.toHaveBeenCalled();
+        expect(reexec).not.toHaveBeenCalled();
       });
 
       test("end to end: downloads, installs, flips the symlink, re-execs the release binary", async () => {
@@ -956,7 +1097,9 @@ describe("updater", () => {
 
         const reexeced: string[] = [];
         await applyPendingUpdateInForeground(eligible(), {
-          reexec: (path) => reexeced.push(path),
+          reexec: (path) => {
+            reexeced.push(path);
+          },
         });
 
         expect(reexeced).toEqual([
@@ -977,43 +1120,85 @@ describe("updater", () => {
     });
 
     // The re-exec is the part that has to behave like execve: same arguments,
-    // same exit status, and the loop marker set for the process that takes over.
-    // Exercised against a real child process, not a stub.
+    // same exit status, signals reaching the child, and the loop marker set for
+    // the process that takes over. Exercised against real child processes.
     describe.skipIf(process.platform === "win32")(
       "reexecIntoUpdatedBinary",
       () => {
-        test("passes argv through, sets the loop marker, propagates the exit code", () => {
-          const script = join(tempHome, "fake-squirrel");
-          const out = join(tempHome, "argv.txt");
-          writeFileSync(
-            script,
-            `#!/bin/sh\nprintf '%s|' "$@" > ${out}\nprintf 'marker=%s' "$${FOREGROUND_UPDATE_ENV}" >> ${out}\nexit 42\n`
-          );
-          chmodSync(script, 0o755);
+        let exits: number[];
 
+        beforeEach(() => {
+          exits = [];
           spyOn(process, "exit").mockImplementation(((code?: number) => {
-            throw new Error(`__exit__:${code}`);
+            exits.push(code ?? -1);
           }) as never);
+        });
 
-          expect(() =>
-            reexecIntoUpdatedBinary(script, ["audit", "https://example.com"])
-          ).toThrow("__exit__:42");
+        function writeScript(name: string, body: string): string {
+          const path = join(tempHome, name);
+          writeFileSync(path, `#!/bin/sh\n${body}\n`);
+          chmodSync(path, 0o755);
+          return path;
+        }
+
+        async function waitFor(
+          predicate: () => boolean,
+          label: string
+        ): Promise<void> {
+          for (let i = 0; i < 400; i++) {
+            if (predicate()) return;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          throw new Error(`timed out waiting for ${label}`);
+        }
+
+        test("passes argv through, sets the loop marker, propagates the exit code", async () => {
+          const out = join(tempHome, "argv.txt");
+          const script = writeScript(
+            "fake-squirrel",
+            `printf '%s|' "$@" > ${out}\n` +
+              `printf 'marker=%s' "$${FOREGROUND_UPDATE_ENV}" >> ${out}\n` +
+              "exit 42"
+          );
+
+          void reexecIntoUpdatedBinary(script, [
+            "audit",
+            "https://example.com",
+          ]);
+          await waitFor(() => exits.length > 0, "the child to exit");
+
+          expect(exits).toEqual([42]);
           expect(readFileSync(out, "utf-8")).toBe(
             "audit|https://example.com|marker=1"
           );
         });
 
-        test("a child that cannot start returns (so the caller falls back) and restores signals", () => {
+        // The waiting parent must not swallow cancellation: a supervisor that
+        // signals THIS pid has to reach the command the user asked for.
+        test("forwards a signal sent to this process to the child", async () => {
+          const started = join(tempHome, "started");
+          const script = writeScript(
+            "trapping-squirrel",
+            `trap 'exit 7' TERM\ntouch ${started}\nsleep 10 &\nwait`
+          );
+
+          void reexecIntoUpdatedBinary(script, []);
+          await waitFor(() => existsSync(started), "the child to start");
+
+          process.emit("SIGTERM");
+          await waitFor(() => exits.length > 0, "the child to handle SIGTERM");
+
+          expect(exits).toEqual([7]);
+          // The forwarding handlers must not outlive the child.
+          expect(process.listenerCount("SIGTERM")).toBe(0);
+        });
+
+        test("a child that cannot start resolves (so the caller falls back) and restores signals", async () => {
           const before = process.listenerCount("SIGINT");
-          const exitSpy = spyOn(process, "exit").mockImplementation(((
-            code?: number
-          ) => {
-            throw new Error(`__exit__:${code}`);
-          }) as never);
 
-          reexecIntoUpdatedBinary(join(tempHome, "does-not-exist"), []);
+          await reexecIntoUpdatedBinary(join(tempHome, "does-not-exist"), []);
 
-          expect(exitSpy).not.toHaveBeenCalled();
+          expect(exits).toEqual([]);
           expect(process.listenerCount("SIGINT")).toBe(before);
         });
       }


### PR DESCRIPTION
Closes #170

## What changed

When auto-update is on and an earlier background check has already recorded a pending update, the CLI now **installs it before running the command** and re-executes the original argv on the new binary. Previously `maybeSpawnAutoUpdate` fired a detached `self update --auto` child and the current invocation carried on with the old version, so a run right after a release could report results from a version behind, sometimes for several invocations.

Entry point: `foregroundUpdateTarget()` (synchronous gate) + `applyPendingUpdateInForeground()` (`apps/cli/src/self/updater.ts`), wired into `run()` in `apps/cli/src/cli/index.ts`.

## Behaviour

- **Fast path untouched.** The gate is synchronous and settings-only, so with nothing pending there is no `await`, no network and no extra fs work at startup. Measured: 0.145s for `self doctor` with nothing pending, same as before.
- **Suppression gates all skip it**, verified against a real binary: CI, `SQUIRREL_NO_UPDATE`, unmanaged install, `auto_update: false`, dismissed version, the hourly attempt throttle, and the update lock (contention falls back to the current binary immediately).
- **`update_check_interval_hours` is untouched.** The foreground path never performs a check of its own; it acts only on the notification the hourly check already stored. Its own dispatch is throttled by `last_auto_update_attempt`, the same hourly throttle the background dispatch uses.
- **Failure-safe.** Any download / checksum / install / re-exec failure logs and runs the command on the current binary. Never a hard error for the user's command.
- **Loop-proof.** The re-executed process carries `SQUIRREL_UPDATE_REEXEC=1` and `foregroundUpdateTarget()` returns null whenever it is set.
- **Bounded.** The wait is capped at 2 minutes; past that the download is handed to the detached updater (pre-#170 behaviour) and the command runs now, so slow links still get updated, just not in-line.
- **`self install|update|uninstall`, `mcp`, `--offline`, `--version`, `--help`** keep skipping every background task, exactly as before.
- **The "✓ auto-updated" notice still appears exactly once**, printed by the re-executed run — now from the common startup path (`cli/index.ts`), so it announces regardless of which command was invoked. It used to be printed only by `audit`/`crawl`, which meant an update applied before `config`/`credits`/`analyze` was never announced and the marker surfaced later on an unrelated audit. The run that applies the update still cannot print it (the existing `applied.to_version !== version` guard).

## Windows

**The foreground path is POSIX only**, guarded in `foregroundUpdateTarget()`; Windows keeps today's in-process/background updater. On Windows the thing on PATH is a *copy* of the binary rather than a symlink (`link-binary.ts`), and it is the running image being replaced — a synchronous swap-then-re-exec has to reason about a loaded exe renamed out from under the process about to spawn from it. Given the #1538 EPERM history there, that is not a path worth shipping without a Windows box to prove it on. `foregroundUpdateTarget` has a test asserting win32 returns null.

## Re-exec mechanism

`spawn` (async) with `stdio: "inherit"`, the process's own argv/env/cwd, plus the loop marker. Exit status is propagated; a child killed by a signal makes this process re-raise the same signal (falling back to the shell's `128+n` encoding). SIGINT/SIGTERM/SIGHUP/SIGQUIT are **forwarded** to the child rather than held, so a supervisor signalling this pid still cancels the command. The freshly installed release path is used rather than the symlink, so a concurrent updater cannot flip it between install and spawn.

## Review

Two `codex` passes over `git diff origin/main`. Findings and resolutions:

| # | Finding | Resolution |
|---|---|---|
| High | `spawnSync` blocked the loop for the whole child run, so a SIGTERM aimed at this pid reached nothing — the command was uncancellable for as long as it ran | Async `spawn` + signal forwarding + signal re-raise (commit 2) |
| High | Unbounded wait: `releases.ts` only times out response *headers*, so a stalled body hung the CLI forever | 2-minute ceiling via `AbortController`, with a detached handoff on deadline (commit 2) |
| Medium | Lock contention counted as a failed attempt and could arm the #1085 loud fallback box while the lock holder was still working | New `runAutoUpdate({ onStart })`, fired only once the lock is held (commit 2) |
| Medium | Notification not revalidated between snapshot and install | Re-read before installing; a concurrent run's install is re-executed instead of re-downloaded (commit 2) |
| Medium | "notification consumed + binary on disk" was read as "installed", but `self update --dismiss` produces that state and old releases are kept for rollback | Require the `auto_update_applied` marker for that exact version; a dismissal recorded since the snapshot vetoes (commit 3) |
| Medium | `spawnDetachedAutoUpdate` caught only synchronous throws; an async `error` event would take the CLI down | `child.once("error")` before `unref` (commit 3). Pre-existing on the background dispatch |
| Low | Test leaked signal listeners; several tests weaker than their names | Rewritten: real lock contention, full deadline chain, signal-death branch, dismissed/stale-copy cases |

Not addressed, with reasons: the "✓ auto-updated" notice is not atomic across two *simultaneous* new-binary runs (`banner.ts` read-print-clear over unlocked `updateSettings`) — pre-existing, unrelated to this change, and it needs a settings-level lock to fix properly. `update_auto_started` telemetry still fires before lock acquisition — deliberate per its #1074 comment.

## Test evidence

```
cd apps/cli
bun run typecheck   # tsgo --noEmit, clean
bun run lint        # oxlint, clean
bun run format:check  # (after `bun run format` at repo root) clean
bun test            # 1848 pass, 1 skip, 0 fail (147 files)
bun test tests/self/updater.test.ts   # 60 pass
```

Plus a real end-to-end run: a v0.0.80 binary installed as a managed install under a temp `HOME` with a pending update to v0.0.89 (the live release).

- update applied in the foreground, `self doctor` in the re-executed run reports `Binary: v0.0.89 installed` and the symlink pointing at `releases/0.0.89`
- non-zero exit propagates: `squirrel audit` with no URL through the re-exec exits 1, matching the same command without an update, and the usage banner reads `squirrel audit v0.0.89`
- `kill -TERM` to the parent pid during the re-executed audit: whole thing exits in 2s with code 143, no orphans (before the fix this was ignored for the entire run)
- "✓ squirrel auto-updated v0.0.80 → v0.0.89" printed on the next audit, zero times on the one after
- CI / `SQUIRREL_NO_UPDATE` / `SQUIRREL_UPDATE_REEXEC` / `auto_update: false` / unmanaged: no notice, no install



## Round 3: acceptance review

Four more fixes (commit 5) and four rulings.

**Fixed.** The "✓ auto-updated" notice moved from `audit`/`crawl` into the common startup path, so every command announces an update applied before it (`shouldRunBackgroundTasks(argv)` is now exported and tested, with a case per command). The update lock is checked in `foregroundUpdateTarget()` rather than being discovered inside `runAutoUpdate` — a lock held by another updater now skips the foreground path silently, without announcing anything or burning the hourly throttle on work someone else is doing. `SQUIRREL_UPDATE_REEXEC` is consumed at the gate instead of leaking into the whole descendant tree and muting a nested `squirrel`'s own update. SIGUSR1/SIGUSR2 joined the forwarded-signal list.

**`update_check_interval_hours` does not veto applying a stored update — deliberate.** The setting governs how often the CLI *checks*; applying an update it already knows about is the entire point of this change, and vetoing on the interval would be self-defeating, since the interval always reads as "recently checked" right after the check that recorded the notification. Pinned by a test asserting a stored pending update is still applied with the interval at its 31-day maximum.

**Dismissal mid-download — fixed rather than documented.** A download lasts long enough for `squirrel self update --dismiss` to land in the middle of one, so `performUpdate` now re-reads settings immediately before the binary swap and aborts if that exact version has since been dismissed. Unattended paths opt in (`runAutoUpdate`, so both the detached updater and this one); explicit `squirrel self update` deliberately does not, because asking for an update outranks an earlier dismissal. The test was checked for falsifiability by disabling the guard.

**Not fixed, and why.** The notice is still not atomic across two *simultaneous* new-binary runs: `banner.ts` reads, prints, then clears over an unlocked `updateSettings`. Pre-existing, unrelated to this change, and a proper fix needs a settings-level lock. Likewise, a re-exec child that fails to start asynchronously counts toward the #1085 per-version failure counter — the attempt genuinely began (lock taken, download done, install landed), so the accounting is imprecise only on an error path that already means the update is in a bad state; not worth a separate outcome channel. `update_auto_started` telemetry also still fires before lock acquisition, which its #1074 comment says is intentional.

## Additional test evidence (round 3)

`bun test` 1874 pass / 1 skip / 0 fail across 148 files; the updater suite is 65, plus 21 new in `tests/cli/startup.test.ts`.

Against real binaries under a fake `HOME`: `credits`, `config show` and `self doctor` each print the notice exactly once and zero times on the following run — none of them could print it at all before; `audit` still prints it once; `--offline` and `--version` stay silent. A separate run also exercised the failure-safe path for real: one foreground attempt failed on a transient network error, the command ran on the current binary and exited 0, and the hourly throttle correctly suppressed a retry on the next invocation.
