### PR TITLE
fix(crawler): keep the fetch deadline armed through the body read

### DIFF
--- a/packages/crawler/src/agent-access.ts
+++ b/packages/crawler/src/agent-access.ts
@@ -1,7 +1,8 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
-import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
+
+import { safeFetchWithDeadline } from "./deadline";
 
 import type {
   AgentAccessData,
@@ -46,24 +47,16 @@ export function detectPayment(status: number, headers: Headers, body: string): s
   return null;
 }
 
-function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  // #1395: manual redirects — per-hop scheme allowlist + strip secret
-  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
-  // The probe identity's User-Agent is on the allowlist, so it survives the hop.
-  return safeRedirectFetch(url, { ...options, signal: controller.signal })
-    .then((result) => result.response)
-    .finally(() => clearTimeout(timeout));
-}
-
 async function probeOne(
   homeUrl: string,
   identity: ProbeIdentity,
   customHeaders?: Record<string, string>,
 ): Promise<AgentAccessProbe> {
   try {
-    const response = await fetchWithTimeout(
+    // #1395: manual redirects — per-hop scheme allowlist + strip secret
+    // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
+    // The probe identity's User-Agent is on the allowlist, so it survives the hop.
+    return await safeFetchWithDeadline(
       homeUrl,
       {
         // A configured custom User-Agent (any casing) must not replace the probe
@@ -78,22 +71,24 @@ async function probeOne(
         redirect: "follow",
       },
       PROBE_TIMEOUT_MS,
+      async (response) => {
+        const raw = await readBodyCapped(response, AGENT_ACCESS_MAX_BYTES);
+        const body = truncateToBytes(raw, AGENT_ACCESS_MAX_BYTES);
+        const challengeSignal = detectChallenge(response.headers, body);
+        const paymentSignal = detectPayment(response.status, response.headers, body);
+        return {
+          userAgent: identity.label,
+          userAgentString: identity.ua,
+          status: response.status,
+          bodySize: byteLength(body),
+          challenged: challengeSignal !== null,
+          challengeSignal,
+          paymentRequired: paymentSignal !== null,
+          paymentSignal,
+          error: null,
+        };
+      },
     );
-    const raw = await readBodyCapped(response, AGENT_ACCESS_MAX_BYTES);
-    const body = truncateToBytes(raw, AGENT_ACCESS_MAX_BYTES);
-    const challengeSignal = detectChallenge(response.headers, body);
-    const paymentSignal = detectPayment(response.status, response.headers, body);
-    return {
-      userAgent: identity.label,
-      userAgentString: identity.ua,
-      status: response.status,
-      bodySize: byteLength(body),
-      challenged: challengeSignal !== null,
-      challengeSignal,
-      paymentRequired: paymentSignal !== null,
-      paymentSignal,
-      error: null,
-    };
   } catch (e) {
     return {
       userAgent: identity.label,

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -17,6 +17,7 @@ import {
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 import { urlHostKey } from "@squirrelscan/utils/url";
 
+import { withRequestDeadline } from "../deadline";
 import { computeSitemapUrlCap, discoverSitemaps, selectSitemapUrls } from "../sitemaps";
 
 import type { RobotsEvaluator } from "../robots";
@@ -1455,13 +1456,37 @@ export function createCrawler(
      */
     const detectRedirects = (targetUrl: string): Effect.Effect<string, never, never> =>
       Effect.promise(async () => {
+        // `settledUrl` is the last URL that actually served a response, so every
+        // exit below can fall back to it. `currentUrl` cannot: after a
+        // client-side redirect it holds a page-supplied target we have not
+        // fetched yet, and handing that back as the crawl's seed would let a
+        // meta-refresh reroute the audit on the strength of a later timeout.
+        let settledUrl = targetUrl;
         try {
           const MAX_REDIRECTS = 10;
           const REDIRECT_TIMEOUT_MS = 10_000;
+          const REDIRECT_TOTAL_BUDGET_MS = 30_000;
+          // Seed resolution is a crawl request like any other, so it honors the
+          // crawl's own per-request timeout when that is tighter (the 30s
+          // default leaves the 10s ceiling in place).
+          const hopTimeoutMs = Math.max(1, Math.min(REDIRECT_TIMEOUT_MS, config.timeoutMs));
+          // Whole-chain budget. Ten bounded hops still add up to 100s on a slow
+          // origin, and this runs BEFORE the crawl emits `started` — so an
+          // overrun doesn't read as "the crawl was slow", it reads as a crawl
+          // that never began (#1699). Seed resolution is not worth more of the
+          // crawl-phase budget than this.
+          const deadline =
+            Date.now() + Math.min(REDIRECT_TOTAL_BUDGET_MS, hopTimeoutMs * MAX_REDIRECTS);
           let currentUrl = targetUrl;
           const visited = new Set<string>();
 
           for (let i = 0; i < MAX_REDIRECTS; i++) {
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) {
+              logger.debug("redirect budget exhausted, stopping", currentUrl);
+              break;
+            }
+
             // Prevent loops
             if (visited.has(currentUrl)) {
               logger.debug("redirect loop detected, stopping", currentUrl);
@@ -1469,45 +1494,60 @@ export function createCrawler(
             }
             visited.add(currentUrl);
 
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), REDIRECT_TIMEOUT_MS);
-            const response = await fetch(currentUrl, {
-              method: "GET",
-              signal: controller.signal,
-              redirect: "follow",
-            }).finally(() => clearTimeout(timeout));
+            const hopUrl = currentUrl;
+            const next = await withRequestDeadline(
+              Math.min(hopTimeoutMs, remainingMs),
+              (signal) => fetch(hopUrl, { method: "GET", signal, redirect: "follow" }),
+              // The deadline stays armed for the whole callback, so the body
+              // read below is bounded too — before #1699 the timer was cleared
+              // as soon as the headers landed and a stalled body hung here
+              // forever, with no `started` event ever reaching the caller.
+              async (response) => {
+                // response.url is post-redirect and definitionally served; the
+                // fallback covers runtimes/mocks that leave it empty.
+                const served = response.url || hopUrl;
 
-            // Check if HTTP redirect occurred
-            if (response.url !== currentUrl) {
-              logger.debug("HTTP redirect", currentUrl, "→", response.url);
-              currentUrl = response.url;
-              continue;
-            }
+                // Check if HTTP redirect occurred
+                if (served !== hopUrl) {
+                  logger.debug("HTTP redirect", hopUrl, "→", served);
+                  // Nothing here reads the body, so release the connection
+                  // rather than leaving a response half-consumed per hop.
+                  await response.body?.cancel().catch(() => {});
+                  return { served, redirectTo: served };
+                }
 
-            // Check for client-side redirects (meta refresh, JS)
-            const contentType = response.headers.get("content-type") || "";
-            if (contentType.includes("text/html")) {
-              // Runs during seed redirect resolution, before the crawl has any
-              // size limits of its own, so this read needs its own bound.
-              const html = await readBodyCapped(response, DEFAULT_MAX_DOCUMENT_BODY_BYTES);
-              const clientRedirect = findClientRedirects(html, currentUrl);
+                // Check for client-side redirects (meta refresh, JS)
+                const contentType = response.headers.get("content-type") || "";
+                if (!contentType.includes("text/html")) {
+                  await response.body?.cancel().catch(() => {});
+                  return { served, redirectTo: undefined };
+                }
 
-              if (clientRedirect && clientRedirect !== currentUrl) {
-                logger.debug("client-side redirect", currentUrl, "→", clientRedirect);
-                currentUrl = clientRedirect;
-                continue;
-              }
-            }
+                // Runs during seed redirect resolution, before the crawl has any
+                // size limits of its own, so this read needs its own bound.
+                const html = await readBodyCapped(response, DEFAULT_MAX_DOCUMENT_BODY_BYTES);
+                const clientRedirect = findClientRedirects(html, hopUrl);
 
-            // No more redirects
-            break;
+                if (clientRedirect && clientRedirect !== hopUrl) {
+                  logger.debug("client-side redirect", hopUrl, "→", clientRedirect);
+                  return { served, redirectTo: clientRedirect };
+                }
+
+                // No more redirects
+                return { served, redirectTo: undefined };
+              },
+            );
+
+            settledUrl = next.served;
+            if (next.redirectTo === undefined) break;
+            currentUrl = next.redirectTo;
           }
 
-          return currentUrl;
+          return settledUrl;
         } catch (error) {
           // Log error before falling back
           logger.debug("redirect detection failed", targetUrl, error);
-          return targetUrl;
+          return settledUrl;
         }
       });
 

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -1495,7 +1495,7 @@ export function createCrawler(
             visited.add(currentUrl);
 
             const hopUrl = currentUrl;
-            const next = await withRequestDeadline(
+            const redirectTo = await withRequestDeadline(
               Math.min(hopTimeoutMs, remainingMs),
               (signal) => fetch(hopUrl, { method: "GET", signal, redirect: "follow" }),
               // The deadline stays armed for the whole callback, so the body
@@ -1503,9 +1503,12 @@ export function createCrawler(
               // as soon as the headers landed and a stalled body hung here
               // forever, with no `started` event ever reaching the caller.
               async (response) => {
-                // response.url is post-redirect and definitionally served; the
-                // fallback covers runtimes/mocks that leave it empty.
+                // Headers are in, so this URL demonstrably serves — bank it
+                // BEFORE the body read, which is the step that can still time
+                // out. response.url is post-redirect; the fallback covers
+                // runtimes and mocks that leave it empty.
                 const served = response.url || hopUrl;
+                settledUrl = served;
 
                 // Check if HTTP redirect occurred
                 if (served !== hopUrl) {
@@ -1513,14 +1516,14 @@ export function createCrawler(
                   // Nothing here reads the body, so release the connection
                   // rather than leaving a response half-consumed per hop.
                   await response.body?.cancel().catch(() => {});
-                  return { served, redirectTo: served };
+                  return served;
                 }
 
                 // Check for client-side redirects (meta refresh, JS)
                 const contentType = response.headers.get("content-type") || "";
                 if (!contentType.includes("text/html")) {
                   await response.body?.cancel().catch(() => {});
-                  return { served, redirectTo: undefined };
+                  return undefined;
                 }
 
                 // Runs during seed redirect resolution, before the crawl has any
@@ -1530,17 +1533,16 @@ export function createCrawler(
 
                 if (clientRedirect && clientRedirect !== hopUrl) {
                   logger.debug("client-side redirect", hopUrl, "→", clientRedirect);
-                  return { served, redirectTo: clientRedirect };
+                  return clientRedirect;
                 }
 
                 // No more redirects
-                return { served, redirectTo: undefined };
+                return undefined;
               },
             );
 
-            settledUrl = next.served;
-            if (next.redirectTo === undefined) break;
-            currentUrl = next.redirectTo;
+            if (redirectTo === undefined) break;
+            currentUrl = redirectTo;
           }
 
           return settledUrl;

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -1466,17 +1466,19 @@ export function createCrawler(
           const MAX_REDIRECTS = 10;
           const REDIRECT_TIMEOUT_MS = 10_000;
           const REDIRECT_TOTAL_BUDGET_MS = 30_000;
+          // The whole chain is worth this many full request timeouts and no
+          // more. Deliberately well under MAX_REDIRECTS: ten individually
+          // bounded hops still add up to 100s on a slow origin, and this runs
+          // BEFORE the crawl emits `started`, so an overrun doesn't read as "the
+          // crawl was slow" — it reads as a crawl that never began (#1699).
+          const REDIRECT_BUDGET_HOPS = 3;
           // Seed resolution is a crawl request like any other, so it honors the
           // crawl's own per-request timeout when that is tighter (the 30s
-          // default leaves the 10s ceiling in place).
+          // default leaves the 10s ceiling, and so the 30s chain budget, in
+          // place).
           const hopTimeoutMs = Math.max(1, Math.min(REDIRECT_TIMEOUT_MS, config.timeoutMs));
-          // Whole-chain budget. Ten bounded hops still add up to 100s on a slow
-          // origin, and this runs BEFORE the crawl emits `started` — so an
-          // overrun doesn't read as "the crawl was slow", it reads as a crawl
-          // that never began (#1699). Seed resolution is not worth more of the
-          // crawl-phase budget than this.
           const deadline =
-            Date.now() + Math.min(REDIRECT_TOTAL_BUDGET_MS, hopTimeoutMs * MAX_REDIRECTS);
+            Date.now() + Math.min(REDIRECT_TOTAL_BUDGET_MS, hopTimeoutMs * REDIRECT_BUDGET_HOPS);
           let currentUrl = targetUrl;
           const visited = new Set<string>();
 

--- a/packages/crawler/src/deadline.ts
+++ b/packages/crawler/src/deadline.ts
@@ -1,0 +1,49 @@
+// Request deadlines that survive into the body read (#1699).
+
+import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+
+/**
+ * Run a request under a deadline that stays armed until its body has been read.
+ *
+ * The tempting shape — `fetch(...).finally(() => clearTimeout(timer))` — disarms
+ * the abort the moment the response HEADERS land, which leaves the body read
+ * with no time bound at all: an origin that answers 200 promptly and then
+ * trickles or stalls the body parks the caller forever. `readBodyCapped` caps
+ * BYTES, not seconds, so it cannot save you either. Holding the timer across
+ * `use` means such a stall aborts the body stream instead of hanging.
+ *
+ * `use` must finish with the response (read or cancel its body) before it
+ * returns — the deadline is disarmed as soon as it does.
+ */
+export async function withRequestDeadline<T>(
+  timeoutMs: number,
+  perform: (signal: AbortSignal) => Promise<Response>,
+  use: (response: Response) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await use(await perform(controller.signal));
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * `withRequestDeadline` over `safeRedirectFetch` — the shape every root probe in
+ * the crawl preamble (robots, llms, markdown, well-known, agent-access, rsl,
+ * sitemaps) uses. Manual redirects apply the per-hop scheme allowlist and strip
+ * secret customHeaders when the origin changes (#1395).
+ */
+export function safeFetchWithDeadline<T>(
+  url: string,
+  options: RequestInit,
+  timeoutMs: number,
+  use: (response: Response) => Promise<T>,
+): Promise<T> {
+  return withRequestDeadline(
+    timeoutMs,
+    (signal) => safeRedirectFetch(url, { ...options, signal }).then((result) => result.response),
+    use,
+  );
+}

--- a/packages/crawler/src/llms.ts
+++ b/packages/crawler/src/llms.ts
@@ -26,14 +26,20 @@ async function fetchOne(
       { headers: { "User-Agent": userAgent, Accept: "text/plain, text/markdown, */*", ...customHeaders } },
       LLMS_FETCH_TIMEOUT_MS,
       async (response) => {
-        if (response.status === 404 || !response.ok) return emptyFile(url);
+        if (response.status === 404 || !response.ok) {
+          await response.body?.cancel().catch(() => {});
+          return emptyFile(url);
+        }
         // The content-length pre-check is a cheap fast path only: it is absent on a
         // chunked response and reports the COMPRESSED size on an encoded one, so it
         // cannot bound the read. readBodyCapped enforces the limit against the
         // decoded stream and cancels at the cap, which is what stops a small
         // compressed body from expanding to gigabytes in memory.
         const declared = Number(response.headers.get("content-length") ?? "0");
-        if (Number.isFinite(declared) && declared > LLMS_MAX_BYTES) return emptyFile(url);
+        if (Number.isFinite(declared) && declared > LLMS_MAX_BYTES) {
+          await response.body?.cancel().catch(() => {});
+          return emptyFile(url);
+        }
         const raw = await readBodyCapped(response, LLMS_MAX_BYTES);
         // #1293: byte-accurate cap — a `.length` slice over-keeps a multi-byte body.
         // Still applied after the capped read: decoding can emit replacement chars

--- a/packages/crawler/src/llms.ts
+++ b/packages/crawler/src/llms.ts
@@ -1,7 +1,8 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
-import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
+
+import { safeFetchWithDeadline } from "./deadline";
 
 import type { LlmsTxtData, LlmsTxtFile } from "@squirrelscan/core-contracts";
 
@@ -13,16 +14,6 @@ function emptyFile(url: string): LlmsTxtFile {
   return { url, exists: false, content: null, sizeBytes: 0 };
 }
 
-function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  // #1395: manual redirects — per-hop scheme allowlist + strip secret
-  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
-  return safeRedirectFetch(url, { ...options, signal: controller.signal })
-    .then((result) => result.response)
-    .finally(() => clearTimeout(timeout));
-}
-
 // Fetch one well-known file; a 404/error/oversize file is "absent", never a throw.
 async function fetchOne(
   url: string,
@@ -30,25 +21,27 @@ async function fetchOne(
   customHeaders?: Record<string, string>,
 ): Promise<LlmsTxtFile> {
   try {
-    const response = await fetchWithTimeout(
+    return await safeFetchWithDeadline(
       url,
       { headers: { "User-Agent": userAgent, Accept: "text/plain, text/markdown, */*", ...customHeaders } },
       LLMS_FETCH_TIMEOUT_MS,
+      async (response) => {
+        if (response.status === 404 || !response.ok) return emptyFile(url);
+        // The content-length pre-check is a cheap fast path only: it is absent on a
+        // chunked response and reports the COMPRESSED size on an encoded one, so it
+        // cannot bound the read. readBodyCapped enforces the limit against the
+        // decoded stream and cancels at the cap, which is what stops a small
+        // compressed body from expanding to gigabytes in memory.
+        const declared = Number(response.headers.get("content-length") ?? "0");
+        if (Number.isFinite(declared) && declared > LLMS_MAX_BYTES) return emptyFile(url);
+        const raw = await readBodyCapped(response, LLMS_MAX_BYTES);
+        // #1293: byte-accurate cap — a `.length` slice over-keeps a multi-byte body.
+        // Still applied after the capped read: decoding can emit replacement chars
+        // that are wider than the bytes they replace.
+        const content = truncateToBytes(raw, LLMS_MAX_BYTES);
+        return { url, exists: true, content, sizeBytes: byteLength(content) };
+      },
     );
-    if (response.status === 404 || !response.ok) return emptyFile(url);
-    // The content-length pre-check is a cheap fast path only: it is absent on a
-    // chunked response and reports the COMPRESSED size on an encoded one, so it
-    // cannot bound the read. readBodyCapped enforces the limit against the
-    // decoded stream and cancels at the cap, which is what stops a small
-    // compressed body from expanding to gigabytes in memory.
-    const declared = Number(response.headers.get("content-length") ?? "0");
-    if (Number.isFinite(declared) && declared > LLMS_MAX_BYTES) return emptyFile(url);
-    const raw = await readBodyCapped(response, LLMS_MAX_BYTES);
-    // #1293: byte-accurate cap — a `.length` slice over-keeps a multi-byte body.
-    // Still applied after the capped read: decoding can emit replacement chars
-    // that are wider than the bytes they replace.
-    const content = truncateToBytes(raw, LLMS_MAX_BYTES);
-    return { url, exists: true, content, sizeBytes: byteLength(content) };
   } catch {
     return emptyFile(url);
   }

--- a/packages/crawler/src/markdown.ts
+++ b/packages/crawler/src/markdown.ts
@@ -1,21 +1,12 @@
 import { Effect } from "effect";
-import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+
+import { safeFetchWithDeadline } from "./deadline";
 
 import type { MarkdownProbeData } from "@squirrelscan/core-contracts";
 
 const PROBE_TIMEOUT_MS = 30_000;
 
 const isMarkdown = (ct: string | null): boolean => ct != null && /markdown/i.test(ct);
-
-function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  // #1395: manual redirects — per-hop scheme allowlist + strip secret
-  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
-  return safeRedirectFetch(url, { ...options, signal: controller.signal })
-    .then((result) => result.response)
-    .finally(() => clearTimeout(timeout));
-}
 
 // Parse a `Link:` response header for a `rel="alternate"; type="text/markdown"`
 // entry and resolve it to an absolute URL. Returns null if none matches.
@@ -54,22 +45,24 @@ async function probeOne(
   customHeaders?: Record<string, string>,
 ): Promise<ProbeResult> {
   try {
-    const res = await fetchWithTimeout(
+    return await safeFetchWithDeadline(
       url,
       { headers: { "User-Agent": userAgent, Accept: accept, ...customHeaders } },
       PROBE_TIMEOUT_MS,
+      async (res) => {
+        const contentType = res.headers.get("content-type");
+        const result: ProbeResult = {
+          ok: res.ok,
+          contentType,
+          vary: res.headers.get("vary"),
+          markdownTokens: res.headers.get("x-markdown-tokens"),
+          originalTokens: res.headers.get("x-original-tokens"),
+          alternateMarkdownUrl: parseAlternateMarkdownLink(res.headers.get("link"), url),
+        };
+        await res.body?.cancel().catch(() => {});
+        return result;
+      },
     );
-    const contentType = res.headers.get("content-type");
-    const result: ProbeResult = {
-      ok: res.ok,
-      contentType,
-      vary: res.headers.get("vary"),
-      markdownTokens: res.headers.get("x-markdown-tokens"),
-      originalTokens: res.headers.get("x-original-tokens"),
-      alternateMarkdownUrl: parseAlternateMarkdownLink(res.headers.get("link"), url),
-    };
-    await res.body?.cancel().catch(() => {});
-    return result;
   } catch {
     return {
       ok: false,

--- a/packages/crawler/src/robots.ts
+++ b/packages/crawler/src/robots.ts
@@ -92,10 +92,12 @@ export function fetchRobotsEvaluator(
         30_000,
         async (response) => {
           if (response.status === 404) {
+            await response.body?.cancel().catch(() => {});
             return createRobotsEvaluator(robotsUrl, null, userAgent);
           }
 
           if (!response.ok) {
+            await response.body?.cancel().catch(() => {});
             const data = emptyRobotsData(robotsUrl, `HTTP ${response.status}`);
             return {
               data,

--- a/packages/crawler/src/robots.ts
+++ b/packages/crawler/src/robots.ts
@@ -4,7 +4,8 @@ import robotsParser from "robots-parser";
 import type { RobotsTxtData } from "@squirrelscan/core-contracts";
 import { parseRobotsTxt } from "@squirrelscan/utils/robots-txt";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
-import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+
+import { safeFetchWithDeadline } from "./deadline";
 
 // Matches the limit Google documents for robots.txt; anything past it is
 // ignored by real crawlers, so there is nothing to gain by reading further.
@@ -63,21 +64,6 @@ export function createRobotsEvaluator(
   };
 }
 
-function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  // #1395: follow redirects manually so per-hop the scheme allowlist applies and
-  // the caller's secret customHeaders are stripped when a redirect changes origin
-  // (native redirect:"follow" would replay them cross-origin).
-  return safeRedirectFetch(url, {
-    ...options,
-    signal: controller.signal,
-  })
-    .then((result) => result.response)
-    .finally(() => clearTimeout(timeout));
-}
-
 export function fetchRobotsEvaluator(
   baseUrl: string,
   userAgent: string,
@@ -91,8 +77,8 @@ export function fetchRobotsEvaluator(
   }
 
   return Effect.tryPromise({
-    try: async () => {
-      const response = await fetchWithTimeout(
+    try: () =>
+      safeFetchWithDeadline(
         robotsUrl,
         {
           headers: {
@@ -104,27 +90,27 @@ export function fetchRobotsEvaluator(
           },
         },
         30_000,
-      );
+        async (response) => {
+          if (response.status === 404) {
+            return createRobotsEvaluator(robotsUrl, null, userAgent);
+          }
 
-      if (response.status === 404) {
-        return createRobotsEvaluator(robotsUrl, null, userAgent);
-      }
+          if (!response.ok) {
+            const data = emptyRobotsData(robotsUrl, `HTTP ${response.status}`);
+            return {
+              data,
+              isAllowed: () => true,
+              crawlDelayMs: null,
+            };
+          }
 
-      if (!response.ok) {
-        const data = emptyRobotsData(robotsUrl, `HTTP ${response.status}`);
-        return {
-          data,
-          isAllowed: () => true,
-          crawlDelayMs: null,
-        };
-      }
-
-      // Bounded: robots.txt is fetched before anything else is known about the
-      // host, so an unbounded read here is reachable on the very first request
-      // of an audit.
-      const content = await readBodyCapped(response, ROBOTS_MAX_BYTES);
-      return createRobotsEvaluator(robotsUrl, content, userAgent);
-    },
+          // Bounded: robots.txt is fetched before anything else is known about the
+          // host, so an unbounded read here is reachable on the very first request
+          // of an audit.
+          const content = await readBodyCapped(response, ROBOTS_MAX_BYTES);
+          return createRobotsEvaluator(robotsUrl, content, userAgent);
+        },
+      ),
     catch: (error) => {
       const data = emptyRobotsData(robotsUrl, (error as Error).message);
       return {

--- a/packages/crawler/src/rsl.ts
+++ b/packages/crawler/src/rsl.ts
@@ -1,7 +1,9 @@
 import { Effect } from "effect";
 import { truncateToBytes } from "@squirrelscan/utils/bytes";
-import { isHttpOrHttpsUrl, safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
+
+import { safeFetchWithDeadline } from "./deadline";
 
 import type { RslData, RslLicenseDoc } from "@squirrelscan/core-contracts";
 
@@ -48,23 +50,13 @@ export function looksLikeXml(body: string): boolean {
   return head.startsWith("<?xml") || head.startsWith("<");
 }
 
-function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  // #1395: manual redirects — per-hop scheme allowlist + strip secret
-  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
-  return safeRedirectFetch(url, { ...options, signal: controller.signal })
-    .then((result) => result.response)
-    .finally(() => clearTimeout(timeout));
-}
-
 async function fetchLicenseDoc(
   url: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
 ): Promise<RslLicenseDoc> {
   try {
-    const response = await fetchWithTimeout(
+    return await safeFetchWithDeadline(
       url,
       {
         headers: {
@@ -74,19 +66,21 @@ async function fetchLicenseDoc(
         },
       },
       PROBE_TIMEOUT_MS,
+      async (response) => {
+        const contentType = response.headers.get("content-type");
+        const raw = await readBodyCapped(response, RSL_MAX_BYTES);
+        const body = truncateToBytes(raw, RSL_MAX_BYTES);
+        return {
+          url,
+          status: response.status,
+          contentType,
+          xmlValid: looksLikeXml(body),
+          looksRsl: looksLikeRsl(body),
+          excerpt: truncateToBytes(body, EXCERPT_MAX_BYTES),
+          error: null,
+        };
+      },
     );
-    const contentType = response.headers.get("content-type");
-    const raw = await readBodyCapped(response, RSL_MAX_BYTES);
-    const body = truncateToBytes(raw, RSL_MAX_BYTES);
-    return {
-      url,
-      status: response.status,
-      contentType,
-      xmlValid: looksLikeXml(body),
-      looksRsl: looksLikeRsl(body),
-      excerpt: truncateToBytes(body, EXCERPT_MAX_BYTES),
-      error: null,
-    };
   } catch (e) {
     return {
       url,
@@ -113,18 +107,20 @@ export function fetchRslLicensing(
     let robotsBody = "";
     let linkHeader: string | null = null;
     try {
-      const response = await fetchWithTimeout(
+      await safeFetchWithDeadline(
         robotsUrl,
         { headers: { "User-Agent": userAgent, Accept: "text/plain, */*", ...customHeaders } },
         PROBE_TIMEOUT_MS,
+        async (response) => {
+          if (response.ok) {
+            const raw = await readBodyCapped(response, ROBOTS_MAX_BYTES);
+            robotsBody = truncateToBytes(raw, ROBOTS_MAX_BYTES);
+            linkHeader = response.headers.get("link");
+          } else {
+            await response.body?.cancel().catch(() => {});
+          }
+        },
       );
-      if (response.ok) {
-        const raw = await readBodyCapped(response, ROBOTS_MAX_BYTES);
-        robotsBody = truncateToBytes(raw, ROBOTS_MAX_BYTES);
-        linkHeader = response.headers.get("link");
-      } else {
-        await response.body?.cancel().catch(() => {});
-      }
     } catch {
       // robots unreachable → no licensing signal; return empty below.
     }

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -1,4 +1,4 @@
-import { Effect, pipe } from "effect";
+import { Effect } from "effect";
 import { XMLParser } from "fast-xml-parser";
 
 import type {
@@ -7,7 +7,9 @@ import type {
   SitemapFetchFailure,
   SitemapUrl,
 } from "@squirrelscan/core-contracts";
-import { isHttpOrHttpsUrl, safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
+import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
+
+import { safeFetchWithDeadline } from "./deadline";
 
 const logger = {
   debug: (_message: string, ..._args: unknown[]) => {},
@@ -150,20 +152,6 @@ export type SitemapFetchResult =
   | { success: true; data: SitemapData }
   | { success: false; url: string; error: string };
 
-function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  // #1395: manual redirects — per-hop scheme allowlist + strip secret
-  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
-  return safeRedirectFetch(url, {
-    ...options,
-    signal: controller.signal,
-  })
-    .then((result) => result.response)
-    .finally(() => clearTimeout(timeout));
-}
-
 export function fetchSitemap(
   url: string,
   userAgent: string,
@@ -176,71 +164,42 @@ export function fetchSitemap(
   // When baseHost is unset (direct callers/tests), preserve prior behavior.
   const originScopedHeaders =
     baseHost !== undefined && new URL(url).host !== baseHost ? undefined : customHeaders;
-  return pipe(
-    Effect.tryPromise({
-      try: () =>
-        fetchWithTimeout(
-          url,
-          {
-            headers: {
-              "User-Agent": userAgent,
-              Accept: "application/xml, text/xml, */*",
-              "Accept-Language": "en-US,en;q=0.9",
-              ...originScopedHeaders,
-            },
-            redirect: "follow",
+  return Effect.promise(async (): Promise<SitemapFetchResult> => {
+    try {
+      // #1395: manual redirects — per-hop scheme allowlist + strip secret
+      // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
+      // The deadline covers the body read too: a sitemap index that answers 200
+      // and then stalls its body would otherwise park the crawl forever (#1699).
+      return await safeFetchWithDeadline(
+        url,
+        {
+          headers: {
+            "User-Agent": userAgent,
+            Accept: "application/xml, text/xml, */*",
+            "Accept-Language": "en-US,en;q=0.9",
+            ...originScopedHeaders,
           },
-          30_000,
-        ),
-      catch: (error) => ({
-        status: 0,
-        ok: false,
-        error: error instanceof Error ? error.message : "Network error",
-      }),
-    }),
-    Effect.flatMap((response) => {
-      if (!response.ok) {
-        const errorMsg =
-          "status" in response && response.status
-            ? `HTTP ${response.status}`
-            : "error" in response
-              ? String(response.error)
-              : "Network error";
-        return Effect.succeed<SitemapFetchResult>({
-          success: false,
-          url,
-          error: errorMsg,
-        });
-      }
-
-      return Effect.tryPromise({
-        try: () => response.text(),
-        catch: () => null,
-      }).pipe(
-        Effect.map((content): SitemapFetchResult => {
-          if (!content) {
-            return {
-              success: false,
-              url,
-              error: "Empty response",
-            };
+          redirect: "follow",
+        },
+        30_000,
+        async (response): Promise<SitemapFetchResult> => {
+          if (!response.ok) {
+            await response.body?.cancel().catch(() => {});
+            return { success: false, url, error: `HTTP ${response.status}` };
           }
-
-          return {
-            success: true,
-            data: parseSitemap(content, url),
-          };
-        }),
+          const content = await response.text();
+          if (!content) return { success: false, url, error: "Empty response" };
+          return { success: true, data: parseSitemap(content, url) };
+        },
       );
-    }),
-    Effect.catchAll(() =>
-      Effect.succeed({
+    } catch (error) {
+      return {
         success: false,
         url,
-        error: "Unexpected error",
-      } as SitemapFetchResult),
-    ),
-  );
+        error: error instanceof Error ? error.message : "Network error",
+      };
+    }
+  });
 }
 
 const SITEMAP_FETCH_CONCURRENCY = 5;

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -187,7 +187,16 @@ export function fetchSitemap(
             await response.body?.cancel().catch(() => {});
             return { success: false, url, error: `HTTP ${response.status}` };
           }
-          const content = await response.text();
+          // A body that never arrives (including a deadline abort) classifies
+          // as "Empty response", the same as one that arrives empty. This text
+          // reaches persisted sitemap-failure records, so it stays what it was
+          // before the read moved inside the deadline.
+          let content: string;
+          try {
+            content = await response.text();
+          } catch {
+            return { success: false, url, error: "Empty response" };
+          }
           if (!content) return { success: false, url, error: "Empty response" };
           return { success: true, data: parseSitemap(content, url) };
         },

--- a/packages/crawler/src/well-known.ts
+++ b/packages/crawler/src/well-known.ts
@@ -1,7 +1,8 @@
 import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
-import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
+
+import { safeFetchWithDeadline } from "./deadline";
 
 import type { WellKnownProbe, WellKnownProbeData } from "@squirrelscan/core-contracts";
 
@@ -93,16 +94,6 @@ export function looksLikeMarkdown(body: string): boolean {
   return /\[[^\]]+\]\([^)]+\)/.test(trimmed.slice(0, 4_096));
 }
 
-function fetchWithTimeout(url: string, options: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  // #1395: manual redirects — per-hop scheme allowlist + strip secret
-  // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
-  return safeRedirectFetch(url, { ...options, signal: controller.signal })
-    .then((result) => result.response)
-    .finally(() => clearTimeout(timeout));
-}
-
 async function probeOne(
   baseUrl: string,
   path: string,
@@ -111,7 +102,7 @@ async function probeOne(
 ): Promise<WellKnownProbe> {
   const url = new URL(path, baseUrl).toString();
   try {
-    const response = await fetchWithTimeout(
+    return await safeFetchWithDeadline(
       url,
       {
         headers: {
@@ -121,54 +112,56 @@ async function probeOne(
         },
       },
       PROBE_TIMEOUT_MS,
+      async (response) => {
+        const contentType = response.headers.get("content-type");
+        const isOAuth = isOAuthMetadataPath(path);
+        // Skip reading a pathologically large body (18 probes run concurrently).
+        const declared = Number(response.headers.get("content-length") ?? "0");
+        if (Number.isFinite(declared) && declared > WELL_KNOWN_MAX_BYTES) {
+          await response.body?.cancel().catch(() => {});
+          return {
+            path,
+            url,
+            status: response.status,
+            contentType,
+            bodySize: declared,
+            looksHtml: false,
+            jsonValid: false,
+            jsonKeys: [],
+            markdownLike: false,
+            excerpt: "",
+            oauthRegistrationEndpoint: null,
+            oauthClientIdMetadataDocumentSupported: null,
+            error: "body exceeds cap",
+          };
+        }
+        const raw = await readBodyCapped(response, WELL_KNOWN_MAX_BYTES);
+        const body = truncateToBytes(raw, WELL_KNOWN_MAX_BYTES);
+        const looksHtml = looksLikeHtml(body);
+        // A SPA-fallback HTML page must never count as valid JSON/markdown.
+        const json = looksHtml ? { valid: false, keys: [] } : sniffJson(body);
+        // Extract OAuth AS/PRM fields rules need; only for real JSON on the two paths.
+        const oauth =
+          isOAuth && json.valid && !looksHtml
+            ? extractOAuthFields(body)
+            : { registrationEndpoint: null, clientIdMetadataDocumentSupported: null };
+        return {
+          path,
+          url,
+          status: response.status,
+          contentType,
+          bodySize: byteLength(body),
+          looksHtml,
+          jsonValid: json.valid,
+          jsonKeys: json.keys,
+          markdownLike: !looksHtml && looksLikeMarkdown(body),
+          excerpt: truncateToBytes(body, isOAuth ? OAUTH_EXCERPT_MAX_BYTES : EXCERPT_MAX_BYTES),
+          oauthRegistrationEndpoint: oauth.registrationEndpoint,
+          oauthClientIdMetadataDocumentSupported: oauth.clientIdMetadataDocumentSupported,
+          error: null,
+        };
+      },
     );
-    const contentType = response.headers.get("content-type");
-    const isOAuth = isOAuthMetadataPath(path);
-    // Skip reading a pathologically large body (18 probes run concurrently).
-    const declared = Number(response.headers.get("content-length") ?? "0");
-    if (Number.isFinite(declared) && declared > WELL_KNOWN_MAX_BYTES) {
-      await response.body?.cancel().catch(() => {});
-      return {
-        path,
-        url,
-        status: response.status,
-        contentType,
-        bodySize: declared,
-        looksHtml: false,
-        jsonValid: false,
-        jsonKeys: [],
-        markdownLike: false,
-        excerpt: "",
-        oauthRegistrationEndpoint: null,
-        oauthClientIdMetadataDocumentSupported: null,
-        error: "body exceeds cap",
-      };
-    }
-    const raw = await readBodyCapped(response, WELL_KNOWN_MAX_BYTES);
-    const body = truncateToBytes(raw, WELL_KNOWN_MAX_BYTES);
-    const looksHtml = looksLikeHtml(body);
-    // A SPA-fallback HTML page must never count as valid JSON/markdown.
-    const json = looksHtml ? { valid: false, keys: [] } : sniffJson(body);
-    // Extract OAuth AS/PRM fields rules need; only for real JSON on the two paths.
-    const oauth =
-      isOAuth && json.valid && !looksHtml
-        ? extractOAuthFields(body)
-        : { registrationEndpoint: null, clientIdMetadataDocumentSupported: null };
-    return {
-      path,
-      url,
-      status: response.status,
-      contentType,
-      bodySize: byteLength(body),
-      looksHtml,
-      jsonValid: json.valid,
-      jsonKeys: json.keys,
-      markdownLike: !looksHtml && looksLikeMarkdown(body),
-      excerpt: truncateToBytes(body, isOAuth ? OAUTH_EXCERPT_MAX_BYTES : EXCERPT_MAX_BYTES),
-      oauthRegistrationEndpoint: oauth.registrationEndpoint,
-      oauthClientIdMetadataDocumentSupported: oauth.clientIdMetadataDocumentSupported,
-      error: null,
-    };
   } catch (e) {
     return {
       path,

--- a/packages/crawler/tests/deadline.test.ts
+++ b/packages/crawler/tests/deadline.test.ts
@@ -24,37 +24,57 @@ function serveStalledBody() {
   });
 }
 
+const DEADLINE_MS = 300;
+
 describe("withRequestDeadline (#1699)", () => {
   test("a body that stalls after the headers aborts at the deadline", async () => {
     const server = serveStalledBody();
+    let signal: AbortSignal | undefined;
     const startedAt = Date.now();
     try {
       const read = withRequestDeadline(
-        300,
-        (signal) => fetch(`http://localhost:${server.port}/`, { signal }),
+        DEADLINE_MS,
+        (s) => {
+          signal = s;
+          return fetch(`http://localhost:${server.port}/`, { signal: s });
+        },
         (response) => response.text(),
       );
-      expect(read).rejects.toThrow();
-      await read.catch(() => {});
-      // Bounded by the deadline, not by the origin eventually relenting.
-      expect(Date.now() - startedAt).toBeLessThan(5_000);
+      await expect(read).rejects.toThrow();
+      const elapsed = Date.now() - startedAt;
+
+      // It ended because the deadline fired, not because the origin relented.
+      expect(signal?.aborted).toBe(true);
+      // Close to the deadline, not merely "eventually": a bound that fires an
+      // order of magnitude late is not a bound.
+      expect(elapsed).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+      expect(elapsed).toBeLessThan(DEADLINE_MS * 5);
     } finally {
       server.stop(true);
     }
   });
 
-  test("a normal response is read in full and the deadline does not fire", async () => {
+  test("a normal response is read in full and the deadline is disarmed", async () => {
     const server = Bun.serve({
       port: 0,
       fetch: () => new Response("hello", { headers: { "content-type": "text/plain" } }),
     });
+    let signal: AbortSignal | undefined;
     try {
       const body = await withRequestDeadline(
-        5_000,
-        (signal) => fetch(`http://localhost:${server.port}/`, { signal }),
+        DEADLINE_MS,
+        (s) => {
+          signal = s;
+          return fetch(`http://localhost:${server.port}/`, { signal: s });
+        },
         (response) => response.text(),
       );
       expect(body).toBe("hello");
+
+      // Wait out the deadline. Still un-aborted ⇒ the timer was cleared;
+      // without the clearTimeout this flips to true here.
+      await Bun.sleep(DEADLINE_MS * 2);
+      expect(signal?.aborted).toBe(false);
     } finally {
       server.stop(true);
     }
@@ -98,12 +118,13 @@ describe("safeFetchWithDeadline (#1699)", () => {
       const read = safeFetchWithDeadline(
         `http://localhost:${server.port}/`,
         { headers: { "User-Agent": "squirrel-test" } },
-        300,
+        DEADLINE_MS,
         (response) => response.text(),
       );
-      expect(read).rejects.toThrow();
-      await read.catch(() => {});
-      expect(Date.now() - startedAt).toBeLessThan(5_000);
+      await expect(read).rejects.toThrow();
+      const elapsed = Date.now() - startedAt;
+      expect(elapsed).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+      expect(elapsed).toBeLessThan(DEADLINE_MS * 5);
     } finally {
       server.stop(true);
     }

--- a/packages/crawler/tests/deadline.test.ts
+++ b/packages/crawler/tests/deadline.test.ts
@@ -60,14 +60,16 @@ describe("withRequestDeadline (#1699)", () => {
     }
   });
 
-  test("the deadline covers work `use` does after the headers, not just the fetch", async () => {
+  test("the signal is still armed while `use` runs, so a consumer can observe the expiry", async () => {
     const server = Bun.serve({
       port: 0,
       idleTimeout: 0,
       fetch: () => new Response("body", { headers: { "content-type": "text/plain" } }),
     });
     try {
-      // `use` observes an already-armed signal, so a slow consumer is bounded too.
+      // The deadline aborts the REQUEST, which is what unblocks a stalled body
+      // read; it does not preempt unrelated work `use` chooses to do. What this
+      // asserts is that the signal has not been disarmed by the time `use` runs.
       const aborted = await withRequestDeadline(
         200,
         (signal) => fetch(`http://localhost:${server.port}/`, { signal }).then((r) => {

--- a/packages/crawler/tests/deadline.test.ts
+++ b/packages/crawler/tests/deadline.test.ts
@@ -1,0 +1,109 @@
+// #1699 — a request deadline must cover the BODY read, not just the headers.
+// The `fetch(...).finally(() => clearTimeout(t))` shape these helpers used to
+// share disarmed the abort the moment the headers landed, so an origin that
+// answered 200 and then stalled its body hung the caller forever.
+
+import { describe, expect, test } from "bun:test";
+
+import { safeFetchWithDeadline, withRequestDeadline } from "../src/deadline";
+
+// Serves headers immediately, then holds the body stream open forever.
+function serveStalledBody() {
+  return Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch() {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("<!doctype html>"));
+          // Never closed: the client is what has to give up.
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/html" } });
+    },
+  });
+}
+
+describe("withRequestDeadline (#1699)", () => {
+  test("a body that stalls after the headers aborts at the deadline", async () => {
+    const server = serveStalledBody();
+    const startedAt = Date.now();
+    try {
+      const read = withRequestDeadline(
+        300,
+        (signal) => fetch(`http://localhost:${server.port}/`, { signal }),
+        (response) => response.text(),
+      );
+      expect(read).rejects.toThrow();
+      await read.catch(() => {});
+      // Bounded by the deadline, not by the origin eventually relenting.
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a normal response is read in full and the deadline does not fire", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("hello", { headers: { "content-type": "text/plain" } }),
+    });
+    try {
+      const body = await withRequestDeadline(
+        5_000,
+        (signal) => fetch(`http://localhost:${server.port}/`, { signal }),
+        (response) => response.text(),
+      );
+      expect(body).toBe("hello");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("the deadline covers work `use` does after the headers, not just the fetch", async () => {
+    const server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch: () => new Response("body", { headers: { "content-type": "text/plain" } }),
+    });
+    try {
+      // `use` observes an already-armed signal, so a slow consumer is bounded too.
+      const aborted = await withRequestDeadline(
+        200,
+        (signal) => fetch(`http://localhost:${server.port}/`, { signal }).then((r) => {
+          // Stash the signal the way a real consumer would observe it.
+          (r as Response & { signal?: AbortSignal }).signal = signal;
+          return r;
+        }),
+        async (response) => {
+          const signal = (response as Response & { signal?: AbortSignal }).signal;
+          await Bun.sleep(500);
+          return signal?.aborted ?? false;
+        },
+      );
+      expect(aborted).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+describe("safeFetchWithDeadline (#1699)", () => {
+  test("propagates the deadline through safeRedirectFetch into the body read", async () => {
+    const server = serveStalledBody();
+    const startedAt = Date.now();
+    try {
+      const read = safeFetchWithDeadline(
+        `http://localhost:${server.port}/`,
+        { headers: { "User-Agent": "squirrel-test" } },
+        300,
+        (response) => response.text(),
+      );
+      expect(read).rejects.toThrow();
+      await read.catch(() => {});
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/packages/crawler/tests/slow-origin-crawl.test.ts
+++ b/packages/crawler/tests/slow-origin-crawl.test.ts
@@ -1,0 +1,165 @@
+// #1699 — a slow origin must not wedge the crawl before it starts.
+//
+// `start()` resolves the seed's redirects before it emits `started`, and that
+// probe's abort deadline used to be cleared as soon as the response HEADERS
+// arrived, leaving the body read unbounded. An origin that answered 200 and
+// then stalled or trickled its body parked `start()` there forever, so no
+// `started` event ever reached the caller — which is exactly the condition the
+// cloud runner reports as "Crawl phase wedged before any pages were collected".
+//
+// Every test here fails by TIMING OUT against the pre-fix crawler, not by
+// asserting a wrong value.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect, Stream } from "effect";
+
+import { createCrawler } from "../src/core/crawler";
+import type { CrawlerConfig, CrawlerEvent } from "../src/core/types";
+
+const PAGE = `<!doctype html><html><head><title>t</title></head><body>
+<a href="/one">one</a><a href="/two">two</a></body></html>`;
+
+// Short per-request timeout so the seed probe's deadline (min(10s, timeoutMs))
+// is a few hundred ms — the same code path production runs at 10s.
+const CONFIG: Partial<CrawlerConfig> = {
+  maxPages: 3,
+  concurrency: 2,
+  perHostConcurrency: 2,
+  delayMs: 0,
+  perHostDelayMs: 0,
+  timeoutMs: 500,
+  userAgent: "squirrel-test",
+  respectRobots: false,
+  incremental: false,
+  useCacheControl: false,
+  breadthFirst: false,
+  coverageMode: "full",
+};
+
+const servers: Array<{ stop: (closeActive?: boolean) => void }> = [];
+afterEach(() => {
+  for (const s of servers.splice(0)) s.stop(true);
+});
+
+function serve(handler: (req: Request) => Response | Promise<Response>) {
+  // idleTimeout: 0 — the server must never be the thing that gives up, or the
+  // test would pass on the pre-fix crawler too.
+  const server = Bun.serve({ port: 0, idleTimeout: 0, fetch: handler });
+  servers.push(server);
+  // Trailing slash matters: seeded without it, `response.url` comes back
+  // normalized, the seed probe reads that as a redirect and moves to the next
+  // hop WITHOUT touching the body — which would skip the very read under test.
+  return `http://localhost:${server.port}/`;
+}
+
+function htmlResponse(body = PAGE) {
+  return new Response(body, { headers: { "content-type": "text/html" } });
+}
+
+// 200 headers, then a body stream that is never closed.
+function stalledBodyResponse() {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("<!doctype html><html><body>"));
+      },
+    }),
+    { headers: { "content-type": "text/html" } },
+  );
+}
+
+interface CrawlOutcome {
+  startedAfterMs: number | undefined;
+  pages: number;
+  totalMs: number;
+}
+
+async function crawl(origin: string, config = CONFIG): Promise<CrawlOutcome> {
+  const startedAt = Date.now();
+  const crawler = await Effect.runPromise(createCrawler({ config }));
+
+  let startedAfterMs: number | undefined;
+  Effect.runFork(
+    Stream.runForEach(crawler.events, (event: CrawlerEvent) =>
+      Effect.sync(() => {
+        if (event.type === "started") startedAfterMs = Date.now() - startedAt;
+      }),
+    ),
+  );
+
+  const crawlId = await Effect.runPromise(crawler.start(origin, origin));
+  const pages = await Effect.runPromise(crawler.storage.getPages(crawlId));
+  return { startedAfterMs, pages: pages.length, totalMs: Date.now() - startedAt };
+}
+
+describe("slow origin does not wedge the crawl (#1699)", () => {
+  test("a root whose body stalls after the headers still starts and collects pages", async () => {
+    let rootHits = 0;
+    const origin = serve((req) => {
+      const path = new URL(req.url).pathname;
+      if (path === "/robots.txt") {
+        return new Response("", { headers: { "content-type": "text/plain" } });
+      }
+      // Only the seed probe (the first hit on the root) stalls; the crawl's own
+      // fetch of the root afterwards is healthy, so a crawl that gets past the
+      // probe has real pages to collect.
+      if (path === "/" && ++rootHits === 1) return stalledBodyResponse();
+      return htmlResponse();
+    });
+
+    const out = await crawl(origin);
+
+    expect(out.startedAfterMs).toBeDefined();
+    // The probe gave up at its deadline instead of hanging on the body.
+    expect(out.startedAfterMs!).toBeLessThan(5_000);
+    expect(out.pages).toBeGreaterThan(0);
+  });
+
+  test("a root that trickles its body forever is bounded the same way", async () => {
+    let rootHits = 0;
+    const origin = serve((req) => {
+      const path = new URL(req.url).pathname;
+      if (path === "/robots.txt") {
+        return new Response("", { headers: { "content-type": "text/plain" } });
+      }
+      if (path === "/" && ++rootHits === 1) {
+        // A byte every 50ms, forever: never idle, so only a real time bound
+        // ends it. `readBodyCapped`'s BYTE cap cannot.
+        return new Response(
+          new ReadableStream({
+            async pull(controller) {
+              await Bun.sleep(50);
+              controller.enqueue(new TextEncoder().encode("<!-- x -->"));
+            },
+          }),
+          { headers: { "content-type": "text/html" } },
+        );
+      }
+      return htmlResponse();
+    });
+
+    const out = await crawl(origin);
+
+    expect(out.startedAfterMs).toBeDefined();
+    expect(out.startedAfterMs!).toBeLessThan(5_000);
+    expect(out.pages).toBeGreaterThan(0);
+  });
+
+  test("an origin that is slow on every response still collects pages", async () => {
+    // Proportionally what daigo.ru looks like: a delay on every single response,
+    // including all ~38 root probes the preamble issues before the first page.
+    const origin = serve(async (req) => {
+      await Bun.sleep(120);
+      const path = new URL(req.url).pathname;
+      if (path === "/robots.txt") {
+        return new Response("", { headers: { "content-type": "text/plain" } });
+      }
+      return htmlResponse();
+    });
+
+    const out = await crawl(origin, { ...CONFIG, timeoutMs: 5_000 });
+
+    expect(out.startedAfterMs).toBeDefined();
+    expect(out.pages).toBeGreaterThan(0);
+  });
+});

--- a/packages/crawler/tests/slow-origin-crawl.test.ts
+++ b/packages/crawler/tests/slow-origin-crawl.test.ts
@@ -192,4 +192,48 @@ describe("slow origin does not wedge the crawl (#1699)", () => {
 
     expect(resolved).toBe(`${origin}second`);
   });
+
+  test("a client-redirect target that never serves headers is not adopted", async () => {
+    // The mirror of the test above, and the reason the fallback cannot simply
+    // be `currentUrl`: /dead is a page-supplied meta-refresh target that never
+    // responded at all. Handing it back would let a meta-refresh reroute the
+    // crawl's base to a URL that was never reachable.
+    const origin = serve(async (req) => {
+      const path = new URL(req.url).pathname;
+      if (path === "/dead") await new Promise(() => {});
+      return htmlResponse(
+        `<!doctype html><html><head><meta http-equiv="refresh" content="0; url=/dead"></head><body>x</body></html>`,
+      );
+    });
+
+    const crawler = await Effect.runPromise(createCrawler({ config: CONFIG }));
+    const resolved = await Effect.runPromise(crawler.detectRedirects(origin));
+
+    expect(resolved).toBe(origin);
+  });
+
+  test("the chain budget stops a redirect chain short of MAX_REDIRECTS hops", async () => {
+    // Each hop is individually inside its per-hop deadline, so only a
+    // whole-chain budget can end this early. Without one, all 10 hops run.
+    const HOP_DELAY_MS = 300;
+    let hits = 0;
+    const origin = serve(async (req) => {
+      hits++;
+      await Bun.sleep(HOP_DELAY_MS);
+      const n = Number(new URL(req.url).pathname.replace("/m", "")) || 0;
+      return htmlResponse(
+        `<!doctype html><html><head><meta http-equiv="refresh" content="0; url=/m${n + 1}"></head><body>x</body></html>`,
+      );
+    });
+
+    // hop deadline 600ms (> HOP_DELAY_MS, so no hop times out on its own);
+    // chain budget = 3 × 600ms = 1800ms, i.e. ~6 hops of 300ms.
+    const crawler = await Effect.runPromise(
+      createCrawler({ config: { ...CONFIG, timeoutMs: 600 } }),
+    );
+    await Effect.runPromise(crawler.detectRedirects(`${origin}m0`));
+
+    expect(hits).toBeGreaterThan(1);
+    expect(hits).toBeLessThan(10);
+  });
 });

--- a/packages/crawler/tests/slow-origin-crawl.test.ts
+++ b/packages/crawler/tests/slow-origin-crawl.test.ts
@@ -7,11 +7,13 @@
 // `started` event ever reached the caller — which is exactly the condition the
 // cloud runner reports as "Crawl phase wedged before any pages were collected".
 //
-// Every test here fails by TIMING OUT against the pre-fix crawler, not by
-// asserting a wrong value.
+// The two stalled-body tests fail against the pre-fix crawler by TIMING OUT,
+// not by asserting a wrong value. The slow-on-every-response test is a guard
+// rather than a reproduction: plain latency never wedged the crawl, only an
+// unbounded body read did, and that distinction is the root cause.
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { Effect, Stream } from "effect";
+import { Effect, Fiber, Stream } from "effect";
 
 import { createCrawler } from "../src/core/crawler";
 import type { CrawlerConfig, CrawlerEvent } from "../src/core/types";
@@ -79,7 +81,9 @@ async function crawl(origin: string, config = CONFIG): Promise<CrawlOutcome> {
   const crawler = await Effect.runPromise(createCrawler({ config }));
 
   let startedAfterMs: number | undefined;
-  Effect.runFork(
+  // `Stream.fromPubSub` never completes on its own, so this fiber has to be
+  // interrupted or it outlives the test.
+  const events = Effect.runFork(
     Stream.runForEach(crawler.events, (event: CrawlerEvent) =>
       Effect.sync(() => {
         if (event.type === "started") startedAfterMs = Date.now() - startedAt;
@@ -87,9 +91,13 @@ async function crawl(origin: string, config = CONFIG): Promise<CrawlOutcome> {
     ),
   );
 
-  const crawlId = await Effect.runPromise(crawler.start(origin, origin));
-  const pages = await Effect.runPromise(crawler.storage.getPages(crawlId));
-  return { startedAfterMs, pages: pages.length, totalMs: Date.now() - startedAt };
+  try {
+    const crawlId = await Effect.runPromise(crawler.start(origin, origin));
+    const pages = await Effect.runPromise(crawler.storage.getPages(crawlId));
+    return { startedAfterMs, pages: pages.length, totalMs: Date.now() - startedAt };
+  } finally {
+    await Effect.runPromise(Fiber.interrupt(events));
+  }
 }
 
 describe("slow origin does not wedge the crawl (#1699)", () => {
@@ -161,5 +169,27 @@ describe("slow origin does not wedge the crawl (#1699)", () => {
 
     expect(out.startedAfterMs).toBeDefined();
     expect(out.pages).toBeGreaterThan(0);
+  });
+
+  test("a hop that serves headers and then stalls still counts as resolved", async () => {
+    // The seed meta-refreshes to /second, whose headers arrive before its body
+    // stalls. /second demonstrably serves, so it — not the seed — is what the
+    // probe resolves to. Banking the URL only after the body read would throw
+    // that away and hand the crawl back the pre-redirect seed.
+    const origin = serve((req) => {
+      const path = new URL(req.url).pathname;
+      if (path === "/") {
+        return htmlResponse(
+          `<!doctype html><html><head><meta http-equiv="refresh" content="0; url=/second"></head><body>x</body></html>`,
+        );
+      }
+      if (path === "/second") return stalledBodyResponse();
+      return htmlResponse();
+    });
+
+    const crawler = await Effect.runPromise(createCrawler({ config: CONFIG }));
+    const resolved = await Effect.runPromise(crawler.detectRedirects(origin));
+
+    expect(resolved).toBe(`${origin}second`);
   });
 });


### PR DESCRIPTION
## The bug

A crawl of a slow origin could park forever before it emitted its `started` event, so the caller saw a crawl that never began rather than one that ran out of time.

Every fetch in the crawl preamble armed an `AbortController` deadline and cleared it in `.finally()` on the *fetch* promise — which settles the moment the response **headers** arrive. The body was read afterwards by `readBodyCapped`, which caps **bytes**, not seconds, and holds no live abort signal. An origin that answers `200` promptly and then trickles or stalls its body hung there indefinitely.

The pre-`started` instance is the seed's `detectRedirects` probe, the only network call ahead of the `started` event. That is the discriminator: a hang anywhere later finalizes with whatever pages exist, while a hang here looks like a crawl that never started.

Isolated against a synthetic Bun origin (`idleTimeout: 0`, so the client is what has to give up):

| root stalls | result |
|---|---|
| **before** it sends headers | deadline fires, `started` emitted at 10.17s, crawl proceeds |
| **after** it sends headers (the body) | no `started` event at all; `start()` still hung when the harness gave up at 45s |

Row one proves the deadline works for headers; row two proves it is already disarmed by the time the body is read.

## The fix

- New `packages/crawler/src/deadline.ts`: `withRequestDeadline` holds the timer across the body read, and `safeFetchWithDeadline` is that over `safeRedirectFetch` for the root probes. All eight sites that had the broken shape now route through it — `core/crawler.ts`, `robots.ts`, `llms.ts`, `markdown.ts`, `well-known.ts`, `agent-access.ts`, `rsl.ts`, `sitemaps.ts`. (The page fetcher in `packages/fetchers` already used the correct `try/finally` shape and is untouched.)
- `detectRedirects` gains a whole-chain wall-clock budget, so ten individually bounded hops cannot accumulate past the crawl-phase setup slack, and honors the crawl's configured `timeoutMs` when it is tighter than the 10s ceiling (the 30s default leaves prod behavior unchanged).
- `detectRedirects` now falls back to the last URL that actually served a response, banked as soon as its headers land, instead of to an unfetched client-redirect target. A meta-refresh can no longer reroute the seed on the strength of a later timeout.
- Paths that inspect only the headers now cancel the body instead of leaving the response half-consumed.

## Tests

`packages/crawler/tests/deadline.test.ts` covers the helper directly. `packages/crawler/tests/slow-origin-crawl.test.ts` drives a Bun origin whose root answers 200 and then stalls (and a second that trickles a byte every 50ms forever, which no byte cap can end), plus an origin that is slow on every single response, plus the served-URL semantics above.

Verified the regression tests fail against the pre-fix crawler: both stalled-body tests time out at 25s on `origin/main`, and the served-URL test returns the pre-redirect seed. Suites: crawler 264 pass, `apps/cli` 1889 pass, `audit-engine` golden 63 pass; `tsgo --noEmit` clean for crawler, audit-engine and cli.

Fixes the crawl wedge tracked in https://github.com/squirrelscan/repo/issues/1699 (root-cause write-up posted there).


Also covered: a client-redirect target that never serves headers (the case that distinguishes the settled-URL fallback from returning `currentUrl`), and a redirect chain the whole-chain budget must stop short of `MAX_REDIRECTS`. Every new assertion was mutation-checked — reverting the behavior it covers makes it fail.

## Scope note

The crawl preamble still has no budget *as a whole*: its stages are sequential with fixed per-probe deadlines, so an origin whose root-probe paths answer 200 and then stall their bodies burns **150.3s measured** before the first page, against a 120s crawl-phase floor plus 30s grace. That is tracked separately in https://github.com/squirrelscan/repo/issues/1733 (P2) rather than fixed here: a shared budget trades AX data completeness on slow-but-healthy origins for phase bounding, which is a product call, and the structurally correct version (`stop()` aborting in-flight preamble requests) means threading an AbortSignal through all seven probe modules. The per-request deadlines in this PR are the precondition for either.
