### PR TITLE
fix(rules): leaked-secrets look-back spends its budget on the key, not the whitespace

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -326,7 +326,7 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 1187
+        "line_number": 1189
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T13:09:43Z"
+  "generated_at": "2026-09-01T13:25:29Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -326,7 +326,7 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 1088
+        "line_number": 1187
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T09:45:09Z"
+  "generated_at": "2026-09-01T13:09:43Z"
 }

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -828,8 +828,15 @@ function isSpaceAt(text: string, index: number): boolean {
 // the walk across the whole window.
 const LOOKBEHIND_SCAN_LIMIT = SECRET_KEY_LOOKBEHIND_SIZE * 8;
 
+export interface KeyLookBack {
+  /** The text immediately before the match, for reading the key off. */
+  before: string;
+  /** `before` opens part-way through a key, so it opens on a fragment. */
+  cut: boolean;
+}
+
 /**
- * The text immediately before a match, for reading the key off.
+ * Read back from a match to the key in front of it.
  *
  * SECRET_KEY_LOOKBEHIND_SIZE is a budget over the characters that carry
  * meaning: whitespace is skipped for free. Charging for it is what lost the
@@ -848,11 +855,6 @@ const LOOKBEHIND_SCAN_LIMIT = SECRET_KEY_LOOKBEHIND_SIZE * 8;
  * position 0 settles nothing either: the window carries a lead-in precisely
  * because its left edge can land mid-key.
  */
-export interface KeyLookBack {
-  before: string;
-  cut: boolean;
-}
-
 export function readKeyLookBack(text: string, index: number): KeyLookBack {
   const scanFloor = Math.max(0, index - LOOKBEHIND_SCAN_LIMIT);
 

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -762,6 +762,9 @@ const CREDENTIAL_KEY_WORDS = new Set([
   "credentials",
 ]);
 
+// What keyWords glues into a single word: everything it does not split on.
+const WORD_CHAR_RE = /[A-Za-z0-9]/;
+
 // `x-api-key`, `apiKey`, `SHA256`, `"sha256"` -> the words a key is made of.
 // A one-letter word is also glued to its successor so lower-camel `eTagKey`
 // yields `etag`, not `e` + `tag`.
@@ -801,19 +804,78 @@ function isMinifiedMemberKey(key: string, viaBracket: boolean): boolean {
 // of a run of them would hand classifyKeyContext a truncated key.
 const KEY_CHAR_RE = /[A-Za-z0-9_$.-]/;
 
+// Whitespace between a key and its value is layout, not content: a formatter,
+// an aligned manifest or a minifier's line break can put arbitrarily much of it
+// there without changing a word of what the key says.
+const SPACE_CHAR_RE = /\s/;
+
+/**
+ * `\s` for one position, decided on the code unit. The look-back tests every
+ * character it walks over, and a regex call per character costs more than the
+ * whole rest of the walk — but only the ASCII half is worth open-coding, so the
+ * Unicode spaces `\s` also accepts (NBSP, the line separators) fall through to
+ * it and stay in step with the `\s*` in the key patterns.
+ */
+function isSpaceAt(text: string, index: number): boolean {
+  const code = text.charCodeAt(index);
+  if (code === 32 || (code >= 9 && code <= 13)) return true;
+  if (code < 0x80) return false;
+  return SPACE_CHAR_RE.test(text[index] ?? "");
+}
+
+// How far back the walk may reach in total. The budget below buys significant
+// characters only, so without a second bound one long run of spaces would drag
+// the walk across the whole window.
+const LOOKBEHIND_SCAN_LIMIT = SECRET_KEY_LOOKBEHIND_SIZE * 8;
+
 /**
  * The text immediately before a match, for reading the key off.
  *
- * SECRET_KEY_LOOKBEHIND_SIZE is a budget, not a hard cut: slicing at exactly
- * that offset can land inside the key itself, and `redential="` classifies as
- * nothing at all. So the slice walks back to the nearest non-key character,
- * spending at most the same budget again before giving up.
+ * SECRET_KEY_LOOKBEHIND_SIZE is a budget over the characters that carry
+ * meaning: whitespace is skipped for free. Charging for it is what lost the
+ * key — `{"sha256"` and `:"<hex>"` are one assignment however many spaces sit
+ * between them, but 62 of them pushed `sha256` out of the window, the digest
+ * read back as a bare `:`, and an unnamed assignment reports.
+ *
+ * The budget is not a hard cut either: stopping at exactly that offset can land
+ * inside the key itself, and `redential="` classifies as nothing at all. So the
+ * walk continues to the nearest non-key character, spending at most the same
+ * budget again before giving up.
+ *
+ * A walk that runs out of room — the scan limit, the second budget, or the left
+ * edge of the window it was handed — never saw where the key began, so `cut`
+ * says the text opens on a fragment rather than on a whole key. Reaching
+ * position 0 settles nothing either: the window carries a lead-in precisely
+ * because its left edge can land mid-key.
  */
-export function lookBehind(text: string, index: number): string {
-  const floor = Math.max(0, index - SECRET_KEY_LOOKBEHIND_SIZE * 2);
-  let start = Math.max(0, index - SECRET_KEY_LOOKBEHIND_SIZE);
+export interface KeyLookBack {
+  before: string;
+  cut: boolean;
+}
+
+export function readKeyLookBack(text: string, index: number): KeyLookBack {
+  const scanFloor = Math.max(0, index - LOOKBEHIND_SCAN_LIMIT);
+
+  let start = index;
+  let budget = SECRET_KEY_LOOKBEHIND_SIZE;
+  while (start > scanFloor && budget > 0) {
+    if (!isSpaceAt(text, start - 1)) budget--;
+    start--;
+  }
+
+  const floor = Math.max(scanFloor, start - SECRET_KEY_LOOKBEHIND_SIZE);
   while (start > floor && KEY_CHAR_RE.test(text[start - 1] ?? "")) start--;
-  return text.slice(start, index);
+
+  // Stopping on a non-key character is the walk reaching the key's left edge;
+  // stopping anywhere else is it running out of room part-way through one.
+  const opensOnKeyChar = KEY_CHAR_RE.test(text[start] ?? "");
+  const reachedEdge = start > 0 && !KEY_CHAR_RE.test(text[start - 1] ?? "");
+  return { before: text.slice(start, index), cut: opensOnKeyChar && !reachedEdge };
+}
+
+/** The look-back text on its own, for callers that only read the key off it. */
+export function lookBehind(text: string, index: number): string {
+  return readKeyLookBack(text, index).before;
 }
 
 // The three regexes below all separate a key from its value with
@@ -980,22 +1042,59 @@ function classifyTagKeys(tag: string, keyword: string): KeyContext | "unknown" {
  *   Not reported.
  *
  * Digest beats credential when a key claims both, so `sha256Key` is a checksum.
+ *
+ * `keyCut` says the look-back opens on a fragment (see readKeyLookBack), and a
+ * fragment costs two different things.
+ *
+ * A word read out of it may never have existed: `api_key_xsha256` cut to
+ * `sha256` reads as a checksum and would suppress a real credential. Only a
+ * separator inside the fragment redeems a word — it marks a left edge the walk
+ * did see, so `x.sha256` really does carry `sha256`, whatever `x` was cut from.
+ *
+ * And a key that begins inside the fragment is not the whole key, so "this key
+ * says nothing" is a verdict about a truncated read: the part that was cut off
+ * is exactly where the words live. Such a key leaves the value where an
+ * unreadable key always leaves it — `assigned`, and reported.
  */
 export function classifyKeyContext(
   before: string,
   keyword: string,
-  tag?: string
+  tag?: string,
+  keyCut = false
 ): KeyContext {
-  if (DIGEST_PREFIX_RE.test(before) || INTEGRITY_ATTR_RE.test(before)) {
+  let fragment = 0;
+  while (keyCut && KEY_CHAR_RE.test(before[fragment] ?? "")) fragment++;
+
+  // A match can start past the character the fragment opens with — the key
+  // patterns cannot begin on a digit, a `-` or a `.` — so "starts at index 0"
+  // is not the question. The question is whether the character to its left is
+  // glued to it, which is what keyWords reads as one word.
+  const wordsAreWhole = (found: RegExpExecArray | null) => {
+    if (!found || found.index >= fragment) return found !== null;
+    // Nothing at all to the left is the cut itself, which proves nothing.
+    const left = before[found.index - 1];
+    return left !== undefined && !WORD_CHAR_RE.test(left);
+  };
+
+  if (
+    wordsAreWhole(DIGEST_PREFIX_RE.exec(before)) ||
+    wordsAreWhole(INTEGRITY_ATTR_RE.exec(before))
+  ) {
     return "digest";
   }
 
   const bracket = BRACKET_KEY_RE.exec(before);
   const match = bracket ?? PRECEDING_KEY_RE.exec(before);
   const key = match?.[1];
+  const cutKey = match !== null && match.index < fragment;
 
-  if (key) {
-    const direct = classifyKeyName(key, keyword);
+  // Read the key from wherever its left edge was actually seen: a key opening
+  // on the cut opens on a word taken from the middle of one, and dropping that
+  // word is what stops `…_xsha256` from reading as `sha256`.
+  const readable = key && !wordsAreWhole(match) ? key.replace(/^[A-Za-z0-9]+/, "") : key;
+
+  if (readable) {
+    const direct = classifyKeyName(readable, keyword);
     if (direct !== "unknown") return direct;
   }
 
@@ -1006,7 +1105,7 @@ export function classifyKeyContext(
   }
 
   if (key) {
-    return isMinifiedMemberKey(key, bracket !== null) ? "assigned" : "none";
+    return cutKey || isMinifiedMemberKey(key, bracket !== null) ? "assigned" : "none";
   }
 
   if (AUTH_SCHEME_RE.test(before)) return "credential";
@@ -1206,10 +1305,12 @@ export function scanContent(
         // Bare-shape patterns are the shape of a SHA-256 digest, so the key in
         // front of the value decides: never report under sha256/integrity/
         // checksum/commit/cache, or with no assignment context at all.
+        const back = readKeyLookBack(window, match.index);
         const keyContext = classifyKeyContext(
-          lookBehind(window, match.index),
+          back.before,
           keyword,
-          enclosingTag(window, match.index)
+          enclosingTag(window, match.index),
+          back.cut
         );
         if (keyContext === "digest" || keyContext === "none") {
           continue;

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -476,7 +476,9 @@ describe("classifyKeyContext", () => {
     // The window's left edge can land mid-key, and the fragment left over can
     // read as a whole key: `sha256"   :"` is what `"api_key_xsha256"` looks
     // like once cut. `cut` is how classifyKeyContext knows not to trust it.
-    const fragment = readKeyLookBack(`sha256"${" ".repeat(200)}:"`, 209);
+    const readBack = (text: string) => readKeyLookBack(text, text.length);
+
+    const fragment = readBack(`sha256"${" ".repeat(200)}:"`);
     expect(fragment.cut).toBe(true);
     expect(classifyKeyContext(fragment.before, "together", undefined, true)).toBe(
       "assigned"
@@ -486,7 +488,7 @@ describe("classifyKeyContext", () => {
     expect(classifyKeyContext(fragment.before, "together")).toBe("digest");
 
     // A key with its left edge in view is not a fragment.
-    const whole = readKeyLookBack(`{"sha256"${" ".repeat(200)}:"`, 211);
+    const whole = readBack(`{"sha256"${" ".repeat(200)}:"`);
     expect(whole.cut).toBe(false);
     expect(classifyKeyContext(whole.before, "together", undefined, whole.cut)).toBe(
       "digest"
@@ -494,7 +496,7 @@ describe("classifyKeyContext", () => {
 
     // Cutting must not cost the assignment itself: a minified member access at
     // the edge still means the value was assigned, and assigned values report.
-    const minified = readKeyLookBack(`t.a||"`, 6);
+    const minified = readBack(`t.a||"`);
     expect(minified.cut).toBe(true);
     expect(classifyKeyContext(minified.before, "together", undefined, true)).toBe(
       "assigned"

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -26,6 +26,7 @@ import {
   classifyKeyContext,
   leakedSecretsRule,
   lookBehind,
+  readKeyLookBack,
   scanContent,
 } from "../src/security/leaked-secrets";
 import type { RuleContext } from "../src/types";
@@ -156,6 +157,32 @@ describe("security/leaked-secrets: hex digests are not secrets", () => {
   test("a naming attribute after the value still suppresses a digest", () => {
     const content = `<p>together</p><meta content="${DIGEST}" name="release-sha256">`;
     expect(scanContent(content, "html")).toEqual([]);
+  });
+
+  test("a pretty-printed manifest keeps its digest a digest across the whitespace", () => {
+    // #177: the key and the value are one assignment however far apart an
+    // aligned manifest writes them. The look-back used to spend its budget on
+    // the spaces and lose `sha256` entirely, reporting the checksum as a key.
+    for (const gap of [1, SECRET_KEY_LOOKBEHIND_SIZE, SECRET_KEY_LOOKBEHIND_SIZE * 4]) {
+      const content = `{"vendor":"together","sha256"${" ".repeat(gap)}:"${DIGEST}"}`;
+      expect(scanContent(content, "inline-script")).toEqual([]);
+    }
+    // The same distance under a credential key still reports.
+    const leak = `{"vendor":"together","token"${" ".repeat(SECRET_KEY_LOOKBEHIND_SIZE * 4)}:"${TOGETHER_KEY}"}`;
+    expect(scanContent(leak, "inline-script").map((f) => f.type)).toEqual([
+      "Together AI Key",
+    ]);
+
+    // The invariant under all of it: the distance between a key and its value
+    // is not evidence. A key that names something which is not a credential
+    // reads the same at 200 spaces as it does at none — before this, the same
+    // page said "checksum" up close and "unnamed assignment" further away.
+    for (const key of ["filename", "description", "sha256"]) {
+      for (const gap of [0, 1, SECRET_KEY_LOOKBEHIND_SIZE * 3]) {
+        const content = `{"vendor":"together","${key}"${" ".repeat(gap)}:"${DIGEST}"}`;
+        expect(scanContent(content, "inline-script")).toEqual([]);
+      }
+    }
   });
 
   test("a short key that names something is not a minified member access", () => {
@@ -297,6 +324,27 @@ describe("security/leaked-secrets: real credentials still report", () => {
     expect(found.map((f) => f.value)).toEqual([TOGETHER_KEY]);
   });
 
+  test("a key too long for the look-back cannot invent a digest word", () => {
+    // The walk runs out of room part-way through this key, and the fragment it
+    // is left holding says `sha256` — a word the whole key never had. Reading
+    // the fragment as a key suppresses a real credential, so a cut read is not
+    // read at all: #175's direction, applied to the look-back itself.
+    // Each separator puts the cut at a different offset inside the key, and a
+    // `-`, a `.` or a digit is one the key patterns cannot start a match on.
+    for (const separator of ["_", "-", ".", "7"]) {
+      const key = `api_key_${"q".repeat(100)}${separator}${"z".repeat(84)}_xsha256`;
+      const content = `"${key}"${" ".repeat(100)}:"${TOGETHER_KEY}"; // together.ai`; // pragma: allowlist secret
+      expect(scanContent(content, "inline-script").map((f) => f.value)).toEqual([
+        TOGETHER_KEY,
+      ]);
+    }
+
+    // A digest key the walk does reach the start of still suppresses, so the
+    // guard buys the silence back only where the evidence was never read.
+    const short = `"cache_${"z".repeat(20)}_sha256"${" ".repeat(100)}:"${DIGEST}"; // together.ai`;
+    expect(scanContent(short, "inline-script")).toEqual([]);
+  });
+
   test("public-by-design client keys stay informational, not leaks", () => {
     const page = html(
       `<script>const cfg={apiKey:"AIzaSyD3mQ8xR2vT7pLnK4hW9cB1sE6yU0zJfXa"};</script>`, // pragma: allowlist secret
@@ -395,6 +443,84 @@ describe("classifyKeyContext", () => {
   test("etag is recognised in lower-camel form", () => {
     expect(classifyKeyContext(`eTag: "`, "together")).toBe("digest");
     expect(classifyKeyContext(`eTagKey: "`, "together")).toBe("digest");
+  });
+
+  test("whitespace between the key and its value does not spend the budget", () => {
+    // #177: a formatter, an aligned manifest or a minified line break can put
+    // any amount of space between `"sha256"` and its value. Charging the budget
+    // for it pushed the key out of the window, the look-back read back a bare
+    // `:`, and an unnamed assignment reports — the digest became a leak.
+    const classify = (text: string) =>
+      classifyKeyContext(lookBehind(text, text.length), "together");
+
+    for (const gap of [1, SECRET_KEY_LOOKBEHIND_SIZE, SECRET_KEY_LOOKBEHIND_SIZE * 4]) {
+      const space = " ".repeat(gap);
+      expect(classify(`{"sha256"${space}:"`)).toBe("digest");
+      // The same shape under a credential key still reads as one, so the
+      // silence is bought by reading the key rather than by giving up on it.
+      expect(classify(`{"api_key"${space}:"`)).toBe("credential");
+    }
+    // Newlines and indentation are the same separator, however they are spelt.
+    expect(classify(`{\n  "checksum"\n${" ".repeat(80)}:\n    "`)).toBe("digest");
+    // A non-breaking space is whitespace to the `\s*` in the key patterns, so
+    // the walk has to agree with them about it.
+    expect(classify(`{"sha256"${"\u00a0".repeat(100)}:"`)).toBe("digest");
+    // Free is not unbounded: past the scan limit the key is out of reach and
+    // the look-back is a cut read again, which reports rather than suppresses.
+    expect(classify(`{"sha256"${" ".repeat(SECRET_CONTEXT_WINDOW_SIZE * 4)}:"`)).toBe(
+      "assigned"
+    );
+  });
+
+  test("a look-back that opens on a fragment reports the cut", () => {
+    // The window's left edge can land mid-key, and the fragment left over can
+    // read as a whole key: `sha256"   :"` is what `"api_key_xsha256"` looks
+    // like once cut. `cut` is how classifyKeyContext knows not to trust it.
+    const fragment = readKeyLookBack(`sha256"${" ".repeat(200)}:"`, 209);
+    expect(fragment.cut).toBe(true);
+    expect(classifyKeyContext(fragment.before, "together", undefined, true)).toBe(
+      "assigned"
+    );
+    // Read as if it were whole, the same text says "digest" — which is exactly
+    // the suppression the flag exists to withhold.
+    expect(classifyKeyContext(fragment.before, "together")).toBe("digest");
+
+    // A key with its left edge in view is not a fragment.
+    const whole = readKeyLookBack(`{"sha256"${" ".repeat(200)}:"`, 211);
+    expect(whole.cut).toBe(false);
+    expect(classifyKeyContext(whole.before, "together", undefined, whole.cut)).toBe(
+      "digest"
+    );
+
+    // Cutting must not cost the assignment itself: a minified member access at
+    // the edge still means the value was assigned, and assigned values report.
+    const minified = readKeyLookBack(`t.a||"`, 6);
+    expect(minified.cut).toBe(true);
+    expect(classifyKeyContext(minified.before, "together", undefined, true)).toBe(
+      "assigned"
+    );
+  });
+
+  test("a cut is where the key stops being readable, not where it starts", () => {
+    const cut = (text: string) => classifyKeyContext(text, "together", undefined, true);
+
+    // The key patterns cannot open on a digit, a `-` or a `.`, so the match can
+    // start one character into the fragment and still be built out of it.
+    expect(cut(`9sha256":"`)).toBe("assigned");
+    expect(cut(`xsha256":"`)).toBe("assigned");
+    expect(cut(`sha256":"`)).toBe("assigned");
+    // A separator inside the fragment is a left edge the walk did see, so the
+    // word after it is a word the key really has, whatever preceded the cut.
+    expect(cut(`x.sha256":"`)).toBe("digest");
+    expect(cut(`x-sha256":"`)).toBe("digest");
+    expect(cut(`.sha256":"`)).toBe("digest");
+    // Reading whole words off a cut key still leaves the key itself truncated,
+    // and "this key says nothing" is not a verdict a truncated key can carry.
+    expect(cut(`-zzzz_xsha256":"`)).toBe("assigned");
+    expect(cut(`zzzz.filename":"`)).toBe("assigned");
+    // Trusted, the same two texts are exactly the suppressions being withheld.
+    expect(classifyKeyContext(`sha256":"`, "together")).toBe("digest");
+    expect(classifyKeyContext(`zzzz.filename":"`, "together")).toBe("none");
   });
 
   test("reads the naming attribute of the same tag in either order", () => {


### PR DESCRIPTION
Closes #177

`{"sha256"` + 62 spaces + `:"<64-hex>"` reported a published checksum as a leaked Together AI key. `SECRET_KEY_LOOKBEHIND_SIZE` was charged for every character walked, so a whitespace run pushed `sha256` out of the window; the look-back read back a bare `:`, and an unnamed assignment reports.

Reproduced on `origin/main` before touching anything: the digest reports from gap 62 upward, and is silent below it.

## The fix

Whitespace is free during the walk — only characters that carry meaning spend the budget, because `{"sha256"` and `:"<hex>"` are one assignment however many spaces a formatter wrote between them. A second bound, `LOOKBEHIND_SCAN_LIMIT` (8x the budget), caps the total reach so a pathological run still costs a bounded walk. Past it the key is out of reach and the look-back is a cut read, which reports rather than suppresses — the direction #175 settled on.

`isSpaceAt` open-codes ASCII `\s` on the code unit and falls back to the regex for the Unicode spaces. A regex call per character cost more than the whole rest of the walk (a 20x hot-path regression); this is 3.7x on the microbenchmark and invisible at page level.

## The hazard reading further back exposed

Reaching further back also reaches into keys the walk cannot finish, and a fragment can invent a word its key never had: `"api_key_xsha256"` cut to `sha256` reads as a checksum and silently drops a real credential. That hazard predates this PR, and widening the walk made it four times more likely.

So `readKeyLookBack` now reports whether it was cut, and `classifyKeyContext` refuses to read evidence out of the fragment. Two separate costs:

- **A word read out of the fragment may never have existed.** Only a separator inside it redeems one: a `-`, `.`, `_` or `$` is a left edge the walk did see, so `x.sha256` really does carry `sha256` whatever `x` was cut from, while `xsha256` carries nothing. Note the key patterns cannot open on a digit, a `-` or a `.`, so "starts at index 0" is not the test — what matters is whether the character to the left is glued to it, which is what `keyWords` reads as one word.
- **A key that begins inside the fragment is not the whole key**, so "this key says nothing" is a verdict about a truncated read, and the part cut off is exactly where the words live. Such a key falls to `assigned`, and reports.

## Measured

Two differential sweeps against `origin/main`. A dropped credential is a real leak silently suppressed; a reported digest is a checksum shown to the user as a leak.

| | credentials silently dropped | digests reported as leaks |
|---|---|---|
| `origin/main` | 208 / 896 | 294 / 420 |
| this walk, cut handling off | 784 / 896 | 42 / 420 |
| **this PR** | **0 / 896** | **42 / 420** |

The remaining 42 all sit past `LOOKBEHIND_SCAN_LIMIT`, where a cut read reports rather than suppresses. The cut handling costs nothing on the false-positive side and closes the pre-existing 208 as well as the 576 the wider walk would have added.

Performance: page-level scan cost unchanged (1.078 -> 1.085 ms median, 66KB release page, 600 digests). Pathological inputs at 8k / 64k / 200k are linear in every shape probed (whitespace runs, `: " ` churn, key-character runs, hyphen runs into a cut key, many-findings pages) — worst case 2.7ms on a 195KB page. No regex was changed; the only new one is a single-character `\s` class.

## Acceptance criteria

- [x] a digest-named key separated from its value by a whitespace run longer than the lookbehind budget is still classified as a digest (not reported)
- [x] a credential-named key in the same shape is still reported
- [x] existing leaked-secrets tests pass unchanged (50 existing, untouched; 5 added)

## Verification

- Focused suite 55 pass / 0 fail; full `packages/rules` suite 1546 pass / 0 fail; `tsgo --noEmit` clean.
- Falsifiability: ten mutations, each reverting one behaviour decision; every one fails at least one named test. Reverting the walk fails 4; removing the scan limit 1; dropping the Unicode fallback 1; forcing `cut: false` 2; treating position 0 as a real key edge 1; ignoring the fragment length 9; refusing separators 1; trusting the cut itself 2; letting a truncated key say `none` 3; keeping the cut word 2.
- Three Codex review rounds. The first two each found a High: the fragment hazard above, then that `index === 0` was the wrong predicate for it (both fixed here). The third found none, and its own differential over 91,500 combinations found no credential that `main` reports and this branch suppresses.