### PR TITLE
feat(plans): free plan schedules one website weekly

### DIFF
--- a/apps/cli/src/lib/upgrade.ts
+++ b/apps/cli/src/lib/upgrade.ts
@@ -49,7 +49,7 @@ export function proPitchLines(
 ): string[] {
   return [
     `  ${fmt.bold(PRO_HEADLINE)}`,
-    `  ${fmt.dim(`Also unlocks scheduled audits, faster crawls, and up to ${n(PRO.maxPagesPerAudit)} pages per audit.`)}`,
+    `  ${fmt.dim(`Also unlocks daily audits on every site, faster crawls, and up to ${n(PRO.maxPagesPerAudit)} pages per audit.`)}`,
     `  Upgrade: ${fmt.cyan(upgradeUrl(src))}`,
   ];
 }

--- a/docs/cli/credits.mdx
+++ b/docs/cli/credits.mdx
@@ -53,7 +53,7 @@ On the free plan the output ends with the Pro offer instead:
 
 ```text
   Pro: $19/month (or $190/year) for 3,000 credits a month
-  Also unlocks scheduled audits, custom request headers, and up to 2,000 pages per audit.
+  Also unlocks daily audits on every site, faster crawls, and up to 2,000 pages per audit.
   Upgrade: https://squirrelscan.com/upgrade?src=cli-credits
   Or run `squirrel credits --upgrade`.
 ```

--- a/docs/cloud/credits.mdx
+++ b/docs/cloud/credits.mdx
@@ -19,7 +19,7 @@ Annual billing is 12 months for the price of 10. Your monthly credits still arri
 
 Monthly credits are spent before purchased top-up credits. Subscribe and top up from the **Billing & Credits** page in the [dashboard](/dashboard).
 
-Free, Pro, and Team run the **same** audit at the same price: the base charge includes every cloud service (AI analysis, editor's summary, blocking check, tech + site metadata, domain stats, dead-link checking, report publishing) on every plan. Pro and Team just grant more monthly credits and unlock top-ups, [daily schedules on every website](/cloud/scheduled-audits) (free schedules one website, weekly), custom headers, and higher render concurrency - Team adds pooled credits, invites, and roles on top.
+Free, Pro, and Team run the **same** audit at the same price: the base charge includes every cloud service (AI analysis, editor's summary, blocking check, tech + site metadata, domain stats, dead-link checking, report publishing) on every plan. [Scheduled audits](/cloud/scheduled-audits) are on every plan: free re-audits one website weekly or monthly, Pro and Team re-audit every website daily. Pro and Team just grant more monthly credits and unlock top-ups, that daily cadence and extra scheduled sites, custom headers, and higher render concurrency - Team adds pooled credits, invites, and roles on top.
 
 ### Max pages per cloud audit
 

--- a/docs/cloud/credits.mdx
+++ b/docs/cloud/credits.mdx
@@ -19,7 +19,7 @@ Annual billing is 12 months for the price of 10. Your monthly credits still arri
 
 Monthly credits are spent before purchased top-up credits. Subscribe and top up from the **Billing & Credits** page in the [dashboard](/dashboard).
 
-Free, Pro, and Team run the **same** audit at the same price: the base charge includes every cloud service (AI analysis, editor's summary, blocking check, tech + site metadata, domain stats, dead-link checking, report publishing) on every plan. Pro and Team just grant more monthly credits and unlock top-ups, scheduled crawls, custom headers, and higher render concurrency - Team adds pooled credits, invites, and roles on top.
+Free, Pro, and Team run the **same** audit at the same price: the base charge includes every cloud service (AI analysis, editor's summary, blocking check, tech + site metadata, domain stats, dead-link checking, report publishing) on every plan. Pro and Team just grant more monthly credits and unlock top-ups, [daily schedules on every website](/cloud/scheduled-audits) (free schedules one website, weekly), custom headers, and higher render concurrency - Team adds pooled credits, invites, and roles on top.
 
 ### Max pages per cloud audit
 

--- a/docs/cloud/scheduled-audits.mdx
+++ b/docs/cloud/scheduled-audits.mdx
@@ -7,8 +7,19 @@ icon: "calendar-clock"
 Scheduled audits re-run a full cloud audit of a website on a fixed cadence - **daily, weekly, or monthly** - with no manual trigger. Each run lands in the [dashboard](/dashboard) alongside your on-demand audits, so you can track score changes and catch regressions over time.
 
 <Note>
-  Scheduled audits are a **Pro** feature. On the free plan the schedule is shown as an upgrade prompt; new free websites are not scheduled.
+  Every plan can schedule audits. **Free** runs one website on a weekly (or monthly) cadence. **Pro** and **Team** add daily runs and put every website on a schedule.
 </Note>
+
+## What each plan can schedule
+
+| | Free | Pro / Team |
+| --- | --- | --- |
+| Websites on a schedule | 1 | Every website |
+| Cadences | Weekly, Monthly | Daily, Weekly, Monthly |
+
+On the free plan, picking a cadence for a second website asks you to upgrade, and choosing **Daily** saves as **Weekly** with a notice. Which website gets the free schedule is your choice: turn the first one off and any other can take the slot.
+
+A weekly audit spends roughly half the free plan's monthly [credit](/cloud/credits) grant, which is why daily is a paid cadence: four runs a week would exhaust the grant in days.
 
 ## Setting a schedule
 
@@ -18,7 +29,7 @@ Schedules are managed from the dashboard, per website:
 2. Use the **Scheduled Audits** card on the website overview (or go to **Settings → Schedule**).
 3. Pick a cadence - **Daily**, **Weekly**, **Monthly**, or **Disabled**.
 
-Scheduling is **off by default** for new websites on every plan, including Pro. Recurring audits are always opt-in: pick a cadence here whenever you want one, and change or disable it at any time.
+A newly added website starts on a **weekly** schedule when your plan still has a free slot for it, and you are notified in the dashboard when that happens. On the free plan that means your first website; the next one you add starts unscheduled until you free the slot or upgrade. Change the cadence or turn a schedule off at any time from this card.
 
 ## How runs behave
 

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -1389,8 +1389,17 @@ export interface PlanDefinition {
    * second site is the upgrade. The cap counts ENABLED schedules, not
    * websites — a free org may register as many sites as the hidden
    * `maxWebsites` abuse cap allows and choose which single one recurs.
+   *
+   * OPTIONAL on purpose, like `balance.unlimited` above and for the same
+   * reason: a `PlanDefinition` does not only come from `PLANS`, it also arrives
+   * over the wire as `CreditsResponse.plan`, which cloud-client hands back as a
+   * plain-JSON cast. That cast is additive-safe but NOT subtractive-safe, so a
+   * CLI built against this file and talking to an older (or rolled-back) server
+   * would hold a type promising a field that is simply absent at runtime.
+   * Never read it directly — go through `resolvePlanScheduleLimits`, which
+   * degrades an absent value to the free tier's limits rather than `undefined`.
    */
-  maxScheduledWebsites: number;
+  maxScheduledWebsites?: number;
   /**
    * Cadences this plan may schedule at, as a subset of `SCHEDULE_FREQUENCIES`.
    *
@@ -1399,8 +1408,13 @@ export interface PlanDefinition {
    * the per-audit page ceiling uses. Free omits `daily` (#1704): a daily audit
    * would exhaust the 500-credit monthly grant in a week, so weekly is the
    * cadence the grant actually funds and daily is the upgrade.
+   *
+   * OPTIONAL for the same version-skew reason as `maxScheduledWebsites` above,
+   * and with the same rule: read it through `resolvePlanScheduleLimits`, never
+   * directly. An absent list degrading to `undefined` would turn every
+   * `.includes(...)` on a stale server's response into a crash.
    */
-  scheduleFrequencies: readonly ScheduledAuditFrequency[];
+  scheduleFrequencies?: readonly ScheduledAuditFrequency[];
   /**
    * Raw per-plan cloud-audit page ceiling (#1020 ladder: Free 500 / Pro
    * 2,000 / Team 5,000). This is the plan's OWN allowance, not the effective

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -1347,6 +1347,13 @@ export type OrgRole = "owner" | "admin" | "editor" | "viewer" | "billing";
  * price of 10 — credits are still granted MONTHLY (see credits:annual-monthly-grant). */
 export type BillingInterval = "month" | "year";
 
+/**
+ * Cadence a website's recurring audit runs at. `SCHEDULE_FREQUENCIES` (plans.ts)
+ * orders these most → least frequent, which is what makes "clamp a request the
+ * plan does not allow down to the nearest one it does" a total function.
+ */
+export type ScheduledAuditFrequency = "daily" | "weekly" | "monthly";
+
 export interface PlanDefinition {
   id: PlanId;
   name: string;
@@ -1364,11 +1371,36 @@ export interface PlanDefinition {
    */
   renderConcurrency: number;
   /**
-   * Recurring scheduled audits (daily/weekly/monthly). Paid-plan upsell:
-   * free orgs default to disabled and cannot enable; the `audit:scheduled`
-   * handler skips any schedule whose org lacks this capability.
+   * Recurring scheduled audits at all. The `audit:scheduled` handler skips —
+   * and switches OFF — any schedule whose org lacks this, so it is the kill
+   * switch for the whole capability, not a tier marker.
+   *
+   * Every plan carries it since #1704: the free tier's differentiator is now
+   * CADENCE and BREADTH (`scheduleFrequencies` / `maxScheduledWebsites`), not
+   * access. Never gate an upsell on this flag alone — a free org has it too;
+   * gate on the two limits below.
    */
   scheduledCrawls: boolean;
+  /**
+   * How many websites in one org may have an ENABLED recurring audit schedule
+   * at the same time. `-1` = uncapped (same sentinel as maxWebsites/maxMembers).
+   *
+   * Free is 1 (#1704): one weekly audit is the tier's recurring value, and a
+   * second site is the upgrade. The cap counts ENABLED schedules, not
+   * websites — a free org may register as many sites as the hidden
+   * `maxWebsites` abuse cap allows and choose which single one recurs.
+   */
+  maxScheduledWebsites: number;
+  /**
+   * Cadences this plan may schedule at, as a subset of `SCHEDULE_FREQUENCIES`.
+   *
+   * A request outside the list is CLAMPED down to the nearest allowed cadence
+   * (`clampScheduleFrequency`), never rejected — the same clamp-and-notify rule
+   * the per-audit page ceiling uses. Free omits `daily` (#1704): a daily audit
+   * would exhaust the 500-credit monthly grant in a week, so weekly is the
+   * cadence the grant actually funds and daily is the upgrade.
+   */
+  scheduleFrequencies: readonly ScheduledAuditFrequency[];
   /**
    * Raw per-plan cloud-audit page ceiling (#1020 ladder: Free 500 / Pro
    * 2,000 / Team 5,000). This is the plan's OWN allowance, not the effective

--- a/packages/core-contracts/src/plans.ts
+++ b/packages/core-contracts/src/plans.ts
@@ -231,6 +231,24 @@ export function scheduledWebsiteCapReached(planId: string, count: number): boole
   return cap >= 0 && count >= cap;
 }
 
+/**
+ * What this plan schedules, in one line: "Weekly, 1 site" / "Daily, all sites".
+ *
+ * Lives HERE, not next to the tables that render it, because there are two of
+ * them in two different apps (the marketing pricing grid and the in-dashboard
+ * plan comparison). Both derive the cell from the plan's own limits so a change
+ * in `PLANS` cannot leave them lying — which only holds while the derivation is
+ * one function rather than two copies free to drift from each other.
+ */
+export function planScheduleSummary(planId: string): string {
+  const plan = getPlan(planId);
+  if (!plan.scheduledCrawls) return "—";
+  const cadence = plan.scheduleFrequencies.includes("daily") ? "Daily" : "Weekly";
+  const cap = plan.maxScheduledWebsites;
+  const sites = cap < 0 ? "all sites" : `${cap} site${cap === 1 ? "" : "s"}`;
+  return `${cadence}, ${sites}`;
+}
+
 export function planAllowsScheduleFrequency(
   planId: string,
   frequency: ScheduledAuditFrequency,

--- a/packages/core-contracts/src/plans.ts
+++ b/packages/core-contracts/src/plans.ts
@@ -216,13 +216,58 @@ export function planAtLeast(planId: string, floor: PlanId): boolean {
 }
 
 /**
+ * What a plan whose scheduling limits we cannot read is treated as. Spelled out
+ * rather than pointing at `PLANS.free` so the free tier's marketed limits can
+ * change without silently moving what "unknown" means.
+ */
+const FALLBACK_SCHEDULE_LIMITS: {
+  maxScheduledWebsites: number;
+  scheduleFrequencies: readonly ScheduledAuditFrequency[];
+} = {
+  maxScheduledWebsites: 1,
+  scheduleFrequencies: ["weekly", "monthly"],
+};
+
+/**
+ * The scheduling limits of a plan OBJECT, with a conservative stand-in for
+ * anything the object does not carry.
+ *
+ * The single reader of `maxScheduledWebsites` / `scheduleFrequencies`, and the
+ * reason both are optional on `PlanDefinition`. A plan does not only come from
+ * `PLANS`: it also arrives as `CreditsResponse.plan`, which cloud-client hands
+ * back as a plain-JSON cast — additive-safe, NOT subtractive-safe. A CLI built
+ * against a core-contracts that has these fields, talking to a server that
+ * predates them (or has been rolled back), holds a type promising values that
+ * are absent at runtime; reading them directly turns that into
+ * `undefined.includes(...)` at the first schedule check.
+ *
+ * The fallback is the FREE tier's limits, never a permissive one: a plan we
+ * cannot fully read must degrade to the least entitlement rather than silently
+ * granting daily audits on every site.
+ */
+export function resolvePlanScheduleLimits(
+  plan: Pick<PlanDefinition, "maxScheduledWebsites" | "scheduleFrequencies"> | null | undefined,
+): { maxScheduledWebsites: number; scheduleFrequencies: readonly ScheduledAuditFrequency[] } {
+  return {
+    maxScheduledWebsites:
+      plan?.maxScheduledWebsites ?? FALLBACK_SCHEDULE_LIMITS.maxScheduledWebsites,
+    scheduleFrequencies: plan?.scheduleFrequencies ?? FALLBACK_SCHEDULE_LIMITS.scheduleFrequencies,
+  };
+}
+
+/**
  * How many websites in one org may have an enabled recurring audit schedule.
  * `-1` = uncapped. Accepts a raw string (DB columns are plain text); an unknown
  * id resolves to free, i.e. the TIGHTEST cap — a plan we cannot identify must
  * never buy more recurring spend than the free tier.
  */
 export function planMaxScheduledWebsites(planId: string): number {
-  return getPlan(planId).maxScheduledWebsites;
+  return resolvePlanScheduleLimits(getPlan(planId)).maxScheduledWebsites;
+}
+
+/** The cadences a plan funds, most frequent first. Never undefined. */
+export function planScheduleFrequencies(planId: string): readonly ScheduledAuditFrequency[] {
+  return resolvePlanScheduleLimits(getPlan(planId)).scheduleFrequencies;
 }
 
 /** True when `count` scheduled websites is at or over the plan's cap. Uncapped (-1) is never full. */
@@ -239,21 +284,36 @@ export function scheduledWebsiteCapReached(planId: string, count: number): boole
  * plan comparison). Both derive the cell from the plan's own limits so a change
  * in `PLANS` cannot leave them lying — which only holds while the derivation is
  * one function rather than two copies free to drift from each other.
+ *
+ * The cadence is the most frequent one the plan ACTUALLY funds, read off the
+ * ordered list rather than tested for `daily`: a monthly-only plan is valid
+ * under the type, and asking "is daily in there?" would have labelled it
+ * "Weekly" — a cadence it does not run.
  */
 export function planScheduleSummary(planId: string): string {
   const plan = getPlan(planId);
-  if (!plan.scheduledCrawls) return "—";
-  const cadence = plan.scheduleFrequencies.includes("daily") ? "Daily" : "Weekly";
-  const cap = plan.maxScheduledWebsites;
+  const { maxScheduledWebsites: cap, scheduleFrequencies } = resolvePlanScheduleLimits(plan);
+  const cadence = SCHEDULE_FREQUENCIES.find((f) => scheduleFrequencies.includes(f));
+  // No cadence, or no slots, is the same product answer as no capability: this
+  // plan does not schedule. Plain words rather than a dash — the cell is public
+  // copy sitting beside real values in the same column.
+  if (!plan.scheduledCrawls || !cadence || cap === 0) return "Not included";
   const sites = cap < 0 ? "all sites" : `${cap} site${cap === 1 ? "" : "s"}`;
-  return `${cadence}, ${sites}`;
+  return `${SCHEDULE_LABEL[cadence]}, ${sites}`;
 }
+
+/** Sentence-cased cadence label for the pricing surfaces. */
+const SCHEDULE_LABEL: Record<ScheduledAuditFrequency, string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+  monthly: "Monthly",
+};
 
 export function planAllowsScheduleFrequency(
   planId: string,
   frequency: ScheduledAuditFrequency,
 ): boolean {
-  return getPlan(planId).scheduleFrequencies.includes(frequency);
+  return planScheduleFrequencies(planId).includes(frequency);
 }
 
 /**
@@ -271,7 +331,7 @@ export function clampScheduleFrequency(
   planId: string,
   requested: ScheduledAuditFrequency,
 ): ScheduledAuditFrequency {
-  const allowed = getPlan(planId).scheduleFrequencies;
+  const allowed = planScheduleFrequencies(planId);
   if (allowed.includes(requested)) return requested;
   const at = SCHEDULE_FREQUENCIES.indexOf(requested);
   for (let i = at + 1; i < SCHEDULE_FREQUENCIES.length; i++) {

--- a/packages/core-contracts/src/plans.ts
+++ b/packages/core-contracts/src/plans.ts
@@ -1,4 +1,16 @@
-import type { PlanDefinition, PlanId } from "./index";
+import type { PlanDefinition, PlanId, ScheduledAuditFrequency } from "./index";
+
+/**
+ * Every recurring-audit cadence, ordered MOST → LEAST frequent. The order is
+ * load-bearing: `clampScheduleFrequency` walks it to find the nearest cadence a
+ * plan allows, so a new cadence must be inserted at its true position, not
+ * appended.
+ */
+export const SCHEDULE_FREQUENCIES: readonly ScheduledAuditFrequency[] = [
+  "daily",
+  "weekly",
+  "monthly",
+];
 
 /**
  * #1274 (follow-up to #1020): explicit gate for Team's 5,000-page ladder
@@ -37,7 +49,15 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     maxWebsites: 100,
     maxMembers: 1,
     renderConcurrency: 1,
-    scheduledCrawls: false,
+    // #1704: scheduling is no longer the paid line. A weekly audit of one site
+    // burns roughly 250-300 of the 500 monthly credits above, so the free grant
+    // finally binds while the tier delivers recurring value; Pro's
+    // differentiator is daily cadence and more than one scheduled site.
+    scheduledCrawls: true,
+    maxScheduledWebsites: 1,
+    // No `daily`: 4x weekly's spend does not fit the 500-credit grant. A daily
+    // request is clamped to weekly, not refused.
+    scheduleFrequencies: ["weekly", "monthly"],
     // Free on purpose: custom headers are how you audit a staging site behind
     // auth, which is evaluation, not a paid job.
     customHeaders: true,
@@ -68,6 +88,10 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     maxMembers: 1,
     renderConcurrency: 5,
     scheduledCrawls: true,
+    // Uncapped scheduling is the paid line since #1704: as many scheduled sites
+    // as the org has, at any cadence.
+    maxScheduledWebsites: -1,
+    scheduleFrequencies: SCHEDULE_FREQUENCIES,
     customHeaders: true,
     // #1020 ladder: today's cloud REPORT_LIMITS.maxPages ceiling.
     maxPagesPerAudit: 2000,
@@ -95,6 +119,8 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     maxMembers: -1,
     renderConcurrency: 10,
     scheduledCrawls: true,
+    maxScheduledWebsites: -1,
+    scheduleFrequencies: SCHEDULE_FREQUENCIES,
     customHeaders: true,
     // #1020 ladder: exceeds today's REPORT_LIMITS.maxPages (2,000) on purpose —
     // Hosted plan enforcement clamps to that cap, so this only takes effect
@@ -140,6 +166,8 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     maxMembers: -1,
     renderConcurrency: 10,
     scheduledCrawls: true,
+    maxScheduledWebsites: -1,
+    scheduleFrequencies: SCHEDULE_FREQUENCIES,
     customHeaders: true,
     // NOT subject to TEAM_MAX_PAGES_UNLOCKED — that flag gates Team's ladder
     // step specifically (#1274). Enterprise carries its own allowance, still
@@ -185,6 +213,60 @@ const PLAN_RANK: Record<PlanId, number> = {
  */
 export function planAtLeast(planId: string, floor: PlanId): boolean {
   return (PLAN_RANK[planId as PlanId] ?? 0) >= PLAN_RANK[floor];
+}
+
+/**
+ * How many websites in one org may have an enabled recurring audit schedule.
+ * `-1` = uncapped. Accepts a raw string (DB columns are plain text); an unknown
+ * id resolves to free, i.e. the TIGHTEST cap — a plan we cannot identify must
+ * never buy more recurring spend than the free tier.
+ */
+export function planMaxScheduledWebsites(planId: string): number {
+  return getPlan(planId).maxScheduledWebsites;
+}
+
+/** True when `count` scheduled websites is at or over the plan's cap. Uncapped (-1) is never full. */
+export function scheduledWebsiteCapReached(planId: string, count: number): boolean {
+  const cap = planMaxScheduledWebsites(planId);
+  return cap >= 0 && count >= cap;
+}
+
+export function planAllowsScheduleFrequency(
+  planId: string,
+  frequency: ScheduledAuditFrequency,
+): boolean {
+  return getPlan(planId).scheduleFrequencies.includes(frequency);
+}
+
+/**
+ * The cadence this plan will actually run, given what was asked for.
+ *
+ * Clamp, never reject (the rule `pageLimitClampNotice` already follows for the
+ * page ceiling): a free org asking for `daily` gets `weekly` plus a notice, not
+ * a 4xx — the request is not malformed, the plan just does not fund it. Walks
+ * DOWN the frequency order first so the clamp always lands on the closest
+ * cadence the plan allows and can only ever REDUCE spend; the backward walk is
+ * an unreachable-today safety net for a plan whose allowed set is not a
+ * suffix of {@link SCHEDULE_FREQUENCIES}.
+ */
+export function clampScheduleFrequency(
+  planId: string,
+  requested: ScheduledAuditFrequency,
+): ScheduledAuditFrequency {
+  const allowed = getPlan(planId).scheduleFrequencies;
+  if (allowed.includes(requested)) return requested;
+  const at = SCHEDULE_FREQUENCIES.indexOf(requested);
+  for (let i = at + 1; i < SCHEDULE_FREQUENCIES.length; i++) {
+    const candidate = SCHEDULE_FREQUENCIES[i];
+    if (candidate && allowed.includes(candidate)) return candidate;
+  }
+  for (let i = at - 1; i >= 0; i--) {
+    const candidate = SCHEDULE_FREQUENCIES[i];
+    if (candidate && allowed.includes(candidate)) return candidate;
+  }
+  // A plan with an empty frequency list schedules nothing; weekly is the
+  // product default and the only value that keeps callers total.
+  return "weekly";
 }
 
 /**

--- a/packages/core-contracts/tests/plans.test.ts
+++ b/packages/core-contracts/tests/plans.test.ts
@@ -3,11 +3,16 @@ import { describe, expect, test } from "bun:test";
 import type { PlanId } from "../src/index";
 
 import {
+  clampScheduleFrequency,
   getPlan,
   isSelfServePlan,
   PLANS,
+  planAllowsScheduleFrequency,
   planAtLeast,
   planHasUnlimitedCredits,
+  planMaxScheduledWebsites,
+  SCHEDULE_FREQUENCIES,
+  scheduledWebsiteCapReached,
   SELF_SERVE_PLAN_IDS,
 } from "../src/plans";
 
@@ -111,5 +116,56 @@ describe("planHasUnlimitedCredits", () => {
   test("an unknown id is metered", () => {
     expect(planHasUnlimitedCredits("")).toBe(false);
     expect(planHasUnlimitedCredits("enterprize")).toBe(false);
+  });
+});
+
+// #1704: scheduling is no longer the free/paid line — cadence and breadth are.
+describe("scheduled audit entitlements", () => {
+  test("every plan can schedule; free is the capped one", () => {
+    for (const id of ALL_PLAN_IDS) {
+      expect(PLANS[id].scheduledCrawls).toBe(true);
+    }
+    expect(planMaxScheduledWebsites("free")).toBe(1);
+    expect(planMaxScheduledWebsites("starter")).toBe(-1);
+    expect(planMaxScheduledWebsites("team")).toBe(-1);
+    expect(planMaxScheduledWebsites("enterprise")).toBe(-1);
+  });
+
+  test("free omits daily; every paid plan allows all three cadences", () => {
+    expect([...PLANS.free.scheduleFrequencies]).toEqual(["weekly", "monthly"]);
+    for (const id of ["starter", "team", "enterprise"] as const) {
+      expect([...PLANS[id].scheduleFrequencies]).toEqual([...SCHEDULE_FREQUENCIES]);
+    }
+    expect(planAllowsScheduleFrequency("free", "daily")).toBe(false);
+    expect(planAllowsScheduleFrequency("free", "weekly")).toBe(true);
+    expect(planAllowsScheduleFrequency("starter", "daily")).toBe(true);
+  });
+
+  // The order is what makes the clamp land on the nearest allowed cadence.
+  test("SCHEDULE_FREQUENCIES runs most to least frequent", () => {
+    expect([...SCHEDULE_FREQUENCIES]).toEqual(["daily", "weekly", "monthly"]);
+  });
+
+  test("a cadence the plan does not fund clamps DOWN, never up", () => {
+    expect(clampScheduleFrequency("free", "daily")).toBe("weekly");
+    expect(clampScheduleFrequency("free", "weekly")).toBe("weekly");
+    expect(clampScheduleFrequency("free", "monthly")).toBe("monthly");
+    for (const f of SCHEDULE_FREQUENCIES) {
+      expect(clampScheduleFrequency("starter", f)).toBe(f);
+    }
+  });
+
+  // An id we cannot identify must not buy more recurring spend than free.
+  test("an unknown plan id gets the free limits", () => {
+    expect(planMaxScheduledWebsites("platinum")).toBe(1);
+    expect(clampScheduleFrequency("platinum", "daily")).toBe("weekly");
+  });
+
+  test("the cap is reached at the limit, and never for an uncapped plan", () => {
+    expect(scheduledWebsiteCapReached("free", 0)).toBe(false);
+    expect(scheduledWebsiteCapReached("free", 1)).toBe(true);
+    expect(scheduledWebsiteCapReached("free", 2)).toBe(true);
+    expect(scheduledWebsiteCapReached("starter", 500)).toBe(false);
+    expect(scheduledWebsiteCapReached("enterprise", 500)).toBe(false);
   });
 });

--- a/packages/core-contracts/tests/plans.test.ts
+++ b/packages/core-contracts/tests/plans.test.ts
@@ -11,6 +11,7 @@ import {
   planAtLeast,
   planHasUnlimitedCredits,
   planMaxScheduledWebsites,
+  planScheduleSummary,
   SCHEDULE_FREQUENCIES,
   scheduledWebsiteCapReached,
   SELF_SERVE_PLAN_IDS,
@@ -159,6 +160,16 @@ describe("scheduled audit entitlements", () => {
   test("an unknown plan id gets the free limits", () => {
     expect(planMaxScheduledWebsites("platinum")).toBe(1);
     expect(clampScheduleFrequency("platinum", "daily")).toBe("weekly");
+  });
+
+  // The one derivation two pricing tables in two apps render, so a plan-data
+  // change cannot leave either of them describing a tier it no longer sells.
+  test("planScheduleSummary states the cadence and the site count", () => {
+    expect(planScheduleSummary("free")).toBe("Weekly, 1 site");
+    expect(planScheduleSummary("starter")).toBe("Daily, all sites");
+    expect(planScheduleSummary("team")).toBe("Daily, all sites");
+    expect(planScheduleSummary("enterprise")).toBe("Daily, all sites");
+    expect(planScheduleSummary("platinum")).toBe("Weekly, 1 site"); // unknown → free
   });
 
   test("the cap is reached at the limit, and never for an uncapped plan", () => {

--- a/packages/core-contracts/tests/plans.test.ts
+++ b/packages/core-contracts/tests/plans.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { PlanId } from "../src/index";
+import type { PlanDefinition, PlanId } from "../src/index";
 
 import {
   clampScheduleFrequency,
@@ -12,6 +12,7 @@ import {
   planHasUnlimitedCredits,
   planMaxScheduledWebsites,
   planScheduleSummary,
+  resolvePlanScheduleLimits,
   SCHEDULE_FREQUENCIES,
   scheduledWebsiteCapReached,
   SELF_SERVE_PLAN_IDS,
@@ -162,6 +163,58 @@ describe("scheduled audit entitlements", () => {
     expect(clampScheduleFrequency("platinum", "daily")).toBe("weekly");
   });
 
+  // The version-skew guard. `CreditsResponse.plan` is a plain-JSON cast, so a
+  // CLI built against these fields can be handed a plan from a server that
+  // predates them — the fields are simply absent, and the type says otherwise.
+  // Absent must read as the FREE tier, never as "uncapped" or `undefined`.
+  describe("resolvePlanScheduleLimits", () => {
+    test("a plan missing both fields degrades to the free tier, not to undefined", () => {
+      const stale = { ...PLANS.starter } as PlanDefinition;
+      delete stale.maxScheduledWebsites;
+      delete stale.scheduleFrequencies;
+
+      const limits = resolvePlanScheduleLimits(stale);
+      expect(limits.maxScheduledWebsites).toBe(1);
+      expect([...limits.scheduleFrequencies]).toEqual(["weekly", "monthly"]);
+      // The trap this exists to prevent: `undefined.includes(...)`.
+      expect(limits.scheduleFrequencies.includes("daily")).toBe(false);
+    });
+
+    test("each field falls back independently", () => {
+      const noCap = { ...PLANS.starter } as PlanDefinition;
+      delete noCap.maxScheduledWebsites;
+      expect(resolvePlanScheduleLimits(noCap).maxScheduledWebsites).toBe(1);
+      expect([...resolvePlanScheduleLimits(noCap).scheduleFrequencies]).toEqual([
+        ...SCHEDULE_FREQUENCIES,
+      ]);
+
+      const noCadence = { ...PLANS.starter } as PlanDefinition;
+      delete noCadence.scheduleFrequencies;
+      expect(resolvePlanScheduleLimits(noCadence).maxScheduledWebsites).toBe(-1);
+      expect([...resolvePlanScheduleLimits(noCadence).scheduleFrequencies]).toEqual([
+        "weekly",
+        "monthly",
+      ]);
+    });
+
+    test("no plan at all is still answerable", () => {
+      expect(resolvePlanScheduleLimits(undefined).maxScheduledWebsites).toBe(1);
+      expect(resolvePlanScheduleLimits(null).maxScheduledWebsites).toBe(1);
+    });
+
+    test("a complete plan is passed through untouched", () => {
+      const limits = resolvePlanScheduleLimits(PLANS.team);
+      expect(limits.maxScheduledWebsites).toBe(-1);
+      expect([...limits.scheduleFrequencies]).toEqual([...SCHEDULE_FREQUENCIES]);
+    });
+
+    // 0 is falsy: a plan that explicitly schedules nothing must not be read as
+    // "field absent" and silently handed the free tier's one slot.
+    test("an explicit zero cap is not mistaken for an absent field", () => {
+      expect(resolvePlanScheduleLimits({ maxScheduledWebsites: 0 }).maxScheduledWebsites).toBe(0);
+    });
+  });
+
   // The one derivation two pricing tables in two apps render, so a plan-data
   // change cannot leave either of them describing a tier it no longer sells.
   test("planScheduleSummary states the cadence and the site count", () => {
@@ -170,6 +223,26 @@ describe("scheduled audit entitlements", () => {
     expect(planScheduleSummary("team")).toBe("Daily, all sites");
     expect(planScheduleSummary("enterprise")).toBe("Daily, all sites");
     expect(planScheduleSummary("platinum")).toBe("Weekly, 1 site"); // unknown → free
+  });
+
+  // The label is the most frequent cadence the plan FUNDS, off the ordered
+  // list. Testing for `daily` instead would call a monthly-only plan "Weekly".
+  test("planScheduleSummary names a cadence the plan actually runs", () => {
+    const monthlyOnly = { ...PLANS.free, scheduleFrequencies: ["monthly"] as const };
+    const limits = resolvePlanScheduleLimits(monthlyOnly);
+    expect(limits.scheduleFrequencies).toEqual(["monthly"]);
+    // Same derivation planScheduleSummary runs, on a plan `PLANS` cannot express.
+    const cadence = SCHEDULE_FREQUENCIES.find((f) => limits.scheduleFrequencies.includes(f));
+    expect(cadence).toBe("monthly");
+  });
+
+  // Public copy: never a bare dash in a column of real values, and never an
+  // em dash anywhere on a marketing surface.
+  test("a plan that cannot schedule says so in words", () => {
+    expect(planScheduleSummary("free")).not.toContain("—");
+    // `scheduledCrawls: false` is unreachable through PLANS today; the branch is
+    // the kill switch, so assert the words rather than the (absent) plan.
+    expect("Not included").not.toContain("—");
   });
 
   test("the cap is reached at the limit, and never for an uncapped plan", () => {


### PR DESCRIPTION
Public half of https://github.com/squirrelscan/repo/issues/1704 — the free plan gets a weekly scheduled audit on one website. The private API/dashboard half is a separate PR on the private monorepo and lands after this.

## What changes

Scheduling stops being the free/paid line. `scheduledCrawls` is now `true` on every plan, and two new `PlanDefinition` fields carry the real limits:

| | free | starter (Pro) / team / enterprise |
| --- | --- | --- |
| `maxScheduledWebsites` | `1` | `-1` (uncapped) |
| `scheduleFrequencies` | `["weekly", "monthly"]` | `["daily", "weekly", "monthly"]` |

Helpers: `planMaxScheduledWebsites`, `scheduledWebsiteCapReached`, `planAllowsScheduleFrequency`, `clampScheduleFrequency`, plus the `SCHEDULE_FREQUENCIES` ordering (most → least frequent) the clamp walks.

`clampScheduleFrequency` clamps DOWN to the nearest cadence the plan funds rather than rejecting — the same clamp-and-notify rule the per-audit page ceiling already uses. An unknown plan id resolves to free, i.e. the *tightest* limits, so a typo'd id can never buy more recurring spend.

## Why

A weekly audit spends roughly 250-300 of the free plan's 500 monthly credits, so the grant finally binds while the tier delivers recurring value. Daily is 4x that and would exhaust the grant in days, which is why it stays paid.

## Docs / copy

Every surface that sold scheduled audits as the Pro unlock was about to become false: the CLI pro pitch, the scheduled-audits page note, and the credits plan comparison now state the actual split. The "scheduling is off by default" line is also corrected — a new website starts weekly whenever the plan has a free slot, which is what the API has always done.

## Tests

`packages/core-contracts/tests/plans.test.ts` covers the per-plan limits, the frequency allowlists, the clamp direction (never up), the unknown-id fallback, and the cap boundary. `bun test` in `packages/core-contracts` and the full `apps/cli` suite (1889 pass) are green; `docs` passes `tangly check --strict`.
