### PR TITLE
fix(crawler): bound the crawl preamble with one phase budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,18 @@ jobs:
       - uses: ./.github/actions/setup-bun
       - run: bun run test:engine
 
+  # `bun test` above runs from apps/cli, so packages/crawler's suite — the
+  # crawl-preamble, deadline, and sitemap guards — was never executed by CI.
+  crawler-tests:
+    name: Crawler tests
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-bun
+      - run: bun run test:crawler
+
   release-tooling:
     name: Release tooling tests
     needs: quality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,18 +93,6 @@ jobs:
       - uses: ./.github/actions/setup-bun
       - run: bun run test:engine
 
-  # `bun test` above runs from apps/cli, so packages/crawler's suite — the
-  # crawl-preamble, deadline, and sitemap guards — was never executed by CI.
-  crawler-tests:
-    name: Crawler tests
-    needs: quality
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/setup-bun
-      - run: bun run test:crawler
-
   release-tooling:
     name: Release tooling tests
     needs: quality

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -154,7 +154,10 @@ export function reconstructReport(
           sizeBytes: robotsRecord.sizeBytes,
           sitemaps: robotsRecord.sitemaps,
           rules: [],
-          errors: [],
+          // Why the fetch produced nothing, when it did. Without this the CLI
+          // report cannot tell a confirmed 404 from a probe that never got an
+          // answer, and reports the second as a missing file (#1733).
+          errors: robotsRecord.error ? [robotsRecord.error] : [],
         }
       : undefined;
 
@@ -183,8 +186,12 @@ export function reconstructReport(
         }))
       );
     }
+    // A truncated walk with zero results still needs a sitemap section: it is
+    // the only place the report can say the check did not complete, and
+    // `undefined` reads downstream as "no data" rather than "not finished".
+    const sitemapWalkTruncated = crawl.stats?.sitemapDiscoveryTruncated ?? false;
     const sitemaps: SitemapDiscovery | undefined =
-      sitemapRecords.length > 0
+      sitemapRecords.length > 0 || sitemapWalkTruncated
         ? {
             discovered: sitemapRecords.map((s) => ({
               url: s.url,
@@ -202,6 +209,7 @@ export function reconstructReport(
             orphanPages: [],
             missingPages: [],
             failed: [], // Not persisted to storage
+            truncated: sitemapWalkTruncated,
           }
         : undefined;
 

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -189,7 +189,8 @@ export function reconstructReport(
     // A truncated walk with zero results still needs a sitemap section: it is
     // the only place the report can say the check did not complete, and
     // `undefined` reads downstream as "no data" rather than "not finished".
-    const sitemapWalkTruncated = crawl.stats?.sitemapDiscoveryTruncated ?? false;
+    const sitemapWalkTruncated =
+      crawl.stats?.sitemapDiscoveryTruncated ?? false;
     const sitemaps: SitemapDiscovery | undefined =
       sitemapRecords.length > 0 || sitemapWalkTruncated
         ? {

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -66,6 +66,12 @@ export interface SitemapDiscovery {
   orphanPages: string[]; // in sitemap but not crawled
   missingPages: string[]; // crawled but not in sitemap
   failed: SitemapFetchFailure[]; // sitemaps that failed to fetch
+  /**
+   * Discovery stopped before visiting every candidate location, so an empty
+   * `discovered` is unknown rather than absent (squirrelscan/repo#1733).
+   * Optional: absent reads as "the walk completed".
+   */
+  truncated?: boolean;
 }
 
 // ============================================

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "typecheck": "bun run --sequential --filter '*' --if-present typecheck",
     "test": "cd apps/cli && bun test",
     "test:engine": "cd packages/audit-engine && bun run test:golden",
-    "test:crawler": "cd packages/crawler && bun test",
     "test:release": "bash scripts/test-changelog-extraction.sh && bun test scripts/release-version.test.ts",
     "docs:check": "cd docs && bun run check",
     "docs:build": "cd docs && bun run build",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "bun run --sequential --filter '*' --if-present typecheck",
     "test": "cd apps/cli && bun test",
     "test:engine": "cd packages/audit-engine && bun run test:golden",
+    "test:crawler": "cd packages/crawler && bun test",
     "test:release": "bash scripts/test-changelog-extraction.sh && bun test scripts/release-version.test.ts",
     "docs:check": "cd docs && bun run check",
     "docs:build": "cd docs && bun run build",

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -601,6 +601,10 @@ export function fetchResourceAssets(
       orphanPages: [] as string[],
       missingPages: [] as string[],
       failed: [],
+      // Rules run against THIS object, not the report built later, so the
+      // truncation flag has to be here or crawl/sitemap-exists still reports
+      // "No XML sitemap found" for a walk that never looked (#1733).
+      truncated: crawl?.stats?.sitemapDiscoveryTruncated ?? false,
     };
 
     if (sitemapDiscovery.discovered.length > 0) {
@@ -1157,6 +1161,10 @@ export function runRulesOnStorage(
       orphanPages: [] as string[],
       missingPages: [] as string[],
       failed: [], // Not persisted to storage, only available during live audit
+      // Rules run against THIS object, not the report built later, so the
+      // truncation flag has to be here or crawl/sitemap-exists still reports
+      // "No XML sitemap found" for a walk that never looked (#1733).
+      truncated: crawl?.stats?.sitemapDiscoveryTruncated ?? false,
     };
 
     // Sitemap array limits must match the API schema caps (REPORT_LIMITS.maxPages).
@@ -1725,6 +1733,10 @@ function buildStreamingSiteData(
       orphanPages: [] as string[],
       missingPages: [] as string[],
       failed: [],
+      // Rules run against THIS object, not the report built later, so the
+      // truncation flag has to be here or crawl/sitemap-exists still reports
+      // "No XML sitemap found" for a walk that never looked (#1733).
+      truncated: crawl?.stats?.sitemapDiscoveryTruncated ?? false,
     };
 
     const SITEMAP_ARRAY_CAP = REPORT_LIMITS.maxPages;

--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -93,6 +93,11 @@ export function buildRobotsData(robots: RobotsTxtRecord | null): RobotsTxtData |
     const parsed = parseRobotsTxt(robots.content, robots.url);
     rules = parsed.rules;
     errors = parsed.errors;
+  } else if (robots.error) {
+    // No content because the fetch never produced one. Surfacing the reason is
+    // what lets crawl/robots-txt tell an unanswered probe apart from a confirmed
+    // 404 instead of reporting both as "No robots.txt found" (#1733).
+    errors = [robots.error];
   }
 
   return {
@@ -525,6 +530,9 @@ export function buildV1Report(
         orphanPages: [],
         missingPages: [],
         failed: [], // Not persisted to storage, only available during live audit
+        // Persisted via crawl stats, because an empty `discovered` here must not
+        // be read as "no sitemap" when the walk simply stopped early (#1733).
+        truncated: crawl?.stats?.sitemapDiscoveryTruncated ?? false,
       },
       healthScore,
       ruleResults: toReportRuleResults(ruleResults.ruleResultsMap),
@@ -779,6 +787,9 @@ export function buildV2Report(
         orphanPages: [],
         missingPages: [],
         failed: [], // Not persisted to storage, only available during live audit
+        // Persisted via crawl stats, because an empty `discovered` here must not
+        // be read as "no sitemap" when the walk simply stopped early (#1733).
+        truncated: crawl?.stats?.sitemapDiscoveryTruncated ?? false,
       },
       healthScore,
       ruleResults: toReportRuleResults(input.ruleResultsMap),

--- a/packages/audit-engine/tests/truncated-sitemap-discovery.test.ts
+++ b/packages/audit-engine/tests/truncated-sitemap-discovery.test.ts
@@ -1,0 +1,107 @@
+// squirrelscan/repo#1733 — a truncated sitemap walk must reach the RULES, not
+// just the finished report.
+//
+// The first attempt at this fix set `truncated` only where the report is
+// assembled, which runs AFTER the rules have scored. The flag was inert:
+// crawl/sitemap-exists still saw `undefined`, took its normal path, and emitted
+// the weight-10 "No XML sitemap found" for a walk that never looked. A test
+// asserting on the finished report passed anyway, because the report gets its
+// copy from the other path — so this drives the rule executor itself and asserts
+// on the check the rule actually produced.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { Config } from "@squirrelscan/config";
+import type { CheckResult } from "@squirrelscan/core-contracts";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+
+import { buildSiteContext, runRulesOnStorage, type PreFetchedAssets } from "../src/adapter";
+
+const RULE_ID = "crawl/sitemap-exists";
+
+// `filterRules` defaults every rule to disabled, so the enable list is
+// mandatory — `rules: {}` would run nothing and pass vacuously.
+const CONFIG = {
+  rule_options: {},
+  rules: { enable: [RULE_ID] },
+} as unknown as Config;
+
+const EMPTY_ASSETS: PreFetchedAssets = { css: new Map(), js: new Map(), images: new Map() };
+
+const PAGE_HTML = "<!doctype html><html><head><title>t</title></head><body>x</body></html>";
+
+const BASE_STATS = {
+  pagesTotal: 1,
+  pagesFetched: 1,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+// No sitemaps stored at all — the ambiguous state. Whether that means "this site
+// has none" or "we never finished looking" is exactly what the flag decides.
+async function sitemapChecks(truncated: boolean): Promise<CheckResult[]> {
+  const storage = new SQLiteStorage(":memory:");
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* storage.init();
+      const crawlId = yield* storage.createCrawl({
+        baseUrl: "https://example.com",
+        originalUrl: "https://example.com",
+        startedAt: Date.now(),
+        status: "completed",
+        config: {} as never,
+        stats: { ...BASE_STATS, sitemapDiscoveryTruncated: truncated },
+      });
+      yield* storage.upsertPage(crawlId, {
+        url: "https://example.com/",
+        normalizedUrl: "https://example.com/",
+        finalUrl: "https://example.com/",
+        depth: 0,
+        status: 200,
+        contentType: "text/html",
+        sizeBytes: PAGE_HTML.length,
+        loadTimeMs: 1,
+        fetchedAt: Date.now(),
+        etag: null,
+        lastModified: null,
+        contentHash: "test",
+        html: PAGE_HTML,
+        parsedData: null,
+        headers: {},
+        securityHeaders: {},
+      });
+      const pages = yield* storage.getPages(crawlId);
+      const siteContext = yield* buildSiteContext(pages);
+      const result = yield* runRulesOnStorage(storage, crawlId, siteContext, CONFIG, EMPTY_ASSETS);
+      return result.ruleResultsMap.get(RULE_ID)?.checks ?? [];
+    }).pipe(Effect.ensuring(storage.close().pipe(Effect.orDie))),
+  );
+}
+
+const named = (checks: CheckResult[], name: string) => checks.find((c) => c.name === name);
+
+describe("truncated sitemap discovery reaches the rules (squirrelscan/repo#1733)", () => {
+  test("a truncated walk does not produce the missing-sitemap failure", async () => {
+    const check = named(await sitemapChecks(true), "sitemap-exists");
+
+    expect(check).toBeDefined();
+    expect(check!.status).toBe("info");
+    expect(check!.message).not.toContain("No XML sitemap found");
+  });
+
+  test("a completed walk that found nothing still fails", async () => {
+    // The other half: the flag must not blanket-suppress a real finding, or the
+    // fix would trade a false positive for a false negative.
+    const check = named(await sitemapChecks(false), "sitemap-exists");
+
+    expect(check).toBeDefined();
+    expect(check!.status).toBe("fail");
+    expect(check!.message).toBe("No XML sitemap found");
+  });
+});

--- a/packages/audit-engine/tests/truncated-sitemap-discovery.test.ts
+++ b/packages/audit-engine/tests/truncated-sitemap-discovery.test.ts
@@ -18,13 +18,14 @@ import { SQLiteStorage } from "@squirrelscan/crawler";
 
 import { buildSiteContext, runRulesOnStorage, type PreFetchedAssets } from "../src/adapter";
 
-const RULE_ID = "crawl/sitemap-exists";
+const EXISTS_RULE = "crawl/sitemap-exists";
+const VALID_RULE = "crawl/sitemap-valid";
 
 // `filterRules` defaults every rule to disabled, so the enable list is
 // mandatory — `rules: {}` would run nothing and pass vacuously.
 const CONFIG = {
   rule_options: {},
-  rules: { enable: [RULE_ID] },
+  rules: { enable: [EXISTS_RULE, VALID_RULE] },
 } as unknown as Config;
 
 const EMPTY_ASSETS: PreFetchedAssets = { css: new Map(), js: new Map(), images: new Map() };
@@ -45,7 +46,7 @@ const BASE_STATS = {
 
 // No sitemaps stored at all — the ambiguous state. Whether that means "this site
 // has none" or "we never finished looking" is exactly what the flag decides.
-async function sitemapChecks(truncated: boolean): Promise<CheckResult[]> {
+async function sitemapChecks(truncated: boolean): Promise<Map<string, CheckResult[]>> {
   const storage = new SQLiteStorage(":memory:");
   return Effect.runPromise(
     Effect.gen(function* () {
@@ -79,16 +80,20 @@ async function sitemapChecks(truncated: boolean): Promise<CheckResult[]> {
       const pages = yield* storage.getPages(crawlId);
       const siteContext = yield* buildSiteContext(pages);
       const result = yield* runRulesOnStorage(storage, crawlId, siteContext, CONFIG, EMPTY_ASSETS);
-      return result.ruleResultsMap.get(RULE_ID)?.checks ?? [];
+      return new Map([
+        [EXISTS_RULE, result.ruleResultsMap.get(EXISTS_RULE)?.checks ?? []],
+        [VALID_RULE, result.ruleResultsMap.get(VALID_RULE)?.checks ?? []],
+      ]);
     }).pipe(Effect.ensuring(storage.close().pipe(Effect.orDie))),
   );
 }
 
-const named = (checks: CheckResult[], name: string) => checks.find((c) => c.name === name);
+const named = (checks: Map<string, CheckResult[]>, ruleId: string, name: string) =>
+  (checks.get(ruleId) ?? []).find((c) => c.name === name);
 
 describe("truncated sitemap discovery reaches the rules (squirrelscan/repo#1733)", () => {
   test("a truncated walk does not produce the missing-sitemap failure", async () => {
-    const check = named(await sitemapChecks(true), "sitemap-exists");
+    const check = named(await sitemapChecks(true), EXISTS_RULE, "sitemap-exists");
 
     expect(check).toBeDefined();
     expect(check!.status).toBe("info");
@@ -98,10 +103,28 @@ describe("truncated sitemap discovery reaches the rules (squirrelscan/repo#1733)
   test("a completed walk that found nothing still fails", async () => {
     // The other half: the flag must not blanket-suppress a real finding, or the
     // fix would trade a false positive for a false negative.
-    const check = named(await sitemapChecks(false), "sitemap-exists");
+    const check = named(await sitemapChecks(false), EXISTS_RULE, "sitemap-exists");
 
     expect(check).toBeDefined();
     expect(check!.status).toBe("fail");
     expect(check!.message).toBe("No XML sitemap found");
+  });
+
+  test("sitemap-valid says the check did not complete, not that there was nothing", async () => {
+    // The other rule that reads an empty sitemap set. "No sitemap to validate"
+    // reads as a finished check; a truncated walk finished nothing.
+    const check = named(await sitemapChecks(true), VALID_RULE, "sitemap-valid");
+
+    expect(check).toBeDefined();
+    expect(check!.status).toBe("info");
+    expect(check!.message).toContain("did not complete");
+  });
+
+  test("sitemap-valid still skips normally when the walk completed", async () => {
+    const check = named(await sitemapChecks(false), VALID_RULE, "sitemap-valid");
+
+    expect(check).toBeDefined();
+    expect(check!.status).toBe("skipped");
+    expect(check!.message).toBe("No sitemap to validate");
   });
 });

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -1202,6 +1202,12 @@ export interface SitemapDiscovery {
   orphanPages: string[];
   missingPages: string[];
   failed: SitemapFetchFailure[];
+  /**
+   * Discovery stopped before visiting every candidate location, so an empty
+   * `discovered` is unknown rather than absent (squirrelscan/repo#1733).
+   * Optional: absent reads as "the walk completed".
+   */
+  truncated?: boolean;
 }
 
 export interface SitemapUrlStatusData {

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -874,6 +874,13 @@ export interface AgentAccessRecord {
  */
 export const PROBE_NOT_ATTEMPTED_ERROR = "crawl phase budget exhausted";
 
+/**
+ * Recorded against a sitemap the walk stopped before reaching. Distinct from a
+ * fetch failure: nothing was requested, so it is not evidence the sitemap is
+ * broken or absent (squirrelscan/repo#1733).
+ */
+export const SITEMAP_NOT_CHECKED_ERROR = "sitemap walk stopped before reaching this location";
+
 export interface RslLicenseDoc {
   url: string;
   /** Final HTTP status; 0 = network error, or the probe was never attempted. */

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -164,6 +164,13 @@ export interface CrawlStats {
   /** Approximate bytes saved by skipping fresh requests entirely. (#106) */
   bytesCacheSaved?: number;
   /**
+   * Sitemap discovery stopped before visiting every entry point, so an empty
+   * sitemap set is UNCONFIRMED rather than evidence the site has none
+   * (squirrelscan/repo#1733). Optional for backward compatibility with older
+   * persisted stats blobs; absent reads as "the walk completed".
+   */
+  sitemapDiscoveryTruncated?: boolean;
+  /**
    * Per-reason cache-hit counts across pages AND sub-resources (#107/#108).
    * Drives the hits-by-reason breakdown. Optional for backward compatibility.
    */
@@ -743,6 +750,16 @@ export interface RobotsTxtRecord {
   sizeBytes: number;
   sitemaps: string[];
   fetchedAt: number;
+  /**
+   * Why the fetch did not produce a robots.txt, when it did not. `exists:false`
+   * alone conflates "the origin answered 404" with "we never got an answer" —
+   * a timeout, a 5xx, or a probe the crawl budget cut short. Only the first is
+   * evidence of absence, so consumers MUST treat a non-null error here as
+   * unknown rather than reporting a missing robots.txt. Optional: older
+   * persisted rows and storage backends that predate it leave it undefined,
+   * which reads as the confirmed case.
+   */
+  error?: string | null;
 }
 
 // Persisted llms.txt + llms-full.txt root fetch; mirrors RobotsTxtRecord.
@@ -846,9 +863,20 @@ export interface AgentAccessRecord {
 }
 
 // One fetched RSL (rslstandard.org) license document referenced from robots.txt.
+/**
+ * Recorded as a probe's `error` when the crawl never attempted it, because the
+ * preamble's wall-clock budget was already spent (squirrelscan/repo#1733).
+ *
+ * The distinction matters to rules: a probe that was ATTEMPTED and failed is
+ * evidence (a dead URL is a real broken reference worth reporting), while one
+ * that was never attempted is evidence of nothing and must degrade to unknown.
+ * Both land as `status: 0`, so this exact string is the discriminator.
+ */
+export const PROBE_NOT_ATTEMPTED_ERROR = "crawl phase budget exhausted";
+
 export interface RslLicenseDoc {
   url: string;
-  /** Final HTTP status; 0 = network error. */
+  /** Final HTTP status; 0 = network error, or the probe was never attempted. */
   status: number;
   contentType: string | null;
   /** Parsed as XML (and not HTML). */

--- a/packages/crawler/src/agent-access.ts
+++ b/packages/crawler/src/agent-access.ts
@@ -2,8 +2,9 @@ import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
-import { safeFetchWithDeadline } from "./deadline";
+import { BUDGET_EXHAUSTED_ERROR, budgetedTimeoutMs, safeFetchWithDeadline } from "./deadline";
 
+import type { PhaseBudget } from "./deadline";
 import type {
   AgentAccessData,
   AgentAccessProbe,
@@ -47,11 +48,26 @@ export function detectPayment(status: number, headers: Headers, body: string): s
   return null;
 }
 
+const unreachableProbe = (identity: ProbeIdentity, error: string): AgentAccessProbe => ({
+  userAgent: identity.label,
+  userAgentString: identity.ua,
+  status: 0,
+  bodySize: 0,
+  challenged: false,
+  challengeSignal: null,
+  paymentRequired: false,
+  paymentSignal: null,
+  error,
+});
+
 async function probeOne(
   homeUrl: string,
   identity: ProbeIdentity,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Promise<AgentAccessProbe> {
+  const timeoutMs = budgetedTimeoutMs(budget, PROBE_TIMEOUT_MS);
+  if (timeoutMs === null) return unreachableProbe(identity, BUDGET_EXHAUSTED_ERROR);
   try {
     // #1395: manual redirects — per-hop scheme allowlist + strip secret
     // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
@@ -70,7 +86,7 @@ async function probeOne(
         },
         redirect: "follow",
       },
-      PROBE_TIMEOUT_MS,
+      timeoutMs,
       async (response) => {
         const raw = await readBodyCapped(response, AGENT_ACCESS_MAX_BYTES);
         const body = truncateToBytes(raw, AGENT_ACCESS_MAX_BYTES);
@@ -90,17 +106,7 @@ async function probeOne(
       },
     );
   } catch (e) {
-    return {
-      userAgent: identity.label,
-      userAgentString: identity.ua,
-      status: 0,
-      bodySize: 0,
-      challenged: false,
-      challengeSignal: null,
-      paymentRequired: false,
-      paymentSignal: null,
-      error: (e as Error).message,
-    };
+    return unreachableProbe(identity, (e as Error).message);
   }
 }
 
@@ -110,6 +116,7 @@ export function probeAgentAccess(
   baseUrl: string,
   browserUserAgent: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Effect.Effect<AgentAccessData, never, never> {
   const homeUrl = new URL("/", baseUrl).toString();
   const identities: ProbeIdentity[] = [
@@ -118,7 +125,9 @@ export function probeAgentAccess(
     { label: "claude-user", ua: CLAUDE_USER_UA },
   ];
   return Effect.promise(async () => {
-    const probes = await Promise.all(identities.map((id) => probeOne(homeUrl, id, customHeaders)));
+    const probes = await Promise.all(
+      identities.map((id) => probeOne(homeUrl, id, customHeaders, budget)),
+    );
     return { probes };
   });
 }

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -17,7 +17,8 @@ import {
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 import { urlHostKey } from "@squirrelscan/utils/url";
 
-import { withRequestDeadline } from "../deadline";
+import { createPhaseBudget, withRequestDeadline } from "../deadline";
+import type { PhaseBudget } from "../deadline";
 import { computeSitemapUrlCap, discoverSitemaps, selectSitemapUrls } from "../sitemaps";
 
 import type { RobotsEvaluator } from "../robots";
@@ -87,6 +88,33 @@ const MAX_ROBOTS_CRAWL_DELAY_MS = 2000;
 // the audit re-parses (~12.5ms/page) instead of holding every DOM in memory
 // for the remainder of the crawl.
 const PARSED_PAGE_CACHE_MAX_PAGES = COVERAGE_PAGE_LIMITS.quick;
+
+// ---- Crawl preamble budget (squirrelscan/repo#1733) ----
+//
+// Everything before the first page — seed redirect resolution, robots.txt, the
+// llms / markdown / well-known / agent-access / RSL probes, and sitemap
+// discovery — runs as sequential stages, each with its own 15-30s request
+// deadline. Individually bounded, their SUM is not: an origin that answers 200
+// on every root path and then stalls the body burned 150.3s across 28 requests
+// before page 1, which is the entire 120s crawl phase a quick cloud audit gets,
+// on a site that crawls perfectly well once the preamble is past.
+//
+// One budget spans the phase. Each request takes min(its own deadline, what the
+// budget has left); once it is spent the remaining probes are skipped and store
+// the same "unreachable" shape a network failure gives them, so no probe's row
+// goes missing — the trade is AX completeness on a pathologically slow origin
+// for a crawl that actually reaches its pages.
+const PREAMBLE_TOTAL_BUDGET_MS = 45_000;
+// ...and no more than this many full request timeouts, so a config asking for
+// snappy requests gets a proportionally snappy preamble. Mirrors
+// REDIRECT_BUDGET_HOPS in detectRedirects, which bounds a chain the same way.
+const PREAMBLE_BUDGET_REQUESTS = 3;
+
+/** The preamble's wall-clock allowance for a given per-request timeout. */
+export function preambleBudgetMs(timeoutMs: number): number {
+  return Math.min(PREAMBLE_TOTAL_BUDGET_MS, Math.max(1, timeoutMs) * PREAMBLE_BUDGET_REQUESTS);
+}
+
 const logger = {
   debug: (_message: string, ..._args: unknown[]) => {},
   warn: (_message: string, ..._args: unknown[]) => {},
@@ -1454,7 +1482,10 @@ export function createCrawler(
      * Detect and follow both HTTP and client-side redirects
      * Returns the final URL after following up to MAX_REDIRECTS hops
      */
-    const detectRedirects = (targetUrl: string): Effect.Effect<string, never, never> =>
+    const detectRedirects = (
+      targetUrl: string,
+      budget?: PhaseBudget,
+    ): Effect.Effect<string, never, never> =>
       Effect.promise(async () => {
         // `settledUrl` is the last URL that actually served a response, so every
         // exit below can fall back to it. `currentUrl` cannot: after a
@@ -1477,8 +1508,13 @@ export function createCrawler(
           // default leaves the 10s ceiling, and so the 30s chain budget, in
           // place).
           const hopTimeoutMs = Math.max(1, Math.min(REDIRECT_TIMEOUT_MS, config.timeoutMs));
-          const deadline =
-            Date.now() + Math.min(REDIRECT_TOTAL_BUDGET_MS, hopTimeoutMs * REDIRECT_BUDGET_HOPS);
+          // Seed resolution is the preamble's first stage, so the phase budget
+          // caps the chain too — and every millisecond spent here is one the
+          // root probes downstream no longer have (squirrelscan/repo#1733).
+          const deadline = Math.min(
+            Date.now() + Math.min(REDIRECT_TOTAL_BUDGET_MS, hopTimeoutMs * REDIRECT_BUDGET_HOPS),
+            budget?.deadlineAt ?? Number.POSITIVE_INFINITY,
+          );
           let currentUrl = targetUrl;
           const visited = new Set<string>();
 
@@ -1560,8 +1596,12 @@ export function createCrawler(
       originalUrl?: string,
     ): Effect.Effect<string, CrawlerError | StorageError, never> =>
       Effect.gen(function* () {
+        // One wall-clock budget for the whole preamble, armed before the first
+        // request of the crawl. See PREAMBLE_TOTAL_BUDGET_MS.
+        const preamble = createPhaseBudget(preambleBudgetMs(config.timeoutMs));
+
         // Follow redirects to get final URL (both HTTP and client-side)
-        const rawFinalTargetUrl = yield* detectRedirects(targetUrl);
+        const rawFinalTargetUrl = yield* detectRedirects(targetUrl, preamble);
         // SECURITY (#1396) defense-in-depth: detectRedirects follows client-side
         // redirects (meta refresh / JS) whose target is page-controlled.
         // findMetaRefresh / findJavaScriptRedirect already restrict to
@@ -1676,7 +1716,7 @@ export function createCrawler(
         // sitemap discovery and the crawl/robots-txt rule need it. Only
         // Disallow enforcement and Crawl-delay honoring are conditional.
         const robotsResult = yield* Effect.either(
-          fetchRobots(baseUrl, config.userAgent, true, config.headers),
+          fetchRobots(baseUrl, config.userAgent, true, config.headers, preamble),
         );
         if (robotsResult._tag === "Right") {
           robots = robotsResult.right;
@@ -1693,7 +1733,7 @@ export function createCrawler(
         }
 
         // Fetch llms.txt + llms-full.txt at the root once, independent of robots.
-        const llms = yield* fetchLlmsTxt(baseUrl, config.userAgent, config.headers);
+        const llms = yield* fetchLlmsTxt(baseUrl, config.userAgent, config.headers, preamble);
         yield* storage.setLlmsTxt(crawlId, {
           llmsTxt: {
             url: llms.llmsTxt.url,
@@ -1711,18 +1751,33 @@ export function createCrawler(
         });
 
         // Probe homepage markdown content-negotiation + .md variant once.
-        const markdown = yield* probeMarkdownResponse(baseUrl, config.userAgent, config.headers);
+        const markdown = yield* probeMarkdownResponse(
+          baseUrl,
+          config.userAgent,
+          config.headers,
+          preamble,
+        );
         yield* storage.setMarkdownProbe(crawlId, { ...markdown, fetchedAt: Date.now() });
 
         // AX prefetches: well-known/agent files, homepage access under AI-crawler
         // UAs, and RSL licensing — fetched unconditionally like llms/markdown.
-        const wellKnown = yield* probeWellKnown(baseUrl, config.userAgent, config.headers);
+        const wellKnown = yield* probeWellKnown(
+          baseUrl,
+          config.userAgent,
+          config.headers,
+          preamble,
+        );
         yield* storage.setWellKnownProbe(crawlId, { ...wellKnown, fetchedAt: Date.now() });
 
-        const agentAccess = yield* probeAgentAccess(baseUrl, config.userAgent, config.headers);
+        const agentAccess = yield* probeAgentAccess(
+          baseUrl,
+          config.userAgent,
+          config.headers,
+          preamble,
+        );
         yield* storage.setAgentAccess(crawlId, { ...agentAccess, fetchedAt: Date.now() });
 
-        const rsl = yield* fetchRslLicensing(baseUrl, config.userAgent, config.headers);
+        const rsl = yield* fetchRslLicensing(baseUrl, config.userAgent, config.headers, preamble);
         yield* storage.setRsl(crawlId, { ...rsl, fetchedAt: Date.now() });
 
         // Discover and fetch sitemaps (from robots.txt and common locations)
@@ -1748,7 +1803,7 @@ export function createCrawler(
               }
             : null,
           config.userAgent,
-          { maxUrls: sitemapUrlCap, customHeaders: config.headers },
+          { maxUrls: sitemapUrlCap, customHeaders: config.headers, budget: preamble },
         );
 
         const sitemapByUrl = new Map(sitemapResult.all.map((sitemap) => [sitemap.url, sitemap]));
@@ -1915,8 +1970,15 @@ export function createCrawler(
         Object.assign(config, crawl.config);
 
         // Fetch robots.txt again — always, regardless of respectRobots (#790).
+        // Budgeted like every other preamble fetch (squirrelscan/repo#1733).
         const robotsResult = yield* Effect.either(
-          fetchRobots(baseUrl, config.userAgent, true, config.headers),
+          fetchRobots(
+            baseUrl,
+            config.userAgent,
+            true,
+            config.headers,
+            createPhaseBudget(preambleBudgetMs(config.timeoutMs)),
+          ),
         );
         if (robotsResult._tag === "Right") {
           robots = robotsResult.right;
@@ -2054,9 +2116,12 @@ export function createCrawler(
           maxPages: config.maxPages,
         });
 
+        // One wall-clock budget for this restart's preamble, same as start().
+        const preamble = createPhaseBudget(preambleBudgetMs(config.timeoutMs));
+
         // Fetch robots.txt — always, regardless of respectRobots (#790).
         const robotsResult = yield* Effect.either(
-          fetchRobots(baseUrl, config.userAgent, true, config.headers),
+          fetchRobots(baseUrl, config.userAgent, true, config.headers, preamble),
         );
         if (robotsResult._tag === "Right") {
           robots = robotsResult.right;
@@ -2076,7 +2141,7 @@ export function createCrawler(
         }
 
         // Fetch llms.txt + llms-full.txt at the root once, independent of robots.
-        const llms = yield* fetchLlmsTxt(baseUrl, config.userAgent, config.headers);
+        const llms = yield* fetchLlmsTxt(baseUrl, config.userAgent, config.headers, preamble);
         yield* storage.setLlmsTxt(crawlId, {
           llmsTxt: {
             url: llms.llmsTxt.url,
@@ -2094,18 +2159,33 @@ export function createCrawler(
         });
 
         // Probe homepage markdown content-negotiation + .md variant once.
-        const markdown = yield* probeMarkdownResponse(baseUrl, config.userAgent, config.headers);
+        const markdown = yield* probeMarkdownResponse(
+          baseUrl,
+          config.userAgent,
+          config.headers,
+          preamble,
+        );
         yield* storage.setMarkdownProbe(crawlId, { ...markdown, fetchedAt: Date.now() });
 
         // AX prefetches: well-known/agent files, homepage access under AI-crawler
         // UAs, and RSL licensing — fetched unconditionally like llms/markdown.
-        const wellKnown = yield* probeWellKnown(baseUrl, config.userAgent, config.headers);
+        const wellKnown = yield* probeWellKnown(
+          baseUrl,
+          config.userAgent,
+          config.headers,
+          preamble,
+        );
         yield* storage.setWellKnownProbe(crawlId, { ...wellKnown, fetchedAt: Date.now() });
 
-        const agentAccess = yield* probeAgentAccess(baseUrl, config.userAgent, config.headers);
+        const agentAccess = yield* probeAgentAccess(
+          baseUrl,
+          config.userAgent,
+          config.headers,
+          preamble,
+        );
         yield* storage.setAgentAccess(crawlId, { ...agentAccess, fetchedAt: Date.now() });
 
-        const rsl = yield* fetchRslLicensing(baseUrl, config.userAgent, config.headers);
+        const rsl = yield* fetchRslLicensing(baseUrl, config.userAgent, config.headers, preamble);
         yield* storage.setRsl(crawlId, { ...rsl, fetchedAt: Date.now() });
 
         // Seed the crawl queue with root URL

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -19,7 +19,12 @@ import { urlHostKey } from "@squirrelscan/utils/url";
 
 import { createPhaseBudget, withRequestDeadline } from "../deadline";
 import type { PhaseBudget } from "../deadline";
-import { computeSitemapUrlCap, discoverSitemaps, selectSitemapUrls } from "../sitemaps";
+import {
+  computeSitemapUrlCap,
+  discoverSitemaps,
+  selectSitemapUrls,
+  sitemapWalkWindowMs,
+} from "../sitemaps";
 
 import type { RobotsEvaluator } from "../robots";
 import type {
@@ -91,19 +96,25 @@ const PARSED_PAGE_CACHE_MAX_PAGES = COVERAGE_PAGE_LIMITS.quick;
 
 // ---- Crawl preamble budget (squirrelscan/repo#1733) ----
 //
-// Everything before the first page — seed redirect resolution, robots.txt, the
-// llms / markdown / well-known / agent-access / RSL probes, and sitemap
-// discovery — runs as sequential stages, each with its own 15-30s request
-// deadline. Individually bounded, their SUM is not: an origin that answers 200
-// on every root path and then stalls the body burned 150.3s across 28 requests
-// before page 1, which is the entire 120s crawl phase a quick cloud audit gets,
-// on a site that crawls perfectly well once the preamble is past.
+// The root probes before the first page — seed redirect resolution, robots.txt,
+// and the llms / markdown / well-known / agent-access / RSL sweep — run as
+// sequential stages, each with its own 15-30s request deadline. Individually
+// bounded, their SUM is not: an origin that answers 200 on every root path and
+// then stalls the body burned 150.3s across 28 requests before page 1, which is
+// the entire 120s crawl phase a quick cloud audit gets, on a site that crawls
+// perfectly well once the preamble is past.
 //
-// One budget spans the phase. Each request takes min(its own deadline, what the
-// budget has left); once it is spent the remaining probes are skipped and store
-// the same "unreachable" shape a network failure gives them, so no probe's row
-// goes missing — the trade is AX completeness on a pathologically slow origin
-// for a crawl that actually reaches its pages.
+// One budget spans those stages. Each request takes min(its own deadline, what
+// the budget has left); once it is spent the rest are skipped and store the same
+// "unreachable" shape a network failure gives them, so no probe's row goes
+// missing and every consumer keeps a reason to report.
+//
+// What this budget deliberately does NOT cover is sitemap discovery, which runs
+// after it on a progress window of its own (see SITEMAP_WALK_WINDOW_MS). The
+// asymmetry is the whole design: cutting the AX probes short costs metadata,
+// and their rules already degrade to unknown, whereas cutting the sitemap walk
+// short costs PAGES — a site with many legitimate sitemaps is slow without being
+// stalled, and truncating it would silently shrink the crawl.
 const PREAMBLE_TOTAL_BUDGET_MS = 45_000;
 // ...and no more than this many full request timeouts, so a config asking for
 // snappy requests gets a proportionally snappy preamble. Mirrors
@@ -1737,6 +1748,10 @@ export function createCrawler(
             sizeBytes: robotsResult.right.data.sizeBytes,
             sitemaps: robotsResult.right.data.sitemaps,
             fetchedAt: Date.now(),
+            // Keeps "never got an answer" distinguishable from a confirmed 404
+            // so the robots-txt rule does not report a missing file it never
+            // established was missing (squirrelscan/repo#1733).
+            error: robotsResult.right.data.errors[0] ?? null,
           });
         }
 
@@ -1811,8 +1826,25 @@ export function createCrawler(
               }
             : null,
           config.userAgent,
-          { maxUrls: sitemapUrlCap, customHeaders: config.headers, budget: preamble },
+          {
+            maxUrls: sitemapUrlCap,
+            customHeaders: config.headers,
+            walkWindowMs: sitemapWalkWindowMs(config.timeoutMs),
+          },
         );
+
+        // The walk is bounded by its own progress window, NOT the preamble
+        // budget: truncating it costs pages rather than AX metadata, and a site
+        // with many legitimate sitemaps is slow without being stalled. When it
+        // did stop early, record that — an empty discovery must not be read as
+        // "this site has no sitemap" (squirrelscan/repo#1733).
+        if (sitemapResult.truncated) {
+          logger.warn(
+            "sitemap discovery truncated",
+            "the walk stopped before visiting every entry point; absence is unconfirmed",
+          );
+          yield* storage.updateStats(crawlId, { sitemapDiscoveryTruncated: true });
+        }
 
         const sitemapByUrl = new Map(sitemapResult.all.map((sitemap) => [sitemap.url, sitemap]));
 
@@ -2000,6 +2032,10 @@ export function createCrawler(
             sizeBytes: robotsResult.right.data.sizeBytes,
             sitemaps: robotsResult.right.data.sitemaps,
             fetchedAt: Date.now(),
+            // Keeps "never got an answer" distinguishable from a confirmed 404
+            // so the robots-txt rule does not report a missing file it never
+            // established was missing (squirrelscan/repo#1733).
+            error: robotsResult.right.data.errors[0] ?? null,
           });
         }
 
@@ -2141,6 +2177,10 @@ export function createCrawler(
             sizeBytes: robotsResult.right.data.sizeBytes,
             sitemaps: robotsResult.right.data.sitemaps,
             fetchedAt: Date.now(),
+            // Keeps "never got an answer" distinguishable from a confirmed 404
+            // so the robots-txt rule does not report a missing file it never
+            // established was missing (squirrelscan/repo#1733).
+            error: robotsResult.right.data.errors[0] ?? null,
           });
 
           for (const sitemapUrl of robots.data.sitemaps) {

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -1598,6 +1598,14 @@ export function createCrawler(
       Effect.gen(function* () {
         // One wall-clock budget for the whole preamble, armed before the first
         // request of the crawl. See PREAMBLE_TOTAL_BUDGET_MS.
+        //
+        // Scoped to this call deliberately. Callers that pre-resolve the seed
+        // (the CLI controllers, the cloud runtime) spend a separate redirect
+        // allowance before they ever reach here — that duplicate resolution is
+        // #1727's to remove, and handing it THIS budget would be worse: the
+        // caller's own work between the two sits inside the window, so a slow
+        // local storage lookup could arrive here with the budget already spent
+        // and silently skip every probe on a perfectly healthy origin.
         const preamble = createPhaseBudget(preambleBudgetMs(config.timeoutMs));
 
         // Follow redirects to get final URL (both HTTP and client-side)

--- a/packages/crawler/src/deadline.ts
+++ b/packages/crawler/src/deadline.ts
@@ -1,4 +1,5 @@
-// Request deadlines that survive into the body read (#1699).
+// Request deadlines that survive into the body read (#1699), and the phase
+// budget that bounds a whole sequence of them (squirrelscan/repo#1733).
 
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
@@ -46,4 +47,56 @@ export function safeFetchWithDeadline<T>(
     (signal) => safeRedirectFetch(url, { ...options, signal }).then((result) => result.response),
     use,
   );
+}
+
+/**
+ * A wall-clock budget shared by every request in one crawl phase.
+ *
+ * Per-request deadlines bound one request each; they say nothing about a
+ * SEQUENCE of them. The crawl preamble is seven sequential stages carrying
+ * 15-30s deadlines apiece, so what a caller actually waits through is their sum
+ * — 150s against an origin that answers 200 on every root path and then stalls
+ * the body, which is the entire crawl phase a quick cloud audit gets
+ * (squirrelscan/repo#1733). One budget spans the phase and each request takes
+ * whatever is left of it.
+ *
+ * Absolute (an epoch deadline), not a countdown: stages are sequential and some
+ * fan out internally, so time already spent has to stay spent no matter which
+ * stage asks.
+ */
+export interface PhaseBudget {
+  /** Epoch ms past which no further request in the phase may start. */
+  readonly deadlineAt: number;
+}
+
+/** Error text recorded by a probe that was skipped because the budget ran out. */
+export const BUDGET_EXHAUSTED_ERROR = "crawl phase budget exhausted";
+
+export function createPhaseBudget(totalMs: number, startedAt: number = Date.now()): PhaseBudget {
+  return { deadlineAt: startedAt + Math.max(0, totalMs) };
+}
+
+/** Milliseconds left on the budget, floored at 0. `Infinity` when unbudgeted. */
+export function budgetRemainingMs(budget: PhaseBudget | undefined): number {
+  if (!budget) return Number.POSITIVE_INFINITY;
+  return Math.max(0, budget.deadlineAt - Date.now());
+}
+
+/**
+ * The deadline one request may use: its own timeout, clamped to what the phase
+ * has left.
+ *
+ * `null` means the budget is spent and the request must be SKIPPED — the caller
+ * returns its normal unreachable/empty shape, the same one a network failure
+ * produces, so nothing downstream needs a new code path. `null` rather than `0`
+ * on purpose: a numeric zero reads as "no timeout" at a glance, and skipping is
+ * not something a caller may quietly ignore.
+ */
+export function budgetedTimeoutMs(
+  budget: PhaseBudget | undefined,
+  requestTimeoutMs: number,
+): number | null {
+  const remaining = budgetRemainingMs(budget);
+  if (remaining <= 0) return null;
+  return Math.min(requestTimeoutMs, remaining);
 }

--- a/packages/crawler/src/deadline.ts
+++ b/packages/crawler/src/deadline.ts
@@ -1,6 +1,7 @@
 // Request deadlines that survive into the body read (#1699), and the phase
 // budget that bounds a whole sequence of them (squirrelscan/repo#1733).
 
+import { PROBE_NOT_ATTEMPTED_ERROR } from "@squirrelscan/core-contracts/storage";
 import { safeRedirectFetch } from "@squirrelscan/utils/safe-fetch";
 
 /**
@@ -69,8 +70,13 @@ export interface PhaseBudget {
   readonly deadlineAt: number;
 }
 
-/** Error text recorded by a probe that was skipped because the budget ran out. */
-export const BUDGET_EXHAUSTED_ERROR = "crawl phase budget exhausted";
+/**
+ * Error text recorded by a probe that was skipped because the budget ran out.
+ * Shared with the rules package via core-contracts: consumers key off this
+ * exact string to tell "never attempted" apart from "attempted and failed",
+ * which look identical otherwise (both are `status: 0`).
+ */
+export const BUDGET_EXHAUSTED_ERROR = PROBE_NOT_ATTEMPTED_ERROR;
 
 export function createPhaseBudget(totalMs: number, startedAt: number = Date.now()): PhaseBudget {
   return { deadlineAt: startedAt + Math.max(0, totalMs) };

--- a/packages/crawler/src/llms.ts
+++ b/packages/crawler/src/llms.ts
@@ -2,8 +2,9 @@ import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
-import { safeFetchWithDeadline } from "./deadline";
+import { budgetedTimeoutMs, safeFetchWithDeadline } from "./deadline";
 
+import type { PhaseBudget } from "./deadline";
 import type { LlmsTxtData, LlmsTxtFile } from "@squirrelscan/core-contracts";
 
 const LLMS_FETCH_TIMEOUT_MS = 30_000;
@@ -19,12 +20,16 @@ async function fetchOne(
   url: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Promise<LlmsTxtFile> {
+  // Budget spent: same "absent" shape a 404 or a network failure produces.
+  const timeoutMs = budgetedTimeoutMs(budget, LLMS_FETCH_TIMEOUT_MS);
+  if (timeoutMs === null) return emptyFile(url);
   try {
     return await safeFetchWithDeadline(
       url,
       { headers: { "User-Agent": userAgent, Accept: "text/plain, text/markdown, */*", ...customHeaders } },
-      LLMS_FETCH_TIMEOUT_MS,
+      timeoutMs,
       async (response) => {
         if (response.status === 404 || !response.ok) {
           await response.body?.cancel().catch(() => {});
@@ -58,13 +63,14 @@ export function fetchLlmsTxt(
   baseUrl: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Effect.Effect<LlmsTxtData, never, never> {
   const llmsUrl = new URL("/llms.txt", baseUrl).toString();
   const fullUrl = new URL("/llms-full.txt", baseUrl).toString();
   return Effect.promise(async () => {
     const [llmsTxt, llmsFullTxt] = await Promise.all([
-      fetchOne(llmsUrl, userAgent, customHeaders),
-      fetchOne(fullUrl, userAgent, customHeaders),
+      fetchOne(llmsUrl, userAgent, customHeaders, budget),
+      fetchOne(fullUrl, userAgent, customHeaders, budget),
     ]);
     return { llmsTxt, llmsFullTxt };
   });

--- a/packages/crawler/src/markdown.ts
+++ b/packages/crawler/src/markdown.ts
@@ -1,7 +1,8 @@
 import { Effect } from "effect";
 
-import { safeFetchWithDeadline } from "./deadline";
+import { budgetedTimeoutMs, safeFetchWithDeadline } from "./deadline";
 
+import type { PhaseBudget } from "./deadline";
 import type { MarkdownProbeData } from "@squirrelscan/core-contracts";
 
 const PROBE_TIMEOUT_MS = 30_000;
@@ -37,18 +38,30 @@ interface ProbeResult {
   alternateMarkdownUrl: string | null;
 }
 
+const unreachableProbe = (): ProbeResult => ({
+  ok: false,
+  contentType: null,
+  vary: null,
+  markdownTokens: null,
+  originalTokens: null,
+  alternateMarkdownUrl: null,
+});
+
 // Probe one URL for its status + headers only; never downloads the body.
 async function probeOne(
   url: string,
   userAgent: string,
   accept: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Promise<ProbeResult> {
+  const timeoutMs = budgetedTimeoutMs(budget, PROBE_TIMEOUT_MS);
+  if (timeoutMs === null) return unreachableProbe();
   try {
     return await safeFetchWithDeadline(
       url,
       { headers: { "User-Agent": userAgent, Accept: accept, ...customHeaders } },
-      PROBE_TIMEOUT_MS,
+      timeoutMs,
       async (res) => {
         const contentType = res.headers.get("content-type");
         const result: ProbeResult = {
@@ -64,14 +77,7 @@ async function probeOne(
       },
     );
   } catch {
-    return {
-      ok: false,
-      contentType: null,
-      vary: null,
-      markdownTokens: null,
-      originalTokens: null,
-      alternateMarkdownUrl: null,
-    };
+    return unreachableProbe();
   }
 }
 
@@ -80,13 +86,14 @@ export function probeMarkdownResponse(
   baseUrl: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Effect.Effect<MarkdownProbeData, never, never> {
   const homeUrl = new URL("/", baseUrl).toString();
   const mdUrl = new URL("/index.md", baseUrl).toString();
   return Effect.promise(async () => {
     const [neg, md] = await Promise.all([
-      probeOne(homeUrl, userAgent, "text/markdown, text/x-markdown, */*", customHeaders),
-      probeOne(mdUrl, userAgent, "text/markdown, text/plain, */*", customHeaders),
+      probeOne(homeUrl, userAgent, "text/markdown, text/x-markdown, */*", customHeaders, budget),
+      probeOne(mdUrl, userAgent, "text/markdown, text/plain, */*", customHeaders, budget),
     ]);
     return {
       negotiatedUrl: homeUrl,

--- a/packages/crawler/src/robots.ts
+++ b/packages/crawler/src/robots.ts
@@ -5,11 +5,14 @@ import type { RobotsTxtData } from "@squirrelscan/core-contracts";
 import { parseRobotsTxt } from "@squirrelscan/utils/robots-txt";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
-import { safeFetchWithDeadline } from "./deadline";
+import { BUDGET_EXHAUSTED_ERROR, budgetedTimeoutMs, safeFetchWithDeadline } from "./deadline";
+
+import type { PhaseBudget } from "./deadline";
 
 // Matches the limit Google documents for robots.txt; anything past it is
 // ignored by real crawlers, so there is nothing to gain by reading further.
 const ROBOTS_MAX_BYTES = 512 * 1024;
+const ROBOTS_FETCH_TIMEOUT_MS = 30_000;
 
 export interface RobotsEvaluator {
   data: RobotsTxtData;
@@ -64,16 +67,26 @@ export function createRobotsEvaluator(
   };
 }
 
+function unreachableEvaluator(robotsUrl: string, error: string): RobotsEvaluator {
+  return { data: emptyRobotsData(robotsUrl, error), isAllowed: () => true, crawlDelayMs: null };
+}
+
 export function fetchRobotsEvaluator(
   baseUrl: string,
   userAgent: string,
   respectRobots: boolean,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Effect.Effect<RobotsEvaluator, never, never> {
   const robotsUrl = new URL("/robots.txt", baseUrl).toString();
 
   if (!respectRobots) {
     return Effect.succeed(createRobotsEvaluator(robotsUrl, null, userAgent));
+  }
+
+  const timeoutMs = budgetedTimeoutMs(budget, ROBOTS_FETCH_TIMEOUT_MS);
+  if (timeoutMs === null) {
+    return Effect.succeed(unreachableEvaluator(robotsUrl, BUDGET_EXHAUSTED_ERROR));
   }
 
   return Effect.tryPromise({
@@ -89,7 +102,7 @@ export function fetchRobotsEvaluator(
             ...customHeaders,
           },
         },
-        30_000,
+        timeoutMs,
         async (response) => {
           if (response.status === 404) {
             await response.body?.cancel().catch(() => {});
@@ -98,12 +111,7 @@ export function fetchRobotsEvaluator(
 
           if (!response.ok) {
             await response.body?.cancel().catch(() => {});
-            const data = emptyRobotsData(robotsUrl, `HTTP ${response.status}`);
-            return {
-              data,
-              isAllowed: () => true,
-              crawlDelayMs: null,
-            };
+            return unreachableEvaluator(robotsUrl, `HTTP ${response.status}`);
           }
 
           // Bounded: robots.txt is fetched before anything else is known about the
@@ -113,13 +121,6 @@ export function fetchRobotsEvaluator(
           return createRobotsEvaluator(robotsUrl, content, userAgent);
         },
       ),
-    catch: (error) => {
-      const data = emptyRobotsData(robotsUrl, (error as Error).message);
-      return {
-        data,
-        isAllowed: () => true,
-        crawlDelayMs: null,
-      };
-    },
+    catch: (error) => unreachableEvaluator(robotsUrl, (error as Error).message),
   }).pipe(Effect.catchAll((err) => Effect.succeed(err)));
 }

--- a/packages/crawler/src/rsl.ts
+++ b/packages/crawler/src/rsl.ts
@@ -3,8 +3,9 @@ import { truncateToBytes } from "@squirrelscan/utils/bytes";
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
-import { safeFetchWithDeadline } from "./deadline";
+import { BUDGET_EXHAUSTED_ERROR, budgetedTimeoutMs, safeFetchWithDeadline } from "./deadline";
 
+import type { PhaseBudget } from "./deadline";
 import type { RslData, RslLicenseDoc } from "@squirrelscan/core-contracts";
 
 const PROBE_TIMEOUT_MS = 15_000;
@@ -50,11 +51,24 @@ export function looksLikeXml(body: string): boolean {
   return head.startsWith("<?xml") || head.startsWith("<");
 }
 
+const unreachableDoc = (url: string, error: string): RslLicenseDoc => ({
+  url,
+  status: 0,
+  contentType: null,
+  xmlValid: false,
+  looksRsl: false,
+  excerpt: "",
+  error,
+});
+
 async function fetchLicenseDoc(
   url: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Promise<RslLicenseDoc> {
+  const timeoutMs = budgetedTimeoutMs(budget, PROBE_TIMEOUT_MS);
+  if (timeoutMs === null) return unreachableDoc(url, BUDGET_EXHAUSTED_ERROR);
   try {
     return await safeFetchWithDeadline(
       url,
@@ -65,7 +79,7 @@ async function fetchLicenseDoc(
           ...customHeaders,
         },
       },
-      PROBE_TIMEOUT_MS,
+      timeoutMs,
       async (response) => {
         const contentType = response.headers.get("content-type");
         const raw = await readBodyCapped(response, RSL_MAX_BYTES);
@@ -82,15 +96,7 @@ async function fetchLicenseDoc(
       },
     );
   } catch (e) {
-    return {
-      url,
-      status: 0,
-      contentType: null,
-      xmlValid: false,
-      looksRsl: false,
-      excerpt: "",
-      error: (e as Error).message,
-    };
+    return unreachableDoc(url, (e as Error).message);
   }
 }
 
@@ -101,26 +107,32 @@ export function fetchRslLicensing(
   baseUrl: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Effect.Effect<RslData, never, never> {
   const robotsUrl = new URL("/robots.txt", baseUrl).toString();
   return Effect.promise(async () => {
     let robotsBody = "";
     let linkHeader: string | null = null;
+    // A skipped robots read leaves robotsBody empty, which is the same "no
+    // licensing signal" state an unreachable robots.txt produces below.
+    const robotsTimeoutMs = budgetedTimeoutMs(budget, PROBE_TIMEOUT_MS);
     try {
-      await safeFetchWithDeadline(
-        robotsUrl,
-        { headers: { "User-Agent": userAgent, Accept: "text/plain, */*", ...customHeaders } },
-        PROBE_TIMEOUT_MS,
-        async (response) => {
-          if (response.ok) {
-            const raw = await readBodyCapped(response, ROBOTS_MAX_BYTES);
-            robotsBody = truncateToBytes(raw, ROBOTS_MAX_BYTES);
-            linkHeader = response.headers.get("link");
-          } else {
-            await response.body?.cancel().catch(() => {});
-          }
-        },
-      );
+      if (robotsTimeoutMs !== null) {
+        await safeFetchWithDeadline(
+          robotsUrl,
+          { headers: { "User-Agent": userAgent, Accept: "text/plain, */*", ...customHeaders } },
+          robotsTimeoutMs,
+          async (response) => {
+            if (response.ok) {
+              const raw = await readBodyCapped(response, ROBOTS_MAX_BYTES);
+              robotsBody = truncateToBytes(raw, ROBOTS_MAX_BYTES);
+              linkHeader = response.headers.get("link");
+            } else {
+              await response.body?.cancel().catch(() => {});
+            }
+          },
+        );
+      }
     } catch {
       // robots unreachable → no licensing signal; return empty below.
     }
@@ -148,7 +160,7 @@ export function fetchRslLicensing(
     const documents = await Promise.all(
       licenseUrls.map((url) => {
         const sameOrigin = new URL(url).host === baseHost;
-        return fetchLicenseDoc(url, userAgent, sameOrigin ? customHeaders : undefined);
+        return fetchLicenseDoc(url, userAgent, sameOrigin ? customHeaders : undefined, budget);
       }),
     );
 

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -266,8 +266,8 @@ export function fetchSitemapsRecursive(
   }
   // Wall-clock budget spent: abandon the descent rather than walking a
   // sitemap index's thousands of children just to record a skip for each.
-  // The chunk loop below still relies on `fetchSitemap`'s own check for a
-  // budget that expires partway through a level.
+  // The chunk loop below carries the same guard for a budget that expires
+  // partway through a level, which this one cannot see.
   if (budgetedTimeoutMs(budget, SITEMAP_FETCH_TIMEOUT_MS) === null) {
     return Effect.succeed([]);
   }

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -9,7 +9,9 @@ import type {
 } from "@squirrelscan/core-contracts";
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 
-import { safeFetchWithDeadline } from "./deadline";
+import { BUDGET_EXHAUSTED_ERROR, budgetedTimeoutMs, safeFetchWithDeadline } from "./deadline";
+
+import type { PhaseBudget } from "./deadline";
 
 const logger = {
   debug: (_message: string, ..._args: unknown[]) => {},
@@ -152,11 +154,14 @@ export type SitemapFetchResult =
   | { success: true; data: SitemapData }
   | { success: false; url: string; error: string };
 
+const SITEMAP_FETCH_TIMEOUT_MS = 30_000;
+
 export function fetchSitemap(
   url: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
   baseHost?: string,
+  budget?: PhaseBudget,
 ): Effect.Effect<SitemapFetchResult, never, never> {
   // #1393: the caller's secret customHeaders are scoped to the audited origin. A
   // `Sitemap:` directive (robots.txt) or child-sitemap reference can point at an
@@ -165,6 +170,10 @@ export function fetchSitemap(
   const originScopedHeaders =
     baseHost !== undefined && new URL(url).host !== baseHost ? undefined : customHeaders;
   return Effect.promise(async (): Promise<SitemapFetchResult> => {
+    // Budget spent: recorded as a fetch failure, the same shape an unreachable
+    // sitemap already produces, so discovery keeps its normal result contract.
+    const timeoutMs = budgetedTimeoutMs(budget, SITEMAP_FETCH_TIMEOUT_MS);
+    if (timeoutMs === null) return { success: false, url, error: BUDGET_EXHAUSTED_ERROR };
     try {
       // #1395: manual redirects — per-hop scheme allowlist + strip secret
       // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
@@ -181,7 +190,7 @@ export function fetchSitemap(
           },
           redirect: "follow",
         },
-        30_000,
+        timeoutMs,
         async (response): Promise<SitemapFetchResult> => {
           if (!response.ok) {
             await response.body?.cancel().catch(() => {});
@@ -244,11 +253,22 @@ export function fetchSitemapsRecursive(
   // #1393: host of the audited origin; customHeaders are only forwarded to
   // matching-host sitemap fetches. Threaded through the recursion.
   baseHost?: string,
+  // squirrelscan/repo#1733: the crawl preamble's shared wall-clock budget.
+  // Threaded through the recursion so a spent budget ends the whole descent,
+  // not just the request that noticed.
+  budget?: PhaseBudget,
 ): Effect.Effect<SitemapFetchResult[], never, never> {
   if (currentDepth >= maxDepth || urls.length === 0) {
     return Effect.succeed([]);
   }
   if (urlBudget && urlBudget.remaining <= 0) {
+    return Effect.succeed([]);
+  }
+  // Wall-clock budget spent: abandon the descent rather than walking a
+  // sitemap index's thousands of children just to record a skip for each.
+  // The chunk loop below still relies on `fetchSitemap`'s own check for a
+  // budget that expires partway through a level.
+  if (budgetedTimeoutMs(budget, SITEMAP_FETCH_TIMEOUT_MS) === null) {
     return Effect.succeed([]);
   }
 
@@ -279,7 +299,7 @@ export function fetchSitemapsRecursive(
 
       const chunk = unseenUrls.slice(i, i + SITEMAP_FETCH_CONCURRENCY);
       const chunkResults = yield* Effect.all(
-        chunk.map((url) => fetchSitemap(url, userAgent, customHeaders, baseHost)),
+        chunk.map((url) => fetchSitemap(url, userAgent, customHeaders, baseHost, budget)),
         { concurrency: SITEMAP_FETCH_CONCURRENCY },
       );
       fetchResults.push(...chunkResults);
@@ -322,6 +342,7 @@ export function fetchSitemapsRecursive(
       urlBudget,
       customHeaders,
       baseHost,
+      budget,
     );
 
     return [...fetchResults, ...childResults];
@@ -350,6 +371,12 @@ export interface DiscoverSitemapsOptions {
   maxUrls?: number;
   /** Custom HTTP headers attached to every sitemap fetch (e.g. Web Bot Auth signatures). */
   customHeaders?: Record<string, string>;
+  /**
+   * Wall-clock budget shared with the rest of the crawl preamble. Discovery is
+   * its last stage, so it usually inherits whatever the root probes left over
+   * (squirrelscan/repo#1733).
+   */
+  budget?: PhaseBudget;
 }
 
 export function discoverSitemaps(
@@ -400,6 +427,7 @@ export function discoverSitemaps(
       urlBudget,
       options.customHeaders,
       baseHost,
+      options.budget,
     );
 
     const allSitemaps = allResults.filter((result) => result.success).map((result) => result.data);

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -9,9 +9,10 @@ import type {
 } from "@squirrelscan/core-contracts";
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 
-import { BUDGET_EXHAUSTED_ERROR, budgetedTimeoutMs, safeFetchWithDeadline } from "./deadline";
+import { safeFetchWithDeadline } from "./deadline";
 
-import type { PhaseBudget } from "./deadline";
+/** Recorded against a sitemap the walk gave up on before reaching it. */
+export const SITEMAP_NOT_REACHED_ERROR = "sitemap walk stopped before reaching this location";
 
 const logger = {
   debug: (_message: string, ..._args: unknown[]) => {},
@@ -156,12 +157,51 @@ export type SitemapFetchResult =
 
 const SITEMAP_FETCH_TIMEOUT_MS = 30_000;
 
+/**
+ * How long the sitemap walk may go without completing a single fetch
+ * (squirrelscan/repo#1733).
+ *
+ * The walk is the one preamble stage whose truncation costs PAGES, not just AX
+ * metadata: cutting it short on a healthy site silently drops URLs the crawl
+ * would have visited. So it is not governed by the root probes' shared ceiling,
+ * which a site with many legitimate sitemaps would blow through honestly (60
+ * one-URL sitemaps at ~4s a chunk is ~48s of perfectly good work).
+ *
+ * What separates that from the failure this issue is about is PROGRESS. A
+ * stalled origin completes nothing, so the window expires after one dead chunk
+ * and the walk stops; a slow-but-healthy origin keeps finishing chunks and
+ * keeps earning a fresh window. Worst case for a stalled origin is therefore
+ * roughly one chunk, not the whole walk.
+ */
+export const SITEMAP_WALK_WINDOW_MS = 20_000;
+/** …and no more than this many full request timeouts, so a config asking for
+ *  snappy requests gets a proportionally snappy walk. */
+const WALK_WINDOW_REQUESTS = 3;
+
+/** The walk's progress window for a given per-request timeout. */
+export function sitemapWalkWindowMs(timeoutMs: number): number {
+  return Math.min(SITEMAP_WALK_WINDOW_MS, Math.max(1, timeoutMs) * WALK_WINDOW_REQUESTS);
+}
+
+/** Mutable progress window shared across the recursive walk. */
+interface WalkWindow {
+  deadlineAt: number;
+  /** Length of a fresh window, re-armed after each chunk that completes work. */
+  windowMs: number;
+}
+
+function newWalkWindow(windowMs: number = SITEMAP_WALK_WINDOW_MS): WalkWindow {
+  return { deadlineAt: Date.now() + windowMs, windowMs };
+}
+
 export function fetchSitemap(
   url: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
   baseHost?: string,
-  budget?: PhaseBudget,
+  // squirrelscan/repo#1733: deadline for this one fetch, tightened by the
+  // caller when the walk's progress window has less than a full timeout left.
+  timeoutMs: number = SITEMAP_FETCH_TIMEOUT_MS,
 ): Effect.Effect<SitemapFetchResult, never, never> {
   // #1393: the caller's secret customHeaders are scoped to the audited origin. A
   // `Sitemap:` directive (robots.txt) or child-sitemap reference can point at an
@@ -170,10 +210,7 @@ export function fetchSitemap(
   const originScopedHeaders =
     baseHost !== undefined && new URL(url).host !== baseHost ? undefined : customHeaders;
   return Effect.promise(async (): Promise<SitemapFetchResult> => {
-    // Budget spent: recorded as a fetch failure, the same shape an unreachable
-    // sitemap already produces, so discovery keeps its normal result contract.
-    const timeoutMs = budgetedTimeoutMs(budget, SITEMAP_FETCH_TIMEOUT_MS);
-    if (timeoutMs === null) return { success: false, url, error: BUDGET_EXHAUSTED_ERROR };
+    if (timeoutMs <= 0) return { success: false, url, error: SITEMAP_NOT_REACHED_ERROR };
     try {
       // #1395: manual redirects — per-hop scheme allowlist + strip secret
       // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
@@ -253,10 +290,10 @@ export function fetchSitemapsRecursive(
   // #1393: host of the audited origin; customHeaders are only forwarded to
   // matching-host sitemap fetches. Threaded through the recursion.
   baseHost?: string,
-  // squirrelscan/repo#1733: the crawl preamble's shared wall-clock budget.
-  // Threaded through the recursion so a spent budget ends the whole descent,
-  // not just the request that noticed.
-  budget?: PhaseBudget,
+  // squirrelscan/repo#1733: progress window shared across the whole walk, so a
+  // stalled origin ends the descent after one dead chunk while a slow-but-
+  // healthy one keeps going. Created on the first call and threaded down.
+  walkWindow: WalkWindow = newWalkWindow(),
 ): Effect.Effect<SitemapFetchResult[], never, never> {
   if (currentDepth >= maxDepth || urls.length === 0) {
     return Effect.succeed([]);
@@ -264,14 +301,6 @@ export function fetchSitemapsRecursive(
   if (urlBudget && urlBudget.remaining <= 0) {
     return Effect.succeed([]);
   }
-  // Wall-clock budget spent: abandon the descent rather than walking a
-  // sitemap index's thousands of children just to record a skip for each.
-  // The chunk loop below carries the same guard for a budget that expires
-  // partway through a level, which this one cannot see.
-  if (budgetedTimeoutMs(budget, SITEMAP_FETCH_TIMEOUT_MS) === null) {
-    return Effect.succeed([]);
-  }
-
   return Effect.gen(function* () {
     const unseenUrls = urls.filter((url) => {
       if (seen.has(url)) return false;
@@ -296,24 +325,33 @@ export function fetchSitemapsRecursive(
         );
         break;
       }
-      // The wall-clock budget can expire PARTWAY through a level, and the
-      // entry-guard above only runs on the way in. Without this, an index
-      // listing thousands of children would still be chunked and awaited
-      // one skip-result at a time after the deadline had already passed.
-      if (budgetedTimeoutMs(budget, SITEMAP_FETCH_TIMEOUT_MS) === null) {
+      // The window can expire PARTWAY through a level, and the entry guard
+      // above only runs on the way in. Without this, an index listing thousands
+      // of children would still be chunked and awaited one skip-result at a
+      // time after the walk had already given up.
+      const remainingMs = walkWindow.deadlineAt - Date.now();
+      if (remainingMs <= 0) {
         logger.debug(
-          "sitemap phase budget exhausted, skipping remaining sitemaps",
+          "sitemap walk made no progress, skipping remaining sitemaps",
           `${unseenUrls.length - i} skipped at depth ${currentDepth}`,
         );
         break;
       }
 
       const chunk = unseenUrls.slice(i, i + SITEMAP_FETCH_CONCURRENCY);
+      const chunkTimeoutMs = Math.min(SITEMAP_FETCH_TIMEOUT_MS, remainingMs);
       const chunkResults = yield* Effect.all(
-        chunk.map((url) => fetchSitemap(url, userAgent, customHeaders, baseHost, budget)),
+        chunk.map((url) => fetchSitemap(url, userAgent, customHeaders, baseHost, chunkTimeoutMs)),
         { concurrency: SITEMAP_FETCH_CONCURRENCY },
       );
       fetchResults.push(...chunkResults);
+      // A completed fetch earns a fresh window. Only successes count, and that
+      // is deliberate: an all-404 level answers in milliseconds and finishes
+      // inside the first window regardless, so the window only ever bites a walk
+      // that is BOTH slow and getting nothing — which is the stall.
+      if (chunkResults.some((result) => result.success)) {
+        walkWindow.deadlineAt = Date.now() + walkWindow.windowMs;
+      }
 
       for (const result of chunkResults) {
         if (!result.success) continue;
@@ -353,7 +391,7 @@ export function fetchSitemapsRecursive(
       urlBudget,
       customHeaders,
       baseHost,
-      budget,
+      walkWindow,
     );
 
     return [...fetchResults, ...childResults];
@@ -375,6 +413,12 @@ export interface SitemapDiscoveryResult {
   discovered: SitemapData[];
   all: SitemapData[];
   failed: SitemapFetchFailure[];
+  /**
+   * The walk gave up before visiting every entry point, so `discovered` being
+   * empty is NOT evidence that the site has no sitemap (squirrelscan/repo#1733).
+   * Consumers must report unknown rather than missing when this is set.
+   */
+  truncated: boolean;
 }
 
 export interface DiscoverSitemapsOptions {
@@ -383,11 +427,11 @@ export interface DiscoverSitemapsOptions {
   /** Custom HTTP headers attached to every sitemap fetch (e.g. Web Bot Auth signatures). */
   customHeaders?: Record<string, string>;
   /**
-   * Wall-clock budget shared with the rest of the crawl preamble. Discovery is
-   * its last stage, so it usually inherits whatever the root probes left over
-   * (squirrelscan/repo#1733).
+   * How long the walk may go without completing a fetch before it gives up.
+   * Defaults to SITEMAP_WALK_WINDOW_MS; pass `sitemapWalkWindowMs(timeoutMs)` to
+   * scale it with a crawl's per-request timeout (squirrelscan/repo#1733).
    */
-  budget?: PhaseBudget;
+  walkWindowMs?: number;
 }
 
 export function discoverSitemaps(
@@ -438,25 +482,35 @@ export function discoverSitemaps(
       urlBudget,
       options.customHeaders,
       baseHost,
-      options.budget,
+      newWalkWindow(options.walkWindowMs),
     );
 
     const allSitemaps = allResults.filter((result) => result.success).map((result) => result.data);
     const entryPointSet = new Set(entryPoints);
     const discovered = allSitemaps.filter((sitemap) => entryPointSet.has(sitemap.url));
 
+    const sourceOf = (url: string) =>
+      robotsSitemaps.has(url) ? ("robots.txt" as const) : ("common" as const);
+
     const failed: SitemapFetchFailure[] = allResults
       .filter(
         (result): result is { success: false; url: string; error: string } =>
           !result.success && entryPointSet.has(result.url),
       )
-      .map((result) => ({
-        url: result.url,
-        source: robotsSitemaps.has(result.url) ? ("robots.txt" as const) : ("common" as const),
-        error: result.error,
-      }));
+      .map((result) => ({ url: result.url, source: sourceOf(result.url), error: result.error }));
 
-    return { discovered, all: allSitemaps, failed };
+    // An entry point with NO result at all was never visited — the walk stopped
+    // first. Record each one rather than letting it vanish, so "we did not look"
+    // is never silently indistinguishable from "there was nothing there".
+    const attempted = new Set(
+      allResults.map((result) => (result.success ? result.data.url : result.url)),
+    );
+    const unvisited = entryPoints.filter((url) => !attempted.has(url));
+    for (const url of unvisited) {
+      failed.push({ url, source: sourceOf(url), error: SITEMAP_NOT_REACHED_ERROR });
+    }
+
+    return { discovered, all: allSitemaps, failed, truncated: unvisited.length > 0 };
   });
 }
 

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -296,6 +296,17 @@ export function fetchSitemapsRecursive(
         );
         break;
       }
+      // The wall-clock budget can expire PARTWAY through a level, and the
+      // entry-guard above only runs on the way in. Without this, an index
+      // listing thousands of children would still be chunked and awaited
+      // one skip-result at a time after the deadline had already passed.
+      if (budgetedTimeoutMs(budget, SITEMAP_FETCH_TIMEOUT_MS) === null) {
+        logger.debug(
+          "sitemap phase budget exhausted, skipping remaining sitemaps",
+          `${unseenUrls.length - i} skipped at depth ${currentDepth}`,
+        );
+        break;
+      }
 
       const chunk = unseenUrls.slice(i, i + SITEMAP_FETCH_CONCURRENCY);
       const chunkResults = yield* Effect.all(

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -9,10 +9,17 @@ import type {
 } from "@squirrelscan/core-contracts";
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 
+import { SITEMAP_NOT_CHECKED_ERROR } from "@squirrelscan/core-contracts/storage";
+
 import { safeFetchWithDeadline } from "./deadline";
 
-/** Recorded against a sitemap the walk gave up on before reaching it. */
-export const SITEMAP_NOT_REACHED_ERROR = "sitemap walk stopped before reaching this location";
+/**
+ * Recorded against a sitemap the walk gave up on before reaching it. Shared
+ * with the rules package via core-contracts, so `crawl/sitemap-valid` can tell
+ * it apart from a real fetch failure rather than reporting a defect for work
+ * that was never attempted.
+ */
+export const SITEMAP_NOT_REACHED_ERROR = SITEMAP_NOT_CHECKED_ERROR;
 
 const logger = {
   debug: (_message: string, ..._args: unknown[]) => {},
@@ -183,15 +190,51 @@ export function sitemapWalkWindowMs(timeoutMs: number): number {
   return Math.min(SITEMAP_WALK_WINDOW_MS, Math.max(1, timeoutMs) * WALK_WINDOW_REQUESTS);
 }
 
-/** Mutable progress window shared across the recursive walk. */
+/**
+ * Absolute ceiling on the whole walk, on top of the progress window.
+ *
+ * The window alone is gameable: an origin that answers ONE request per chunk
+ * instantly and stalls the other four spends a full window per chunk and
+ * re-arms it every time, so "makes progress" stays true forever and the walk
+ * runs for as long as the origin cares to keep it up. Progress tells a stall
+ * from honest slowness; it cannot tell honest slowness from a slow-drip attack,
+ * and only a hard stop can.
+ *
+ * Truncating here is safe in a way it would not have been before: the walk
+ * reports `truncated`, so consumers say "we did not finish looking" rather than
+ * "this site has no sitemap". The cost of the cap is an honest gap in coverage,
+ * not a false finding.
+ */
+export const SITEMAP_WALK_TOTAL_MS = 60_000;
+
+/** Mutable walk state shared across the recursion. */
 interface WalkWindow {
+  /** Progress window; re-armed after each chunk that completes work. */
   deadlineAt: number;
-  /** Length of a fresh window, re-armed after each chunk that completes work. */
+  /** Length of a fresh window. */
   windowMs: number;
+  /** Hard stop for the walk as a whole, never extended. */
+  hardDeadlineAt: number;
+  /** Set whenever the walk abandons candidates it had not visited. */
+  stoppedEarly: boolean;
 }
 
-function newWalkWindow(windowMs: number = SITEMAP_WALK_WINDOW_MS): WalkWindow {
-  return { deadlineAt: Date.now() + windowMs, windowMs };
+function newWalkWindow(
+  windowMs: number = SITEMAP_WALK_WINDOW_MS,
+  totalMs: number = SITEMAP_WALK_TOTAL_MS,
+): WalkWindow {
+  const now = Date.now();
+  return {
+    deadlineAt: now + windowMs,
+    windowMs,
+    hardDeadlineAt: now + Math.max(windowMs, totalMs),
+    stoppedEarly: false,
+  };
+}
+
+/** ms the walk may still spend: the progress window or the hard stop, whichever is nearer. */
+function walkRemainingMs(walkWindow: WalkWindow): number {
+  return Math.min(walkWindow.deadlineAt, walkWindow.hardDeadlineAt) - Date.now();
 }
 
 export function fetchSitemap(
@@ -295,10 +338,11 @@ export function fetchSitemapsRecursive(
   // healthy one keeps going. Created on the first call and threaded down.
   walkWindow: WalkWindow = newWalkWindow(),
 ): Effect.Effect<SitemapFetchResult[], never, never> {
-  if (currentDepth >= maxDepth || urls.length === 0) {
-    return Effect.succeed([]);
-  }
-  if (urlBudget && urlBudget.remaining <= 0) {
+  if (urls.length === 0) return Effect.succeed([]);
+  // Candidates exist but the walk will not visit them: that is a gap in
+  // coverage, and absence must not be inferred from it downstream.
+  if (currentDepth >= maxDepth || (urlBudget && urlBudget.remaining <= 0)) {
+    walkWindow.stoppedEarly = true;
     return Effect.succeed([]);
   }
   return Effect.gen(function* () {
@@ -323,18 +367,20 @@ export function fetchSitemapsRecursive(
           "sitemap URL budget exhausted, skipping remaining sitemaps",
           `${unseenUrls.length - i} skipped at depth ${currentDepth}`,
         );
+        walkWindow.stoppedEarly = true;
         break;
       }
-      // The window can expire PARTWAY through a level, and the entry guard
-      // above only runs on the way in. Without this, an index listing thousands
-      // of children would still be chunked and awaited one skip-result at a
-      // time after the walk had already given up.
-      const remainingMs = walkWindow.deadlineAt - Date.now();
+      // The window can expire PARTWAY through a level, and the recursion only
+      // checks on the way in. Without this, an index listing thousands of
+      // children would still be chunked and awaited one skip-result at a time
+      // after the walk had already given up.
+      const remainingMs = walkRemainingMs(walkWindow);
       if (remainingMs <= 0) {
         logger.debug(
-          "sitemap walk made no progress, skipping remaining sitemaps",
+          "sitemap walk stopped, skipping remaining sitemaps",
           `${unseenUrls.length - i} skipped at depth ${currentDepth}`,
         );
+        walkWindow.stoppedEarly = true;
         break;
       }
 
@@ -350,7 +396,10 @@ export function fetchSitemapsRecursive(
       // inside the first window regardless, so the window only ever bites a walk
       // that is BOTH slow and getting nothing — which is the stall.
       if (chunkResults.some((result) => result.success)) {
-        walkWindow.deadlineAt = Date.now() + walkWindow.windowMs;
+        walkWindow.deadlineAt = Math.min(
+          Date.now() + walkWindow.windowMs,
+          walkWindow.hardDeadlineAt,
+        );
       }
 
       for (const result of chunkResults) {
@@ -432,6 +481,8 @@ export interface DiscoverSitemapsOptions {
    * scale it with a crawl's per-request timeout (squirrelscan/repo#1733).
    */
   walkWindowMs?: number;
+  /** Hard stop for the whole walk. Defaults to SITEMAP_WALK_TOTAL_MS. */
+  walkTotalMs?: number;
 }
 
 export function discoverSitemaps(
@@ -473,6 +524,11 @@ export function discoverSitemaps(
     const entryPoints = Array.from(sitemapUrls);
     const urlBudget: SitemapUrlBudget | undefined =
       options.maxUrls !== undefined ? { remaining: options.maxUrls } : undefined;
+    // Shared with the recursion so a level abandoned DEEP in the walk still
+    // reports truncation. Counting only unvisited entry points would miss it:
+    // every common location can be visited while an index's children are
+    // dropped, which is a real gap in the URLs the crawl will see.
+    const walkWindow = newWalkWindow(options.walkWindowMs, options.walkTotalMs);
     const allResults = yield* fetchSitemapsRecursive(
       entryPoints,
       userAgent,
@@ -482,7 +538,7 @@ export function discoverSitemaps(
       urlBudget,
       options.customHeaders,
       baseHost,
-      newWalkWindow(options.walkWindowMs),
+      walkWindow,
     );
 
     const allSitemaps = allResults.filter((result) => result.success).map((result) => result.data);
@@ -510,7 +566,12 @@ export function discoverSitemaps(
       failed.push({ url, source: sourceOf(url), error: SITEMAP_NOT_REACHED_ERROR });
     }
 
-    return { discovered, all: allSitemaps, failed, truncated: unvisited.length > 0 };
+    return {
+      discovered,
+      all: allSitemaps,
+      failed,
+      truncated: walkWindow.stoppedEarly || unvisited.length > 0,
+    };
   });
 }
 

--- a/packages/crawler/src/sitemaps.ts
+++ b/packages/crawler/src/sitemaps.ts
@@ -160,7 +160,22 @@ export function parseSitemap(content: string, url: string): SitemapData {
 
 export type SitemapFetchResult =
   | { success: true; data: SitemapData }
-  | { success: false; url: string; error: string };
+  | {
+      success: false;
+      url: string;
+      error: string;
+      /**
+       * The origin answered and the request finished — a 404, a 500, an empty
+       * body. False when nothing came back: a stall aborted at the deadline, a
+       * connection error, or a fetch the walk never attempted.
+       *
+       * The walk's progress window keys off this rather than off `success`. A
+       * fast 404 is real progress: the origin is responsive and the walk is
+       * getting through its candidates, it just is not finding sitemaps
+       * (squirrelscan/repo#1733).
+       */
+      settled: boolean;
+    };
 
 const SITEMAP_FETCH_TIMEOUT_MS = 30_000;
 
@@ -227,7 +242,10 @@ function newWalkWindow(
   return {
     deadlineAt: now + windowMs,
     windowMs,
-    hardDeadlineAt: now + Math.max(windowMs, totalMs),
+    // NOT max(): a caller asking for a hard stop shorter than the window means
+    // it, and silently widening a configured bound is how a cap stops being one.
+    // `walkRemainingMs` takes whichever of the two is nearer.
+    hardDeadlineAt: now + totalMs,
     stoppedEarly: false,
   };
 }
@@ -253,7 +271,9 @@ export function fetchSitemap(
   const originScopedHeaders =
     baseHost !== undefined && new URL(url).host !== baseHost ? undefined : customHeaders;
   return Effect.promise(async (): Promise<SitemapFetchResult> => {
-    if (timeoutMs <= 0) return { success: false, url, error: SITEMAP_NOT_REACHED_ERROR };
+    if (timeoutMs <= 0) {
+      return { success: false, url, error: SITEMAP_NOT_REACHED_ERROR, settled: false };
+    }
     try {
       // #1395: manual redirects — per-hop scheme allowlist + strip secret
       // customHeaders on cross-origin redirects (native redirect:"follow" leaks them).
@@ -274,7 +294,8 @@ export function fetchSitemap(
         async (response): Promise<SitemapFetchResult> => {
           if (!response.ok) {
             await response.body?.cancel().catch(() => {});
-            return { success: false, url, error: `HTTP ${response.status}` };
+            // The origin answered; the status IS the answer.
+            return { success: false, url, error: `HTTP ${response.status}`, settled: true };
           }
           // A body that never arrives (including a deadline abort) classifies
           // as "Empty response", the same as one that arrives empty. This text
@@ -284,9 +305,11 @@ export function fetchSitemap(
           try {
             content = await response.text();
           } catch {
-            return { success: false, url, error: "Empty response" };
+            // The read never finished — a stalled or aborted body.
+            return { success: false, url, error: "Empty response", settled: false };
           }
-          if (!content) return { success: false, url, error: "Empty response" };
+          // Arrived, just empty.
+          if (!content) return { success: false, url, error: "Empty response", settled: true };
           return { success: true, data: parseSitemap(content, url) };
         },
       );
@@ -295,6 +318,7 @@ export function fetchSitemap(
         success: false,
         url,
         error: error instanceof Error ? error.message : "Network error",
+        settled: false,
       };
     }
   });
@@ -370,10 +394,9 @@ export function fetchSitemapsRecursive(
         walkWindow.stoppedEarly = true;
         break;
       }
-      // The window can expire PARTWAY through a level, and the recursion only
-      // checks on the way in. Without this, an index listing thousands of
-      // children would still be chunked and awaited one skip-result at a time
-      // after the walk had already given up.
+      // Checked per chunk, not once per level: a level can hold thousands of an
+      // index's children, and without this every remaining one is still chunked
+      // and awaited just to record a skip after the walk has given up.
       const remainingMs = walkRemainingMs(walkWindow);
       if (remainingMs <= 0) {
         logger.debug(
@@ -391,11 +414,13 @@ export function fetchSitemapsRecursive(
         { concurrency: SITEMAP_FETCH_CONCURRENCY },
       );
       fetchResults.push(...chunkResults);
-      // A completed fetch earns a fresh window. Only successes count, and that
-      // is deliberate: an all-404 level answers in milliseconds and finishes
-      // inside the first window regardless, so the window only ever bites a walk
-      // that is BOTH slow and getting nothing — which is the stall.
-      if (chunkResults.some((result) => result.success)) {
+      // Any chunk where the origin ANSWERED earns a fresh window — a fast 404
+      // is progress, not a stall. Keying this off `success` instead punished a
+      // real shape: one quick 404 alongside four stalled bodies is a responsive
+      // origin the walk is getting through, yet the chunk found no sitemap and
+      // the window died after one round. Only a chunk where nothing came back
+      // at all burns it.
+      if (chunkResults.some((result) => result.success || result.settled)) {
         walkWindow.deadlineAt = Math.min(
           Date.now() + walkWindow.windowMs,
           walkWindow.hardDeadlineAt,
@@ -550,7 +575,7 @@ export function discoverSitemaps(
 
     const failed: SitemapFetchFailure[] = allResults
       .filter(
-        (result): result is { success: false; url: string; error: string } =>
+        (result): result is { success: false; url: string; error: string; settled: boolean } =>
           !result.success && entryPointSet.has(result.url),
       )
       .map((result) => ({ url: result.url, source: sourceOf(result.url), error: result.error }));

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -59,7 +59,7 @@ export interface ContentStoreAdapter {
 // Schema version - increment when schema changes.
 // Exported so migration tests can assert "this DB reached the CURRENT version" rather than pinning a
 // literal, which turned every schema bump into two unrelated test failures.
-export const SCHEMA_VERSION = 22;
+export const SCHEMA_VERSION = 23;
 
 // Migrations to run when upgrading from older versions
 const MIGRATIONS: Record<number, string[]> = {
@@ -315,6 +315,13 @@ const MIGRATIONS: Record<number, string[]> = {
     `ALTER TABLE page_features ADD COLUMN theme_color TEXT`,
     `ALTER TABLE page_features ADD COLUMN og_image TEXT`,
   ],
+  // Version 23: why a robots.txt fetch produced nothing. `found = 0` conflated
+  // "the origin answered 404" with "we never got an answer" (timeout, 5xx, or a
+  // probe the crawl budget cut short), and the weight-8 crawl/robots-txt rule
+  // reported the second as a definite "No robots.txt found"
+  // (squirrelscan/repo#1733). ADDITIVE; ALTER is idempotent (the runner swallows
+  // "duplicate column name"). Local sqlite only — NOT a prod migration.
+  23: [`ALTER TABLE robots_txt ADD COLUMN error TEXT`],
 };
 
 // Nullable columns added to `pages` via ALTER migrations over time, with the
@@ -497,6 +504,9 @@ CREATE TABLE IF NOT EXISTS robots_txt (
   size_bytes INTEGER NOT NULL,
   sitemaps TEXT NOT NULL,
   fetched_at INTEGER NOT NULL,
+  -- Why the fetch produced nothing, when it did. Distinguishes a confirmed 404
+  -- from a probe that never got an answer; see migration 23.
+  error TEXT,
   FOREIGN KEY (crawl_id) REFERENCES crawls(id)
 );
 
@@ -2114,8 +2124,8 @@ export class SQLiteStorage implements CrawlStorage {
       try: () => {
         const db = this.getDb();
         const stmt = db.prepare(`
-          INSERT OR REPLACE INTO robots_txt (crawl_id, url, found, content, size_bytes, sitemaps, fetched_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
+          INSERT OR REPLACE INTO robots_txt (crawl_id, url, found, content, size_bytes, sitemaps, fetched_at, error)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         `);
         stmt.run(
           crawlId,
@@ -2124,7 +2134,8 @@ export class SQLiteStorage implements CrawlStorage {
           robots.content,
           robots.sizeBytes,
           JSON.stringify(robots.sitemaps),
-          robots.fetchedAt
+          robots.fetchedAt,
+          robots.error ?? null
         );
       },
       catch: (e) => StorageError.write(e),
@@ -2147,6 +2158,7 @@ export class SQLiteStorage implements CrawlStorage {
           sizeBytes: row.size_bytes as number,
           sitemaps: this.safeJsonParse<string[]>(row.sitemaps as string, []),
           fetchedAt: row.fetched_at as number,
+          error: (row.error as string | null) ?? null,
         };
       },
       catch: (e) => StorageError.read(e),

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -356,6 +356,16 @@ const SITEMAPS_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: string }> = [
   { name: "is_news_sitemap", type: "INTEGER" },
 ];
 
+// Same guard for `robots_txt`. Migration 23 added `error`; a DB stamped past 23
+// by a build that numbered its own migration 23 skips it forever, and then
+// setRobotsTxt throws "no column named error" on the crawl's first write. This
+// has now bitten `pages` and `sitemaps` in turn, so the column goes on the list
+// at the same time it goes in the migration. Any new ALTER-added `robots_txt`
+// column MUST be listed here.
+const ROBOTS_TXT_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: string }> = [
+  { name: "error", type: "TEXT" },
+];
+
 const SCHEMA = `
 -- Crawl sessions
 CREATE TABLE IF NOT EXISTS crawls (
@@ -938,9 +948,10 @@ export class SQLiteStorage implements CrawlStorage {
     // skipped. Runs unconditionally (PRAGMA table_info is the source of truth,
     // not the schema_version counter), so a DB stuck at the current version
     // with a missing column recovers instead of throwing on every write. See
-    // PAGES_ALTER_COLUMNS and SITEMAPS_ALTER_COLUMNS.
+    // PAGES_ALTER_COLUMNS, SITEMAPS_ALTER_COLUMNS and ROBOTS_TXT_ALTER_COLUMNS.
     this.reconcilePagesColumns();
     this.reconcileColumns("sitemaps", SITEMAPS_ALTER_COLUMNS);
+    this.reconcileColumns("robots_txt", ROBOTS_TXT_ALTER_COLUMNS);
   }
 
   /**
@@ -955,7 +966,7 @@ export class SQLiteStorage implements CrawlStorage {
   }
 
   private reconcileColumns(
-    table: "pages" | "sitemaps",
+    table: "pages" | "sitemaps" | "robots_txt",
     columns: ReadonlyArray<{ name: string; type: string }>
   ): void {
     const db = this.getDb();

--- a/packages/crawler/src/well-known.ts
+++ b/packages/crawler/src/well-known.ts
@@ -2,8 +2,9 @@ import { Effect } from "effect";
 import { byteLength, truncateToBytes } from "@squirrelscan/utils/bytes";
 import { readBodyCapped } from "@squirrelscan/utils/response-body";
 
-import { safeFetchWithDeadline } from "./deadline";
+import { BUDGET_EXHAUSTED_ERROR, budgetedTimeoutMs, safeFetchWithDeadline } from "./deadline";
 
+import type { PhaseBudget } from "./deadline";
 import type { WellKnownProbe, WellKnownProbeData } from "@squirrelscan/core-contracts";
 
 const PROBE_TIMEOUT_MS = 15_000;
@@ -94,13 +95,32 @@ export function looksLikeMarkdown(body: string): boolean {
   return /\[[^\]]+\]\([^)]+\)/.test(trimmed.slice(0, 4_096));
 }
 
+const unreachableProbe = (path: string, url: string, error: string): WellKnownProbe => ({
+  path,
+  url,
+  status: 0,
+  contentType: null,
+  bodySize: 0,
+  looksHtml: false,
+  jsonValid: false,
+  jsonKeys: [],
+  markdownLike: false,
+  excerpt: "",
+  oauthRegistrationEndpoint: null,
+  oauthClientIdMetadataDocumentSupported: null,
+  error,
+});
+
 async function probeOne(
   baseUrl: string,
   path: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Promise<WellKnownProbe> {
   const url = new URL(path, baseUrl).toString();
+  const timeoutMs = budgetedTimeoutMs(budget, PROBE_TIMEOUT_MS);
+  if (timeoutMs === null) return unreachableProbe(path, url, BUDGET_EXHAUSTED_ERROR);
   try {
     return await safeFetchWithDeadline(
       url,
@@ -111,7 +131,7 @@ async function probeOne(
           ...customHeaders,
         },
       },
-      PROBE_TIMEOUT_MS,
+      timeoutMs,
       async (response) => {
         const contentType = response.headers.get("content-type");
         const isOAuth = isOAuthMetadataPath(path);
@@ -163,21 +183,7 @@ async function probeOne(
       },
     );
   } catch (e) {
-    return {
-      path,
-      url,
-      status: 0,
-      contentType: null,
-      bodySize: 0,
-      looksHtml: false,
-      jsonValid: false,
-      jsonKeys: [],
-      markdownLike: false,
-      excerpt: "",
-      oauthRegistrationEndpoint: null,
-      oauthClientIdMetadataDocumentSupported: null,
-      error: (e as Error).message,
-    };
+    return unreachableProbe(path, url, (e as Error).message);
   }
 }
 
@@ -186,10 +192,11 @@ export function probeWellKnown(
   baseUrl: string,
   userAgent: string,
   customHeaders?: Record<string, string>,
+  budget?: PhaseBudget,
 ): Effect.Effect<WellKnownProbeData, never, never> {
   return Effect.promise(async () => {
     const probes = await Promise.all(
-      WELL_KNOWN_PATHS.map((path) => probeOne(baseUrl, path, userAgent, customHeaders)),
+      WELL_KNOWN_PATHS.map((path) => probeOne(baseUrl, path, userAgent, customHeaders, budget)),
     );
     return { probes };
   });

--- a/packages/crawler/tests/pages-alter-columns-guard.test.ts
+++ b/packages/crawler/tests/pages-alter-columns-guard.test.ts
@@ -55,4 +55,27 @@ describe("PAGES_ALTER_COLUMNS drift guard (#921)", () => {
     const missing = [...migrationCols].filter((c) => !reconciledCols.has(c));
     expect(missing).toEqual([]);
   });
+
+  // And `robots_txt`, whose `error` column (migration 23) carries WHY a fetch
+  // produced nothing — without it setRobotsTxt throws on a version-collided DB
+  // and the crawl fails at its first write (squirrelscan/repo#1733).
+  test("every 'ALTER TABLE robots_txt ADD COLUMN' in MIGRATIONS is in ROBOTS_TXT_ALTER_COLUMNS", () => {
+    const src = readFileSync(new URL("../src/storage/sqlite.ts", import.meta.url), "utf8");
+
+    const migrationCols = new Set<string>();
+    for (const m of src.matchAll(/ALTER TABLE robots_txt ADD COLUMN\s+(\w+)/g)) {
+      migrationCols.add(m[1]!);
+    }
+
+    const listBlock = src.match(/ROBOTS_TXT_ALTER_COLUMNS[^[]*\[([\s\S]*?)\];/);
+    expect(listBlock).not.toBeNull();
+    const reconciledCols = new Set<string>();
+    for (const m of listBlock![1]!.matchAll(/name:\s*"(\w+)"/g)) {
+      reconciledCols.add(m[1]!);
+    }
+
+    expect(migrationCols.size).toBeGreaterThan(0);
+    const missing = [...migrationCols].filter((c) => !reconciledCols.has(c));
+    expect(missing).toEqual([]);
+  });
 });

--- a/packages/crawler/tests/preamble-budget.test.ts
+++ b/packages/crawler/tests/preamble-budget.test.ts
@@ -17,7 +17,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { Effect, Fiber, Stream } from "effect";
 
 import { createCrawler, preambleBudgetMs } from "../src/core/crawler";
-import { BUDGET_EXHAUSTED_ERROR } from "../src/deadline";
+import { BUDGET_EXHAUSTED_ERROR, createPhaseBudget } from "../src/deadline";
+import { discoverSitemaps } from "../src/sitemaps";
 import { WELL_KNOWN_PATHS } from "../src/well-known";
 import type { CrawlerConfig, CrawlerEvent } from "../src/core/types";
 
@@ -250,6 +251,63 @@ describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
       expect(probe.error).not.toBe(BUDGET_EXHAUSTED_ERROR);
     }
     expect(sitemaps.length).toBeGreaterThan(0);
+  }, 30_000);
+});
+
+describe("sitemap discovery under the budget", () => {
+  test("a budget that expires mid-level stops the level, it does not skip URL by URL", async () => {
+    // The entry guard only runs on the way INTO a recursion level. A sitemap
+    // index is attacker-sized — one can list thousands of children — so a
+    // budget that expires partway through must break the chunk loop rather
+    // than chunking and awaiting a skip result for every remaining child.
+    const STALL_MS = 400;
+    let requests = 0;
+    const server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      async fetch() {
+        requests++;
+        await Bun.sleep(STALL_MS);
+        return new Response('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>', {
+          headers: { "content-type": "application/xml" },
+        });
+      },
+    });
+    servers.push(server);
+
+    const origin = `http://localhost:${server.port}`;
+    // robots.txt declares far more sitemaps than one chunk holds, so the level
+    // needs several chunks and the budget runs out during it.
+    const declared = Array.from({ length: 60 }, (_, i) => `${origin}/s${i}.xml`);
+
+    const result = await Effect.runPromise(
+      discoverSitemaps(
+        origin,
+        {
+          exists: true,
+          url: `${origin}/robots.txt`,
+          content: null,
+          sizeBytes: 0,
+          sitemaps: declared,
+          rules: [],
+          errors: [],
+        },
+        "squirrel-test",
+        { maxUrls: 10_000, budget: createPhaseBudget(STALL_MS * 2) },
+      ),
+    );
+
+    // Chunks are 5 wide and each takes STALL_MS, so a 2×STALL_MS budget buys
+    // roughly two chunks' worth of real fetches out of ~68 entry points.
+    expect(requests).toBeGreaterThan(0);
+    expect(result.all.length).toBeGreaterThan(0);
+
+    // The load-bearing assertion. `fetchSitemap` short-circuits a spent budget
+    // in ~0ms, so request COUNT stays low either way — what tells the two
+    // implementations apart is whether the loop kept going. Without the chunk
+    // guard every remaining entry point is chunked, awaited, and comes back a
+    // budget-exhausted failure, so `failed` fills up with ~58 of them.
+    expect(result.failed.length).toBeLessThan(10);
   }, 30_000);
 });
 

--- a/packages/crawler/tests/preamble-budget.test.ts
+++ b/packages/crawler/tests/preamble-budget.test.ts
@@ -34,6 +34,9 @@ import {
 import { WELL_KNOWN_PATHS } from "../src/well-known";
 import type { CrawlerConfig, CrawlerEvent } from "../src/core/types";
 
+// Mirrors SITEMAP_FETCH_CONCURRENCY in src/sitemaps.ts (not exported).
+const SITEMAP_FETCH_CONCURRENCY = 5;
+
 const PAGE = `<!doctype html><html><head><title>t</title></head><body>
 <a href="/one">one</a><a href="/two">two</a></body></html>`;
 
@@ -376,6 +379,44 @@ describe("sitemap walk progress window (squirrelscan/repo#1733)", () => {
       result.failed.some((failure) => failure.error === SITEMAP_NOT_REACHED_ERROR),
     ).toBe(true);
   }, 30_000);
+
+  test("a slow-drip origin cannot re-arm the window forever", async () => {
+    // The progress window on its own is gameable. An origin that answers ONE
+    // request per chunk instantly and stalls the other four spends a whole
+    // window per chunk and re-arms it every time, so "is making progress" stays
+    // true indefinitely. Progress separates a stall from honest slowness; only
+    // the hard stop separates honest slowness from a deliberate slow drip.
+    let served = 0;
+    const server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch() {
+        // One in five completes; the rest never finish their body.
+        if (served++ % SITEMAP_FETCH_CONCURRENCY === 0) {
+          return new Response(EMPTY_SITEMAP, { headers: { "content-type": "application/xml" } });
+        }
+        return stalledBodyResponse();
+      },
+    });
+    servers.push(server);
+    const origin = `http://localhost:${server.port}`;
+
+    const startedAt = Date.now();
+    const result = await Effect.runPromise(
+      discoverSitemaps(origin, robotsDeclaring(origin, 400), "squirrel-test", {
+        maxUrls: 10_000,
+        walkWindowMs: WALK_WINDOW_MS,
+        walkTotalMs: WALK_WINDOW_MS * 3,
+      }),
+    );
+    const elapsed = Date.now() - startedAt;
+
+    // Bounded by the hard stop rather than by the origin's willingness to drip.
+    // Without it this runs for 408 entry points x one window each.
+    expect(elapsed).toBeLessThan(WALK_WINDOW_MS * 8);
+    // And it says it did not finish, so no consumer reads this as "no sitemap".
+    expect(result.truncated).toBe(true);
+  }, 60_000);
 });
 
 describe("preambleBudgetMs", () => {

--- a/packages/crawler/tests/preamble-budget.test.ts
+++ b/packages/crawler/tests/preamble-budget.test.ts
@@ -10,15 +10,27 @@
 //
 // The stalled-origin tests below fail against the pre-fix crawler by TIMING OUT
 // rather than by asserting a wrong value: their whole point is wall clock. The
-// healthy-origin test is the other half of the bargain — a budget that quietly
-// dropped probe data on normal sites would be a worse bug than the one fixed.
+// slow-but-healthy tests are the other half of the bargain — a budget that
+// quietly dropped probe data on normal sites would be a worse bug than the one
+// fixed, so every response in those is deliberately slow. An instant-response
+// "healthy" test passes under any budget, however brutal, and proves nothing.
+//
+// The sitemap WALK is not on this budget, and the split is the point: cutting
+// the root probes short costs AX metadata, which degrades to unknown, while
+// cutting the walk short costs PAGES. The walk runs on a progress window
+// instead — it stops when it stops completing fetches, not when a clock runs
+// out — so an honest site with many sitemaps keeps all of them.
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { Effect, Fiber, Stream } from "effect";
 
 import { createCrawler, preambleBudgetMs } from "../src/core/crawler";
-import { BUDGET_EXHAUSTED_ERROR, createPhaseBudget } from "../src/deadline";
-import { discoverSitemaps } from "../src/sitemaps";
+import { BUDGET_EXHAUSTED_ERROR } from "../src/deadline";
+import {
+  discoverSitemaps,
+  SITEMAP_NOT_REACHED_ERROR,
+  sitemapWalkWindowMs,
+} from "../src/sitemaps";
 import { WELL_KNOWN_PATHS } from "../src/well-known";
 import type { CrawlerConfig, CrawlerEvent } from "../src/core/types";
 
@@ -31,6 +43,7 @@ const PAGE = `<!doctype html><html><head><title>t</title></head><body>
 // so nothing here can pass on per-request bounds alone.
 const TIMEOUT_MS = 500;
 const BUDGET_MS = preambleBudgetMs(TIMEOUT_MS);
+const WALK_WINDOW_MS = sitemapWalkWindowMs(TIMEOUT_MS);
 
 const CONFIG: Partial<CrawlerConfig> = {
   maxPages: 3,
@@ -143,11 +156,10 @@ describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
 
     expect(out.pages).toBeGreaterThan(0);
     expect(out.firstPageAfterMs).toBeDefined();
-    // The preamble is bounded by the budget, not by the sum of the probe
-    // deadlines. robots.txt stalls and eats the budget on its own, so this
-    // lands at ~1.04x BUDGET_MS locally; 3x is scheduling headroom for a busy
-    // CI box, and still ~120x under the ~180s that sum of deadlines costs.
-    expect(out.firstPageAfterMs!).toBeLessThan(BUDGET_MS * 3);
+    // Bounded by the root-probe budget PLUS the sitemap walk's own progress
+    // window (one dead chunk, since this origin completes nothing), not by the
+    // sum of every probe's deadline. Still ~50x under the ~180s that sum costs.
+    expect(out.firstPageAfterMs!).toBeLessThan((BUDGET_MS + WALK_WINDOW_MS) * 2);
   }, 30_000);
 
   test("stages after the budget is spent are skipped, not merely deadlined", async () => {
@@ -156,14 +168,19 @@ describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
     await crawl(origin.url);
 
     // robots.txt is the first budgeted stage and it stalls, so it consumes the
-    // whole budget on its own. Everything downstream must then issue NO request
-    // at all — a request that was merely given a short deadline would still show
-    // up here, which is exactly how per-request bounds differ from a phase budget.
+    // whole budget on its own. Every optional AX probe downstream must then
+    // issue NO request at all — a request that was merely given a short deadline
+    // would still show up here, which is exactly how per-request bounds differ
+    // from a phase budget.
     expect(origin.hits.get("/robots.txt") ?? 0).toBeGreaterThan(0);
     expect(origin.hits.get("/llms.txt") ?? 0).toBe(0);
     expect(origin.hits.get("/index.md") ?? 0).toBe(0);
     expect(origin.hits.get("/.well-known/mcp.json") ?? 0).toBe(0);
-    expect(origin.hits.get("/sitemap.xml") ?? 0).toBe(0);
+
+    // Sitemap discovery is the exception, and deliberately so: truncating it
+    // costs PAGES rather than AX metadata, so it runs on its own progress
+    // window instead of the root probes' budget and still gets its attempt.
+    expect(origin.hits.get("/sitemap.xml") ?? 0).toBeGreaterThan(0);
   }, 30_000);
 
   test("probes cut short by the budget still store their unreachable result", async () => {
@@ -186,6 +203,9 @@ describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
 
     expect(robots).not.toBeNull();
     expect(robots!.exists).toBe(false);
+    // …and WHY, so crawl/robots-txt can tell this apart from a confirmed 404
+    // instead of reporting "No robots.txt found" for a file it never reached.
+    expect(robots!.error).toBeTruthy();
     expect(llms).not.toBeNull();
     expect(llms!.llmsTxt.exists).toBe(false);
     expect(markdown).not.toBeNull();
@@ -206,12 +226,18 @@ describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
     }
   }, 30_000);
 
-  test("a healthy origin loses no probe data to the budget", async () => {
+  test("a SLOW but healthy origin loses no probe data to the budget", async () => {
     // The guard on the tradeoff: the budget must only ever bite an origin that
-    // is actually burning wall clock.
+    // is actually burning wall clock. Every response here is deliberately slow
+    // — instant responses would pass no matter how tight the budget was, and so
+    // could not tell a working budget from one that starves honest origins.
+    // Seven sequential stages at LATENCY_MS each still fit inside the budget.
+    const LATENCY_MS = 80;
     const server = Bun.serve({
       port: 0,
-      fetch(req) {
+      idleTimeout: 0,
+      async fetch(req) {
+        await Bun.sleep(LATENCY_MS);
         const path = new URL(req.url).pathname;
         if (path === "/robots.txt") {
           return new Response("User-agent: *\nSitemap: /sitemap.xml\n", {
@@ -246,6 +272,9 @@ describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
     const sitemaps = await read(out.crawler.storage.getSitemaps(out.crawlId));
 
     expect(robots!.exists).toBe(true);
+    // No recorded reason: the fetch completed, so nothing downstream has cause
+    // to treat this crawl's robots.txt as unconfirmed.
+    expect(robots!.error ?? null).toBeNull();
     expect(llms!.llmsTxt.exists).toBe(true);
     // Real 404s, not budget skips: the probes all ran.
     for (const probe of wellKnown!.probes) {
@@ -255,60 +284,97 @@ describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
   }, 30_000);
 });
 
-describe("sitemap discovery under the budget", () => {
-  test("a budget that expires mid-level stops the level, it does not skip URL by URL", async () => {
-    // The entry guard only runs on the way INTO a recursion level. A sitemap
-    // index is attacker-sized — one can list thousands of children — so a
-    // budget that expires partway through must break the chunk loop rather
-    // than chunking and awaiting a skip result for every remaining child.
-    const STALL_MS = 400;
+// robots.txt declaring far more sitemaps than one chunk holds, so the walk
+// needs many chunks and its progress window is what decides where it stops.
+function robotsDeclaring(origin: string, count: number) {
+  return {
+    exists: true,
+    url: `${origin}/robots.txt`,
+    content: null,
+    sizeBytes: 0,
+    sitemaps: Array.from({ length: count }, (_, i) => `${origin}/s${i}.xml`),
+    rules: [],
+    errors: [],
+  };
+}
+
+const EMPTY_SITEMAP = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>';
+
+describe("sitemap walk progress window (squirrelscan/repo#1733)", () => {
+  test("a slow but HEALTHY walk runs to completion and loses no sitemaps", async () => {
+    // The reason the walk is not on the root probes' budget. Each fetch here is
+    // slower than a whole budget's worth of time, but every one SUCCEEDS, and a
+    // site with many legitimate sitemaps must not silently lose the pages they
+    // list. Under a fixed preamble budget this walk is cut off partway.
+    const RESPONSE_MS = 120;
     let requests = 0;
     const server = Bun.serve({
       port: 0,
       idleTimeout: 0,
       async fetch() {
         requests++;
-        await Bun.sleep(STALL_MS);
-        return new Response('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>', {
-          headers: { "content-type": "application/xml" },
-        });
+        await Bun.sleep(RESPONSE_MS);
+        return new Response(EMPTY_SITEMAP, { headers: { "content-type": "application/xml" } });
       },
     });
     servers.push(server);
-
     const origin = `http://localhost:${server.port}`;
-    // robots.txt declares far more sitemaps than one chunk holds, so the level
-    // needs several chunks and the budget runs out during it.
-    const declared = Array.from({ length: 60 }, (_, i) => `${origin}/s${i}.xml`);
 
     const result = await Effect.runPromise(
-      discoverSitemaps(
-        origin,
-        {
-          exists: true,
-          url: `${origin}/robots.txt`,
-          content: null,
-          sizeBytes: 0,
-          sitemaps: declared,
-          rules: [],
-          errors: [],
-        },
-        "squirrel-test",
-        { maxUrls: 10_000, budget: createPhaseBudget(STALL_MS * 2) },
-      ),
+      discoverSitemaps(origin, robotsDeclaring(origin, 60), "squirrel-test", {
+        maxUrls: 10_000,
+        walkWindowMs: WALK_WINDOW_MS,
+      }),
     );
 
-    // Chunks are 5 wide and each takes STALL_MS, so a 2×STALL_MS budget buys
-    // roughly two chunks' worth of real fetches out of ~68 entry points.
-    expect(requests).toBeGreaterThan(0);
-    expect(result.all.length).toBeGreaterThan(0);
+    // Every declared sitemap plus the common locations was actually fetched:
+    // completing a chunk earns a fresh window, so honest slowness never runs out.
+    expect(requests).toBeGreaterThanOrEqual(60);
+    expect(result.all.length).toBeGreaterThanOrEqual(60);
+    expect(result.truncated).toBe(false);
+  }, 30_000);
 
-    // The load-bearing assertion. `fetchSitemap` short-circuits a spent budget
-    // in ~0ms, so request COUNT stays low either way — what tells the two
-    // implementations apart is whether the loop kept going. Without the chunk
-    // guard every remaining entry point is chunked, awaited, and comes back a
-    // budget-exhausted failure, so `failed` fills up with ~58 of them.
-    expect(result.failed.length).toBeLessThan(10);
+  test("a STALLED walk stops after roughly one chunk and says so", async () => {
+    // The mirror case. Nothing completes, so no chunk earns a fresh window and
+    // the walk gives up almost immediately instead of running 68 entry points
+    // to their individual deadlines. The entry guard only runs on the way INTO
+    // a level, so the chunk loop needs its own guard for a window that expires
+    // partway through — otherwise every remaining URL is still chunked and
+    // awaited just to record a skip.
+    let requests = 0;
+    const server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch() {
+        requests++;
+        return stalledBodyResponse();
+      },
+    });
+    servers.push(server);
+    const origin = `http://localhost:${server.port}`;
+
+    const startedAt = Date.now();
+    const result = await Effect.runPromise(
+      discoverSitemaps(origin, robotsDeclaring(origin, 60), "squirrel-test", {
+        maxUrls: 10_000,
+        walkWindowMs: WALK_WINDOW_MS,
+      }),
+    );
+    const elapsed = Date.now() - startedAt;
+
+    // Roughly one chunk of five, not all 68.
+    expect(requests).toBeGreaterThan(0);
+    expect(requests).toBeLessThan(20);
+    expect(elapsed).toBeLessThan(WALK_WINDOW_MS * 4);
+
+    // AC3: nothing vanishes. Every entry point the walk never reached is still
+    // recorded, and the result says absence was never established — which is
+    // what stops crawl/sitemap-exists reporting "No XML sitemap found".
+    expect(result.truncated).toBe(true);
+    expect(result.failed.length).toBeGreaterThanOrEqual(60);
+    expect(
+      result.failed.some((failure) => failure.error === SITEMAP_NOT_REACHED_ERROR),
+    ).toBe(true);
   }, 30_000);
 });
 

--- a/packages/crawler/tests/preamble-budget.test.ts
+++ b/packages/crawler/tests/preamble-budget.test.ts
@@ -144,9 +144,10 @@ describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
     expect(out.pages).toBeGreaterThan(0);
     expect(out.firstPageAfterMs).toBeDefined();
     // The preamble is bounded by the budget, not by the sum of the probe
-    // deadlines. Generous slack over BUDGET_MS for scheduling, and still two
-    // orders of magnitude under the ~180s that sum would cost.
-    expect(out.firstPageAfterMs!).toBeLessThan(BUDGET_MS * 6);
+    // deadlines. robots.txt stalls and eats the budget on its own, so this
+    // lands at ~1.04x BUDGET_MS locally; 3x is scheduling headroom for a busy
+    // CI box, and still ~120x under the ~180s that sum of deadlines costs.
+    expect(out.firstPageAfterMs!).toBeLessThan(BUDGET_MS * 3);
   }, 30_000);
 
   test("stages after the budget is spent are skipped, not merely deadlined", async () => {

--- a/packages/crawler/tests/preamble-budget.test.ts
+++ b/packages/crawler/tests/preamble-budget.test.ts
@@ -1,0 +1,269 @@
+// squirrelscan/repo#1733 — the crawl preamble needs a budget as a WHOLE, not
+// just a deadline per request.
+//
+// #1699 gave every root probe a deadline that survives its body read, which
+// stopped a stalled body hanging the crawl forever. It left the sum untouched:
+// the preamble is seven sequential stages carrying 15-30s deadlines apiece, so
+// an origin that answers 200 on every root path and then stalls the body burned
+// 150.3s across 28 requests before page 1 — the entire 120s crawl phase a quick
+// cloud audit gets, on a site whose real pages serve perfectly well.
+//
+// The stalled-origin tests below fail against the pre-fix crawler by TIMING OUT
+// rather than by asserting a wrong value: their whole point is wall clock. The
+// healthy-origin test is the other half of the bargain — a budget that quietly
+// dropped probe data on normal sites would be a worse bug than the one fixed.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect, Fiber, Stream } from "effect";
+
+import { createCrawler, preambleBudgetMs } from "../src/core/crawler";
+import { BUDGET_EXHAUSTED_ERROR } from "../src/deadline";
+import { WELL_KNOWN_PATHS } from "../src/well-known";
+import type { CrawlerConfig, CrawlerEvent } from "../src/core/types";
+
+const PAGE = `<!doctype html><html><head><title>t</title></head><body>
+<a href="/one">one</a><a href="/two">two</a></body></html>`;
+
+// The budget is min(45s, timeoutMs × 3), so a 500ms per-request timeout buys a
+// 1500ms preamble — the same arithmetic production runs, three orders of
+// magnitude faster. Every probe's OWN deadline (15-30s, fixed) is far larger,
+// so nothing here can pass on per-request bounds alone.
+const TIMEOUT_MS = 500;
+const BUDGET_MS = preambleBudgetMs(TIMEOUT_MS);
+
+const CONFIG: Partial<CrawlerConfig> = {
+  maxPages: 3,
+  concurrency: 2,
+  perHostConcurrency: 2,
+  delayMs: 0,
+  perHostDelayMs: 0,
+  timeoutMs: TIMEOUT_MS,
+  userAgent: "squirrel-test",
+  respectRobots: false,
+  incremental: false,
+  useCacheControl: false,
+  breadthFirst: false,
+  coverageMode: "full",
+};
+
+const servers: Array<{ stop: (closeActive?: boolean) => void }> = [];
+afterEach(() => {
+  for (const s of servers.splice(0)) s.stop(true);
+});
+
+const REAL_PAGES = new Set(["/", "/one", "/two"]);
+
+function htmlResponse(body = PAGE) {
+  return new Response(body, { headers: { "content-type": "text/html" } });
+}
+
+// 200 headers, then a body stream that is never closed. This is the daigo.ru
+// shape: the probe cannot tell from the status line that it will never finish.
+function stalledBodyResponse() {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("<!doctype html><html><body>"));
+      },
+    }),
+    { headers: { "content-type": "text/html" } },
+  );
+}
+
+interface Origin {
+  url: string;
+  hits: Map<string, number>;
+}
+
+// Real pages serve normally; every root-probe path stalls its body. `idleTimeout: 0`
+// so the server is never the thing that gives up — the client has to be.
+function serveStallingProbes(): Origin {
+  const hits = new Map<string, number>();
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      const path = new URL(req.url).pathname;
+      hits.set(path, (hits.get(path) ?? 0) + 1);
+      return REAL_PAGES.has(path) ? htmlResponse() : stalledBodyResponse();
+    },
+  });
+  servers.push(server);
+  // Trailing slash: seeded without it, `response.url` comes back normalized and
+  // the seed probe reads that as a redirect, skipping the body read entirely.
+  return { url: `http://localhost:${server.port}/`, hits };
+}
+
+interface CrawlOutcome {
+  crawlId: string;
+  crawler: Awaited<ReturnType<typeof Effect.runPromise<Awaited<ReturnType<typeof createCrawler>>>>>;
+  pages: number;
+  firstPageAfterMs: number | undefined;
+  totalMs: number;
+}
+
+async function crawl(origin: string, config = CONFIG): Promise<CrawlOutcome> {
+  const startedAt = Date.now();
+  const crawler = await Effect.runPromise(createCrawler({ config }));
+
+  let firstPageAfterMs: number | undefined;
+  // `Stream.fromPubSub` never completes on its own, so this fiber has to be
+  // interrupted or it outlives the test.
+  const events = Effect.runFork(
+    Stream.runForEach(crawler.events, (event: CrawlerEvent) =>
+      Effect.sync(() => {
+        if (event.type === "page:fetched" && firstPageAfterMs === undefined) {
+          firstPageAfterMs = Date.now() - startedAt;
+        }
+      }),
+    ),
+  );
+
+  try {
+    const crawlId = await Effect.runPromise(crawler.start(origin, origin));
+    const pages = await Effect.runPromise(crawler.storage.getPages(crawlId));
+    return {
+      crawlId,
+      crawler,
+      pages: pages.length,
+      firstPageAfterMs,
+      totalMs: Date.now() - startedAt,
+    };
+  } finally {
+    await Effect.runPromise(Fiber.interrupt(events));
+  }
+}
+
+describe("crawl preamble budget (squirrelscan/repo#1733)", () => {
+  test("an origin whose root probes stall still reaches its pages inside the budget", async () => {
+    const origin = serveStallingProbes();
+
+    const out = await crawl(origin.url);
+
+    expect(out.pages).toBeGreaterThan(0);
+    expect(out.firstPageAfterMs).toBeDefined();
+    // The preamble is bounded by the budget, not by the sum of the probe
+    // deadlines. Generous slack over BUDGET_MS for scheduling, and still two
+    // orders of magnitude under the ~180s that sum would cost.
+    expect(out.firstPageAfterMs!).toBeLessThan(BUDGET_MS * 6);
+  }, 30_000);
+
+  test("stages after the budget is spent are skipped, not merely deadlined", async () => {
+    const origin = serveStallingProbes();
+
+    await crawl(origin.url);
+
+    // robots.txt is the first budgeted stage and it stalls, so it consumes the
+    // whole budget on its own. Everything downstream must then issue NO request
+    // at all — a request that was merely given a short deadline would still show
+    // up here, which is exactly how per-request bounds differ from a phase budget.
+    expect(origin.hits.get("/robots.txt") ?? 0).toBeGreaterThan(0);
+    expect(origin.hits.get("/llms.txt") ?? 0).toBe(0);
+    expect(origin.hits.get("/index.md") ?? 0).toBe(0);
+    expect(origin.hits.get("/.well-known/mcp.json") ?? 0).toBe(0);
+    expect(origin.hits.get("/sitemap.xml") ?? 0).toBe(0);
+  }, 30_000);
+
+  test("probes cut short by the budget still store their unreachable result", async () => {
+    const origin = serveStallingProbes();
+
+    const out = await crawl(origin.url);
+    const read = <T>(effect: Effect.Effect<T, unknown, never>) =>
+      Effect.runPromise(effect as Effect.Effect<T, never, never>);
+
+    // Every probe's row is still written. A budget that dropped rows instead of
+    // storing an "unreachable" shape would silently blank AX data in reports.
+    const [robots, llms, markdown, wellKnown, agentAccess, rsl] = await Promise.all([
+      read(out.crawler.storage.getRobotsTxt(out.crawlId)),
+      read(out.crawler.storage.getLlmsTxt(out.crawlId)),
+      read(out.crawler.storage.getMarkdownProbe(out.crawlId)),
+      read(out.crawler.storage.getWellKnownProbe(out.crawlId)),
+      read(out.crawler.storage.getAgentAccess(out.crawlId)),
+      read(out.crawler.storage.getRsl(out.crawlId)),
+    ]);
+
+    expect(robots).not.toBeNull();
+    expect(robots!.exists).toBe(false);
+    expect(llms).not.toBeNull();
+    expect(llms!.llmsTxt.exists).toBe(false);
+    expect(markdown).not.toBeNull();
+    expect(markdown!.servesMarkdown).toBe(false);
+    expect(rsl).not.toBeNull();
+    expect(rsl!.licenseUrls).toEqual([]);
+
+    // The skipped probes carry the full path/identity list with the budget
+    // reason recorded, the same shape an unreachable host produces.
+    expect(wellKnown!.probes).toHaveLength(WELL_KNOWN_PATHS.length);
+    for (const probe of wellKnown!.probes) {
+      expect(probe.status).toBe(0);
+      expect(probe.error).toBe(BUDGET_EXHAUSTED_ERROR);
+    }
+    expect(agentAccess!.probes).toHaveLength(3);
+    for (const probe of agentAccess!.probes) {
+      expect(probe.error).toBe(BUDGET_EXHAUSTED_ERROR);
+    }
+  }, 30_000);
+
+  test("a healthy origin loses no probe data to the budget", async () => {
+    // The guard on the tradeoff: the budget must only ever bite an origin that
+    // is actually burning wall clock.
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        if (path === "/robots.txt") {
+          return new Response("User-agent: *\nSitemap: /sitemap.xml\n", {
+            headers: { "content-type": "text/plain" },
+          });
+        }
+        if (path === "/llms.txt") {
+          return new Response("# Site\n", { headers: { "content-type": "text/plain" } });
+        }
+        if (path === "/sitemap.xml") {
+          return new Response(
+            `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+              `<url><loc>http://localhost:${server.port}/one</loc></url></urlset>`,
+            { headers: { "content-type": "application/xml" } },
+          );
+        }
+        if (REAL_PAGES.has(path)) return htmlResponse();
+        return new Response("nope", { status: 404 });
+      },
+    });
+    servers.push(server);
+
+    const out = await crawl(`http://localhost:${server.port}/`);
+    const read = <T>(effect: Effect.Effect<T, unknown, never>) =>
+      Effect.runPromise(effect as Effect.Effect<T, never, never>);
+
+    expect(out.pages).toBeGreaterThan(0);
+
+    const robots = await read(out.crawler.storage.getRobotsTxt(out.crawlId));
+    const llms = await read(out.crawler.storage.getLlmsTxt(out.crawlId));
+    const wellKnown = await read(out.crawler.storage.getWellKnownProbe(out.crawlId));
+    const sitemaps = await read(out.crawler.storage.getSitemaps(out.crawlId));
+
+    expect(robots!.exists).toBe(true);
+    expect(llms!.llmsTxt.exists).toBe(true);
+    // Real 404s, not budget skips: the probes all ran.
+    for (const probe of wellKnown!.probes) {
+      expect(probe.error).not.toBe(BUDGET_EXHAUSTED_ERROR);
+    }
+    expect(sitemaps.length).toBeGreaterThan(0);
+  }, 30_000);
+});
+
+describe("preambleBudgetMs", () => {
+  test("caps at the ceiling and scales down with a tighter per-request timeout", () => {
+    // Default crawl (30s per request): the 45s ceiling binds, NOT 30 × 3.
+    expect(preambleBudgetMs(30_000)).toBe(45_000);
+    expect(preambleBudgetMs(60_000)).toBe(45_000);
+    // A config asking for snappy requests gets a proportionally snappy preamble.
+    expect(preambleBudgetMs(10_000)).toBe(30_000);
+    expect(preambleBudgetMs(500)).toBe(1_500);
+    // Degenerate timeouts must not produce a zero or negative budget, which
+    // would skip the preamble outright rather than bounding it.
+    expect(preambleBudgetMs(0)).toBe(3);
+    expect(preambleBudgetMs(-1)).toBe(3);
+  });
+});

--- a/packages/crawler/tests/preamble-budget.test.ts
+++ b/packages/crawler/tests/preamble-budget.test.ts
@@ -29,6 +29,7 @@ import { BUDGET_EXHAUSTED_ERROR } from "../src/deadline";
 import {
   discoverSitemaps,
   SITEMAP_NOT_REACHED_ERROR,
+  SITEMAP_WALK_WINDOW_MS,
   sitemapWalkWindowMs,
 } from "../src/sitemaps";
 import { WELL_KNOWN_PATHS } from "../src/well-known";
@@ -338,12 +339,11 @@ describe("sitemap walk progress window (squirrelscan/repo#1733)", () => {
   }, 30_000);
 
   test("a STALLED walk stops after roughly one chunk and says so", async () => {
-    // The mirror case. Nothing completes, so no chunk earns a fresh window and
-    // the walk gives up almost immediately instead of running 68 entry points
-    // to their individual deadlines. The entry guard only runs on the way INTO
-    // a level, so the chunk loop needs its own guard for a window that expires
-    // partway through — otherwise every remaining URL is still chunked and
-    // awaited just to record a skip.
+    // The mirror case. Nothing comes back at all, so no chunk earns a fresh
+    // window and the walk gives up almost immediately instead of running 68
+    // entry points to their individual deadlines. The window is checked per
+    // CHUNK, which is what stops the rest of a level being chunked and awaited
+    // just to record a skip.
     let requests = 0;
     const server = Bun.serve({
       port: 0,
@@ -379,6 +379,41 @@ describe("sitemap walk progress window (squirrelscan/repo#1733)", () => {
       result.failed.some((failure) => failure.error === SITEMAP_NOT_REACHED_ERROR),
     ).toBe(true);
   }, 30_000);
+
+  test("a fast 404 counts as progress, so a mixed level is not cut short", async () => {
+    // Keying the re-arm off `success` punished a real shape: one quick 404
+    // alongside four stalled bodies is a RESPONSIVE origin the walk is getting
+    // through, but the chunk finds no sitemap, so the window died after one
+    // round and 5 of 68 candidates were ever visited. Only a chunk where
+    // nothing came back at all should burn the window.
+    let requests = 0;
+    const server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch() {
+        // One in five answers immediately (404); the rest never finish.
+        if (requests++ % SITEMAP_FETCH_CONCURRENCY === 0) {
+          return new Response("nope", { status: 404 });
+        }
+        return stalledBodyResponse();
+      },
+    });
+    servers.push(server);
+    const origin = `http://localhost:${server.port}`;
+
+    const result = await Effect.runPromise(
+      discoverSitemaps(origin, robotsDeclaring(origin, 60), "squirrel-test", {
+        maxUrls: 10_000,
+        walkWindowMs: WALK_WINDOW_MS,
+        // Generous hard stop: the window, not the cap, is what is under test.
+        walkTotalMs: WALK_WINDOW_MS * 40,
+      }),
+    );
+
+    // It kept going well past the first chunk. Without the fix this stops at 5.
+    expect(requests).toBeGreaterThan(SITEMAP_FETCH_CONCURRENCY * 4);
+    expect(result.failed.length).toBeGreaterThan(SITEMAP_FETCH_CONCURRENCY);
+  }, 60_000);
 
   test("a slow-drip origin cannot re-arm the window forever", async () => {
     // The progress window on its own is gameable. An origin that answers ONE
@@ -417,6 +452,33 @@ describe("sitemap walk progress window (squirrelscan/repo#1733)", () => {
     // And it says it did not finish, so no consumer reads this as "no sitemap".
     expect(result.truncated).toBe(true);
   }, 60_000);
+});
+
+describe("sitemapWalkWindowMs / walk hard stop", () => {
+  test("scales the progress window down with a tighter per-request timeout", () => {
+    expect(sitemapWalkWindowMs(30_000)).toBe(SITEMAP_WALK_WINDOW_MS);
+    expect(sitemapWalkWindowMs(500)).toBe(1_500);
+    expect(sitemapWalkWindowMs(0)).toBe(3);
+  });
+
+  test("a hard stop shorter than the window is honored, not widened to it", async () => {
+    // Silently raising a configured cap to the window length is how a bound
+    // stops being one. The nearer of the two wins.
+    const server = Bun.serve({ port: 0, idleTimeout: 0, fetch: () => stalledBodyResponse() });
+    servers.push(server);
+    const origin = `http://localhost:${server.port}`;
+
+    const startedAt = Date.now();
+    await Effect.runPromise(
+      discoverSitemaps(origin, robotsDeclaring(origin, 60), "squirrel-test", {
+        maxUrls: 10_000,
+        walkWindowMs: 2_000,
+        walkTotalMs: 200,
+      }),
+    );
+
+    expect(Date.now() - startedAt).toBeLessThan(1_500);
+  }, 30_000);
 });
 
 describe("preambleBudgetMs", () => {

--- a/packages/rules/src/ax/rsl-license.ts
+++ b/packages/rules/src/ax/rsl-license.ts
@@ -1,5 +1,7 @@
 // ax/rsl-license - detect a robots.txt License: directive pointing to a valid RSL document
 
+import { PROBE_NOT_ATTEMPTED_ERROR } from "@squirrelscan/core-contracts/storage";
+
 import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
 
 export const rslLicenseRule: Rule = {
@@ -53,7 +55,17 @@ export const rslLicenseRule: Rule = {
     });
 
     const validDocs = rsl.documents.filter((d) => d.status === 200 && d.xmlValid && d.looksRsl);
-    const brokenDocs = rsl.documents.filter((d) => !(d.status === 200 && d.xmlValid && d.looksRsl));
+    // A document the crawl never REQUESTED proves nothing about the reference.
+    // Note how narrow this is: a URL we actually tried and could not fetch stays
+    // a broken reference (that is the defect this rule exists to surface), and
+    // only the never-attempted case degrades to unknown. Both look like
+    // `status: 0`, so the recorded reason is the only discriminator.
+    const notAttempted = rsl.documents.filter(
+      (d) => d.status === 0 && d.error === PROBE_NOT_ATTEMPTED_ERROR,
+    );
+    const brokenDocs = rsl.documents.filter(
+      (d) => !notAttempted.includes(d) && !(d.status === 200 && d.xmlValid && d.looksRsl),
+    );
 
     if (validDocs.length > 0) {
       checks.push({
@@ -64,6 +76,22 @@ export const rslLicenseRule: Rule = {
         }`,
         value: "valid",
         details: { validUrls: validDocs.map((d) => d.url) },
+      });
+      return { checks };
+    }
+
+    // Nothing resolved AND nothing was actually checked: report what we don't
+    // know rather than a defect the audit never established.
+    if (brokenDocs.length === 0 && notAttempted.length > 0) {
+      checks.push({
+        name: "rsl-license-valid",
+        status: "info",
+        message: `License declared but the referenced document was not checked (${notAttempted.length} URL${
+          notAttempted.length === 1 ? "" : "s"
+        })`,
+        value: "unknown",
+        items: notAttempted.map((d) => ({ id: d.url, label: `${d.url} — not checked` })),
+        details: { notCheckedUrls: notAttempted.map((d) => d.url) },
       });
       return { checks };
     }

--- a/packages/rules/src/crawl/robots-txt.ts
+++ b/packages/rules/src/crawl/robots-txt.ts
@@ -28,7 +28,20 @@ export const robotsTxtRule: Rule = {
       return { checks };
     }
 
-    // Check existence
+    // Check existence. `exists: false` with a recorded error means the probe
+    // never got an answer — a timeout, a 5xx, or a fetch the crawl budget cut
+    // short. Absence was not established, so this reports what is unknown
+    // instead of a definite missing-file finding (squirrelscan/repo#1733).
+    if (!robotsTxt.exists && robotsTxt.errors.length > 0) {
+      checks.push({
+        name: "robots-txt-exists",
+        status: "info",
+        message: "robots.txt could not be checked",
+        value: robotsTxt.errors[0] ?? "the request did not complete",
+      });
+      return { checks };
+    }
+
     if (!robotsTxt.exists) {
       checks.push({
         name: "robots-txt-exists",

--- a/packages/rules/src/crawl/robots-txt.ts
+++ b/packages/rules/src/crawl/robots-txt.ts
@@ -37,7 +37,10 @@ export const robotsTxtRule: Rule = {
         name: "robots-txt-exists",
         status: "info",
         message: "robots.txt could not be checked",
-        value: robotsTxt.errors[0] ?? "the request did not complete",
+        // Deliberately not the raw reason: for a skipped probe that string is
+        // an internal marker ("crawl phase budget exhausted"), which is not
+        // something to show a reader. Report the consequence instead.
+        value: "The request did not complete, so this is unknown, not missing",
       });
       return { checks };
     }

--- a/packages/rules/src/crawl/sitemap-exists.ts
+++ b/packages/rules/src/crawl/sitemap-exists.ts
@@ -29,6 +29,20 @@ export const sitemapExistsRule: Rule = {
       return { checks };
     }
 
+    // Discovery stopped before visiting every candidate location, so nothing
+    // was established about whether a sitemap exists. Reporting a definite
+    // "No XML sitemap found" here would turn a check we never finished into a
+    // weight-10 defect on a site that may well have one (squirrelscan/repo#1733).
+    if (sitemaps.discovered.length === 0 && sitemaps.truncated) {
+      checks.push({
+        name: "sitemap-exists",
+        status: "info",
+        message: "Sitemap discovery did not complete, so no sitemap check was made",
+        value: "Not all candidate locations were reached",
+      });
+      return { checks };
+    }
+
     // Check if any sitemaps were discovered
     if (sitemaps.discovered.length === 0) {
       checks.push({

--- a/packages/rules/src/crawl/sitemap-valid.ts
+++ b/packages/rules/src/crawl/sitemap-valid.ts
@@ -1,5 +1,7 @@
 // crawl/sitemap-valid - Sitemap validation
 
+import { SITEMAP_NOT_CHECKED_ERROR } from "@squirrelscan/core-contracts/storage";
+
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
 const MAX_URLS_PER_SITEMAP = 50000;
@@ -23,9 +25,14 @@ export const sitemapValidRule: Rule = {
     const checks: CheckResult[] = [];
     const sitemaps = ctx.site?.sitemaps;
 
-    // Check for sitemaps from robots.txt that failed to fetch
+    // Check for sitemaps from robots.txt that failed to fetch. A sitemap the
+    // walk never REQUESTED is not a fetch failure — it is a gap in what was
+    // checked, and reporting it as "failed to fetch" would invent a defect out
+    // of work the audit skipped (squirrelscan/repo#1733).
     const failedFromRobots =
-      sitemaps?.failed?.filter((f) => f.source === "robots.txt") ?? [];
+      sitemaps?.failed?.filter(
+        (f) => f.source === "robots.txt" && f.error !== SITEMAP_NOT_CHECKED_ERROR,
+      ) ?? [];
 
     if (failedFromRobots.length > 0) {
       checks.push({

--- a/packages/rules/src/crawl/sitemap-valid.ts
+++ b/packages/rules/src/crawl/sitemap-valid.ts
@@ -52,6 +52,19 @@ export const sitemapValidRule: Rule = {
         return { checks };
       }
 
+      // "No sitemap to validate" reads as a finished check that found nothing.
+      // When the walk stopped early it is neither: candidates were left
+      // unvisited, so say the check did not complete (squirrelscan/repo#1733).
+      if (sitemaps?.truncated) {
+        checks.push({
+          name: "sitemap-valid",
+          status: "info",
+          message: "Sitemap discovery did not complete, so no sitemap was validated",
+          value: "Not all candidate locations were reached",
+        });
+        return { checks };
+      }
+
       checks.push({
         name: "sitemap-valid",
         status: "skipped",

--- a/packages/rules/tests/unconfirmed-probe-not-missing.test.ts
+++ b/packages/rules/tests/unconfirmed-probe-not-missing.test.ts
@@ -1,0 +1,161 @@
+// squirrelscan/repo#1733 — a probe that never got an answer is UNKNOWN, and
+// must never be reported as a confirmed absence.
+//
+// `exists: false` / `discovered: []` each conflate two different worlds: the
+// origin answered 404 (evidence of absence) and we never got an answer at all —
+// a timeout, a 5xx, or a fetch the crawl cut short. Reporting the second as
+// "No robots.txt found" or "No XML sitemap found" turns a check the audit never
+// completed into a definite, high-weight defect on a site that may well have
+// the file. Same rule as the content-encoding probes in public #9: a failed
+// confirmation degrades to unknown, never to a negative.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  CheckResult,
+  RobotsTxtData,
+  RslData,
+  RslLicenseDoc,
+  SitemapDiscovery,
+} from "@squirrelscan/core-contracts";
+
+import { robotsTxtRule } from "../src/crawl/robots-txt";
+import { sitemapExistsRule } from "../src/crawl/sitemap-exists";
+import { rslLicenseRule } from "../src/ax/rsl-license";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+function ctx(site: Partial<RuleContext["site"]>): RuleContext {
+  return {
+    page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+    parsed: {} as ParsedPage,
+    site: {
+      baseUrl: "https://example.com",
+      pages: [],
+      robotsTxt: null,
+      sitemaps: null,
+      ...site,
+    } as RuleContext["site"],
+    options: {},
+  };
+}
+
+function robots(over: Partial<RobotsTxtData> = {}): RobotsTxtData {
+  return {
+    exists: false,
+    url: "https://example.com/robots.txt",
+    content: null,
+    sizeBytes: 0,
+    sitemaps: [],
+    rules: [],
+    errors: [],
+    ...over,
+  };
+}
+
+function sitemaps(over: Partial<SitemapDiscovery> = {}): SitemapDiscovery {
+  return {
+    discovered: [],
+    sources: { robotsTxt: [], commonLocations: [] },
+    totalUrls: 0,
+    orphanPages: [],
+    missingPages: [],
+    failed: [],
+    ...over,
+  };
+}
+
+const byName = (checks: CheckResult[], name: string) => checks.find((c) => c.name === name);
+
+describe("crawl/robots-txt does not report a missing file it never confirmed", () => {
+  test("a probe that never completed reports unknown, not a failure", () => {
+    // Anything the crawler records a reason for: a budget-skipped fetch, a
+    // timeout, a 5xx. None of them establish that robots.txt is absent.
+    for (const reason of ["crawl phase budget exhausted", "The operation timed out", "HTTP 503"]) {
+      const checks = robotsTxtRule.run(ctx({ robotsTxt: robots({ errors: [reason] }) })).checks;
+      const check = byName(checks, "robots-txt-exists");
+
+      expect(check?.status).toBe("info");
+      expect(check?.message).not.toContain("No robots.txt found");
+      // The reason travels with the finding so a reader can tell why.
+      expect(check?.value).toBe(reason);
+    }
+  });
+
+  test("a confirmed 404 still fails — this must not blanket-suppress the finding", () => {
+    // The crawler records NO error for a clean 404, which is the whole
+    // discriminator. Losing this case would trade a false positive for a false
+    // negative and make the rule useless.
+    const checks = robotsTxtRule.run(ctx({ robotsTxt: robots({ errors: [] }) })).checks;
+    const check = byName(checks, "robots-txt-exists");
+
+    expect(check?.status).toBe("fail");
+    expect(check?.message).toBe("No robots.txt found");
+  });
+});
+
+describe("crawl/sitemap-exists does not report a missing sitemap it never looked for", () => {
+  test("a truncated discovery reports unknown, not a failure", () => {
+    const checks = sitemapExistsRule.run(
+      ctx({ sitemaps: sitemaps({ truncated: true }), robotsTxt: robots() }),
+    ).checks;
+    const check = byName(checks, "sitemap-exists");
+
+    expect(check?.status).toBe("info");
+    expect(check?.message).not.toContain("No XML sitemap found");
+  });
+
+  test("a completed discovery that found nothing still fails", () => {
+    const checks = sitemapExistsRule.run(
+      ctx({ sitemaps: sitemaps({ truncated: false }), robotsTxt: robots() }),
+    ).checks;
+    const check = byName(checks, "sitemap-exists");
+
+    expect(check?.status).toBe("fail");
+    expect(check?.message).toBe("No XML sitemap found");
+  });
+
+  test("an absent `truncated` (older reports) reads as a completed walk", () => {
+    // The field is optional so pre-#1733 persisted reports still score the same.
+    const checks = sitemapExistsRule.run(ctx({ sitemaps: sitemaps(), robotsTxt: robots() })).checks;
+
+    expect(byName(checks, "sitemap-exists")?.status).toBe("fail");
+  });
+});
+
+describe("ax/rsl-license does not call an unreachable document broken", () => {
+  const unreachable: RslLicenseDoc = {
+    url: "https://example.com/license.xml",
+    status: 0,
+    contentType: null,
+    xmlValid: false,
+    looksRsl: false,
+    excerpt: "",
+    error: "crawl phase budget exhausted",
+  };
+
+  function rsl(documents: RslLicenseDoc[]): RslData {
+    return {
+      licenseUrls: documents.map((d) => d.url),
+      robotsHasLicense: true,
+      linkHeaderPresent: false,
+      documents,
+    };
+  }
+
+  test("status 0 reports unknown and does not leak the internal reason", () => {
+    const checks = rslLicenseRule.run(ctx({ rsl: rsl([unreachable]) } as never)).checks;
+    const check = byName(checks, "rsl-license-valid");
+
+    expect(check?.status).toBe("info");
+    expect(check?.value).toBe("unknown");
+    // "crawl phase budget exhausted" is an internal detail, not user-facing copy.
+    expect(JSON.stringify(check)).not.toContain("budget exhausted");
+  });
+
+  test("a document that genuinely resolved wrong is still reported broken", () => {
+    const notRsl: RslLicenseDoc = { ...unreachable, status: 200, error: null };
+    const checks = rslLicenseRule.run(ctx({ rsl: rsl([notRsl]) } as never)).checks;
+
+    expect(byName(checks, "rsl-license-valid")?.status).toBe("warn");
+  });
+});

--- a/packages/rules/tests/unconfirmed-probe-not-missing.test.ts
+++ b/packages/rules/tests/unconfirmed-probe-not-missing.test.ts
@@ -76,8 +76,8 @@ describe("crawl/robots-txt does not report a missing file it never confirmed", (
 
       expect(check?.status).toBe("info");
       expect(check?.message).not.toContain("No robots.txt found");
-      // The reason travels with the finding so a reader can tell why.
-      expect(check?.value).toBe(reason);
+      // The internal skip marker must never reach user-facing copy.
+      expect(JSON.stringify(check)).not.toContain("budget exhausted");
     }
   });
 

--- a/packages/synthetic-site/src/storage-writer.ts
+++ b/packages/synthetic-site/src/storage-writer.ts
@@ -342,6 +342,10 @@ async function writeCrawlBody(
       sizeBytes: Buffer.byteLength(robotsBody, "utf8"),
       sitemaps: [sitemapUrl],
       fetchedAt,
+      // The fixture's robots.txt was fetched successfully, so there is no
+      // reason to record. Explicit rather than omitted so the fixture keeps
+      // matching the shape a real crawl writes (squirrelscan/repo#1733).
+      error: null,
     }),
   );
   await run(


### PR DESCRIPTION
Fixes squirrelscan/repo#1733 (private tracker).

## The bug

PR #187 (for #1699) gave every root probe a deadline that survives its body read. It left the **sum** untouched: seven sequential stages carrying fixed 15-30s deadlines, so an origin answering `200` on every root path and then stalling the body burned **150.3s across 28 requests before page 1** - the entire 120s crawl phase a quick cloud audit gets, on a site that crawls fine once the preamble is past.

## Two bounds, because the two halves fail differently

The central design decision, and it changed during review: the preamble is not one homogeneous thing.

**Root probes (redirect resolution, robots, llms, markdown, well-known, agent-access, RSL) share one wall-clock budget.**

```
budget = min(45_000ms, timeoutMs x 3)
```

Each request takes `min(its own deadline, what the budget has left)`; once spent, the rest are skipped without a request and store the same unreachable shape a network failure gives them. Cutting these short costs AX **metadata**, and their rules degrade to unknown.

**The sitemap walk is NOT on that budget.** It runs on a progress window: it stops when it stops *completing* fetches, not when a clock expires. Cutting the walk short costs **pages**, and a site with 60 legitimate sitemaps (~48s of honest work) is slow without being stalled. A stalled origin completes nothing, so the window expires after ~one chunk; a healthy one keeps earning a fresh window and walks every sitemap.

That asymmetry is the fix for the review's MED 2 (silent page loss on a healthy origin) without reopening the hole the issue is about.

## An unconfirmed probe is unknown, never a confirmed absence

The first round of this PR degraded budget exhaustion into confident **negatives**. `exists: false` and `discovered: []` each conflate "the origin answered 404" with "we never got an answer", and the rules turned the second into definite, high-weight findings.

Both cases **predate this PR** - a robots.txt that timed out or 5xx'd has always reported "No robots.txt found" (weight 8). The budget made them far more reachable, so they are fixed here:

| probe | before | now |
|---|---|---|
| robots.txt | "No robots.txt found" (fail, w8) | "robots.txt could not be checked" (info) when a reason was recorded; a clean 404 records none and still fails |
| sitemap | "No XML sitemap found" (fail, w10) | "discovery did not complete" (info) when the walk was truncated |
| RSL | "broken" warn, leaking the internal reason | unknown **only** when the doc was never attempted |

The RSL fix is deliberately narrow. A URL we actually tried and could not fetch stays a broken reference - that is the defect the rule exists to surface, and an existing test pins it. Both are `status: 0`, so `PROBE_NOT_ATTEMPTED_ERROR` (now in core-contracts) is the discriminator.

Carrying the signal needed `RobotsTxtRecord.error` (schema 23, one additive ALTER, **local sqlite only, not a prod migration**) and `SitemapDiscovery.truncated` (persisted via crawl stats, no migration). Both optional, so older rows and other storage backends read as the confirmed case. The new column is on the reconciler's self-heal list and the drift guard, because the migration-renumbering gap has already bitten `pages` and `sitemaps` in turn.

## Tests

`packages/crawler/tests/preamble-budget.test.ts` and `packages/rules/tests/unconfirmed-probe-not-missing.test.ts`.

Every test was verified to **fail** with its fix reverted: the stalled-origin tests time out at 30s (they would take ~180s), the truncation test reports 63 not-reached records instead of 0, and each rules test flips back to the missing-finding. The healthy-origin tests use deliberately **slow** responses - instant ones pass under any budget however brutal, and falsify nothing.

Two guards were dropped rather than kept untested: the sitemap recursion's entry guard (the chunk-loop guard already covers it, and no test could tell them apart) and the redundant `crawler-tests` CI job - `cli-tests` runs bare `bun test` from the repo root, which already covered `packages/crawler`.

### Where the signal has to live

`truncated` first went only into `report-stream.ts`, which assembles the report **after** rules have scored. It was inert - `crawl/sitemap-exists` still saw `undefined` and still failed. Rules read the `SitemapDiscovery` built in `adapter.ts` (three literals), so it goes there. The first test missed this by asserting on the finished report and passed with the fix deleted; it now drives `runRulesOnStorage` and asserts on the check the rule produced.

### Bounding the walk

The progress window alone is gameable: an origin answering ONE request per chunk instantly and stalling the other four spends a full window per chunk and re-arms it every time, so the walk runs as long as the origin likes. There is now a hard stop (`SITEMAP_WALK_TOTAL_MS`, 60s) the re-arm cannot reach past. Truncating there is safe only because truncation is honest - we say we did not finish rather than claiming the site has no sitemap. A configured hard stop shorter than the window is honored rather than silently widened to it.

**What counts as progress** is a settled fetch, not a successful one. Keying the re-arm off `success` punished a real shape: one quick 404 alongside four stalled bodies is a *responsive* origin the walk is getting through, but the chunk finds no sitemap, so the window died after one round and 5 of 68 candidates were ever visited. Failure results now carry `settled` - the origin answered and the request finished, whether that was a 404, a 500, or an empty body - and only a chunk where nothing came back at all burns the window.

Worst case before page 1 is therefore 45s (root probes) + 60s (walk hard stop) = **105s**, against the 120s a quick cloud crawl gets. Those two maxima do not co-occur naturally: an origin that stalls the root probes completes nothing during the walk either, so its walk dies at the first 20s window. Reaching 105s takes an origin that stalls the probes *and* drips settled responses through the walk. The lever if you want a tighter guarantee is `SITEMAP_WALK_TOTAL_MS`, at the cost of truncating honest slow walks sooner - which is now an explicit, reported gap rather than silent page loss.

Truncation deep in the recursion was also being lost: it was computed only from unvisited **top-level** entry points, so an index whose children were abandoned reported `truncated: false`. The walk now records it wherever it gives up, including the depth cap and the URL budget.

## Deliberately not in scope

The same unknown-vs-absent conflation exists in the llms.txt / markdown / well-known probes and in `crawl/sitemap-coverage` + `integrity/orphan-page` (which infer from a possibly-partial sitemap corpus). All pre-existing, all mostly informational rather than scored, and each needs its own probe contract plus rule change. Filed as squirrelscan/repo#1760 rather than bundled here. The plumbing this PR adds - `PROBE_NOT_ATTEMPTED_ERROR`, `SITEMAP_NOT_CHECKED_ERROR`, `SitemapDiscovery.truncated` - is what that work builds on.

## Verification

whole-tree `bun test` 4903 pass / 4 skip / 0 fail; audit-engine goldens 63 pass with byte-identical numbers (98221 findings, healthScore 48); typecheck clean across 16 workspaces; lint, format:check and detect-secrets clean; all 13 CI checks green.
