### PR TITLE
feat(rules): report uncompressed text assets over size threshold #9

### DIFF
--- a/apps/cli/src/audit/adapter.ts
+++ b/apps/cli/src/audit/adapter.ts
@@ -659,13 +659,16 @@ export function fetchResourceAssets(
 
     const allResourceChecks = Effect.all(
       {
-        css: checkResourceSizes(
-          Array.from(resourceOccurrences.css.keys()),
-          resourceCheckOptions
-        ),
+        // verifyCompression only on the two pools perf/asset-compression reads
+        // (#9) — the pdf and sitemap checks below never report on compression,
+        // so they keep the cheap HEAD path and pay nothing for it.
+        css: checkResourceSizes(Array.from(resourceOccurrences.css.keys()), {
+          ...resourceCheckOptions,
+          verifyCompression: true,
+        }),
         images: checkResourceSizes(
           Array.from(resourceOccurrences.images.keys()),
-          resourceCheckOptions
+          { ...resourceCheckOptions, verifyCompression: true }
         ),
         scripts: fetchScriptContents(
           Array.from(resourceOccurrences.scripts.keys()),

--- a/apps/cli/src/audit/adapter.ts
+++ b/apps/cli/src/audit/adapter.ts
@@ -766,6 +766,7 @@ export function fetchResourceAssets(
         redirected: fetch.redirected,
         finalUrl: fetch.finalUrl,
         sourceMapHeader: fetch.sourceMapHeader,
+        contentEncoding: fetch.contentEncoding,
       })),
       pdfSizes: resourceResults.pdfs.map((check) => ({
         url: check.url,

--- a/apps/cli/src/crawler/script-fetcher.ts
+++ b/apps/cli/src/crawler/script-fetcher.ts
@@ -3,6 +3,8 @@
 
 import { Effect } from "effect";
 
+import { normalizeEncoding } from "@squirrelscan/audit-engine";
+
 import { SCRIPT_FETCH_LIMITS, SQUIRRELSCAN_USER_AGENT } from "@/constants";
 import {
   getGlobalContentStore,
@@ -21,6 +23,12 @@ export interface ScriptFetchResult {
   fromCache?: boolean;
   /** SourceMap or X-SourceMap response header value, if present */
   sourceMapHeader?: string;
+  /**
+   * content-encoding observed on this fetch: a transfer coding or `null` for
+   * identity/absent. Absent (`undefined`) when no response was seen — notably
+   * on a content-store cache hit, which never touches the network. (#9)
+   */
+  contentEncoding?: string | null;
 }
 
 export interface ScriptFetcherOptions {
@@ -107,6 +115,13 @@ async function fetchSingleScriptAsync(
       response.headers.get("x-sourcemap") ||
       undefined;
 
+    // #9: a transfer coding (gzip/br/…) or null for identity/absent. `fetch`
+    // decodes the body but leaves this header intact, so it stays observable
+    // even though `sizeBytes` below measures the DECODED text.
+    const contentEncoding = normalizeEncoding(
+      response.headers.get("content-encoding")
+    );
+
     // Track redirect info from the response
     const wasRedirected = response.redirected;
     const finalUrl = wasRedirected ? response.url : undefined;
@@ -125,6 +140,7 @@ async function fetchSingleScriptAsync(
         redirected: wasRedirected,
         finalUrl,
         sourceMapHeader,
+        contentEncoding,
         error: "script too large",
       };
     }
@@ -138,6 +154,7 @@ async function fetchSingleScriptAsync(
         redirected: wasRedirected,
         finalUrl,
         sourceMapHeader,
+        contentEncoding,
         error: `HTTP ${response.status}`,
       };
     }
@@ -151,6 +168,7 @@ async function fetchSingleScriptAsync(
         redirected: wasRedirected,
         finalUrl,
         sourceMapHeader,
+        contentEncoding,
         error: "not javascript",
       };
     }
@@ -172,6 +190,7 @@ async function fetchSingleScriptAsync(
         redirected: wasRedirected,
         finalUrl,
         sourceMapHeader,
+        contentEncoding,
         error: "script too large",
       };
     }
@@ -185,6 +204,7 @@ async function fetchSingleScriptAsync(
       redirected: wasRedirected,
       finalUrl,
       sourceMapHeader,
+      contentEncoding,
     };
   } catch (error) {
     clearTimeout(timeoutId);
@@ -229,6 +249,10 @@ function fetchSingleScript(
         redirected: false,
         finalUrl: undefined,
         fromCache: true,
+        // contentEncoding is deliberately LEFT UNSET (undefined): this path
+        // never touched the network, so the response headers were never seen.
+        // Do not default it to null — null means "observed, not compressed",
+        // and perf/asset-compression would report every cached script. (#9)
       } satisfies ScriptFetchResult;
     }
 

--- a/apps/cli/src/crawler/script-fetcher.ts
+++ b/apps/cli/src/crawler/script-fetcher.ts
@@ -1,9 +1,8 @@
 // Script content fetcher for security scanning
 // Fetches actual JS content for secrets detection
 
-import { Effect } from "effect";
-
 import { normalizeEncoding } from "@squirrelscan/audit-engine";
+import { Effect } from "effect";
 
 import { SCRIPT_FETCH_LIMITS, SQUIRRELSCAN_USER_AGENT } from "@/constants";
 import {

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -309,6 +309,12 @@ export interface ScriptContentData {
   finalUrl?: string;
   /** SourceMap or X-SourceMap response header value, if present */
   sourceMapHeader?: string;
+  /**
+   * content-encoding observed on THIS fetch: a transfer coding (gzip/br/…) or
+   * `null` for identity/absent. `undefined` means never observed (content-store
+   * cache hit) — treat as unknown, NOT as uncompressed. (#9)
+   */
+  contentEncoding?: string | null;
 }
 
 export interface SitemapUrlStatusData {

--- a/apps/cli/tests/crawler/script-fetcher-encoding.test.ts
+++ b/apps/cli/tests/crawler/script-fetcher-encoding.test.ts
@@ -5,8 +5,8 @@
 // has a content-store cache the engine fork lacks — a cache hit never touches
 // the network, so it must report the encoding as unknown rather than as absent.
 
-import { Effect } from "effect";
 import { afterAll, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
 
 import { fetchScriptContents } from "@/crawler/script-fetcher";
 

--- a/apps/cli/tests/crawler/script-fetcher-encoding.test.ts
+++ b/apps/cli/tests/crawler/script-fetcher-encoding.test.ts
@@ -1,0 +1,72 @@
+// content-encoding capture in the CLI's script fetcher (#9).
+//
+// apps/cli/src/crawler/script-fetcher.ts is a FORK of the audit-engine fetcher,
+// not a re-export, so the engine's capture test proves nothing about it. It also
+// has a content-store cache the engine fork lacks — a cache hit never touches
+// the network, so it must report the encoding as unknown rather than as absent.
+
+import { Effect } from "effect";
+import { afterAll, describe, expect, test } from "bun:test";
+
+import { fetchScriptContents } from "@/crawler/script-fetcher";
+
+const BODY = `console.log(${JSON.stringify("x".repeat(2000))});`;
+const GZIPPED = Bun.gzipSync(new TextEncoder().encode(BODY));
+
+const server = Bun.serve({
+  port: 0,
+  fetch(req) {
+    const path = new URL(req.url).pathname;
+    if (path === "/gzip.js") {
+      return new Response(GZIPPED, {
+        headers: {
+          "content-type": "application/javascript",
+          "content-encoding": "gzip",
+          "content-length": String(GZIPPED.length),
+        },
+      });
+    }
+    return new Response(BODY, {
+      headers: {
+        "content-type": "application/javascript",
+        "content-length": String(BODY.length),
+      },
+    });
+  },
+});
+
+const base = `http://localhost:${server.port}`;
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("CLI script fetcher content-encoding (#9)", () => {
+  test("an uncompressed script records null — observed, and absent", async () => {
+    const [result] = await Effect.runPromise(
+      fetchScriptContents([`${base}/plain.js`])
+    );
+    expect(result?.status).toBe(200);
+    expect(result?.contentEncoding).toBe(null);
+  });
+
+  test("a gzipped script records the coding, not null", async () => {
+    const [result] = await Effect.runPromise(
+      fetchScriptContents([`${base}/gzip.js`])
+    );
+    expect(result?.status).toBe(200);
+    expect(result?.contentEncoding).toBe("gzip");
+    // fetch decodes the body; the header survives and sizeBytes is the decoded
+    // length. That mismatch is why the rule never judges size on a compressed
+    // asset — it only ever reports assets with no coding at all.
+    expect(result?.sizeBytes).toBe(BODY.length);
+  });
+
+  // The fetcher's content-store cache-hit branch deliberately leaves
+  // contentEncoding unset, since it never sees a response. That branch is
+  // currently unreachable and so cannot be tested: fetchSingleScript reads with
+  // `hashContent(url)` but writes with `store.put(content)`, which keys by
+  // `hashContent(content)` — the two hashes never match, so the cache never
+  // hits. Reported separately rather than changed here; fixing the key is a
+  // caching behaviour change, not part of #9.
+});

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -488,6 +488,7 @@
               "rules/perf/total-byte-weight",
               "rules/perf/cache-headers",
               "rules/perf/compression",
+              "rules/perf/asset-compression",
               "rules/perf/bad-caching",
               "rules/perf/http2",
               "rules/perf/animated-content",

--- a/docs/rules/perf/asset-compression.mdx
+++ b/docs/rules/perf/asset-compression.mdx
@@ -1,0 +1,105 @@
+---
+title: "Uncompressed Assets"
+description: "Checks for large CSS, JavaScript, and other text assets served without gzip or Brotli"
+---
+
+Checks for large CSS, JavaScript, and other text assets served without gzip or Brotli.
+
+| | |
+|---|---|
+| **Rule ID** | `perf/asset-compression` |
+| **Category** | [Performance](/rules/perf) |
+| **Scope** | Site-wide |
+| **Severity** | warning |
+| **Weight** | 6/10 |
+
+## What it checks
+
+[`perf/compression`](/rules/perf/compression) judges the HTML document's own
+response. This rule judges everything the page pulls in afterwards.
+
+A server that compresses `text/html` but not `text/css` is a common
+misconfiguration, and it is invisible to the size rules:
+[`perf/css-file-size`](/rules/perf/css-file-size) and
+[`perf/js-file-size`](/rules/perf/js-file-size) measure bytes but never look at
+`Content-Encoding`. So a 300 KB stylesheet shipped uncompressed costs every
+visitor the full 300 KB while the audit reports only that the file is large.
+
+For each crawled sub-resource this rule reports the asset when all of the
+following hold:
+
+- the response is **2xx** and its `Content-Type` is compressible text: `text/*`,
+  `application/json`, `application/javascript`, `application/xml`, or any
+  `+json`/`+xml` type (this is what includes SVG and excludes PNG, WebP, fonts,
+  and PDFs, which are already compressed),
+- no `Content-Encoding` of `gzip`, `br`, `deflate`, or `zstd` was returned, and
+- the asset is larger than the size threshold (100 KB by default).
+
+Findings list each asset URL biggest-first with its size, the pages that
+reference it, and the estimated saving.
+
+<Note>
+The rule stays silent about any asset whose encoding it could not observe
+first-hand on this run, rather than guessing. That covers sub-resources reused
+from a previous crawl's cache (their headers belong to that older run) and
+scripts served from the CLI's local content store. A re-audit with
+`--refresh` re-fetches everything and judges the full set.
+</Note>
+
+## Solution
+
+Enable gzip or Brotli for static text assets, not just HTML. Server config often
+compresses `text/html` but omits `text/css` and `application/javascript`: add
+those MIME types to your compression list (nginx `gzip_types`, Apache
+`AddOutputFilterByType`). On a CDN, check that compression is on for static file
+extensions. Brotli beats gzip on text and every current browser accepts it.
+
+```nginx nginx.conf
+gzip on;
+gzip_types text/plain text/css application/json application/javascript
+           application/xml image/svg+xml;
+gzip_min_length 1024;
+```
+
+## Options
+
+This rule supports the following configuration options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `min_bytes` | number | `102400` | Only report uncompressed assets larger than this many bytes |
+
+### Configuration example
+
+```toml squirrel.toml
+[rules."perf/asset-compression"]
+min_bytes = 102400
+```
+
+Lower `min_bytes` to catch smaller assets. Compression starts paying off at
+around 1 KB, so `min_bytes = 1024` is a reasonable strict setting; the 100 KB
+default keeps the report focused on assets whose size is already worth acting on.
+
+## Enable / disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["perf/asset-compression"]
+```
+
+### Disable all Performance rules
+
+```toml squirrel.toml
+[rules]
+disable = ["perf/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["perf/asset-compression"]
+disable = ["*"]
+```

--- a/docs/rules/perf/asset-compression.mdx
+++ b/docs/rules/perf/asset-compression.mdx
@@ -50,7 +50,9 @@ body, and a server whose compression runs as a body filter (nginx's `gzip`
 module, and many CDNs on range requests) answers it with no `Content-Encoding`
 at all. Reporting that as uncompressed would be wrong, so when an asset still
 looks uncompressed the crawler confirms with an ordinary `GET` before the rule
-will name it.
+will name it. If that confirming request cannot be made, because the origin
+rate-limited it or the check ran out of time, the asset's encoding stays
+unknown and the rule leaves it alone rather than assuming the worst.
 </Note>
 
 ## Solution

--- a/docs/rules/perf/asset-compression.mdx
+++ b/docs/rules/perf/asset-compression.mdx
@@ -41,9 +41,16 @@ reference it, and the estimated saving.
 <Note>
 The rule stays silent about any asset whose encoding it could not observe
 first-hand on this run, rather than guessing. That covers sub-resources reused
-from a previous crawl's cache (their headers belong to that older run) and
-scripts served from the CLI's local content store. A re-audit with
-`--refresh` re-fetches everything and judges the full set.
+from a previous crawl's cache, whose headers belong to that older run: a
+re-audit with `--refresh` re-fetches everything and judges the full set.
+
+Proving an asset is genuinely uncompressed also costs an extra request.
+Stylesheets and images are normally sized with a `HEAD`, but a `HEAD` has no
+body, and a server whose compression runs as a body filter (nginx's `gzip`
+module, and many CDNs on range requests) answers it with no `Content-Encoding`
+at all. Reporting that as uncompressed would be wrong, so when an asset still
+looks uncompressed the crawler confirms with an ordinary `GET` before the rule
+will name it.
 </Note>
 
 ## Solution

--- a/docs/rules/perf/index.mdx
+++ b/docs/rules/perf/index.mdx
@@ -26,6 +26,9 @@ Page speed and loading performance
   <Card title="Compression" icon="triangle-exclamation" href="/rules/perf/compression">
     Checks for Gzip or Brotli compression
   </Card>
+  <Card title="Uncompressed Assets" icon="triangle-exclamation" href="/rules/perf/asset-compression">
+    Checks for large CSS, JavaScript, and other text assets served without gzip or Brotli
+  </Card>
   <Card title="Critical Request Chains" icon="triangle-exclamation" href="/rules/perf/critical-request-chains">
     Identifies chains of dependent resources that delay rendering
   </Card>

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -823,6 +823,7 @@ export function fetchResourceAssets(
         redirected: fetch.redirected,
         finalUrl: fetch.finalUrl,
         sourceMapHeader: fetch.sourceMapHeader,
+        contentEncoding: fetch.contentEncoding,
       })),
       pdfSizes: resourceResults.pdfs.map((check) => ({
         url: check.url,

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -718,11 +718,17 @@ export function fetchResourceAssets(
 
     const allResourceChecks = Effect.all(
       {
-        css: checkResourceSizes(Array.from(resourceOccurrences.css.keys()), resourceCheckOptions),
-        images: checkResourceSizes(
-          Array.from(resourceOccurrences.images.keys()),
-          resourceCheckOptions,
-        ),
+        // verifyCompression only on the two pools perf/asset-compression reads
+        // (#9) — the pdf and sitemap checks below never report on compression,
+        // so they keep the cheap HEAD path and pay nothing for it.
+        css: checkResourceSizes(Array.from(resourceOccurrences.css.keys()), {
+          ...resourceCheckOptions,
+          verifyCompression: true,
+        }),
+        images: checkResourceSizes(Array.from(resourceOccurrences.images.keys()), {
+          ...resourceCheckOptions,
+          verifyCompression: true,
+        }),
         scripts: fetchScriptContents(
           Array.from(resourceOccurrences.scripts.keys()),
           scriptFetchOptions,

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -163,7 +163,7 @@ export type { DetectedTechnology, TechCategory } from "@squirrelscan/tech-detect
 export { computeLockedRules, deriveHomepageSummary } from "./publish-meta";
 
 // Re-export checker types + impl for consumers (CLI re-exports checkResourceSizes)
-export { checkResourceSizes, varyForbidsReuse } from "./resource-checker";
+export { checkResourceSizes, normalizeEncoding, varyForbidsReuse } from "./resource-checker";
 export type { ResourceCheckResult, ResourceCheckerOptions } from "./resource-checker";
 export type { ScriptFetchResult } from "./script-fetcher";
 export type { ExternalCheckResult, LinkCache, LinkCacheEntry } from "./external-checker";

--- a/packages/audit-engine/src/resource-checker.ts
+++ b/packages/audit-engine/src/resource-checker.ts
@@ -104,8 +104,12 @@ function validateContentType(
   return contentType.toLowerCase().startsWith(expectedPrefix.toLowerCase());
 }
 
-/** Normalize content-encoding to a stored value (null for identity/none). */
-function normalizeEncoding(value: string | null): string | null {
+/**
+ * Normalize content-encoding to a stored value (null for identity/none). Shared
+ * with the script fetcher (#9) so assets and scripts store the SAME shape and a
+ * rule can rely on `null` meaning "observed, and not compressed".
+ */
+export function normalizeEncoding(value: string | null): string | null {
   if (!value) return null;
   const enc = value.trim().toLowerCase();
   return enc && enc !== "identity" ? enc : null;

--- a/packages/audit-engine/src/resource-checker.ts
+++ b/packages/audit-engine/src/resource-checker.ts
@@ -25,8 +25,15 @@ export interface ResourceCheckResult {
   contentType: string | null;
   sizeBytes: number | null;
   redirectTarget: string | null;
-  /** content-encoding (gzip/br/deflate/zstd) or null for identity. (#107) */
-  contentEncoding: string | null;
+  /**
+   * content-encoding (gzip/br/deflate/zstd), or null for identity/none. (#107)
+   *
+   * `undefined` is a third state, not a missing field: the response was seen but
+   * its encoding could NOT be established (#9 — a ranged 206 whose confirming
+   * GET failed). Consumers judging compression must treat it as unknown rather
+   * than as "no coding"; see perf/asset-compression.
+   */
+  contentEncoding: string | null | undefined;
   /**
    * Encoded body size (Content-Length) — the bytes a full GET transfers over the
    * wire for a MISS; 0 for a cache HIT (no body fetched this run). On a HEAD
@@ -415,14 +422,24 @@ async function checkSingleResourceAsync(
     // bytes=0-0` can answer identity for an asset whose ordinary GET is gzipped.
     // One plain GET settles it; we only want its headers, so the body is
     // cancelled immediately and the size stays whatever the cheap probes found.
-    // If that request fails we keep what we have rather than lose the record —
-    // the surrounding try/catch would otherwise discard a usable size.
+    let resolvedEncoding: string | null | undefined = meta.contentEncoding;
     if (
       options.verifyCompression &&
       getResponse.status === 206 &&
       meta.contentEncoding === null &&
       isCompressibleContentType(meta.contentType)
     ) {
+      // The 206's own `null` is not evidence, so it cannot be the fallback: if
+      // the confirmation never answers, the encoding is UNKNOWN, not absent.
+      // Keeping the ranged null here would hand perf/asset-compression exactly
+      // the false positive this block exists to prevent — a gzipped asset
+      // reported as uncompressed — and the failure modes are ordinary: the
+      // confirmation shares this check's AbortController (so a slow HEAD +
+      // ranged GET can leave it no deadline), and a second immediate request
+      // for the same asset is what rate-limiters answer with 429/503. `size`
+      // and every other field survive; only the encoding degrades to unknown,
+      // which the rule reads as "stay silent".
+      resolvedEncoding = undefined;
       try {
         const { response: confirmResponse } = await safeRedirectFetch(url, {
           method: "GET",
@@ -435,13 +452,13 @@ async function checkSingleResourceAsync(
         });
         confirmResponse.body?.cancel();
         if (confirmResponse.status < 400) {
-          meta.contentEncoding = normalizeEncoding(
+          resolvedEncoding = normalizeEncoding(
             confirmResponse.headers.get("content-encoding")
           );
         }
       } catch {
-        // Keep the ranged response's view; a failed confirmation must not
-        // discard an otherwise good record.
+        // Leave it unknown; a failed confirmation must not invent a finding,
+        // and must not discard the otherwise usable size either.
       }
     }
 
@@ -454,7 +471,7 @@ async function checkSingleResourceAsync(
         ...defaultResult,
         status: getResponse.status,
         contentType: meta.contentType,
-        contentEncoding: meta.contentEncoding,
+        contentEncoding: resolvedEncoding,
         cacheControl: meta.cacheControl,
         etag: meta.etag,
         lastModified: meta.lastModified,
@@ -483,7 +500,7 @@ async function checkSingleResourceAsync(
       contentType: meta.contentType,
       sizeBytes,
       transferBytes,
-      contentEncoding: meta.contentEncoding,
+      contentEncoding: resolvedEncoding,
       cacheControl: meta.cacheControl,
       etag: meta.etag,
       lastModified: meta.lastModified,

--- a/packages/audit-engine/src/resource-checker.ts
+++ b/packages/audit-engine/src/resource-checker.ts
@@ -73,6 +73,16 @@ export interface ResourceCheckerOptions {
    * skipped. Absent (CLI) → every resource is fetched as today.
    */
   budget?: FetchBudget;
+  /**
+   * #9: prove whether this pool's assets are really uncompressed. Neither cheap
+   * probe is conclusive on its own — a bodiless HEAD and a ranged 206 can BOTH
+   * omit Content-Encoding on a server that compresses ordinary GETs — so
+   * settling it costs one extra request per compressible asset that still looks
+   * uncompressed. Only the pools perf/asset-compression reads (CSS, images)
+   * enable this; sitemap and PDF checks never report on compression and keep
+   * the cheap HEAD path. Default off.
+   */
+  verifyCompression?: boolean;
 }
 
 const DEFAULT_OPTIONS: ResourceCheckerOptions = {
@@ -107,8 +117,12 @@ function validateContentType(
 
 /**
  * Normalize content-encoding to a stored value (null for identity/none). Shared
- * with the script fetcher (#9) so assets and scripts store the SAME shape and a
- * rule can rely on `null` meaning "observed, and not compressed".
+ * with the script fetcher (#9) so assets and scripts store the SAME shape.
+ *
+ * `null` on its own does NOT mean "observed, and not compressed": this module
+ * also initializes it to null for timeouts, budget skips, and cache reuse of a
+ * record written before #107 added the column. A caller judging compression must
+ * check status/error/cacheReason too — see perf/asset-compression.
  */
 export function normalizeEncoding(value: string | null): string | null {
   if (!value) return null;
@@ -302,13 +316,13 @@ async function checkSingleResourceAsync(
       // body filter (nginx's gzip module is the common one) answers it with NO
       // Content-Encoding and the UNCOMPRESSED Content-Length — indistinguishable
       // from a genuinely uncompressed asset. Absence of the header on a bodiless
-      // response is not evidence of absence, so for compressible text that looks
-      // uncompressed we decline the HEAD shortcut and fall through to the GET
-      // below, which is authoritative. A HEAD that DOES name a coding is
-      // positive evidence and still takes the shortcut, as does any asset whose
-      // type gains nothing from compression, so the extra request is confined to
-      // exactly the assets a compression rule would otherwise misreport.
+      // response is not evidence of absence, so when this pool's findings depend
+      // on the answer we decline the HEAD shortcut for compressible text that
+      // looks uncompressed and fall through to the GET below. A HEAD that DOES
+      // name a coding is positive evidence and still takes the shortcut, as does
+      // any asset whose type gains nothing from compression.
       const headEncodingIsTrustworthy =
+        !options.verifyCompression ||
         meta.contentEncoding !== null ||
         !isCompressibleContentType(meta.contentType);
 
@@ -395,6 +409,41 @@ async function checkSingleResourceAsync(
     const sizeFromLength = parseHeaderInt(
       getResponse.headers.get("content-length")
     );
+
+    // #9: a ranged 206 is no more conclusive than the HEAD was — many origins
+    // and CDNs skip compression for range requests specifically, so `Range:
+    // bytes=0-0` can answer identity for an asset whose ordinary GET is gzipped.
+    // One plain GET settles it; we only want its headers, so the body is
+    // cancelled immediately and the size stays whatever the cheap probes found.
+    // If that request fails we keep what we have rather than lose the record —
+    // the surrounding try/catch would otherwise discard a usable size.
+    if (
+      options.verifyCompression &&
+      getResponse.status === 206 &&
+      meta.contentEncoding === null &&
+      isCompressibleContentType(meta.contentType)
+    ) {
+      try {
+        const { response: confirmResponse } = await safeRedirectFetch(url, {
+          method: "GET",
+          headers: {
+            "User-Agent": options.userAgent,
+            Accept: "*/*",
+            ...options.customHeaders,
+          },
+          signal: controller.signal,
+        });
+        confirmResponse.body?.cancel();
+        if (confirmResponse.status < 400) {
+          meta.contentEncoding = normalizeEncoding(
+            confirmResponse.headers.get("content-encoding")
+          );
+        }
+      } catch {
+        // Keep the ranged response's view; a failed confirmation must not
+        // discard an otherwise good record.
+      }
+    }
 
     if (
       options.validateContentType &&

--- a/packages/audit-engine/src/resource-checker.ts
+++ b/packages/audit-engine/src/resource-checker.ts
@@ -14,6 +14,7 @@ import type {
 import { isCacheHitReason } from "@squirrelscan/core-contracts";
 import { calculateFreshness } from "@squirrelscan/crawler";
 import { RESOURCE_SIZE_LIMITS, SQUIRRELSCAN_USER_AGENT } from "@squirrelscan/utils/constants";
+import { isCompressibleContentType } from "@squirrelscan/utils/headers";
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 import type { FetchBudget, FetchOutcome } from "./fetch-budget";
 
@@ -297,7 +298,21 @@ async function checkSingleResourceAsync(
         };
       }
 
-      if (headResponse.status < 400 && sizeBytes !== null) {
+      // #9: a HEAD carries no body, so a server whose compression runs as a
+      // body filter (nginx's gzip module is the common one) answers it with NO
+      // Content-Encoding and the UNCOMPRESSED Content-Length — indistinguishable
+      // from a genuinely uncompressed asset. Absence of the header on a bodiless
+      // response is not evidence of absence, so for compressible text that looks
+      // uncompressed we decline the HEAD shortcut and fall through to the GET
+      // below, which is authoritative. A HEAD that DOES name a coding is
+      // positive evidence and still takes the shortcut, as does any asset whose
+      // type gains nothing from compression, so the extra request is confined to
+      // exactly the assets a compression rule would otherwise misreport.
+      const headEncodingIsTrustworthy =
+        meta.contentEncoding !== null ||
+        !isCompressibleContentType(meta.contentType);
+
+      if (headResponse.status < 400 && sizeBytes !== null && headEncodingIsTrustworthy) {
         clearTimeout(timeoutId);
         return {
           ...defaultResult,

--- a/packages/audit-engine/src/script-fetcher.ts
+++ b/packages/audit-engine/src/script-fetcher.ts
@@ -7,6 +7,7 @@ import { SCRIPT_FETCH_LIMITS, SQUIRRELSCAN_USER_AGENT } from "@squirrelscan/util
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 import type { FetchBudget, FetchOutcome } from "./fetch-budget";
+import { normalizeEncoding } from "./resource-checker";
 
 export interface ScriptFetchResult {
   url: string;
@@ -19,6 +20,11 @@ export interface ScriptFetchResult {
   finalUrl?: string;
   fromCache?: boolean;
   sourceMapHeader?: string;
+  /**
+   * content-encoding observed on this fetch: a transfer coding or `null` for
+   * identity/absent. Absent (`undefined`) when no response was seen. (#9)
+   */
+  contentEncoding?: string | null;
 }
 
 export interface ScriptFetcherOptions {
@@ -115,6 +121,13 @@ async function fetchSingleScriptAsync(
       response.headers.get("x-sourcemap") ||
       undefined;
 
+    // #9: a transfer coding (gzip/br/…) or null for identity/absent. `fetch`
+    // decodes the body but leaves this header intact, so it stays observable
+    // even though `sizeBytes` below measures the DECODED text.
+    const contentEncoding = normalizeEncoding(
+      response.headers.get("content-encoding")
+    );
+
     const wasRedirected = redirected;
     const finalUrl = wasRedirected ? resolvedFinalUrl : undefined;
 
@@ -131,6 +144,7 @@ async function fetchSingleScriptAsync(
         redirected: wasRedirected,
         finalUrl,
         sourceMapHeader,
+        contentEncoding,
         error: "script too large",
       };
     }
@@ -143,6 +157,7 @@ async function fetchSingleScriptAsync(
         redirected: wasRedirected,
         finalUrl,
         sourceMapHeader,
+        contentEncoding,
         error: `HTTP ${response.status}`,
       };
     }
@@ -155,6 +170,7 @@ async function fetchSingleScriptAsync(
         redirected: wasRedirected,
         finalUrl,
         sourceMapHeader,
+        contentEncoding,
         error: "not javascript",
       };
     }
@@ -178,6 +194,7 @@ async function fetchSingleScriptAsync(
         redirected: wasRedirected,
         finalUrl,
         sourceMapHeader,
+        contentEncoding,
         error: "script too large",
       };
     }
@@ -191,6 +208,7 @@ async function fetchSingleScriptAsync(
       redirected: wasRedirected,
       finalUrl,
       sourceMapHeader,
+      contentEncoding,
     };
   } catch (error) {
     clearTimeout(timeoutId);

--- a/packages/audit-engine/tests/asset-compression-capture.test.ts
+++ b/packages/audit-engine/tests/asset-compression-capture.test.ts
@@ -1,0 +1,155 @@
+// End-to-end capture of `content-encoding` for perf/asset-compression (#9).
+//
+// The rule's own unit tests inject contentEncoding through fixtures, so they
+// would still pass if the capture were deleted from the fetchers. These drive
+// the REAL fetchers against a real local server and assert what actually lands
+// in the record the rule reads — including the nginx-shaped case where a
+// bodiless HEAD hides the compression that a GET reveals.
+
+import { Effect } from "effect";
+import { afterAll, describe, expect, test } from "bun:test";
+
+import { checkResourceSizes } from "../src/resource-checker";
+import { fetchScriptContents } from "../src/script-fetcher";
+
+const BODY = "/* ".concat("x".repeat(300_000), " */");
+const GZIPPED = Bun.gzipSync(new TextEncoder().encode(BODY));
+
+/**
+ * Routes, by path:
+ *   /plain.*        uncompressed on every method
+ *   /gzip.*         compressed, and says so on HEAD as well as GET
+ *   /head-hides-gzip.css   the nginx shape: compression is a body filter, so the
+ *                          bodiless HEAD carries NO Content-Encoding and the
+ *                          UNCOMPRESSED Content-Length, while the GET is gzipped
+ */
+const server = Bun.serve({
+  port: 0,
+  fetch(req) {
+    const path = new URL(req.url).pathname;
+    const isHead = req.method === "HEAD";
+    const type = path.endsWith(".css")
+      ? "text/css"
+      : path.endsWith(".png")
+        ? "image/png"
+        : "application/javascript";
+
+    if (path.startsWith("/gzip")) {
+      return new Response(isHead ? null : GZIPPED, {
+        headers: {
+          "content-type": type,
+          "content-encoding": "gzip",
+          "content-length": String(GZIPPED.length),
+        },
+      });
+    }
+
+    if (path === "/head-hides-gzip.css") {
+      if (isHead) {
+        return new Response(null, {
+          headers: { "content-type": type, "content-length": String(BODY.length) },
+        });
+      }
+      return new Response(GZIPPED, {
+        headers: {
+          "content-type": type,
+          "content-encoding": "gzip",
+          "content-length": String(GZIPPED.length),
+        },
+      });
+    }
+
+    return new Response(isHead ? null : BODY, {
+      headers: { "content-type": type, "content-length": String(BODY.length) },
+    });
+  },
+});
+
+const base = `http://localhost:${server.port}`;
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("script fetcher captures content-encoding (#9)", () => {
+  test("an uncompressed script records null — observed, and absent", async () => {
+    const [result] = await Effect.runPromise(
+      fetchScriptContents([`${base}/plain.js`])
+    );
+    expect(result?.status).toBe(200);
+    expect(result?.contentEncoding).toBe(null);
+  });
+
+  test("a gzipped script records the coding, not null", async () => {
+    const [result] = await Effect.runPromise(
+      fetchScriptContents([`${base}/gzip.js`])
+    );
+    expect(result?.status).toBe(200);
+    expect(result?.contentEncoding).toBe("gzip");
+    // fetch decodes the body, so sizeBytes is the DECODED length while the
+    // header survives — the property the whole rule depends on.
+    expect(result?.sizeBytes).toBe(BODY.length);
+  });
+});
+
+describe("resource checker captures content-encoding (#9)", () => {
+  test("an uncompressed stylesheet records null", async () => {
+    const [result] = await Effect.runPromise(
+      checkResourceSizes([`${base}/plain.css`])
+    );
+    expect(result?.status).toBe(200);
+    expect(result?.contentEncoding).toBe(null);
+    expect(result?.sizeBytes).toBe(BODY.length);
+  });
+
+  test("a gzipped stylesheet records the coding", async () => {
+    const [result] = await Effect.runPromise(
+      checkResourceSizes([`${base}/gzip.css`])
+    );
+    expect(result?.status).toBe(200);
+    expect(result?.contentEncoding).toBe("gzip");
+  });
+
+  test("a HEAD that hides gzip does NOT record a false null", async () => {
+    // Without the fall-through added in #9 this returns contentEncoding null
+    // and sizeBytes 300_009 — a textbook large-uncompressed-CSS finding against
+    // a server that compresses perfectly well.
+    const [result] = await Effect.runPromise(
+      checkResourceSizes([`${base}/head-hides-gzip.css`])
+    );
+    expect(result?.status).toBe(200);
+    expect(result?.contentEncoding).toBe("gzip");
+  });
+
+  test("a compressible type still short-circuits on a HEAD that names a coding", async () => {
+    // The extra GET is confined to assets that would otherwise be misreported;
+    // a HEAD carrying positive evidence must still take the shortcut.
+    const calls: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(init?.method ?? "GET");
+      return realFetch(input as string, init);
+    }) as typeof fetch;
+    try {
+      await Effect.runPromise(checkResourceSizes([`${base}/gzip.css`]));
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(calls).toEqual(["HEAD"]);
+  });
+
+  test("a non-compressible type still short-circuits on HEAD", async () => {
+    const calls: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(init?.method ?? "GET");
+      return realFetch(input as string, init);
+    }) as typeof fetch;
+    try {
+      await Effect.runPromise(checkResourceSizes([`${base}/plain.png`]));
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(calls).toEqual(["HEAD"]);
+  });
+});

--- a/packages/audit-engine/tests/asset-compression-capture.test.ts
+++ b/packages/audit-engine/tests/asset-compression-capture.test.ts
@@ -22,46 +22,65 @@ const GZIPPED = Bun.gzipSync(new TextEncoder().encode(BODY));
  *   /head-hides-gzip.css   the nginx shape: compression is a body filter, so the
  *                          bodiless HEAD carries NO Content-Encoding and the
  *                          UNCOMPRESSED Content-Length, while the GET is gzipped
+ *   /range-hides-gzip.css  the CDN shape: compression is skipped for RANGE
+ *                          requests specifically, so both the HEAD and the
+ *                          ranged 206 look identity and only a plain GET is
+ *                          gzipped
  */
 const server = Bun.serve({
   port: 0,
   fetch(req) {
     const path = new URL(req.url).pathname;
     const isHead = req.method === "HEAD";
+    const isRanged = req.headers.get("range") !== null;
     const type = path.endsWith(".css")
       ? "text/css"
       : path.endsWith(".png")
         ? "image/png"
         : "application/javascript";
 
-    if (path.startsWith("/gzip")) {
-      return new Response(isHead ? null : GZIPPED, {
+    const gzipped = () =>
+      new Response(isHead ? null : GZIPPED, {
         headers: {
           "content-type": type,
           "content-encoding": "gzip",
           "content-length": String(GZIPPED.length),
         },
       });
-    }
+
+    const identity = () =>
+      new Response(isHead ? null : BODY, {
+        headers: { "content-type": type, "content-length": String(BODY.length) },
+      });
+
+    /** A 206 that answers the one-byte Range without any coding. */
+    const partialIdentity = () =>
+      new Response("x", {
+        status: 206,
+        headers: {
+          "content-type": type,
+          "content-length": "1",
+          "content-range": `bytes 0-0/${BODY.length}`,
+        },
+      });
+
+    if (path.startsWith("/gzip")) return gzipped();
 
     if (path === "/head-hides-gzip.css") {
-      if (isHead) {
-        return new Response(null, {
-          headers: { "content-type": type, "content-length": String(BODY.length) },
-        });
-      }
-      return new Response(GZIPPED, {
-        headers: {
-          "content-type": type,
-          "content-encoding": "gzip",
-          "content-length": String(GZIPPED.length),
-        },
-      });
+      return isHead ? identity() : gzipped();
     }
 
-    return new Response(isHead ? null : BODY, {
-      headers: { "content-type": type, "content-length": String(BODY.length) },
-    });
+    if (path === "/range-hides-gzip.css") {
+      if (isHead) return identity();
+      return isRanged ? partialIdentity() : gzipped();
+    }
+
+    if (path === "/range-really-plain.css") {
+      if (isHead) return identity();
+      return isRanged ? partialIdentity() : identity();
+    }
+
+    return identity();
   },
 });
 
@@ -92,10 +111,30 @@ describe("script fetcher captures content-encoding (#9)", () => {
   });
 });
 
+/** Record the method + Range of every request one check makes. */
+async function traceRequests(fn: () => Promise<unknown>): Promise<string[]> {
+  const calls: string[] = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const ranged = new Headers(init?.headers).get("range") !== null;
+    calls.push(ranged ? `${method}(range)` : method);
+    return realFetch(input as string, init);
+  }) as typeof fetch;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  return calls;
+}
+
+const VERIFY = { verifyCompression: true };
+
 describe("resource checker captures content-encoding (#9)", () => {
   test("an uncompressed stylesheet records null", async () => {
     const [result] = await Effect.runPromise(
-      checkResourceSizes([`${base}/plain.css`])
+      checkResourceSizes([`${base}/plain.css`], VERIFY)
     );
     expect(result?.status).toBe(200);
     expect(result?.contentEncoding).toBe(null);
@@ -104,52 +143,75 @@ describe("resource checker captures content-encoding (#9)", () => {
 
   test("a gzipped stylesheet records the coding", async () => {
     const [result] = await Effect.runPromise(
-      checkResourceSizes([`${base}/gzip.css`])
+      checkResourceSizes([`${base}/gzip.css`], VERIFY)
     );
     expect(result?.status).toBe(200);
     expect(result?.contentEncoding).toBe("gzip");
   });
 
   test("a HEAD that hides gzip does NOT record a false null", async () => {
-    // Without the fall-through added in #9 this returns contentEncoding null
-    // and sizeBytes 300_009 — a textbook large-uncompressed-CSS finding against
-    // a server that compresses perfectly well.
+    // Without the HEAD fall-through this returns contentEncoding null and
+    // sizeBytes 300_009 — a textbook large-uncompressed-CSS finding against a
+    // server that compresses perfectly well.
     const [result] = await Effect.runPromise(
-      checkResourceSizes([`${base}/head-hides-gzip.css`])
+      checkResourceSizes([`${base}/head-hides-gzip.css`], VERIFY)
     );
     expect(result?.status).toBe(200);
     expect(result?.contentEncoding).toBe("gzip");
   });
 
-  test("a compressible type still short-circuits on a HEAD that names a coding", async () => {
-    // The extra GET is confined to assets that would otherwise be misreported;
-    // a HEAD carrying positive evidence must still take the shortcut.
-    const calls: string[] = [];
-    const realFetch = globalThis.fetch;
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      calls.push(init?.method ?? "GET");
-      return realFetch(input as string, init);
-    }) as typeof fetch;
-    try {
-      await Effect.runPromise(checkResourceSizes([`${base}/gzip.css`]));
-    } finally {
-      globalThis.fetch = realFetch;
-    }
+  test("a ranged 206 that hides gzip does NOT record a false null", async () => {
+    // The CDN shape: HEAD and the one-byte Range BOTH answer identity, and only
+    // an ordinary GET reveals the coding.
+    const [result] = await Effect.runPromise(
+      checkResourceSizes([`${base}/range-hides-gzip.css`], VERIFY)
+    );
+    expect(result?.contentEncoding).toBe("gzip");
+  });
+
+  test("a genuinely uncompressed asset survives all three probes as null", async () => {
+    // The counterpart to the case above: same request sequence, and the finding
+    // must still be produced. Otherwise the fix would just silence the rule.
+    const [result] = await Effect.runPromise(
+      checkResourceSizes([`${base}/range-really-plain.css`], VERIFY)
+    );
+    expect(result?.contentEncoding).toBe(null);
+    expect(result?.sizeBytes).toBe(BODY.length);
+  });
+
+  test("verification costs at most one extra plain GET", async () => {
+    const calls = await traceRequests(() =>
+      Effect.runPromise(
+        checkResourceSizes([`${base}/range-hides-gzip.css`], VERIFY)
+      )
+    );
+    expect(calls).toEqual(["HEAD", "GET(range)", "GET"]);
+  });
+});
+
+describe("resource checker keeps the cheap path when verification is off (#9)", () => {
+  // The sitemap and PDF pools call the same checker but never report on
+  // compression. text/html is compressible, so without the option gate every
+  // sitemap URL would pay for the extra requests above.
+  test("a compressible type short-circuits on HEAD by default", async () => {
+    const calls = await traceRequests(() =>
+      Effect.runPromise(checkResourceSizes([`${base}/head-hides-gzip.css`]))
+    );
     expect(calls).toEqual(["HEAD"]);
   });
 
-  test("a non-compressible type still short-circuits on HEAD", async () => {
-    const calls: string[] = [];
-    const realFetch = globalThis.fetch;
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      calls.push(init?.method ?? "GET");
-      return realFetch(input as string, init);
-    }) as typeof fetch;
-    try {
-      await Effect.runPromise(checkResourceSizes([`${base}/plain.png`]));
-    } finally {
-      globalThis.fetch = realFetch;
-    }
+  test("a compressible type still short-circuits on a HEAD that names a coding", async () => {
+    // Even with verification on, a HEAD carrying positive evidence is enough.
+    const calls = await traceRequests(() =>
+      Effect.runPromise(checkResourceSizes([`${base}/gzip.css`], VERIFY))
+    );
+    expect(calls).toEqual(["HEAD"]);
+  });
+
+  test("a non-compressible type short-circuits on HEAD even with verification on", async () => {
+    const calls = await traceRequests(() =>
+      Effect.runPromise(checkResourceSizes([`${base}/plain.png`], VERIFY))
+    );
     expect(calls).toEqual(["HEAD"]);
   });
 });

--- a/packages/audit-engine/tests/asset-compression-capture.test.ts
+++ b/packages/audit-engine/tests/asset-compression-capture.test.ts
@@ -26,6 +26,8 @@ const GZIPPED = Bun.gzipSync(new TextEncoder().encode(BODY));
  *                          requests specifically, so both the HEAD and the
  *                          ranged 206 look identity and only a plain GET is
  *                          gzipped
+ *   /confirm-503.css       the same CDN shape, except the confirming GET is
+ *                          rate-limited away — the encoding is unknowable
  */
 const server = Bun.serve({
   port: 0,
@@ -78,6 +80,14 @@ const server = Bun.serve({
     if (path === "/range-really-plain.css") {
       if (isHead) return identity();
       return isRanged ? partialIdentity() : identity();
+    }
+
+    // The asset IS gzipped, but the confirming GET never gets to say so.
+    if (path === "/confirm-503.css") {
+      if (isHead) return identity();
+      return isRanged
+        ? partialIdentity()
+        : new Response("slow down", { status: 503 });
     }
 
     return identity();
@@ -177,6 +187,29 @@ describe("resource checker captures content-encoding (#9)", () => {
     );
     expect(result?.contentEncoding).toBe(null);
     expect(result?.sizeBytes).toBe(BODY.length);
+  });
+
+  test("an unconfirmable 206 records unknown, NOT a false null", async () => {
+    // The whole point of the confirming GET is that a ranged 206's missing
+    // Content-Encoding proves nothing. So when that GET cannot answer — 429/503
+    // from a rate-limiter, or a timeout on the AbortController it shares with
+    // the two probes before it — falling back to the 206's own null would
+    // report this gzipped asset as 300KB of uncompressed CSS: precisely the
+    // false positive the verification exists to prevent.
+    const [result] = await Effect.runPromise(
+      checkResourceSizes([`${base}/confirm-503.css`], VERIFY)
+    );
+    expect(result?.contentEncoding).toBeUndefined();
+  });
+
+  test("an unconfirmable 206 still keeps its size for the other rules", async () => {
+    // Only the encoding degrades to unknown. perf/css-file-size and
+    // perf/total-byte-weight still need the size, so the record must survive.
+    const [result] = await Effect.runPromise(
+      checkResourceSizes([`${base}/confirm-503.css`], VERIFY)
+    );
+    expect(result?.sizeBytes).toBe(BODY.length);
+    expect(result?.error).toBe(null);
   });
 
   test("verification costs at most one extra plain GET", async () => {

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -97,7 +97,12 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // 98219 -> 98220: social/asset-divergence, likewise site-scoped, adds its
       // own single whole-crawl check (#1371). healthScore.overall is UNMOVED at
       // 48: one weight-3 warning check in a 5-rule category cannot dominate it.
-      expect(v1.findings.length).toBe(98220);
+      // 98220 -> 98221: perf/asset-compression, likewise site-scoped, adds its
+      // own single whole-crawl check (#9). That check is `skipped` here — the
+      // harness supplies empty resourceSizes/scripts pools, so the rule has no
+      // sub-resource to judge — which is why the pass/warn/fail tallies and
+      // healthScore.overall (48) are all UNMOVED and only the raw count shifts.
+      expect(v1.findings.length).toBe(98221);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
@@ -106,9 +111,10 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // 272 -> 273 schema/rating-scope, 273 -> 274 crawl/sitemap-lastmod-churn,
       // 274 -> 275 crawl/sitemap-lastmod-drift, 275 -> 276
       // content/date-agreement, 276 -> 277 links/no-contextual-inbound,
-      // 277 -> 278 social/asset-divergence; anything else means a rule id
-      // leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(278);
+      // 277 -> 278 social/asset-divergence, 278 -> 279 perf/asset-compression;
+      // anything else means a rule id leaked in, so fix that rather than this
+      // number.
+      expect(v1.perRuleTally.length).toBe(279);
     },
     180_000,
   );

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -1154,6 +1154,14 @@ export interface ScriptContentData {
   redirected?: boolean;
   finalUrl?: string;
   sourceMapHeader?: string;
+  /**
+   * content-encoding observed on THIS fetch, normalized like the sub-resource
+   * checker's: a transfer coding (gzip/br/…) or `null` for identity/absent.
+   * `undefined` means the encoding was never observed (e.g. the CLI's
+   * content-store cache hit, which skips the network) — callers must treat
+   * that as unknown, NOT as uncompressed. (#9)
+   */
+  contentEncoding?: string | null;
 }
 
 export interface SitemapUrl {

--- a/packages/rules/src/performance/asset-compression.ts
+++ b/packages/rules/src/performance/asset-compression.ts
@@ -10,6 +10,7 @@
 import { z } from "zod";
 
 import { ASSET_COMPRESSION_LIMITS } from "@squirrelscan/utils/constants";
+import { isCompressibleContentType } from "@squirrelscan/utils/headers";
 
 import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
 
@@ -27,32 +28,18 @@ function formatBytes(bytes: number): string {
 }
 
 /**
- * Whether this media type gets a real win from a transfer coding. Classified by
- * content-type rather than by which crawl pool the asset came from, so an SVG
- * discovered as an <img> is judged as the XML text it is, while a PNG/JPEG/WebP
- * in that same pool (already entropy-coded) is left alone.
- */
-function isCompressibleType(contentType: string | null): boolean {
-  if (!contentType) return false;
-  const t = contentType.toLowerCase();
-  return (
-    t.includes("text/") ||
-    t.includes("application/json") ||
-    t.includes("application/javascript") ||
-    t.includes("application/xml") ||
-    t.includes("+xml") ||
-    t.includes("+json")
-  );
-}
-
-/**
  * `content-encoding` is a three-state signal here, and conflating the last two
  * is how this rule would earn a reputation for lying:
  *   - a coding string  → compressed, nothing to report
- *   - `null`           → observed on a live response, and there was none
+ *   - `null`           → no coding on the response
  *   - `undefined`      → never observed (the CLI's script content-store cache,
  *                        or a resource record written before #107 added the
  *                        column) — unknown, so stay silent
+ *
+ * `null` alone does NOT prove a live observation: the sub-resource checker also
+ * initializes it to `null` on a timeout or a budget skip. Those records carry no
+ * 2xx status, so the status gate in `run` is what actually establishes "we saw
+ * this response" — not the encoding field on its own.
  */
 function isKnownUncompressed(encoding: string | null | undefined): boolean {
   if (encoding === undefined) return false;
@@ -70,6 +57,7 @@ function isKnownUncompressed(encoding: string | null | undefined): boolean {
 interface Candidate {
   url: string;
   status: number | null;
+  error: string | null;
   contentType: string | null;
   sizeBytes: number | null;
   contentEncoding?: string | null;
@@ -129,9 +117,14 @@ export const assetCompressionRule: Rule = {
         c.status !== null &&
         c.status >= 200 &&
         c.status < 300 &&
+        // A record carrying an error has a size we cannot stand behind: the
+        // script fetcher's "script too large" bail reports the byte where it
+        // stopped reading, not the asset's real length, and this rule's finding
+        // names that size out loud.
+        c.error === null &&
         (c.cacheReason ?? null) === null &&
         c.contentEncoding !== undefined &&
-        isCompressibleType(c.contentType)
+        isCompressibleContentType(c.contentType)
     );
 
     if (observed.length === 0) {

--- a/packages/rules/src/performance/asset-compression.ts
+++ b/packages/rules/src/performance/asset-compression.ts
@@ -50,8 +50,18 @@ function isKnownUncompressed(encoding: string | null | undefined): boolean {
   // "uncompressed" — exactly the false positive this rule must not produce.
   // `identity` is the one value that explicitly means no coding, and
   // perf/compression already treats it as compression deliberately disabled.
-  const enc = encoding.trim().toLowerCase();
-  return enc === "" || enc === "identity";
+  //
+  // Content-Encoding is a comma-separated LIST, so this reads every token
+  // rather than the whole header: `identity, identity` is still no coding, and
+  // `identity, gzip` is still compressed. The fetchers normalize a lone
+  // `identity` to null, but they match one token, so a list reaches this
+  // function verbatim.
+  return encoding
+    .split(",")
+    .every((token) => {
+      const coding = token.trim().toLowerCase();
+      return coding === "" || coding === "identity";
+    });
 }
 
 interface Candidate {

--- a/packages/rules/src/performance/asset-compression.ts
+++ b/packages/rules/src/performance/asset-compression.ts
@@ -1,0 +1,196 @@
+// perf/asset-compression - Uncompressed text sub-resources (#9)
+//
+// perf/compression judges the HTML DOCUMENT's own response. This rule judges the
+// crawled SUB-RESOURCES: a big CSS/JS/SVG file shipped without gzip/Brotli costs
+// every visitor the full uncompressed transfer even when the HTML around it is
+// compressed, and neither perf/css-file-size nor perf/js-file-size looks at
+// content-encoding at all. Site-scope because sub-resources are shared across
+// pages — reporting them per page would repeat one asset N times.
+
+import { z } from "zod";
+
+import { ASSET_COMPRESSION_LIMITS } from "@squirrelscan/utils/constants";
+
+import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
+
+export const optionsSchema = z.object({
+  min_bytes: z
+    .number()
+    .default(ASSET_COMPRESSION_LIMITS.MIN_BYTES)
+    .describe("Only report uncompressed assets larger than this many bytes"),
+});
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+/**
+ * Whether this media type gets a real win from a transfer coding. Classified by
+ * content-type rather than by which crawl pool the asset came from, so an SVG
+ * discovered as an <img> is judged as the XML text it is, while a PNG/JPEG/WebP
+ * in that same pool (already entropy-coded) is left alone.
+ */
+function isCompressibleType(contentType: string | null): boolean {
+  if (!contentType) return false;
+  const t = contentType.toLowerCase();
+  return (
+    t.includes("text/") ||
+    t.includes("application/json") ||
+    t.includes("application/javascript") ||
+    t.includes("application/xml") ||
+    t.includes("+xml") ||
+    t.includes("+json")
+  );
+}
+
+/**
+ * `content-encoding` is a three-state signal here, and conflating the last two
+ * is how this rule would earn a reputation for lying:
+ *   - a coding string  → compressed, nothing to report
+ *   - `null`           → observed on a live response, and there was none
+ *   - `undefined`      → never observed (the CLI's script content-store cache,
+ *                        or a resource record written before #107 added the
+ *                        column) — unknown, so stay silent
+ */
+function isKnownUncompressed(encoding: string | null | undefined): boolean {
+  if (encoding === undefined) return false;
+  if (encoding === null) return true;
+  // ANY declared coding counts as compressed, rather than matching against a
+  // list of codings we know. An allowlist would report `zstd`, `dcb`/`dcz`
+  // (shared-dictionary), or anything else newer than this file as
+  // "uncompressed" — exactly the false positive this rule must not produce.
+  // `identity` is the one value that explicitly means no coding, and
+  // perf/compression already treats it as compression deliberately disabled.
+  const enc = encoding.trim().toLowerCase();
+  return enc === "" || enc === "identity";
+}
+
+interface Candidate {
+  url: string;
+  status: number | null;
+  contentType: string | null;
+  sizeBytes: number | null;
+  contentEncoding?: string | null;
+  sourcePages: string[];
+  /** Set only on sub-resources reused from a prior crawl without a real fetch. */
+  cacheReason?: string | null;
+}
+
+export const assetCompressionRule: Rule = {
+  meta: {
+    id: "perf/asset-compression",
+    name: "Uncompressed Assets",
+    description:
+      "Checks for large CSS, JavaScript, and other text assets served without gzip or Brotli",
+    solution:
+      "Enable gzip or Brotli for static text assets, not just HTML. Server config often compresses text/html but omits text/css and application/javascript: add those MIME types to your compression list (nginx 'gzip_types', Apache 'AddOutputFilterByType'). On a CDN, check that compression is on for static file extensions. Brotli beats gzip on text and every current browser accepts it.",
+    category: "perf",
+    scope: "site",
+    severity: "warning",
+    weight: 6,
+    optionsSchema,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const opts = optionsSchema.parse(ctx.options);
+    const checks: CheckResult[] = [];
+
+    // Every pool the crawler exposes that can hold text. `images` is included
+    // deliberately — SVG lands there — and filtered by content-type below.
+    // JSON/XML fetched on their own are not crawled as sub-resources today, so
+    // they only appear here when served under one of these pools' URLs.
+    const candidates: Candidate[] = [
+      ...(ctx.site?.resourceSizes?.css ?? []),
+      ...(ctx.site?.resourceSizes?.images ?? []),
+      ...(ctx.site?.scripts ?? []),
+    ];
+
+    if (candidates.length === 0) {
+      checks.push({
+        name: "asset-compression",
+        status: "skipped",
+        message: "No sub-resources were crawled",
+        skipReason: "no_data",
+      });
+      return { checks };
+    }
+
+    // Only responses whose encoding we can actually vouch for this run. A
+    // cache-reused record (cacheReason set) carries the PRIOR crawl's headers,
+    // and for a record written before #107 that prior encoding is an un-backed
+    // null — reporting on it would invent findings the current server never
+    // justified. An `undefined` encoding is likewise unjudgeable. Excluding
+    // both here (rather than only at the report step) keeps the pass message
+    // honest: it counts assets we genuinely checked.
+    const observed = candidates.filter(
+      (c) =>
+        c.status !== null &&
+        c.status >= 200 &&
+        c.status < 300 &&
+        (c.cacheReason ?? null) === null &&
+        c.contentEncoding !== undefined &&
+        isCompressibleType(c.contentType)
+    );
+
+    if (observed.length === 0) {
+      checks.push({
+        name: "asset-compression",
+        status: "skipped",
+        message: "No compressible text assets with observed response headers",
+        skipReason: "no_data",
+      });
+      return { checks };
+    }
+
+    const uncompressed = observed.filter(
+      (c) =>
+        isKnownUncompressed(c.contentEncoding) &&
+        c.sizeBytes !== null &&
+        c.sizeBytes > opts.min_bytes
+    );
+
+    if (uncompressed.length === 0) {
+      checks.push({
+        name: "asset-compression",
+        status: "pass",
+        message: `All ${observed.length} compressible asset(s) are compressed or under ${formatBytes(opts.min_bytes)}`,
+      });
+      return { checks };
+    }
+
+    // Biggest first: the top of the list is where the bandwidth actually is.
+    const sorted = [...uncompressed].sort(
+      (a, b) => (b.sizeBytes ?? 0) - (a.sizeBytes ?? 0)
+    );
+    const wastedBytes = sorted.reduce((sum, c) => sum + (c.sizeBytes ?? 0), 0);
+
+    checks.push({
+      name: "asset-compression",
+      status: "warn",
+      message: `${sorted.length} text asset(s) over ${formatBytes(opts.min_bytes)} served without compression`,
+      expected: "gzip, Brotli, or zstd on every large text asset",
+      items: sorted.map((c) => ({
+        id: c.url,
+        sourcePages: c.sourcePages,
+        meta: {
+          sizeBytes: c.sizeBytes,
+          size: formatBytes(c.sizeBytes ?? 0),
+          contentType: c.contentType ?? undefined,
+        },
+      })),
+      details: {
+        thresholdBytes: opts.min_bytes,
+        total: sorted.length,
+        compressibleAssets: observed.length,
+        uncompressedBytes: wastedBytes,
+        // Text typically compresses ~70%, the same ratio perf/compression
+        // quotes for the HTML document.
+        estimatedSavings: formatBytes(Math.round(wastedBytes * 0.7)),
+      },
+    });
+
+    return { checks };
+  },
+};

--- a/packages/rules/src/performance/index.ts
+++ b/packages/rules/src/performance/index.ts
@@ -3,6 +3,7 @@
 import type { Rule } from "../types";
 
 import { animatedContentRule } from "./animated-content";
+import { assetCompressionRule } from "./asset-compression";
 import { badCachingRule } from "./bad-caching";
 import { browserRequiredRule } from "./browser-required";
 import { cacheHeadersRule } from "./cache-headers";
@@ -46,6 +47,7 @@ export const rules: Rule[] = [
   carouselHiddenEagerRule,
   cssFileSizeRule,
   jsFileSizeRule,
+  assetCompressionRule,
   domSizeRule,
   ttfbRule,
   jsRedirectsRule,
@@ -67,6 +69,7 @@ export const rules: Rule[] = [
 
 export {
   animatedContentRule,
+  assetCompressionRule,
   badCachingRule,
   browserRequiredRule,
   cacheHeadersRule,

--- a/packages/rules/tests/asset-compression.test.ts
+++ b/packages/rules/tests/asset-compression.test.ts
@@ -1,0 +1,254 @@
+// perf/asset-compression — uncompressed text sub-resources (#9).
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult } from "@squirrelscan/core-contracts";
+import { ASSET_COMPRESSION_LIMITS } from "@squirrelscan/utils/constants";
+
+import { assetCompressionRule } from "../src/performance/asset-compression";
+import { compressionRule } from "../src/performance/compression";
+import type {
+  ParsedPage,
+  ResourceSizeData,
+  RuleContext,
+  ScriptContentData,
+  SiteData,
+} from "../src/types";
+
+const BIG = ASSET_COMPRESSION_LIMITS.MIN_BYTES * 2;
+const SMALL = Math.floor(ASSET_COMPRESSION_LIMITS.MIN_BYTES / 2);
+
+function css(overrides: Partial<ResourceSizeData> = {}): ResourceSizeData {
+  return {
+    url: "https://example.com/app.css",
+    status: 200,
+    error: null,
+    contentType: "text/css",
+    sizeBytes: BIG,
+    sourcePages: ["https://example.com/"],
+    contentEncoding: null,
+    ...overrides,
+  };
+}
+
+function script(overrides: Partial<ScriptContentData> = {}): ScriptContentData {
+  return {
+    url: "https://example.com/app.js",
+    status: 200,
+    error: null,
+    contentType: "application/javascript",
+    sizeBytes: BIG,
+    content: null,
+    sourcePages: ["https://example.com/"],
+    contentEncoding: null,
+    ...overrides,
+  };
+}
+
+function ctx(site: Partial<SiteData["resourceSizes"]> & {
+  scripts?: ScriptContentData[];
+  css?: ResourceSizeData[];
+  images?: ResourceSizeData[];
+} = {}): RuleContext {
+  return {
+    page: {
+      url: "https://example.com/",
+      html: "",
+      statusCode: 200,
+      loadTime: 0,
+      headers: {},
+    },
+    parsed: {} as ParsedPage,
+    site: {
+      baseUrl: "https://example.com",
+      pages: [],
+      robotsTxt: null,
+      sitemaps: null,
+      resourceSizes: { css: site.css ?? [], images: site.images ?? [] },
+      scripts: site.scripts ?? [],
+    },
+    options: {},
+  };
+}
+
+function run(c: RuleContext): CheckResult[] {
+  return assetCompressionRule.run(c).checks as CheckResult[];
+}
+
+function only(checks: CheckResult[]): CheckResult {
+  expect(checks).toHaveLength(1);
+  return checks[0]!;
+}
+
+function itemIds(check: CheckResult): string[] {
+  return (check.items ?? []).map((i) => i.id);
+}
+
+describe("perf/asset-compression — reports", () => {
+  test("a large uncompressed CSS file is reported with its URL and size", () => {
+    const check = only(run(ctx({ css: [css()] })));
+    expect(check.status).toBe("warn");
+    expect(itemIds(check)).toEqual(["https://example.com/app.css"]);
+    expect(check.items?.[0]?.meta?.sizeBytes).toBe(BIG);
+    expect(check.items?.[0]?.meta?.size).toBe("200.0 KB");
+  });
+
+  test("a large uncompressed JS file is reported", () => {
+    const check = only(run(ctx({ scripts: [script()] })));
+    expect(check.status).toBe("warn");
+    expect(itemIds(check)).toEqual(["https://example.com/app.js"]);
+  });
+
+  test("an SVG in the image pool is reported (image/svg+xml is text)", () => {
+    const check = only(
+      run(
+        ctx({
+          images: [
+            css({ url: "https://example.com/hero.svg", contentType: "image/svg+xml" }),
+          ],
+        })
+      )
+    );
+    expect(check.status).toBe("warn");
+    expect(itemIds(check)).toEqual(["https://example.com/hero.svg"]);
+  });
+
+  test.each([
+    ["identity", "identity"],
+    ["IDENTITY (uppercase)", "IDENTITY"],
+  ])("%s is reported — it means compression is off, not unknown", (_l, enc) => {
+    const check = only(run(ctx({ css: [css({ contentEncoding: enc })] })));
+    expect(check.status).toBe("warn");
+  });
+
+  test("findings are sorted biggest-first and totalled", () => {
+    const check = only(
+      run(
+        ctx({
+          css: [
+            css({ url: "https://example.com/small.css", sizeBytes: BIG }),
+            css({ url: "https://example.com/huge.css", sizeBytes: BIG * 3 }),
+          ],
+        })
+      )
+    );
+    expect(itemIds(check)).toEqual([
+      "https://example.com/huge.css",
+      "https://example.com/small.css",
+    ]);
+    expect(check.details?.uncompressedBytes).toBe(BIG * 4);
+  });
+});
+
+describe("perf/asset-compression — stays silent", () => {
+  // Each case is the reporting test above with exactly ONE field changed, so a
+  // rule that stopped filtering would flip these to "warn" rather than pass for
+  // an unrelated reason.
+  test.each([
+    ["gzip", { contentEncoding: "gzip" }],
+    ["brotli", { contentEncoding: "br" }],
+    ["zstd", { contentEncoding: "zstd" }],
+    ["deflate", { contentEncoding: "deflate" }],
+    ["mixed codings", { contentEncoding: "gzip, br" }],
+    ["uppercase header value", { contentEncoding: "GZIP" }],
+    ["padded header value", { contentEncoding: "  br  " }],
+    // A coding this file has never heard of is still a coding. Reporting it as
+    // uncompressed is the false positive the rule most needs to avoid.
+    ["shared-dictionary (dcb)", { contentEncoding: "dcb" }],
+    ["some future coding", { contentEncoding: "not-invented-yet" }],
+  ])("a %s-compressed asset is not reported", (_label, override) => {
+    const check = only(run(ctx({ css: [css(override)] })));
+    expect(check.status).toBe("pass");
+  });
+
+
+  test("an asset under the threshold is not reported", () => {
+    const check = only(run(ctx({ css: [css({ sizeBytes: SMALL })] })));
+    expect(check.status).toBe("pass");
+  });
+
+  test("an asset exactly at the threshold is not reported (strict >)", () => {
+    const check = only(
+      run(ctx({ css: [css({ sizeBytes: ASSET_COMPRESSION_LIMITS.MIN_BYTES })] }))
+    );
+    expect(check.status).toBe("pass");
+  });
+
+  test("unknown encoding (undefined) is not treated as uncompressed", () => {
+    // The CLI's script content-store cache returns a hit without ever seeing
+    // response headers. Defaulting that to null would report every cached script.
+    const c = ctx({ scripts: [script()] });
+    delete (c.site!.scripts![0] as ScriptContentData).contentEncoding;
+    expect(only(run(c)).status).toBe("skipped");
+  });
+
+  test("a cache-reused record is not reported (headers are the prior crawl's)", () => {
+    const check = only(run(ctx({ css: [css({ cacheReason: "max-age" })] })));
+    expect(check.status).toBe("skipped");
+  });
+
+  test.each([
+    ["PNG", "image/png"],
+    ["WebP", "image/webp"],
+    ["woff2 font", "font/woff2"],
+    ["PDF", "application/pdf"],
+    ["octet-stream", "application/octet-stream"],
+  ])("a large %s is not reported (not compressible text)", (_label, contentType) => {
+    const check = only(run(ctx({ images: [css({ contentType })] })));
+    expect(check.status).toBe("skipped");
+  });
+
+  test.each([
+    ["a 404", { status: 404 }],
+    ["a 301", { status: 301 }],
+    ["a failed fetch", { status: null }],
+  ])("%s is not reported", (_label, override) => {
+    const check = only(run(ctx({ css: [css(override)] })));
+    expect(check.status).toBe("skipped");
+  });
+
+  test("an unknown size is not reported", () => {
+    const check = only(run(ctx({ css: [css({ sizeBytes: null })] })));
+    expect(check.status).toBe("pass");
+  });
+
+  test("no crawled sub-resources at all → skipped, not pass", () => {
+    const check = only(run(ctx()));
+    expect(check.status).toBe("skipped");
+    expect(check.skipReason).toBe("no_data");
+  });
+});
+
+describe("perf/asset-compression — options", () => {
+  test("min_bytes lowers the threshold", () => {
+    const c = ctx({ css: [css({ sizeBytes: SMALL })] });
+    c.options = { min_bytes: 1024 };
+    expect(only(run(c)).status).toBe("warn");
+  });
+});
+
+describe("perf/compression is untouched by this rule", () => {
+  // #9's acceptance criteria: the HTML-document check keeps its behaviour. The
+  // new rule is site-scope and reads ctx.site; perf/compression is page-scope
+  // and reads ctx.page.headers, so asset data must not reach it.
+  test("still judges only the page's own response headers", () => {
+    const c = ctx({ css: [css()] });
+    c.page.headers = { "content-type": "text/html", "content-encoding": "br" };
+    const checks = compressionRule.run(c).checks as CheckResult[];
+    expect(only(checks).status).toBe("pass");
+    expect(only(checks).value).toBe("br");
+  });
+
+  test("still fails an uncompressed HTML document", () => {
+    const c = ctx();
+    c.page.headers = { "content-type": "text/html" };
+    c.page.html = "x".repeat(5000);
+    const checks = compressionRule.run(c).checks as CheckResult[];
+    expect(only(checks).status).toBe("fail");
+  });
+
+  test("perf/compression is page-scope, perf/asset-compression is site-scope", () => {
+    expect(compressionRule.meta.scope).toBe("page");
+    expect(assetCompressionRule.meta.scope).toBe("site");
+  });
+});

--- a/packages/rules/tests/asset-compression.test.ts
+++ b/packages/rules/tests/asset-compression.test.ts
@@ -207,6 +207,16 @@ describe("perf/asset-compression — stays silent", () => {
     expect(check.status).toBe("skipped");
   });
 
+  test("a record carrying an error is not reported (its size is not trustworthy)", () => {
+    // The script fetcher's "script too large" bail reports the byte it stopped
+    // reading at, not the asset's real length — and this rule's finding names
+    // that size out loud, so it must not speak for such a record.
+    const check = only(
+      run(ctx({ scripts: [script({ error: "script too large" })] }))
+    );
+    expect(check.status).toBe("skipped");
+  });
+
   test("an unknown size is not reported", () => {
     const check = only(run(ctx({ css: [css({ sizeBytes: null })] })));
     expect(check.status).toBe("pass");

--- a/packages/rules/tests/asset-compression.test.ts
+++ b/packages/rules/tests/asset-compression.test.ts
@@ -162,6 +162,30 @@ describe("perf/asset-compression — stays silent", () => {
   });
 
 
+  test("an all-identity coding list is still reported as uncompressed", () => {
+    // Content-Encoding is a LIST. The fetchers normalize a lone `identity` to
+    // null, but they match one token, so `identity, identity` arrives verbatim
+    // and must not be mistaken for a real coding.
+    const check = only(run(ctx({ css: [css({ contentEncoding: "identity, identity" })] })));
+    expect(check.status).toBe("warn");
+    expect(itemIds(check)).toEqual(["https://example.com/app.css"]);
+  });
+
+  test("a list is compressed when any token is a real coding", () => {
+    const check = only(run(ctx({ css: [css({ contentEncoding: "identity, gzip" })] })));
+    expect(check.status).toBe("pass");
+  });
+
+  test("a 206 whose confirming GET failed is not reported", () => {
+    // The end of the chain the resource checker's capture tests start: an
+    // unconfirmable ranged 206 records `undefined`, and the rule must stay
+    // silent rather than report a possibly-gzipped asset as uncompressed.
+    const check = only(
+      run(ctx({ css: [css({ status: 206, contentEncoding: undefined })] }))
+    );
+    expect(check.status).toBe("skipped");
+  });
+
   test("an asset under the threshold is not reported", () => {
     const check = only(run(ctx({ css: [css({ sizeBytes: SMALL })] })));
     expect(check.status).toBe("pass");

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -15,6 +15,15 @@ export const RESOURCE_SIZE_LIMITS = {
   MAX_RETRIES: 2,
 } as const;
 
+// Sub-resource compression thresholds (#9). Compression helps from ~1KB up, but
+// a low bar turns every small uncompressed asset into a finding. 100KB matches
+// the size at which the reporter of #9 noticed the problem and sits just under
+// CSS_WARN_BYTES, so an asset big enough to trip perf/css-file-size is always
+// big enough to be judged on compression too. Tunable per-rule via `min_bytes`.
+export const ASSET_COMPRESSION_LIMITS = {
+  MIN_BYTES: 100 * 1024, // 100KB
+} as const;
+
 // Script content fetch limits (for security scanning)
 export const SCRIPT_FETCH_LIMITS = {
   MAX_SCRIPTS_TO_FETCH: 50,

--- a/packages/utils/src/headers.ts
+++ b/packages/utils/src/headers.ts
@@ -82,3 +82,29 @@ export function recordToHeaders(record: Record<string, string>): Headers {
   }
   return headers;
 }
+
+/**
+ * Whether a media type gets a real win from a transfer coding (#9). Shared by
+ * the sub-resource checker (which decides whether a bodiless HEAD is trustworthy
+ * evidence) and perf/asset-compression (which decides what to judge), so the two
+ * can never disagree about what "text" means.
+ *
+ * Deliberately classifies by media type rather than by file extension or by
+ * which crawl pool a URL came from: an SVG discovered as an <img> is the XML it
+ * says it is, while a PNG/WebP/AVIF/font/PDF in that same pool is already
+ * entropy-coded and gains nothing.
+ */
+export function isCompressibleContentType(
+  contentType: string | null | undefined
+): boolean {
+  if (!contentType) return false;
+  const t = contentType.toLowerCase();
+  return (
+    t.includes("text/") ||
+    t.includes("application/json") ||
+    t.includes("application/javascript") ||
+    t.includes("application/xml") ||
+    t.includes("+xml") ||
+    t.includes("+json")
+  );
+}


### PR DESCRIPTION
Closes #9

`perf/compression` only judged the HTML document's own response. A server that compresses `text/html` but not `text/css` is a common misconfiguration, and it was invisible: `perf/css-file-size` and `perf/js-file-size` measure bytes but never look at `content-encoding`, so a 300 KB uncompressed stylesheet was reported only as "large".

## The rule

New `perf/asset-compression` (site scope, warning, weight 6). A crawled sub-resource is reported when it is 2xx, its content-type is compressible text, it carries no transfer coding, and it is over 100 KB. Findings list each asset URL biggest-first with its size, source pages, and the estimated saving. Threshold is `ASSET_COMPRESSION_LIMITS.MIN_BYTES`, tunable per-rule via `min_bytes`.

Site scope because sub-resources are shared: reporting them per page would repeat one asset N times. `perf/compression` is untouched — `git diff` on that file is empty, and a test asserts it still judges only `ctx.page.headers`.

Classification is by **content-type, not by crawl pool**, so an SVG discovered as an `<img>` is judged as the XML it is, while PNG/WebP/font/PDF in that same pool are excluded.

## Investigation

Headers were already available. `ResourceSizeData.contentEncoding` exists from #107 for CSS and images. Scripts had no seam, so this captures it in both **forked** script fetchers (~1 line each) and passes it through both adapters. In-memory only, no storage column, no migration. Bun's `fetch` decodes the body but leaves the header intact, so the encoding stays observable even though script `sizeBytes` is the decoded length.

JSON and XML fetched on their own are **not covered**: the crawler discovers stylesheets, images, and `<script src>` only. Adding a neutral text-subresource pool is a crawler change, not this one — putting JSON into the CSS or image pools would corrupt their size rules. The rule classifies by content-type, so such assets are handled the moment a pool exists. Happy to file that as a follow-up.

## Two false positives, designed out

**`content-encoding` is tri-state.** `undefined` (never observed) is not `null` (observed, absent). Cache-reused records carry a prior crawl's headers, and pre-#107 rows have an un-backed `null`, so both are skipped — as are records carrying an error, whose size is not trustworthy ("script too large" reports the byte it stopped reading at, and this rule's finding names the size out loud).

**Any declared coding counts as compressed**, rather than matching a known list. An allowlist would report `zstd`, `dcb`/`dcz`, or anything newer than the file as uncompressed. `identity` is the one value meaning compression is off.

## A real false positive found in review, and fixed

Codex review caught that neither cheap probe proves absence of compression, and both reproduce:

- A **HEAD carries no body**, so a server whose compression is a body filter (nginx's `gzip` module) answers with no `Content-Encoding` *and the uncompressed `Content-Length`* — exactly the shape of a large uncompressed asset. Every gzipped stylesheet over the threshold on such a server would have been reported.
- A **ranged 206 is equally inconclusive**: many origins and CDNs skip compression for range requests specifically.

Absence of the header on a bodiless or ranged response is not evidence of absence. The checker now falls through to the GET, and confirms with one plain GET (body cancelled once headers are in) when the 206 still looks uncompressed. A HEAD that *names* a coding is positive evidence and still short-circuits.

Because `checkResourceSizes` is generic and also backs the PDF and sitemap-orphan checks — and `text/html` is compressible — verification is opt-in per pool (`verifyCompression`), set only on the css and images pools this rule reads. Sitemap checks keep the cheap HEAD path and pay nothing.

## Testing

- `packages/rules/tests/asset-compression.test.ts` — 34 tests: reported vs silent, threshold edge (strict `>`), casing, mixed codings, `identity`, unknown codings, non-text types, non-2xx, cache reuse, options.
- `packages/audit-engine/tests/asset-compression-capture.test.ts` — 11 tests driving the **real** fetchers against a local server, including HEAD-hides-gzip, range-hides-gzip, a genuinely uncompressed asset that must still be reported after all three probes, and request-sequence assertions so the cost stays visible.
- `apps/cli/tests/crawler/script-fetcher-encoding.test.ts` — the CLI fork is separate code the engine's suite cannot speak for.

Every one of these was **mutation-tested**: reverting the HEAD fall-through, the 206 confirmation, the pool gating, the encoding capture in either fetcher, the tri-state handling, the content-type filter, or the threshold comparison each turns tests red.

Suites: rules 1576 pass, audit-engine 307 pass, cli audit+crawler 377 pass, utils 102 pass. Typechecks clean across rules, utils, core-contracts, audit-engine, cli. `make validate` in `docs/` passes (385 pages, orphan count unchanged).

`packages/crawler`'s `full-crawl-harness.test.ts` has 2 timeout failures — pre-existing and load-related; verified identical on a clean `origin/main` checkout, and this branch changes no file in that package.

## Golden delta

`findings 98220 -> 98221`, `perRuleTally 278 -> 279`. One `skipped` whole-crawl check: the harness supplies empty `resourceSizes`/`scripts` pools, so the rule has nothing to judge. Pass/warn/fail tallies and `healthScore.overall` (48) are all unmoved — the same shape as the `social/asset-divergence` precedent documented in that test.

## Noted, not fixed

The CLI script fetcher's content store can never hit: it reads with `hashContent(url)` but writes with `store.put(content)`, which keys by `hashContent(content)`. Left alone — fixing the key is a caching behaviour change, unrelated to #9. Its cache-hit branch is nonetheless correct for this rule (it leaves `contentEncoding` unset rather than defaulting to `null`).

`perf/compression` and `perf/bad-caching` keep their own inline compressible-type checks. `isCompressibleContentType` moved to `@squirrelscan/utils/headers` and is shared by the checker and the new rule; the shared version lowercases content-types and the inline ones do not, so folding them in would change behaviour that acceptance criterion 3 requires to stay put.
