### PR TITLE
docs: scheduled-audit digest, pause link, and a page for every automatic email

### DIFF
--- a/docs/cloud/scheduled-audits.mdx
+++ b/docs/cloud/scheduled-audits.mdx
@@ -38,6 +38,41 @@ A newly added website starts on a **weekly** schedule when your plan still has a
 - If an audit for the website is already running when the schedule fires, the scheduled run is skipped for that cycle.
 - Results, score deltas, new issues, and notifications appear in the dashboard automatically.
 
+## The digest email
+
+A completed scheduled run sends a digest, so a recurring audit is never silent. It arrives whatever the run found, including the runs where nothing moved: an email that only shows up on bad news would teach you that no email means nothing ran.
+
+There are three variants, and the subject line tells you which one you have:
+
+| Variant | Subject | Sent when | What is in it |
+| --- | --- | --- | --- |
+| Changes | "What changed on your-site.com" | The comparison against the previous audit found movement | New, fixed and worse counts, up to five leading new and worsened findings with the page each was found on, and the score change where both audits scored |
+| All clear | "Nothing changed on your-site.com" | The comparison ran and found nothing | The health score and the same three counts, all at zero |
+| First audit | "First audit of your-site.com" | There is no earlier audit to compare against | That run's own error and warning counts and pages crawled, with no claim about change |
+
+Every variant carries the health score, how often the audit runs, a link to the full report, and the pause link below.
+
+The digest replaces the audit completion email for that run, so a scheduled audit never sends you two emails about the same thing. Two cases fall back to the ordinary audit email: a run that fails sends the failure email, and a run whose comparison cannot be built sends the completion email rather than guessing at what changed.
+
+The digest follows the website's **Settings → Alerts** toggle. Turn email notifications off for the site and the schedule keeps running without mailing you.
+
+## Pausing from the email
+
+Each digest has a **pause these audits** link that needs no login. Following it opens a confirmation page, and the button on that page stops recurring audits for that one website. The link only ever pauses a schedule, it cannot read your reports or change anything else, and it stops working 90 days after the email was sent.
+
+The confirmation step is deliberate. Mail security scanners and link prefetchers open every link in an email, so following the link alone never pauses anything.
+
+To start the audits again, open the website in the dashboard and pick a cadence under **Settings → Schedule**. Nothing else about the website changes while it is paused.
+
+## When a schedule pauses itself
+
+Two conditions stop a schedule without you asking, so a recurring audit cannot keep spending credits on something that is not working:
+
+- **Three failed runs in a row.** Usually an unreachable site, a firewall or WAF blocking our crawler, or a URL that has moved. Failed audits are refunded, so the failures themselves cost nothing.
+- **Not enough credits.** A run the balance cannot cover is skipped without a charge, and the schedule pauses instead of skipping again every cycle.
+
+Either way an email says which it was, and it arrives whatever the website's **Settings → Alerts** toggle says, because a credit-spending service switching itself off is account news. It is capped at one per account per day, so several sites pausing at once still means one email; the rest appear in the dashboard bell. Turn the schedule back on from **Settings → Schedule** once the cause is fixed.
+
 ## Audit source
 
 Every audit records where it was triggered from. In the dashboard, audits and reports are tagged with a **source** badge:
@@ -54,3 +89,4 @@ This makes it easy to tell an automated weekly run apart from one you kicked off
 - [Cloud overview](/cloud) - what cloud features add
 - [Credits & Pricing](/cloud/credits) - how scheduled runs are billed
 - [Dashboard](/dashboard) - where scheduled results live
+- [Emails we send](/dashboard/emails) - every automatic email and how to stop it

--- a/docs/cloud/scheduled-audits.mdx
+++ b/docs/cloud/scheduled-audits.mdx
@@ -40,7 +40,9 @@ A newly added website starts on a **weekly** schedule when your plan still has a
 
 ## The digest email
 
-A completed scheduled run sends a digest, so a recurring audit is never silent. It arrives whatever the run found, including the runs where nothing moved: an email that only shows up on bad news would teach you that no email means nothing ran.
+A completed scheduled run sends a digest to the website's alert address, so a recurring audit does not run silently. It arrives whatever the run found, including the runs where nothing moved: an email that only shows up on bad news would teach you that no email means nothing ran.
+
+There are four cases where a completed run sends no digest. Email notifications are off for the website, the account has no usable address, that address is on the [suppression list](/dashboard/emails#unsubscribing-and-the-suppression-list), or the comparison against the previous audit could not be completed.
 
 There are three variants, and the subject line tells you which one you have:
 
@@ -52,7 +54,7 @@ There are three variants, and the subject line tells you which one you have:
 
 Every variant carries the health score, how often the audit runs, a link to the full report, and the pause link below.
 
-The digest replaces the audit completion email for that run, so a scheduled audit never sends you two emails about the same thing. Two cases fall back to the ordinary audit email: a run that fails sends the failure email, and a run whose comparison cannot be built sends the completion email rather than guessing at what changed.
+The digest replaces the audit completion email for that run, so a scheduled audit never sends you two emails about the same thing. Where a digest is withheld the ordinary audit email covers the run instead: a run that fails sends the failure email, and a run whose comparison could not be built sends the completion email rather than guessing at what changed.
 
 The digest follows the website's **Settings → Alerts** toggle. Turn email notifications off for the site and the schedule keeps running without mailing you.
 
@@ -71,7 +73,7 @@ Two conditions stop a schedule without you asking, so a recurring audit cannot k
 - **Three failed runs in a row.** Usually an unreachable site, a firewall or WAF blocking our crawler, or a URL that has moved. Failed audits are refunded, so the failures themselves cost nothing.
 - **Not enough credits.** A run the balance cannot cover is skipped without a charge, and the schedule pauses instead of skipping again every cycle.
 
-Either way an email says which it was, and it arrives whatever the website's **Settings → Alerts** toggle says, because a credit-spending service switching itself off is account news. It is capped at one per account per day, so several sites pausing at once still means one email; the rest appear in the dashboard bell. Turn the schedule back on from **Settings → Schedule** once the cause is fixed.
+Either way an email says which it was, and it arrives whatever the website's **Settings → Alerts** toggle says, because a credit-spending service switching itself off is account news. It is throttled to roughly one per account in any rolling 24 hours, so several sites pausing around the same time do not each send mail; the rest appear in the dashboard bell. Turn the schedule back on from **Settings → Schedule** once the cause is fixed.
 
 ## Audit source
 

--- a/docs/dashboard/audit-settings.mdx
+++ b/docs/dashboard/audit-settings.mdx
@@ -46,6 +46,12 @@ The **Max credits per audit** card sets a hard spend ceiling for a single cloud 
 
 The estimate is an upper bound: the audit is billed as it runs (50 credits base plus 2 per rendered page, see [Credits](/cloud/credits)), so most audits cost less than the cap. This setting is **per website**.
 
+## Email notifications
+
+A sibling page, **Website → Settings → Alerts**, holds the **Email notifications** toggle for this website. It controls the audit completion email, the audit failure email, and the [scheduled-audit digest](/cloud/scheduled-audits).
+
+A few emails are account level and arrive whatever this toggle says, including the low-credit warning and the notice that a website's recurring audits paused themselves. [Emails we send](/dashboard/emails) lists every automatic email, what triggers it, and where its off switch is.
+
 ## What runs where
 
 | Surface | Honors this website's audit settings? |

--- a/docs/dashboard/emails.mdx
+++ b/docs/dashboard/emails.mdx
@@ -1,0 +1,105 @@
+---
+title: "Emails we send"
+description: "Every automatic email a squirrelscan account can receive, what triggers it, and how to turn it off"
+icon: "mail"
+---
+
+squirrelscan sends a small number of automatic emails. This page lists every one of them, what makes it arrive, and where the off switch is.
+
+Most of them are per website and ride a single toggle. A few are account level and arrive whatever that toggle says, because they report something that affects your credits or a service switching itself off.
+
+<Note>
+  The per-website switch is **Website → Settings → Alerts → Audit completion notifications** in the dashboard.
+</Note>
+
+## Per-website emails
+
+These follow the website's **Email notifications** toggle. Turn it off and none of them arrive for that site.
+
+### Audit complete
+
+Arrives when an audit of the website finishes and its report reaches the cloud. That covers dashboard runs, scheduled runs, and CLI, API and GitHub audits that publish their report. It carries the health score, the error, warning and passing counts, and a link to the full report.
+
+A scheduled run normally sends the [digest](#scheduled-audit-digest) instead, so you get one email about a run, not two.
+
+**How to stop it:** turn off **Settings → Alerts** for that website.
+
+### Audit failed
+
+Arrives when an audit run for the website ends in failure, with the reason and whether the run was scheduled. Failed audits are refunded automatically, so a failure never costs credits.
+
+**How to stop it:** the same **Settings → Alerts** toggle.
+
+### Scheduled-audit digest
+
+Arrives after a [scheduled audit](/cloud/scheduled-audits) completes, including the runs where nothing changed. It has three variants, and the subject line tells you which one you have before you open it.
+
+| Variant | Sent when | What is in it |
+| --- | --- | --- |
+| What changed | The comparison found movement | New, fixed and worse counts, the leading new and worsened findings, and the score change |
+| Nothing changed | The comparison ran and found nothing | The health score and the same three counts, all at zero |
+| First audit | There is no earlier audit to compare against | That run's own error and warning counts and pages crawled, with no claim about change |
+
+Every variant carries the health score, a link to the full report, and a link that pauses the schedule without a login.
+
+Two cases send the ordinary audit email instead. A scheduled run that fails sends the failure email, and a run whose comparison cannot be built falls back to the completion email rather than guessing at what changed.
+
+**How to stop it:** the pause link in the email, the **Settings → Alerts** toggle, or setting the website's schedule to **Disabled**.
+
+## Account-level emails
+
+These are not gated on any per-website toggle.
+
+### Recurring audits paused
+
+Sent when a website's schedule stops on its own. There are two reasons, and the email says which:
+
+- Three scheduled runs in a row failed. The usual causes are an unreachable site, a firewall or WAF blocking our crawler, or a URL that has moved. Those failed runs were refunded, so the pause costs you nothing.
+- The account balance fell below the 50-credit audit base. The run was skipped without a charge, and the schedule paused rather than skipping again every cycle.
+
+It goes to your account address, because a recurring service that spends credits switching itself off is account news. The email is capped at one per organization per day: if several sites pause at once, the rest still pause and still appear in the dashboard bell, but they do not each send mail.
+
+**How to stop it:** it only arrives when a schedule pauses itself, so turning the website's schedule off means it never fires. The **Settings → Alerts** toggle does not suppress it.
+
+### Low credits
+
+Sent when a charge takes the organization's balance down across the low-balance threshold, with the remaining balance, roughly how many more audits it buys, and a link to billing. It fires on the crossing, not on the level, so it does not repeat while the balance stays low. The next one is earned only once credits are added again, whether by a top-up, a monthly grant, a refund or an adjustment.
+
+It goes to one billing contact: the owner where there is one, otherwise another member who can bill, and failing both the person who created the organization.
+
+**How to stop it:** there is no toggle. Handing off the billing role is the practical way out, unless you created the organization, in which case you stay the fallback recipient. The [suppression list](#unsubscribing-and-the-suppression-list) stops it outright.
+
+### Welcome
+
+One email from Nik about an hour after you sign up. Replies go to a real inbox and open a support thread, so answering it reaches a person.
+
+**How to stop it:** an address already on the [suppression list](#unsubscribing-and-the-suppression-list) when the send comes due is skipped. Replying reaches a person but does not unsubscribe you on its own.
+
+### Support ticket confirmation and replies
+
+Opening a ticket from [support](/dashboard/support) sends a confirmation with your ticket reference. Every reply from us arrives by email too, and you can answer by replying rather than returning to the dashboard.
+
+**How to stop it:** these are answers to something you asked, so they have no toggle. They stop when the conversation does.
+
+## How often emails can arrive
+
+Notification emails that also write a dashboard bell entry, which is audit complete, audit failed and the digest, are rate limited per account and per email type: at most one an hour, and at most five in any rolling 24 hours. Over the limit the email is dropped, but the notification still appears in the dashboard bell, in `list_notifications` over [MCP](/developers/mcp), and on any [webhooks](/cloud/webhooks) that carry it. Nothing is lost, it just does not land in your inbox.
+
+The low-credit warning and the pause notice are not on that counter. Each has its own limit instead: once per low-balance crossing, and once per organization per day.
+
+Several notification types never email at all and are in-app only, including issue comments, agent fix runs, and the scheduler's skip notices.
+
+## Unsubscribing and the suppression list
+
+Marketing and announcement emails carry an unsubscribe link. Clicking it adds your address to a global suppression list. A hard bounce or a spam complaint puts an address on the same list.
+
+Suppression stops marketing sends, the scheduled-audit digest, the low-credit warning and a queued welcome email, all of which check the list before sending. It does not currently stop the audit completion and failure emails or support replies, which go out on their own paths, so use the per-website **Settings → Alerts** toggle to turn audit mail off.
+
+If you have stopped receiving expected email and cannot see why, the suppression list is the first thing to check with [support](/dashboard/support).
+
+## Related
+
+- [Audit settings](/dashboard/audit-settings) - what runs for a website's cloud audits
+- [Scheduled audits](/cloud/scheduled-audits) - cadences, the digest, and the pause link
+- [Credits & pricing](/cloud/credits) - what triggers the low-balance warning
+- [Webhooks](/cloud/webhooks) - notification events delivered to your own endpoint

--- a/docs/dashboard/emails.mdx
+++ b/docs/dashboard/emails.mdx
@@ -18,7 +18,7 @@ These follow the website's **Email notifications** toggle. Turn it off and none 
 
 ### Audit complete
 
-Arrives when an audit of the website finishes and its report reaches the cloud. That covers dashboard runs, scheduled runs, and CLI, API and GitHub audits that publish their report. It carries the health score, the error, warning and passing counts, and a link to the full report.
+Arrives when an audit of the website finishes and its report reaches the cloud. That covers dashboard runs, scheduled runs, and CLI, API and GitHub audits that publish their report. It carries the health score and the error, warning and passing counts. The button opens the dashboard rather than that specific report, so you pick the run from the website's audit history.
 
 A scheduled run normally sends the [digest](#scheduled-audit-digest) instead, so you get one email about a run, not two.
 
@@ -57,13 +57,13 @@ Sent when a website's schedule stops on its own. There are two reasons, and the 
 - Three scheduled runs in a row failed. The usual causes are an unreachable site, a firewall or WAF blocking our crawler, or a URL that has moved. Those failed runs were refunded, so the pause costs you nothing.
 - The account balance fell below the 50-credit audit base. The run was skipped without a charge, and the schedule paused rather than skipping again every cycle.
 
-It goes to your account address, because a recurring service that spends credits switching itself off is account news. The email is capped at one per organization per day: if several sites pause at once, the rest still pause and still appear in the dashboard bell, but they do not each send mail.
+It goes to your account address, because a recurring service that spends credits switching itself off is account news. The email is throttled to roughly one per organization in any rolling 24 hours: if several sites pause around the same time, the rest still pause and still appear in the dashboard bell without each sending mail.
 
 **How to stop it:** it only arrives when a schedule pauses itself, so turning the website's schedule off means it never fires. The **Settings → Alerts** toggle does not suppress it.
 
 ### Low credits
 
-Sent when a charge takes the organization's balance down across the low-balance threshold, with the remaining balance, roughly how many more audits it buys, and a link to billing. It fires on the crossing, not on the level, so it does not repeat while the balance stays low. The next one is earned only once credits are added again, whether by a top-up, a monthly grant, a refund or an adjustment.
+Sent when a charge takes the organization's balance down across the low-balance threshold, with the remaining balance, roughly how many more audits it buys, and a link to billing. It fires on the crossing, not on the level, so it does not repeat while the balance stays low. The next one is earned only once credits are added again, whether by a top-up, a monthly grant, a refund or an adjustment. Refunds carry one extra guard: a balance that crosses the line again within an hour of a refund records the warning in the dashboard bell but sends no email, so a failed charge that is refunded and retried cannot mail you twice about the same money.
 
 It goes to one billing contact: the owner where there is one, otherwise another member who can bill, and failing both the person who created the organization.
 
@@ -85,7 +85,7 @@ Opening a ticket from [support](/dashboard/support) sends a confirmation with yo
 
 Notification emails that also write a dashboard bell entry, which is audit complete, audit failed and the digest, are rate limited per account and per email type: at most one an hour, and at most five in any rolling 24 hours. Over the limit the email is dropped, but the notification still appears in the dashboard bell, in `list_notifications` over [MCP](/developers/mcp), and on any [webhooks](/cloud/webhooks) that carry it. Nothing is lost, it just does not land in your inbox.
 
-The low-credit warning and the pause notice are not on that counter. Each has its own limit instead: once per low-balance crossing, and once per organization per day.
+The low-credit warning and the pause notice are not on that counter. Each has its own limit instead: once per low-balance crossing, and roughly once per organization in any rolling 24 hours.
 
 Several notification types never email at all and are in-app only, including issue comments, agent fix runs, and the scheduler's skip notices.
 
@@ -93,7 +93,7 @@ Several notification types never email at all and are in-app only, including iss
 
 Marketing and announcement emails carry an unsubscribe link. Clicking it adds your address to a global suppression list. A hard bounce or a spam complaint puts an address on the same list.
 
-Suppression stops marketing sends, the scheduled-audit digest, the low-credit warning and a queued welcome email, all of which check the list before sending. It does not currently stop the audit completion and failure emails or support replies, which go out on their own paths, so use the per-website **Settings → Alerts** toggle to turn audit mail off.
+Suppression stops marketing sends, the scheduled-audit digest, the low-credit warning and a queued welcome email, all of which check the list before sending. It does not currently stop the audit completion email, the audit failure email, the recurring-audits-paused notice or support replies, which go out on their own paths. Use the per-website **Settings → Alerts** toggle to turn audit mail off, and turn a website's schedule off to stop the pause notice.
 
 If you have stopped receiving expected email and cannot see why, the suppression list is the first thing to check with [support](/dashboard/support).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -653,6 +653,7 @@
             "pages": [
               "dashboard/index",
               "dashboard/audit-settings",
+              "dashboard/emails",
               "dashboard/support"
             ]
           }


### PR DESCRIPTION
Two docs gaps, one PR.

## Scheduled audits

`docs/cloud/scheduled-audits.mdx` said nothing about the digest email that now goes out after a scheduled run, so a customer who got the mail had no page to read. Adds:

- The digest: when it arrives, the three variants (changes / nothing changed / first audit), what each carries, and the two cases that fall back to the ordinary audit email.
- The pause link: no login needed, a confirmation step before anything stops, a 90 day life, and how to turn the audits back on from the site's schedule settings.
- The two conditions that pause a schedule on its own, three consecutive failed runs or a balance under the 50 credit audit base, and the one email that reports it.

## Emails we send

New page at `docs/dashboard/emails.mdx` listing every automatic email an account can receive, what triggers it, and its off switch: the per-website Email notifications toggle, the billing contact role, the pause link, or the unsubscribe and suppression list. Also covers the per-hour and per-day limits on notification email, and which senders actually honour the suppression list.

Linked from `docs/dashboard/audit-settings.mdx` and added to the Dashboard group in `docs.json`.

Every claim was checked against the merged templates and services. Emails that are not live yet are deliberately absent.

`make validate` passes in `docs/`.

Refs squirrelscan/repo#1720, squirrelscan/repo#1726