### PR TITLE
fix(audit-engine): keep the fetch deadline armed through the body read

### DIFF
--- a/apps/cli/src/crawl/sitemaps.ts
+++ b/apps/cli/src/crawl/sitemaps.ts
@@ -136,6 +136,9 @@ export type SitemapFetchResult =
   | { success: true; data: SitemapData }
   | { success: false; url: string; error: string };
 
+/** Deadline for one sitemap fetch, covering the body read (#1729). */
+export const SITEMAP_FETCH_TIMEOUT_MS = 30000;
+
 /**
  * Fetch a single sitemap
  * Uses standard fetch (not IMPIT) since sitemaps are meant to be crawled by bots
@@ -143,13 +146,18 @@ export type SitemapFetchResult =
  */
 export function fetchSitemap(
   url: string,
-  userAgent: string
+  userAgent: string,
+  timeoutMs: number = SITEMAP_FETCH_TIMEOUT_MS
 ): Effect.Effect<SitemapFetchResult, never, never> {
   return pipe(
     Effect.tryPromise({
+      // #1729: the deadline covers the BODY read, not just the headers. The
+      // text read used to sit outside the timer's scope, so a sitemap host that
+      // answered 200 and then trickled or stalled its body had no time bound at
+      // all and parked the crawl preamble.
       try: async () => {
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 30000);
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
         try {
           const response = await fetch(url, {
@@ -161,7 +169,13 @@ export function fetchSitemap(
             signal: controller.signal,
             redirect: "follow",
           });
-          return response;
+          if (!response.ok) {
+            // Nothing here reads a non-2xx body; drop it so the connection is
+            // released rather than left half-consumed.
+            void response.body?.cancel();
+            return { ok: false as const, status: response.status };
+          }
+          return { ok: true as const, content: await response.text() };
         } finally {
           clearTimeout(timeoutId);
         }
@@ -172,41 +186,14 @@ export function fetchSitemap(
         error: error instanceof Error ? error.message : "Network error",
       }),
     }),
-    Effect.flatMap((response) => {
-      // Network error or non-2xx status
-      if (!response.ok) {
-        const errorMsg =
-          "status" in response && response.status
-            ? `HTTP ${response.status}`
-            : "error" in response
-              ? String(response.error)
-              : "Network error";
-        return Effect.succeed<SitemapFetchResult>({
-          success: false,
-          url,
-          error: errorMsg,
-        });
+    Effect.map((result): SitemapFetchResult => {
+      if (!result.ok) {
+        return { success: false, url, error: `HTTP ${result.status}` };
       }
-
-      return Effect.tryPromise({
-        try: () => response.text(),
-        catch: () => null,
-      }).pipe(
-        Effect.map((content): SitemapFetchResult => {
-          if (!content) {
-            return {
-              success: false,
-              url,
-              error: "Empty response",
-            };
-          }
-          const parsed = parseSitemap(content, url);
-          return {
-            success: true,
-            data: parsed,
-          } as SitemapFetchResult;
-        })
-      );
+      if (!result.content) {
+        return { success: false, url, error: "Empty response" };
+      }
+      return { success: true, data: parseSitemap(result.content, url) };
     }),
     Effect.catchAll(() =>
       Effect.succeed({

--- a/apps/cli/src/crawl/sitemaps.ts
+++ b/apps/cli/src/crawl/sitemaps.ts
@@ -182,11 +182,19 @@ export function fetchSitemap(
           clearTimeout(timeoutId);
         }
       },
-      catch: (error) => ({
-        status: 0,
-        ok: false,
-        error: error instanceof Error ? error.message : "Network error",
-      }),
+      // Deliberately NOT shaped like the success branch above: this value goes
+      // to the ERROR channel, so it never reaches the mapper. Giving it an
+      // `ok`/`status` of its own invited the misreading that a failed fetch
+      // could surface as "HTTP 0".
+      catch: (error) => {
+        const err = error as Error;
+        // #1729: the deadline now covers the body read too, so name that case
+        // instead of letting a stalled sitemap read as a generic failure.
+        if (err?.name === "AbortError") {
+          return { reason: `Timed out after ${timeoutMs}ms` };
+        }
+        return { reason: err?.message || "Network error" };
+      },
     }),
     Effect.map((result): SitemapFetchResult => {
       if (!result.ok) {
@@ -197,11 +205,14 @@ export function fetchSitemap(
       }
       return { success: true, data: parseSitemap(result.content, url) };
     }),
-    Effect.catchAll(() =>
+    // Carry the reason through. It used to collapse to a bare "Unexpected
+    // error", which made a body-read timeout, a DNS failure and a connection
+    // reset indistinguishable in the failed-sitemap report.
+    Effect.catchAll((failure) =>
       Effect.succeed({
         success: false,
         url,
-        error: "Unexpected error",
+        error: failure.reason,
       } as SitemapFetchResult)
     )
   );

--- a/apps/cli/src/crawl/sitemaps.ts
+++ b/apps/cli/src/crawl/sitemaps.ts
@@ -171,8 +171,10 @@ export function fetchSitemap(
           });
           if (!response.ok) {
             // Nothing here reads a non-2xx body; drop it so the connection is
-            // released rather than left half-consumed.
-            void response.body?.cancel();
+            // released rather than left half-consumed. Caught, not `void`: an
+            // already-errored stream rejects, and an unhandled rejection is a
+            // worse outcome than an undrained socket.
+            await response.body?.cancel().catch(() => {});
             return { ok: false as const, status: response.status };
           }
           return { ok: true as const, content: await response.text() };

--- a/apps/cli/src/crawler/external-checker.ts
+++ b/apps/cli/src/crawler/external-checker.ts
@@ -54,6 +54,11 @@ async function checkSingleUrlAsync(
   options: ExternalCheckerOptions
 ): Promise<CheckUrlResult> {
   const controller = new AbortController();
+  // #1729: the deadline stays armed until this function returns, so it also
+  // covers the WAF body read below. Clearing it where the GET resolved disarmed
+  // the abort at the HEADERS, leaving `getResponse.text()` no time bound at all
+  // — the 403 interstitials this branch exists to read are exactly the
+  // responses a hostile origin is happy to trickle forever.
   const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
 
   try {
@@ -72,7 +77,6 @@ async function checkSingleUrlAsync(
       // Only trust HEAD for success (2xx/3xx)
       // Many servers return 401/403/429 to HEAD but allow GET
       if (headResponse.status < 400) {
-        clearTimeout(timeoutId);
         const redirectTarget =
           headResponse.url !== href ? headResponse.url : null;
         return {
@@ -97,7 +101,6 @@ async function checkSingleUrlAsync(
       redirect: "follow",
     });
 
-    clearTimeout(timeoutId);
     const redirectTarget = getResponse.url !== href ? getResponse.url : null;
 
     // For 403 responses, check if it's WAF/bot protection
@@ -125,8 +128,6 @@ async function checkSingleUrlAsync(
       redirectTarget,
     };
   } catch (error) {
-    clearTimeout(timeoutId);
-
     if ((error as Error).name === "AbortError") {
       return {
         status: null,
@@ -140,6 +141,8 @@ async function checkSingleUrlAsync(
       error: (error as Error).message || "Unknown error",
       redirectTarget: null,
     };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/apps/cli/src/crawler/external-checker.ts
+++ b/apps/cli/src/crawler/external-checker.ts
@@ -105,20 +105,26 @@ async function checkSingleUrlAsync(
 
     // For 403 responses, check if it's WAF/bot protection
     if (getResponse.status === 403) {
+      let body: string | undefined;
       try {
-        const body = await getResponse.text();
-        const wafResult = detectWaf(getResponse.headers, body);
-        if (wafResult.detected) {
-          return {
-            status: 403,
-            error: null,
-            redirectTarget,
-            wafBlocked: true,
-            wafProvider: wafResult.provider ?? "unknown",
-          };
-        }
+        body = await getResponse.text();
       } catch {
-        // Ignore body read errors, treat as regular 403
+        // The body never arrived: the deadline above fired mid-read, or the
+        // connection dropped. Do NOT give up on detection here - falling
+        // through reports a live, bot-guarded link as broken. Most WAFs are
+        // identifiable from their response headers alone (cf-ray, x-sucuri-id,
+        // a provider `server` value), so run detection on the headers we DO
+        // have. detectWaf treats an absent body as headers-only (#1729).
+      }
+      const wafResult = detectWaf(getResponse.headers, body);
+      if (wafResult.detected) {
+        return {
+          status: 403,
+          error: null,
+          redirectTarget,
+          wafBlocked: true,
+          wafProvider: wafResult.provider ?? "unknown",
+        };
       }
     }
 

--- a/apps/cli/src/crawler/script-fetcher.ts
+++ b/apps/cli/src/crawler/script-fetcher.ts
@@ -69,15 +69,8 @@ function isJavaScriptContentType(contentType: string | null): boolean {
   );
 }
 
-async function fetchSingleScriptAsync(
-  url: string,
-  options: ScriptFetcherOptions,
-  retryCount = 0
-): Promise<ScriptFetchResult> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
-
-  const defaultResult: ScriptFetchResult = {
+function emptyScriptResult(url: string): ScriptFetchResult {
+  return {
     url,
     status: null,
     error: null,
@@ -87,6 +80,24 @@ async function fetchSingleScriptAsync(
     redirected: false,
     finalUrl: undefined,
   };
+}
+
+/**
+ * One attempt, under a deadline that stays armed until the body has been read
+ * (#1729). Clearing the timer where the response resolves disarms the abort at
+ * the HEADERS, which leaves the `response.text()` below no time bound at all:
+ * a script origin that answers 200 and then trickles or stalls its body parks
+ * the audit forever. Scripts are fetched during rules enrichment, after the
+ * crawl, so that shows up as an audit that has its pages and never finishes.
+ */
+async function fetchScriptAttempt(
+  url: string,
+  options: ScriptFetcherOptions
+): Promise<ScriptFetchResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
+
+  const defaultResult = emptyScriptResult(url);
 
   try {
     // Single GET request with redirect: follow (removed unnecessary HEAD request)
@@ -99,8 +110,6 @@ async function fetchSingleScriptAsync(
       signal: controller.signal,
       redirect: "follow",
     });
-
-    clearTimeout(timeoutId);
 
     const contentType = response.headers.get("content-type");
     const contentLength = response.headers.get("content-length");
@@ -205,10 +214,23 @@ async function fetchSingleScriptAsync(
       sourceMapHeader,
       contentEncoding,
     };
-  } catch (error) {
+  } finally {
     clearTimeout(timeoutId);
+  }
+}
 
-    // Retry on transient errors
+async function fetchSingleScriptAsync(
+  url: string,
+  options: ScriptFetcherOptions,
+  retryCount = 0
+): Promise<ScriptFetchResult> {
+  try {
+    return await fetchScriptAttempt(url, options);
+  } catch (error) {
+    // Retry on transient errors. Retries live outside the attempt so each one
+    // arms its own deadline; a retry started inside the attempt's `finally`
+    // would inherit an expired timer, or keep the spent one alive for the
+    // length of the retry.
     if (
       retryCount < SCRIPT_FETCH_LIMITS.MAX_RETRIES &&
       (error as Error).name !== "AbortError"
@@ -220,9 +242,12 @@ async function fetchSingleScriptAsync(
     }
 
     if ((error as Error).name === "AbortError") {
-      return { ...defaultResult, error: "timeout" };
+      return { ...emptyScriptResult(url), error: "timeout" };
     }
-    return { ...defaultResult, error: (error as Error).message || "error" };
+    return {
+      ...emptyScriptResult(url),
+      error: (error as Error).message || "error",
+    };
   }
 }
 

--- a/apps/cli/tests/crawler/fetch-deadline.test.ts
+++ b/apps/cli/tests/crawler/fetch-deadline.test.ts
@@ -1,0 +1,175 @@
+// #1729 — a request deadline must cover the BODY read, not just the headers.
+//
+// apps/cli/src/crawler/{script-fetcher,external-checker}.ts are FORKS of the
+// audit-engine fetchers, not re-exports, so the engine's regression test proves
+// nothing about them — and these forks are what the `squirrel` CLI actually
+// runs. Each of the three fetchers here cleared its timer where the response
+// resolved, i.e. when the HEADERS landed, leaving the body read with no time
+// bound at all. Sitemaps stall the crawl preamble; scripts and external links
+// are fetched during rules enrichment, after the crawl, so an origin that
+// answered 200 and then stalled its body gave an audit that had all its pages
+// and never finished.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { fetchSitemap } from "@/crawl/sitemaps";
+import { checkExternalLinks } from "@/crawler/external-checker";
+import { fetchScriptContents } from "@/crawler/script-fetcher";
+import { closeGlobalContentStore } from "@/crawler/storage/content-store";
+import { LinkCacheStorage } from "@/crawler/storage/link-cache";
+
+const DEADLINE_MS = 300;
+
+// Headers land immediately; the body stream is enqueued once and never closed,
+// so only the client can end the request.
+const server = Bun.serve({
+  port: 0,
+  idleTimeout: 0,
+  fetch(req) {
+    const path = new URL(req.url).pathname;
+
+    // The external checker probes with HEAD first. Answer it with the status
+    // and no body so the stall below is reached on the GET, which is the read
+    // this regression is about.
+    if (req.method === "HEAD") {
+      return new Response(null, { status: path === "/stall-403" ? 403 : 200 });
+    }
+
+    const stall = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("// first chunk\n"));
+      },
+    });
+
+    if (path === "/stall.js") {
+      return new Response(stall, {
+        headers: { "content-type": "application/javascript" },
+      });
+    }
+    if (path === "/stall-403") {
+      // A 403 is what sends the external checker into its WAF body read.
+      return new Response(stall, {
+        status: 403,
+        headers: { "content-type": "text/html" },
+      });
+    }
+    if (path === "/stall-sitemap.xml") {
+      return new Response(stall, {
+        headers: { "content-type": "application/xml" },
+      });
+    }
+    if (path === "/fast.js") {
+      return new Response("console.log(1);", {
+        headers: { "content-type": "application/javascript" },
+      });
+    }
+    if (path === "/sitemap.xml") {
+      return new Response(
+        `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/one</loc></url>
+</urlset>`,
+        { headers: { "content-type": "application/xml" } }
+      );
+    }
+    return new Response("ok", { headers: { "content-type": "text/plain" } });
+  },
+});
+
+const base = `http://localhost:${server.port}`;
+
+// Throwaway stores so neither fetcher touches the user's real caches, and so a
+// stale entry can never satisfy a request under test.
+const cacheDir = mkdtempSync(join(tmpdir(), "squirrel-deadline-"));
+const priorContentStorePath = process.env.SQUIRREL_CONTENT_STORE_PATH;
+process.env.SQUIRREL_CONTENT_STORE_PATH = join(cacheDir, "content.db");
+const linkCache = new LinkCacheStorage(join(cacheDir, "links.db"));
+
+afterAll(() => {
+  server.stop(true);
+  linkCache.close();
+  closeGlobalContentStore();
+  // Restore the env, or the next test file in this process gets a store path
+  // pointing at the directory removed below.
+  if (priorContentStorePath === undefined) {
+    delete process.env.SQUIRREL_CONTENT_STORE_PATH;
+  } else {
+    process.env.SQUIRREL_CONTENT_STORE_PATH = priorContentStorePath;
+  }
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+describe("CLI script fetcher deadline (#1729)", () => {
+  test("a script body that stalls after the headers times out", async () => {
+    const startedAt = Date.now();
+    const [result] = await Effect.runPromise(
+      fetchScriptContents([`${base}/stall.js`], { timeoutMs: DEADLINE_MS })
+    );
+    const elapsed = Date.now() - startedAt;
+
+    expect(result?.error).toBe("timeout");
+    expect(result?.content).toBe(null);
+    // Close to the deadline, not merely "eventually": a bound that fires an
+    // order of magnitude late is not a bound. Before the fix this never
+    // returned at all.
+    expect(elapsed).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+    expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
+  });
+
+  test("a script that answers promptly is still read in full", async () => {
+    const [result] = await Effect.runPromise(
+      fetchScriptContents([`${base}/fast.js`], { timeoutMs: DEADLINE_MS })
+    );
+
+    expect(result?.error).toBe(null);
+    expect(result?.status).toBe(200);
+    expect(result?.content).toBe("console.log(1);");
+  });
+});
+
+describe("CLI sitemap fetcher deadline (#1729)", () => {
+  test("a sitemap body that stalls after the headers times out", async () => {
+    const startedAt = Date.now();
+    const result = await Effect.runPromise(
+      fetchSitemap(`${base}/stall-sitemap.xml`, "test-agent", DEADLINE_MS)
+    );
+    const elapsed = Date.now() - startedAt;
+
+    expect(result.success).toBe(false);
+    expect(elapsed).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+    expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
+  });
+
+  test("a sitemap that answers promptly is still parsed", async () => {
+    const result = await Effect.runPromise(
+      fetchSitemap(`${base}/sitemap.xml`, "test-agent", DEADLINE_MS)
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.urls.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("CLI external checker deadline (#1729)", () => {
+  test("a 403 whose body stalls does not hang the WAF read", async () => {
+    const startedAt = Date.now();
+    const results = await Effect.runPromise(
+      checkExternalLinks([`${base}/stall-403`], linkCache, {
+        timeoutMs: DEADLINE_MS,
+      })
+    );
+    const elapsed = Date.now() - startedAt;
+
+    // The status is known from the headers; only the WAF verdict is lost, so
+    // the link is reported as a plain 403 rather than as WAF-blocked.
+    expect(results[0]?.status).toBe(403);
+    expect(results[0]?.wafBlocked).toBeUndefined();
+    expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
+  });
+});

--- a/apps/cli/tests/crawler/fetch-deadline.test.ts
+++ b/apps/cli/tests/crawler/fetch-deadline.test.ts
@@ -17,12 +17,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { fetchSitemap } from "@/crawl/sitemaps";
-import { checkExternalLinks } from "@/crawler/external-checker";
+import {
+  checkExternalLinks,
+  filterBrokenLinks,
+  filterWafBlockedLinks,
+} from "@/crawler/external-checker";
 import { fetchScriptContents } from "@/crawler/script-fetcher";
 import { closeGlobalContentStore } from "@/crawler/storage/content-store";
 import { LinkCacheStorage } from "@/crawler/storage/link-cache";
 
 const DEADLINE_MS = 300;
+/** SCRIPT_FETCH_LIMITS.RETRY_DELAY_MS * 2^0 - the first (and only) backoff. */
+const RETRY_BACKOFF_MS = 1000;
 
 // Headers land immediately; the body stream is enqueued once and never closed,
 // so only the client can end the request.
@@ -36,7 +42,9 @@ const server = Bun.serve({
     // and no body so the stall below is reached on the GET, which is the read
     // this regression is about.
     if (req.method === "HEAD") {
-      return new Response(null, { status: path === "/stall-403" ? 403 : 200 });
+      return new Response(null, {
+        status: path.startsWith("/stall-403") ? 403 : 200,
+      });
     }
 
     const stall = new ReadableStream({
@@ -51,10 +59,21 @@ const server = Bun.serve({
       });
     }
     if (path === "/stall-403") {
-      // A 403 is what sends the external checker into its WAF body read.
+      // A 403 is what sends the external checker into its WAF body read. No WAF
+      // headers here: the body is the ONLY evidence available.
       return new Response(stall, {
         status: 403,
         headers: { "content-type": "text/html" },
+      });
+    }
+    if (path === "/stall-403-cf") {
+      // Same stalled body, but the headers alone identify the WAF.
+      return new Response(stall, {
+        status: 403,
+        headers: {
+          "content-type": "text/html",
+          "cf-ray": "8a1b2c3d4e5f6789-SYD",
+        },
       });
     }
     if (path === "/stall-sitemap.xml") {
@@ -66,6 +85,9 @@ const server = Bun.serve({
       return new Response("console.log(1);", {
         headers: { "content-type": "application/javascript" },
       });
+    }
+    if (path === "/missing.xml") {
+      return new Response("nope", { status: 404 });
     }
     if (path === "/sitemap.xml") {
       return new Response(
@@ -131,6 +153,49 @@ describe("CLI script fetcher deadline (#1729)", () => {
   });
 });
 
+describe("CLI script fetcher retry deadline (#1729)", () => {
+  // The retry loop moved OUT of the attempt so each attempt arms its own
+  // controller and timer. One deadline spanning the whole retry sequence would
+  // hand attempt 2 an already-expired abort.
+  test("attempt 2 gets a fresh deadline, not the spent one", async () => {
+    const realFetch = globalThis.fetch;
+    let attempts = 0;
+    // Attempt 1 fails at connect — a transient network error, NOT an abort, so
+    // it takes the retry path. (A server-side stream error will not do: Bun
+    // delivers it to the client as a clean end-of-stream, which reads as an
+    // empty body and never retries.)
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      attempts += 1;
+      if (attempts === 1)
+        return Promise.reject(new TypeError("connection reset"));
+      return realFetch(input, init);
+    }) as typeof fetch;
+
+    try {
+      const startedAt = Date.now();
+      // Attempt 2 hits the STALLED script, so its own deadline is what has to
+      // end the run. Three things are pinned at once: a retry happened, the
+      // retry's deadline covers its BODY read (an unbounded one hangs here),
+      // and that deadline is fresh - a spent timer or an already-aborted
+      // controller would fail attempt 2 instantly, at ~backoff rather than
+      // ~backoff + deadline.
+      const [result] = await Effect.runPromise(
+        fetchScriptContents([`${base}/stall.js`], { timeoutMs: DEADLINE_MS })
+      );
+      const elapsed = Date.now() - startedAt;
+
+      expect(attempts).toBe(2);
+      expect(result?.error).toBe("timeout");
+      expect(elapsed).toBeGreaterThanOrEqual(
+        RETRY_BACKOFF_MS + DEADLINE_MS - 100
+      );
+      expect(elapsed).toBeLessThan(RETRY_BACKOFF_MS + DEADLINE_MS * 8);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  }, 15_000);
+});
+
 describe("CLI sitemap fetcher deadline (#1729)", () => {
   test("a sitemap body that stalls after the headers times out", async () => {
     const startedAt = Date.now();
@@ -154,6 +219,47 @@ describe("CLI sitemap fetcher deadline (#1729)", () => {
       expect(result.data.urls.length).toBeGreaterThan(0);
     }
   });
+
+  test("each failure keeps its own reason instead of collapsing to one string", async () => {
+    // A body-deadline abort, an HTTP error and a connect failure used to be
+    // indistinguishable in the failed-sitemap report: every non-HTTP failure
+    // collapsed to a bare "Unexpected error".
+    const stalled = await Effect.runPromise(
+      fetchSitemap(`${base}/stall-sitemap.xml`, "test-agent", DEADLINE_MS)
+    );
+    const notFound = await Effect.runPromise(
+      fetchSitemap(`${base}/missing.xml`, "test-agent", DEADLINE_MS)
+    );
+
+    // The connect failure is injected rather than aimed at an unresolvable
+    // host: real DNS can outrun a short deadline, in which case the abort wins
+    // the race and the run reports a timeout — correctly, but it proves nothing
+    // about the connect path.
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.reject(new TypeError("connection refused"))) as typeof fetch;
+    let unreachable;
+    try {
+      unreachable = await Effect.runPromise(
+        fetchSitemap(`${base}/sitemap.xml`, "test-agent", DEADLINE_MS)
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    expect(stalled.success).toBe(false);
+    expect(notFound.success).toBe(false);
+    expect(unreachable.success).toBe(false);
+    if (stalled.success || notFound.success || unreachable.success) return;
+
+    expect(stalled.error).toContain("Timed out");
+    expect(notFound.error).toBe("HTTP 404");
+    expect(unreachable.error).toBe("connection refused");
+    // None of the three collapse into the old catch-all.
+    expect(
+      new Set([stalled.error, notFound.error, unreachable.error]).size
+    ).toBe(3);
+  });
 });
 
 describe("CLI external checker deadline (#1729)", () => {
@@ -166,10 +272,28 @@ describe("CLI external checker deadline (#1729)", () => {
     );
     const elapsed = Date.now() - startedAt;
 
-    // The status is known from the headers; only the WAF verdict is lost, so
-    // the link is reported as a plain 403 rather than as WAF-blocked.
+    // The status is known from the headers. With no WAF signature in the
+    // headers and no body to read, this stays a plain 403 - the pre-existing
+    // ambiguity, unchanged by this fix.
     expect(results[0]?.status).toBe(403);
     expect(results[0]?.wafBlocked).toBeUndefined();
     expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
+  });
+
+  test("an unreadable 403 body still gets WAF detection from the headers", async () => {
+    const results = await Effect.runPromise(
+      checkExternalLinks([`${base}/stall-403-cf`], linkCache, {
+        timeoutMs: DEADLINE_MS,
+      })
+    );
+
+    // The deadline now cuts the WAF body read short, so giving up on detection
+    // there would report a live, bot-guarded link as broken. Headers are
+    // evidence in their own right: detection runs on them regardless.
+    expect(results[0]?.status).toBe(403);
+    expect(results[0]?.wafBlocked).toBe(true);
+    expect(results[0]?.wafProvider).toBe("cloudflare");
+    expect(filterBrokenLinks(results)).toEqual([]);
+    expect(filterWafBlockedLinks(results).length).toBe(1);
   });
 });

--- a/packages/audit-engine/package.json
+++ b/packages/audit-engine/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "typecheck": "tsgo --noEmit",
-    "test:golden": "bun test tests/*golden*.test.ts tests/streaming*.test.ts tests/redirect-chains-*.test.ts"
+    "test:golden": "bun test tests/*golden*.test.ts tests/streaming*.test.ts tests/redirect-chains-*.test.ts tests/*deadline*.test.ts"
   },
   "dependencies": {
     "@squirrelscan/cloud-client": "workspace:*",

--- a/packages/audit-engine/src/external-checker.ts
+++ b/packages/audit-engine/src/external-checker.ts
@@ -136,20 +136,26 @@ async function checkSingleUrlAsync(
     const redirectTarget = getResponse.url !== href ? getResponse.url : null;
 
     if (getResponse.status === 403) {
+      let body: string | undefined;
       try {
-        const body = await getResponse.text();
-        const wafResult = detectWaf(getResponse.headers, body);
-        if (wafResult.detected) {
-          return {
-            status: 403,
-            error: null,
-            redirectTarget,
-            wafBlocked: true,
-            wafProvider: wafResult.provider ?? "unknown",
-          };
-        }
+        body = await getResponse.text();
       } catch {
-        // Ignore body read errors
+        // The body never arrived: the deadline above fired mid-read, or the
+        // connection dropped. Do NOT give up on detection here — falling
+        // through reports a live, bot-guarded link as broken. Most WAFs are
+        // identifiable from their response headers alone (cf-ray, x-sucuri-id,
+        // a provider `server` value), so run detection on the headers we DO
+        // have. `detectWaf` treats an absent body as headers-only (#1729).
+      }
+      const wafResult = detectWaf(getResponse.headers, body);
+      if (wafResult.detected) {
+        return {
+          status: 403,
+          error: null,
+          redirectTarget,
+          wafBlocked: true,
+          wafProvider: wafResult.provider ?? "unknown",
+        };
       }
     }
 

--- a/packages/audit-engine/src/external-checker.ts
+++ b/packages/audit-engine/src/external-checker.ts
@@ -99,6 +99,11 @@ async function checkSingleUrlAsync(
   options: ExternalCheckerOptions
 ): Promise<CheckUrlResult> {
   const controller = new AbortController();
+  // #1729: the deadline stays armed until this function returns, so it also
+  // covers the WAF body read below. Clearing it where the GET resolved disarmed
+  // the abort at the HEADERS, leaving `getResponse.text()` no time bound at all
+  // — the 403 interstitials this branch exists to read are exactly the
+  // responses a hostile origin is happy to trickle forever.
   const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
 
   try {
@@ -111,7 +116,6 @@ async function checkSingleUrlAsync(
       });
 
       if (headResponse.status < 400) {
-        clearTimeout(timeoutId);
         return {
           status: headResponse.status,
           error: null,
@@ -129,7 +133,6 @@ async function checkSingleUrlAsync(
       redirect: "follow",
     });
 
-    clearTimeout(timeoutId);
     const redirectTarget = getResponse.url !== href ? getResponse.url : null;
 
     if (getResponse.status === 403) {
@@ -152,11 +155,12 @@ async function checkSingleUrlAsync(
 
     return { status: getResponse.status, error: null, redirectTarget };
   } catch (error) {
-    clearTimeout(timeoutId);
     if ((error as Error).name === "AbortError") {
       return { status: null, error: "timeout", redirectTarget: null };
     }
     return { status: null, error: (error as Error).message || "Unknown error", redirectTarget: null };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/packages/audit-engine/src/script-fetcher.ts
+++ b/packages/audit-engine/src/script-fetcher.ts
@@ -70,15 +70,8 @@ function isJavaScriptContentType(contentType: string | null): boolean {
   );
 }
 
-async function fetchSingleScriptAsync(
-  url: string,
-  options: ScriptFetcherOptions,
-  retryCount = 0
-): Promise<ScriptFetchResult> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
-
-  const defaultResult: ScriptFetchResult = {
+function emptyScriptResult(url: string): ScriptFetchResult {
+  return {
     url,
     status: null,
     error: null,
@@ -88,6 +81,24 @@ async function fetchSingleScriptAsync(
     redirected: false,
     finalUrl: undefined,
   };
+}
+
+/**
+ * One attempt, under a deadline that stays armed until the body has been read
+ * (#1729). Clearing the timer where the response resolves disarms the abort at
+ * the HEADERS, and `readBodyCapped` below caps BYTES rather than seconds, so a
+ * script origin that answers 200 and then trickles or stalls its body would
+ * park the audit forever. Scripts are fetched during rules enrichment, after
+ * the crawl, so that shows up as an audit that has its pages and never finishes.
+ */
+async function fetchScriptAttempt(
+  url: string,
+  options: ScriptFetcherOptions
+): Promise<ScriptFetchResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
+
+  const defaultResult = emptyScriptResult(url);
 
   try {
     // #1395: follow redirects manually so per hop the http/https scheme
@@ -107,8 +118,6 @@ async function fetchSingleScriptAsync(
       },
       signal: controller.signal,
     });
-
-    clearTimeout(timeoutId);
 
     const contentType = response.headers.get("content-type");
     const contentLength = response.headers.get("content-length");
@@ -180,8 +189,10 @@ async function fetchSingleScriptAsync(
     // rejects anything OVER the cap, so reading exactly `maxSizeBytes` would
     // truncate an oversized script to precisely the limit and the rejection
     // would never fire. At cap+1 an oversized body still trips it, while the
-    // read stays bounded — previously this was an unbounded `.text()` whose
-    // size was only measured once the whole body was already in memory.
+    // read stays bounded in BYTES — previously this was an unbounded `.text()`
+    // whose size was only measured once the whole body was already in memory.
+    // The bound in SECONDS is the still-armed deadline above, not this cap: a
+    // body can sit under the cap and never arrive.
     const text = await readBodyCapped(response, maxSizeBytes + 1);
     const sizeBytes = new TextEncoder().encode(text).length;
 
@@ -210,9 +221,22 @@ async function fetchSingleScriptAsync(
       sourceMapHeader,
       contentEncoding,
     };
-  } catch (error) {
+  } finally {
     clearTimeout(timeoutId);
+  }
+}
 
+async function fetchSingleScriptAsync(
+  url: string,
+  options: ScriptFetcherOptions,
+  retryCount = 0
+): Promise<ScriptFetchResult> {
+  try {
+    return await fetchScriptAttempt(url, options);
+  } catch (error) {
+    // Retries live outside the attempt so each one arms its own deadline; a
+    // retry started inside the attempt's `finally` would inherit an expired
+    // timer, or keep the spent one alive for the length of the retry.
     if (
       retryCount < SCRIPT_FETCH_LIMITS.MAX_RETRIES &&
       (error as Error).name !== "AbortError"
@@ -224,9 +248,12 @@ async function fetchSingleScriptAsync(
     }
 
     if ((error as Error).name === "AbortError") {
-      return { ...defaultResult, error: "timeout" };
+      return { ...emptyScriptResult(url), error: "timeout" };
     }
-    return { ...defaultResult, error: (error as Error).message || "error" };
+    return {
+      ...emptyScriptResult(url),
+      error: (error as Error).message || "error",
+    };
   }
 }
 
@@ -245,16 +272,7 @@ function fetchSingleScript(
   return Effect.promise(async () => {
     // #1252: skip before launching once the budget is spent or the host tarpits.
     if (options.budget?.shouldSkip(url)) {
-      return {
-        url,
-        status: null,
-        error: "skipped",
-        contentType: null,
-        sizeBytes: null,
-        content: null,
-        redirected: false,
-        finalUrl: undefined,
-      } satisfies ScriptFetchResult;
+      return { ...emptyScriptResult(url), error: "skipped" };
     }
     const startedAt = Date.now();
     const result = await fetchSingleScriptAsync(url, options);

--- a/packages/audit-engine/tests/fetch-deadline.test.ts
+++ b/packages/audit-engine/tests/fetch-deadline.test.ts
@@ -9,10 +9,16 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 
-import { checkExternalLinks } from "../src/external-checker";
+import {
+  checkExternalLinks,
+  filterBrokenLinks,
+  filterWafBlockedLinks,
+} from "../src/external-checker";
 import { fetchScriptContents } from "../src/script-fetcher";
 
 const DEADLINE_MS = 300;
+/** SCRIPT_FETCH_LIMITS.RETRY_DELAY_MS * 2^0 — the first (and only) backoff. */
+const RETRY_BACKOFF_MS = 1000;
 
 // Headers land immediately; the body stream is enqueued once and never closed,
 // so only the client can end the request.
@@ -26,7 +32,9 @@ const server = Bun.serve({
     // and no body so the stall below is reached on the GET, which is the read
     // this regression is about.
     if (req.method === "HEAD") {
-      return new Response(null, { status: path === "/stall-403" ? 403 : 200 });
+      return new Response(null, {
+        status: path.startsWith("/stall-403") ? 403 : 200,
+      });
     }
 
     const stall = new ReadableStream({
@@ -41,10 +49,18 @@ const server = Bun.serve({
       });
     }
     if (path === "/stall-403") {
-      // A 403 is what sends the external checker into its WAF body read.
+      // A 403 is what sends the external checker into its WAF body read. No WAF
+      // headers here: the body is the ONLY evidence available.
       return new Response(stall, {
         status: 403,
         headers: { "content-type": "text/html" },
+      });
+    }
+    if (path === "/stall-403-cf") {
+      // Same stalled body, but the headers alone identify the WAF.
+      return new Response(stall, {
+        status: 403,
+        headers: { "content-type": "text/html", "cf-ray": "8a1b2c3d4e5f6789-SYD" },
       });
     }
     if (path === "/fast.js") {
@@ -90,6 +106,48 @@ describe("script fetcher deadline (#1729)", () => {
   });
 });
 
+describe("script fetcher retry deadline (#1729)", () => {
+  // The retry loop moved OUT of the attempt so each attempt arms its own
+  // controller and timer. If a retry reused the first attempt's, it would start
+  // life already aborted (or on an expired deadline) and could never succeed.
+  // The backoff here is longer than the deadline, so a reused timer has
+  // certainly fired by the time attempt 2 runs.
+  test("attempt 2 gets a fresh deadline, not the spent one", async () => {
+    const realFetch = globalThis.fetch;
+    let attempts = 0;
+    // Attempt 1 fails at connect — a transient network error, NOT an abort, so
+    // it takes the retry path rather than the timeout path. (A server-side
+    // stream error will not do: Bun delivers it to the client as a clean
+    // end-of-stream, which reads as an empty body and never retries.)
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      attempts += 1;
+      if (attempts === 1) return Promise.reject(new TypeError("connection reset"));
+      return realFetch(input, init);
+    }) as typeof fetch;
+
+    try {
+      const startedAt = Date.now();
+      // Attempt 2 hits the STALLED script, so its own deadline is what has to
+      // end the run. Three things are pinned at once: a retry happened, the
+      // retry's deadline covers its BODY read (an unbounded one hangs here),
+      // and that deadline is fresh — a spent timer or an already-aborted
+      // controller would fail attempt 2 instantly, at ~backoff rather than
+      // ~backoff + deadline.
+      const [result] = await Effect.runPromise(
+        fetchScriptContents([`${base}/stall.js`], { timeoutMs: DEADLINE_MS }),
+      );
+      const elapsed = Date.now() - startedAt;
+
+      expect(attempts).toBe(2);
+      expect(result?.error).toBe("timeout");
+      expect(elapsed).toBeGreaterThanOrEqual(RETRY_BACKOFF_MS + DEADLINE_MS - 100);
+      expect(elapsed).toBeLessThan(RETRY_BACKOFF_MS + DEADLINE_MS * 8);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  }, 15_000);
+});
+
 describe("external checker deadline (#1729)", () => {
   test("a 403 whose body stalls does not hang the WAF read", async () => {
     const startedAt = Date.now();
@@ -100,10 +158,26 @@ describe("external checker deadline (#1729)", () => {
     );
     const elapsed = Date.now() - startedAt;
 
-    // The status is known from the headers; only the WAF verdict is lost, so
-    // the link is reported as a plain 403 rather than as WAF-blocked.
+    // The status is known from the headers. With no WAF signature in the
+    // headers and no body to read, this stays a plain 403 — the pre-existing
+    // ambiguity, unchanged by this fix.
     expect(results[0]?.status).toBe(403);
     expect(results[0]?.wafBlocked).toBeUndefined();
     expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
+  });
+
+  test("an unreadable 403 body still gets WAF detection from the headers", async () => {
+    const results = await Effect.runPromise(
+      checkExternalLinks([`${base}/stall-403-cf`], null, { timeoutMs: DEADLINE_MS }),
+    );
+
+    // The deadline now cuts the WAF body read short, so giving up on detection
+    // there would report a live, bot-guarded link as broken. Headers are
+    // evidence in their own right: detection runs on them regardless.
+    expect(results[0]?.status).toBe(403);
+    expect(results[0]?.wafBlocked).toBe(true);
+    expect(results[0]?.wafProvider).toBe("cloudflare");
+    expect(filterBrokenLinks(results)).toEqual([]);
+    expect(filterWafBlockedLinks(results).length).toBe(1);
   });
 });

--- a/packages/audit-engine/tests/fetch-deadline.test.ts
+++ b/packages/audit-engine/tests/fetch-deadline.test.ts
@@ -1,0 +1,109 @@
+// #1729 — a request deadline must cover the BODY read, not just the headers.
+//
+// Both fetchers here cleared their timer where the response resolved, i.e. when
+// the HEADERS landed. `readBodyCapped` caps BYTES, not seconds, so an origin
+// that answered 200 and then stalled its body left the read with no bound at
+// all. Scripts and external links are fetched during rules enrichment, after
+// the crawl, so the audit had all its pages and simply never finished.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { checkExternalLinks } from "../src/external-checker";
+import { fetchScriptContents } from "../src/script-fetcher";
+
+const DEADLINE_MS = 300;
+
+// Headers land immediately; the body stream is enqueued once and never closed,
+// so only the client can end the request.
+const server = Bun.serve({
+  port: 0,
+  idleTimeout: 0,
+  fetch(req) {
+    const path = new URL(req.url).pathname;
+
+    // The external checker probes with HEAD first. Answer it with the status
+    // and no body so the stall below is reached on the GET, which is the read
+    // this regression is about.
+    if (req.method === "HEAD") {
+      return new Response(null, { status: path === "/stall-403" ? 403 : 200 });
+    }
+
+    const stall = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("// first chunk\n"));
+      },
+    });
+
+    if (path === "/stall.js") {
+      return new Response(stall, {
+        headers: { "content-type": "application/javascript" },
+      });
+    }
+    if (path === "/stall-403") {
+      // A 403 is what sends the external checker into its WAF body read.
+      return new Response(stall, {
+        status: 403,
+        headers: { "content-type": "text/html" },
+      });
+    }
+    if (path === "/fast.js") {
+      return new Response("console.log(1);", {
+        headers: { "content-type": "application/javascript" },
+      });
+    }
+    return new Response("ok", { headers: { "content-type": "text/plain" } });
+  },
+});
+
+const base = `http://localhost:${server.port}`;
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("script fetcher deadline (#1729)", () => {
+  test("a script body that stalls after the headers times out", async () => {
+    const startedAt = Date.now();
+    const [result] = await Effect.runPromise(
+      fetchScriptContents([`${base}/stall.js`], { timeoutMs: DEADLINE_MS }),
+    );
+    const elapsed = Date.now() - startedAt;
+
+    expect(result?.error).toBe("timeout");
+    expect(result?.content).toBe(null);
+    // Close to the deadline, not merely "eventually": a bound that fires an
+    // order of magnitude late is not a bound. Before the fix this never
+    // returned at all.
+    expect(elapsed).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+    expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
+  });
+
+  test("a script that answers promptly is still read in full", async () => {
+    const [result] = await Effect.runPromise(
+      fetchScriptContents([`${base}/fast.js`], { timeoutMs: DEADLINE_MS }),
+    );
+
+    expect(result?.error).toBe(null);
+    expect(result?.status).toBe(200);
+    expect(result?.content).toBe("console.log(1);");
+  });
+});
+
+describe("external checker deadline (#1729)", () => {
+  test("a 403 whose body stalls does not hang the WAF read", async () => {
+    const startedAt = Date.now();
+    const results = await Effect.runPromise(
+      checkExternalLinks([`${base}/stall-403`], null, {
+        timeoutMs: DEADLINE_MS,
+      }),
+    );
+    const elapsed = Date.now() - startedAt;
+
+    // The status is known from the headers; only the WAF verdict is lost, so
+    // the link is reported as a plain 403 rather than as WAF-blocked.
+    expect(results[0]?.status).toBe(403);
+    expect(results[0]?.wafBlocked).toBeUndefined();
+    expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
+  });
+});

--- a/packages/crawler/src/fetcher.ts
+++ b/packages/crawler/src/fetcher.ts
@@ -625,7 +625,16 @@ function fetchPageStandardOnce(
   // process alive.
   let held: TimedResponse | null = null;
   const release = (): void => {
-    held?.disarm();
+    if (!held) return;
+    held.disarm();
+    // Aborting, not just disarming. `release` runs only as this effect leaves,
+    // so nothing reads the held body afterwards: on the success path the stream
+    // is already drained and this is a no-op, and on every failure path —
+    // a terminal 403/429/5xx that fails the status guard before any read, or a
+    // hop still held when the NEXT request fails — nobody ever consumes it.
+    // Disarming alone parked that socket and its buffered chunks for the life
+    // of the process, which is the leak class this whole change exists to kill.
+    held.abort();
     held = null;
   };
 
@@ -771,7 +780,18 @@ function fetchPageStandardOnce(
     // here is safe; an unreadable body falls through to the generic server error.
     const challengeBody =
       finalResponse.status === 503
-        ? yield* Effect.orElseSucceed(readBody, () => undefined)
+        ? yield* readBody.pipe(
+            Effect.catchAll((error) =>
+              // #1729: a deadline firing on a stalled body is a TIMEOUT, and
+              // swallowing it here reclassified it as the generic "Server error:
+              // 503" — the origin blamed for what was actually our own deadline.
+              // Every other read failure still degrades to "no body" so the
+              // guard can classify the 503 from its headers alone.
+              error.type === "timeout"
+                ? Effect.fail(error)
+                : Effect.succeed(undefined),
+            ),
+          )
         : undefined;
 
     yield* applyStatusGuards(url, finalResponse.status, finalResponse.headers, challengeBody);

--- a/packages/crawler/src/fetcher.ts
+++ b/packages/crawler/src/fetcher.ts
@@ -214,12 +214,26 @@ export function applyBrowserHeaders(headers: Headers, userAgent: string): void {
   }
 }
 
+/**
+ * A response whose deadline is still armed. The timer that aborts the request
+ * survives past the headers, so it still covers the caller's body read (#1729);
+ * ownership passes to the caller, which must `disarm` it on every exit path.
+ */
+interface TimedResponse {
+  response: Response;
+  timing: RequestTiming;
+  /** Clear the deadline. Idempotent; safe after the response is fully read. */
+  disarm: () => void;
+  /** Abort the request — cancels an in-flight body read and frees the socket. */
+  abort: () => void;
+}
+
 function requestWithTiming(
   url: string,
   options: RequestInit,
   timeoutMs: number,
   userAgent: string,
-): Effect.Effect<{ response: Response; timing: RequestTiming }, CrawlError, never> {
+): Effect.Effect<TimedResponse, CrawlError, never> {
   return Effect.tryPromise({
     // Forward the fiber-interrupt signal so a wedged socket is aborted and the host-slot release runs (#405).
     try: async (signal) => {
@@ -230,6 +244,7 @@ function requestWithTiming(
       if (signal.aborted) controller.abort();
       else signal.addEventListener("abort", onInterrupt, { once: true });
 
+      let handedOff = false;
       try {
         const headers = new Headers(options.headers);
         applyBrowserHeaders(headers, userAgent);
@@ -241,10 +256,24 @@ function requestWithTiming(
         });
 
         const responseTime = Date.now();
-        return { response, timing: { fetchStart, responseTime } };
+        // #1729: the deadline is deliberately NOT cleared here. `fetch` settles
+        // when the HEADERS land, so clearing it here left the caller's body read
+        // with no time bound — an origin that answered 200 and then stalled its
+        // body burned the whole per-URL watchdog instead of `timeoutMs`. The
+        // caller disarms once it has read or abandoned the body.
+        handedOff = true;
+        return {
+          response,
+          timing: { fetchStart, responseTime },
+          disarm: () => clearTimeout(timeout),
+          abort: () => controller.abort(),
+        };
       } finally {
-        clearTimeout(timeout);
+        // The request-phase interrupt bridge always ends here — this signal
+        // belongs to THIS effect and means nothing once it settles. The body
+        // read installs its own bridge through `abort`.
         signal.removeEventListener("abort", onInterrupt);
+        if (!handedOff) clearTimeout(timeout);
       }
     },
     catch: (error) => {
@@ -579,6 +608,27 @@ function fetchPageStandard(
   url: string,
   options: FetchOptions,
 ): Effect.Effect<FetchResult, CrawlError, never> {
+  // Suspended so the armed-deadline state below is built per RUN, not per call:
+  // callers retry this same Effect value (see `withRetry` on the fallback path),
+  // and two runs must never share one `held` slot.
+  return Effect.suspend(() => fetchPageStandardOnce(url, options));
+}
+
+function fetchPageStandardOnce(
+  url: string,
+  options: FetchOptions,
+): Effect.Effect<FetchResult, CrawlError, never> {
+  // #1729: the response whose deadline is still armed. Held across the redirect
+  // loop and the body read, and released by the `Effect.ensuring` below on EVERY
+  // exit — success, failure, or interrupt. A `try/finally` inside `Effect.gen`
+  // would not run on failure, which is how a dangling timer would keep a
+  // process alive.
+  let held: TimedResponse | null = null;
+  const release = (): void => {
+    held?.disarm();
+    held = null;
+  };
+
   return Effect.gen(function* () {
     let headers = new Headers({
       "User-Agent": options.userAgent,
@@ -606,7 +656,7 @@ function fetchPageStandard(
       }
       visited.add(currentUrl);
 
-      const { response, timing } = yield* requestWithTiming(
+      const timed = yield* requestWithTiming(
         currentUrl,
         {
           method: "GET",
@@ -616,6 +666,14 @@ function fetchPageStandard(
         options.timeoutMs,
         options.userAgent,
       );
+      const { response, timing } = timed;
+
+      // This hop supersedes the previous one: once a newer response exists the
+      // older can no longer become `lastResponse`, so drop its body (freeing the
+      // socket, which the redirect loop never did) and its deadline.
+      held?.abort();
+      held?.disarm();
+      held = timed;
 
       lastResponse = response;
       lastTiming = timing;
@@ -682,8 +740,16 @@ function fetchPageStandard(
           return await Promise.race([
             readBodyCapped(finalResponse, DEFAULT_MAX_DOCUMENT_BODY_BYTES),
             new Promise<never>((_, reject) => {
-              if (signal.aborted) return reject(new Error("aborted"));
-              onAbort = () => reject(new Error("aborted"));
+              // #1729: aborting the request as well as losing the race is what
+              // actually cancels the read. Rejecting alone only frees the FIBER
+              // — `readBodyCapped` would stay parked on `reader.read()` for the
+              // life of the process, holding the socket and its buffered chunks.
+              const giveUp = (): void => {
+                held?.abort();
+                reject(new Error("aborted"));
+              };
+              if (signal.aborted) return giveUp();
+              onAbort = giveUp;
               signal.addEventListener("abort", onAbort, { once: true });
             }),
           ]);
@@ -691,8 +757,13 @@ function fetchPageStandard(
           if (onAbort) signal.removeEventListener("abort", onAbort);
         }
       },
-      catch: (error) =>
-        CrawlError.parse(url, `Failed to read response: ${(error as Error).message}`),
+      catch: (error) => {
+        // #1729: the deadline firing mid-body is a timeout, not a malformed
+        // response — report it as the same class as a headers-phase timeout so
+        // it is not miscounted as a parse failure.
+        if ((error as Error).name === "AbortError") return CrawlError.timeout(url);
+        return CrawlError.parse(url, `Failed to read response: ${(error as Error).message}`);
+      },
     });
 
     // A 503 needs its body to tell a bot-challenge interstitial from a real
@@ -755,7 +826,7 @@ function fetchPageStandard(
       // Plain-HTTP path — served directly by `fetch`, no cloud render (#512).
       fetcherId: "fetch",
     };
-  });
+  }).pipe(Effect.ensuring(Effect.sync(release)));
 }
 
 export function fetchPage(

--- a/packages/crawler/tests/fetch-body-deadline.test.ts
+++ b/packages/crawler/tests/fetch-body-deadline.test.ts
@@ -24,15 +24,30 @@ const FETCH_OPTIONS = {
   followRedirects: true,
 };
 
+/** Never-closing body stream — only the client can end the request. */
+function stallingStream(): ReadableStream {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("<!doctype html><html><body>"));
+    },
+  });
+}
+
 /**
- * Headers land at once; the body emits one chunk and then never closes.
+ * Serves a stalled body at every path, at `status`.
  *
  * `seen.aborted` records whether the CLIENT actually cancelled the request,
- * which is the half of this bug that ending the fiber does not prove: the old
- * code lost the race and abandoned the fiber while `readBodyCapped` stayed
- * parked on the socket.
+ * which is the half of these bugs that ending the fiber does not prove: the old
+ * code abandoned the fiber while `readBodyCapped` stayed parked on the socket.
+ *
+ * `/hop` answers a 302 pointing at a closed port, so the NEXT request fails
+ * while this hop is still held — the second release-without-read path.
  */
-function serveStalledBody(seen: { aborted: boolean }): ReturnType<typeof Bun.serve> {
+function serveStalling(
+  seen: { aborted: boolean },
+  status = 200,
+  extraHeaders: Record<string, string> = {},
+): ReturnType<typeof Bun.serve> {
   return Bun.serve({
     port: 0,
     idleTimeout: 0,
@@ -40,13 +55,17 @@ function serveStalledBody(seen: { aborted: boolean }): ReturnType<typeof Bun.ser
       req.signal.addEventListener("abort", () => {
         seen.aborted = true;
       });
-      const stream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode("<!doctype html><html><body>"));
-          // Never closed: only the client can end this.
-        },
+      if (new URL(req.url).pathname === "/hop") {
+        return new Response(stallingStream(), {
+          status: 302,
+          // Port 1 is never listening: the next hop fails to connect.
+          headers: { location: "http://127.0.0.1:1/dead" },
+        });
+      }
+      return new Response(stallingStream(), {
+        status,
+        headers: { "content-type": "text/html", ...extraHeaders },
       });
-      return new Response(stream, { headers: { "content-type": "text/html" } });
     },
   });
 }
@@ -59,7 +78,7 @@ async function settle(ms = 500): Promise<void> {
 describe("standard fetch body deadline (#1729)", () => {
   test("a body that stalls after the headers fails at timeoutMs, not the watchdog", async () => {
     const seen = { aborted: false };
-    const server = serveStalledBody(seen);
+    const server = serveStalling(seen);
     try {
       const startedAt = Date.now();
       const result = await Effect.runPromise(
@@ -87,7 +106,7 @@ describe("standard fetch body deadline (#1729)", () => {
 
   test("a fiber interrupt during the body read cancels the request, not just the fiber", async () => {
     const seen = { aborted: false };
-    const server = serveStalledBody(seen);
+    const server = serveStalling(seen);
     try {
       const startedAt = Date.now();
       // A deadline far longer than the interrupt, so only the interrupt can end
@@ -124,6 +143,70 @@ describe("standard fetch body deadline (#1729)", () => {
       );
       expect(result.status).toBe(200);
       expect(result.body).toBe(body);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a terminal status released without a read still cancels the connection", async () => {
+    // A 403 fails `applyStatusGuards` BEFORE any body read, so the held
+    // response is released without one. Disarming the timer alone left the
+    // stalled body and its socket parked for the life of the process.
+    const seen = { aborted: false };
+    const server = serveStalling(seen, 403);
+    try {
+      const result = await Effect.runPromise(
+        Effect.either(fetchPage(`http://localhost:${server.port}/`, FETCH_OPTIONS)),
+      );
+
+      expect(result._tag).toBe("Left");
+      if (result._tag === "Left") expect(result.left.type).toBe("blocked");
+
+      await settle();
+      expect(seen.aborted).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a hop still held when the next request fails cancels that hop", async () => {
+    // The loop drops a superseded hop only once a NEWER response arrives. When
+    // the next request fails outright, the previous hop is still held and only
+    // the final release can free it.
+    const seen = { aborted: false };
+    const server = serveStalling(seen);
+    try {
+      const result = await Effect.runPromise(
+        Effect.either(fetchPage(`http://localhost:${server.port}/hop`, FETCH_OPTIONS)),
+      );
+
+      expect(result._tag).toBe("Left");
+
+      await settle();
+      expect(seen.aborted).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a stalled 503 body is classified as a timeout, not a server error", async () => {
+    // 503 is the one status whose body is read BEFORE the status guard, to tell
+    // a bot-challenge interstitial from a real outage. That read used to
+    // swallow every failure, so our own deadline firing came back as the
+    // generic "Server error: 503" — blaming the origin for our timeout.
+    const seen = { aborted: false };
+    const server = serveStalling(seen, 503);
+    try {
+      const startedAt = Date.now();
+      const result = await Effect.runPromise(
+        Effect.either(fetchPage(`http://localhost:${server.port}/`, FETCH_OPTIONS)),
+      );
+      const elapsed = Date.now() - startedAt;
+
+      expect(result._tag).toBe("Left");
+      if (result._tag === "Left") expect(result.left.type).toBe("timeout");
+      expect(elapsed).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+      expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
     } finally {
       server.stop(true);
     }

--- a/packages/crawler/tests/fetch-body-deadline.test.ts
+++ b/packages/crawler/tests/fetch-body-deadline.test.ts
@@ -1,0 +1,157 @@
+// #1729 — the standard fetch path's deadline must cover the BODY read.
+//
+// `requestWithTiming` cleared its timer in a `finally` that closed at the fetch,
+// and the Response escaped to be read much later in `fetchPageStandard`. That is
+// the same clear-at-headers bug as #1699, wearing a `try/finally` that looks
+// correct: `fetch` settles when the HEADERS land, so a 200 followed by a stalled
+// body had no bound from `timeoutMs` at all. It was not an unbounded hang — the
+// per-URL watchdog in crawler.ts (>= 120s) is the backstop — but a stalled page
+// burned the whole watchdog instead of `timeoutMs`, and because the same
+// `finally` also removed the interrupt bridge, the watchdog's abort never
+// reached the reader: `readBodyCapped` stayed parked on `reader.read()` for the
+// life of the process, holding the socket and its buffered chunks.
+
+import { describe, expect, test } from "bun:test";
+import { Duration, Effect } from "effect";
+
+import { fetchPage } from "../src/fetcher";
+
+const DEADLINE_MS = 400;
+
+const FETCH_OPTIONS = {
+  userAgent: "squirrel-test",
+  timeoutMs: DEADLINE_MS,
+  followRedirects: true,
+};
+
+/**
+ * Headers land at once; the body emits one chunk and then never closes.
+ *
+ * `seen.aborted` records whether the CLIENT actually cancelled the request,
+ * which is the half of this bug that ending the fiber does not prove: the old
+ * code lost the race and abandoned the fiber while `readBodyCapped` stayed
+ * parked on the socket.
+ */
+function serveStalledBody(seen: { aborted: boolean }): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      req.signal.addEventListener("abort", () => {
+        seen.aborted = true;
+      });
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("<!doctype html><html><body>"));
+          // Never closed: only the client can end this.
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/html" } });
+    },
+  });
+}
+
+/** Give the runtime a moment to propagate a socket close to the server. */
+async function settle(ms = 500): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("standard fetch body deadline (#1729)", () => {
+  test("a body that stalls after the headers fails at timeoutMs, not the watchdog", async () => {
+    const seen = { aborted: false };
+    const server = serveStalledBody(seen);
+    try {
+      const startedAt = Date.now();
+      const result = await Effect.runPromise(
+        Effect.either(fetchPage(`http://localhost:${server.port}/`, FETCH_OPTIONS)),
+      );
+      const elapsed = Date.now() - startedAt;
+
+      // The request deadline ended it, and it is reported as a timeout rather
+      // than as a malformed response.
+      expect(result._tag).toBe("Left");
+      if (result._tag === "Left") expect(result.left.type).toBe("timeout");
+
+      // Close to timeoutMs. Before the fix nothing here fired at all: the read
+      // parked until the caller's own watchdog interrupted it.
+      expect(elapsed).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+      expect(elapsed).toBeLessThan(DEADLINE_MS * 8);
+
+      // The socket was released, not merely abandoned.
+      await settle();
+      expect(seen.aborted).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a fiber interrupt during the body read cancels the request, not just the fiber", async () => {
+    const seen = { aborted: false };
+    const server = serveStalledBody(seen);
+    try {
+      const startedAt = Date.now();
+      // A deadline far longer than the interrupt, so only the interrupt can end
+      // this. Ending the FIBER was never the hard part — the old code won that
+      // race too. What it did not do was cancel the underlying read, because
+      // the interrupt bridge had already been unhooked when the headers landed.
+      const result = await Effect.runPromise(
+        fetchPage(`http://localhost:${server.port}/`, {
+          ...FETCH_OPTIONS,
+          timeoutMs: 60_000,
+        }).pipe(Effect.timeout(Duration.millis(300)), Effect.either),
+      );
+      const elapsed = Date.now() - startedAt;
+
+      expect(result._tag).toBe("Left");
+      expect(elapsed).toBeLessThan(5_000);
+
+      await settle();
+      expect(seen.aborted).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a normal body is still read in full and the deadline is released", async () => {
+    const body = "<!doctype html><html><head><title>ok</title></head><body>hi</body></html>";
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(body, { headers: { "content-type": "text/html" } }),
+    });
+    try {
+      const result = await Effect.runPromise(
+        fetchPage(`http://localhost:${server.port}/`, FETCH_OPTIONS),
+      );
+      expect(result.status).toBe(200);
+      expect(result.body).toBe(body);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("a redirect chain still resolves once the abandoned hops are dropped", async () => {
+    // The loop now aborts each superseded hop. The final response must survive
+    // that, and the chain must still be recorded.
+    const body = "<!doctype html><html><head><title>done</title></head><body>x</body></html>";
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        if (path === "/") return new Response(null, { status: 301, headers: { location: "/a" } });
+        if (path === "/a") return new Response(null, { status: 302, headers: { location: "/b" } });
+        return new Response(body, { headers: { "content-type": "text/html" } });
+      },
+    });
+    try {
+      const result = await Effect.runPromise(
+        fetchPage(`http://localhost:${server.port}/`, FETCH_OPTIONS),
+      );
+      expect(result.status).toBe(200);
+      expect(result.body).toBe(body);
+      expect(result.finalUrl).toBe(`http://localhost:${server.port}/b`);
+      expect(result.redirectChain.hops.length).toBe(3);
+    } finally {
+      server.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
Five fetchers cleared their `AbortController` timer where the fetch resolved, i.e. when the response **headers** landed, leaving the body read with no time bound at all. `readBodyCapped` and `response.text()` cap **bytes**, not seconds, so an origin that answers 200 and then trickles or stalls its body parked the caller forever.

Same bug class as #187, which fixed it in the crawler. These are the stragglers.

## Sites fixed

| file | unbounded read |
|---|---|
| `packages/audit-engine/src/script-fetcher.ts` | `readBodyCapped` after `clearTimeout` |
| `packages/audit-engine/src/external-checker.ts` | `getResponse.text()` on a 403, for WAF detection |
| `apps/cli/src/crawler/script-fetcher.ts` | `response.text()` (fork of the engine fetcher) |
| `apps/cli/src/crawler/external-checker.ts` | same WAF read (fork) |
| `apps/cli/src/crawl/sitemaps.ts` | `response.text()` in a later Effect stage, outside the timer's scope |

The two CLI files are **forks**, not re-exports: `apps/cli/src/audit/adapter.ts` imports `@/crawler/*`, so they are what the `squirrel` binary actually runs. Fixing only the package would have left every CLI user hanging.

## Fix

`clearTimeout` moves into a `finally` that wraps the body read, matching `packages/crawler/src/deadline.ts` and `packages/fetchers/src/index.ts`. The script fetchers additionally split their retry loop out of the attempt, so each retry arms a fresh deadline rather than inheriting a spent one or keeping it alive across the backoff.

## Impact

Scripts and external links are fetched during rules enrichment, **after** pages are collected, so the failure mode was the post-crawl hang class rather than a crawl-phase wedge: the audit has all its pages and never finishes. The sitemap read hangs the crawl preamble instead.

Behaviour changes only on the previously-hanging path. A stalled script body now returns `error: "timeout"`; a stalled WAF 403 body returns the plain 403 it already knew from the headers (the WAF verdict degrades to unknown, matching the existing "ignore body read errors" branch); a stalled sitemap returns a failure result.

## Tests

`apps/cli/tests/crawler/fetch-deadline.test.ts` and `packages/audit-engine/tests/fetch-deadline.test.ts` serve headers immediately, then hold the body stream open forever. Verified by reverting each source file to `main` and re-running: all five cases hang and fail on Bun's test timeout without the fix, and return within the deadline with it. Each fetcher also has a fast-path test proving normal responses are still read in full.

`packages/audit-engine/package.json`'s `test:golden` glob gains `tests/*deadline*.test.ts` — the CI engine job runs only that script, so a new test file would otherwise never execute in CI.

- `bun test` in `apps/cli`: 1903 pass, 0 fail
- `bun run test:engine`: 66 pass, 0 fail, golden baseline unchanged (`pages=518 findings=98221 healthScore=48`)
- `bun run typecheck` (all workspaces), `lint`, `format:check`: clean

No HTML output bytes change, so `REPORT_HTML_VERSION` is untouched.

## Follow-up, not in this PR

`apps/cli/src/tools/request.ts` (`request` / `requestOnceWithTiming`) has the same shape: it clears the deadline and hands the `Response` to callers that read the body later (`robots.ts`, reachability, and others). Fixing it properly means moving those call sites to a `withRequestDeadline(timeoutMs, perform, use)` contract, which is a wider refactor than this PR should carry. Filed separately.

Refs squirrelscan/repo#1729