### PR TITLE
fix(rules): leaked-secrets detects quoted JSON keys, env fallbacks, standard-base64 bearer tokens (#150)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -326,7 +326,7 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 1047
+        "line_number": 1088
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T09:13:55Z"
+  "generated_at": "2026-09-01T09:45:09Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -291,42 +291,42 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 386
+        "line_number": 394
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "daefe0b4345a654580dcad25c7c11ff4c944a8c0",
         "is_verified": false,
-        "line_number": 391
+        "line_number": 399
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "f0778f3e140a61d5bbbed5430773e52af2f5fba4",
         "is_verified": false,
-        "line_number": 396
+        "line_number": 404
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 409
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
         "is_verified": false,
-        "line_number": 406
+        "line_number": 414
       },
       {
         "type": "Secret Keyword",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 986
+        "line_number": 1028
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T08:23:23Z"
+  "generated_at": "2026-09-01T08:45:44Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -326,7 +326,7 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 950
+        "line_number": 986
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-31T23:41:35Z"
+  "generated_at": "2026-09-01T08:23:23Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -291,42 +291,42 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 394
+        "line_number": 399
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "daefe0b4345a654580dcad25c7c11ff4c944a8c0",
         "is_verified": false,
-        "line_number": 399
+        "line_number": 404
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "f0778f3e140a61d5bbbed5430773e52af2f5fba4",
         "is_verified": false,
-        "line_number": 404
+        "line_number": 409
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
         "is_verified": false,
-        "line_number": 409
+        "line_number": 414
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
         "is_verified": false,
-        "line_number": 414
+        "line_number": 419
       },
       {
         "type": "Secret Keyword",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 1028
+        "line_number": 1047
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T08:45:44Z"
+  "generated_at": "2026-09-01T09:13:55Z"
 }

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -420,25 +420,47 @@ const FAST_PATTERNS: FastPattern[] = [
   },
 
   // Generic patterns (lower confidence, check context)
+  //
+  // Three things separate the key from its value here, and all three are
+  // optional because all three are ordinary:
+  //
+  // - a closing quote, because JSON quotes its keys: `{"apiKey":"…"}` and
+  //   `{"x-api-key":"…"}` are how an embedded config blob or a
+  //   `<script type="application/json">` payload writes an assignment.
+  // - a `key`/`token` tail, so `SECRET_KEY` reads as one key and not as
+  //   `secret` followed by something that broke the match.
+  // - `||` / `??` as well as `:` / `=`, because a hardcoded fallback behind an
+  //   env var (`process.env.SECRET_KEY || "…"`) is one of the likeliest ways a
+  //   real credential reaches a bundle: it looks safe in source and the
+  //   bundler inlines it at build.
+  //
+  // The key still has to END where the separator begins, so `secret_hash`,
+  // `apiKeyHash` and `secretHash` match nothing — a digest key never becomes a
+  // credential key by widening this.
   {
     name: "Generic API Key Assignment",
-    pattern: /(?:api[_-]?key|apikey)\s*[:=]\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+    pattern:
+      /(?:api[_-]?key|apikey)['"]?\s*(?:[:=]|\|\||\?\?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
     confidence: "medium",
   },
   {
     name: "Generic Secret Assignment",
-    pattern: /(?:secret|password|passwd|pwd)\s*[:=]\s*['"][^'"]{8,}['"]/gi,
+    pattern:
+      /(?:secret|password|passwd|pwd)(?:[_-]?(?:key|token))?['"]?\s*(?:[:=]|\|\||\?\?)\s*['"][^'"]{8,}['"]/gi,
     confidence: "medium",
   },
   {
     name: "Generic Token Assignment",
     pattern:
-      /(?:access[_-]?token|auth[_-]?token)\s*[:=]\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+      /(?:access[_-]?token|auth[_-]?token)['"]?\s*(?:[:=]|\|\||\?\?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
     confidence: "medium",
   },
   {
+    // Standard base64, not just base64url: a token with `+` or `/` in its first
+    // 20 characters used to stop the match short of the length threshold and
+    // report nothing at all, and `=` padding was dropped from the value.
     name: "Bearer Token",
-    pattern: /Bearer\s+[a-zA-Z0-9_-]{20,}/g,
+    pattern: /Bearer\s+[a-zA-Z0-9_+/=-]{20,}/g,
     confidence: "medium",
   },
   {
@@ -643,6 +665,13 @@ function isInValuePosition(
     return true;
   }
 
+  // A fallback behind an env var — `process.env.SECRET_KEY || "value"`,
+  // `?? "value"` — is a value position too. classifyKeyContext still reads the
+  // key in front of the `||`, so a `cacheKey || "…"` fallback stays a digest.
+  if (/(?:\|\||\?\?)\s*['"`]?$/.test(before)) {
+    return true;
+  }
+
   // Check if it's in a quoted string that's an object value
   // e.g., { key: "value" } or "key": "value"
   if (/:\s*['"`]$/.test(before) && /^['"`]/.test(after)) {
@@ -760,16 +789,23 @@ export function lookBehind(text: string, index: number): string {
   return text.slice(start, index);
 }
 
+// The three regexes below all separate a key from its value with
+// `(?:[:=]|\|\||\?\?)`. `||` and `??` are there for the same reason
+// isInValuePosition accepts them: `process.env.SECRET_KEY || "…"` is an
+// assignment. Reading the key across the fallback is what keeps it honest —
+// `cacheKey || "<hex>"` still classifies as a digest.
+
 // The key an assignment puts immediately in front of a value:
-// `sha256:"`, `api_key = "`, `"x-api-key":`, `apiKey:`
+// `sha256:"`, `api_key = "`, `"x-api-key":`, `apiKey:`, `SECRET_KEY || "`
 const PRECEDING_KEY_RE =
-  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*[:=]\s*["'`]?\s*$/;
+  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*(?:[:=]|\|\||\?\?)\s*["'`]?\s*$/;
 
 // The same, written as a bracket access: `cfg["apiKey"] = "`, `cfg['sha256'] =`
-const BRACKET_KEY_RE = /\[\s*["'`]([^"'`\]]{1,64})["'`]\s*\]\s*[:=]\s*["'`]?\s*$/;
+const BRACKET_KEY_RE =
+  /\[\s*["'`]([^"'`\]]{1,64})["'`]\s*\]\s*(?:[:=]|\|\||\?\?)\s*["'`]?\s*$/;
 
 // Anything at all in value position, whatever the key turned out to be
-const ASSIGNMENT_RE = /[:=]\s*["'`]?\s*$/;
+const ASSIGNMENT_RE = /(?:[:=]|\|\||\?\?)\s*["'`]?\s*$/;
 
 // SRI and prefixed-digest values: integrity="sha384-…", `sha256-…`, `md5:…`
 const DIGEST_PREFIX_RE = /(?:sha-?(?:1|256|384|512)|md5)\s*[-:]\s*[\w+/=-]*$/i;

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -22,6 +22,13 @@ type FastPattern = {
    * false positive that erodes trust in the security category.
    */
   publicByDesign?: boolean;
+  /**
+   * The pattern anchors on a credential word that can appear part-way through
+   * a longer key (`cache-api-key`, `checksum_secret`). Such a match reads the
+   * rest of its own key and drops out if that key says "digest" — see
+   * startsInsideDigestKey.
+   */
+  keyAnchored?: boolean;
 };
 
 // Type for context patterns (generic patterns, only run if keyword present)
@@ -47,7 +54,12 @@ type ContextPattern = {
 // `AKIA`, `pk_live_`), a suffix (`NRAL`, `-us1`), a URL host, a PEM header, or a
 // required keyword in the pattern itself (AWS secret key, the generic
 // assignments, `Bearer`). None of them match a bare digest, so none of them
-// needs the key-context gate the CONTEXT_PATTERNS tier uses.
+// needs the whole key-context gate the CONTEXT_PATTERNS tier uses.
+//
+// The entries whose marker is a keyword the key can merely CONTAIN — the AWS
+// secret key and the three generic assignments — carry `keyAnchored` instead,
+// a much narrower check: the key they matched part-way through must not be a
+// digest key. `cache-api-key` is a cache key however it ends.
 const FAST_PATTERNS: FastPattern[] = [
   // AI/ML Services
   {
@@ -184,6 +196,7 @@ const FAST_PATTERNS: FastPattern[] = [
     pattern:
       /(?:aws[_-]?(?:secret)?[_-]?(?:access)?[_-]?key|secret[_-]?access[_-]?key)['"]?\s*[:=]\s*['"]?[A-Za-z0-9/+=]{40}['"]?/gi,
     confidence: "medium",
+    keyAnchored: true,
   },
   {
     // AIza… keys in frontend code are Maps/Firebase browser keys — meant to
@@ -421,46 +434,57 @@ const FAST_PATTERNS: FastPattern[] = [
 
   // Generic patterns (lower confidence, check context)
   //
-  // Three things separate the key from its value here, and all three are
-  // optional because all three are ordinary:
+  // Four things can sit between the key and its value here, and all four are
+  // optional because all four are ordinary:
   //
-  // - a closing quote, because JSON quotes its keys: `{"apiKey":"…"}` and
-  //   `{"x-api-key":"…"}` are how an embedded config blob or a
-  //   `<script type="application/json">` payload writes an assignment.
+  // - a closing quote and a `]`, because JSON quotes its keys and code reaches
+  //   for them: `{"apiKey":"…"}`, `{"x-api-key":"…"}` and
+  //   `process.env["SECRET_KEY"] || "…"` are how an embedded config blob, a
+  //   `<script type="application/json">` payload and a build-time env read
+  //   write an assignment.
   // - a `key`/`token` tail, so `SECRET_KEY` reads as one key and not as
   //   `secret` followed by something that broke the match.
-  // - `||` / `??` as well as `:` / `=`, because a hardcoded fallback behind an
-  //   env var (`process.env.SECRET_KEY || "…"`) is one of the likeliest ways a
-  //   real credential reaches a bundle: it looks safe in source and the
-  //   bundler inlines it at build.
+  // - `||` / `??` (and their `||=` / `??=` forms) as well as `:` / `=`,
+  //   because a hardcoded fallback behind an env var
+  //   (`process.env.SECRET_KEY || "…"`) is one of the likeliest ways a real
+  //   credential reaches a bundle: it looks safe in source and the bundler
+  //   inlines it at build.
   //
-  // The key still has to END where the separator begins, so `secret_hash`,
-  // `apiKeyHash` and `secretHash` match nothing — a digest key never becomes a
-  // credential key by widening this.
+  // The key has to END where the separator begins, so `secret_hash`,
+  // `apiKeyHash` and `secretHash` match nothing; and because each of these
+  // anchors on a credential word rather than on the start of the key, they are
+  // `keyAnchored` and read their own left edge too, so `cache-api-key` and
+  // `checksum_secret` stay digests.
   {
     name: "Generic API Key Assignment",
     pattern:
-      /(?:api[_-]?key|apikey)['"]?\s*(?:[:=]|\|\||\?\?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+      /(?:api[_-]?key|apikey)['"]?\s*\]?\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
     confidence: "medium",
+    keyAnchored: true,
   },
   {
     name: "Generic Secret Assignment",
     pattern:
-      /(?:secret|password|passwd|pwd)(?:[_-]?(?:key|token))?['"]?\s*(?:[:=]|\|\||\?\?)\s*['"][^'"]{8,}['"]/gi,
+      /(?:secret|password|passwd|pwd)(?:[_-]?(?:key|token))?['"]?\s*\]?\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][^'"]{8,}['"]/gi,
     confidence: "medium",
+    keyAnchored: true,
   },
   {
     name: "Generic Token Assignment",
     pattern:
-      /(?:access[_-]?token|auth[_-]?token)['"]?\s*(?:[:=]|\|\||\?\?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+      /(?:access[_-]?token|auth[_-]?token)['"]?\s*\]?\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
     confidence: "medium",
+    keyAnchored: true,
   },
   {
     // Standard base64, not just base64url: a token with `+` or `/` in its first
     // 20 characters used to stop the match short of the length threshold and
     // report nothing at all, and `=` padding was dropped from the value.
+    //
+    // Padding is trailing and at most two characters, which is what keeps
+    // `Bearer ====================` from being a token.
     name: "Bearer Token",
-    pattern: /Bearer\s+[a-zA-Z0-9_+/=-]{20,}/g,
+    pattern: /Bearer\s+[a-zA-Z0-9_+/-]{20,}={0,2}/g,
     confidence: "medium",
   },
   {
@@ -668,7 +692,7 @@ function isInValuePosition(
   // A fallback behind an env var — `process.env.SECRET_KEY || "value"`,
   // `?? "value"` — is a value position too. classifyKeyContext still reads the
   // key in front of the `||`, so a `cacheKey || "…"` fallback stays a digest.
-  if (/(?:\|\||\?\?)\s*['"`]?$/.test(before)) {
+  if (/(?:\|\||\?\?)=?\s*['"`]?$/.test(before)) {
     return true;
   }
 
@@ -798,14 +822,14 @@ export function lookBehind(text: string, index: number): string {
 // The key an assignment puts immediately in front of a value:
 // `sha256:"`, `api_key = "`, `"x-api-key":`, `apiKey:`, `SECRET_KEY || "`
 const PRECEDING_KEY_RE =
-  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*(?:[:=]|\|\||\?\?)\s*["'`]?\s*$/;
+  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*\]?\s*(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
 
 // The same, written as a bracket access: `cfg["apiKey"] = "`, `cfg['sha256'] =`
 const BRACKET_KEY_RE =
-  /\[\s*["'`]([^"'`\]]{1,64})["'`]\s*\]\s*(?:[:=]|\|\||\?\?)\s*["'`]?\s*$/;
+  /\[\s*["'`]([^"'`\]]{1,64})["'`]\s*\]\s*(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
 
 // Anything at all in value position, whatever the key turned out to be
-const ASSIGNMENT_RE = /(?:[:=]|\|\||\?\?)\s*["'`]?\s*$/;
+const ASSIGNMENT_RE = /(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
 
 // SRI and prefixed-digest values: integrity="sha384-…", `sha256-…`, `md5:…`
 const DIGEST_PREFIX_RE = /(?:sha-?(?:1|256|384|512)|md5)\s*[-:]\s*[\w+/=-]*$/i;
@@ -844,6 +868,29 @@ export function enclosingTag(text: string, index: number): string | undefined {
   if (text.slice(open, index).includes(">")) return undefined;
   const close = text.indexOf(">", index);
   return close === -1 ? undefined : text.slice(open, close + 1);
+}
+
+/**
+ * Does the key this match started in the middle of say "digest"?
+ *
+ * The generic assignments anchor on a credential word, not on the start of the
+ * key, so `cache-api-key:"…"` starts an `api-key` match at character 6 and
+ * `checksum_secret = "…"` starts a `secret` match at character 9. Nothing
+ * behind them catches it: the FAST tier has no classifyKeyContext gate, by
+ * design — every other pattern in it carries a literal marker that a digest
+ * cannot wear. These three do not, so they read their own left edge.
+ *
+ * Bounded by the same budget as lookBehind. Running out mid-key can only
+ * truncate the prefix, and a truncated prefix suppresses at worst.
+ */
+function startsInsideDigestKey(text: string, index: number): boolean {
+  const floor = Math.max(0, index - SECRET_KEY_LOOKBEHIND_SIZE * 2);
+  let start = index;
+  while (start > floor && KEY_CHAR_RE.test(text[start - 1] ?? "")) start--;
+  if (start === index) return false;
+  return keyWords(text.slice(start, index)).some((word) =>
+    DIGEST_KEY_WORDS.has(word)
+  );
 }
 
 /** Every key a tag names, whichever attribute order it wrote them in. */
@@ -1001,7 +1048,8 @@ export function scanContent(
     name: string,
     pattern: RegExp,
     confidence: "high" | "medium",
-    publicByDesign: boolean
+    publicByDesign: boolean,
+    keyAnchored = false
   ) => {
     // Reset pattern state for global regex
     pattern.lastIndex = 0;
@@ -1009,6 +1057,12 @@ export function scanContent(
     let match: RegExpExecArray | null;
     while ((match = pattern.exec(text)) !== null) {
       const value = match[0];
+
+      // A generic assignment can start part-way through a longer key, so the
+      // words to its left decide too: `cache-api-key` is a cache key.
+      if (keyAnchored && startsInsideDigestKey(text, match.index)) {
+        continue;
+      }
 
       // Skip duplicates, overlapping rematches, and false positives
       if (
@@ -1032,8 +1086,21 @@ export function scanContent(
   };
 
   // Pass 1: Run all fast patterns (distinctive prefixes, O(n) safe)
-  for (const { name, pattern, confidence, publicByDesign } of FAST_PATTERNS) {
-    processMatches(content, name, pattern, confidence, publicByDesign ?? false);
+  for (const {
+    name,
+    pattern,
+    confidence,
+    publicByDesign,
+    keyAnchored,
+  } of FAST_PATTERNS) {
+    processMatches(
+      content,
+      name,
+      pattern,
+      confidence,
+      publicByDesign ?? false,
+      keyAnchored ?? false
+    );
   }
 
   // Pass 2: Run context patterns only on windows around keyword occurrences

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -437,11 +437,14 @@ const FAST_PATTERNS: FastPattern[] = [
   // Four things can sit between the key and its value here, and all four are
   // optional because all four are ordinary:
   //
-  // - a closing quote and a `]`, because JSON quotes its keys and code reaches
-  //   for them: `{"apiKey":"…"}`, `{"x-api-key":"…"}` and
+  // - a closing quote, optionally followed by the `]` that closes a bracket
+  //   access, because JSON quotes its keys and code reaches for them:
+  //   `{"apiKey":"…"}`, `{"x-api-key":"…"}` and
   //   `process.env["SECRET_KEY"] || "…"` are how an embedded config blob, a
   //   `<script type="application/json">` payload and a build-time env read
-  //   write an assignment.
+  //   write an assignment. The `]` only counts WITH that quote — a bare
+  //   `translations[apiKey] ||= "…"` is a lookup keyed by a variable, and the
+  //   variable's name does not name the value.
   // - a `key`/`token` tail, so `SECRET_KEY` reads as one key and not as
   //   `secret` followed by something that broke the match.
   // - `||` / `??` (and their `||=` / `??=` forms) as well as `:` / `=`,
@@ -453,26 +456,26 @@ const FAST_PATTERNS: FastPattern[] = [
   // The key has to END where the separator begins, so `secret_hash`,
   // `apiKeyHash` and `secretHash` match nothing; and because each of these
   // anchors on a credential word rather than on the start of the key, they are
-  // `keyAnchored` and read their own left edge too, so `cache-api-key` and
+  // `keyAnchored` and read their own left edge too, so `"cache-api-key"` and
   // `checksum_secret` stay digests.
   {
     name: "Generic API Key Assignment",
     pattern:
-      /(?:api[_-]?key|apikey)['"]?\s*(?:\]\s*)?(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+      /(?:api[_-]?key|apikey)(?:['"]\s*\]|['"]?)\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
     confidence: "medium",
     keyAnchored: true,
   },
   {
     name: "Generic Secret Assignment",
     pattern:
-      /(?:secret|password|passwd|pwd)(?:[_-]?(?:key|token))?['"]?\s*(?:\]\s*)?(?:[:=]|\|\|=?|\?\?=?)\s*['"][^'"]{8,}['"]/gi,
+      /(?:secret|password|passwd|pwd)(?:[_-]?(?:key|token))?(?:['"]\s*\]|['"]?)\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][^'"]{8,}['"]/gi,
     confidence: "medium",
     keyAnchored: true,
   },
   {
     name: "Generic Token Assignment",
     pattern:
-      /(?:access[_-]?token|auth[_-]?token)['"]?\s*(?:\]\s*)?(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+      /(?:access[_-]?token|auth[_-]?token)(?:['"]\s*\]|['"]?)\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
     confidence: "medium",
     keyAnchored: true,
   },
@@ -822,7 +825,7 @@ export function lookBehind(text: string, index: number): string {
 // The key an assignment puts immediately in front of a value:
 // `sha256:"`, `api_key = "`, `"x-api-key":`, `apiKey:`, `SECRET_KEY || "`
 const PRECEDING_KEY_RE =
-  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*(?:\]\s*)?(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
+  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)(?:["'`]\s*\]|["'`]?)\s*(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
 
 // The same, written as a bracket access: `cfg["apiKey"] = "`, `cfg['sha256'] =`
 const BRACKET_KEY_RE =
@@ -870,10 +873,33 @@ export function enclosingTag(text: string, index: number): string | undefined {
   return close === -1 ? undefined : text.slice(open, close + 1);
 }
 
-// The characters one key NAME is made of. `.` is absent on purpose: it starts a
-// new name rather than continuing this one, so `cache.apiKey` is the `apiKey`
-// of a cache and not a key called `cache.apiKey`.
+// The characters a bare identifier is made of. `.` is absent on purpose: it
+// starts a new name rather than continuing this one, so `cache.apiKey` is the
+// `apiKey` of a cache and not a key called `cache.apiKey`. `-` is absent for a
+// sharper reason: between two identifiers it is the subtraction operator.
+const IDENT_CHAR_RE = /[A-Za-z0-9_$]/;
+
+// The same, plus the `-` that a quoted key or an HTML attribute name spells one
+// name with: `"x-api-key"`, `<img data-cache-api-key="…">`.
 const KEY_SEGMENT_CHAR_RE = /[A-Za-z0-9_$-]/;
+
+const QUOTE_CHAR_RE = /["'`]/;
+
+/**
+ * Is this the position an HTML attribute name occupies — whitespace behind it,
+ * inside an unclosed tag? Bounded to the lookBehind budget, so a value far
+ * enough into a long tag simply reads as "not an attribute".
+ */
+function isAttributeNamePosition(text: string, start: number): boolean {
+  if (!/\s/.test(text[start - 1] ?? "")) return false;
+  const floor = Math.max(0, start - SECRET_KEY_LOOKBEHIND_SIZE * 2);
+  for (let i = start - 1; i >= floor; i--) {
+    const char = text[i];
+    if (char === ">") return false;
+    if (char === "<") return true;
+  }
+  return false;
+}
 
 /**
  * Does the key this match started in the middle of say "digest"?
@@ -885,6 +911,12 @@ const KEY_SEGMENT_CHAR_RE = /[A-Za-z0-9_$-]/;
  * design — every other pattern in it carries a literal marker that a digest
  * cannot wear. These three do not, so they read their own left edge.
  *
+ * Only syntax makes a `-` part of a name. Inside quotes it is a JSON or YAML
+ * key and inside a tag it is an attribute name, so `"cache-api-key"` and
+ * `data-cache-api-key=` are single digest keys. Everywhere else it is the
+ * subtraction operator, and reading `cache-apiKey||"…"` as one key would let a
+ * minified expression swallow a real credential.
+ *
  * Spending the whole lookBehind budget without reaching the start of the key
  * means the prefix was never read, only cut, and a cut prefix is not evidence
  * in either direction: it can drop the `cache` off `cache-…-api-key` and it can
@@ -894,14 +926,23 @@ const KEY_SEGMENT_CHAR_RE = /[A-Za-z0-9_$-]/;
  */
 function startsInsideDigestKey(text: string, index: number): boolean {
   const floor = Math.max(0, index - SECRET_KEY_LOOKBEHIND_SIZE * 2);
+
+  // Walk the hyphenated run first, only to see what encloses it.
+  let runStart = index;
+  while (runStart > floor && KEY_SEGMENT_CHAR_RE.test(text[runStart - 1] ?? "")) {
+    runStart--;
+  }
+  const hyphenJoins =
+    QUOTE_CHAR_RE.test(text[runStart - 1] ?? "") ||
+    isAttributeNamePosition(text, runStart);
+  const keyChar = hyphenJoins ? KEY_SEGMENT_CHAR_RE : IDENT_CHAR_RE;
+
   let start = index;
-  while (start > floor && KEY_SEGMENT_CHAR_RE.test(text[start - 1] ?? "")) {
+  while (start > floor && keyChar.test(text[start - 1] ?? "")) {
     start--;
   }
   if (start === index) return false;
-  if (start === floor && KEY_SEGMENT_CHAR_RE.test(text[start - 1] ?? "")) {
-    return false;
-  }
+  if (start === floor && keyChar.test(text[start - 1] ?? "")) return false;
   return keyWords(text.slice(start, index)).some((word) =>
     DIGEST_KEY_WORDS.has(word)
   );

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -458,21 +458,21 @@ const FAST_PATTERNS: FastPattern[] = [
   {
     name: "Generic API Key Assignment",
     pattern:
-      /(?:api[_-]?key|apikey)['"]?\s*\]?\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+      /(?:api[_-]?key|apikey)['"]?\s*(?:\]\s*)?(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
     confidence: "medium",
     keyAnchored: true,
   },
   {
     name: "Generic Secret Assignment",
     pattern:
-      /(?:secret|password|passwd|pwd)(?:[_-]?(?:key|token))?['"]?\s*\]?\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][^'"]{8,}['"]/gi,
+      /(?:secret|password|passwd|pwd)(?:[_-]?(?:key|token))?['"]?\s*(?:\]\s*)?(?:[:=]|\|\|=?|\?\?=?)\s*['"][^'"]{8,}['"]/gi,
     confidence: "medium",
     keyAnchored: true,
   },
   {
     name: "Generic Token Assignment",
     pattern:
-      /(?:access[_-]?token|auth[_-]?token)['"]?\s*\]?\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+      /(?:access[_-]?token|auth[_-]?token)['"]?\s*(?:\]\s*)?(?:[:=]|\|\|=?|\?\?=?)\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
     confidence: "medium",
     keyAnchored: true,
   },
@@ -822,14 +822,14 @@ export function lookBehind(text: string, index: number): string {
 // The key an assignment puts immediately in front of a value:
 // `sha256:"`, `api_key = "`, `"x-api-key":`, `apiKey:`, `SECRET_KEY || "`
 const PRECEDING_KEY_RE =
-  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*\]?\s*(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
+  /["'`]?([A-Za-z_$][A-Za-z0-9_$.-]*)["'`]?\s*(?:\]\s*)?(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
 
 // The same, written as a bracket access: `cfg["apiKey"] = "`, `cfg['sha256'] =`
 const BRACKET_KEY_RE =
   /\[\s*["'`]([^"'`\]]{1,64})["'`]\s*\]\s*(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
 
 // Anything at all in value position, whatever the key turned out to be
-const ASSIGNMENT_RE = /(?:[:=]|\|\|=?|\?\?=?)\s*["'`]?\s*$/;
+const ASSIGNMENT_RE = /[:=]\s*["'`]?\s*$/;
 
 // SRI and prefixed-digest values: integrity="sha384-…", `sha256-…`, `md5:…`
 const DIGEST_PREFIX_RE = /(?:sha-?(?:1|256|384|512)|md5)\s*[-:]\s*[\w+/=-]*$/i;
@@ -870,6 +870,11 @@ export function enclosingTag(text: string, index: number): string | undefined {
   return close === -1 ? undefined : text.slice(open, close + 1);
 }
 
+// The characters one key NAME is made of. `.` is absent on purpose: it starts a
+// new name rather than continuing this one, so `cache.apiKey` is the `apiKey`
+// of a cache and not a key called `cache.apiKey`.
+const KEY_SEGMENT_CHAR_RE = /[A-Za-z0-9_$-]/;
+
 /**
  * Does the key this match started in the middle of say "digest"?
  *
@@ -880,14 +885,23 @@ export function enclosingTag(text: string, index: number): string | undefined {
  * design — every other pattern in it carries a literal marker that a digest
  * cannot wear. These three do not, so they read their own left edge.
  *
- * Bounded by the same budget as lookBehind. Running out mid-key can only
- * truncate the prefix, and a truncated prefix suppresses at worst.
+ * Spending the whole lookBehind budget without reaching the start of the key
+ * means the prefix was never read, only cut, and a cut prefix is not evidence
+ * in either direction: it can drop the `cache` off `cache-…-api-key` and it can
+ * invent one out of the tail of `xcache-…`. So an over-long key does not
+ * suppress — a missed digest reads as one extra medium-confidence warning,
+ * where an invented one silently drops a real leak.
  */
 function startsInsideDigestKey(text: string, index: number): boolean {
   const floor = Math.max(0, index - SECRET_KEY_LOOKBEHIND_SIZE * 2);
   let start = index;
-  while (start > floor && KEY_CHAR_RE.test(text[start - 1] ?? "")) start--;
+  while (start > floor && KEY_SEGMENT_CHAR_RE.test(text[start - 1] ?? "")) {
+    start--;
+  }
   if (start === index) return false;
+  if (start === floor && KEY_SEGMENT_CHAR_RE.test(text[start - 1] ?? "")) {
+    return false;
+  }
   return keyWords(text.slice(start, index)).some((word) =>
     DIGEST_KEY_WORDS.has(word)
   );

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -38,11 +38,11 @@ const DIGEST_2 = "7b2c40e91af38d605c7e1b94a2f6d083e5c19b7a4d0f38e6215ca9b70d4f8e
 const TOGETHER_KEY = "9f3c1d7ba24e08f65c1b93d0e47af215c806b3e9d24f71a5c0938e6b1df42a70"; // pragma: allowlist secret
 const COMMIT = "3f9a1c5d7e2b48061a9c3d5f7e8b2a4c6d0e1f93"; // pragma: allowlist secret
 
-// #150 fixtures. A standard-base64 token, `+` and `/` inside its first 20
-// characters and `=` padding on the end — the shape the base64url Bearer class
-// used to stop matching at.
-const B64_TOKEN = "ab+cd/efGH12+34/jkLMnopQRstuvWXyz0123456789ABCDefgh=="; // pragma: allowlist secret
-const B64_TOKEN_2 = "Qr7/tU2+vW9xYz0AbCdEfGhIjKlMnOpQrStUvWxYz12345678+/=="; // pragma: allowlist secret
+// #150 fixtures. Real standard base64 — 47 bytes each, so 64 characters and
+// one `=` of padding, and both carry a `+` and a `/` inside their first 20
+// characters, which is where the base64url class used to give up.
+const B64_TOKEN = "2MBqfKhL/eXCwg0Zt+RZ2klzNCF0inWnUM3Jb0UiyC1WDP53Cxm5f6UUyrjnQH8="; // pragma: allowlist secret
+const B64_TOKEN_2 = "yS9+/xwatK/BZkejOF5vKuKCuzfMdMV55oZv26BLG8DoO6+VamfQB1mP0TbXYOc="; // pragma: allowlist secret
 // A real sha384 SRI hash is standard base64 too, `+` and `/` and all.
 const SRI_B64 = "oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"; // pragma: allowlist secret
 const OAUTH_TOKEN = "Zk8pR3vN6mQ1tX4wL7cH2sB5dF9gJ0aY"; // pragma: allowlist secret
@@ -228,7 +228,10 @@ describe("security/leaked-secrets: real credentials still report", () => {
       `cfg["together"] = "${TOGETHER_KEY}"`, // pragma: allowlist secret
     ]) {
       const found = scanContent(assignment, "inline-script");
-      expect(found.map((f) => f.value)).toContain(TOGETHER_KEY);
+      // The generic FAST tier claims the `cfg["apiKey"] = ` form now that it
+      // reads across `"]` (#150), so the key rides inside the reported value
+      // rather than being the whole of it.
+      expect(found.some((f) => f.value.includes(TOGETHER_KEY))).toBe(true);
     }
   });
 
@@ -475,6 +478,31 @@ describe("security/leaked-secrets: #150 missed shapes", () => {
     }
   });
 
+  test("a compound key whose left half says digest is not a credential", () => {
+    // These start the match part-way through the key — `cache-api-key` begins
+    // an `api-key` match at character 6 — and the FAST tier has no
+    // classifyKeyContext behind it, so the pattern reads its own left edge.
+    for (const key of [
+      "cache-api-key",
+      "cache_api_key",
+      "cacheApiKey",
+      "checksum-secret",
+      "checksumSecret",
+      "integrity-auth-token",
+      "sha256_secret",
+      "etag-api-key",
+    ]) {
+      expect(scanContent(`{"${key}":"${COMMIT}"}`, "html")).toEqual([]);
+      expect(scanContent(`{${key}:"${COMMIT}"}`, "html")).toEqual([]);
+      expect(scanContent(`x = ${key} || "${COMMIT}";`, "inline-script")).toEqual([]);
+    }
+    // The word to the left has to actually say digest: `x-api-key` and
+    // `stripe_secret` are the same shape and both still report.
+    for (const key of ["x-api-key", "myApiKey", "stripe_secret", "next_auth_token"]) {
+      expect(scanContent(`{"${key}":"${COMMIT}"}`, "html")).not.toEqual([]); // pragma: allowlist secret
+    }
+  });
+
   test("a hardcoded fallback behind an env var is reported", () => {
     const cases = [
       `const k = process.env.SECRET_KEY || "${TOGETHER_KEY}";`, // pragma: allowlist secret
@@ -482,6 +510,10 @@ describe("security/leaked-secrets: #150 missed shapes", () => {
       `const k = process.env.API_KEY || "${TOGETHER_KEY}";`, // pragma: allowlist secret
       `const k = process.env.AUTH_TOKEN || "${TOGETHER_KEY}";`, // pragma: allowlist secret
       `const k = process.env.PASSWORD||"${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `process.env.SECRET_KEY ||= "${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `process.env.SECRET_KEY ??= "${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `const k = process.env["SECRET_KEY"] || "${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `const k = process.env['API_KEY'] ?? "${TOGETHER_KEY}";`, // pragma: allowlist secret
     ];
     for (const content of cases) {
       const found = scanContent(content, "inline-script");
@@ -509,9 +541,23 @@ describe("security/leaked-secrets: #150 missed shapes", () => {
   });
 
   test("a standard-base64 Bearer token is reported with its padding intact", () => {
+    // The fixture is genuine base64: it survives a decode/encode round trip, so
+    // this pins support for the real encoding, not just for the characters.
+    expect(Buffer.from(B64_TOKEN, "base64").toString("base64")).toBe(B64_TOKEN);
+
     const found = scanContent(`authorization: "Bearer ${B64_TOKEN}"`, "html"); // pragma: allowlist secret
     expect(found.map((f) => f.type)).toEqual(["Bearer Token"]);
     expect(found[0]?.value).toBe(`Bearer ${B64_TOKEN}`);
+  });
+
+  test("padding alone is not a Bearer token", () => {
+    // `=` is trailing and capped at two, so a run of padding characters cannot
+    // reach the length threshold on its own.
+    expect(scanContent(`Bearer ${"=".repeat(40)}`, "html")).toEqual([]);
+    expect(scanContent(`Bearer ${"=".repeat(19)}abc`, "html")).toEqual([]);
+    // …and a token never carries more than two.
+    const found = scanContent(`Bearer ${B64_TOKEN}====`, "html"); // pragma: allowlist secret
+    expect(found[0]?.value).toBe(`Bearer ${B64_TOKEN}=`);
   });
 
   test("a base64url Bearer token still matches after the class widened", () => {

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -503,6 +503,56 @@ describe("security/leaked-secrets: #150 missed shapes", () => {
     }
   });
 
+  test("a digest word in a member path is not part of the key", () => {
+    // `cache.apiKey` is the apiKey OF a cache, not a key called
+    // `cache.apiKey` — the walk stops at the dot.
+    for (const path of ["cache.apiKey", "config.cache.apiKey", "sha256.apiKey"]) {
+      expect(scanContent(`${path} = "${COMMIT}";`, "inline-script")).not.toEqual([]); // pragma: allowlist secret
+    }
+  });
+
+  test("a key too long to read whole does not suppress", () => {
+    // Spending the whole look-back budget means the prefix was cut, not read.
+    const budget = SECRET_KEY_LOOKBEHIND_SIZE * 2;
+
+    // A cut can lose a digest word off the front…
+    const lost = `cache-${"y".repeat(budget)}-api-key`;
+    expect(scanContent(`{"${lost}":"${COMMIT}"}`, "html")).not.toEqual([]); // pragma: allowlist secret
+
+    // …and it can invent one out of the middle. `cache-` here is the tail of
+    // `xcache-`, not a word, and the cut lands on exactly its first character.
+    // Without the guard the key reads as a digest and the credential goes
+    // silent — the one direction that must never happen by accident.
+    const invented = `xcache-${"y".repeat(budget - 7)}-api-key`;
+    expect(invented.indexOf("api-key")).toBe(budget + 1);
+    expect(scanContent(`{"${invented}":"${COMMIT}"}`, "html")).not.toEqual([]); // pragma: allowlist secret
+
+    // The guard is about the budget, not about giving up: a digest word the
+    // walk reaches within it still suppresses.
+    const read = `cache-${"y".repeat(100)}-api-key`;
+    expect(read.indexOf("api-key")).toBeLessThan(budget);
+    expect(scanContent(`{"${read}":"${COMMIT}"}`, "html")).toEqual([]);
+  });
+
+  test("a fallback with no key in front of it is not an assignment", () => {
+    // `||` only makes a value position when something nameable precedes it.
+    // A call expression names nothing, and a checksum falling back to a
+    // literal is exactly the shape that would be misread.
+    for (const expr of ["getChecksum()", "hashes.get(name)", "digestOf(x)"]) {
+      const content = `const v = ${expr} || "${DIGEST}"; // together.ai`;
+      expect(scanContent(content, "inline-script")).toEqual([]);
+    }
+    // A name in front of the fallback still reports, minified ones included.
+    for (const content of [
+      `const v = cfg.token || "${TOGETHER_KEY}"; // together.ai`, // pragma: allowlist secret
+      `t.a||"${TOGETHER_KEY}"; // together.ai`, // pragma: allowlist secret
+    ]) {
+      expect(scanContent(content, "inline-script").map((f) => f.value)).toEqual([
+        TOGETHER_KEY,
+      ]);
+    }
+  });
+
   test("a hardcoded fallback behind an env var is reported", () => {
     const cases = [
       `const k = process.env.SECRET_KEY || "${TOGETHER_KEY}";`, // pragma: allowlist secret
@@ -616,6 +666,12 @@ describe("security/leaked-secrets: #150 missed shapes", () => {
     const chunk = `var a${"b".repeat(40)}=function(t){return t.apiKey||t.secret||"Bearer "+t.token};`;
     for (const line of [
       chunk.repeat(4000),
+      // A credential word followed by a long whitespace run and no separator.
+      // Two adjacent unbounded `\s*` quantifiers here would partition the run
+      // every possible way before giving up: 12s at 64 KB, and `\s` matches
+      // newlines, so pretty-printed HTML gets there on its own.
+      `apiKey${" ".repeat(200_000)}x`,
+      `{"apiKey"${"\n".repeat(200_000)}:"x"}`,
       // Unterminated quoted values: the generic secret pattern's `[^'"]{8,}`
       // has to give up on each of these without exploring the whole tail.
       `x={${`secret:"${"y".repeat(200)},`.repeat(2000)}}`,

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -333,6 +333,20 @@ describe("classifyKeyContext", () => {
     expect(classifyKeyContext(`cfg["filename"] = "`, "together")).toBe("none");
   });
 
+  test("an unquoted bracket names nothing", () => {
+    // `labels[secret]` is a lookup keyed by a variable that happens to be
+    // called secret. Only a quoted key inside the brackets names the value.
+    expect(classifyKeyContext(`labels[secret] || "`, "together")).toBe("none");
+    // A `:` or `=` still lands in the plain assignment fallback, which reports
+    // on purpose — an unreadable key is how minified bundles look. Only the
+    // fallback operators, where the left side is an expression, mean "none".
+    expect(classifyKeyContext(`labels[apiKey]: "`, "together")).toBe("assigned");
+    expect(classifyKeyContext(`cfg["apiKey"] || "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`process.env["SECRET_KEY"] || "`, "together")).toBe(
+      "credential"
+    );
+  });
+
   test("a minifier's member access is treated as no key at all", () => {
     expect(classifyKeyContext(`t.a = "`, "together")).toBe("assigned");
     expect(classifyKeyContext(`e.x2="`, "together")).toBe("assigned");
@@ -482,16 +496,9 @@ describe("security/leaked-secrets: #150 missed shapes", () => {
     // These start the match part-way through the key — `cache-api-key` begins
     // an `api-key` match at character 6 — and the FAST tier has no
     // classifyKeyContext behind it, so the pattern reads its own left edge.
-    for (const key of [
-      "cache-api-key",
-      "cache_api_key",
-      "cacheApiKey",
-      "checksum-secret",
-      "checksumSecret",
-      "integrity-auth-token",
-      "sha256_secret",
-      "etag-api-key",
-    ]) {
+    // `_` and camelCase join a name wherever they appear; `-` needs syntax to
+    // say so, which is the next test.
+    for (const key of ["cache_api_key", "cacheApiKey", "checksumSecret", "sha256_secret"]) {
       expect(scanContent(`{"${key}":"${COMMIT}"}`, "html")).toEqual([]);
       expect(scanContent(`{${key}:"${COMMIT}"}`, "html")).toEqual([]);
       expect(scanContent(`x = ${key} || "${COMMIT}";`, "inline-script")).toEqual([]);
@@ -500,6 +507,57 @@ describe("security/leaked-secrets: #150 missed shapes", () => {
     // `stripe_secret` are the same shape and both still report.
     for (const key of ["x-api-key", "myApiKey", "stripe_secret", "next_auth_token"]) {
       expect(scanContent(`{"${key}":"${COMMIT}"}`, "html")).not.toEqual([]); // pragma: allowlist secret
+    }
+  });
+
+  test("a hyphen joins a key only where the syntax says it does", () => {
+    const hyphenated = [
+      "cache-api-key",
+      "checksum-secret",
+      "integrity-auth-token",
+      "etag-api-key",
+    ];
+    for (const key of hyphenated) {
+      // Quoted: a JSON or YAML key, one name, a digest.
+      expect(scanContent(`{"${key}":"${COMMIT}"}`, "html")).toEqual([]);
+      expect(scanContent(`{'${key}':"${COMMIT}"}`, "html")).toEqual([]);
+      // An HTML attribute name: also one name.
+      expect(scanContent(`<img alt="" ${key}="${COMMIT}">`, "html")).toEqual([]);
+      expect(scanContent(`<img alt="" data-${key}="${COMMIT}">`, "html")).toEqual([]);
+      // Bare, in identifier position, `-` is the subtraction operator. Reading
+      // it as one key is what let a minified expression swallow a credential.
+      expect(scanContent(`const x=${key}||"${COMMIT}"`, "inline-script")).not.toEqual([]); // pragma: allowlist secret
+      expect(scanContent(`x = ${key} || "${COMMIT}";`, "inline-script")).not.toEqual([]); // pragma: allowlist secret
+    }
+    // The shape the fix exists for: a real credential behind a minified
+    // subtraction. `cache-apiKey` is `cache` minus `apiKey`, not a cache key.
+    expect(
+      scanContent(`const x=cache-apiKey||"${TOGETHER_KEY}"`, "inline-script") // pragma: allowlist secret
+        .some((f) => f.value.includes(TOGETHER_KEY))
+    ).toBe(true);
+  });
+
+  test("an unquoted computed lookup is not a credential name", () => {
+    // `translations[apiKey]` names a translation, not a key. The `]` only
+    // counts when it closes a QUOTED key.
+    for (const expr of [
+      `translations[apiKey] ||= "This is a harmless display label"`,
+      `labels[secret] || "Password must have eight characters"`,
+      `messages[apiKey] || "${COMMIT}"`,
+      `t[access_token] ||= "${COMMIT}"`,
+      // The context tier reads the same bracket, so it needs the same rule.
+      `labels[secret] || "${DIGEST}"; // together.ai`,
+      `strings[apiKey] || "${DIGEST}"; // together.ai`,
+    ]) {
+      expect(scanContent(expr, "inline-script")).toEqual([]);
+    }
+    // The quoted bracket form is still read.
+    for (const expr of [
+      `cfg["apiKey"] || "${COMMIT}"`, // pragma: allowlist secret
+      `cfg['x-api-key'] = "${COMMIT}"`, // pragma: allowlist secret
+      `const k = process.env["SECRET_KEY"] || "${TOGETHER_KEY}";`, // pragma: allowlist secret
+    ]) {
+      expect(scanContent(expr, "inline-script")).not.toEqual([]);
     }
   });
 

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -38,6 +38,15 @@ const DIGEST_2 = "7b2c40e91af38d605c7e1b94a2f6d083e5c19b7a4d0f38e6215ca9b70d4f8e
 const TOGETHER_KEY = "9f3c1d7ba24e08f65c1b93d0e47af215c806b3e9d24f71a5c0938e6b1df42a70"; // pragma: allowlist secret
 const COMMIT = "3f9a1c5d7e2b48061a9c3d5f7e8b2a4c6d0e1f93"; // pragma: allowlist secret
 
+// #150 fixtures. A standard-base64 token, `+` and `/` inside its first 20
+// characters and `=` padding on the end — the shape the base64url Bearer class
+// used to stop matching at.
+const B64_TOKEN = "ab+cd/efGH12+34/jkLMnopQRstuvWXyz0123456789ABCDefgh=="; // pragma: allowlist secret
+const B64_TOKEN_2 = "Qr7/tU2+vW9xYz0AbCdEfGhIjKlMnOpQrStUvWxYz12345678+/=="; // pragma: allowlist secret
+// A real sha384 SRI hash is standard base64 too, `+` and `/` and all.
+const SRI_B64 = "oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"; // pragma: allowlist secret
+const OAUTH_TOKEN = "Zk8pR3vN6mQ1tX4wL7cH2sB5dF9gJ0aY"; // pragma: allowlist secret
+
 function html(body: string): string {
   return `<!DOCTYPE html><html><head><title>Releases</title></head><body>${body}</body></html>`;
 }
@@ -166,14 +175,19 @@ describe("security/leaked-secrets: hex digests are not secrets", () => {
 
 describe("security/leaked-secrets: real credentials still report", () => {
   test("a Together key under a credential key is still reported as one", () => {
-    for (const assignment of [
-      `const togetherKey = "${TOGETHER_KEY}"`, // pragma: allowlist secret
-      `{"together_secret":"${TOGETHER_KEY}"}`, // pragma: allowlist secret
-      `window.TOGETHER_TOKEN = "${TOGETHER_KEY}"`, // pragma: allowlist secret
-    ]) {
+    // One finding each, and the value is always the key itself. The quoted JSON
+    // form is claimed by the generic FAST tier now that it accepts a closing
+    // quote (#150), so it reports under the broader name and carries the key
+    // inside its match rather than as the whole match.
+    const cases: Array<[string, string]> = [
+      [`const togetherKey = "${TOGETHER_KEY}"`, "Together AI Key"], // pragma: allowlist secret
+      [`{"together_secret":"${TOGETHER_KEY}"}`, "Generic Secret Assignment"], // pragma: allowlist secret
+      [`window.TOGETHER_TOKEN = "${TOGETHER_KEY}"`, "Together AI Key"], // pragma: allowlist secret
+    ];
+    for (const [assignment, type] of cases) {
       const found = scanContent(assignment, "inline-script");
-      expect(found.map((f) => f.type)).toEqual(["Together AI Key"]);
-      expect(found[0]?.value).toBe(TOGETHER_KEY);
+      expect(found.map((f) => f.type)).toEqual([type]);
+      expect(found[0]?.value).toContain(TOGETHER_KEY);
     }
   });
 
@@ -394,5 +408,176 @@ describe("classifyKeyContext", () => {
         tag(`name="algolia-api-key" lang="en" dir="ltr" data-testid="release-row" content="x"`)
       )
     ).toBe("credential");
+  });
+
+  test("reads the key across an env-var fallback", () => {
+    expect(classifyKeyContext(`process.env.SECRET_KEY || "`, "together")).toBe(
+      "credential"
+    );
+    expect(classifyKeyContext(`process.env.TOKEN ?? "`, "together")).toBe("credential");
+    expect(classifyKeyContext(`togetherKey||"`, "together")).toBe("credential");
+    // The fallback does not launder a digest key into a credential.
+    expect(classifyKeyContext(`cacheKey || "`, "together")).toBe("digest");
+    expect(classifyKeyContext(`sha256 ?? "`, "together")).toBe("digest");
+    expect(classifyKeyContext(`commitHash || "`, "together")).toBe("digest");
+    // Nor a key that means nothing into one that does.
+    expect(classifyKeyContext(`filename || "`, "together")).toBe("none");
+    expect(classifyKeyContext(`t.a || "`, "together")).toBe("assigned");
+  });
+});
+
+// #150: three shapes that carry a real credential and used to report nothing.
+// Each block pairs the shape with the false positive it sits next to, because
+// widening a pattern is only correct if the silence it was protecting survives.
+describe("security/leaked-secrets: #150 missed shapes", () => {
+  test("a quoted JSON key is reported", () => {
+    for (const key of ["apiKey", "api_key", "x-api-key", "APIKEY"]) {
+      const found = scanContent(`{"${key}":"${COMMIT}"}`, "html"); // pragma: allowlist secret
+      expect(found.map((f) => f.type)).toEqual(["Generic API Key Assignment"]);
+      expect(found[0]?.value).toContain(COMMIT);
+    }
+  });
+
+  test("a quoted JSON key inside a script[type=application/json] block is reported", () => {
+    const page = html(
+      `<script type="application/json">{"x-api-key":"${COMMIT}"}</script>` // pragma: allowlist secret
+    );
+    const items = findings(leakedSecretsRule.run(ctx(page)).checks);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toContain("Generic API Key Assignment");
+  });
+
+  test("the same 40 hex characters stay silent under a git-object key", () => {
+    // Nothing in the value tells a git object id apart from an API key — only
+    // the key in front of it does. The FAST tier carries its credential
+    // keyword in the pattern, so `commit` can never reach it, and the
+    // bare-shape CONTEXT tier needs a brand keyword a release page has no
+    // reason to carry.
+    for (const key of ["commit", "gitCommit", "sha", "revision", "etag", "cacheKey"]) {
+      expect(scanContent(`{"${key}":"${COMMIT}"}`, "html")).toEqual([]);
+    }
+  });
+
+  test("a key that only ends in a credential word is not one", () => {
+    // The key has to END where the separator begins, which is what stops the
+    // widened patterns from claiming a digest whose name happens to start with
+    // a credential word.
+    for (const key of [
+      "secret_hash",
+      "secretHash",
+      "apiKeyHash",
+      "api_key_digest",
+      "passwordDigest",
+      "access_token_sha256",
+    ]) {
+      expect(scanContent(`{"${key}":"${COMMIT}"}`, "html")).toEqual([]);
+      expect(scanContent(`x = ${key} || "${COMMIT}";`, "inline-script")).toEqual([]);
+    }
+  });
+
+  test("a hardcoded fallback behind an env var is reported", () => {
+    const cases = [
+      `const k = process.env.SECRET_KEY || "${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `const k = process.env.SECRET_KEY ?? "${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `const k = process.env.API_KEY || "${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `const k = process.env.AUTH_TOKEN || "${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `const k = process.env.PASSWORD||"${TOGETHER_KEY}";`, // pragma: allowlist secret
+    ];
+    for (const content of cases) {
+      const found = scanContent(content, "inline-script");
+      expect(found).toHaveLength(1);
+      expect(found[0]?.value).toContain(TOGETHER_KEY);
+    }
+  });
+
+  test("a fallback reaches the context tier too, without laundering a digest", () => {
+    // No FAST pattern matches `togetherKey`, so this only reports if
+    // isInValuePosition and classifyKeyContext both read across the `||`.
+    for (const content of [
+      `const v = togetherKey || "${TOGETHER_KEY}";`, // pragma: allowlist secret
+      `const v = credential ?? "${TOGETHER_KEY}"; // together.ai`, // pragma: allowlist secret
+    ]) {
+      expect(scanContent(content, "inline-script").map((f) => f.value)).toEqual([
+        TOGETHER_KEY,
+      ]);
+    }
+    // Same shape, digest key: the published checksum stays silent.
+    for (const key of ["cacheKey", "sha256", "etag", "commitHash", "integrityHash"]) {
+      const content = `const v = ${key} || "${DIGEST}"; // together.ai`;
+      expect(scanContent(content, "inline-script")).toEqual([]);
+    }
+  });
+
+  test("a standard-base64 Bearer token is reported with its padding intact", () => {
+    const found = scanContent(`authorization: "Bearer ${B64_TOKEN}"`, "html"); // pragma: allowlist secret
+    expect(found.map((f) => f.type)).toEqual(["Bearer Token"]);
+    expect(found[0]?.value).toBe(`Bearer ${B64_TOKEN}`);
+  });
+
+  test("a base64url Bearer token still matches after the class widened", () => {
+    // `-` sits last in `[a-zA-Z0-9_+/=-]` so it stays a literal, not a range.
+    const urlSafe = "ab-cd_efGH12-34_jkLMnopQRstuvWXyz0123456789ABCDefgh"; // pragma: allowlist secret
+    const found = scanContent(`authorization: "Bearer ${urlSafe}"`, "html"); // pragma: allowlist secret
+    expect(found.map((f) => f.value)).toEqual([`Bearer ${urlSafe}`]);
+  });
+
+  test("npm lockfile integrity entries report nothing", () => {
+    // The highest-volume standard-base64 blob on the real web, `+` `/` `=` and
+    // all. It has to survive the widened Bearer class untouched.
+    const entry = (i: number) =>
+      `"node_modules/pkg-${i}": { "version": "1.2.${i}", "integrity": "sha512-${SRI_B64}${i}Xy+9/Qz==" }`;
+    const lock = `{ "packages": { ${[0, 1, 2, 3, 4].map(entry).join(", ")} } }`;
+    expect(scanContent(lock, "html")).toEqual([]);
+  });
+
+  test("an SRI hash in standard base64 is not a Bearer token", () => {
+    const tag = `<script src="https://cdn.example.net/lib.js" integrity="sha384-${SRI_B64}" crossorigin="anonymous"></script>`;
+    expect(scanContent(tag, "html")).toEqual([]);
+    // Still silent with the word Bearer on the same page: the class stops at
+    // the space, so `Bearer token.` never reaches the length threshold.
+    expect(scanContent(`<p>Send a Bearer token.</p>${tag}`, "html")).toEqual([]);
+  });
+
+  test("a base64 image data URI reports nothing", () => {
+    const page = html(
+      `<img alt="logo" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HgAGgwJ/lK3Q6wAAAABJRU5ErkJggg==">`
+    );
+    expect(findings(leakedSecretsRule.run(ctx(page)).checks)).toEqual([]);
+  });
+
+  test("two secrets on one line are both reported", () => {
+    // A widened pattern that ran to end of line would swallow the second one.
+    const line = `{"apiKey":"${COMMIT}","access_token":"${OAUTH_TOKEN}"}`; // pragma: allowlist secret
+    const found = scanContent(line, "html");
+    expect(found.map((f) => f.type)).toEqual([
+      "Generic API Key Assignment",
+      "Generic Token Assignment",
+    ]);
+    expect(found[0]?.value).toContain(COMMIT);
+    expect(found[1]?.value).toContain(OAUTH_TOKEN);
+
+    const headers = `{"authorization":"Bearer ${B64_TOKEN}","x-proxy":"Bearer ${B64_TOKEN_2}"}`; // pragma: allowlist secret
+    expect(scanContent(headers, "html").map((f) => f.value)).toEqual([
+      `Bearer ${B64_TOKEN}`,
+      `Bearer ${B64_TOKEN_2}`,
+    ]);
+  });
+
+  test("a long minified line stays linear", () => {
+    // These patterns run over whole crawled bundles. Every one of them is a
+    // literal keyword plus one greedy character class, so the work is linear —
+    // this pins that it stays that way after the widening.
+    const chunk = `var a${"b".repeat(40)}=function(t){return t.apiKey||t.secret||"Bearer "+t.token};`;
+    for (const line of [
+      chunk.repeat(4000),
+      // Unterminated quoted values: the generic secret pattern's `[^'"]{8,}`
+      // has to give up on each of these without exploring the whole tail.
+      `x={${`secret:"${"y".repeat(200)},`.repeat(2000)}}`,
+      `Bearer ${"A+b/c=".repeat(20000)}`,
+    ]) {
+      const start = performance.now();
+      scanContent(line, "external-script");
+      expect(performance.now() - start).toBeLessThan(5000);
+    }
   });
 });


### PR DESCRIPTION
Closes #150

`security/leaked-secrets` missed three shapes that each carry a real credential. All three reproduce on `main` today.

## The three shapes

**1. A quoted JSON key.** The generic assignment patterns required the separator to follow the key name directly, so JSON's closing quote broke the match:

```js
{"apiKey":"3f9a1c5d7e2b48061a9c3d5f7e8b2a4c6d0e1f93"}   // silent
```

The separator now accepts an optional closing quote (and an optional `]`, so `process.env["SECRET_KEY"]` reads too). Covered inside a `<script type="application/json">` block as well.

**2. An env-var fallback.** `isInValuePosition` and `classifyKeyContext` only recognised `:` and `=`, so a hardcoded fallback was not a value position:

```js
const k = process.env.SECRET_KEY || "9f3c…a70";   // silent
```

`||`, `??`, `||=` and `??=` are now separators in both tiers, and the secret pattern takes a `key`/`token` tail so `SECRET_KEY` reads as one key rather than as `secret` followed by something that broke the match.

**3. A standard-base64 Bearer token.** The class was base64**url**, so `+` or `/` inside the first 20 characters stopped the match short of the length threshold and nothing was reported at all; `=` padding was dropped from the value when it did match:

```
authorization: "Bearer 2MBqfKhL/eXCwg0Zt+RZ…QH8="   // silent
```

The class carries `+` and `/` now, with padding trailing and capped at two, so `Bearer ====================` is still not a token.

## Keeping the silence

The rule's whole design is that a bare hex run is a checksum far more often than a credential, so every widening was paired with the false positive it sits next to.

Two guards were needed because the FAST tier has no `classifyKeyContext` behind it:

- **`keyAnchored` / `startsInsideDigestKey`.** These patterns anchor on a credential word, not on the start of the key, so `cache-api-key:"…"` starts an `api-key` match at character 6. They now read their own left edge and drop out under a digest key. This also closes the same hole on the unquoted form and on the AWS secret-key pattern, both already reachable on `main`. A `.` ends the walk, so `cache.apiKey = "…"` is the apiKey **of** a cache and still reports. An over-long key whose prefix gets cut rather than read never suppresses: a cut can invent a `cache` as easily as lose one, and an extra warning beats a silently dropped leak.
- **A keyless fallback is not an assignment.** `getChecksum() || "<hex>"` and `hashes.get(name) ?? "<hex>"` report nothing; `cfg.token || "<hex>"` and a minified `t.a||"<hex>"` still do.

### Evidence

| | result |
|---|---|
| 1060 targeted negative fixtures (npm lock `integrity`, SRI script/link tags, checksum tables and `.txt`, git object ids, ETags, cache keys, build fingerprints, base64 png/woff data URIs, 10 compound digest keys × 3 syntaxes, keyless fallbacks, Bearer near-misses) | `main` reports **10**, this reports **0** |
| 165 MB differential scan, `main` vs this branch (950 real minified JS bundles + 5000 JSON/sourcemap/HTML/MDX/Markdown files) | **3** new findings, all genuine hardcoded credentials in third-party example code (`password': 'super-secret'`, `SECRET \|\| "my-secret"`); **0** suppressed |
| Falsifiability | all 13 behaviour changes reverted one at a time; each fails a named test |

## Runtime

These patterns run over full crawled bundles, so both tiers were checked for backtracking. `[a-zA-Z0-9_+/-]{20,}={0,2}` and the separator alternations are linear.

The first draft of this PR was not: `['"]?\s*\]?\s*` placed two unbounded whitespace quantifiers next to each other, and since `\s` matches newlines, pretty-printed HTML was enough to reach it.

| whitespace run after `apiKey` | first draft | shipped | `main` |
|---|---|---|---|
| 8 KB | 1045 ms | 0.1 ms | 0.0 ms |
| 64 KB | 12868 ms | 0.5 ms | 0.2 ms |

Anchoring the optional `]` inside its own group fixes it; there is a 200 KB regression test for both the trailing-space and the newlines-before-colon form.

## Tests

`packages/rules/tests/leaked-secrets.test.ts`: 47 pass (24 new assertions' worth of fixtures). Full `packages/rules` suite 1538 pass, `packages/audit-engine` 296 pass / 3 skip, `tsgo --noEmit` clean.

Two existing assertions changed, both attribution rather than detection: `{"together_secret":"<key>"}` and `cfg["apiKey"] = "<key>"` are now claimed by the generic FAST tier first, so they report under `Generic Secret Assignment` / `Generic API Key Assignment` with the key inside the reported value instead of under the service-specific name. The leak is still reported in both cases; the tests now pin the new type explicitly rather than being loosened.

## Reviewed

Two adversarial Codex passes. The first found the compound-digest-key hole, the unrestricted `=` in the Bearer class, and that the base64 fixtures were 53 characters (impossible for padded base64 — they are real 47-byte encodings now, pinned with a decode/encode round trip). The second found the backtracking regression above, the dotted-member-path suppression, and the keyless-fallback classification. All fixed.

## Reported, not fixed here

Two pre-existing issues the review surfaced. Neither is a regression and both are filed separately:

- `overlapsSeenValue` is O(findings²). At 16k findings on an 880 KB page the *same* input costs 2613 ms on `main` and 2515 ms here — the algorithm is untouched; this change only widens which inputs reach the cliff, which needs thousands of distinct findings on one page.
- `lookBehind`'s 64-character cut loses the key when it lands in a whitespace run, so `{"sha256"` + 62 spaces + `:"<hex>"}` misclassifies. It reports identically on `origin/main`.
