### PR TITLE
docs: rule count 279 after the uncompressed-assets rule (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **278 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **279 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more
@@ -44,7 +44,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Security | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | Links | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
 | Content | 18 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
-| Performance | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
+| Performance | 30 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | Images | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | Structured Data | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus rating markup that is not about the page it sits on |
 | Accessibility | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 278 rules across 21 categories**
+**Total: 279 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/agent-setup/index.mdx
+++ b/docs/agent-setup/index.mdx
@@ -92,7 +92,7 @@ other MCP client works too: see [MCP clients](/developers/mcp-clients).
 <div class="agent-facts">
   <div class="agent-fact">
     <span class="agent-fact-key">Audit</span>
-    <span class="agent-fact-val">278 rules across SEO, performance, security, accessibility, and agent experience.</span>
+    <span class="agent-fact-val">279 rules across SEO, performance, security, accessibility, and agent experience.</span>
   </div>
   <div class="agent-fact">
     <span class="agent-fact-key">Read</span>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="278 rules, 21 categories"
+    title="279 rules, 21 categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule categories
 
-squirrelscan runs **278 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **279 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -227,7 +227,7 @@ squirrelscan runs **278 rules** across **21 categories**, plus opt-in cloud gap 
 | **Security** | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | **Links** | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
 | **Content** | 18 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
-| **Performance** | 29 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
+| **Performance** | 30 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | **Structured Data** | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have and rating markup that is not about the page it sits on |
 | **Accessibility** | 61 | WCAG coverage: ARIA roles and names, form labels and autocomplete tokens, colour contrast, heading order, landmarks, tables and lists, focus visibility, touch targets, captions |
@@ -242,7 +242,7 @@ squirrelscan runs **278 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 278 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 279 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules reference"
-description: "All 278 audit rules organized by score group and category"
+description: "All 279 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **278 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **279 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -70,7 +70,7 @@ Page speed and loading behavior.
 
 <CardGroup cols={2}>
   <Card title="Performance" icon="folder" href="/rules/perf">
-    Page speed and loading performance (29 rules)
+    Page speed and loading performance (30 rules)
   </Card>
 </CardGroup>
 

--- a/docs/rules/performance/index.mdx
+++ b/docs/rules/performance/index.mdx
@@ -8,7 +8,7 @@ Performance is one of the four score groups on every report. It measures page
 speed and loading behavior: Core Web Vitals hints (LCP, CLS, INP), render
 blocking, resource weight, caching, compression, and delivery.
 
-The group is a single category with 29 rules. Most run locally against the HTML
+The group is a single category with 30 rules. Most run locally against the HTML
 and response headers; a few need [browser rendering](/guides/browser-rendering)
 for measurements only a real browser can take.
 
@@ -16,7 +16,7 @@ for measurements only a real browser can take.
 
 <CardGroup cols={2}>
   <Card title="Performance" icon="folder" href="/rules/perf">
-    Page speed and loading performance (29 rules)
+    Page speed and loading performance (30 rules)
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Follow-up to #179, which added the uncompressed-assets rule without moving the count copy: totals 278 -> 279 and performance 29 -> 30 on README, docs index, rules index, the performance group page, and agent-setup. Verified against the private derived-surface guards (128/128 public-surface checks pass with the submodule at this head; the two remaining failures are private-repo surfaces fixed in the gitlink reconcile). tangly validate: 385 pages, all checks passed.