### PR TITLE
feat(cli): agent setup prompt on the auth success page and terminal #180

### DIFF
--- a/apps/cli/src/cli/agent-setup.ts
+++ b/apps/cli/src/cli/agent-setup.ts
@@ -1,0 +1,18 @@
+// The agent setup pointer printed after a successful `squirrel auth login`
+// (#180). The browser callback page offers the same prompt; both read it from
+// AGENT_SETUP_PROMPT so the two surfaces can never drift. Headless and SSH
+// users only ever see this one.
+
+import { AGENT_SETUP_PROMPT, AGENT_SETUP_URL } from "@/constants";
+
+import { fmt } from "./format";
+
+/** Lines to print after sign-in, in order. Pure: the caller does the I/O. */
+export function agentSetupLines(): string[] {
+  return [
+    "",
+    "Set up your coding agent: paste this prompt into it.",
+    `  ${fmt.cyan(AGENT_SETUP_PROMPT)}`,
+    fmt.dim(`  Or read it yourself first: ${AGENT_SETUP_URL}`),
+  ];
+}

--- a/apps/cli/src/cli/commands/auth.ts
+++ b/apps/cli/src/cli/commands/auth.ts
@@ -12,6 +12,7 @@ import {
 import { safeExit } from "@/self/updater";
 
 import { version } from "../../../package.json";
+import { agentSetupLines } from "../agent-setup";
 import { fmt } from "../format";
 
 /**
@@ -61,6 +62,9 @@ const authLogin = defineCommand({
         )
       );
     }
+    // `auth login` has no --json/--quiet mode to suppress this under; add the
+    // guard here alongside the other output if one is ever introduced.
+    for (const line of agentSetupLines()) console.log(line);
   },
 });
 

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -65,6 +65,13 @@ export const DASHBOARD_URL = "https://app.squirrelscan.com";
 // Public pricing page — linked from Team-plan upsell messaging (#739)
 export const PRICING_URL = "https://squirrelscan.com/pricing";
 
+// Agent setup (#180) — the human-readable landing page, and the one-liner a
+// user pastes into their coding agent. The prompt is deliberately identical to
+// the one the docs page's own copy button produces: the long-form instructions
+// live at /agent-setup/prompt.md and are never forked into the CLI.
+export const AGENT_SETUP_URL = "https://docs.squirrelscan.com/agent-setup";
+export const AGENT_SETUP_PROMPT = `Fetch and follow the setup instructions for squirrelscan at ${AGENT_SETUP_URL}/prompt.md`;
+
 // Informational status requests (whoami, balance preflight) must never stall
 // a command — a wedged local dev API hangs an un-timed fetch indefinitely.
 export const STATUS_REQUEST_TIMEOUT_MS = 10_000;

--- a/apps/cli/src/controllers/auth/login.ts
+++ b/apps/cli/src/controllers/auth/login.ts
@@ -8,6 +8,7 @@ import {
 } from "node:http";
 import { hostname } from "node:os";
 
+import { AGENT_SETUP_PROMPT, AGENT_SETUP_URL } from "@/constants";
 import { type Result, ok, err, commandError } from "@/controllers/types";
 import { cliApi } from "@/lib/api-client";
 import { openBrowser } from "@/lib/browser";
@@ -45,6 +46,149 @@ function escapeHtml(s: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
+}
+
+/**
+ * The callback success page (#180). Beyond confirming the sign-in it hands the
+ * user the agent setup prompt, which is the next thing they want anyway.
+ *
+ * Nothing here is interpolated except the escaped email: the prompt and the
+ * docs link are compile-time constants, and the inline script reads the prompt
+ * out of the DOM rather than from a JS string literal, so there is no
+ * script-context injection surface at all. The prompt is rendered as plain
+ * selectable text, so it is copyable by hand when the clipboard API is not.
+ */
+export function renderAuthSuccessPage(email: string): string {
+  return `
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <title>Authentication Successful</title>
+              <style>
+                body {
+                  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+                  display: flex;
+                  justify-content: center;
+                  align-items: center;
+                  min-height: 100vh;
+                  margin: 0;
+                  padding: 24px;
+                  box-sizing: border-box;
+                  background: #f5f5f4;
+                }
+                .container {
+                  text-align: center;
+                  padding: 40px;
+                  background: white;
+                  border-radius: 8px;
+                  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+                  box-sizing: border-box;
+                  width: 100%;
+                  max-width: 560px;
+                }
+                h1 { color: #22c55e; margin-bottom: 10px; }
+                p { color: #666; }
+                .agent {
+                  margin: 28px 0 0;
+                  padding-top: 24px;
+                  border-top: 1px solid #e7e5e4;
+                  text-align: left;
+                }
+                .agent h2 {
+                  font-size: 16px;
+                  color: #1c1917;
+                  margin: 0 0 6px;
+                }
+                .agent p { margin: 0 0 12px; font-size: 14px; }
+                .agent code {
+                  display: block;
+                  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                  font-size: 13px;
+                  line-height: 1.5;
+                  color: #292524;
+                  background: #fafaf9;
+                  border: 1px solid #e7e5e4;
+                  border-radius: 6px;
+                  padding: 12px;
+                  overflow-wrap: anywhere;
+                  user-select: all;
+                }
+                .actions {
+                  display: flex;
+                  flex-wrap: wrap;
+                  align-items: center;
+                  gap: 12px;
+                  margin-top: 12px;
+                }
+                .actions button {
+                  font: inherit;
+                  font-size: 14px;
+                  color: white;
+                  background: #22c55e;
+                  border: 0;
+                  border-radius: 6px;
+                  padding: 8px 14px;
+                  cursor: pointer;
+                }
+                .actions a { color: #16a34a; font-size: 14px; }
+                .status { font-size: 13px; color: #78716c; }
+              </style>
+            </head>
+            <body>
+              <div class="container">
+                <h1>Authentication Successful!</h1>
+                <p>Signed in as ${escapeHtml(email)}</p>
+                <p>You can close this window and return to the terminal.</p>
+                <div class="agent">
+                  <h2>Use squirrelscan with your AI agent</h2>
+                  <p>Paste this into your coding agent. It reads the setup docs, wires up the CLI and MCP, and audits this project.</p>
+                  <code id="agent-prompt">${escapeHtml(AGENT_SETUP_PROMPT)}</code>
+                  <div class="actions">
+                    <button id="copy-prompt" type="button">Copy prompt</button>
+                    <a href="${escapeHtml(AGENT_SETUP_URL)}">view the agent setup</a>
+                    <span class="status" id="copy-status" role="status" aria-live="polite"></span>
+                  </div>
+                </div>
+              </div>
+              <script>
+                (function () {
+                  var prompt = document.getElementById("agent-prompt");
+                  var button = document.getElementById("copy-prompt");
+                  var status = document.getElementById("copy-status");
+                  function say(text) { status.textContent = text; }
+                  function selectPrompt() {
+                    var selection = window.getSelection && window.getSelection();
+                    if (!selection || !document.createRange) return false;
+                    var range = document.createRange();
+                    range.selectNodeContents(prompt);
+                    selection.removeAllRanges();
+                    selection.addRange(range);
+                    return true;
+                  }
+                  function fallback() {
+                    if (!selectPrompt()) {
+                      say("Select the prompt above and copy it.");
+                      return;
+                    }
+                    var copied = false;
+                    try { copied = document.execCommand("copy"); } catch (e) {}
+                    say(copied ? "Copied." : "Selected. Press ctrl+c, or cmd+c on a mac.");
+                  }
+                  button.addEventListener("click", function () {
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                      navigator.clipboard.writeText(prompt.textContent).then(
+                        function () { say("Copied."); },
+                        fallback
+                      );
+                      return;
+                    }
+                    fallback();
+                  });
+                })();
+              </script>
+            </body>
+            </html>
+          `;
 }
 
 interface LoginOptions {
@@ -156,41 +300,7 @@ function startCallbackServer(
 
           if (status.status === "completed" && status.token && status.user) {
             res.writeHead(200, { "Content-Type": "text/html" });
-            res.end(`
-            <!DOCTYPE html>
-            <html>
-            <head>
-              <title>Authentication Successful</title>
-              <style>
-                body {
-                  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-                  display: flex;
-                  justify-content: center;
-                  align-items: center;
-                  height: 100vh;
-                  margin: 0;
-                  background: #f5f5f4;
-                }
-                .container {
-                  text-align: center;
-                  padding: 40px;
-                  background: white;
-                  border-radius: 8px;
-                  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-                }
-                h1 { color: #22c55e; margin-bottom: 10px; }
-                p { color: #666; }
-              </style>
-            </head>
-            <body>
-              <div class="container">
-                <h1>Authentication Successful!</h1>
-                <p>Signed in as ${escapeHtml(status.user.email)}</p>
-                <p>You can close this window and return to the terminal.</p>
-              </div>
-            </body>
-            </html>
-          `);
+            res.end(renderAuthSuccessPage(status.user.email));
             onComplete(status);
           } else if (status.status === "expired") {
             res.writeHead(410, { "Content-Type": "text/html" });

--- a/apps/cli/src/controllers/auth/login.ts
+++ b/apps/cli/src/controllers/auth/login.ts
@@ -207,7 +207,7 @@ interface SessionResponse {
   expiresAt: string;
 }
 
-interface SessionStatusResponse {
+export interface SessionStatusResponse {
   status: "pending" | "completed" | "expired" | "consumed";
   token?: string;
   expiresAt?: string;
@@ -277,6 +277,73 @@ export function fetchSessionStatus(
   });
 }
 
+/**
+ * The page the callback server serves for a given session status. Pure, so
+ * each of the four is testable on its own: only a completed sign-in with a
+ * token gets the success page and the agent setup block (#180). A "completed"
+ * status without one is still a wait, exactly as before.
+ */
+export function renderCallbackPage(status: SessionStatusResponse): {
+  code: number;
+  html: string;
+} {
+  if (status.status === "completed" && status.token && status.user) {
+    return { code: 200, html: renderAuthSuccessPage(status.user.email) };
+  }
+
+  if (status.status === "expired") {
+    return {
+      code: 410,
+      html: `
+            <!DOCTYPE html>
+            <html>
+            <head><title>Session Expired</title></head>
+            <body style="font-family: sans-serif; text-align: center; padding: 40px;">
+              <h1>Session Expired</h1>
+              <p>Please run 'squirrel auth login' again.</p>
+            </body>
+            </html>
+          `,
+    };
+  }
+
+  if (status.status === "consumed") {
+    // Token was already retrieved once (one-time read) — a bare retry would
+    // poll forever. Terminal: tell the user to re-login.
+    return {
+      code: 410,
+      html: `
+            <!DOCTYPE html>
+            <html>
+            <head><title>Session Already Used</title></head>
+            <body style="font-family: sans-serif; text-align: center; padding: 40px;">
+              <h1>Login Session Already Used</h1>
+              <p>Please run 'squirrel auth login' again.</p>
+            </body>
+            </html>
+          `,
+    };
+  }
+
+  // Still pending - try again
+  return {
+    code: 202,
+    html: `
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <title>Waiting...</title>
+              <meta http-equiv="refresh" content="1">
+            </head>
+            <body style="font-family: sans-serif; text-align: center; padding: 40px;">
+              <h1>Waiting for authentication...</h1>
+              <p>Please complete sign-in in your browser.</p>
+            </body>
+            </html>
+          `,
+  };
+}
+
 /** Start a local HTTP server to receive the callback. */
 function startCallbackServer(
   port: number,
@@ -298,58 +365,20 @@ function startCallbackServer(
           );
           const status = (await statusRes.json()) as SessionStatusResponse;
 
+          const page = renderCallbackPage(status);
+          res.writeHead(page.code, { "Content-Type": "text/html" });
+          res.end(page.html);
+
           if (status.status === "completed" && status.token && status.user) {
-            res.writeHead(200, { "Content-Type": "text/html" });
-            res.end(renderAuthSuccessPage(status.user.email));
             onComplete(status);
           } else if (status.status === "expired") {
-            res.writeHead(410, { "Content-Type": "text/html" });
-            res.end(`
-            <!DOCTYPE html>
-            <html>
-            <head><title>Session Expired</title></head>
-            <body style="font-family: sans-serif; text-align: center; padding: 40px;">
-              <h1>Session Expired</h1>
-              <p>Please run 'squirrel auth login' again.</p>
-            </body>
-            </html>
-          `);
             onError(new Error("Session expired"));
           } else if (status.status === "consumed") {
-            // Token was already retrieved once (one-time read) — a bare
-            // retry would poll forever. Terminal: tell the user to re-login.
-            res.writeHead(410, { "Content-Type": "text/html" });
-            res.end(`
-            <!DOCTYPE html>
-            <html>
-            <head><title>Session Already Used</title></head>
-            <body style="font-family: sans-serif; text-align: center; padding: 40px;">
-              <h1>Login Session Already Used</h1>
-              <p>Please run 'squirrel auth login' again.</p>
-            </body>
-            </html>
-          `);
             onError(
               new Error(
                 "Login session already used — run 'squirrel auth login' again"
               )
             );
-          } else {
-            // Still pending - try again
-            res.writeHead(202, { "Content-Type": "text/html" });
-            res.end(`
-            <!DOCTYPE html>
-            <html>
-            <head>
-              <title>Waiting...</title>
-              <meta http-equiv="refresh" content="1">
-            </head>
-            <body style="font-family: sans-serif; text-align: center; padding: 40px;">
-              <h1>Waiting for authentication...</h1>
-              <p>Please complete sign-in in your browser.</p>
-            </body>
-            </html>
-          `);
           }
         } catch (error) {
           res.writeHead(500, { "Content-Type": "text/plain" });

--- a/apps/cli/src/controllers/auth/login.ts
+++ b/apps/cli/src/controllers/auth/login.ts
@@ -49,6 +49,49 @@ function escapeHtml(s: string): string {
 }
 
 /**
+ * The success page's inline script (#180), exported so the tests drive the
+ * exact source the page ships instead of re-deriving it from the rendered
+ * HTML. It reads the prompt out of the DOM via textContent, so no value is
+ * ever interpolated into script context; keep it that way.
+ */
+export const AUTH_SUCCESS_PAGE_SCRIPT = `
+                (function () {
+                  var prompt = document.getElementById("agent-prompt");
+                  var button = document.getElementById("copy-prompt");
+                  var status = document.getElementById("copy-status");
+                  function say(text) { status.textContent = text; }
+                  function selectPrompt() {
+                    var selection = window.getSelection && window.getSelection();
+                    if (!selection || !document.createRange) return false;
+                    var range = document.createRange();
+                    range.selectNodeContents(prompt);
+                    selection.removeAllRanges();
+                    selection.addRange(range);
+                    return true;
+                  }
+                  function fallback() {
+                    if (!selectPrompt()) {
+                      say("Select the prompt above and copy it.");
+                      return;
+                    }
+                    var copied = false;
+                    try { copied = document.execCommand("copy"); } catch (e) {}
+                    say(copied ? "Copied." : "Selected. Press ctrl+c, or cmd+c on a mac.");
+                  }
+                  button.addEventListener("click", function () {
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                      navigator.clipboard.writeText(prompt.textContent).then(
+                        function () { say("Copied."); },
+                        fallback
+                      );
+                      return;
+                    }
+                    fallback();
+                  });
+                })();
+              `;
+
+/**
  * The callback success page (#180). Beyond confirming the sign-in it hands the
  * user the agent setup prompt, which is the next thing they want anyway.
  *
@@ -150,42 +193,7 @@ export function renderAuthSuccessPage(email: string): string {
                   </div>
                 </div>
               </div>
-              <script>
-                (function () {
-                  var prompt = document.getElementById("agent-prompt");
-                  var button = document.getElementById("copy-prompt");
-                  var status = document.getElementById("copy-status");
-                  function say(text) { status.textContent = text; }
-                  function selectPrompt() {
-                    var selection = window.getSelection && window.getSelection();
-                    if (!selection || !document.createRange) return false;
-                    var range = document.createRange();
-                    range.selectNodeContents(prompt);
-                    selection.removeAllRanges();
-                    selection.addRange(range);
-                    return true;
-                  }
-                  function fallback() {
-                    if (!selectPrompt()) {
-                      say("Select the prompt above and copy it.");
-                      return;
-                    }
-                    var copied = false;
-                    try { copied = document.execCommand("copy"); } catch (e) {}
-                    say(copied ? "Copied." : "Selected. Press ctrl+c, or cmd+c on a mac.");
-                  }
-                  button.addEventListener("click", function () {
-                    if (navigator.clipboard && navigator.clipboard.writeText) {
-                      navigator.clipboard.writeText(prompt.textContent).then(
-                        function () { say("Copied."); },
-                        fallback
-                      );
-                      return;
-                    }
-                    fallback();
-                  });
-                })();
-              </script>
+              <script>${AUTH_SUCCESS_PAGE_SCRIPT}</script>
             </body>
             </html>
           `;

--- a/apps/cli/tests/controllers/auth-login.test.ts
+++ b/apps/cli/tests/controllers/auth-login.test.ts
@@ -159,12 +159,12 @@ async function loadPageScript(
   script: string
 ): Promise<{ boot: (w: unknown, d: unknown, n: unknown) => void }> {
   const dir = await mkdtemp(join(tmpdir(), "squirrel-auth-page-"));
-  const file = join(dir, "page.mjs");
-  await Bun.write(
-    file,
-    `export function boot(window, document, navigator) {${script}}`
-  );
   try {
+    const file = join(dir, "page.mjs");
+    await Bun.write(
+      file,
+      `export function boot(window, document, navigator) {${script}}`
+    );
     return (await import(file)) as {
       boot: (w: unknown, d: unknown, n: unknown) => void;
     };

--- a/apps/cli/tests/controllers/auth-login.test.ts
+++ b/apps/cli/tests/controllers/auth-login.test.ts
@@ -1,8 +1,17 @@
 // auth login — actionable error hints (#1 of the auth/cloud guardrails).
 
 import { describe, expect, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { localApiHint, normalizeBrowserUrl } from "@/controllers/auth/login";
+import { agentSetupLines } from "@/cli/agent-setup";
+import { AGENT_SETUP_PROMPT, AGENT_SETUP_URL } from "@/constants";
+import {
+  localApiHint,
+  normalizeBrowserUrl,
+  renderAuthSuccessPage,
+} from "@/controllers/auth/login";
 import { DEFAULT_API_URL } from "@/self/api";
 
 describe("auth/login — localApiHint", () => {
@@ -44,5 +53,233 @@ describe("auth/login — browser URL validation", () => {
     expect(() => normalizeBrowserUrl("file:///tmp/payload")).toThrow(
       "must use HTTP or HTTPS"
     );
+  });
+});
+
+describe("auth/login — agent setup on the callback success page (#180)", () => {
+  const page = renderAuthSuccessPage("dev@example.com");
+
+  test("offers the prompt, a copy button and the docs link", () => {
+    expect(page).toContain("Use squirrelscan with your AI agent");
+    expect(page).toContain(">Copy prompt<");
+    expect(page).toContain(`href="${AGENT_SETUP_URL}"`);
+    expect(page).toContain("view the agent setup");
+  });
+
+  test("prints the prompt as a plain text node, copyable without JS at all", () => {
+    expect(page).toContain(
+      `<code id="agent-prompt">${AGENT_SETUP_PROMPT}</code>`
+    );
+  });
+
+  test("falls back to selecting that text when the clipboard API is missing", () => {
+    // Guarded call, then a selection of the prompt node: neither a bare
+    // navigator.clipboard.writeText() nor a silent no-op on refusal.
+    expect(page).toContain(
+      "navigator.clipboard && navigator.clipboard.writeText"
+    );
+    expect(page).toContain("range.selectNodeContents(prompt)");
+    expect(page).toContain("Press ctrl+c");
+  });
+
+  test("carries the prompt exactly once, never as a script string literal", () => {
+    // The inline script reads prompt.textContent instead, so the constant is
+    // never parsed in JS context. Interpolating it into the script would
+    // reintroduce the injection surface this asserts away.
+    expect(page.split(AGENT_SETUP_PROMPT)).toHaveLength(2);
+    expect(page).toContain("prompt.textContent");
+  });
+
+  test("escapes the email rather than trusting the API response", () => {
+    const hostile = renderAuthSuccessPage(
+      'evil"<img src=x onerror=alert(1)>@example.com'
+    );
+    expect(hostile).not.toContain("<img");
+    expect(hostile).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(hostile).toContain("evil&quot;");
+  });
+
+  test("leaves the pending, expired and consumed pages bare", async () => {
+    // Those three stay inline in startCallbackServer; only a completed
+    // sign-in earns the prompt. renderAuthSuccessPage sits above that
+    // function, so the slice is exactly the other three templates.
+    const source = await Bun.file(
+      new URL("../../src/controllers/auth/login.ts", import.meta.url)
+    ).text();
+    const others = source.slice(source.indexOf("function startCallbackServer"));
+    // Anchors: if these pages are renamed the negative assertions below stop
+    // proving anything, so fail loudly instead.
+    expect(others).toContain("Session Expired");
+    expect(others).toContain("Login Session Already Used");
+    expect(others).toContain("Waiting for authentication...");
+    expect(others).not.toContain("Use squirrelscan with your AI agent");
+    expect(others).not.toContain("AGENT_SETUP");
+  });
+});
+
+/**
+ * Load the page's own inline script as a real module, wrapped so its three
+ * globals arrive as parameters. Nothing is interpolated into `script`: it is
+ * sliced straight out of the rendered page. (A data: URL would be tidier, but
+ * Bun's resolver rejects one this long with NameTooLong.)
+ */
+async function loadPageScript(
+  script: string
+): Promise<{ boot: (w: unknown, d: unknown, n: unknown) => void }> {
+  const file = join(
+    tmpdir(),
+    `squirrel-auth-page-${Bun.hash(script).toString(16)}.mjs`
+  );
+  await Bun.write(
+    file,
+    `export function boot(window, document, navigator) {${script}}`
+  );
+  try {
+    return (await import(file)) as {
+      boot: (w: unknown, d: unknown, n: unknown) => void;
+    };
+  } finally {
+    rmSync(file, { force: true });
+  }
+}
+
+/**
+ * Runs the page's own inline script against a stub DOM and clicks the button,
+ * so the copy path is exercised rather than grepped for. `clipboard` picks
+ * which browser the button meets: one that copies, one that refuses (Safari
+ * outside a user gesture, a page without permission), and one with no
+ * clipboard API at all.
+ */
+async function clickCopyPrompt(opts: {
+  clipboard: "ok" | "refuses" | "absent";
+  execCommand: boolean;
+}): Promise<{
+  copied: string | null;
+  status: string;
+  selected: string | null;
+}> {
+  const page = renderAuthSuccessPage("dev@example.com");
+  const script = page.slice(
+    page.indexOf("<script>") + "<script>".length,
+    page.indexOf("</script>")
+  );
+
+  let copied: string | null = null;
+  let clicked: (() => void) | undefined;
+  const node = (text: string) => ({
+    textContent: text,
+    addEventListener: (_type: string, fn: () => void) => {
+      clicked = fn;
+    },
+  });
+  const prompt = node(AGENT_SETUP_PROMPT);
+  const button = node("Copy prompt");
+  const status = node("");
+
+  const selection = {
+    range: null as { node: typeof prompt | null } | null,
+    removeAllRanges() {
+      this.range = null;
+    },
+    addRange(range: { node: typeof prompt | null }) {
+      this.range = range;
+    },
+  };
+  const win = { getSelection: () => selection };
+  const doc = {
+    getElementById: (id: string) =>
+      ({
+        "agent-prompt": prompt,
+        "copy-prompt": button,
+        "copy-status": status,
+      })[id],
+    createRange: () => {
+      const range: {
+        node: typeof prompt | null;
+        selectNodeContents(n: typeof prompt): void;
+      } = {
+        node: null,
+        selectNodeContents(n) {
+          range.node = n;
+        },
+      };
+      return range;
+    },
+    execCommand: (command: string) => {
+      if (!opts.execCommand) throw new Error("execCommand is not a function");
+      if (command !== "copy" || !selection.range?.node) return false;
+      copied = selection.range.node.textContent;
+      return true;
+    },
+  };
+  const nav =
+    opts.clipboard === "absent"
+      ? {}
+      : {
+          clipboard: {
+            writeText: (text: string) => {
+              if (opts.clipboard === "refuses") {
+                return Promise.reject(new Error("NotAllowedError"));
+              }
+              copied = text;
+              return Promise.resolve();
+            },
+          },
+        };
+
+  const { boot } = await loadPageScript(script);
+  boot(win, doc, nav);
+  clicked?.();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  return {
+    copied,
+    status: status.textContent,
+    selected: selection.range?.node?.textContent ?? null,
+  };
+}
+
+describe("auth/login — the copy prompt button (#180)", () => {
+  test("copies the prompt when the clipboard API is available", async () => {
+    const result = await clickCopyPrompt({
+      clipboard: "ok",
+      execCommand: true,
+    });
+    expect(result.copied).toBe(AGENT_SETUP_PROMPT);
+    expect(result.status).toBe("Copied.");
+  });
+
+  test("falls back to execCommand when the clipboard API refuses", async () => {
+    const result = await clickCopyPrompt({
+      clipboard: "refuses",
+      execCommand: true,
+    });
+    expect(result.copied).toBe(AGENT_SETUP_PROMPT);
+    expect(result.selected).toBe(AGENT_SETUP_PROMPT);
+  });
+
+  test("selects the prompt and says so when nothing can copy for you", async () => {
+    const result = await clickCopyPrompt({
+      clipboard: "absent",
+      execCommand: false,
+    });
+    expect(result.copied).toBeNull();
+    // The user is not left staring at a dead button: the text is selected and
+    // the status names the keystroke.
+    expect(result.selected).toBe(AGENT_SETUP_PROMPT);
+    expect(result.status).toContain("Press ctrl+c");
+  });
+});
+
+describe("auth login — agent setup in the terminal (#180)", () => {
+  const output = agentSetupLines().join("\n");
+
+  test("prints the same prompt constant the browser page shows", () => {
+    expect(output).toContain(AGENT_SETUP_PROMPT);
+    expect(output).toContain(AGENT_SETUP_URL);
+  });
+
+  test("names it as something to paste, so SSH users know what it is for", () => {
+    expect(output).toContain("paste this prompt");
   });
 });

--- a/apps/cli/tests/controllers/auth-login.test.ts
+++ b/apps/cli/tests/controllers/auth-login.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { agentSetupLines } from "@/cli/agent-setup";
 import { AGENT_SETUP_PROMPT, AGENT_SETUP_URL } from "@/constants";
 import {
+  AUTH_SUCCESS_PAGE_SCRIPT,
   localApiHint,
   normalizeBrowserUrl,
   renderAuthSuccessPage,
@@ -74,14 +75,18 @@ describe("auth/login — agent setup on the callback success page (#180)", () =>
     );
   });
 
-  test("falls back to selecting that text when the clipboard API is missing", () => {
-    // Guarded call, then a selection of the prompt node: neither a bare
-    // navigator.clipboard.writeText() nor a silent no-op on refusal.
-    expect(page).toContain(
-      "navigator.clipboard && navigator.clipboard.writeText"
-    );
-    expect(page).toContain("range.selectNodeContents(prompt)");
-    expect(page).toContain("Press ctrl+c");
+  test("ships the exact script the tests drive, not a copy of it", () => {
+    // Byte-identity between the page and AUTH_SUCCESS_PAGE_SCRIPT is what
+    // makes the behavioural tests below evidence about the shipped page.
+    expect(page).toContain(AUTH_SUCCESS_PAGE_SCRIPT);
+    expect(page).toContain(`<script>${AUTH_SUCCESS_PAGE_SCRIPT}</script>`);
+  });
+
+  test("renders exactly the ids its script asks for", () => {
+    for (const id of [PROMPT_ID, BUTTON_ID, STATUS_ID]) {
+      expect(page).toContain(`id="${id}"`);
+      expect(AUTH_SUCCESS_PAGE_SCRIPT).toContain(`getElementById("${id}")`);
+    }
   });
 
   test("carries the prompt exactly once, never as a script string literal", () => {
@@ -89,7 +94,8 @@ describe("auth/login — agent setup on the callback success page (#180)", () =>
     // never parsed in JS context. Interpolating it into the script would
     // reintroduce the injection surface this asserts away.
     expect(page.split(AGENT_SETUP_PROMPT)).toHaveLength(2);
-    expect(page).toContain("prompt.textContent");
+    expect(AUTH_SUCCESS_PAGE_SCRIPT).toContain("prompt.textContent");
+    expect(AUTH_SUCCESS_PAGE_SCRIPT).not.toContain(AGENT_SETUP_PROMPT);
   });
 
   test("escapes the email rather than trusting the API response", () => {
@@ -146,10 +152,21 @@ describe("auth/login — agent setup on the callback success page (#180)", () =>
 });
 
 /**
+ * The ids the page's script reaches for. Kept here so the stub DOM below can
+ * refuse anything else; `renders exactly the ids its script asks for` ties
+ * them back to the markup, so renaming one in the page fails loudly instead
+ * of handing the script an undefined node.
+ */
+const PROMPT_ID = "agent-prompt";
+const BUTTON_ID = "copy-prompt";
+const STATUS_ID = "copy-status";
+
+/**
  * Load the page's own inline script as a real module, wrapped so its three
- * globals arrive as parameters. Nothing is interpolated into `script`: it is
- * sliced straight out of the rendered page. (A data: URL would be tidier, but
- * Bun's resolver rejects one this long with NameTooLong.)
+ * globals arrive as parameters. The source is AUTH_SUCCESS_PAGE_SCRIPT itself,
+ * imported from the controller: no slicing or re-parsing of rendered HTML, so
+ * what runs here is byte-identical to what the page serves. (A data: URL would
+ * be tidier, but Bun's resolver rejects one this long with NameTooLong.)
  *
  * Its own directory per call, so a parallel run cannot delete the file out
  * from under another import, and each call gets a fresh module rather than a
@@ -188,12 +205,6 @@ async function clickCopyPrompt(opts: {
   status: string;
   selected: string | null;
 }> {
-  const page = renderAuthSuccessPage("dev@example.com");
-  const script = page.slice(
-    page.indexOf("<script>") + "<script>".length,
-    page.indexOf("</script>")
-  );
-
   let copied: string | null = null;
   let clicked: (() => void) | undefined;
   const node = (text: string) => ({
@@ -216,13 +227,19 @@ async function clickCopyPrompt(opts: {
     },
   };
   const win = { getSelection: () => selection };
+  const elements: Record<string, typeof prompt> = {
+    [PROMPT_ID]: prompt,
+    [BUTTON_ID]: button,
+    [STATUS_ID]: status,
+  };
   const doc = {
-    getElementById: (id: string) =>
-      ({
-        "agent-prompt": prompt,
-        "copy-prompt": button,
-        "copy-status": status,
-      })[id],
+    getElementById: (id: string) => {
+      // Loud, not undefined: an id the page renamed would otherwise surface as
+      // a confusing "cannot read textContent of undefined" three frames later.
+      const element = elements[id];
+      if (!element) throw new Error(`script asked for unstubbed id: ${id}`);
+      return element;
+    },
     createRange: () => {
       const range: {
         node: typeof prompt | null;
@@ -257,7 +274,7 @@ async function clickCopyPrompt(opts: {
           },
         };
 
-  const { boot } = await loadPageScript(script);
+  const { boot } = await loadPageScript(AUTH_SUCCESS_PAGE_SCRIPT);
   boot(win, doc, nav);
   clicked?.();
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -286,6 +303,9 @@ describe("auth/login — the copy prompt button (#180)", () => {
     });
     expect(result.copied).toBe(AGENT_SETUP_PROMPT);
     expect(result.selected).toBe(AGENT_SETUP_PROMPT);
+    // The live region reports the same success as the clipboard path: a copy
+    // that worked must never look like one that only selected the text.
+    expect(result.status).toBe("Copied.");
   });
 
   test("selects the prompt and says so when nothing can copy for you", async () => {

--- a/apps/cli/tests/controllers/auth-login.test.ts
+++ b/apps/cli/tests/controllers/auth-login.test.ts
@@ -1,7 +1,7 @@
 // auth login — actionable error hints (#1 of the auth/cloud guardrails).
 
 import { describe, expect, test } from "bun:test";
-import { rmSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -11,6 +11,8 @@ import {
   localApiHint,
   normalizeBrowserUrl,
   renderAuthSuccessPage,
+  renderCallbackPage,
+  type SessionStatusResponse,
 } from "@/controllers/auth/login";
 import { DEFAULT_API_URL } from "@/self/api";
 
@@ -99,21 +101,47 @@ describe("auth/login — agent setup on the callback success page (#180)", () =>
     expect(hostile).toContain("evil&quot;");
   });
 
-  test("leaves the pending, expired and consumed pages bare", async () => {
-    // Those three stay inline in startCallbackServer; only a completed
-    // sign-in earns the prompt. renderAuthSuccessPage sits above that
-    // function, so the slice is exactly the other three templates.
-    const source = await Bun.file(
-      new URL("../../src/controllers/auth/login.ts", import.meta.url)
-    ).text();
-    const others = source.slice(source.indexOf("function startCallbackServer"));
-    // Anchors: if these pages are renamed the negative assertions below stop
-    // proving anything, so fail loudly instead.
-    expect(others).toContain("Session Expired");
-    expect(others).toContain("Login Session Already Used");
-    expect(others).toContain("Waiting for authentication...");
-    expect(others).not.toContain("Use squirrelscan with your AI agent");
-    expect(others).not.toContain("AGENT_SETUP");
+  test("only a completed sign-in with a token gets the block", () => {
+    const bare: SessionStatusResponse[] = [
+      { status: "pending" },
+      { status: "expired" },
+      { status: "consumed" },
+      // "completed" with no token yet is still a wait, not a sign-in.
+      { status: "completed" },
+    ];
+    for (const status of bare) {
+      const { html } = renderCallbackPage(status);
+      expect(html).not.toContain("Use squirrelscan with your AI agent");
+      expect(html).not.toContain(AGENT_SETUP_PROMPT);
+    }
+
+    const done = renderCallbackPage({
+      status: "completed",
+      token: "tok",
+      user: { id: "u1", email: "dev@example.com", name: null },
+    });
+    expect(done.code).toBe(200);
+    expect(done.html).toContain(AGENT_SETUP_PROMPT);
+  });
+
+  test("serves the same status codes and pages as before for the rest", () => {
+    expect(renderCallbackPage({ status: "expired" })).toMatchObject({
+      code: 410,
+    });
+    expect(renderCallbackPage({ status: "expired" }).html).toContain(
+      "Session Expired"
+    );
+    expect(renderCallbackPage({ status: "consumed" })).toMatchObject({
+      code: 410,
+    });
+    expect(renderCallbackPage({ status: "consumed" }).html).toContain(
+      "Login Session Already Used"
+    );
+    const pending = renderCallbackPage({ status: "pending" });
+    expect(pending.code).toBe(202);
+    expect(pending.html).toContain("Waiting for authentication...");
+    // The pending page reloads itself; that is what makes polling work.
+    expect(pending.html).toContain('http-equiv="refresh"');
   });
 });
 
@@ -122,14 +150,16 @@ describe("auth/login — agent setup on the callback success page (#180)", () =>
  * globals arrive as parameters. Nothing is interpolated into `script`: it is
  * sliced straight out of the rendered page. (A data: URL would be tidier, but
  * Bun's resolver rejects one this long with NameTooLong.)
+ *
+ * Its own directory per call, so a parallel run cannot delete the file out
+ * from under another import, and each call gets a fresh module rather than a
+ * path-cached one.
  */
 async function loadPageScript(
   script: string
 ): Promise<{ boot: (w: unknown, d: unknown, n: unknown) => void }> {
-  const file = join(
-    tmpdir(),
-    `squirrel-auth-page-${Bun.hash(script).toString(16)}.mjs`
-  );
+  const dir = await mkdtemp(join(tmpdir(), "squirrel-auth-page-"));
+  const file = join(dir, "page.mjs");
   await Bun.write(
     file,
     `export function boot(window, document, navigator) {${script}}`
@@ -139,7 +169,7 @@ async function loadPageScript(
       boot: (w: unknown, d: unknown, n: unknown) => void;
     };
   } finally {
-    rmSync(file, { force: true });
+    await rm(dir, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
Closes #180

After `squirrel auth login` succeeds, both surfaces stopped at "signed in", at exactly the moment the user is most ready to wire up their agent. Both now hand over the one-liner that points a coding agent at the setup docs.

## The prompt

One constant, `AGENT_SETUP_PROMPT` in `apps/cli/src/constants.ts`, feeds both surfaces:

```
Fetch and follow the setup instructions for squirrelscan at https://docs.squirrelscan.com/agent-setup/prompt.md
```

That is byte-for-byte the string the docs page's own **Copy prompt** button produces (`docs/agent-setup/index.mdx`), so the two can never drift and nothing from the docs is forked into the CLI. `/agent-setup/prompt.md` is the agent-facing markdown (verified: 200, `text/markdown`); the human-facing `/agent-setup` page is what the block links to.

## The browser page

Under the "Signed in as ..." confirmation, separated by a hairline rule:

- h2 "Use squirrelscan with your AI agent"
- one line of explainer: "Paste this into your coding agent. It reads the setup docs, wires up the CLI and MCP, and audits this project."
- the prompt in a bordered monospace box, `user-select: all`, wrapping on narrow windows
- a green "Copy prompt" button, a "view the agent setup" link to https://docs.squirrelscan.com/agent-setup, and a live-region status span that reports the result

Everything is inline: no external assets, no fonts, no scripts. The page renders offline, as it must, being served from 127.0.0.1.

The card grew, so `height: 100vh` became `min-height: 100vh` with body padding and `box-sizing`, and the container took a `max-width: 560px`. Without that the taller card overflows the viewport on a short window.

**Copy behaviour**, in order:

1. `navigator.clipboard.writeText` when it exists, status reads "Copied."
2. On rejection or a missing clipboard API: select the prompt's text node, try `document.execCommand("copy")`, status reads "Copied."
3. If that fails too: the text stays selected and the status names the keystroke.
4. If selection itself is unavailable: "Select the prompt above and copy it."

The prompt is a plain text node either way, so it is selectable and copyable with JavaScript disabled entirely.

## The terminal

```
Authenticated as nik@example.com

Set up your coding agent: paste this prompt into it.
  Fetch and follow the setup instructions for squirrelscan at https://docs.squirrelscan.com/agent-setup/prompt.md
  Or read it yourself first: https://docs.squirrelscan.com/agent-setup
```

`auth login` takes only `--device-name`: there is no `--json` or `--quiet` mode to suppress this under, and nothing in the repo executes and parses its stdout. A comment at the call site says where the guard goes if one is ever added.

## XSS

The block interpolates nothing request-derived. The email is the only such value on the page and keeps its existing `escapeHtml`. The prompt is escaped into a text node and the inline script reads it back with `prompt.textContent`, so the constant is never parsed in script context: a test asserts it appears in the page exactly once, which fails if anyone inlines it into the script.

## Expired, consumed, pending

Unchanged markup and status codes. Codex flagged that the first version of that test read the source file, which would have gone quiet if one of those branches ever started calling the success renderer. The status-to-page mapping is now a pure `renderCallbackPage()` and the test asserts all four pages directly.

## Evidence

- `bun test` in `apps/cli`: 1886 pass, 1 skip, 0 fail (148 files). The new file: 16 pass.
- `bun run typecheck`, `bun run lint`, root `bun run format:check`: clean.
- Every new assertion mutation-tested. Dropping the fallback selection, inlining the prompt into the script, removing `escapeHtml`, dropping the prompt line from the terminal output, and leaking the success page into the expired branch each fail the test that claims to cover it.
- The three copy-button tests load the page's own inline script as a module against a stub DOM and click the button, so all three clipboard paths are exercised rather than grepped for.
- Rendered and screenshotted the page headless to confirm layout.

## Codex review

Four findings, all addressed:

1. The source-slicing test could false-pass. Replaced with `renderCallbackPage()` plus direct per-status assertions.
2. `loadPageScript` used a shared deterministic temp path. Now `mkdtemp` per call.
3. `Bun.write` sat outside the `try` that cleans the directory up. Moved inside.
4. Confirmed clean: escaping is sufficient for both contexts used, no DOM-clobbering surface, the selection exists before `execCommand`, no dead-button path, and the refactor is behaviour-preserving.
