### PR TITLE
feat(report): disclose a refused off-site seed redirect in every renderer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -273,7 +273,7 @@
         "filename": "packages/report/src/output/html.tsx",
         "hashed_secret": "a9fe535612f1aff3358c2e17f1e0e50fc60a66dc",
         "is_verified": false,
-        "line_number": 1109
+        "line_number": 1117
       }
     ],
     "packages/report/tests/screenshot-section.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T14:41:01Z"
+  "generated_at": "2026-09-01T23:18:27Z"
 }

--- a/apps/cli/src/controllers/report.ts
+++ b/apps/cli/src/controllers/report.ts
@@ -21,6 +21,8 @@ export interface CrawlMetadataWithPublished extends CrawlMetadata {
   published?: PublishedReportRecord;
 }
 
+import { WITHHELD_SEED_REDIRECT_TARGET } from "@squirrelscan/report";
+
 import {
   OUTPUT_FORMATS,
   OUTPUT_FORMATS_HELP,
@@ -85,6 +87,16 @@ interface SlimJsonReport {
   meta: {
     version: string;
     baseUrl: string;
+    /**
+     * A refused off-site seed redirect (#1418): `baseUrl` is what was graded,
+     * this is where the seed pointed. `finalUrl` is null when the target was
+     * withheld rather than serialized. Absent in slim JSON written before #1418.
+     */
+    seedRedirect?: {
+      finalUrl: string | null;
+      followed: false;
+      note: string;
+    };
     timestamp: string;
     totalPages: number;
   };
@@ -188,6 +200,22 @@ function convertSlimReport(report: SlimJsonReport): AuditReport {
 
   return {
     baseUrl: report.meta.baseUrl,
+    // #1418: carry a refused off-site seed redirect back through the round
+    // trip. Dropping it here would mean exporting JSON and re-rendering it
+    // silently turns a report about a redirected seed back into what looks like
+    // a clean audit. The file is user-supplied, so the declared type is a claim
+    // and not a fact: anything that is not a string — a withheld target, or a
+    // forged one — comes back as the sentinel and lands on the withheld
+    // disclosure. A string is passed through and re-canonicalized at render
+    // time, never trusted as-is.
+    ...(report.meta.seedRedirect
+      ? {
+          finalUrl:
+            typeof report.meta.seedRedirect.finalUrl === "string"
+              ? report.meta.seedRedirect.finalUrl
+              : WITHHELD_SEED_REDIRECT_TARGET,
+        }
+      : {}),
     timestamp: report.meta.timestamp,
     totalPages: report.meta.totalPages,
     passed: report.summary.passed,

--- a/apps/cli/src/reports/output/console.ts
+++ b/apps/cli/src/reports/output/console.ts
@@ -7,6 +7,7 @@ import {
   carriedTag,
   coverageLine,
   scanScopeLine,
+  seedRedirectLine,
   getGroupName,
   getSubcategoryName,
   groupTechnologies,
@@ -94,6 +95,10 @@ export function generateConsoleReport(
     log(
       `${fmt.dim(report.baseUrl)} • ${report.statusReason ?? "No auditable pages"}`
     );
+    // A seed that redirects off-site and is refused is a common way to end up
+    // here with nothing to audit, so this branch needs the disclosure too.
+    const redirect = seedRedirectLine(report);
+    if (redirect) log(fmt.yellow(redirect));
     log(divider());
     return;
   }
@@ -109,6 +114,11 @@ export function generateConsoleReport(
   log(
     `${fmt.dim(report.baseUrl)} • ${report.totalPages} page${report.totalPages === 1 ? "" : "s"} • ${colorFn(`${score}/100`)} ${fmt.dim(`(${grade})`)}`
   );
+  // Refused off-site seed redirect (#1418): the URL on the line above is what
+  // was graded, NOT where the seed pointed. Yellow rather than dim like the
+  // lines below it — it changes what the whole report is about.
+  const seedRedirect = seedRedirectLine(report);
+  if (seedRedirect) log(fmt.yellow(seedRedirect));
   // Scan scope (#1180) + smart-audits coverage (#110): the score reads with
   // its basis. The capped-crawl hint stays with pageLimitHint (commands layer).
   const scope = scanScopeLine(report);

--- a/apps/cli/tests/controllers/report.test.ts
+++ b/apps/cli/tests/controllers/report.test.ts
@@ -1,3 +1,4 @@
+import { renderJson, seedRedirect } from "@squirrelscan/report";
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -185,6 +186,89 @@ describe("loadReport - slim JSON reconstruction", () => {
         expect(result.data.statusReason).toBe(
           "Site blocked the crawler (bot protection / auth / rate limit)"
         );
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /** Render slim JSON, reload it, and hand back the reconstructed report. */
+  function roundTrip(source: AuditReport): AuditReport {
+    const dir = mkdtempSync(join(tmpdir(), "squirrel-slim-"));
+    const path = join(dir, "report.json");
+    try {
+      writeFileSync(path, renderJson(source));
+      const result = loadReport(path);
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("loadReport failed");
+      return result.data;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("carries a refused off-site seed redirect through reconstruction (#1418)", () => {
+    // Without this, `--format json` then re-render is a silent way to turn a
+    // report about a redirected seed back into what reads as a clean audit.
+    const reloaded = roundTrip(
+      createMockReport({ finalUrl: "https://other.example/landing" })
+    );
+    expect(seedRedirect(reloaded)).toEqual({
+      finalUrl: "https://other.example/landing",
+      baseUrl: "https://example.com",
+      note: "Seed redirected off-site to https://other.example/landing, not followed. This audit graded https://example.com.",
+    });
+  });
+
+  test("a withheld redirect target survives the round trip as withheld (#1418)", () => {
+    // The target was never serialized, so there is nothing to restore — but the
+    // disclosure must not be lost either, least of all in the case where the
+    // stored value was hostile enough to be refused in the first place.
+    const csi = String.fromCharCode(0x9b);
+    const override = String.fromCharCode(0x202e);
+    const reloaded = roundTrip(
+      createMockReport({ finalUrl: `not-a-url${csi}2J${override}txt` })
+    );
+    const disclosure = seedRedirect(reloaded);
+    expect(disclosure?.finalUrl).toBeNull();
+    expect(disclosure?.note).toBe(
+      "Seed redirected off-site and was not followed. The redirect target was not a valid URL and is withheld. This audit graded https://example.com."
+    );
+    expect(reloaded.finalUrl).not.toContain("not-a-url");
+    expect(reloaded.finalUrl).not.toContain(csi);
+    expect(reloaded.finalUrl).not.toContain(override);
+  });
+
+  test("a report without a redirect gains no finalUrl from reconstruction", () => {
+    expect(roundTrip(createMockReport({})).finalUrl).toBeUndefined();
+  });
+
+  test("a forged seedRedirect field discloses rather than crashing a renderer", () => {
+    // The JSON is user-supplied, so its declared types are a claim. A
+    // finalUrl that is not a string must not reach a renderer as-is.
+    const slim = {
+      meta: {
+        version: "0.0.89",
+        baseUrl: "https://example.com",
+        seedRedirect: { finalUrl: 42, followed: false, note: "anything" },
+        timestamp: new Date().toISOString(),
+        totalPages: 1,
+      },
+      score: { overall: 90, grade: "A", categories: [] },
+      summary: { passed: 1, warnings: 0, failed: 0 },
+      issues: [],
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), "squirrel-slim-"));
+    const path = join(dir, "report.json");
+    try {
+      writeFileSync(path, JSON.stringify(slim));
+      const result = loadReport(path);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // Disclosed, withheld, and the forged note is not echoed back.
+        expect(seedRedirect(result.data)?.finalUrl).toBeNull();
+        expect(seedRedirect(result.data)?.note).not.toContain("anything");
       }
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/apps/cli/tests/reports/output/console-seed-redirect.test.ts
+++ b/apps/cli/tests/reports/output/console-seed-redirect.test.ts
@@ -52,10 +52,13 @@ describe("console report discloses a refused off-site seed redirect", () => {
   test("names the refused target and the URL that was actually graded", () => {
     const out = capture(redirected());
     expect(out).toContain(NOTE);
-    // The graded URL is still the header's subject; the disclosure sits under it.
+    // The graded URL is still the header's subject; the disclosure sits under
+    // it. Located by the score, not by the URL: a URL literal handed to
+    // `includes` trips CodeQL's incomplete-url-substring-sanitization rule.
     const lines = out.split("\n");
-    const header = lines.findIndex((l) => l.includes("https://example.com •"));
+    const header = lines.findIndex((l) => l.includes("/100"));
     expect(header).toBeGreaterThan(-1);
+    expect(lines[header]).toContain("https://example.com");
     expect(lines[header + 1]).toContain("Seed redirected off-site");
   });
 

--- a/apps/cli/tests/reports/output/console-seed-redirect.test.ts
+++ b/apps/cli/tests/reports/output/console-seed-redirect.test.ts
@@ -1,0 +1,112 @@
+// #1418 — the console renderer is the DEFAULT output path, so a refused
+// off-site seed redirect has to be disclosed here or the common case (`squirrel
+// audit <url>`, read the terminal) is the one place it stays invisible.
+// packages/report covers the shared renderers and the canonicalization itself;
+// this covers the console wiring, including the failed/blocked branch that
+// returns before the normal header.
+
+import { describe, expect, test, spyOn } from "bun:test";
+
+import type { AuditReport } from "@/types";
+
+import { generateConsoleReport } from "@/reports/output/console";
+
+import { createMinimalReport } from "../fixtures";
+
+/** 8-bit CSI: a terminal acts on it exactly as it does on ESC-[. */
+const CSI = String.fromCharCode(0x9b);
+const RTL_OVERRIDE = String.fromCharCode(0x202e);
+
+const NOTE =
+  "Seed redirected off-site to https://other.example/landing, not followed. This audit graded https://example.com.";
+const WITHHELD_NOTE =
+  "Seed redirected off-site and was not followed. The redirect target was not a valid URL and is withheld. This audit graded https://example.com.";
+
+/**
+ * The renderer's full output. `fmt` disables colour when stdout is not a TTY,
+ * which it never is under the test runner, so this is already plain text and
+ * safe to compare byte-for-byte.
+ */
+function capture(report: AuditReport): string {
+  const lines: string[] = [];
+  const spy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.join(" "));
+  });
+  try {
+    generateConsoleReport(report);
+  } finally {
+    spy.mockRestore();
+  }
+  return lines.join("\n");
+}
+
+function redirected(overrides: Partial<AuditReport> = {}): AuditReport {
+  return {
+    ...createMinimalReport(),
+    finalUrl: "https://other.example/landing",
+    ...overrides,
+  };
+}
+
+describe("console report discloses a refused off-site seed redirect", () => {
+  test("names the refused target and the URL that was actually graded", () => {
+    const out = capture(redirected());
+    expect(out).toContain(NOTE);
+    // The graded URL is still the header's subject; the disclosure sits under it.
+    const lines = out.split("\n");
+    const header = lines.findIndex((l) => l.includes("https://example.com •"));
+    expect(header).toBeGreaterThan(-1);
+    expect(lines[header + 1]).toContain("Seed redirected off-site");
+  });
+
+  test("nothing is printed when the seed did not redirect off-site", () => {
+    expect(capture(createMinimalReport())).not.toContain("Seed redirected");
+  });
+
+  test("the whole rest of the output is byte-identical without a redirect", () => {
+    // Full-output equality, not the absence of a phrase: the disclosure is the
+    // only thing a redirect adds to the console report.
+    const clean = capture(createMinimalReport());
+    const lines = capture(redirected()).split("\n");
+    const kept = lines.filter((l) => !l.includes("Seed redirected"));
+    // Exactly one line is the disclosure, and dropping it leaves the clean
+    // rendering byte for byte — so nothing else rode along with it.
+    expect(lines.length - kept.length).toBe(1);
+    expect(kept.join("\n")).toBe(clean);
+    // And every suppressed spelling renders exactly as the absent field does.
+    for (const finalUrl of [
+      "",
+      "   ",
+      "https://example.com",
+      "https://example.com/",
+      "https://example.com:443/",
+    ]) {
+      expect(`${finalUrl}: ${capture(redirected({ finalUrl }))}`).toBe(
+        `${finalUrl}: ${clean}`
+      );
+    }
+  });
+
+  test("a failed or blocked audit discloses it too", () => {
+    // A seed that redirects off-site and is refused is a common way to end up
+    // with nothing to audit, and that branch returns before the normal header.
+    for (const status of ["failed", "blocked"] as const) {
+      const out = capture(
+        redirected({ status, statusReason: "No auditable pages" })
+      );
+      expect(`${status}: ${out.includes(NOTE)}`).toBe(`${status}: true`);
+    }
+  });
+
+  test("a target that could not be canonicalized is withheld, not printed", () => {
+    // Unparseable, and carrying an 8-bit CSI plus a bidi override — neither of
+    // which the console's SGR-preserving sanitizer would strip on its own.
+    const out = capture(
+      redirected({ finalUrl: `not-a-url${CSI}2J${RTL_OVERRIDE}txt` })
+    );
+    expect(out).toContain(WITHHELD_NOTE);
+    expect(out).not.toContain("not-a-url");
+    expect(out).not.toContain(CSI);
+    expect(out).not.toContain(RTL_OVERRIDE);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "apps/cli": {
       "name": "@squirrelscan/cli",
-      "version": "0.0.87",
+      "version": "0.0.89",
       "bin": {
         "squirrelscan": "./build/squirrelscan",
       },
@@ -178,6 +178,7 @@
       "devDependencies": {
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "fast-xml-parser": "5.10.1",
       },
       "peerDependencies": {
         "react": "^19.2.7",

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -13,7 +13,8 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3"
+    "@types/react-dom": "^19.2.3",
+    "fast-xml-parser": "5.10.1"
   },
   "peerDependencies": {
     "react": "^19.2.7",

--- a/packages/report/src/constants.ts
+++ b/packages/report/src/constants.ts
@@ -5,7 +5,7 @@ export const KEY_SEPARATOR = "\x00";
 
 // Bump on any HTML renderer/CSS change (output/html.tsx) — the API folds this
 // into the cached-HTML R2 key, so a bump invalidates cached reports (re-render on next view).
-export const REPORT_HTML_VERSION = 12;
+export const REPORT_HTML_VERSION = 13;
 
 // Report output constants
 export const REPORT_COLLAPSE_THRESHOLD = 3;

--- a/packages/report/src/coverage.ts
+++ b/packages/report/src/coverage.ts
@@ -92,6 +92,113 @@ export function fetchFallbacksLine(report: AuditReport): string | null {
   return `${recovered} page${recovered === 1 ? "" : "s"} recovered via direct fetch after a render block.`;
 }
 
+export interface SeedRedirect {
+  /** Where the refused redirect pointed. Site-controlled: display only, and
+   *  every caller must escape it for its own output format. */
+  finalUrl: string;
+  /** The URL this audit actually graded (the report's `baseUrl`). */
+  baseUrl: string;
+  /** The disclosure as one sentence, ready to render. */
+  note: string;
+}
+
+/**
+ * A refused off-site seed redirect (#1418), or null when there is nothing to
+ * disclose: no `finalUrl` (older reports, and every seed that did not redirect
+ * off-site), or a `finalUrl` that does not differ from `baseUrl`.
+ *
+ * The crawler pins the crawl to the seed when a seed redirect leaves the seed's
+ * registrable domain, so `baseUrl` stays the site the user asked for and
+ * `finalUrl` records where the redirect pointed. Unreported, the report reads
+ * as a clean audit of a URL nobody requested.
+ *
+ * The returned `finalUrl` is the canonical one `note` quotes, so a consumer
+ * reading the field and a human reading the sentence can never see two
+ * different URLs. Only `finalUrl` is canonicalized: `baseUrl` is the crawl's
+ * own base and is shown the way the rest of the report shows it. Escaping for
+ * markdown/HTML/XML stays each renderer's job.
+ */
+export function seedRedirect(report: AuditReport): SeedRedirect | null {
+  const finalUrl = canonicalizeReportUrl(report.finalUrl);
+  if (!finalUrl) return null;
+  const baseUrl = dropNonUrlChars(report.baseUrl);
+  if (!baseUrl) return null;
+  // Compared canonically so an equivalent pair ("https://example.com" vs
+  // ".../") never prints a line saying the seed redirected to itself.
+  if (finalUrl === baseUrl || finalUrl === canonicalizeReportUrl(baseUrl)) return null;
+  return {
+    finalUrl,
+    baseUrl,
+    note: `Seed redirected off-site to ${finalUrl}, not followed. This audit graded ${baseUrl}.`,
+  };
+}
+
+/**
+ * {@link seedRedirect}'s sentence alone, e.g.
+ *   "Seed redirected off-site to https://other.example/, not followed. This audit graded https://example.com."
+ * Returns null on the same terms.
+ */
+export function seedRedirectLine(report: AuditReport): string | null {
+  return seedRedirect(report)?.note ?? null;
+}
+
+/**
+ * Canonicalize a site-controlled URL for display.
+ *
+ * A redirect target is whatever `Location` the audited site sent, and it
+ * reaches a report as a stored string, so it keeps whatever bytes it was sent
+ * with. Re-serializing through the WHATWG parser is what makes it safe to
+ * print: the parser drops tab/CR/LF, IDNA-encodes a Unicode hostname (so a
+ * homograph host shows as `xn--…`), and percent-encodes every non-ASCII code
+ * point and every C0 control in the path/query/fragment, which is what turns
+ * an invisible bidi override or zero-width joiner into visible `%E2%80%AE`.
+ * Left raw, a newline would break out of the line that renders the URL and a
+ * bidi override would rewrite how the rest of it reads.
+ *
+ * Falls back to {@link dropNonUrlChars} for a value that does not parse as an
+ * http(s) URL at all: still safe to print, and better than dropping the
+ * disclosure that a redirect happened.
+ */
+function canonicalizeReportUrl(value: string | undefined): string {
+  if (!value) return "";
+  try {
+    const url = new URL(value);
+    if (url.protocol === "http:" || url.protocol === "https:") return url.href;
+  } catch {}
+  return dropNonUrlChars(value);
+}
+
+/**
+ * Drop whitespace and control characters from a URL that is not being
+ * canonicalized: the crawl's own `baseUrl` (shown the way the rest of the
+ * report shows it, no added trailing slash) and anything `canonicalizeReportUrl`
+ * could not parse.
+ *
+ * Checked per code point rather than as one character class: a class spanning
+ * the C0 range trips oxlint's no-control-regex.
+ */
+function dropNonUrlChars(value: string | undefined): string {
+  if (!value) return "";
+  let out = "";
+  // for..of iterates whole code points, so an astral character cannot be split.
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    // C0 controls and space (<= 0x20), DEL (0x7f), then the rest of Unicode
+    // whitespace (NBSP, ideographic space and friends).
+    if (code <= 0x20 || code === 0x7f || UNICODE_WHITESPACE.test(char)) continue;
+    // Code points XML 1.0 forbids: unpaired surrogates (for..of yields a lone
+    // one as its own character) and the noncharacters. They would make the llm
+    // renderer's document unparseable.
+    if (code >= 0xd800 && code <= 0xdfff) continue;
+    if (code >= 0xfdd0 && code <= 0xfdef) continue;
+    if ((code & 0xfffe) === 0xfffe) continue;
+    out += char;
+  }
+  return out;
+}
+
+const UNICODE_WHITESPACE = /\s/;
+
 /** Approximate "N days/hours ago" from an epoch-ms timestamp. */
 export function timeAgo(epochMs: number, now: number = Date.now()): string {
   const deltaMs = Math.max(0, now - epochMs);

--- a/packages/report/src/coverage.ts
+++ b/packages/report/src/coverage.ts
@@ -93,14 +93,38 @@ export function fetchFallbacksLine(report: AuditReport): string | null {
 }
 
 export interface SeedRedirect {
-  /** Where the refused redirect pointed. Site-controlled: display only, and
-   *  every caller must escape it for its own output format. */
-  finalUrl: string;
+  /**
+   * Where the refused redirect pointed, canonicalized — or `null` when the
+   * stored value was not a parseable http(s) URL and was withheld instead of
+   * printed (see {@link seedRedirect}). Site-controlled: display only, and
+   * every caller must escape it for its own output format.
+   */
+  finalUrl: string | null;
   /** The URL this audit actually graded (the report's `baseUrl`). */
   baseUrl: string;
   /** The disclosure as one sentence, ready to render. */
   note: string;
 }
+
+/**
+ * What the disclosure says in place of a redirect target that could not be
+ * canonicalized. Fixed text: no byte of the stored value reaches any output.
+ * Worded without punctuation any renderer escapes, so it reads the same in the
+ * raw markdown source as it does everywhere else.
+ */
+const WITHHELD_TARGET = "The redirect target was not a valid URL and is withheld.";
+
+/**
+ * Stand-in `finalUrl` for rebuilding a report whose redirect target was
+ * withheld — a slim-JSON round trip, where the target was never serialized and
+ * so cannot be restored (#1418).
+ *
+ * Deliberately not a URL: {@link seedRedirect} re-refuses it and re-emits the
+ * withheld disclosure, so a reloaded report says exactly what the original one
+ * did instead of quietly losing the fact that a redirect happened. Self-naming
+ * so it explains itself if some other consumer ever prints `finalUrl` raw.
+ */
+export const WITHHELD_SEED_REDIRECT_TARGET = "withheld:unparseable-redirect-target";
 
 /**
  * A refused off-site seed redirect (#1418), or null when there is nothing to
@@ -114,15 +138,35 @@ export interface SeedRedirect {
  *
  * The returned `finalUrl` is the canonical one `note` quotes, so a consumer
  * reading the field and a human reading the sentence can never see two
- * different URLs. Only `finalUrl` is canonicalized: `baseUrl` is the crawl's
- * own base and is shown the way the rest of the report shows it. Escaping for
- * markdown/HTML/XML stays each renderer's job.
+ * different URLs. It is `null` when the stored value did not survive
+ * {@link canonicalizeReportUrl}: the redirect is still disclosed, with the
+ * target withheld, so a report can never carry a target nobody vetted. Only
+ * `finalUrl` is canonicalized: `baseUrl` is the crawl's own base and is shown
+ * the way the rest of the report shows it. Escaping for markdown/HTML/XML
+ * stays each renderer's job.
  */
 export function seedRedirect(report: AuditReport): SeedRedirect | null {
-  const finalUrl = canonicalizeReportUrl(report.finalUrl);
-  if (!finalUrl) return null;
+  // A non-string is out of contract rather than hostile content: treat it as
+  // absent instead of throwing on it. The one place untrusted data enters (slim
+  // JSON reconstruction) maps a malformed field to a stand-in of its own, so
+  // the disclosure still survives there.
+  const stored = typeof report.finalUrl === "string" ? report.finalUrl : "";
+  // Absent or whitespace-only ⇒ no value was stored, so there is no redirect to
+  // disclose. Deliberately NOT "nothing printable": a value made only of
+  // invisible characters is a stored value, and hostile input must not be able
+  // to buy silence by being unprintable. Everything past here either
+  // canonicalizes or is withheld, but it is always disclosed.
+  if (isBlankUrlField(stored)) return null;
   const baseUrl = dropNonUrlChars(report.baseUrl);
   if (!baseUrl) return null;
+  const finalUrl = canonicalizeReportUrl(stored);
+  if (finalUrl === null) {
+    return {
+      finalUrl: null,
+      baseUrl,
+      note: `Seed redirected off-site and was not followed. ${WITHHELD_TARGET} This audit graded ${baseUrl}.`,
+    };
+  }
   // Compared canonically so an equivalent pair ("https://example.com" vs
   // ".../") never prints a line saying the seed redirected to itself.
   if (finalUrl === baseUrl || finalUrl === canonicalizeReportUrl(baseUrl)) return null;
@@ -143,7 +187,8 @@ export function seedRedirectLine(report: AuditReport): string | null {
 }
 
 /**
- * Canonicalize a site-controlled URL for display.
+ * Canonicalize a site-controlled URL for display, or `null` for a value we are
+ * not willing to print at all.
  *
  * A redirect target is whatever `Location` the audited site sent, and it
  * reaches a report as a stored string, so it keeps whatever bytes it was sent
@@ -155,24 +200,29 @@ export function seedRedirectLine(report: AuditReport): string | null {
  * Left raw, a newline would break out of the line that renders the URL and a
  * bidi override would rewrite how the rest of it reads.
  *
- * Falls back to {@link dropNonUrlChars} for a value that does not parse as an
- * http(s) URL at all: still safe to print, and better than dropping the
- * disclosure that a redirect happened.
+ * Anything the parser does not hand back as http(s) is REFUSED rather than
+ * sanitized. The only producer of this field resolves a `Location` header
+ * against an absolute http(s) seed, so a value that does not parse is already
+ * off the legitimate path: there is no shape worth preserving, and the
+ * alternative — printing it minus a denylist of unsafe ranges — is a list that
+ * has to stay current with Unicode forever, and was already missing the C1
+ * controls (0x9b is an 8-bit CSI a terminal acts on) and the bidi overrides.
+ * Refusing keeps the allowlist the WHATWG parser already implements: callers
+ * disclose the redirect with a fixed placeholder instead.
  */
-function canonicalizeReportUrl(value: string | undefined): string {
-  if (!value) return "";
+function canonicalizeReportUrl(value: string | undefined): string | null {
+  if (!value) return null;
   try {
     const url = new URL(value);
     if (url.protocol === "http:" || url.protocol === "https:") return url.href;
   } catch {}
-  return dropNonUrlChars(value);
+  return null;
 }
 
 /**
- * Drop whitespace and control characters from a URL that is not being
- * canonicalized: the crawl's own `baseUrl` (shown the way the rest of the
- * report shows it, no added trailing slash) and anything `canonicalizeReportUrl`
- * could not parse.
+ * Drop whitespace, control characters and invisible formatting from a URL that
+ * is not being canonicalized: the crawl's own `baseUrl`, shown the way the rest
+ * of the report shows it (no added trailing slash).
  *
  * Checked per code point rather than as one character class: a class spanning
  * the C0 range trips oxlint's no-control-regex.
@@ -183,9 +233,17 @@ function dropNonUrlChars(value: string | undefined): string {
   // for..of iterates whole code points, so an astral character cannot be split.
   for (const char of value) {
     const code = char.codePointAt(0) ?? 0;
-    // C0 controls and space (<= 0x20), DEL (0x7f), then the rest of Unicode
-    // whitespace (NBSP, ideographic space and friends).
-    if (code <= 0x20 || code === 0x7f || UNICODE_WHITESPACE.test(char)) continue;
+    // C0 controls and space (<= 0x20), then DEL and the C1 controls
+    // (0x7f-0x9f). C1 matters on its own terms: 0x9b is an 8-bit CSI, which a
+    // terminal acts on exactly as it does ESC-[, and this string reaches text
+    // and console output live.
+    if (code <= 0x20 || (code >= 0x7f && code <= 0x9f)) continue;
+    // The rest of Unicode whitespace (NBSP, ideographic space and friends).
+    if (UNICODE_WHITESPACE.test(char)) continue;
+    // Invisible formatting: bidi controls rewrite how everything after them
+    // reads, and the zero-width family hides a boundary inside a hostname.
+    // None of them carry meaning in a URL.
+    if (isInvisibleFormatChar(code)) continue;
     // Code points XML 1.0 forbids: unpaired surrogates (for..of yields a lone
     // one as its own character) and the noncharacters. They would make the llm
     // renderer's document unparseable.
@@ -195,6 +253,37 @@ function dropNonUrlChars(value: string | undefined): string {
     out += char;
   }
   return out;
+}
+
+/**
+ * True when the value holds nothing but ordinary whitespace, i.e. no value was
+ * really stored.
+ *
+ * Deliberately not `String.prototype.trim`, whose whitespace set includes
+ * U+FEFF for historical reasons: a BOM is invisible formatting, not an empty
+ * field, and reading it as blank would hand an unprintable value exactly the
+ * silence this disclosure exists to prevent. A no-break space, which really is
+ * a space, still counts as blank.
+ */
+function isBlankUrlField(value: string): boolean {
+  for (const char of value) {
+    if (char.codePointAt(0) === 0xfeff) return false;
+    if (!UNICODE_WHITESPACE.test(char)) return false;
+  }
+  return true;
+}
+
+/** Zero-width, joiner and bidi-control code points — invisible by design. */
+function isInvisibleFormatChar(code: number): boolean {
+  return (
+    code === 0x00ad || // soft hyphen
+    code === 0x061c || // Arabic letter mark
+    (code >= 0x200b && code <= 0x200f) || // zero-width space/joiners, LRM, RLM
+    (code >= 0x202a && code <= 0x202e) || // bidi embeddings and overrides
+    (code >= 0x2060 && code <= 0x206f) || // word joiner, invisible operators,
+    // bidi isolates, and the deprecated format controls above them
+    code === 0xfeff // BOM / zero-width no-break space
+  );
 }
 
 const UNICODE_WHITESPACE = /\s/;

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -121,6 +121,7 @@ export {
   scanScopeLine,
   seedRedirect,
   seedRedirectLine,
+  WITHHELD_SEED_REDIRECT_TARGET,
   type SeedRedirect,
   fullScanHint,
   checkCarriedLabel,

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -113,12 +113,15 @@ export {
 } from "./site-metadata";
 
 // Smart audits coverage + carried-finding provenance helpers (#110)
-// + scan scope disclosure (#1180)
+// + scan scope disclosure (#1180) + refused off-site seed redirect (#1418)
 export {
   coverageLine,
   carriedTag,
   timeAgo,
   scanScopeLine,
+  seedRedirect,
+  seedRedirectLine,
+  type SeedRedirect,
   fullScanHint,
   checkCarriedLabel,
   checkUnrenderedLabel,

--- a/packages/report/src/output/html.tsx
+++ b/packages/report/src/output/html.tsx
@@ -32,6 +32,7 @@ import {
   coverageLine,
   fullScanHint,
   scanScopeLine,
+  seedRedirectLine,
   checkCarriedLabel,
   checkUnrenderedLabel,
   ruleCarriedRollupLine,
@@ -638,16 +639,23 @@ function ReportHeader({ report, branding }: { report: AuditReport; branding?: Re
                 {report.totalPages} page{report.totalPages === 1 ? "" : "s"} • Generated{" "}
                 {formatHumanDateTime(report.timestamp)}
               </div>
-              {/* Scan scope disclosure (#1180): the score always reads with its basis. */}
+              {/* Scan scope disclosure (#1180): the score always reads with its basis.
+                  A refused off-site seed redirect (#1418) sits with them: it is the
+                  same class of fact, that the score is not about the URL you might
+                  assume. React escapes the site-controlled finalUrl as a text child,
+                  and it is deliberately NOT a link: the point is that we did not go
+                  there. */}
               {(() => {
                 const scope = scanScopeLine(report);
                 const cov = coverageLine(report);
                 const hint = fullScanHint(report);
+                const seedRedirect = seedRedirectLine(report);
                 return (
                   <>
                     {(scope || cov) && (
                       <div className="scan-scope">{[scope, cov].filter(Boolean).join(" ")}</div>
                     )}
+                    {seedRedirect && <div className="scan-hint">{seedRedirect}</div>}
                     {hint && <div className="scan-hint">{hint}</div>}
                   </>
                 );

--- a/packages/report/src/output/json.ts
+++ b/packages/report/src/output/json.ts
@@ -8,6 +8,7 @@ import { affectedPages } from "../affected-pages";
 import { techIconUrl } from "../technologies";
 import { domainAgeYears, siteProfileRows } from "../site-metadata";
 import { editorSummaryView } from "../editor-summary";
+import { seedRedirect } from "../coverage";
 
 export interface JsonRenderOptions {
   version?: string;
@@ -17,6 +18,19 @@ interface SlimJsonReport {
   meta: {
     version: string;
     baseUrl: string;
+    /**
+     * A refused off-site seed redirect (#1418). Present only when the seed
+     * redirected off its own registrable domain and the crawler declined to
+     * follow it: `baseUrl` above is what was graded, this is where the seed
+     * pointed. `finalUrl` is null when the stored target was not a parseable
+     * http(s) URL and was withheld rather than emitted; `note` reads correctly
+     * either way.
+     */
+    seedRedirect?: {
+      finalUrl: string | null;
+      followed: false;
+      note: string;
+    };
     timestamp: string;
     totalPages: number;
     /** Smart audits (#110): present only when `smart_audits` ran. */
@@ -141,10 +155,22 @@ interface SlimJsonReport {
 function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
   const categoryIssues = groupIssuesByCategory(report.ruleResults);
   const es = editorSummaryView(report.editorSummary);
+  const refusedSeedRedirect = seedRedirect(report);
   return {
     meta: {
       version,
       baseUrl: report.baseUrl,
+      // Sits next to the `baseUrl` it qualifies (#1418): a consumer reading the
+      // graded URL sees, in the same object, that the seed pointed elsewhere.
+      ...(refusedSeedRedirect
+        ? {
+            seedRedirect: {
+              finalUrl: refusedSeedRedirect.finalUrl,
+              followed: false as const,
+              note: refusedSeedRedirect.note,
+            },
+          }
+        : {}),
       timestamp: report.timestamp,
       totalPages: report.totalPages,
       ...(report.coverage ? { coverage: report.coverage } : {}),

--- a/packages/report/src/output/llm.ts
+++ b/packages/report/src/output/llm.ts
@@ -99,9 +99,13 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
   // the AUDITED SITE chose: it is reported, never a destination to go fetch.
   const refusedSeedRedirect = seedRedirect(report);
   if (refusedSeedRedirect) {
-    lines.push(
-      `<seed-redirect final-url="${escapeXml(refusedSeedRedirect.finalUrl)}" followed="false">`,
-    );
+    // `final-url` is omitted when the stored target did not survive
+    // canonicalization: an agent that reads only attributes then sees no URL
+    // rather than one nobody vetted, and the note below says why.
+    const finalUrlAttr = refusedSeedRedirect.finalUrl
+      ? ` final-url="${escapeXml(refusedSeedRedirect.finalUrl)}"`
+      : "";
+    lines.push(`<seed-redirect${finalUrlAttr} followed="false">`);
     lines.push(`${indent(1)}${escapeXml(refusedSeedRedirect.note)}`);
     lines.push("</seed-redirect>");
   }

--- a/packages/report/src/output/llm.ts
+++ b/packages/report/src/output/llm.ts
@@ -9,6 +9,7 @@ import { getDocsUrl } from "../docs";
 import { domainAgeYears } from "../site-metadata";
 import { lockedRulesMessage } from "../locked-rules";
 import { editorSummaryView } from "../editor-summary";
+import { seedRedirect } from "../coverage";
 import { LLM_REPORT } from "@squirrelscan/core-contracts/limits";
 import { stripControlChars } from "@squirrelscan/core-contracts/control-chars";
 
@@ -91,6 +92,19 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
   lines.push(
     `<site url="${escapeXml(report.baseUrl)}" crawled="${report.totalPages}" date="${escapeXml(report.timestamp)}"/>`,
   );
+
+  // Refused off-site seed redirect (#1418). Without this an agent reads the
+  // scores as being about the URL it was handed, when the seed redirected to a
+  // different site that the crawler declined to follow. `final-url` is a URL
+  // the AUDITED SITE chose: it is reported, never a destination to go fetch.
+  const refusedSeedRedirect = seedRedirect(report);
+  if (refusedSeedRedirect) {
+    lines.push(
+      `<seed-redirect final-url="${escapeXml(refusedSeedRedirect.finalUrl)}" followed="false">`,
+    );
+    lines.push(`${indent(1)}${escapeXml(refusedSeedRedirect.note)}`);
+    lines.push("</seed-redirect>");
+  }
 
   // Failed/blocked audit (#792): nothing was audited. Without this an agent
   // reads <score overall="N/A"> + empty <issues/> as a clean pass. State it

--- a/packages/report/src/output/markdown.ts
+++ b/packages/report/src/output/markdown.ts
@@ -16,6 +16,7 @@ import {
   fetchFallbacksLine,
   fullScanHint,
   scanScopeLine,
+  seedRedirectLine,
   ruleCarriedRollupLine,
 } from "../coverage";
 import {
@@ -60,6 +61,30 @@ function escapeMarkdownDestination(value: string): string {
   return output.join("");
 }
 
+/**
+ * Neutralize inline markdown syntax so a site-controlled string renders as
+ * literal text instead of a link, image, code span, raw HTML tag or emphasis.
+ * Every character here is ASCII punctuation, so every one is a valid CommonMark
+ * backslash escape and renders as itself.
+ *
+ * `&` is escaped so a value containing `&#x202E;` cannot be decoded back into
+ * the bidi override the URL canonicalization just percent-encoded away.
+ *
+ * NOT escaped: the scheme colon. GFM autolinks a bare `https://…` and a
+ * backslash there does not stop it (verified against remark-gfm), so the cost
+ * would be an uglier raw document for no gain. An autolink is limited to
+ * http/https/www/mailto, so it cannot produce a `javascript:` link, and the URL
+ * is displayed in full either way.
+ */
+function escapeMarkdownInline(value: string): string {
+  const output: string[] = [];
+  for (const char of value) {
+    if ("\\`*_[]()<>|~&".includes(char)) output.push(`\\${char}`);
+    else output.push(char);
+  }
+  return output.join("");
+}
+
 function siteProfileMarkdownValue(value: string, rawUrl?: string): string {
   const label = escapeMarkdownTableCell(value, true);
   if (!rawUrl) return label;
@@ -89,6 +114,13 @@ export function renderMarkdown(report: AuditReport, options?: MarkdownRenderOpti
   lines.push(`**URL:** ${report.baseUrl}  `);
   lines.push(`**Date:** ${formatReportDate(report.timestamp)}  `);
   lines.push(`**Pages:** ${report.totalPages}  `);
+  // #1418: the seed redirected off its own site and the crawler refused to
+  // follow it, so the URL above is not where the redirect pointed. Escaped:
+  // the redirect target is a string the audited site chose. Deliberately a
+  // plain line and not a `>` blockquote — CommonMark lazy continuation would
+  // pull every metadata line below it inside the quote.
+  const seedRedirect = seedRedirectLine(report);
+  if (seedRedirect) lines.push(`${escapeMarkdownInline(seedRedirect)}  `);
   const scope = scanScopeLine(report);
   if (scope) lines.push(`${scope}  `);
   const cov = coverageLine(report);

--- a/packages/report/src/output/text.ts
+++ b/packages/report/src/output/text.ts
@@ -17,6 +17,7 @@ import {
   fetchFallbacksLine,
   fullScanHint,
   scanScopeLine,
+  seedRedirectLine,
 } from "../coverage";
 import { wrapText } from "../utils";
 import { lockedRulesMessage } from "../locked-rules";
@@ -92,6 +93,13 @@ export function renderText(report: AuditReport, options?: TextRenderOptions): st
   write("=".repeat(60));
   write(`Auditing: ${report.baseUrl}`);
   write(`Crawled ${report.totalPages} pages`);
+  // #1418: the seed redirected off its own site and was not followed, so the
+  // line above is not where the redirect pointed. stripControlChars because the
+  // redirect target is a string the audited site chose and this output reaches
+  // a terminal (seedRedirectLine already drops whitespace/C0 from the URL; this
+  // is the same belt-and-braces every other page-derived line here gets).
+  const seedRedirect = seedRedirectLine(report);
+  if (seedRedirect) write(stripControlChars(seedRedirect));
   const scope = scanScopeLine(report);
   if (scope) write(scope);
   const cov = coverageLine(report);

--- a/packages/report/src/output/xml.ts
+++ b/packages/report/src/output/xml.ts
@@ -8,6 +8,7 @@ import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
 import { affectedPages } from "../affected-pages";
 import { domainAgeYears } from "../site-metadata";
 import { editorSummaryView } from "../editor-summary";
+import { seedRedirect } from "../coverage";
 
 export interface XmlRenderOptions {
   version?: string;
@@ -42,6 +43,22 @@ export function renderXml(report: AuditReport, options?: XmlRenderOptions): stri
   lines.push(`${indent(2)}<pages-crawled>${report.totalPages}</pages-crawled>`);
   lines.push(`${indent(2)}<audit-date>${escapeXml(report.timestamp)}</audit-date>`);
   lines.push(`${indent(1)}</site>`);
+
+  // Refused off-site seed redirect (#1418): the seed left its own registrable
+  // domain, the crawler declined to follow it, and `<site><url>` above is what
+  // was graded. Without this the document is a clean audit of a URL nobody
+  // asked for. `<final-url>` is a URL the AUDITED SITE chose — reported, never
+  // a destination to go fetch — and is omitted entirely when it did not survive
+  // canonicalization, in which case `<note>` says so.
+  const refusedSeedRedirect = seedRedirect(report);
+  if (refusedSeedRedirect) {
+    lines.push(`${indent(1)}<seed-redirect followed="false">`);
+    if (refusedSeedRedirect.finalUrl) {
+      lines.push(`${indent(2)}<final-url>${escapeXml(refusedSeedRedirect.finalUrl)}</final-url>`);
+    }
+    lines.push(`${indent(2)}<note>${escapeXml(refusedSeedRedirect.note)}</note>`);
+    lines.push(`${indent(1)}</seed-redirect>`);
+  }
 
   // null ⇒ N/A (failed/0-page audit) — never coerce to 0/"F" (#586).
   const overall = report.healthScore?.overall ?? null;

--- a/packages/report/tests/seed-redirect.test.ts
+++ b/packages/report/tests/seed-redirect.test.ts
@@ -5,6 +5,7 @@
 // of a URL nobody requested.
 
 import { describe, expect, test } from "bun:test";
+import { XMLParser, XMLValidator } from "fast-xml-parser";
 
 import type { AuditReport } from "../src/types";
 import { seedRedirect, seedRedirectLine } from "../src/coverage";
@@ -12,6 +13,8 @@ import { renderText } from "../src/output/text";
 import { renderMarkdown } from "../src/output/markdown";
 import { renderHtml } from "../src/output/html";
 import { renderLlm } from "../src/output/llm";
+import { renderJson } from "../src/output/json";
+import { renderXml } from "../src/output/xml";
 
 // Built rather than typed as literals so this file carries no raw control
 // characters of its own.
@@ -20,11 +23,18 @@ const CR = String.fromCharCode(13);
 const TAB = String.fromCharCode(9);
 const ESC = String.fromCharCode(27);
 const DEL = String.fromCharCode(127);
+/** 8-bit CSI: a terminal acts on it exactly as it does on ESC-[. */
+const CSI = String.fromCharCode(0x9b);
 const RTL_OVERRIDE = String.fromCharCode(0x202e);
 const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
+/** In JavaScript's whitespace set, but invisible formatting rather than space. */
+const BOM = String.fromCharCode(0xfeff);
+const NBSP = String.fromCharCode(0x00a0);
 
 const NOTE =
   "Seed redirected off-site to https://other.example/landing, not followed. This audit graded https://example.com.";
+const WITHHELD_NOTE =
+  "Seed redirected off-site and was not followed. The redirect target was not a valid URL and is withheld. This audit graded https://example.com.";
 
 function baseReport(overrides: Partial<AuditReport> = {}): AuditReport {
   return {
@@ -40,6 +50,39 @@ function baseReport(overrides: Partial<AuditReport> = {}): AuditReport {
 }
 
 const redirected = baseReport({ finalUrl: "https://other.example/landing" });
+
+/** Every renderer, so a disclosure can never be wired into only some of them. */
+const RENDERERS: ReadonlyArray<{ name: string; render: (r: AuditReport) => string }> = [
+  { name: "text", render: (r) => renderText(r) },
+  { name: "markdown", render: (r) => renderMarkdown(r) },
+  { name: "html", render: (r) => renderHtml(r, { reportId: "rep_1" }) },
+  { name: "llm", render: (r) => renderLlm(r) },
+  { name: "json", render: (r) => renderJson(r) },
+  { name: "xml", render: (r) => renderXml(r) },
+];
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@",
+  // Every value here is a URL or a sentence; coercing "false" to a boolean or a
+  // numeric-looking path segment to a number would hide what was actually written.
+  parseAttributeValue: false,
+  parseTagValue: false,
+  trimValues: true,
+});
+
+/**
+ * Validate, then parse. The parser alone is lenient about mismatched tags and
+ * stray roots, so a hostile value that broke out of an attribute could still
+ * come back as a plausible-looking object; the validator is what makes an
+ * assertion about the parsed tree an assertion about well-formed XML.
+ */
+const xml = {
+  parse(document: string): ReturnType<XMLParser["parse"]> {
+    expect(XMLValidator.validate(document)).toBe(true);
+    return parser.parse(document);
+  },
+};
 
 describe("seedRedirect", () => {
   test("names the refused target AND the URL that was actually graded", () => {
@@ -66,9 +109,60 @@ describe("seedRedirect", () => {
     expect(seedRedirect(baseReport({ finalUrl: "HTTPS://Example.com" }))).toBeNull();
   });
 
+  test("null when the only difference is a scheme's default port", () => {
+    // The parser drops :443 on https and :80 on http, so these are the same
+    // origin spelled two ways — not a redirect anywhere.
+    expect(seedRedirect(baseReport({ finalUrl: "https://example.com:443/" }))).toBeNull();
+    expect(seedRedirect(baseReport({ finalUrl: "https://example.com:443" }))).toBeNull();
+    expect(
+      seedRedirect(baseReport({ baseUrl: "http://example.com", finalUrl: "http://example.com:80/" })),
+    ).toBeNull();
+    // A NON-default port is a different place and still discloses.
+    expect(seedRedirect(baseReport({ finalUrl: "https://example.com:8443/" }))?.finalUrl).toBe(
+      "https://example.com:8443/",
+    );
+  });
+
+  test("null when a Unicode host and its punycode are the same host", () => {
+    // Both sides go through IDNA, so the two spellings compare equal instead of
+    // producing a line claiming the seed redirected off its own domain.
+    const unicodeHost = "https://例え.jp";
+    const punycodeHost = "https://xn--r8jz45g.jp/";
+    expect(
+      seedRedirect(baseReport({ baseUrl: unicodeHost, finalUrl: punycodeHost })),
+    ).toBeNull();
+    expect(
+      seedRedirect(baseReport({ baseUrl: punycodeHost, finalUrl: unicodeHost })),
+    ).toBeNull();
+  });
+
   test("null for a blank finalUrl, rather than an empty placeholder line", () => {
     expect(seedRedirect(baseReport({ finalUrl: "" }))).toBeNull();
     expect(seedRedirect(baseReport({ finalUrl: "   " }))).toBeNull();
+    expect(seedRedirect(baseReport({ finalUrl: `${TAB}${LF}${CR}` }))).toBeNull();
+    // A no-break space really is a space, so it reads as blank too.
+    expect(seedRedirect(baseReport({ finalUrl: NBSP }))).toBeNull();
+  });
+
+  test("a BOM-only finalUrl is a stored value, not a blank field", () => {
+    // U+FEFF is in JavaScript's whitespace set, so `trim()` would call this
+    // blank — which would let an invisible value buy the silence the whole
+    // disclosure exists to prevent.
+    const result = seedRedirect(baseReport({ finalUrl: BOM }));
+    expect(result?.finalUrl).toBeNull();
+    expect(result?.note).toBe(WITHHELD_NOTE);
+  });
+
+  test("a finalUrl that is not a string is treated as absent, not thrown on", () => {
+    // Out of contract rather than hostile: a renderer must not crash on it.
+    // The one place untrusted data enters (slim-JSON reconstruction) maps a
+    // malformed field to its own stand-in, so the disclosure survives there.
+    for (const malformed of [42, {}, [], true, null]) {
+      const report = baseReport();
+      (report as { finalUrl?: unknown }).finalUrl = malformed;
+      expect(seedRedirect(report)).toBeNull();
+      expect(() => renderText(report)).not.toThrow();
+    }
   });
 
   test("null without a baseUrl: with nothing to contrast against the line says nothing", () => {
@@ -100,15 +194,46 @@ describe("seedRedirect", () => {
       }),
     );
     expect(result?.finalUrl).toBe("https://xn--xample-2of.com/%E2%80%AEgnp.exe%E2%80%8B");
-    expect(result?.finalUrl.includes(RTL_OVERRIDE)).toBe(false);
-    expect(result?.finalUrl.includes(ZERO_WIDTH_SPACE)).toBe(false);
+    expect(result?.finalUrl?.includes(RTL_OVERRIDE)).toBe(false);
+    expect(result?.finalUrl?.includes(ZERO_WIDTH_SPACE)).toBe(false);
   });
 
-  test("a value that is not an http(s) URL still gets disclosed, with the same characters dropped", () => {
-    // Better than staying silent about a redirect that happened. The fallback
-    // is lossy on purpose: it only has to be safe to print.
-    const result = seedRedirect(baseReport({ finalUrl: `javascript:alert(1)${LF}x` }));
-    expect(result?.finalUrl).toBe("javascript:alert(1)x");
+  test("a value that is not an http(s) URL is withheld, and the redirect still disclosed", () => {
+    // Refusing beats sanitizing: the only producer of this field resolves a
+    // `Location` against an absolute http(s) seed, so a value that does not
+    // parse is already off the legitimate path and has no shape worth keeping.
+    // Sanitizing would mean maintaining a denylist of unsafe code points
+    // forever; withholding keeps the WHATWG parser's allowlist. The disclosure
+    // — the load-bearing half — still fires.
+    for (const hostile of [
+      `javascript:alert(1)${LF}x`,
+      "not-a-url",
+      `not-a-url${CSI}2J${RTL_OVERRIDE}txt`,
+      "//protocol-relative/only",
+      "data:text/html,<script>alert(1)</script>",
+      // Invisible characters only. Still a stored value, so still disclosed:
+      // being unprintable must not be a way to buy silence.
+      `${RTL_OVERRIDE}${CSI}`,
+    ]) {
+      const result = seedRedirect(baseReport({ finalUrl: hostile }));
+      expect(result?.finalUrl).toBeNull();
+      expect(result?.note).toBe(WITHHELD_NOTE);
+    }
+  });
+
+  test("baseUrl loses C1 and bidi controls too, not only C0 and whitespace", () => {
+    // baseUrl is not canonicalized (it is shown the way the rest of the report
+    // shows it), so it gets the same floor by subtraction.
+    const result = seedRedirect(
+      baseReport({
+        baseUrl: `https://exa${CSI}mple.com/${RTL_OVERRIDE}p${ZERO_WIDTH_SPACE}`,
+        finalUrl: "https://other.example/",
+      }),
+    );
+    expect(result?.baseUrl).toBe("https://example.com/p");
+    for (const char of [CSI, RTL_OVERRIDE, ZERO_WIDTH_SPACE]) {
+      expect(result?.note.includes(char)).toBe(false);
+    }
   });
 });
 
@@ -154,12 +279,86 @@ describe("renderers surface the refused redirect", () => {
   });
 
   test("llm emits a machine-readable element an agent cannot miss", () => {
-    const llm = renderLlm(redirected);
-    expect(llm).toContain(
-      '<seed-redirect final-url="https://other.example/landing" followed="false">',
-    );
-    expect(llm).toContain(NOTE);
-    expect(renderLlm(baseReport())).not.toContain("<seed-redirect");
+    const doc = xml.parse(renderLlm(redirected));
+    expect(doc.audit["seed-redirect"]).toEqual({
+      "@final-url": "https://other.example/landing",
+      "@followed": "false",
+      "#text": NOTE,
+    });
+    expect(xml.parse(renderLlm(baseReport())).audit["seed-redirect"]).toBeUndefined();
+  });
+
+  test("json carries the canonical URL as a structured field beside baseUrl", () => {
+    const meta = JSON.parse(renderJson(redirected)).meta;
+    expect(meta.seedRedirect).toEqual({
+      finalUrl: "https://other.example/landing",
+      followed: false,
+      note: NOTE,
+    });
+    // The graded URL and the refused target are both present and distinct.
+    expect(meta.baseUrl).toBe("https://example.com");
+    expect(JSON.parse(renderJson(baseReport())).meta.seedRedirect).toBeUndefined();
+  });
+
+  test("xml carries the canonical URL as a structured element", () => {
+    const doc = xml.parse(renderXml(redirected));
+    expect(doc["squirrelscan-audit"]["seed-redirect"]).toEqual({
+      "@followed": "false",
+      "final-url": "https://other.example/landing",
+      note: NOTE,
+    });
+    expect(xml.parse(renderXml(baseReport()))["squirrelscan-audit"]["seed-redirect"]).toBeUndefined();
+  });
+
+  test("every renderer discloses it — none can be added and left unwired", () => {
+    for (const { name, render } of RENDERERS) {
+      const output = render(redirected);
+      expect(`${name}: ${output.includes("https://other.example/landing")}`).toBe(`${name}: true`);
+      expect(`${name}: ${output.includes("not followed")}`).toBe(`${name}: true`);
+    }
+  });
+});
+
+describe("a target that could not be canonicalized is withheld, not sanitized", () => {
+  // The repro: unparseable, and carrying both an 8-bit CSI (which a terminal
+  // acts on) and a bidi override (which rewrites how the rest reads). Neither
+  // is in the C0/whitespace set the old fallback stripped.
+  const hostile = baseReport({ finalUrl: `not-a-url${CSI}2J${RTL_OVERRIDE}txt` });
+
+  test("no renderer emits any byte of the stored value", () => {
+    for (const { name, render } of RENDERERS) {
+      const output = render(hostile);
+      // The disclosure still happens, unescaped and identical in every format...
+      expect(`${name}: ${output.includes(WITHHELD_NOTE)}`).toBe(`${name}: true`);
+      // ...and nothing site-controlled rides along with it, in any spelling.
+      for (const [label, needle] of [
+        ["raw CSI", CSI],
+        ["raw override", RTL_OVERRIDE],
+        ["stripped value", "not-a-url"],
+        ["escaped override", "%E2%80%AE"],
+        ["escaped CSI", "%C2%9B"],
+      ] as const) {
+        expect(`${name}/${label}: ${output.includes(needle)}`).toBe(`${name}/${label}: false`);
+      }
+    }
+  });
+
+  test("the machine formats say the target is absent rather than inventing one", () => {
+    // A consumer reading only the URL field gets nothing, not a placeholder it
+    // would treat as a URL; the note carries the explanation.
+    expect(JSON.parse(renderJson(hostile)).meta.seedRedirect).toEqual({
+      finalUrl: null,
+      followed: false,
+      note: WITHHELD_NOTE,
+    });
+    expect(xml.parse(renderXml(hostile))["squirrelscan-audit"]["seed-redirect"]).toEqual({
+      "@followed": "false",
+      note: WITHHELD_NOTE,
+    });
+    expect(xml.parse(renderLlm(hostile)).audit["seed-redirect"]).toEqual({
+      "@followed": "false",
+      "#text": WITHHELD_NOTE,
+    });
   });
 });
 
@@ -202,29 +401,108 @@ describe("the site-controlled URL is escaped in every format", () => {
     expect(md).not.toContain("/a&#x202E;b");
   });
 
-  test("llm xml-escapes the attribute value and the sentence", () => {
-    const llm = renderLlm(hostile);
-    expect(llm).toContain(`final-url="${canonical.replaceAll("&", "&amp;")}"`);
-    expect(llm).not.toContain("<img/onerror=y>");
+  test("the XML formats stay well-formed and keep the URL out of the markup", () => {
+    // Parsed, not string-matched: a broken attribute quote or an unescaped `<`
+    // shows up as a parse failure or a stray element, and matching on
+    // substrings would miss both.
+    const fromLlm = xml.parse(renderLlm(hostile)).audit["seed-redirect"];
+    expect(fromLlm["@final-url"]).toBe(canonical);
+    expect(fromLlm["#text"]).toContain(canonical);
+    const fromXml = xml.parse(renderXml(hostile))["squirrelscan-audit"]["seed-redirect"];
+    expect(fromXml["final-url"]).toBe(canonical);
+    expect(fromXml.note).toContain(canonical);
+    // The `<img>` in the value stayed a text/attribute value in both.
+    for (const output of [renderLlm(hostile), renderXml(hostile)]) {
+      expect(output).not.toContain("<img/onerror=y>");
+    }
   });
 
-  test("llm escapes a quote that reached the fallback path, so the attribute cannot be closed", () => {
-    // Canonicalization percent-encodes a quote, but a value that does not parse
-    // as a URL keeps one, and it lands in an XML attribute.
-    const llm = renderLlm(baseReport({ finalUrl: 'not a url" onerror="alert(1)' }));
-    expect(llm).toContain('final-url="notaurl&quot;onerror=&quot;alert(1)" followed="false"');
+  test("json holds the URL as data, with no escaping of its own to get wrong", () => {
+    const meta = JSON.parse(renderJson(hostile)).meta;
+    expect(meta.seedRedirect.finalUrl).toBe(canonical);
+    expect(meta.seedRedirect.note).toContain(canonical);
   });
 
   test("no renderer lets a newline in finalUrl start a line of its own", () => {
     const withNewline = baseReport({ finalUrl: `https://evil.example/a${LF}# Everything is fine` });
-    for (const output of [
-      renderText(withNewline),
-      renderMarkdown(withNewline),
-      renderLlm(withNewline),
-      renderHtml(withNewline, { reportId: "rep_1" }),
-    ]) {
-      expect(output).toContain("https://evil.example/a#%20Everything%20is%20fine");
-      expect(output).not.toContain(`${LF}# Everything is fine`);
+    for (const { name, render } of RENDERERS) {
+      const output = render(withNewline);
+      expect(`${name}: ${output.includes("https://evil.example/a#%20Everything%20is%20fine")}`).toBe(
+        `${name}: true`,
+      );
+      expect(`${name}: ${output.includes(`${LF}# Everything is fine`)}`).toBe(`${name}: false`);
     }
   });
+});
+
+/**
+ * Return the single contiguous chunk `after` adds to `before`, failing if the
+ * two differ by anything else. Asserting on the reconstruction is what makes
+ * this a full-output equality check: everything outside the returned chunk is
+ * byte-identical, so a report with no redirect renders exactly as it did before
+ * the disclosure existed.
+ */
+function soleInsertion(before: string, after: string): string {
+  let prefix = 0;
+  while (prefix < before.length && before[prefix] === after[prefix]) prefix++;
+  let suffix = 0;
+  while (
+    suffix < before.length - prefix &&
+    before[before.length - 1 - suffix] === after[after.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  expect(before).toBe(after.slice(0, prefix) + after.slice(after.length - suffix));
+  return after.slice(prefix, after.length - suffix);
+}
+
+describe("a report with no redirect renders byte-for-byte as it did before", () => {
+  const baseline = baseReport({
+    scanScope: { origin: "cli", maxPages: 100, pagesCrawled: 1, capped: false },
+    coverage: { auditedPages: 1, knownPages: 1, carriedFindings: 0 },
+  });
+
+  // Every input on which `seedRedirect` returns null. Each must produce output
+  // identical to the field being absent entirely — not merely output that lacks
+  // the word "Seed", which a stray blank line or wrapper would still satisfy.
+  const suppressed: ReadonlyArray<[string, string]> = [
+    ["blank", ""],
+    ["whitespace only", "   "],
+    ["tab and newline only", `${TAB}${LF}${CR}`],
+    ["no-break space only", NBSP],
+    ["same as baseUrl", "https://example.com"],
+    ["trailing-slash spelling", "https://example.com/"],
+    ["default port", "https://example.com:443/"],
+    ["case-different scheme and host", "HTTPS://Example.com"],
+  ];
+
+  for (const { name, render } of RENDERERS) {
+    test(`${name}: identical to the no-field rendering in every suppressed case`, () => {
+      const withoutField = render(baseline);
+      expect(withoutField).not.toContain("Seed redirected");
+      for (const [label, finalUrl] of suppressed) {
+        // Compared as one labeled string so a failure names the case.
+        const rendered = render(baseReport({ ...baseline, finalUrl }));
+        expect(`${label}: ${rendered}`).toBe(`${label}: ${withoutField}`);
+      }
+    });
+
+    test(`${name}: a redirect adds the disclosure and changes nothing else`, () => {
+      const withoutField = render(baseline);
+      const withRedirect = render(
+        baseReport({ ...baseline, finalUrl: "https://other.example/landing" }),
+      );
+      // Asserts inside: the two outputs differ by exactly this one insertion.
+      const inserted = soleInsertion(withoutField, withRedirect);
+      // ...and that insertion is the disclosure. It comes back rotated: the
+      // diff boundary lands wherever the two outputs stop matching, which is
+      // mid-token when the next line happens to start with the same character.
+      // Doubling makes the block contiguous again.
+      expect(`${inserted}${inserted}`).toContain(NOTE);
+      // Exactly one disclosure in the whole output, so nothing rode along with
+      // it. The note survives every format verbatim (nothing in it is markdown,
+      // XML or JSON syntax), so this counts the same way in all six.
+      expect(withRedirect.split(NOTE).length - 1).toBe(1);
+    });
+  }
 });

--- a/packages/report/tests/seed-redirect.test.ts
+++ b/packages/report/tests/seed-redirect.test.ts
@@ -51,6 +51,18 @@ function baseReport(overrides: Partial<AuditReport> = {}): AuditReport {
 
 const redirected = baseReport({ finalUrl: "https://other.example/landing" });
 
+/**
+ * How many times `needle` appears in `haystack`.
+ *
+ * Used instead of `String.prototype.includes` wherever the needle is a URL:
+ * CodeQL's incomplete-url-substring-sanitization rule reads a URL literal
+ * handed to `includes` as a host check, and these assertions are the opposite
+ * of that — they ask whether a URL is present in a whole rendered document.
+ */
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
 /** Every renderer, so a disclosure can never be wired into only some of them. */
 const RENDERERS: ReadonlyArray<{ name: string; render: (r: AuditReport) => string }> = [
   { name: "text", render: (r) => renderText(r) },
@@ -312,9 +324,9 @@ describe("renderers surface the refused redirect", () => {
 
   test("every renderer discloses it — none can be added and left unwired", () => {
     for (const { name, render } of RENDERERS) {
-      const output = render(redirected);
-      expect(`${name}: ${output.includes("https://other.example/landing")}`).toBe(`${name}: true`);
-      expect(`${name}: ${output.includes("not followed")}`).toBe(`${name}: true`);
+      // Exactly one full disclosure, labeled by renderer so a failure names
+      // the one that is unwired. The note survives every format verbatim.
+      expect(`${name}: ${occurrences(render(redirected), NOTE)}`).toBe(`${name}: 1`);
     }
   });
 });
@@ -427,9 +439,9 @@ describe("the site-controlled URL is escaped in every format", () => {
     const withNewline = baseReport({ finalUrl: `https://evil.example/a${LF}# Everything is fine` });
     for (const { name, render } of RENDERERS) {
       const output = render(withNewline);
-      expect(`${name}: ${output.includes("https://evil.example/a#%20Everything%20is%20fine")}`).toBe(
-        `${name}: true`,
-      );
+      expect(
+        `${name}: ${occurrences(output, "https://evil.example/a#%20Everything%20is%20fine") > 0}`,
+      ).toBe(`${name}: true`);
       expect(`${name}: ${output.includes(`${LF}# Everything is fine`)}`).toBe(`${name}: false`);
     }
   });

--- a/packages/report/tests/seed-redirect.test.ts
+++ b/packages/report/tests/seed-redirect.test.ts
@@ -1,0 +1,230 @@
+// #1418 — refused off-site seed redirect. The crawler pins the crawl to the
+// seed when a seed redirect leaves the seed's registrable domain, so `baseUrl`
+// is the site the user asked for and `finalUrl` records where the redirect
+// pointed. Every renderer has to say so, or the report reads as a clean audit
+// of a URL nobody requested.
+
+import { describe, expect, test } from "bun:test";
+
+import type { AuditReport } from "../src/types";
+import { seedRedirect, seedRedirectLine } from "../src/coverage";
+import { renderText } from "../src/output/text";
+import { renderMarkdown } from "../src/output/markdown";
+import { renderHtml } from "../src/output/html";
+import { renderLlm } from "../src/output/llm";
+
+// Built rather than typed as literals so this file carries no raw control
+// characters of its own.
+const LF = String.fromCharCode(10);
+const CR = String.fromCharCode(13);
+const TAB = String.fromCharCode(9);
+const ESC = String.fromCharCode(27);
+const DEL = String.fromCharCode(127);
+const RTL_OVERRIDE = String.fromCharCode(0x202e);
+const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
+
+const NOTE =
+  "Seed redirected off-site to https://other.example/landing, not followed. This audit graded https://example.com.";
+
+function baseReport(overrides: Partial<AuditReport> = {}): AuditReport {
+  return {
+    baseUrl: "https://example.com",
+    timestamp: "2026-06-16T14:30:00.000Z",
+    totalPages: 1,
+    passed: 0,
+    warnings: 0,
+    failed: 0,
+    ruleResults: {},
+    ...overrides,
+  };
+}
+
+const redirected = baseReport({ finalUrl: "https://other.example/landing" });
+
+describe("seedRedirect", () => {
+  test("names the refused target AND the URL that was actually graded", () => {
+    expect(seedRedirect(redirected)).toEqual({
+      finalUrl: "https://other.example/landing",
+      baseUrl: "https://example.com",
+      note: NOTE,
+    });
+    expect(seedRedirectLine(redirected)).toBe(NOTE);
+  });
+
+  test("null without a finalUrl: older reports and every seed that stayed on-site", () => {
+    expect(seedRedirect(baseReport())).toBeNull();
+    expect(seedRedirectLine(baseReport())).toBeNull();
+  });
+
+  test("null when finalUrl is only an equivalent spelling of baseUrl", () => {
+    // Canonical comparison: a bare origin and a trailing-slash origin are the
+    // same place, and a line saying the seed redirected to itself is worse
+    // than no line.
+    expect(seedRedirect(baseReport({ finalUrl: "https://example.com" }))).toBeNull();
+    expect(seedRedirect(baseReport({ finalUrl: "https://example.com/" }))).toBeNull();
+    expect(seedRedirect(baseReport({ finalUrl: " https://example.com " }))).toBeNull();
+    expect(seedRedirect(baseReport({ finalUrl: "HTTPS://Example.com" }))).toBeNull();
+  });
+
+  test("null for a blank finalUrl, rather than an empty placeholder line", () => {
+    expect(seedRedirect(baseReport({ finalUrl: "" }))).toBeNull();
+    expect(seedRedirect(baseReport({ finalUrl: "   " }))).toBeNull();
+  });
+
+  test("null without a baseUrl: with nothing to contrast against the line says nothing", () => {
+    expect(seedRedirect(baseReport({ baseUrl: "", finalUrl: "https://other.example/" }))).toBeNull();
+  });
+
+  test("canonicalizes the site's URL: control characters cannot survive as themselves", () => {
+    // The redirect target is whatever `Location` the audited site sent and
+    // reaches the report as a stored string, so a raw newline or ESC survives
+    // validation. Re-serializing through the URL parser drops the newline and
+    // percent-encodes the rest, so nothing can break out of the line below.
+    const result = seedRedirect(
+      baseReport({ finalUrl: `https://evil.example/a${LF}${CR}b${TAB}c d${ESC}[2Je${DEL}` }),
+    );
+    expect(result?.finalUrl).toBe("https://evil.example/abc%20d%1B[2Je%7F");
+    expect(result?.note).toContain(`to ${result?.finalUrl},`);
+    for (const char of [LF, CR, TAB, ESC, DEL]) {
+      expect(result?.note.includes(char)).toBe(false);
+    }
+  });
+
+  test("invisible and homograph characters become visible, not silently dropped", () => {
+    // Escaping stops syntax injection; it does nothing about a URL that LOOKS
+    // like another one. A bidi override would reverse how the rest of the path
+    // reads, and a Cyrillic host would read as the site's own.
+    const result = seedRedirect(
+      baseReport({
+        finalUrl: `https://еxample.com/${RTL_OVERRIDE}gnp.exe${ZERO_WIDTH_SPACE}`,
+      }),
+    );
+    expect(result?.finalUrl).toBe("https://xn--xample-2of.com/%E2%80%AEgnp.exe%E2%80%8B");
+    expect(result?.finalUrl.includes(RTL_OVERRIDE)).toBe(false);
+    expect(result?.finalUrl.includes(ZERO_WIDTH_SPACE)).toBe(false);
+  });
+
+  test("a value that is not an http(s) URL still gets disclosed, with the same characters dropped", () => {
+    // Better than staying silent about a redirect that happened. The fallback
+    // is lossy on purpose: it only has to be safe to print.
+    const result = seedRedirect(baseReport({ finalUrl: `javascript:alert(1)${LF}x` }));
+    expect(result?.finalUrl).toBe("javascript:alert(1)x");
+  });
+});
+
+describe("renderers surface the refused redirect", () => {
+  test("text", () => {
+    expect(renderText(redirected)).toContain(NOTE);
+    expect(renderText(baseReport())).not.toContain("Seed redirected");
+  });
+
+  test("markdown", () => {
+    expect(renderMarkdown(redirected)).toContain(NOTE);
+    expect(renderMarkdown(baseReport())).not.toContain("Seed redirected");
+  });
+
+  test("markdown keeps it a plain line: a blockquote would swallow the lines below it", () => {
+    // CommonMark lazy continuation pulls every following non-blank line into an
+    // open blockquote, which would put scan scope, coverage and the version
+    // inside the warning.
+    const md = renderMarkdown(
+      baseReport({
+        finalUrl: "https://other.example/landing",
+        scanScope: { origin: "cli", maxPages: 100, pagesCrawled: 1, capped: false },
+      }),
+      { version: "1.2.3" },
+    );
+    const rendered = md.split("\n");
+    const index = rendered.findIndex((line) => line.includes("Seed redirected"));
+    expect(index).toBeGreaterThan(-1);
+    expect(rendered[index]?.startsWith(">")).toBe(false);
+    // The metadata below it is still its own content, not quoted text.
+    expect(rendered[index + 1]).toContain("Scan: 1 page crawled");
+    expect(rendered.some((line) => line.startsWith("> "))).toBe(false);
+  });
+
+  test("html", () => {
+    const html = renderHtml(redirected, { reportId: "rep_1" });
+    expect(html).toContain("Seed redirected off-site to https://other.example/landing");
+    expect(html).toContain("not followed");
+    // No node at all when there is nothing to disclose.
+    const clean = renderHtml(baseReport(), { reportId: "rep_1" });
+    expect(clean).not.toContain("Seed redirected");
+    expect(clean).not.toContain('class="scan-hint"');
+  });
+
+  test("llm emits a machine-readable element an agent cannot miss", () => {
+    const llm = renderLlm(redirected);
+    expect(llm).toContain(
+      '<seed-redirect final-url="https://other.example/landing" followed="false">',
+    );
+    expect(llm).toContain(NOTE);
+    expect(renderLlm(baseReport())).not.toContain("<seed-redirect");
+  });
+});
+
+describe("the site-controlled URL is escaped in every format", () => {
+  // finalUrl is a string the AUDITED SITE chose. Canonicalization percent-encodes
+  // `<`, `>` and backtick, but not the brackets, parens and underscores markdown
+  // reads as syntax, so each renderer still has to neutralize it for its own
+  // grammar.
+  const hostile = baseReport({
+    finalUrl: 'https://evil.example/[x](javascript:alert(1))`code`_em_<img/onerror=y>&"q"',
+  });
+  const canonical =
+    "https://evil.example/[x](javascript:alert(1))%60code%60_em_%3Cimg/onerror=y%3E&%22q%22";
+
+  test("the canonical form is what every renderer starts from", () => {
+    expect(seedRedirect(hostile)?.finalUrl).toBe(canonical);
+  });
+
+  test("html escapes it as a React text child and never links it", () => {
+    const html = renderHtml(hostile, { reportId: "rep_1" });
+    expect(html).toContain("%3Cimg/onerror=y%3E&amp;");
+    expect(html).not.toContain("<img/onerror=y>");
+    // The whole point of the line is that we did NOT follow the redirect.
+    expect(html).not.toContain('href="https://evil.example/');
+  });
+
+  test("markdown escapes link, image, code-span, emphasis and entity syntax", () => {
+    const md = renderMarkdown(hostile);
+    expect(md).toContain(
+      "https://evil.example/\\[x\\]\\(javascript:alert\\(1\\)\\)%60code%60\\_em\\_%3Cimg/onerror=y%3E\\&%22q%22",
+    );
+    expect(md).not.toContain("[x](javascript:alert(1))");
+  });
+
+  test("markdown escapes an ampersand so a numeric entity cannot be decoded back", () => {
+    // `&#x202E;` would otherwise reintroduce, at render time, the bidi override
+    // canonicalization just percent-encoded away.
+    const md = renderMarkdown(baseReport({ finalUrl: "https://evil.example/a&#x202E;b" }));
+    expect(md).toContain("https://evil.example/a\\&#x202E;b");
+    expect(md).not.toContain("/a&#x202E;b");
+  });
+
+  test("llm xml-escapes the attribute value and the sentence", () => {
+    const llm = renderLlm(hostile);
+    expect(llm).toContain(`final-url="${canonical.replaceAll("&", "&amp;")}"`);
+    expect(llm).not.toContain("<img/onerror=y>");
+  });
+
+  test("llm escapes a quote that reached the fallback path, so the attribute cannot be closed", () => {
+    // Canonicalization percent-encodes a quote, but a value that does not parse
+    // as a URL keeps one, and it lands in an XML attribute.
+    const llm = renderLlm(baseReport({ finalUrl: 'not a url" onerror="alert(1)' }));
+    expect(llm).toContain('final-url="notaurl&quot;onerror=&quot;alert(1)" followed="false"');
+  });
+
+  test("no renderer lets a newline in finalUrl start a line of its own", () => {
+    const withNewline = baseReport({ finalUrl: `https://evil.example/a${LF}# Everything is fine` });
+    for (const output of [
+      renderText(withNewline),
+      renderMarkdown(withNewline),
+      renderLlm(withNewline),
+      renderHtml(withNewline, { reportId: "rep_1" }),
+    ]) {
+      expect(output).toContain("https://evil.example/a#%20Everything%20is%20fine");
+      expect(output).not.toContain(`${LF}# Everything is fine`);
+    }
+  });
+});


### PR DESCRIPTION
## What

When a seed URL redirects off its own registrable domain, the crawler refuses the redirect and pins the crawl to the seed, recording where it pointed in `report.finalUrl`. Nothing read that field, so a report of such a site read as a clean audit of a URL nobody requested: correct scores, correct `baseUrl`, and no sign anywhere that a redirect happened or where it went.

- **`packages/report/src/coverage.ts`**: `seedRedirect()` / `seedRedirectLine()` alongside the other one-line disclosures (`scanScopeLine`, `coverageLine`, `fetchFallbacksLine`). Fires only when `finalUrl` is present, non-blank and not an equivalent spelling of `baseUrl`, so no report without one changes at all.

  > Seed redirected off-site to `<finalUrl>`, not followed. This audit graded `<baseUrl>`.

- **html / markdown / text / llm** all render it. HTML puts it with the scan-scope lines and deliberately does **not** link it: the point of the line is that we did not go there. `llm` also emits `<seed-redirect final-url="…" followed="false">` so an agent cannot read the scores as being about the URL it handed us.

- **`REPORT_HTML_VERSION` 12 → 13.** The API folds this into the cached-report R2 key, so already-published reports pick the line up on next view instead of serving pre-change HTML forever.

## Handling the site-controlled URL

`finalUrl` is whatever `Location` the audited site sent, so it is treated as hostile:

1. **Canonicalized once**, by re-serializing through the WHATWG URL parser (`new URL(v).href` for http/https). That drops tab/CR/LF, IDNA-encodes a Unicode hostname (a Cyrillic homograph shows as `xn--xample-2of.com`), and percent-encodes every non-ASCII code point and C0 control in the path/query/fragment, so an invisible bidi override renders as a visible `%E2%80%AE` rather than silently reversing how the rest of the URL reads. A value that does not parse as an http(s) URL falls back to dropping whitespace, C0/DEL and the code points XML forbids, so the disclosure still happens rather than being swallowed.
2. **Escaped per format**: React text child (HTML), a new `escapeMarkdownInline` (markdown), `escapeXml` on both the attribute and the text (llm), `stripControlChars` (text).

Two details worth a reviewer's eye:

- The markdown line is a **plain line, not a `>` blockquote.** A blockquote there is a live bug: CommonMark lazy continuation pulls every following non-blank line into it, so scan scope, coverage, fallbacks and the version all end up inside the warning. Verified against remark-gfm. (The existing `fullScanHint` line above has the same shape and the same problem for the two lines below it: filed separately, not touched here.)
- `escapeMarkdownInline` escapes `&` (so `&#x202E;` cannot be decoded back into the override canonicalization just encoded away) but **not** the scheme colon. GFM autolinks a bare `https://…` and a backslash before the colon does not stop it (verified against remark-gfm), so escaping it would only make the raw document uglier. An autolink literal is limited to http/https/www/mailto, so it cannot produce a `javascript:` link, and the URL is shown in full either way.

## Test

`packages/report/tests/seed-redirect.test.ts` — 20 tests: present / absent / equivalent-spelling / blank / no-baseUrl; control characters, bidi override, zero-width space and a homograph host through the canonicalizer; the non-URL fallback; every renderer with and without the field; markdown block boundary (no blockquote, the metadata below stays its own content); markdown link/image/code-span/emphasis/entity escaping; XML attribute-quote escaping via the fallback path; and no renderer letting a newline start a line of its own.

- `cd packages/report && bun test` → 276 pass / 0 fail
- `bun run typecheck` (all workspaces) → clean
- `bun run format:check` / `bun run lint` → clean
- root `bun test` (CLI suite) → 4827 pass / 2 fail, both flakes under full-suite load (`report-stream-v2-golden` and `auth-session-status`); each passes on its own both with and without this change.

## Related

Surfacing half of squirrelscan/repo#1657. The private side (the API's own markdown template and the MCP `get_report` summary) is a companion PR there; this is the shared renderer half, and the private repo picks it up with a gitlink bump after this merges.


---

## Review round 2 (efc0253)

Three acceptance findings, all addressed.

### 1. json, xml and the console had no disclosure (medium)

`--format json`, `--format xml` and the **default terminal output** carried neither the refused target nor any sign a redirect had happened. Now wired:

- **json** — `meta.seedRedirect { finalUrl, followed: false, note }`, placed next to the `meta.baseUrl` it qualifies so a consumer reading the graded URL sees the contradiction in the same object.
- **xml** — a `<seed-redirect followed="false">` element beside `<site>`, with `<final-url>` and `<note>` children (child elements rather than attributes, matching how `<site>` carries its own URL).
- **console** — a line under the header, **and in the failed/blocked branch**, which returns early. A seed that redirects off-site and is refused is one of the likeliest ways to end up with nothing to audit, so that branch needed it most.

Both machine formats carry the same canonical URL the prose renderers print.

### 2. The fallback preserved C1 and bidi controls (medium) — decided: reject, not encode

`dropNonUrlChars` stripped C0/DEL/whitespace/XML-noncharacters but kept U+009B (an 8-bit CSI, which a terminal acts on exactly like `ESC[`, and text/console output reaches a live terminal) and U+202E and friends.

**`canonicalizeReportUrl` now refuses anything the WHATWG parser does not hand back as http(s)**, rather than sanitizing it. `SeedRedirect.finalUrl` is `string | null`, and the note becomes fixed text: *"Seed redirected off-site and was not followed. The redirect target was not a valid URL and is withheld. This audit graded X."*

Why reject:

1. The only producer of this field resolves a `Location` header against an absolute http(s) seed and stores an absolute URL. A value that does not parse is already off the legitimate path — it is corrupt or injected, and there is no shape worth preserving.
2. Encoding means maintaining a **denylist** of unsafe ranges that has to stay current with Unicode forever. It was already missing two whole classes. Refusing keeps the **allowlist** the URL parser already implements, and that parser percent-encodes everything non-ASCII on the way out.
3. The load-bearing half of the disclosure still fires. The user still learns the seed redirected off-site and was not followed; only the target is withheld.

Secondary hardening from the same finding:

- `dropNonUrlChars` (now only `baseUrl`, which is not canonicalized) also drops C1 and the invisible-format/bidi ranges: U+00AD, U+061C, U+200B–200F, U+202A–202E, U+2060–206F, U+FEFF.
- Blankness is "nothing but ordinary whitespace", **not `trim()`**: U+FEFF is in JavaScript's whitespace set, so `trim()` would read a BOM-only value as an empty field — handing an unprintable value exactly the silence this disclosure exists to prevent. A no-break space still counts as blank, because it really is a space.

### 3. Tests

- **Byte identity, not phrase absence.** For all six renderers, every suppression case (absent, blank, whitespace-only, NBSP-only, same-as-baseUrl, trailing-slash, default-port, case-different) renders **byte-identical** to the field being absent. And when a redirect *does* fire, `soleInsertion` proves the two outputs differ by exactly **one contiguous insertion** and reconstructs the no-redirect output from it, so everything outside the disclosure is provably unchanged.
- **Default-port and IDN equivalence** suppression cases: `https://example.com:443/`, `http://example.com:80/`, and Unicode-vs-punycode (`https://例え.jp` vs `https://xn--r8jz45g.jp/`) in both directions.
- **The XML formats are parsed, not string-matched** — `XMLValidator.validate()` first (the parser alone is lenient about mismatched tags and stray roots), then `XMLParser`, then assertions on the tree. `fast-xml-parser` added as a devDependency of `packages/report`; it was already a pinned root override at 5.10.1.
- The **`not-a-url<CSI>2J<RLO>txt` repro** is asserted across all six renderers plus the console: the disclosure appears, and no byte of the stored value survives in any spelling (raw, stripped, or percent-encoded).

### Also found and fixed while here

Adding `meta.seedRedirect` to slim JSON exposed a round-trip hole: `convertSlimReport` did not restore it, so `--format json` followed by a re-render silently turned a report about a redirected seed back into what reads as a clean audit. It now restores `finalUrl`. A withheld target has no URL to restore and comes back as `WITHHELD_SEED_REDIRECT_TARGET`, which `seedRedirect` re-refuses into the identical withheld disclosure — so the disclosure survives precisely in the case where the stored value was hostile enough to be refused in the first place. The JSON file is user-supplied, so a `finalUrl` that is not a string takes the same path rather than reaching a renderer.

### Known and deliberate

The markdown line still **GFM-autolinks** the target, where HTML deliberately does not link it. Left as-is: it is base-commit behaviour already documented above, only canonical http(s) targets ever reach the note (so an autolink literal cannot produce a `javascript:` link), and the URL is shown in full either way. The clean fix — a code span — would require markdown to compose its own sentence from the structured fields, breaking the invariant that every format prints one identical note.

### Test evidence

- `packages/report` → 298 pass / 0 fail
- `apps/cli` → 1898 pass / 1 skip / 0 fail
- `bun run typecheck` (all workspaces), `format:check`, `lint`, `notices:check` → clean
- `detect-secrets-hook --baseline .secrets.baseline` over `git ls-files` → clean, baseline unchanged (`html.tsx` untouched, so no line-number shift)

### CodeQL (860e256)

The first push tripped `js/incomplete-url-substring-sanitization` on a **test** assertion: `output.includes("https://other.example/landing")`. The rule matches a URL-shaped literal handed to `includes` regardless of what the haystack is, and here the haystack is a whole rendered report, not a URL. Rewritten to count occurrences via `split()`, which the rule does not match and which tightens the renderer sweep from "discloses" to "discloses exactly once". The console test now locates the header line by the score rather than by the base URL.
