### PR TITLE
perf(rules): leaked-secrets suppresses overlaps by window index, not pairwise

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -326,7 +326,7 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 1189
+        "line_number": 1383
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T13:25:29Z"
+  "generated_at": "2026-09-01T14:41:01Z"
 }

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -1177,26 +1177,213 @@ function extractKeywordWindows(
   return windows;
 }
 
+// One window's worth of characters. Every pattern in this file matches more
+// than a dozen, so a value with no window of its own is rare enough to compare
+// against directly.
+const OVERLAP_WINDOW = 12;
+
+// The longest value worth indexing. Several patterns are unbounded on the right
+// — a connection string runs to the first quote — so one runaway match can be
+// megabytes, and hashing every window of it costs more than the comparisons it
+// saves. Far above any real credential: a Supabase JWT, the longest thing this
+// file matches on purpose, is a few hundred characters.
+const OVERLAP_MAX_INDEXED = 1024;
+
+// Rabin-Karp over one window, mod 2^32. A collision costs one extra comparison
+// and nothing else: no part of the decision rests on the hash.
+const OVERLAP_BASE = 131;
+const OVERLAP_LEAD = (() => {
+  let lead = 1;
+  for (let i = 1; i < OVERLAP_WINDOW; i++) lead = Math.imul(lead, OVERLAP_BASE);
+  return lead >>> 0;
+})();
+
+function windowHash(text: string, start: number): number {
+  let hash = 0;
+  for (let i = 0; i < OVERLAP_WINDOW; i++) {
+    hash = (Math.imul(hash, OVERLAP_BASE) + text.charCodeAt(start + i)) >>> 0;
+  }
+  return hash;
+}
+
+/** The window one character along, without re-reading the eleven it shares. */
+function rollWindow(text: string, hash: number, nextStart: number): number {
+  const dropped = Math.imul(text.charCodeAt(nextStart - 1), OVERLAP_LEAD);
+  const shifted = Math.imul((hash - dropped) >>> 0, OVERLAP_BASE);
+  return (shifted + text.charCodeAt(nextStart + OVERLAP_WINDOW - 1)) >>> 0;
+}
+
+// Bits for the window filter: a page that finds nothing never fills it, and one
+// that finds thousands still stops at a quarter of a megabyte.
+function filterWordCount(contentLength: number): number {
+  const wanted = Math.min(Math.max(contentLength >> 3, 64), 1 << 16);
+  let words = 64;
+  while (words < wanted) words *= 2;
+  return words;
+}
+
+export interface SeenValues {
+  has: (value: string) => boolean;
+  add: (value: string) => void;
+  overlaps: (value: string) => boolean;
+}
+
+/** A seen value with the hash of its first window, for the second reject. */
+interface IndexedValue {
+  value: string;
+  firstHash: number;
+}
+
+/**
+ * The values already kept, and the question asked of them for every candidate:
+ * does either one contain the other?
+ *
+ * Asked pairwise that is quadratic, and it bites — an 880 KB page producing
+ * 16k findings spent 2.1s of a 2.2s scan inside this one loop (#176). But both
+ * halves are really window questions. `value.includes(seen)` is "some window of
+ * `value` equals `seen`", and `seen.includes(value)` is "some window of `seen`
+ * equals `value`", so hashing windows narrows each half to a handful of pairs:
+ *
+ * - a seen value INSIDE the candidate ends on one of the candidate's own
+ *   windows and begins on another, so seen values are indexed by the hash of
+ *   their LAST window and rejected on the hash of their first;
+ * - a seen value CONTAINING the candidate has to be longer than it and has to
+ *   contain its first window, so a filter over every window of every seen value
+ *   rules out nearly every candidate before a comparison happens.
+ *
+ * Indexed by the last window rather than the first because a secret is a family
+ * with a constant head: every JWT this file matches opens with the same 37
+ * characters, `AIza` and `ghp_` and `sk-` open thousands more, and keying on
+ * the head would file a page of them into one bucket and walk it for every
+ * candidate. The random tail is the end that tells them apart.
+ *
+ * Neither structure decides anything. Both only narrow the field, the string
+ * comparison still makes every call, and no pair reaches it that the pairwise
+ * loop did not also compare — so the suppression is the one the loop made.
+ */
+export function createSeenValues(contentLength: number): SeenValues {
+  const values = new Set<string>();
+  const byLastWindow = new Map<number, IndexedValue[]>();
+  const byLength = new Map<number, string[]>();
+  // Values with no window of their own, and values too long to be worth one.
+  // Neither is indexed; both are compared directly, and there are never many.
+  const windowless: string[] = [];
+  const oversized: string[] = [];
+  const windowBits = new Uint32Array(filterWordCount(contentLength));
+  const bitMask = windowBits.length * 32 - 1;
+  // The candidate's own window hashes, reused across candidates so that reading
+  // a value's last window costs a lookup rather than a second pass.
+  const windowHashes = new Uint32Array(OVERLAP_MAX_INDEXED);
+  let longest = 0;
+
+  const setBit = (hash: number) => {
+    const bit = hash & bitMask;
+    windowBits[bit >>> 5]! |= 1 << (bit & 31);
+  };
+
+  const hasBit = (hash: number) => {
+    const bit = hash & bitMask;
+    return (windowBits[bit >>> 5]! & (1 << (bit & 31))) !== 0;
+  };
+
+  const add = (value: string) => {
+    values.add(value);
+    if (value.length > longest) longest = value.length;
+
+    if (value.length < OVERLAP_WINDOW) {
+      windowless.push(value);
+      return;
+    }
+    if (value.length > OVERLAP_MAX_INDEXED) {
+      oversized.push(value);
+      return;
+    }
+
+    const sameLength = byLength.get(value.length);
+    if (sameLength) sameLength.push(value);
+    else byLength.set(value.length, [value]);
+
+    const first = windowHash(value, 0);
+    let hash = first;
+    for (let start = 0; start + OVERLAP_WINDOW <= value.length; start++) {
+      if (start > 0) hash = rollWindow(value, hash, start);
+      setBit(hash);
+    }
+
+    // `hash` has rolled to the last window by now, which is the key.
+    const indexed: IndexedValue = { value, firstHash: first };
+    const bucket = byLastWindow.get(hash);
+    if (bucket) bucket.push(indexed);
+    else byLastWindow.set(hash, [indexed]);
+  };
+
+  const overlaps = (value: string): boolean => {
+    // A candidate the index cannot describe is compared the way it always was.
+    if (value.length < OVERLAP_WINDOW || value.length > OVERLAP_MAX_INDEXED) {
+      for (const seen of values) {
+        if (value.includes(seen) || seen.includes(value)) return true;
+      }
+      return false;
+    }
+
+    // Values outside the index are shorter than every candidate that reaches
+    // here, or longer than all of them, so each can only sit on one side.
+    for (const seen of windowless) {
+      if (value.includes(seen)) return true;
+    }
+    for (const seen of oversized) {
+      if (seen.includes(value)) return true;
+    }
+
+    const lastStart = value.length - OVERLAP_WINDOW;
+    let hash = windowHash(value, 0);
+    windowHashes[0] = hash;
+    for (let start = 1; start <= lastStart; start++) {
+      hash = rollWindow(value, hash, start);
+      windowHashes[start] = hash;
+    }
+
+    // A seen value this one contains ends on one of these windows and begins on
+    // another, so both have to line up before the strings are compared at all.
+    // Where it ends fixes where it begins, which is why the comparison below is
+    // anchored rather than searched for. An equal value is caught here too, on
+    // the windows it shares with itself.
+    for (let end = 0; end <= lastStart; end++) {
+      for (const seen of byLastWindow.get(windowHashes[end]!) ?? []) {
+        const start = end - (seen.value.length - OVERLAP_WINDOW);
+        if (start < 0 || windowHashes[start] !== seen.firstHash) continue;
+        if (value.startsWith(seen.value, start)) return true;
+      }
+    }
+
+    // A seen value containing this one is strictly longer and holds its first
+    // window, so a clear bit ends the question for the whole set.
+    if (value.length < longest && hasBit(windowHashes[0]!)) {
+      for (const [length, sameLength] of byLength) {
+        if (length <= value.length) continue;
+        for (const seen of sameLength) {
+          if (seen.includes(value)) return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  return { has: (value) => values.has(value), add, overlaps };
+}
+
 export function scanContent(
   content: string,
   location: "html" | "inline-script" | "external-script",
   sourceUrl?: string
 ): LeakedSecret[] {
   const found: LeakedSecret[] = [];
-  const seenValues = new Set<string>();
 
   // A later (more generic) pattern re-matching a value an earlier (more
   // specific) pattern already classified — e.g. apiKey:"AIza…" catching the
   // AIza key the public-by-design tier reported — is a duplicate, not a new
   // finding. Specific patterns run first, so first classification wins.
-  const overlapsSeenValue = (value: string): boolean => {
-    for (const seen of seenValues) {
-      if (value.includes(seen) || seen.includes(value)) {
-        return true;
-      }
-    }
-    return false;
-  };
+  const seenValues = createSeenValues(content.length);
 
   // Helper to process regex matches on given text
   const processMatches = (
@@ -1223,7 +1410,7 @@ export function scanContent(
       // Skip duplicates, overlapping rematches, and false positives
       if (
         seenValues.has(value) ||
-        overlapsSeenValue(value) ||
+        seenValues.overlaps(value) ||
         isLikelyFalsePositive(value)
       ) {
         continue;
@@ -1287,7 +1474,7 @@ export function scanContent(
         // Skip duplicates, overlapping rematches, and false positives
         if (
           seenValues.has(value) ||
-          overlapsSeenValue(value) ||
+          seenValues.overlaps(value) ||
           isLikelyFalsePositive(value)
         ) {
           continue;

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -24,6 +24,7 @@ import {
 
 import {
   classifyKeyContext,
+  createSeenValues,
   leakedSecretsRule,
   lookBehind,
   readKeyLookBack,
@@ -867,5 +868,128 @@ describe("security/leaked-secrets: #150 missed shapes", () => {
       scanContent(line, "external-script");
       expect(performance.now() - start).toBeLessThan(5000);
     }
+  });
+});
+
+// #176: overlap suppression was O(findings^2) — every candidate compared
+// against every value already kept. An 880 KB page producing 16k findings spent
+// 2.1s of a 2.2s scan inside that one loop. The window index replaced the loop,
+// and the only thing that matters about it is that it answers identically.
+describe("security/leaked-secrets: overlap suppression", () => {
+  // The predicate the index replaced, verbatim. Every assertion below is the
+  // index against this, because "faster" is only worth having if it agrees.
+  const pairwise = (kept: string[], value: string) =>
+    kept.some((seen) => value.includes(seen) || seen.includes(value));
+
+  const rng = (seed: number) => () =>
+    ((seed = Math.imul(seed ^ (seed >>> 15), 2246822519) + 1) >>> 0) / 4294967296;
+  const CHARS = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const runOf = (r: () => number, n: number) =>
+    Array.from({ length: n }, () => CHARS[Math.floor(r() * CHARS.length)]!).join("");
+
+  test("the index answers exactly what the pairwise scan answered", () => {
+    // The shapes that break a window index if it is wrong: values shorter than
+    // one window and longer than the index will take, values sharing a long
+    // head (every JWT does) or a long tail, values nested inside each other,
+    // and repeats.
+    for (let seed = 1; seed <= 400; seed++) {
+      const r = rng(seed);
+      const head = runOf(r, 20);
+      const tail = runOf(r, 20);
+      const index = createSeenValues(4096);
+      const kept: string[] = [];
+
+      for (let i = 0; i < 60; i++) {
+        const pickShape = Math.floor(r() * 9);
+        let value =
+          pickShape === 0 ? runOf(r, 1 + Math.floor(r() * 11)) // below one window
+          : pickShape === 1 ? `${head}${runOf(r, 1 + Math.floor(r() * 20))}`
+          : pickShape === 2 ? `${runOf(r, 1 + Math.floor(r() * 20))}${tail}`
+          : pickShape === 3 ? `${head}${runOf(r, 10)}${tail}`
+          : pickShape === 4 && kept.length > 0 ? kept[Math.floor(r() * kept.length)]!
+          : pickShape === 5 && kept.length > 0
+            ? (() => {
+                const base = kept[Math.floor(r() * kept.length)]!;
+                return base.slice(Math.floor(r() * base.length)) || base;
+              })()
+          : pickShape === 6 && kept.length > 0
+            ? `${runOf(r, 3)}${kept[Math.floor(r() * kept.length)]!}${runOf(r, 3)}`
+          // Past the length the index will take: a runaway connection-string
+          // match is megabytes, and those are held aside rather than indexed.
+          : pickShape === 7 ? `${head}${runOf(r, 1000 + Math.floor(r() * 60))}`
+            : runOf(r, 12 + Math.floor(r() * 40));
+        if (value === "") value = "x";
+
+        expect(index.overlaps(value)).toBe(pairwise(kept, value));
+        expect(index.has(value)).toBe(kept.includes(value));
+
+        // Mirror scanContent: a value is only kept when nothing suppressed it.
+        if (!index.has(value) && !index.overlaps(value)) {
+          index.add(value);
+          kept.push(value);
+        }
+      }
+    }
+  });
+
+  test("a value equal to, inside, or around a kept value all suppress", () => {
+    const index = createSeenValues(4096);
+    const key = `AIza${"b".repeat(35)}`; // pragma: allowlist secret
+    index.add(key);
+
+    expect(index.overlaps(key)).toBe(true); // the same value
+    expect(index.overlaps(`apiKey:"${key}"`)).toBe(true); // wrapped around it
+    expect(index.overlaps(key.slice(4))).toBe(true); // sitting inside it
+    expect(index.overlaps(`AIza${"c".repeat(35)}`)).toBe(false); // unrelated
+  });
+
+  test("a value shorter than one window is still matched both ways", () => {
+    const index = createSeenValues(4096);
+    index.add("ya29.ab"); // 7 characters, below the window size
+    expect(index.overlaps("ya29.ab")).toBe(true);
+    expect(index.overlaps("token=ya29.ab;")).toBe(true);
+    expect(index.overlaps("ya29.a")).toBe(true); // inside the kept value
+    expect(index.overlaps("ya29.zz")).toBe(false);
+  });
+
+  test("suppression stays linear enough to survive a 16k-finding page", () => {
+    // The page from #176's report: a bundle of distinct browser keys, every one
+    // of them a finding. Pairwise, this took 2.1s; the shape of the check is
+    // what this pins, so the assertion is on how the cost SCALES — an absolute
+    // budget only measures the CI runner, but going quadratic again shows up as
+    // 64x for an 8x page whatever the machine.
+    const r = rng(7);
+    const page = (n: number) =>
+      Array.from({ length: n }, () => `cfg.push({k:"AIza${runOf(r, 35)}"});`).join("");
+    const small = page(2000);
+    const large = page(16000);
+
+    scanContent(small, "inline-script"); // warm the JIT before either reading
+    scanContent(large, "inline-script");
+
+    // Fastest of three: a scheduling pause can only ever make a run look
+    // slower, so the minimum is the reading least likely to flake.
+    const timeOf = (content: string) => {
+      let ms = Infinity;
+      let findings = 0;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const started = performance.now();
+        findings = scanContent(content, "inline-script").length;
+        ms = Math.min(ms, performance.now() - started);
+      }
+      return { ms, findings };
+    };
+    const smallRun = timeOf(small);
+    const largeRun = timeOf(large);
+
+    // Near enough to one finding per key: a couple of the generated keys
+    // genuinely overlap, and suppressing those is the point of the function.
+    expect(smallRun.findings).toBeGreaterThan(1990);
+    expect(largeRun.findings).toBeGreaterThan(15900);
+    // 8x the page. Linear would be 8x the time; the pairwise scan was 64x.
+    expect(largeRun.ms / Math.max(smallRun.ms, 0.5)).toBeLessThan(24);
+    // A backstop for the absolute cliff the issue reported, loose enough for a
+    // loaded CI runner and still an order of magnitude under 2.1s.
+    expect(largeRun.ms).toBeLessThan(1000);
   });
 });


### PR DESCRIPTION
Closes #176

`overlapsSeenValue` compared every candidate finding against every value already kept, so suppression cost grew with the square of the findings. Reproduced before touching anything: an 875 KB page of 16k distinct browser keys spends 2.0s of a 2.2s scan in that one loop, and the growth is cleanly quadratic — 4k=136ms, 8k=528ms, 16k=2039ms.

## The replacement

Both halves of the test are window questions. `value.includes(seen)` asks whether some window of the candidate equals a seen value; `seen.includes(value)` asks whether some window of a seen value equals the candidate. So seen values are indexed by a rolling hash of one 12-character window, and the candidate's own window hashes decide which pairs are worth comparing at all:

- **A seen value inside the candidate** ends on one of the candidate's windows and begins on another. Both have to line up before the strings are touched, and because the end fixes the start, the surviving comparison is anchored rather than searched.
- **A seen value containing the candidate** is strictly longer and holds the candidate's first window, so a bitset of every window of every seen value ends that half outright for nearly every candidate. The bitset is only ever read as a negative; a collision costs one extra comparison and can never suppress anything.

Indexed by the **last** window, not the first, because a secret is a family with a constant head: every JWT this file matches opens with the same 37 characters (`eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.`), and `AIza`, `ghp_` and `sk-` open thousands more. Keying on the head filed a page of them into one bucket and walked it for every candidate — 2047ms, no better than the loop it replaced. Keyed on the tail: 49ms.

Values with no window of their own, and runaway matches past 1024 characters that cost more to hash than to compare, are held aside and compared directly. Several patterns are unbounded on the right, so one match can be megabytes.

## Byte-identical

The hard requirement, and the thing every check below is about. Nothing in the index decides anything: both structures only narrow the field, the string comparison still makes every call, and no pair reaches it that the pairwise loop did not also compare.

- Checked against a generated module holding the old predicate verbatim, on **4000 randomly generated pages** — values below one window, values crossing the 1024-character index limit in both directions, shared heads, shared tails, nesting both ways, repeats, and slices of earlier values — and on seven 16k-finding fixtures. Identical everywhere, longest value compared 2764 characters.
- The comparison is **falsifiable**: eleven mutants of the index, nine caught. The two that stay identical are the two that genuinely are — dropping the first-window reject (a pure filter) and indexing oversized values anyway (correct, just slower). Dropping the windowless scan differs on 761 pages, skipping the containment half on 1438, keying on the first window on 3444, an off-by-one in the window loop on 131.
- The committed test re-runs that same comparison against an inline copy of the old predicate, and catches 9 of those 10 mutants on its own — everything except the pure filter.
- Full `packages/rules` suite 1588 pass / 0 fail, `tsgo --noEmit` clean, and `audit-engine` `test:golden` 63 pass / 0 fail since rules is a shared package.

## Measured

Medians, both implementations warmed and **alternated** — running one to completion and then the other makes the shared call sites megamorphic and charges 2x to whichever goes second.

| page | findings | before | after | |
|---|---|---|---|---|
| 16k browser keys (the reported page) | 15984 | 2039ms | **59ms** | 34.7x |
| 16k mixed lengths | 15979 | 2124ms | **226ms** | 9.4x |
| 16k nested both ways | 7989 | 1072ms | **67ms** | 16.1x |
| 16k sharing a 12-char head | 15990 | 2047ms | **49ms** | 41.7x |
| 16k sharing a 24-char tail | 15997 | 2298ms | 2185ms | 1.1x |
| 16k values below one window | 6643 | 550ms | 549ms | unchanged |
| runaway 46KB matches (1.8MB page) | 200 | 27ms | 27ms | unchanged |

The one shape the index cannot help is 16k values sharing a long **tail** — the mirror image of the families that actually exist. It stays at the pairwise cost rather than exceeding it, which is the property that matters: the index can fail to narrow, but it never adds work the loop was not already doing.

## Acceptance criteria

- [x] overlap suppression on a page producing 16k findings completes in well under 500ms — 59ms, and 226ms on the hardest realistic shape
- [x] suppression behaviour is byte-identical on the existing corpus — 59 tests in the file pass unchanged, plus the differential above
- [x] a perf regression test pins the pathological-page case

The perf test asserts on **scaling**, not on a stopwatch: 2k vs 16k findings, fastest of three runs each, ratio under 24x. An absolute budget only measures the CI runner, but going quadratic again shows up as 64x for an 8x page whatever the machine. On the old implementation the ratio is 54.1x and the absolute 2034ms, so both assertions fail there and pass here (8.6x, 63ms).

## Review

Codex reviewed the diff and found no correctness issues. It raised one medium — a runaway multi-megabyte candidate would allocate a hash buffer proportional to its length and could be materially slower than the old loop — which is what the 1024-character limit above answers; that fixture now measures at parity (27ms vs 27ms). It also flagged the perf test's single timing sample as flake-prone, which is why the test takes the fastest of three.