### PR TITLE
feat(audit-engine): classify the root fetch failure behind a zero-page audit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -273,7 +273,7 @@
         "filename": "packages/report/src/output/html.tsx",
         "hashed_secret": "a9fe535612f1aff3358c2e17f1e0e50fc60a66dc",
         "is_verified": false,
-        "line_number": 1117
+        "line_number": 1124
       }
     ],
     "packages/report/tests/screenshot-section.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T23:18:27Z"
+  "generated_at": "2026-09-03T22:14:20Z"
 }

--- a/apps/cli/src/controllers/report.ts
+++ b/apps/cli/src/controllers/report.ts
@@ -10,6 +10,7 @@ import type {
   PublishedReportRecord,
 } from "@/crawler/storage/types";
 import type {
+  AuditFailureReasonCode,
   AuditReport,
   AuditStatus,
   CheckResult,
@@ -103,6 +104,8 @@ interface SlimJsonReport {
   // Audit validity (#801): absent in slim JSON written before #801 ⇒ completed.
   status?: AuditStatus;
   statusReason?: string;
+  /** Machine-readable class behind `statusReason` (#1822); absent pre-#1822. */
+  statusReasonCode?: AuditFailureReasonCode;
   score: {
     overall: number | null; // null ⇒ N/A (failed/0-page audit, #586)
     grade: string;
@@ -223,6 +226,9 @@ function convertSlimReport(report: SlimJsonReport): AuditReport {
     failed: report.summary.failed,
     ...(report.status ? { status: report.status } : {}),
     ...(report.statusReason ? { statusReason: report.statusReason } : {}),
+    ...(report.statusReasonCode
+      ? { statusReasonCode: report.statusReasonCode }
+      : {}),
     siteChecks: [],
     pages: [],
     summary: {

--- a/apps/cli/src/reports/output/console.ts
+++ b/apps/cli/src/reports/output/console.ts
@@ -3,6 +3,8 @@
 import type { EditorSummaryView } from "@squirrelscan/report";
 
 import { stripControlCharsPreservingSgr } from "@squirrelscan/core-contracts/control-chars";
+import { AUDIT_FAILURE_NEXT_STEP } from "@squirrelscan/core-contracts/failure-reason";
+import { reportFailureReasonCode } from "@squirrelscan/report";
 import {
   carriedTag,
   coverageLine,
@@ -103,6 +105,11 @@ export function generateConsoleReport(
     log(
       `${fmt.dim(report.baseUrl)} • ${report.statusReason ?? "No auditable pages"}`
     );
+    // #1822: the reason above names the failure class; this says what to do
+    // about that class, so the terminal is not the one surface without it.
+    if (report.status === "failed") {
+      log(fmt.dim(AUDIT_FAILURE_NEXT_STEP[reportFailureReasonCode(report)]));
+    }
     // A seed that redirects off-site and is refused is a common way to end up
     // here with nothing to audit, so this branch needs the disclosure too.
     const redirect = seedRedirectLine(report);

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -553,7 +553,11 @@ export function reconstructReport(
           crawl.baseUrl,
           crawl.stats?.pagesRateLimited ?? 0
         ),
-      }
+      },
+      // #1822: the CLI forks the engine's report path, so the crawler's root
+      // failure has to be threaded here too or `squirrel audit` keeps printing
+      // the generic reason the cloud no longer prints.
+      crawl.stats?.rootFailure
     );
 
     // Smart re-audits reflect carried prior state, so keep "completed" when
@@ -569,7 +573,11 @@ export function reconstructReport(
       smartMerge &&
       smartMerge.coverage.knownPages > smartMerge.coverage.auditedPages &&
       rateLimitedCount === 0
-        ? { status: "completed" as const, reason: undefined }
+        ? {
+            status: "completed" as const,
+            reason: undefined,
+            reasonCode: undefined,
+          }
         : runStatus;
 
     // No real audit ⇒ null score (N/A), not 0. Parity with the cloud/live
@@ -606,7 +614,11 @@ export function reconstructReport(
       sitemapUrlStatuses: sitemapUrlStatusEntries,
       // Only stamp when not a normal completed run; absent ⇒ completed (#489).
       ...(auditStatus.status !== "completed"
-        ? { status: auditStatus.status, statusReason: auditStatus.reason }
+        ? {
+            status: auditStatus.status,
+            statusReason: auditStatus.reason,
+            statusReasonCode: auditStatus.reasonCode,
+          }
         : {}),
       // #1829: coverage lost to throttling, in a form renderers can count
       // rather than parse out of the reason prose.

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -181,6 +181,7 @@ export interface ResponseHeaders {
 
 // Re-export from core-contracts (canonical source)
 import type {
+  AuditFailureReasonCode as _AFRC,
   AuditStatus as _AS,
   CacheStats as _CST,
   CategoryScore as _CS,
@@ -193,6 +194,7 @@ import type {
   SiteMetadata as _SM,
 } from "@squirrelscan/core-contracts";
 export type AuditStatus = _AS;
+export type AuditFailureReasonCode = _AFRC;
 export type CategoryScore = _CS;
 export type GroupScore = _GS;
 export type HealthScore = _HS;
@@ -412,6 +414,8 @@ export interface AuditReport {
     /** Host(s) that throttled the crawl. */
     hosts: string[];
   };
+  /** Machine-readable class behind `statusReason` (#1822). */
+  statusReasonCode?: AuditFailureReasonCode;
   siteChecks: CheckResult[];
   pages: PageAudit[];
   summary: {

--- a/docs/dashboard/emails.mdx
+++ b/docs/dashboard/emails.mdx
@@ -28,6 +28,8 @@ A scheduled run normally sends the [digest](#scheduled-audit-digest) instead, so
 
 Arrives when an audit run for the website ends in failure, with the reason and whether the run was scheduled. Failed audits are refunded automatically, so a failure never costs credits.
 
+The reason names the cause the crawl hit, and the email carries the next step for that cause. See [failed audits](/guides/failed-audits) for every reason and what to do about it.
+
 **How to stop it:** the same **Settings → Alerts** toggle.
 
 ### Scheduled-audit digest

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -67,6 +67,7 @@
               "projects",
               "crawl",
               "reports",
+              "guides/failed-audits",
               "guides/badges",
               "guides/browser-rendering",
               "guides/rate-limited-hosts",

--- a/docs/guides/failed-audits.mdx
+++ b/docs/guides/failed-audits.mdx
@@ -22,7 +22,7 @@ If your site actively refused the crawler with a 403 or 429, the audit is marked
 | `tls` | The TLS handshake failed: an expired certificate, a hostname mismatch, a self-signed certificate, or an incomplete chain. | Renew or repair the certificate so it is valid for this hostname and served with the full chain. |
 | `connection` | Nothing answered. The connection was refused, reset, or closed before any response arrived. | Check that the origin server is running and accepting connections from the public internet, and that no firewall is dropping the requests. |
 | `timeout` | The origin accepted the connection but sent no response in time. | Check server load, slow database queries, or a firewall holding connections open. |
-| `http_4xx` | The server refused every request with a 4xx status. | Allowlist the squirrelscan crawler, or check that the URL is publicly reachable without a login. A 403 or 429 is reported as blocked instead. |
+| `http_4xx` | The server answered every request with a 4xx status. | A 401, 403 or 429 is a refusal: allowlist the squirrelscan crawler, or check that the URL is reachable without a login. A 404 or 410 means the page is not there: check the address. A root 403 or 429 is reported as blocked instead. |
 | `http_5xx` | The server returned an error of its own for every request. | Check your error logs, then re-run the audit once the site is serving normally. |
 | `redirect` | The audited URL redirected somewhere the crawl could not follow, usually off its own site. | Audit the URL the site actually serves, or fix the redirect so it stays on the same site. |
 | `robots` | `robots.txt` disallows the crawler on this URL. | Allow the squirrelscan crawler in `robots.txt`, or point the audit at a path it permits. |

--- a/docs/guides/failed-audits.mdx
+++ b/docs/guides/failed-audits.mdx
@@ -1,0 +1,67 @@
+---
+title: "Failed audits"
+icon: "triangle-alert"
+description: "Why an audit fetched nothing, and what to do about each cause"
+---
+
+An audit fails when the crawl finishes without a single auditable page. There is no score and no issue list, because nothing was read.
+
+Every failed audit names the cause. The reason appears in the report, in the failure email, in `squirrel audit` output, and on the `get_audit_status` MCP tool as a short sentence plus a machine-readable code.
+
+<Note>Failed audits are refunded automatically. A run that fetched nothing does not cost you credits.</Note>
+
+## Blocked is not failed
+
+If your site actively refused the crawler with a 403 or 429, the audit is marked **blocked**, not failed. That is a separate state with its own guidance: allowlist the squirrelscan crawler in your WAF or bot protection, turn off bot fight mode for the audit, or run the CLI from a trusted network.
+
+## The failure reasons
+
+| Code | What it means | What to do |
+|---|---|---|
+| `dns` | The hostname did not resolve. | Check the domain's DNS records and that the name resolves from the public internet. If you moved hosts recently, wait for the change to propagate. |
+| `tls` | The TLS handshake failed: an expired certificate, a hostname mismatch, a self-signed certificate, or an incomplete chain. | Renew or repair the certificate so it is valid for this hostname and served with the full chain. |
+| `connection` | Nothing answered. The connection was refused, reset, or closed before any response arrived. | Check that the origin server is running and accepting connections from the public internet, and that no firewall is dropping the requests. |
+| `timeout` | The origin accepted the connection but sent no response in time. | Check server load, slow database queries, or a firewall holding connections open. |
+| `http_4xx` | The server refused every request with a 4xx status. | Allowlist the squirrelscan crawler, or check that the URL is publicly reachable without a login. A 403 or 429 is reported as blocked instead. |
+| `http_5xx` | The server returned an error of its own for every request. | Check your error logs, then re-run the audit once the site is serving normally. |
+| `redirect` | The audited URL redirected somewhere the crawl could not follow, usually off its own site. | Audit the URL the site actually serves, or fix the redirect so it stays on the same site. |
+| `robots` | `robots.txt` disallows the crawler on this URL. | Allow the squirrelscan crawler in `robots.txt`, or point the audit at a path it permits. |
+| `unknown` | The cause could not be attributed. The reason still carries whatever the fetch reported. | Check that the site is reachable and try again. If it keeps failing, send us the report link. |
+
+## Reading the reason
+
+In the CLI, a failed audit prints the reason and the next step:
+
+```text
+AUDIT FAILED
+https://example.com - DNS lookup failed for example.com (NXDOMAIN)
+Check the domain's DNS records and that the hostname resolves from the public internet.
+```
+
+The JSON report carries both the sentence and the code, so a CI job can branch on the cause:
+
+```json
+{
+  "status": "failed",
+  "statusReason": "DNS lookup failed for example.com (NXDOMAIN)",
+  "statusReasonCode": "dns"
+}
+```
+
+The `llm` output states the same thing for an agent:
+
+```xml
+<status state="failed" reason="DNS lookup failed for example.com (NXDOMAIN)">
+  The hostname did not resolve. Check the domain's DNS records, and whether the domain has expired or was recently moved.
+</status>
+```
+
+## Checking it yourself
+
+A failed cloud audit is worth reproducing locally before you change anything: the CLI runs from your network, so a result that differs points at how your origin treats our egress rather than at the site being down.
+
+```bash
+squirrel audit https://example.com --max-pages 1
+```
+
+If the local run succeeds and the cloud run fails with `connection` or `http_4xx`, your origin or its CDN is treating our requests differently from yours.

--- a/docs/guides/failed-audits.mdx
+++ b/docs/guides/failed-audits.mdx
@@ -34,7 +34,7 @@ In the CLI, a failed audit prints the reason and the next step:
 
 ```text
 AUDIT FAILED
-https://example.com - DNS lookup failed for example.com (NXDOMAIN)
+https://example.com - DNS lookup failed for example.com: NXDOMAIN
 Check the domain's DNS records and that the hostname resolves from the public internet.
 ```
 
@@ -43,7 +43,7 @@ The JSON report carries both the sentence and the code, so a CI job can branch o
 ```json
 {
   "status": "failed",
-  "statusReason": "DNS lookup failed for example.com (NXDOMAIN)",
+  "statusReason": "DNS lookup failed for example.com: NXDOMAIN",
   "statusReasonCode": "dns"
 }
 ```
@@ -51,7 +51,7 @@ The JSON report carries both the sentence and the code, so a CI job can branch o
 The `llm` output states the same thing for an agent:
 
 ```xml
-<status state="failed" reason="DNS lookup failed for example.com (NXDOMAIN)">
+<status state="failed" reason="DNS lookup failed for example.com: NXDOMAIN">
   The hostname did not resolve. Check the domain's DNS records, and whether the domain has expired or was recently moved.
 </status>
 ```

--- a/docs/reports.mdx
+++ b/docs/reports.mdx
@@ -708,6 +708,10 @@ Visit the [dashboard](https://app.squirrelscan.com) to manage published reports:
 
 See [Dashboard](/dashboard) for full documentation.
 
+## Failed audits
+
+An audit that fetched no pages has no score and no issue list. The report names why: DNS, TLS, a refused or reset connection, a timeout, a 4xx or 5xx status, a redirect it could not follow, or `robots.txt`. See [failed audits](/guides/failed-audits) for the full list and the fix for each.
+
 ## Related
 
 - [audit](/cli/audit) - Run new audit

--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -588,13 +588,22 @@ export function buildV1Report(
     if (rateLimitedCount > 0) {
       result.rateLimited = { pages: rateLimitedCount, hosts: rateLimitedHosts };
     }
-    const runStatus = deriveAuditStatusFromPages(pages, crawl?.stats?.pagesBlocked ?? 0, {
-      errors: crawl?.stats?.pagesRateLimited ?? 0,
-      hosts: rateLimitedHosts,
-    });
+    const runStatus = deriveAuditStatusFromPages(
+      pages,
+      crawl?.stats?.pagesBlocked ?? 0,
+      {
+        errors: crawl?.stats?.pagesRateLimited ?? 0,
+        hosts: rateLimitedHosts,
+      },
+      // #1822: the crawler's record of WHY the entry URL failed, so a zero-page
+      // cloud audit names DNS/TLS/connection/timeout/4xx/5xx/redirect/robots
+      // instead of "No pages were crawled".
+      crawl?.stats?.rootFailure,
+    );
     if (runStatus.status !== "completed") {
       result.status = runStatus.status;
       result.statusReason = runStatus.reason;
+      result.statusReasonCode = runStatus.reasonCode;
       // No real audit ⇒ no score (N/A), not 0/A. Renderers show the failed/
       // blocked banner and the API persists health_score = NULL (#586).
       // `partial` is deliberately excluded (#1829): a crawl that audited most
@@ -865,10 +874,14 @@ export function buildV2Report(
       rateLimitedErrors: crawl?.stats?.pagesRateLimited ?? 0,
       rateLimitedPages,
       rateLimitedHosts,
+      // #1822: same signal as v1 above. The streamed path has no pages[] to
+      // fall back on, so the crawl stats are its only source for the class.
+      rootFailure: crawl?.stats?.rootFailure,
     });
     if (runStatus.status !== "completed") {
       result.status = runStatus.status;
       result.statusReason = runStatus.reason;
+      result.statusReasonCode = runStatus.reasonCode;
       if (isScorelessStatus(runStatus.status) && result.healthScore) {
         result.healthScore.overall = null;
       }

--- a/packages/audit-engine/src/scoring.ts
+++ b/packages/audit-engine/src/scoring.ts
@@ -6,6 +6,8 @@
 // tsconfig (e.g. the API Worker). types.ts is the leaf type module. (#195)
 import type { RuleRunResult } from "@squirrelscan/rules/types";
 import type {
+  AuditFailureDetail,
+  AuditFailureReasonCode,
   AuditStatus,
   CheckResult,
   HealthScore,
@@ -13,6 +15,10 @@ import type {
   GroupScore,
   RuleGroup,
 } from "@squirrelscan/core-contracts";
+import {
+  auditFailureDetail,
+  auditFailureReasonText,
+} from "@squirrelscan/core-contracts/failure-reason";
 import { getScoreGrade, getScoreColor } from "@squirrelscan/core-contracts/scoring";
 import { isRateLimitStatus } from "@squirrelscan/utils/rate-limit";
 
@@ -609,6 +615,15 @@ export interface AuditStatusSignals {
   rateLimitedPages?: number;
   /** Host(s) that throttled the crawl, for the reason text. */
   rateLimitedHosts?: readonly string[];
+  /**
+   * Why the entry URL could not be audited, recorded by the crawler on
+   * `CrawlStats.rootFailure` (#1822). Read ONLY in the no-content branches that
+   * are neither blocked nor rate limited, so it can never change the status of
+   * a run that produced content, and never displaces the #792 or #1829 reason.
+   * Absent ⇒ the pre-#1822 generic reasons, which is what every stats blob
+   * written before it has.
+   */
+  rootFailure?: AuditFailureDetail;
 }
 
 /**
@@ -620,6 +635,7 @@ export interface AuditStatusSignals {
 export function deriveAuditStatus(s: AuditStatusSignals): {
   status: AuditStatus;
   reason?: string;
+  reasonCode?: AuditFailureReasonCode;
 } {
   const BLOCKED_REASON =
     "Site blocked the crawler (bot protection / auth / rate limit)";
@@ -630,30 +646,58 @@ export function deriveAuditStatus(s: AuditStatusSignals): {
   const rateLimited = (s.rateLimitedErrors ?? 0) + (s.rateLimitedPages ?? 0);
   const hostText = formatRateLimitedHosts(s.rateLimitedHosts);
 
-  if (s.pagesCrawled === 0) {
-    // #1829: rate limiting gets its OWN blocked reason. It reads as "blocked"
-    // because nothing was auditable, but the remedy is to slow the crawl down,
-    // not to allowlist the crawler through a WAF.
-    if (rateLimited > 0 && blocked === 0) {
-      return {
-        status: "blocked",
-        reason: `Rate limited by ${hostText}; no pages could be fetched`,
-      };
+  // #1829: rate limiting gets its OWN blocked reason. It reads as "blocked"
+  // because nothing was auditable, but the remedy is to slow the crawl down,
+  // not to allowlist the crawler through a WAF. #1822 adds only the code: a 429
+  // is a 4xx refusal like the others, even though its fix differs.
+  const rateLimitedResult = (): {
+    status: AuditStatus;
+    reason: string;
+    reasonCode: "http_4xx";
+  } => ({
+    status: "blocked",
+    reason: `Rate limited by ${hostText}; no pages could be fetched`,
+    reasonCode: "http_4xx",
+  });
+
+  // #1822: a block keeps its #792 status AND its #792 sentence — the copy is
+  // load-bearing for the Sentry classifier and for the renderers' blocked
+  // branch. Only the machine-readable code is added, plus the crawler's own
+  // detail (which carries the status and the WAF provider when it detected one)
+  // appended to the end of the same sentence.
+  const blockedResult = (): { status: AuditStatus; reason: string; reasonCode: "http_4xx" } => {
+    const detail = s.rootFailure?.code === "http_4xx" ? s.rootFailure.detail : undefined;
+    return {
+      status: "blocked",
+      reason: detail ? `${BLOCKED_REASON}: ${detail}` : BLOCKED_REASON,
+      reasonCode: "http_4xx",
+    };
+  };
+
+  // The generic fallbacks are kept verbatim for a crawl that recorded nothing
+  // (an older stats blob, or a failure shape the crawler cannot attribute), and
+  // classified `unknown` — which the renderers still print as a failure.
+  const failedResult = (fallback: string) => {
+    const failure = s.rootFailure;
+    if (!failure) {
+      return { status: "failed" as const, reason: fallback, reasonCode: "unknown" as const };
     }
-    return blocked > 0
-      ? { status: "blocked", reason: BLOCKED_REASON }
-      : { status: "failed", reason: "No pages were crawled" };
+    return {
+      status: "failed" as const,
+      reason: auditFailureReasonText(failure),
+      reasonCode: failure.code,
+    };
+  };
+
+  if (s.pagesCrawled === 0) {
+    if (rateLimited > 0 && blocked === 0) return rateLimitedResult();
+    return blocked > 0 ? blockedResult() : failedResult("No pages were crawled");
   }
   if (s.contentPages === 0) {
-    if (rateLimited > 0 && blocked === 0) {
-      return {
-        status: "blocked",
-        reason: `Rate limited by ${hostText}; no pages could be fetched`,
-      };
-    }
+    if (rateLimited > 0 && blocked === 0) return rateLimitedResult();
     return blocked > 0
-      ? { status: "blocked", reason: BLOCKED_REASON }
-      : { status: "failed", reason: "Site unreachable, no pages could be fetched" };
+      ? blockedResult()
+      : failedResult("Site unreachable, no pages could be fetched");
   }
   // Content WAS gathered, but rate limiting shrank the audited set. The numbers
   // present are trustworthy; the coverage is not, and a multi-site operator has
@@ -691,10 +735,12 @@ export function deriveAuditStatusFromPages(
   rateLimit: {
     errors?: number;
     hosts?: readonly string[];
-  } = {}
+  } = {},
+  rootFailure?: AuditFailureDetail
 ): {
   status: AuditStatus;
   reason?: string;
+  reasonCode?: AuditFailureReasonCode;
 } {
   // #1829: a stored 429/430 page is rate limiting, not a bot wall. Counted into
   // its own bucket so the reason text sends the reader to the right fix.
@@ -707,6 +753,37 @@ export function deriveAuditStatusFromPages(
     rateLimitedErrors: rateLimit.errors ?? 0,
     rateLimitedPages,
     rateLimitedHosts: rateLimit.hosts,
+    // #1822: the crawl stats are the source of truth. When they carry nothing —
+    // a report reconstructed from pages alone, or a pre-#1822 crawl — fall back
+    // to the stored statuses, which still name the class for an all-4xx site.
+    rootFailure: rootFailure ?? rootFailureFromPages(pages),
+  });
+}
+
+/**
+ * Last-resort root failure built from stored page statuses (#1822), for reports
+ * whose crawl stats predate `rootFailure`. Only meaningful when NO page
+ * returned content, which is the only situation `deriveAuditStatus` consults
+ * it in; the dominant non-2xx status names the class.
+ */
+function rootFailureFromPages(
+  pages: readonly { status: number }[]
+): AuditFailureDetail | undefined {
+  const errors = pages.filter((p) => p.status >= 400);
+  if (errors.length === 0 || errors.length !== pages.length) return undefined;
+  const counts = new Map<number, number>();
+  for (const page of errors) counts.set(page.status, (counts.get(page.status) ?? 0) + 1);
+  let dominant = errors[0]!.status;
+  let best = 0;
+  for (const [status, count] of counts) {
+    if (count > best) {
+      best = count;
+      dominant = status;
+    }
+  }
+  return auditFailureDetail({
+    code: dominant >= 500 ? "http_5xx" : "http_4xx",
+    status: dominant,
   });
 }
 

--- a/packages/audit-engine/tests/failure-classification.test.ts
+++ b/packages/audit-engine/tests/failure-classification.test.ts
@@ -168,17 +168,34 @@ describe("existing classifications are unchanged (#792, #1829)", () => {
     expect(result.reasonCode).toBe("http_4xx");
   });
 
-  test("a rate-limited root still classifies as blocked", () => {
+  test("a rate-limited root keeps its #1829 status AND its #1829 sentence", () => {
+    // #1829 gives throttling its own signal and its own reason: the remedy is
+    // to slow down, not to allowlist a crawler. #1822 adds only the code.
     const result = deriveAuditStatus({
       pagesCrawled: 0,
       contentPages: 0,
       blockedPages: 0,
-      blockedErrors: 1,
-      rootFailure: crawlErrorToFailureDetail(CrawlError.rateLimit("https://example.com/", 30)),
+      blockedErrors: 0,
+      rateLimitedErrors: 1,
+      rateLimitedHosts: ["example.com"],
+      rootFailure: crawlErrorToFailureDetail(CrawlError.rateLimit("https://example.com/", 30_000)),
     });
     expect(result.status).toBe("blocked");
-    expect(result.reason).toContain("blocked the crawler");
+    expect(result.reason).toContain("Rate limited by example.com");
+    // NOT the bot-wall sentence: those point at opposite fixes.
+    expect(result.reason).not.toContain("blocked the crawler");
     expect(result.reasonCode).toBe("http_4xx");
+  });
+
+  test("a throttle dressed as a 503 is still reported as a 429-shaped refusal", () => {
+    // #1829 accepts a 503 carrying Retry-After as rate limiting. The class must
+    // not follow that status into http_5xx, which would send the owner to their
+    // application logs for a throttle.
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.rateLimit("https://example.com/", 30_000, 503),
+    );
+    expect(detail.code).toBe("http_4xx");
+    expect(detail.status).toBe(429);
   });
 
   test("stored 401/403 pages with no content still classify as blocked", () => {

--- a/packages/audit-engine/tests/failure-classification.test.ts
+++ b/packages/audit-engine/tests/failure-classification.test.ts
@@ -220,6 +220,34 @@ describe("existing classifications are unchanged (#792, #1829)", () => {
     ).toBe("unknown");
   });
 
+  test("a failure on OUR side is not attributed to the audited site", () => {
+    // The cloud container words a failed call to squirrelscan's own API as
+    // "Callback '<label>' failed after N attempts (HTTP 500: ...)". Reading
+    // that "HTTP 500" as the site's status would tell its owner to go and read
+    // their error logs for an outage on ours.
+    const result = deriveAuditStatus({
+      pagesCrawled: 0,
+      contentPages: 0,
+      blockedPages: 0,
+      rootFailure: {
+        code: "unknown",
+        detail: "Callback 'mark-completed' failed after 3 attempts (HTTP 500: internal error)",
+      },
+    });
+    expect(result.reasonCode).toBe("unknown");
+  });
+
+  test("a bare 'HTTP NNN' anywhere in a message is not read as the site's status", () => {
+    expect(
+      deriveAuditStatus({
+        pagesCrawled: 0,
+        contentPages: 0,
+        blockedPages: 0,
+        rootFailure: { code: "unknown", detail: "upload failed, HTTP 503 from storage" },
+      }).reasonCode,
+    ).toBe("unknown");
+  });
+
   test("a healthy crawl is untouched: no status, no reason, no code", () => {
     const result = deriveAuditStatus({
       pagesCrawled: 10,

--- a/packages/audit-engine/tests/failure-classification.test.ts
+++ b/packages/audit-engine/tests/failure-classification.test.ts
@@ -1,0 +1,214 @@
+// #1822 - a zero-page audit must name the root fetch failure.
+//
+// One test per failure class, each driven from a fake fetch result (a
+// `CrawlError` shaped exactly as the fetcher builds it, or a stored page
+// status) through the real classification and into `deriveAuditStatus`. The
+// assertions are on what the user actually sees: the `statusReason` sentence
+// that reaches `agent_runs.error`, the failure email and the report, plus the
+// machine-readable `statusReasonCode` the email and MCP branch on.
+
+import { describe, expect, test } from "bun:test";
+
+import type { AuditFailureReasonCode } from "@squirrelscan/core-contracts";
+import { CrawlError, crawlErrorToFailureDetail } from "@squirrelscan/crawler/fetcher";
+
+import { deriveAuditStatus, deriveAuditStatusFromPages } from "../src/scoring";
+
+const URL_ROOT = "https://ejconsultor.es/";
+
+/** A zero-page crawl whose only signal is the recorded root failure. */
+function zeroPageRun(error: CrawlError) {
+  return deriveAuditStatus({
+    pagesCrawled: 0,
+    contentPages: 0,
+    blockedPages: 0,
+    blockedErrors: 0,
+    rootFailure: crawlErrorToFailureDetail(error),
+  });
+}
+
+describe("deriveAuditStatus names the root failure class (#1822)", () => {
+  test("dns: the reason names DNS and the host", () => {
+    const result = zeroPageRun(
+      CrawlError.network(URL_ROOT, "getaddrinfo ENOTFOUND ejconsultor.es"),
+    );
+    expect(result.status).toBe("failed");
+    expect(result.reasonCode).toBe("dns");
+    expect(result.reason).toContain("DNS");
+    expect(result.reason).toContain("ejconsultor.es");
+  });
+
+  test("tls: the reason names the handshake and carries the certificate detail", () => {
+    const result = zeroPageRun(CrawlError.tls(URL_ROOT, "certificate has expired"));
+    expect(result.status).toBe("failed");
+    expect(result.reasonCode).toBe("tls");
+    expect(result.reason).toContain("TLS handshake");
+    expect(result.reason).toContain("certificate has expired");
+  });
+
+  test("connection: a socket closed before any response says exactly that", () => {
+    // The production case in #1822: the handshake completes, then the origin
+    // closes the connection with no HTTP response.
+    const result = zeroPageRun(
+      CrawlError.network(URL_ROOT, "The socket connection was closed unexpectedly"),
+    );
+    expect(result.status).toBe("failed");
+    expect(result.reasonCode).toBe("connection");
+    expect(result.reason).toContain("before any response");
+    expect(result.reason).toContain("ejconsultor.es");
+  });
+
+  test("timeout: a request that never answered is a timeout, not an outage", () => {
+    const result = zeroPageRun(CrawlError.timeout(URL_ROOT));
+    expect(result.reasonCode).toBe("timeout");
+    expect(result.reason).toContain("No response from ejconsultor.es");
+  });
+
+  test("http_5xx: the reason names the status the origin returned", () => {
+    const result = zeroPageRun(CrawlError.network(URL_ROOT, "Server error: 503", 503));
+    expect(result.status).toBe("failed");
+    expect(result.reasonCode).toBe("http_5xx");
+    expect(result.reason).toContain("503 Service Unavailable");
+  });
+
+  test("http_4xx: a 404 entry URL names the status rather than 'unreachable'", () => {
+    // A 404 is a stored page, so this arrives through the pages path.
+    const result = deriveAuditStatusFromPages([{ status: 404 }]);
+    expect(result.status).toBe("failed");
+    expect(result.reasonCode).toBe("http_4xx");
+    expect(result.reason).toContain("404 Not Found");
+  });
+
+  test("redirect: a refused off-site redirect names the redirect, not a fetch failure", () => {
+    const result = deriveAuditStatus({
+      pagesCrawled: 0,
+      contentPages: 0,
+      blockedPages: 0,
+      rootFailure: {
+        code: "redirect",
+        host: "ejconsultor.es",
+        detail: "redirected off-site to example.com",
+        source: "entry",
+      },
+    });
+    expect(result.status).toBe("failed");
+    expect(result.reasonCode).toBe("redirect");
+    expect(result.reason).toContain("Redirect");
+    expect(result.reason).toContain("example.com");
+  });
+
+  test("robots: a disallowed seed says robots.txt, not 'no pages were crawled'", () => {
+    const result = deriveAuditStatus({
+      pagesCrawled: 0,
+      contentPages: 0,
+      blockedPages: 0,
+      rootFailure: { code: "robots", host: "ejconsultor.es", source: "entry" },
+    });
+    expect(result.status).toBe("failed");
+    expect(result.reasonCode).toBe("robots");
+    expect(result.reason).toContain("robots.txt disallows");
+  });
+
+  test("unknown: an unattributed failure still reads as a failure, with its detail", () => {
+    const result = zeroPageRun(CrawlError.network(URL_ROOT, "something we have never seen"));
+    expect(result.status).toBe("failed");
+    // Never absent, never silently `completed`.
+    expect(result.reasonCode).toBe("unknown");
+    expect(result.reason).toContain("something we have never seen");
+  });
+
+  test("a crawl that recorded nothing keeps the pre-#1822 reason and classifies unknown", () => {
+    const result = deriveAuditStatus({ pagesCrawled: 0, contentPages: 0, blockedPages: 0 });
+    expect(result.status).toBe("failed");
+    expect(result.reason).toBe("No pages were crawled");
+    expect(result.reasonCode).toBe("unknown");
+  });
+
+  test("every class produces a non-empty reason", () => {
+    const codes: AuditFailureReasonCode[] = [
+      "dns",
+      "tls",
+      "connection",
+      "timeout",
+      "http_4xx",
+      "http_5xx",
+      "redirect",
+      "robots",
+      "unknown",
+    ];
+    for (const code of codes) {
+      const result = deriveAuditStatus({
+        pagesCrawled: 0,
+        contentPages: 0,
+        blockedPages: 0,
+        rootFailure: { code, host: "example.com" },
+      });
+      expect(result.reasonCode).toBe(code);
+      expect(result.reason?.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("existing classifications are unchanged (#792, #1829)", () => {
+  test("a WAF-blocked root still classifies as blocked, with the #792 sentence", () => {
+    const result = deriveAuditStatus({
+      pagesCrawled: 0,
+      contentPages: 0,
+      blockedPages: 0,
+      blockedErrors: 1,
+      rootFailure: crawlErrorToFailureDetail(
+        CrawlError.blocked("https://example.com/", "Blocked by Cloudflare challenge (503)", 503),
+      ),
+    });
+    expect(result.status).toBe("blocked");
+    // The #792 copy is load-bearing for the Sentry classifier and the renderers.
+    expect(result.reason).toContain("blocked the crawler");
+    // The provider the crawler detected is appended, not substituted.
+    expect(result.reason).toContain("Cloudflare");
+    expect(result.reasonCode).toBe("http_4xx");
+  });
+
+  test("a rate-limited root still classifies as blocked", () => {
+    const result = deriveAuditStatus({
+      pagesCrawled: 0,
+      contentPages: 0,
+      blockedPages: 0,
+      blockedErrors: 1,
+      rootFailure: crawlErrorToFailureDetail(CrawlError.rateLimit("https://example.com/", 30)),
+    });
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toContain("blocked the crawler");
+    expect(result.reasonCode).toBe("http_4xx");
+  });
+
+  test("stored 401/403 pages with no content still classify as blocked", () => {
+    const result = deriveAuditStatusFromPages([{ status: 403 }, { status: 401 }]);
+    expect(result.status).toBe("blocked");
+    expect(result.reasonCode).toBe("http_4xx");
+  });
+
+  test("a healthy crawl is untouched: no status, no reason, no code", () => {
+    const result = deriveAuditStatus({
+      pagesCrawled: 10,
+      contentPages: 10,
+      blockedPages: 0,
+      // Present but irrelevant: one sub-page 404 must not fail a good audit.
+      rootFailure: { code: "http_4xx", status: 404, host: "example.com" },
+    });
+    expect(result.status).toBe("completed");
+    expect(result.reason).toBeUndefined();
+    expect(result.reasonCode).toBeUndefined();
+  });
+
+  test("the entry URL's failure outranks a sitemap URL's when both are known", () => {
+    // preferRootFailure lives in the crawler; this pins the consequence the
+    // engine relies on - `source` is carried through to the reason builder.
+    const result = deriveAuditStatus({
+      pagesCrawled: 0,
+      contentPages: 0,
+      blockedPages: 0,
+      rootFailure: { code: "dns", host: "ejconsultor.es", source: "entry" },
+    });
+    expect(result.reason).toContain("ejconsultor.es");
+  });
+});

--- a/packages/audit-engine/tests/failure-classification.test.ts
+++ b/packages/audit-engine/tests/failure-classification.test.ts
@@ -187,6 +187,22 @@ describe("existing classifications are unchanged (#792, #1829)", () => {
     expect(result.reasonCode).toBe("http_4xx");
   });
 
+  test("an unrelated upstream 'no response' is not read as a crawl timeout", () => {
+    // The timeout matcher needs BOTH halves of the engine's sentence, so a
+    // reason handed in from somewhere else does not borrow the class.
+    expect(
+      deriveAuditStatus({
+        pagesCrawled: 0,
+        contentPages: 0,
+        blockedPages: 0,
+        rootFailure: {
+          code: "unknown",
+          detail: "got no response from the billing service",
+        },
+      }).reasonCode,
+    ).toBe("unknown");
+  });
+
   test("a healthy crawl is untouched: no status, no reason, no code", () => {
     const result = deriveAuditStatus({
       pagesCrawled: 10,

--- a/packages/core-contracts/package.json
+++ b/packages/core-contracts/package.json
@@ -10,6 +10,7 @@
     "./limits": "./src/limits.ts",
     "./clamp": "./src/clamp.ts",
     "./control-chars": "./src/control-chars.ts",
+    "./failure-reason": "./src/failure-reason.ts",
     "./untrusted-keys": "./src/untrusted-keys.ts",
     "./credits": "./src/credits.ts",
     "./services": "./src/services.ts",

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -438,7 +438,11 @@ export function classifyAuditFailureReasonText(
   // whose BOTH halves are required.
   if (
     (r.includes("page.goto") && r.includes("timeout")) ||
-    /timeout\s+\d+\s?ms\s+exceeded/.test(r) ||
+    // `\s*`, not `\s?`: Playwright writes "Timeout 20000ms exceeded" and
+    // "Timeout 20000 ms exceeded", and a double space should not miss. Not a
+    // backtracking risk despite the adjacent quantifiers, because `\d` and
+    // `\s` are disjoint, so there is no input the engine can split two ways.
+    /timeout\s+\d+\s*ms\s+exceeded/.test(r) ||
     r.includes("navigation timeout") ||
     r.includes("err_timed_out") ||
     r.includes("etimedout") ||
@@ -494,6 +498,14 @@ export function classifyAuditFailureReasonText(
  * failures are worded that way ("Callback 'mark-completed' failed after 3
  * attempts (HTTP 500: ...)"), and reading that as a status blames the audited
  * site for our outage.
+ *
+ * The lead-in is a heuristic, not a parse: "job returned 503 retries remaining"
+ * would read as a 5xx. Bounded on purpose, and the residual risk is a FUTURE
+ * internal message worded "<thing> returned NNN" reaching a surface that
+ * classifies it. The guard against that is not a cleverer regex, it is the
+ * internal-failure branch at the top of `classifyAuditFailureReasonText`: when
+ * a new internal message shape starts arriving, give it an entry there rather
+ * than trying to make this smarter.
  */
 function statusIn(reason: string, min: number, max: number): boolean {
   const match = /\b(?:returned|server error:)\s(\d{3})\b/.exec(reason);

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -385,13 +385,14 @@ export function classifyAuditFailureReasonText(
   if (r.includes("robots.txt disallows")) return "robots";
 
   if (
-    r.includes("dns lookup failed") ||
     r.includes("err_name_not_resolved") ||
     r.includes("enotfound") ||
     r.includes("eai_again") ||
+    r.includes("eai_noname") ||
     r.includes("getaddrinfo") ||
     r.includes("nxdomain") ||
-    r.includes("could not resolve host")
+    r.includes("could not resolve host") ||
+    /dns (lookup|resolution) failed/.test(r)
   ) {
     return "dns";
   }
@@ -399,6 +400,7 @@ export function classifyAuditFailureReasonText(
   if (
     r.includes("tls handshake") ||
     r.includes("tls/connection error") ||
+    r.includes("ssl handshake") ||
     r.includes("err_cert_") ||
     r.includes("err_ssl_") ||
     r.includes("certificate has expired") ||
@@ -410,68 +412,88 @@ export function classifyAuditFailureReasonText(
     return "tls";
   }
 
-  // Checked before the status match so a message that names BOTH a status and a
-  // socket failure ("Server error: 502, socket hang up") reads as the transport
-  // failure it is rather than as an application error the owner should go
+  // Ahead of the status match so a message naming BOTH a status and a socket
+  // failure ("Server error: 502, socket hang up") reads as the transport
+  // failure it is, rather than as an application error the owner should go
   // hunting for in their logs.
   if (
-    r.includes("failed before any response") ||
+    /err_connection_(reset|refused|closed|timed_out|aborted)/.test(r) ||
+    /econn(reset|refused|aborted)/.test(r) ||
+    /connection (reset|refused|closed|timed out)/.test(r) ||
     r.includes("socket connection was closed") ||
+    r.includes("failed before any response") ||
     r.includes("socket hang up") ||
-    r.includes("connection refused") ||
-    r.includes("connection reset") ||
-    r.includes("connection closed") ||
-    r.includes("err_connection_") ||
-    r.includes("err_empty_response") ||
-    r.includes("econnrefused") ||
-    r.includes("econnreset") ||
-    r.includes("econnaborted") ||
-    r.includes("unable to connect")
+    r.includes("unable to connect") ||
+    r.includes("err_empty_response")
   ) {
     return "connection";
   }
 
+  // No bare "timed out": that would swallow an internal DB, R2 or upstream-API
+  // timeout. Only browser/crawler signatures and the engine's own sentence,
+  // whose BOTH halves are required.
   if (
-    // Both halves of the engine's own timeout sentence. A bare "no response
-    // from" would swallow an unrelated upstream failure ("got no response from
-    // the billing service") that some other caller hands this classifier.
-    (r.includes("no response from") && r.includes("within the request timeout")) ||
-    r.includes("crawl request timed out") ||
+    (r.includes("page.goto") && r.includes("timeout")) ||
+    /timeout\s+\d+\s?ms\s+exceeded/.test(r) ||
     r.includes("navigation timeout") ||
     r.includes("err_timed_out") ||
     r.includes("etimedout") ||
-    (r.includes("page.goto") && r.includes("timeout"))
+    r.includes("crawl request timed out") ||
+    (r.includes("no response from") && r.includes("within the request timeout"))
   ) {
     return "timeout";
   }
 
-  if (r.includes("redirect")) return "redirect";
-
-  // "<host> returned 503 Service Unavailable" and the crawler's own
-  // "Server error: 503". One bounded 3-digit match, no adjacent quantifiers.
-  //
-  // A bare "HTTP NNN" is deliberately NOT a lead-in: squirrelscan's own
-  // internal errors are worded that way, and reading one as the audited site's
-  // status blames the site for our outage.
-  const status = /\b(?:returned|server error:)\s(\d{3})\b/.exec(r)?.[1];
-  if (status) {
-    const code = Number.parseInt(status, 10);
-    if (code >= 500) return "http_5xx";
-    if (code >= 400) return "http_4xx";
+  if (
+    r.includes("err_too_many_redirects") ||
+    r.includes("redirect loop") ||
+    r.includes("off-site redirect") ||
+    r.includes("redirected off-site") ||
+    (r.includes("redirect") && r.includes("could not be followed"))
+  ) {
+    return "redirect";
   }
 
-  // The #792 blocked copy and the crawler's own refusal messages: a refusal is
-  // a 4xx whether or not the status survived into the sentence.
+  // The #792 blocked copy, the #1829 rate-limit copy and the crawler's own
+  // refusal messages: a refusal is a 4xx whether or not a status survived into
+  // the sentence. Ahead of the plain status match so a refusal is never read as
+  // an ordinary client error.
   if (
     r.includes("blocked the crawler") ||
     r.includes("bot protection") ||
     r.includes("request blocked by server") ||
     r.includes("too many requests") ||
-    r.includes("rate limit") ||
-    r.includes("captcha")
+    /rate[\s-]?limit/.test(r) ||
+    /\bwaf\b/.test(r) ||
+    r.includes("captcha") ||
+    /\b429\b/.test(r) ||
+    statusIn(r, 401, 401) ||
+    statusIn(r, 403, 403)
   ) {
     return "http_4xx";
   }
 
+  if (statusIn(r, 400, 499)) return "http_4xx";
+  if (statusIn(r, 500, 599)) return "http_5xx";
+
   return "unknown";
+}
+
+/**
+ * Does the reason name an HTTP status in the given range?
+ *
+ * One bounded 3-digit match behind a required lead-in, so a bare port, retry
+ * count or version number is not read as a status. No adjacent quantifiers, so
+ * it cannot backtrack catastrophically.
+ *
+ * Deliberately NOT matching a bare "HTTP NNN": squirrelscan's own callback
+ * failures are worded that way ("Callback 'mark-completed' failed after 3
+ * attempts (HTTP 500: ...)"), and reading that as a status blames the audited
+ * site for our outage.
+ */
+function statusIn(reason: string, min: number, max: number): boolean {
+  const match = /\b(?:returned|server error:)\s(\d{3})\b/.exec(reason);
+  if (!match) return false;
+  const status = Number.parseInt(match[1]!, 10);
+  return status >= min && status <= max;
 }

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -304,6 +304,13 @@ export function classifyAuditFailureReasonText(
   const r = (reason ?? "").toLowerCase();
   if (r.length === 0) return "unknown";
 
+  // OUR failure, not the site's. The cloud container words a failed call to
+  // squirrelscan's own API as "Callback '<label>' failed after N attempts
+  // (HTTP 500: ...)", and that string can reach a surface that classifies it.
+  // Checked first, and answered `unknown`, so an outage on our side is never
+  // reported to a site owner as their server erroring.
+  if (r.includes("callback '") && r.includes("failed after")) return "unknown";
+
   if (r.includes("robots.txt disallows")) return "robots";
 
   if (
@@ -371,7 +378,11 @@ export function classifyAuditFailureReasonText(
 
   // "<host> returned 503 Service Unavailable" and the crawler's own
   // "Server error: 503". One bounded 3-digit match, no adjacent quantifiers.
-  const status = /\b(?:returned|server error:|http)\s(\d{3})\b/.exec(r)?.[1];
+  //
+  // A bare "HTTP NNN" is deliberately NOT a lead-in: squirrelscan's own
+  // internal errors are worded that way, and reading one as the audited site's
+  // status blames the site for our outage.
+  const status = /\b(?:returned|server error:)\s(\d{3})\b/.exec(r)?.[1];
   if (status) {
     const code = Number.parseInt(status, 10);
     if (code >= 500) return "http_5xx";

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -343,7 +343,10 @@ export function classifyAuditFailureReasonText(
   }
 
   if (
-    r.includes("no response from") ||
+    // Both halves of the engine's own timeout sentence. A bare "no response
+    // from" would swallow an unrelated upstream failure ("got no response from
+    // the billing service") that some other caller hands this classifier.
+    (r.includes("no response from") && r.includes("within the request timeout")) ||
     r.includes("crawl request timed out") ||
     r.includes("navigation timeout") ||
     r.includes("err_timed_out") ||

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -1,0 +1,357 @@
+/**
+ * Audit failure classification (#1822).
+ *
+ * A crawl that fetched nothing used to end with one string, "No pages were
+ * crawled", on every surface: `agent_runs.error`, the in-app notification, the
+ * failure email, Sentry grouping and the MCP status. The crawler already knew
+ * WHY the root fetch died, so this module gives that knowledge a small
+ * user-facing vocabulary shared by the engine, the renderers, the CLI and the
+ * cloud/email surfaces.
+ *
+ * Leaf module by design: no imports outside this package's own control-char
+ * helper, so the API Worker, the email templates and the crawler can all pull
+ * it without dragging anything else in.
+ */
+import { stripControlChars } from "./control-chars";
+
+/**
+ * The classes a zero-page audit can fail in. `unknown` is the honest fallback
+ * for a failure we could not attribute; it must NEVER read as "nothing went
+ * wrong" (see the renderers, which still print a failure notice for it).
+ */
+export const AUDIT_FAILURE_REASON_CODES = [
+  "dns",
+  "tls",
+  "connection",
+  "timeout",
+  "http_4xx",
+  "http_5xx",
+  "redirect",
+  "robots",
+  "unknown",
+] as const;
+
+export type AuditFailureReasonCode = (typeof AUDIT_FAILURE_REASON_CODES)[number];
+
+export function isAuditFailureReasonCode(value: unknown): value is AuditFailureReasonCode {
+  return (
+    typeof value === "string" &&
+    (AUDIT_FAILURE_REASON_CODES as readonly string[]).includes(value)
+  );
+}
+
+/** Which fetch the failure came from. `entry` is the audited URL itself. */
+export type AuditFailureSource = "entry" | "robots" | "sitemap";
+
+/**
+ * Structured detail about the fetch failure that ended a crawl with no
+ * auditable content. Recorded by the crawler on {@link CrawlStats}, read by
+ * `deriveAuditStatus` to build the report's `statusReason` +
+ * `statusReasonCode`. Every field past `code` is optional so an older
+ * persisted stats blob (or a fetcher that told us nothing) still classifies.
+ */
+export interface AuditFailureDetail {
+  code: AuditFailureReasonCode;
+  /** Hostname of the URL that failed. Never a full URL: reasons are quoted in
+   *  emails and markdown, and a host cannot carry a path/query payload. */
+  host?: string;
+  /** HTTP status when the origin actually answered. */
+  status?: number;
+  /** One short extra fact (certificate expired, NXDOMAIN, the redirect target).
+   *  Origin-influenced text, so it is stripped and length-capped here. */
+  detail?: string;
+  /** Which fetch failed; absent reads as `entry`. */
+  source?: AuditFailureSource;
+}
+
+/** Keeps a reason inside `agent_runs.error`'s 500-char bound with room to spare. */
+const MAX_DETAIL_LENGTH = 120;
+const MAX_HOST_LENGTH = 80;
+
+/**
+ * Normalize an origin-influenced fragment before it is embedded in a reason
+ * sentence: strip control characters (so a reason can't break a log line, a
+ * markdown table or an email body), collapse whitespace, and cap the length.
+ */
+function sanitizeFragment(value: string | undefined, max: number): string | undefined {
+  if (!value) return undefined;
+  const cleaned = stripControlChars(value).replace(/\s+/g, " ").trim();
+  if (cleaned.length === 0) return undefined;
+  // The ellipsis counts toward the cap: `max` is a hard ceiling because these
+  // fragments are concatenated into a reason bounded by a 500-char DB column.
+  return cleaned.length > max ? `${cleaned.slice(0, max - 3)}...` : cleaned;
+}
+
+/** Build a detail with every origin-influenced field already sanitized. */
+export function auditFailureDetail(input: AuditFailureDetail): AuditFailureDetail {
+  const status =
+    typeof input.status === "number" && Number.isInteger(input.status) ? input.status : undefined;
+  return {
+    code: input.code,
+    ...(sanitizeFragment(input.host, MAX_HOST_LENGTH)
+      ? { host: sanitizeFragment(input.host, MAX_HOST_LENGTH) }
+      : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(sanitizeFragment(input.detail, MAX_DETAIL_LENGTH)
+      ? { detail: sanitizeFragment(input.detail, MAX_DETAIL_LENGTH) }
+      : {}),
+    ...(input.source ? { source: input.source } : {}),
+  };
+}
+
+/** Human phrase for the statuses a root fetch realistically dies on. */
+const STATUS_TEXT: Readonly<Record<number, string>> = {
+  400: "Bad Request",
+  401: "Unauthorized",
+  402: "Payment Required",
+  403: "Forbidden",
+  404: "Not Found",
+  405: "Method Not Allowed",
+  406: "Not Acceptable",
+  408: "Request Timeout",
+  410: "Gone",
+  418: "I'm a Teapot",
+  421: "Misdirected Request",
+  429: "Too Many Requests",
+  451: "Unavailable For Legal Reasons",
+  500: "Internal Server Error",
+  501: "Not Implemented",
+  502: "Bad Gateway",
+  503: "Service Unavailable",
+  504: "Gateway Timeout",
+  508: "Loop Detected",
+  521: "Web Server Is Down",
+  522: "Connection Timed Out",
+  523: "Origin Is Unreachable",
+  525: "SSL Handshake Failed",
+};
+
+function statusPhrase(status: number | undefined): string {
+  if (status === undefined) return "an error";
+  // Object.hasOwn, not `in`/[]: the key comes from a persisted blob and a
+  // prototype method must never surface as a status phrase.
+  const text = Object.hasOwn(STATUS_TEXT, status) ? STATUS_TEXT[status] : undefined;
+  return text ? `${status} ${text}` : String(status);
+}
+
+function siteName(detail: AuditFailureDetail): string {
+  return detail.host ?? "the site";
+}
+
+/**
+ * The short reason sentence stored as `AuditReport.statusReason` and copied to
+ * `agent_runs.error`. Deliberately one sentence and under the 500-char column
+ * bound, and deliberately phrased so {@link classifyAuditFailureReasonText} can
+ * read the class back off it on surfaces that only ever see the string.
+ */
+export function auditFailureReasonText(detail: AuditFailureDetail): string {
+  const site = siteName(detail);
+  const extra = detail.detail ? `: ${detail.detail}` : "";
+  switch (detail.code) {
+    case "dns":
+      return `DNS lookup failed for ${site}${detail.detail ? ` (${detail.detail})` : ""}`;
+    case "tls":
+      return `TLS handshake with ${site} failed${extra}`;
+    case "connection":
+      return `Connection to ${site} failed before any response${extra}`;
+    case "timeout":
+      return `No response from ${site} within the request timeout${extra}`;
+    case "http_4xx":
+    case "http_5xx":
+      return `${site} returned ${statusPhrase(detail.status)}${extra}`;
+    case "redirect":
+      return `Redirect from ${site} could not be followed${extra}`;
+    case "robots":
+      return `robots.txt disallows crawling ${site}`;
+    case "unknown":
+      return `No pages were crawled from ${site}${extra}`;
+  }
+}
+
+/**
+ * What the owner should do next, second person, for the surfaces that address
+ * the site owner directly: the failure email, the HTML report, and the CLI's
+ * text/markdown output.
+ */
+export const AUDIT_FAILURE_NEXT_STEP: Readonly<Record<AuditFailureReasonCode, string>> = {
+  dns: "Check the domain's DNS records and that the hostname resolves from the public internet. If you moved hosts recently, wait for the change to propagate and re-run the audit.",
+  tls: "Renew or repair the TLS certificate so it is valid for this hostname and served with the full chain, then re-run the audit.",
+  connection:
+    "Check that the origin server is running and accepting connections from the public internet, and that no firewall is dropping our requests.",
+  timeout:
+    "The origin accepted the connection but did not answer in time. Check server load, slow database queries, or a firewall holding the connection open, then re-run the audit.",
+  http_4xx:
+    "The server refused the request. Allowlist the squirrelscan crawler in your WAF or bot protection, turn off bot fight mode for the audit, or check that the URL is publicly reachable without a login.",
+  http_5xx:
+    "The server hit an error of its own. Check your error logs and re-run the audit once the site is serving normally.",
+  redirect:
+    "Audit the URL the site actually serves, or fix the redirect so it lands on a page on the same site.",
+  robots:
+    "Allow the squirrelscan crawler in robots.txt, or point the audit at a path robots.txt permits.",
+  // Kept as the pre-#1822 wording: `unknown` is the branch every older report
+  // and every unattributable failure lands in, and this is the copy those
+  // surfaces already shipped.
+  unknown:
+    "No pages could be fetched from this site, so there was nothing to audit. Check that the site is reachable and try again.",
+};
+
+/**
+ * One sentence naming the cause, second person, for the report's failure
+ * notice (the HTML report and the dashboard). Sits above the next step, which
+ * says what to do about it.
+ */
+export const AUDIT_FAILURE_CAUSE: Readonly<Record<AuditFailureReasonCode, string>> = {
+  dns: "We couldn't resolve your site's hostname, so there was no server to fetch pages from and nothing to audit.",
+  tls: "We couldn't complete a TLS handshake with your site, so no page could be read securely and there was nothing to audit.",
+  connection:
+    "Nothing answered at your site's origin. The connection was refused, reset, or closed before any response arrived, so there was nothing to audit.",
+  timeout:
+    "Your site accepted our connection but never sent a response in time, so no page could be read and there was nothing to audit.",
+  http_4xx:
+    "Your site refused every request we made, so no page could be read and there was nothing to audit.",
+  http_5xx:
+    "Your site returned a server error for every request we made, so there was nothing to audit.",
+  redirect:
+    "The URL we audited redirected somewhere we could not follow, so no page on your site could be read.",
+  robots:
+    "Your robots.txt disallows our crawler on this URL, so we did not fetch it and there was nothing to audit.",
+  unknown:
+    "We couldn't fetch any pages from your site, so there was nothing to audit. The site may have been down, unreachable, or timing out when we tried.",
+};
+
+/**
+ * The same guidance in third person, for the agent-facing surfaces (the `llm`
+ * renderer, the API report markdown, the MCP tools) which describe the site to
+ * an agent rather than talking to its owner.
+ */
+export const AUDIT_FAILURE_NEXT_STEP_THIRD: Readonly<Record<AuditFailureReasonCode, string>> = {
+  dns: "The hostname did not resolve. Check the domain's DNS records, and whether the domain has expired or was recently moved.",
+  tls: "The TLS certificate could not be validated for this hostname. Check its expiry, hostname coverage, and that the full chain is served.",
+  connection:
+    "Nothing answered on the origin. Check that the server is running and reachable from the public internet.",
+  timeout:
+    "The origin accepted the connection but never answered. Check server load and any firewall holding connections open.",
+  http_4xx:
+    "The server refused the request. This is usually bot protection, a WAF rule, or a login wall in front of the URL, not a squirrelscan outage.",
+  http_5xx:
+    "The server returned an error of its own. Re-run the audit once the site is serving normally.",
+  redirect:
+    "The audited URL redirected somewhere the crawl could not follow. Audit the URL the site actually serves.",
+  robots: "robots.txt disallows the crawler on this path. Audit a path robots.txt permits.",
+  // Pre-#1822 wording, kept for the same reason as the second-person entry.
+  unknown:
+    "No pages could be fetched from the site, so nothing was audited. The site may have been down, unreachable, or timing out. Check that the site is reachable and try again.",
+};
+
+export function auditFailureNextStep(
+  code: AuditFailureReasonCode,
+  voice: "second" | "third" = "second",
+): string {
+  return voice === "third" ? AUDIT_FAILURE_NEXT_STEP_THIRD[code] : AUDIT_FAILURE_NEXT_STEP[code];
+}
+
+/**
+ * Recover the failure class from a reason STRING.
+ *
+ * Needed because two surfaces only ever see the text: `agent_runs.error` (no
+ * column for the code, and the completion PATCH carries only `error`) and the
+ * Sentry/notification path built from it. The patterns below match the
+ * sentences {@link auditFailureReasonText} produces, plus the raw crawler /
+ * Chromium phrasings that reach the same surfaces from the CLI and the render
+ * worker, so historic reasons classify too.
+ *
+ * An unrecognized reason returns `unknown` — which the renderers still treat as
+ * a failure, never as an absence of one.
+ */
+export function classifyAuditFailureReasonText(
+  reason: string | null | undefined,
+): AuditFailureReasonCode {
+  const r = (reason ?? "").toLowerCase();
+  if (r.length === 0) return "unknown";
+
+  if (r.includes("robots.txt disallows")) return "robots";
+
+  if (
+    r.includes("dns lookup failed") ||
+    r.includes("err_name_not_resolved") ||
+    r.includes("enotfound") ||
+    r.includes("eai_again") ||
+    r.includes("getaddrinfo") ||
+    r.includes("nxdomain") ||
+    r.includes("could not resolve host")
+  ) {
+    return "dns";
+  }
+
+  if (
+    r.includes("tls handshake") ||
+    r.includes("tls/connection error") ||
+    r.includes("err_cert_") ||
+    r.includes("err_ssl_") ||
+    r.includes("certificate has expired") ||
+    r.includes("self-signed certificate") ||
+    r.includes("self signed certificate") ||
+    r.includes("unable to verify the first certificate") ||
+    r.includes("hostname/ip does not match")
+  ) {
+    return "tls";
+  }
+
+  // Checked before the status match so a message that names BOTH a status and a
+  // socket failure ("Server error: 502, socket hang up") reads as the transport
+  // failure it is rather than as an application error the owner should go
+  // hunting for in their logs.
+  if (
+    r.includes("failed before any response") ||
+    r.includes("socket connection was closed") ||
+    r.includes("socket hang up") ||
+    r.includes("connection refused") ||
+    r.includes("connection reset") ||
+    r.includes("connection closed") ||
+    r.includes("err_connection_") ||
+    r.includes("err_empty_response") ||
+    r.includes("econnrefused") ||
+    r.includes("econnreset") ||
+    r.includes("econnaborted") ||
+    r.includes("unable to connect")
+  ) {
+    return "connection";
+  }
+
+  if (
+    r.includes("no response from") ||
+    r.includes("crawl request timed out") ||
+    r.includes("navigation timeout") ||
+    r.includes("err_timed_out") ||
+    r.includes("etimedout") ||
+    (r.includes("page.goto") && r.includes("timeout"))
+  ) {
+    return "timeout";
+  }
+
+  if (r.includes("redirect")) return "redirect";
+
+  // "<host> returned 503 Service Unavailable" and the crawler's own
+  // "Server error: 503". One bounded 3-digit match, no adjacent quantifiers.
+  const status = /\b(?:returned|server error:|http)\s(\d{3})\b/.exec(r)?.[1];
+  if (status) {
+    const code = Number.parseInt(status, 10);
+    if (code >= 500) return "http_5xx";
+    if (code >= 400) return "http_4xx";
+  }
+
+  // The #792 blocked copy and the crawler's own refusal messages: a refusal is
+  // a 4xx whether or not the status survived into the sentence.
+  if (
+    r.includes("blocked the crawler") ||
+    r.includes("bot protection") ||
+    r.includes("request blocked by server") ||
+    r.includes("too many requests") ||
+    r.includes("rate limit") ||
+    r.includes("captcha")
+  ) {
+    return "http_4xx";
+  }
+
+  return "unknown";
+}

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -204,8 +204,12 @@ export const AUDIT_FAILURE_NEXT_STEP: Readonly<Record<AuditFailureReasonCode, st
     "Check that the origin server is running and accepting connections from the public internet, and that no firewall is dropping our requests.",
   timeout:
     "The origin accepted the connection but did not answer in time. Check server load, slow database queries, or a firewall holding the connection open, then re-run the audit.",
+  // Covers both shapes a 4xx entry URL takes, because the class alone cannot
+  // tell them apart and the wrong half of this advice is useless: a refusal
+  // (401/403/429) is a wall to open, a 404/410 is an address to correct. The
+  // reason line printed directly above names the exact status.
   http_4xx:
-    "The server refused the request. Allowlist the squirrelscan crawler in your WAF or bot protection, turn off bot fight mode for the audit, or check that the URL is publicly reachable without a login.",
+    "The server did not return the page. A 401, 403 or 429 is a refusal: allowlist the squirrelscan crawler in your WAF or bot protection, turn off bot fight mode for the audit, or check that the URL is reachable without a login. A 404 or 410 means the page is not there: check that the address is right and that it is published.",
   http_5xx:
     "The server hit an error of its own. Check your error logs and re-run the audit once the site is serving normally.",
   redirect:
@@ -232,7 +236,7 @@ export const AUDIT_FAILURE_CAUSE: Readonly<Record<AuditFailureReasonCode, string
   timeout:
     "Your site accepted our connection but never sent a response in time, so no page could be read and there was nothing to audit.",
   http_4xx:
-    "Your site refused every request we made, so no page could be read and there was nothing to audit.",
+    "Your site did not return a page for any request we made, so there was nothing to audit. Either it refused us, or the address we audited is not there.",
   http_5xx:
     "Your site returned a server error for every request we made, so there was nothing to audit.",
   redirect:
@@ -256,7 +260,7 @@ export const AUDIT_FAILURE_NEXT_STEP_THIRD: Readonly<Record<AuditFailureReasonCo
   timeout:
     "The origin accepted the connection but never answered. Check server load and any firewall holding connections open.",
   http_4xx:
-    "The server refused the request. This is usually bot protection, a WAF rule, or a login wall in front of the URL, not a squirrelscan outage.",
+    "The server did not return the page. A 401, 403 or 429 is a refusal, usually bot protection, a WAF rule or a login wall, and not a squirrelscan outage. A 404 or 410 means the URL does not exist, so the address being audited is probably wrong.",
   http_5xx:
     "The server returned an error of its own. Re-run the audit once the site is serving normally.",
   redirect:

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -69,13 +69,37 @@ const MAX_DETAIL_LENGTH = 120;
 const MAX_HOST_LENGTH = 80;
 
 /**
+ * Absolute URLs inside a runtime error message. Reduced to their host below:
+ * a reason sentence is quoted in an email, a markdown report and a log line,
+ * and the path and query of a site-chosen URL have no business in any of them.
+ * Bounded character classes only, and no adjacent quantifiers, so this cannot
+ * backtrack catastrophically on a hostile message.
+ */
+const ABSOLUTE_URL = /\bhttps?:\/\/([^\s/?#"'<>]{1,253})[^\s"'<>]*/gi;
+
+/**
+ * Characters that would give an origin-influenced fragment STRUCTURE once the
+ * reason is printed: markdown links and code spans, an HTML tag, a table cell
+ * break. Emphasis markers (`*`, `_`) are deliberately left alone: they are
+ * inert inside a one-line fragment, and stripping them mangles ordinary
+ * identifiers (squirrelscan/repo#1798).
+ */
+const STRUCTURAL_CHARS = /[`[\]<>|]/g;
+
+/**
  * Normalize an origin-influenced fragment before it is embedded in a reason
  * sentence: strip control characters (so a reason can't break a log line, a
- * markdown table or an email body), collapse whitespace, and cap the length.
+ * markdown table or an email body), reduce any absolute URL to its host, drop
+ * the characters that would turn text into markup, collapse whitespace, and cap
+ * the length.
  */
 function sanitizeFragment(value: string | undefined, max: number): string | undefined {
   if (!value) return undefined;
-  const cleaned = stripControlChars(value).replace(/\s+/g, " ").trim();
+  const cleaned = stripControlChars(value)
+    .replace(ABSOLUTE_URL, (_match, host: string) => host)
+    .replace(STRUCTURAL_CHARS, "")
+    .replace(/\s+/g, " ")
+    .trim();
   if (cleaned.length === 0) return undefined;
   // The ellipsis counts toward the cap: `max` is a hard ceiling because these
   // fragments are concatenated into a reason bounded by a 500-char DB column.

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -286,6 +286,77 @@ export function auditFailureNextStep(
 }
 
 /**
+ * Runtime error codes, mapped to the class they mean.
+ *
+ * A code is a far better signal than the message it comes with: it is a stable
+ * contract, while the prose around it is reworded between runtime versions. Bun
+ * 1.3 reported a DNS failure as `ConnectionRefused` with the message "Unable to
+ * connect", and Bun 1.4 reports the same failure as `ENOTFOUND` with
+ * "getaddrinfo ENOTFOUND" (squirrelscan/repo#1840). Matching the code means the
+ * classification follows the runtime instead of chasing its wording.
+ *
+ * Keys are lowercased at lookup, so both errno style (`ENOTFOUND`) and Bun's
+ * own PascalCase (`ConnectionRefused`) resolve.
+ */
+const ERRNO_CLASS: Readonly<Record<string, AuditFailureReasonCode>> = {
+  enotfound: "dns",
+  eai_again: "dns",
+  eai_noname: "dns",
+  dnsnotfound: "dns",
+  econnrefused: "connection",
+  econnreset: "connection",
+  econnaborted: "connection",
+  epipe: "connection",
+  ehostunreach: "connection",
+  enetunreach: "connection",
+  connectionrefused: "connection",
+  connectionreset: "connection",
+  connectionclosed: "connection",
+  etimedout: "timeout",
+  timeout: "timeout",
+  eproto: "tls",
+  cert_has_expired: "tls",
+  depth_zero_self_signed_cert: "tls",
+  unable_to_verify_leaf_signature: "tls",
+  err_tls_cert_altname_invalid: "tls",
+};
+
+/** How many nested `error.cause` levels to walk. Runtimes wrap a few deep. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * The first runtime error code on an error or its `cause` chain.
+ *
+ * Mirrors how `isTlsError` in the crawler walks the chain: undici and Bun both
+ * wrap the real failure behind a generic "fetch failed" a level or two up, so
+ * the code on the outermost error is usually absent.
+ */
+export function fetchErrorCode(error: unknown): string | undefined {
+  let current = error as { cause?: unknown; code?: unknown } | null | undefined;
+  for (let depth = 0; current && depth < MAX_CAUSE_DEPTH; depth++) {
+    if (typeof current.code === "string" && current.code.length > 0) return current.code;
+    current = current.cause as typeof current;
+  }
+  return undefined;
+}
+
+/**
+ * Classify a runtime error code, or `undefined` when it names nothing we know.
+ *
+ * Undefined rather than `unknown` on purpose: the caller falls back to reading
+ * the message, and a code we do not recognize must not stop it doing so.
+ */
+export function classifyFetchErrorCode(
+  code: string | null | undefined,
+): AuditFailureReasonCode | undefined {
+  if (!code) return undefined;
+  const key = code.toLowerCase();
+  // Object.hasOwn, not `in`: the code comes from a runtime error and must not
+  // be able to resolve to an inherited Object.prototype member.
+  return Object.hasOwn(ERRNO_CLASS, key) ? ERRNO_CLASS[key] : undefined;
+}
+
+/**
  * Recover the failure class from a reason STRING.
  *
  * Needed because two surfaces only ever see the text: `agent_runs.error` (no

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -180,7 +180,11 @@ export function auditFailureReasonText(detail: AuditFailureDetail): string {
   const extra = detail.detail ? `: ${detail.detail}` : "";
   switch (detail.code) {
     case "dns":
-      return `DNS lookup failed for ${site}${detail.detail ? ` (${detail.detail})` : ""}`;
+      // A colon, like every other class, NOT parentheses: these sentences are
+      // escaped before they reach a markdown report, and `\(NXDOMAIN\)` in
+      // the most-read line of a failed report reads worse than the risk it
+      // would carry unescaped.
+      return `DNS lookup failed for ${site}${extra}`;
     case "tls":
       return `TLS handshake with ${site} failed${extra}`;
     case "connection":

--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -40,13 +40,20 @@ export function isAuditFailureReasonCode(value: unknown): value is AuditFailureR
   );
 }
 
-/** Which fetch the failure came from. `entry` is the audited URL itself. */
-export type AuditFailureSource = "entry" | "robots" | "sitemap";
+/**
+ * Which URL the failure came from. `entry` is the audited URL itself and always
+ * outranks `sitemap` when both are known: the seed is what the user asked for.
+ *
+ * Only these two are produced today. A robots.txt or llms.txt probe failure has
+ * no source of its own because it never ends a crawl on its own; add one here
+ * alongside the code that records it, not ahead of it.
+ */
+export type AuditFailureSource = "entry" | "sitemap";
 
 /**
  * Structured detail about the fetch failure that ended a crawl with no
- * auditable content. Recorded by the crawler on {@link CrawlStats}, read by
- * `deriveAuditStatus` to build the report's `statusReason` +
+ * auditable content. Recorded by the crawler on `CrawlStats.rootFailure`, read
+ * by `deriveAuditStatus` to build the report's `statusReason` +
  * `statusReasonCode`. Every field past `code` is optional so an older
  * persisted stats blob (or a fetcher that told us nothing) still classifies.
  */

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -28,6 +28,10 @@ export * from "./threat-intel";
 // #1185: unsampled publish resolution signal (type + hash).
 export * from "./resolution";
 
+// #1822: failure classification for a zero-page audit (codes, reason text,
+// next steps) — shared by the crawler, the engine, the renderers and the cloud.
+export * from "./failure-reason";
+
 // Import storage types needed locally by interfaces in this file
 import type {
   AgentAccessProbe,
@@ -40,6 +44,7 @@ import type {
 } from "./storage";
 import type { SiteMetadata } from "./site-metadata";
 import type { ResolutionSignal } from "./resolution";
+import type { AuditFailureReasonCode } from "./failure-reason";
 
 export interface CheckItem {
   id: string;
@@ -277,6 +282,14 @@ export interface AuditReport {
     /** Host(s) that throttled the crawl. */
     hosts: string[];
   };
+  /**
+   * Machine-readable class of the failure behind `statusReason` (#1822), so the
+   * email template, the dashboard, the MCP tools and Sentry can branch on the
+   * cause instead of substring-matching prose. Set alongside `statusReason`;
+   * absent on reports stored before #1822, where
+   * `classifyAuditFailureReasonText` recovers the class from the text.
+   */
+  statusReasonCode?: AuditFailureReasonCode;
   healthScore?: HealthScore;
   ruleResults: Record<string, ReportRuleResult>;
   /**

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -3,6 +3,8 @@
 
 import type { Effect } from "effect";
 
+import type { AuditFailureDetail } from "./failure-reason";
+
 // ============================================
 // SHARED DOMAIN TYPES (used by storage + report)
 // ============================================
@@ -174,6 +176,19 @@ export interface CrawlStats {
    * backward compatibility with older persisted stats blobs.
    */
   pagesRateLimited?: number;
+  /**
+   * Why the crawl's ENTRY url could not be audited, when it could not (#1822).
+   * The crawler records the first failure it sees, preferring the seed over a
+   * sitemap/discovered URL, across all three shapes a root failure takes: a
+   * failed fetch (DNS/TLS/connection/timeout/5xx), a stored 4xx page, and a
+   * refusal before any request (robots disallow, off-site redirect).
+   *
+   * Read ONLY by the zero-content branches of `deriveAuditStatus`, so a healthy
+   * site whose seed happened to 404 still scores normally. Optional for
+   * backward compatibility with stats blobs persisted before #1822; absent
+   * falls back to the generic "No pages were crawled" reason.
+   */
+  rootFailure?: AuditFailureDetail;
   pagesSkipped: number;
   pagesUnchanged: number;
   /**

--- a/packages/core-contracts/tests/classifier-parity-corpus.ts
+++ b/packages/core-contracts/tests/classifier-parity-corpus.ts
@@ -1,0 +1,71 @@
+/**
+ * Cross-repo classifier parity corpus (#1822).
+ *
+ * The failure vocabulary is declared TWICE on purpose: the engine owns it in
+ * the public `@squirrelscan/core-contracts` failure-reason module, and the
+ * cloud re-derives it in `@squirrelscan/private-contracts` because the private
+ * repo pins the public one by submodule gitlink and cannot import across it
+ * (squirrelscan/repo#1838 tracks folding them back together).
+ *
+ * "Kept in sync by convention" is not a mechanism. This corpus IS the
+ * mechanism: the identical list lives in both repos, and a rule that drifts on
+ * either side fails a test instead of silently sending one audit a different
+ * failure email depending on which surface classified it. A first pass caught
+ * four real divergences on day one, all on legacy phrasings the comments claim
+ * to support: "Connection timed out", a bare "ETIMEDOUT", "DNS resolution
+ * failed", and a bare "WAF".
+ *
+ * When you change a matcher or a reason sentence, change BOTH copies of this
+ * list in the same pass.
+ */
+export const CLASSIFIER_PARITY_CORPUS: ReadonlyArray<readonly [string, string]> = [
+  // The sentences the engine itself writes.
+  ["DNS lookup failed for ejconsultor.es (NXDOMAIN)", "dns"],
+  ["TLS handshake with example.com failed: certificate has expired", "tls"],
+  ["Connection to example.com failed before any response", "connection"],
+  ["No response from example.com within the request timeout", "timeout"],
+  ["example.com returned 404 Not Found", "http_4xx"],
+  ["example.com returned 503 Service Unavailable", "http_5xx"],
+  ["Redirect from example.com could not be followed: redirected off-site to other.com", "redirect"],
+  ["robots.txt disallows crawling example.com", "robots"],
+  ["No pages were crawled from example.com: something novel", "unknown"],
+
+  // The #792 blocked copy and the #1829 rate-limit copy.
+  ["Site blocked the crawler (bot protection / auth / rate limit)", "http_4xx"],
+  ["Rate limited by example.com; no pages could be fetched", "http_4xx"],
+
+  // Runtime and legacy phrasings that reach these surfaces from older CLI
+  // versions, older engines, and the render worker's Chromium errors.
+  ["getaddrinfo ENOTFOUND example.com", "dns"],
+  ["net::ERR_NAME_NOT_RESOLVED", "dns"],
+  ["DNS resolution failed for x.com", "dns"],
+  ["net::ERR_CERT_DATE_INVALID", "tls"],
+  ["unable to verify the first certificate", "tls"],
+  ["The socket connection was closed unexpectedly", "connection"],
+  ["connect ECONNREFUSED 10.0.0.1:443", "connection"],
+  ["net::ERR_CONNECTION_RESET", "connection"],
+  ["Connection timed out", "connection"],
+  ["socket hang up", "connection"],
+  ["ETIMEDOUT", "timeout"],
+  ["net::ERR_TIMED_OUT", "timeout"],
+  ["page.goto: Timeout 20000ms exceeded", "timeout"],
+  ["Navigation timeout of 30000 ms exceeded", "timeout"],
+  ["Crawl request timed out", "timeout"],
+  ["net::ERR_TOO_MANY_REDIRECTS", "redirect"],
+  ["Off-site redirect to https://other.com/x", "redirect"],
+  ["Server error: 502", "http_5xx"],
+  ["429 Too Many Requests", "http_4xx"],
+  ["Request blocked by server", "http_4xx"],
+  ["WAF challenge detected", "http_4xx"],
+
+  // Ours, not the site's. Every one of these must stay `unknown`, or a failure
+  // email tells a site owner to fix something that was never theirs.
+  ["Callback 'mark-completed' failed after 3 attempts (HTTP 500: internal error)", "unknown"],
+  ["upload failed, HTTP 503 from storage", "unknown"],
+  ["database query timed out", "unknown"],
+  ["R2_ASSETS.put timed out after 5000ms", "unknown"],
+  ["internal API got no response from the billing service", "unknown"],
+  ["database query failed after 403 retries", "unknown"],
+  ["CLI session ended before the audit completed", "unknown"],
+  ["No pages were crawled", "unknown"],
+];

--- a/packages/core-contracts/tests/classifier-parity-corpus.ts
+++ b/packages/core-contracts/tests/classifier-parity-corpus.ts
@@ -15,12 +15,18 @@
  * to support: "Connection timed out", a bare "ETIMEDOUT", "DNS resolution
  * failed", and a bare "WAF".
  *
+ *
+ * Blind spot worth naming: the corpus catches a rule that drifts on the side
+ * being edited. It cannot catch one introduced only on the side nobody
+ * touched, because neither repo's CI runs the other's classifier. That is the
+ * residual risk #1838 removes, and the reason to edit both copies together.
+ *
  * When you change a matcher or a reason sentence, change BOTH copies of this
  * list in the same pass.
  */
 export const CLASSIFIER_PARITY_CORPUS: ReadonlyArray<readonly [string, string]> = [
   // The sentences the engine itself writes.
-  ["DNS lookup failed for ejconsultor.es (NXDOMAIN)", "dns"],
+  ["DNS lookup failed for ejconsultor.es: NXDOMAIN", "dns"],
   ["TLS handshake with example.com failed: certificate has expired", "tls"],
   ["Connection to example.com failed before any response", "connection"],
   ["No response from example.com within the request timeout", "timeout"],
@@ -39,6 +45,9 @@ export const CLASSIFIER_PARITY_CORPUS: ReadonlyArray<readonly [string, string]> 
   ["getaddrinfo ENOTFOUND example.com", "dns"],
   ["net::ERR_NAME_NOT_RESOLVED", "dns"],
   ["DNS resolution failed for x.com", "dns"],
+  // The parenthesised DNS form, which is what reports published before the
+  // template switched to a colon still carry.
+  ["DNS lookup failed for ejconsultor.es (NXDOMAIN)", "dns"],
   ["net::ERR_CERT_DATE_INVALID", "tls"],
   ["unable to verify the first certificate", "tls"],
   ["The socket connection was closed unexpectedly", "connection"],

--- a/packages/core-contracts/tests/classifier-parity.test.ts
+++ b/packages/core-contracts/tests/classifier-parity.test.ts
@@ -32,6 +32,18 @@ describe("classifier parity corpus (#1822)", () => {
     }
   });
 
+  test("Playwright's timeout wording matches with or without a space before ms", () => {
+    // `\s*` not `\s?`: Playwright writes both spacings, and a double space
+    // should not fall through to `unknown`.
+    for (const reason of [
+      "page.goto: Timeout 20000ms exceeded",
+      "Timeout 20000 ms exceeded",
+      "Timeout 20000  ms exceeded",
+    ]) {
+      expect(classifyAuditFailureReasonText(reason)).toBe("timeout");
+    }
+  });
+
   test("our own internal failures never read as the audited site's", () => {
     // The half of the corpus that matters most: every one of these would
     // otherwise tell a site owner to fix something that was never theirs.

--- a/packages/core-contracts/tests/classifier-parity.test.ts
+++ b/packages/core-contracts/tests/classifier-parity.test.ts
@@ -1,0 +1,48 @@
+// #1822 - the PUBLIC half of the cross-repo classifier parity check.
+//
+// The private twin of this file is apps/crawler-worker/src/classifier-parity
+// .test.ts in squirrelscan/repo, and both drive the same corpus. Neither repo
+// can import the other's classifier, so the corpus is what keeps them honest:
+// a rule that drifts on either side fails here or there, instead of silently
+// sending one audit a different failure email depending on which surface
+// classified it.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  AUDIT_FAILURE_REASON_CODES,
+  classifyAuditFailureReasonText,
+} from "../src/failure-reason";
+import { CLASSIFIER_PARITY_CORPUS } from "./classifier-parity-corpus";
+
+describe("classifier parity corpus (#1822)", () => {
+  test("every reason classifies to its agreed code", () => {
+    const wrong: string[] = [];
+    for (const [reason, expected] of CLASSIFIER_PARITY_CORPUS) {
+      const actual = classifyAuditFailureReasonText(reason);
+      if (actual !== expected) wrong.push(`${expected} != ${actual}  ${reason}`);
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  test("the corpus covers every code, so no class goes unexercised", () => {
+    const covered = new Set(CLASSIFIER_PARITY_CORPUS.map(([, code]) => code));
+    for (const code of AUDIT_FAILURE_REASON_CODES) {
+      expect(covered.has(code)).toBe(true);
+    }
+  });
+
+  test("our own internal failures never read as the audited site's", () => {
+    // The half of the corpus that matters most: every one of these would
+    // otherwise tell a site owner to fix something that was never theirs.
+    for (const reason of [
+      "Callback 'mark-completed' failed after 3 attempts (HTTP 500: internal error)",
+      "upload failed, HTTP 503 from storage",
+      "database query timed out",
+      "internal API got no response from the billing service",
+      "database query failed after 403 retries",
+    ]) {
+      expect(classifyAuditFailureReasonText(reason)).toBe("unknown");
+    }
+  });
+});

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -3,8 +3,15 @@
 
 import { Effect, Stream, PubSub, Duration, Deferred } from "effect";
 
-import type { LinkData, SitemapData } from "@squirrelscan/core-contracts";
+import type {
+  AuditFailureDetail,
+  AuditFailureSource,
+  FrontierSource,
+  LinkData,
+  SitemapData,
+} from "@squirrelscan/core-contracts";
 import { isCacheHitReason } from "@squirrelscan/core-contracts";
+import { auditFailureDetail } from "@squirrelscan/core-contracts/failure-reason";
 import { COVERAGE_PAGE_LIMITS, REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
 
 import { extractCrawlableUrls } from "@squirrelscan/parser/extractors";
@@ -47,7 +54,12 @@ import type {
 } from "./types";
 
 import { createHostBackoff, type HostBackoffRegistry } from "../host-backoff";
-import { fetchPageWithRetry, type CrawlFetcher, type RateLimitControl } from "../fetcher";
+import {
+  crawlErrorToFailureDetail,
+  fetchPageWithRetry,
+  type CrawlFetcher,
+  type RateLimitControl,
+} from "../fetcher";
 import { normalizeUrl, isInScope, isOffSiteFinalUrl, resolveSeedRedirect } from "../frontier";
 import {
   buildConditionalHeaders,
@@ -83,6 +95,42 @@ import { createTestStorage } from "../storage";
 import { DEFAULT_CRAWLER_CONFIG, CrawlerError } from "./types";
 
 const PATTERN_SAMPLE_LIMIT = 1;
+/**
+ * Which fetch a root failure came from (#1822). The frontier's own `seed`
+ * source is the audited entry URL; everything else reaching a zero-page crawl
+ * came from sitemap discovery, so it is reported as the weaker `sitemap`
+ * source and only used when the seed itself recorded nothing.
+ */
+function failureSourceFor(source: FrontierSource): AuditFailureSource {
+  return source === "seed" ? "entry" : "sitemap";
+}
+
+/**
+ * Host for a failure reason. `urlHostKey` answers the literal string "unknown"
+ * for an unparseable URL, which would render as a hostname in the sentence
+ * ("unknown returned 404"); drop it so the reason falls back to "the site".
+ */
+function failureHostOf(url: string): string | undefined {
+  const host = urlHostKey(url);
+  return host === "unknown" ? undefined : host;
+}
+
+/**
+ * Keep the most explanatory root failure (#1822): the first one recorded wins,
+ * except that a failure on the audited entry URL always displaces one picked up
+ * from a sitemap URL. Order matters because sitemap URLs and the seed are both
+ * enqueued at depth 0 and can be processed in either order.
+ */
+function preferRootFailure(
+  current: AuditFailureDetail | undefined,
+  incoming: AuditFailureDetail | undefined,
+): AuditFailureDetail | undefined {
+  if (!incoming) return current;
+  if (!current) return incoming;
+  if (current.source !== "entry" && incoming.source === "entry") return incoming;
+  return current;
+}
+
 // Hard cap on robots.txt Crawl-delay when respectRobots is true (#790).
 // WP Engine/Yoast sites commonly ship "Crawl-delay: 10", which stretched a
 // 25-page quick audit past 4 minutes of pure sleep.
@@ -493,6 +541,18 @@ export function createCrawler(
         // Check robots
         if (config.respectRobots && robots && !robots.isAllowed(normalized)) {
           logger.debug("url skipped (robots)", normalized);
+          // #1822: a disallowed SEED is the whole audit, not one skipped URL —
+          // the crawl then ends with zero pages and no fetch ever failed, so
+          // this is the only place the cause is knowable.
+          if (source === "seed") {
+            yield* updateStats(crawlId, {
+              rootFailure: auditFailureDetail({
+                code: "robots",
+                host: failureHostOf(normalized),
+                source: "entry",
+              }),
+            });
+          }
           yield* storage.upsertFrontier(crawlId, {
             normalizedUrl: normalized,
             rawUrl,
@@ -1011,6 +1071,10 @@ export function createCrawler(
             yield* updateStats(crawlId, {
               pagesFailed: 1,
               ...(blockedFetch ? { pagesBlocked: 1 } : {}),
+              // #1822: the fetcher knows WHY (DNS, TLS, socket, timeout, 5xx).
+              // Without this the reason is discarded here and a zero-page audit
+              // can only say "No pages were crawled".
+              rootFailure: crawlErrorToFailureDetail(error, failureSourceFor(entry.source)),
             });
             markPrefixFailed(entry.normalizedUrl, entry.depth);
             return;
@@ -1043,7 +1107,18 @@ export function createCrawler(
               depth: entry.depth,
               timestamp: Date.now(),
             });
-            yield* updateStats(crawlId, { pagesFailed: 1 });
+            yield* updateStats(crawlId, {
+              pagesFailed: 1,
+              // #1822: only the redirect TARGET'S HOST goes in the reason. The
+              // full URL is site-chosen and ends up quoted in an email and a
+              // markdown report; a hostname cannot smuggle a path or query.
+              rootFailure: auditFailureDetail({
+                code: "redirect",
+                host: failureHostOf(entry.normalizedUrl),
+                detail: `redirected off-site to ${urlHostKey(result.finalUrl)}`,
+                source: failureSourceFor(entry.source),
+              }),
+            });
             markPrefixFailed(entry.normalizedUrl, entry.depth);
             return;
           }
@@ -1146,7 +1221,19 @@ export function createCrawler(
               depth: entry.depth,
               timestamp: Date.now(),
             });
-            yield* updateStats(crawlId, { pagesFailed: 1 });
+            yield* updateStats(crawlId, {
+              pagesFailed: 1,
+              // #1822: a 4xx (and, from a custom fetcher, a 5xx) comes back as a
+              // RESULT and is stored as a page, so it never reaches the fetch
+              // error path above. Recorded here so a site whose entry URL only
+              // ever 404s says so instead of "no pages could be fetched".
+              rootFailure: auditFailureDetail({
+                code: result.status >= 500 ? "http_5xx" : "http_4xx",
+                status: result.status,
+                host: failureHostOf(entry.normalizedUrl),
+                source: failureSourceFor(entry.source),
+              }),
+            });
             markPrefixFailed(entry.normalizedUrl, entry.depth);
             return;
           }
@@ -1358,6 +1445,10 @@ export function createCrawler(
             updates.cacheHitsByReason,
           ),
           bytesTotal: current.bytesTotal + (updates.bytesTotal ?? 0),
+          // #1822: not a counter — the first explanatory failure wins, with the
+          // entry URL's failure outranking a sitemap URL's. Listed explicitly
+          // because this helper only carries fields it names.
+          rootFailure: preferRootFailure(current.rootFailure, updates.rootFailure),
         };
 
         // Update average load time

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -353,6 +353,19 @@ export function createCrawler(
     // sitemap reported "907 pages rate limited", which is both wasted work and
     // a wildly overstated loss.
     let pagesRateLimitedThisRun = 0;
+    /**
+     * Authoritative root failure for the current crawl (#1822).
+     *
+     * `updateStats` below is a read-modify-write and the worker pool runs
+     * `concurrency` of them at once, so a worker holding a stale read would
+     * write its own `current.rootFailure` back over a failure another worker
+     * had just recorded (the storage layer's merge is a plain spread of the
+     * full stats object, so `undefined` really does erase it). Keeping the
+     * value here and writing THIS on every stats update means a stale read can
+     * never lose it, and the entry-over-sitemap precedence holds regardless of
+     * the order the workers interleave in. Seeded from storage on resume.
+     */
+    let rootFailure: AuditFailureDetail | undefined;
 
     // Breadth-first tracking
     const prefixStats = new Map<string, { crawled: number; queued: number }>();
@@ -1424,6 +1437,13 @@ export function createCrawler(
         const current = yield* storage.getStats(crawlId);
         if (!current) return;
 
+        // Fold before the write so every concurrent updateStats carries the
+        // newest failure, not the one its own (possibly stale) read saw.
+        rootFailure = preferRootFailure(
+          preferRootFailure(rootFailure, current.rootFailure),
+          updates.rootFailure,
+        );
+
         const newStats: CrawlStats = {
           ...current,
           pagesTotal:
@@ -1445,10 +1465,10 @@ export function createCrawler(
             updates.cacheHitsByReason,
           ),
           bytesTotal: current.bytesTotal + (updates.bytesTotal ?? 0),
-          // #1822: not a counter — the first explanatory failure wins, with the
-          // entry URL's failure outranking a sitemap URL's. Listed explicitly
-          // because this helper only carries fields it names.
-          rootFailure: preferRootFailure(current.rootFailure, updates.rootFailure),
+          // #1822: not a counter. The in-memory value is the authority (see its
+          // declaration); `current` only contributes on the first update after a
+          // resume, and `updates` can only displace a weaker source.
+          rootFailure,
         };
 
         // Update average load time
@@ -1500,6 +1520,9 @@ export function createCrawler(
         // forgetting that lets the resumed run dispatch them all over again.
         const priorStats = yield* storage.getStats(crawlId).pipe(Effect.orElseSucceed(() => null));
         pagesRateLimitedThisRun = priorStats?.pagesRateLimited ?? 0;
+        // Resume-safe for the same reason (#1822): a crawl continuing from
+        // persisted stats keeps whatever root failure the earlier pass recorded.
+        rootFailure = priorStats?.rootFailure;
         // Throttle verdicts do not survive a run. Exhaustion is terminal WITHIN
         // a run (an exhausted host is skipped before any request, so it can never
         // earn the successes that recover it), and carrying it forward would make
@@ -1660,6 +1683,19 @@ export function createCrawler(
                   ),
                   Effect.catchAll(() => Effect.void),
                 );
+                // #1822: a wedged entry fetch dies HERE, not in processUrl's
+                // fetch-error path, so without this an audit whose root simply
+                // never answered fell back to the generic reason instead of
+                // saying it timed out. Stats only, and only the failure class:
+                // the counters stay with the paths that own them.
+                yield* updateStats(crawlId, {
+                  rootFailure: auditFailureDetail({
+                    code: "timeout",
+                    host: failureHostOf(entry.normalizedUrl),
+                    detail: `no response within ${urlTimeoutMs}ms`,
+                    source: failureSourceFor(entry.source),
+                  }),
+                }).pipe(Effect.catchAll(() => Effect.void));
               }),
             ),
             Effect.catchAll((error) => {

--- a/packages/crawler/src/fetcher.ts
+++ b/packages/crawler/src/fetcher.ts
@@ -3,11 +3,17 @@ import type { DocumentFetcher } from "@squirrelscan/fetchers";
 import { Effect, Duration, Schedule, pipe } from "effect";
 
 import type {
+  AuditFailureDetail,
+  AuditFailureSource,
   RedirectChain,
   RedirectHop,
   ResponseHeaders,
   SecurityHeaders,
 } from "@squirrelscan/core-contracts";
+import {
+  auditFailureDetail,
+  classifyAuditFailureReasonText,
+} from "@squirrelscan/core-contracts/failure-reason";
 import { CHROME_SEC_CH_UA } from "@squirrelscan/utils/constants";
 import { headersForRedirect } from "@squirrelscan/utils/headers";
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
@@ -36,6 +42,13 @@ export class CrawlError extends Error {
      * `rate_limit` error, and only when the origin actually sent the header.
      */
     readonly retryAfterMs?: number,
+    /**
+     * The HTTP status the origin answered with, when it answered at all
+     * (#1822). Set for the status guards below (403/429/5xx) so a caller can
+     * classify a root failure as `http_4xx` vs `http_5xx` without re-parsing
+     * the message. Absent for transport-level failures, which never got one.
+     */
+    readonly status?: number,
   ) {
     super(message);
     this.name = "CrawlError";
@@ -45,27 +58,105 @@ export class CrawlError extends Error {
     return new CrawlError(url, "timeout", "Crawl request timed out");
   }
 
-  static network(url: string, message: string): CrawlError {
-    return new CrawlError(url, "network", message);
+  static network(url: string, message: string, status?: number): CrawlError {
+    return new CrawlError(url, "network", message, undefined, status);
   }
 
   static parse(url: string, message: string): CrawlError {
     return new CrawlError(url, "parse", message);
   }
 
-  static blocked(url: string, message = "Request blocked by server"): CrawlError {
-    return new CrawlError(url, "blocked", message);
+  static blocked(url: string, message = "Request blocked by server", status = 403): CrawlError {
+    return new CrawlError(url, "blocked", message, undefined, status);
   }
 
   static rateLimit(url: string, retryAfterMs?: number, status?: number): CrawlError {
     const suffix = status ? ` (${status})` : "";
     const wait =
       retryAfterMs === undefined ? "" : `, retry after ${Math.round(retryAfterMs / 1000)}s`;
-    return new CrawlError(url, "rate_limit", `Rate limited${suffix}${wait}`, retryAfterMs);
+    // #1822: a throttle without an explicit status is still a 429-shaped
+    // refusal, so it classifies with the other 4xx refusals.
+    return new CrawlError(
+      url,
+      "rate_limit",
+      `Rate limited${suffix}${wait}`,
+      retryAfterMs,
+      status ?? 429,
+    );
   }
 
   static tls(url: string, message: string): CrawlError {
     return new CrawlError(url, "tls", `TLS/connection error: ${message}`);
+  }
+}
+
+/** Hostname of a URL, for a failure reason. Never the path/query. */
+function failureHost(url: string): string | undefined {
+  try {
+    return new URL(url).hostname || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Turn a {@link CrawlError} into the structured failure the report's
+ * `statusReason` / `statusReasonCode` are built from (#1822).
+ *
+ * The `type` + `status` the fetcher already carries settle most classes
+ * outright; only a transport-level `network` failure has to be read off the
+ * runtime's message, which is what `classifyAuditFailureReasonText` is for
+ * (Bun, Node and undici all phrase DNS and socket failures differently). A
+ * message we cannot attribute stays `unknown` and keeps the raw text as its
+ * detail, so the reason is still more specific than "No pages were crawled" and
+ * never reads as though nothing failed.
+ */
+export function crawlErrorToFailureDetail(
+  error: CrawlError,
+  source: AuditFailureSource = "entry",
+): AuditFailureDetail {
+  const host = failureHost(error.url);
+  const message = error.message;
+  const base = { host, source, status: error.status };
+
+  switch (error.type) {
+    case "timeout":
+      return auditFailureDetail({ ...base, code: "timeout" });
+    case "tls":
+      // `CrawlError.tls` prefixes the runtime message; drop the prefix so the
+      // reason sentence does not say "TLS" twice.
+      return auditFailureDetail({
+        ...base,
+        code: "tls",
+        detail: message.replace(/^TLS\/connection error:\s?/, ""),
+      });
+    case "blocked":
+      return auditFailureDetail({
+        ...base,
+        code: "http_4xx",
+        status: error.status ?? 403,
+        detail: message,
+      });
+    case "rate_limit":
+      // Always reported as 429, the status a throttle MEANS, even when the
+      // origin dressed it as a 503 with a Retry-After (#1829). The status it
+      // actually sent is already in the message.
+      return auditFailureDetail({ ...base, code: "http_4xx", status: 429, detail: message });
+    case "network": {
+      if (error.status !== undefined && error.status >= 500) {
+        return auditFailureDetail({ ...base, code: "http_5xx" });
+      }
+      if (error.status !== undefined && error.status >= 400) {
+        return auditFailureDetail({ ...base, code: "http_4xx", detail: message });
+      }
+      return auditFailureDetail({
+        ...base,
+        code: classifyAuditFailureReasonText(message),
+        detail: message,
+      });
+    }
+    case "parse":
+      return auditFailureDetail({ ...base, code: "unknown", detail: message });
   }
 }
 
@@ -542,7 +633,7 @@ export function applyStatusGuards(
   }
 
   if (status === 403) {
-    return Effect.fail(CrawlError.blocked(url));
+    return Effect.fail(CrawlError.blocked(url, undefined, 403));
   }
 
   if (status >= 500) {
@@ -554,7 +645,7 @@ export function applyStatusGuards(
       // Cloudflare stamps challenge responses explicitly — a body-independent
       // signal (a 503 passed through from a down origin never carries it).
       if (headers.get("cf-mitigated") === "challenge") {
-        return Effect.fail(CrawlError.blocked(url, "Blocked by Cloudflare challenge (503)"));
+        return Effect.fail(CrawlError.blocked(url, "Blocked by Cloudflare challenge (503)", 503));
       }
       if (body) {
         const challenge = detectWafChallengePage({
@@ -571,6 +662,7 @@ export function applyStatusGuards(
             CrawlError.blocked(
               url,
               `Blocked by ${challenge.provider ?? "bot protection"} challenge (503)`,
+              503,
             ),
           );
         }
@@ -586,7 +678,7 @@ export function applyStatusGuards(
         return Effect.fail(CrawlError.rateLimit(url, retryAfterMs, status));
       }
     }
-    return Effect.fail(CrawlError.network(url, `Server error: ${status}`));
+    return Effect.fail(CrawlError.network(url, `Server error: ${status}`, status));
   }
 
   return Effect.void;

--- a/packages/crawler/src/fetcher.ts
+++ b/packages/crawler/src/fetcher.ts
@@ -13,6 +13,8 @@ import type {
 import {
   auditFailureDetail,
   classifyAuditFailureReasonText,
+  classifyFetchErrorCode,
+  fetchErrorCode,
 } from "@squirrelscan/core-contracts/failure-reason";
 import { CHROME_SEC_CH_UA } from "@squirrelscan/utils/constants";
 import { headersForRedirect } from "@squirrelscan/utils/headers";
@@ -49,6 +51,14 @@ export class CrawlError extends Error {
      * the message. Absent for transport-level failures, which never got one.
      */
     readonly status?: number,
+    /**
+     * The runtime error code behind a transport failure (#1822), read off the
+     * error's `cause` chain. Preferred over the message when classifying: a
+     * code is a stable contract, the prose around it is not. Bun 1.3 called a
+     * DNS failure `ConnectionRefused` with "Unable to connect"; Bun 1.4 calls
+     * the same failure `ENOTFOUND` (squirrelscan/repo#1840).
+     */
+    readonly errorCode?: string,
   ) {
     super(message);
     this.name = "CrawlError";
@@ -58,8 +68,13 @@ export class CrawlError extends Error {
     return new CrawlError(url, "timeout", "Crawl request timed out");
   }
 
-  static network(url: string, message: string, status?: number): CrawlError {
-    return new CrawlError(url, "network", message, undefined, status);
+  static network(
+    url: string,
+    message: string,
+    status?: number,
+    errorCode?: string,
+  ): CrawlError {
+    return new CrawlError(url, "network", message, undefined, status, errorCode);
   }
 
   static parse(url: string, message: string): CrawlError {
@@ -151,7 +166,10 @@ export function crawlErrorToFailureDetail(
       }
       return auditFailureDetail({
         ...base,
-        code: classifyAuditFailureReasonText(message),
+        // The runtime code first, the message only when it names nothing we
+        // recognize: the code is a stable contract, the prose is not.
+        code:
+          classifyFetchErrorCode(error.errorCode) ?? classifyAuditFailureReasonText(message),
         detail: message,
       });
     }
@@ -391,7 +409,11 @@ function requestWithTiming(
       const isAbort = (error as Error).name === "AbortError" || message.includes("timed out");
       if (isAbort) return CrawlError.timeout(url);
       if (isTlsError(error)) return CrawlError.tls(url, (error as Error).message);
-      return CrawlError.network(url, (error as Error).message);
+      // #1822: the runtime code is captured HERE because this is the last place
+      // the original error object exists; everything downstream sees only the
+      // CrawlError. Bun 1.4 reports a DNS failure as ENOTFOUND, which no amount
+      // of reading the message reliably recovers on older runtimes.
+      return CrawlError.network(url, (error as Error).message, undefined, fetchErrorCode(error));
     },
   });
 }

--- a/packages/crawler/tests/root-failure-classification.test.ts
+++ b/packages/crawler/tests/root-failure-classification.test.ts
@@ -1,0 +1,313 @@
+// #1822 - the crawler must record WHY the entry URL could not be audited.
+//
+// Before this, every zero-page crawl ended with one string ("No pages were
+// crawled"): the fetcher knew it was a dead socket, an expired certificate or a
+// 403, and `deriveAuditStatusFromPages` never saw any of it. `CrawlStats
+// .rootFailure` carries that classification out of the crawl, so the report,
+// the failure email and Sentry can all branch on the cause.
+
+import { describe, expect, test } from "bun:test";
+import { Duration, Effect, Stream } from "effect";
+
+import type { CrawlStats } from "@squirrelscan/core-contracts";
+
+import { createCrawler } from "../src/core/crawler";
+import { createTestStorage } from "../src/storage";
+import {
+  applyStatusGuards,
+  crawlErrorToFailureDetail,
+  CrawlError,
+  type CrawlFetcher,
+} from "../src/fetcher";
+import type { CrawlerConfig } from "../src/core/types";
+
+const ORIGIN = "https://example.com";
+const URL_ROOT = `${ORIGIN}/`;
+
+describe("crawlErrorToFailureDetail (#1822)", () => {
+  test("DNS: a resolver failure is named, not reported as a generic network error", () => {
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "getaddrinfo ENOTFOUND example.com"),
+    );
+    expect(detail.code).toBe("dns");
+    expect(detail.host).toBe("example.com");
+    expect(detail.source).toBe("entry");
+  });
+
+  test("DNS: an NXDOMAIN phrased by a different runtime classifies the same", () => {
+    expect(
+      crawlErrorToFailureDetail(CrawlError.network(URL_ROOT, "DNS lookup failed: NXDOMAIN")).code,
+    ).toBe("dns");
+  });
+
+  test("TLS: the runtime message is kept but the doubled prefix is dropped", () => {
+    const detail = crawlErrorToFailureDetail(CrawlError.tls(URL_ROOT, "certificate has expired"));
+    expect(detail.code).toBe("tls");
+    expect(detail.detail).toBe("certificate has expired");
+  });
+
+  test("connection: the ejconsultor.es case (socket closed after the handshake)", () => {
+    // The exact message the failed production runs in #1822 carried.
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "The socket connection was closed unexpectedly"),
+    );
+    expect(detail.code).toBe("connection");
+  });
+
+  test("connection: refused and reset sockets classify alongside it", () => {
+    expect(
+      crawlErrorToFailureDetail(CrawlError.network(URL_ROOT, "connect ECONNREFUSED 10.0.0.1:443"))
+        .code,
+    ).toBe("connection");
+    expect(crawlErrorToFailureDetail(CrawlError.network(URL_ROOT, "read ECONNRESET")).code).toBe(
+      "connection",
+    );
+  });
+
+  test("timeout: an aborted request is a timeout, not a connection failure", () => {
+    expect(crawlErrorToFailureDetail(CrawlError.timeout(URL_ROOT)).code).toBe("timeout");
+  });
+
+  test("http_4xx: a refusal carries the status the guard saw", () => {
+    const detail = crawlErrorToFailureDetail(CrawlError.blocked(URL_ROOT));
+    expect(detail.code).toBe("http_4xx");
+    expect(detail.status).toBe(403);
+  });
+
+  test("http_4xx: a rate limit is a 429 refusal, not a server error", () => {
+    const detail = crawlErrorToFailureDetail(CrawlError.rateLimit(URL_ROOT, 30));
+    expect(detail.code).toBe("http_4xx");
+    expect(detail.status).toBe(429);
+  });
+
+  test("http_5xx: a server error keeps its status and stays attributed to the origin", () => {
+    const detail = crawlErrorToFailureDetail(CrawlError.network(URL_ROOT, "Server error: 503", 503));
+    expect(detail.code).toBe("http_5xx");
+    expect(detail.status).toBe(503);
+  });
+
+  test("unknown: an unattributable message keeps its text rather than vanishing", () => {
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "something we have never seen"),
+    );
+    expect(detail.code).toBe("unknown");
+    // "unknown" must never read as "nothing failed": the text still travels.
+    expect(detail.detail).toBe("something we have never seen");
+  });
+
+  test("origin-influenced text is stripped and capped before it reaches a reason", () => {
+    const esc = String.fromCharCode(27);
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.tls(URL_ROOT, `bad${esc}[2Jcert ${"x".repeat(400)}`),
+    );
+    expect(detail.detail).not.toContain(esc);
+    expect(detail.detail!.length).toBeLessThanOrEqual(120);
+  });
+
+  test("a sitemap URL's failure is marked as the weaker source", () => {
+    expect(crawlErrorToFailureDetail(CrawlError.timeout(URL_ROOT), "sitemap").source).toBe(
+      "sitemap",
+    );
+  });
+});
+
+describe("applyStatusGuards carries the status for classification (#1822)", () => {
+  async function guard(status: number, body?: string, headers?: Record<string, string>) {
+    const result = await Effect.runPromise(
+      Effect.either(applyStatusGuards(URL_ROOT, status, new Headers(headers), body)),
+    );
+    return result._tag === "Left" ? result.left : null;
+  }
+
+  test("403 and 429 guards set the status they matched on", async () => {
+    expect((await guard(403))?.status).toBe(403);
+    expect((await guard(429))?.status).toBe(429);
+  });
+
+  test("a 5xx guard sets the status so it classifies as http_5xx", async () => {
+    const error = await guard(502);
+    expect(error?.status).toBe(502);
+    expect(crawlErrorToFailureDetail(error!).code).toBe("http_5xx");
+  });
+
+  test("a Cloudflare challenge 503 stays a 4xx-shaped refusal, not a server error", async () => {
+    const error = await guard(503, undefined, { "cf-mitigated": "challenge" });
+    expect(error?.type).toBe("blocked");
+    const detail = crawlErrorToFailureDetail(error!);
+    expect(detail.code).toBe("http_4xx");
+    expect(detail.detail).toContain("Cloudflare");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// End to end: the classification has to survive the crawl loop and land on the
+// persisted stats, which is the only thing the report builder reads.
+// ----------------------------------------------------------------------------
+
+const EMPTY_RESPONSE_HEADERS = {
+  contentType: null,
+  contentEncoding: null,
+  cacheControl: null,
+  expires: null,
+  vary: null,
+  etag: null,
+  server: null,
+  lastModified: null,
+  link: null,
+  serverTiming: null,
+  age: null,
+  xCache: null,
+  cfCacheStatus: null,
+  xVercelCache: null,
+  altSvc: null,
+  acceptRanges: null,
+} as const;
+const EMPTY_SECURITY_HEADERS = {
+  hsts: null,
+  csp: null,
+  xFrameOptions: null,
+  xContentTypeOptions: null,
+  referrerPolicy: null,
+  permissionsPolicy: null,
+  xRobotsTag: null,
+} as const;
+
+const BASE_CONFIG: Partial<CrawlerConfig> = {
+  concurrency: 1,
+  perHostConcurrency: 1,
+  delayMs: 0,
+  perHostDelayMs: 0,
+  timeoutMs: 500,
+  userAgent: "test",
+  respectRobots: false,
+  incremental: false,
+  useCacheControl: false,
+  breadthFirst: false,
+  disableLinkDiscovery: true,
+  coverageMode: "full",
+  maxPages: 2,
+};
+
+/** A fetcher that always fails the way one real world origin does. */
+function failingFetcher(error: CrawlError): CrawlFetcher {
+  return () => Effect.fail(error);
+}
+
+/** A fetcher that answers every URL with one status and no body. */
+function statusFetcher(status: number): CrawlFetcher {
+  return (url) =>
+    Effect.gen(function* () {
+      yield* applyStatusGuards(url, status, new Headers(), "");
+      return {
+        url,
+        finalUrl: url,
+        status,
+        loadTime: 1,
+        ttfb: 1,
+        downloadTime: 1,
+        headers: { ...EMPTY_RESPONSE_HEADERS, contentType: "text/html" },
+        securityHeaders: EMPTY_SECURITY_HEADERS,
+        contentType: "text/html",
+        body: "",
+        sizeBytes: 0,
+        redirectChain: {
+          sourceUrl: url,
+          finalUrl: url,
+          hops: [],
+          chainLength: 0,
+          isLoop: false,
+          endsInError: false,
+          httpsToHttp: false,
+          httpToHttps: false,
+        },
+        fetcherId: undefined,
+        fallbackReason: undefined,
+      };
+    });
+}
+
+/** Stub the root probes (robots.txt, llms.txt, sitemaps) so they cost nothing. */
+function withStubbedRootProbes<T>(robotsBody: string, run: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: Parameters<typeof fetch>[0]) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const isRobots = url.endsWith("/robots.txt");
+    const res = new Response(isRobots ? robotsBody : "", {
+      status: isRobots ? 200 : 404,
+      headers: { "content-type": "text/plain" },
+    });
+    Object.defineProperty(res, "url", { value: url, configurable: true });
+    return Promise.resolve(res);
+  }) as typeof globalThis.fetch;
+  return run().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+function runCrawl(
+  fetcher: CrawlFetcher,
+  config: Partial<CrawlerConfig> = {},
+): Promise<CrawlStats | null> {
+  const program = Effect.gen(function* () {
+    const storage = yield* createTestStorage();
+    const crawler = yield* createCrawler({
+      fetcher,
+      storage,
+      config: { ...BASE_CONFIG, ...config },
+    });
+    const drain = yield* Stream.runDrain(
+      crawler.events.pipe(Stream.takeUntil((e) => e.type === "completed")),
+    ).pipe(Effect.fork);
+    yield* Effect.yieldNow();
+    yield* crawler.start(ORIGIN).pipe(Effect.timeout(Duration.seconds(10)), Effect.either);
+    const crawlId = crawler.currentCrawlId!;
+    yield* Effect.ignore(drain.await);
+    return yield* storage.getStats(crawlId).pipe(Effect.orElseSucceed(() => null));
+  });
+  return Effect.runPromise(program);
+}
+
+describe("the classification reaches CrawlStats (#1822)", () => {
+  test("a dead socket on the entry URL is recorded as a connection failure", async () => {
+    const stats = await withStubbedRootProbes("", () =>
+      runCrawl(
+        failingFetcher(
+          CrawlError.network(URL_ROOT, "The socket connection was closed unexpectedly"),
+        ),
+      ),
+    );
+    expect(stats?.pagesFetched).toBe(0);
+    expect(stats?.rootFailure?.code).toBe("connection");
+    expect(stats?.rootFailure?.host).toBe("example.com");
+    expect(stats?.rootFailure?.source).toBe("entry");
+  });
+
+  test("a 404 entry URL is a stored page, and is still recorded as a 4xx failure", async () => {
+    // 404 passes applyStatusGuards, so it never reaches the fetch error path:
+    // it is stored as a page and the stats are the only place the class lands.
+    const stats = await withStubbedRootProbes("", () => runCrawl(statusFetcher(404)));
+    expect(stats?.rootFailure?.code).toBe("http_4xx");
+    expect(stats?.rootFailure?.status).toBe(404);
+  });
+
+  test("a 403 entry URL keeps its blocked accounting AND records the class", async () => {
+    const stats = await withStubbedRootProbes("", () => runCrawl(statusFetcher(403)));
+    // #792's signal is untouched, so the run still classifies as `blocked`.
+    expect(stats?.pagesBlocked).toBe(1);
+    expect(stats?.rootFailure?.code).toBe("http_4xx");
+    expect(stats?.rootFailure?.status).toBe(403);
+  });
+
+  test("a robots.txt that disallows the seed is recorded before any fetch", async () => {
+    const stats = await withStubbedRootProbes("User-agent: *\nDisallow: /", () =>
+      runCrawl(statusFetcher(200), { respectRobots: true }),
+    );
+    expect(stats?.rootFailure?.code).toBe("robots");
+    expect(stats?.rootFailure?.host).toBe("example.com");
+  });
+});

--- a/packages/crawler/tests/root-failure-classification.test.ts
+++ b/packages/crawler/tests/root-failure-classification.test.ts
@@ -10,6 +10,10 @@ import { describe, expect, test } from "bun:test";
 import { Duration, Effect, Stream } from "effect";
 
 import type { CrawlStats } from "@squirrelscan/core-contracts";
+import {
+  classifyFetchErrorCode,
+  fetchErrorCode,
+} from "@squirrelscan/core-contracts/failure-reason";
 
 import { createCrawler } from "../src/core/crawler";
 import { createTestStorage } from "../src/storage";
@@ -122,6 +126,52 @@ describe("crawlErrorToFailureDetail (#1822)", () => {
     for (const char of ["[", "]", "<", ">", "`", "|"]) {
       expect(detail.detail).not.toContain(char);
     }
+  });
+
+  test("the runtime error code wins over the message prose", () => {
+    // Bun 1.3 reported a DNS failure as ConnectionRefused with the message
+    // "Unable to connect", and Bun 1.4 reports the same failure as ENOTFOUND
+    // (squirrelscan/repo#1840). Reading the code means the classification
+    // follows the runtime instead of chasing its wording.
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "Unable to connect. Is the computer able to access the url?", undefined, "ENOTFOUND"),
+    );
+    expect(detail.code).toBe("dns");
+  });
+
+  test("a code we do not recognize falls back to the message, not to unknown", () => {
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "getaddrinfo ENOTFOUND example.com", undefined, "SomethingNew"),
+    );
+    expect(detail.code).toBe("dns");
+  });
+
+  test("Bun's PascalCase codes classify alongside the errno spellings", () => {
+    const bun = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "Unable to connect", undefined, "ConnectionRefused"),
+    );
+    const errno = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "connect failed", undefined, "ECONNREFUSED"),
+    );
+    expect(bun.code).toBe("connection");
+    expect(errno.code).toBe(bun.code);
+  });
+
+  test("the code is read off the cause chain, not just the outer error", () => {
+    // undici and Bun both wrap the real failure behind a generic "fetch failed".
+    const wrapped = Object.assign(new Error("fetch failed"), {
+      cause: Object.assign(new Error("getaddrinfo ENOTFOUND example.com"), {
+        code: "ENOTFOUND",
+      }),
+    });
+    expect(fetchErrorCode(wrapped)).toBe("ENOTFOUND");
+    expect(classifyFetchErrorCode(fetchErrorCode(wrapped))).toBe("dns");
+  });
+
+  test("a prototype member cannot be reached through a hostile code", () => {
+    expect(classifyFetchErrorCode("constructor")).toBeUndefined();
+    expect(classifyFetchErrorCode("toString")).toBeUndefined();
+    expect(classifyFetchErrorCode(undefined)).toBeUndefined();
   });
 
   test("a sitemap URL's failure is marked as the weaker source", () => {

--- a/packages/crawler/tests/root-failure-classification.test.ts
+++ b/packages/crawler/tests/root-failure-classification.test.ts
@@ -104,6 +104,26 @@ describe("crawlErrorToFailureDetail (#1822)", () => {
     expect(detail.detail!.length).toBeLessThanOrEqual(120);
   });
 
+  test("an absolute URL in a runtime message is reduced to its host", () => {
+    // A reason is quoted in an email and a markdown report; the path and query
+    // of a site-chosen URL have no business in either.
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "Failed to fetch https://evil.example/private?token=abc123"),
+    );
+    expect(detail.detail).toContain("evil.example");
+    expect(detail.detail).not.toContain("/private");
+    expect(detail.detail).not.toContain("token=abc123");
+  });
+
+  test("markdown and HTML structure characters are dropped from the detail", () => {
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "bad [link](https://evil.example) <img> `code` a|b"),
+    );
+    for (const char of ["[", "]", "<", ">", "`", "|"]) {
+      expect(detail.detail).not.toContain(char);
+    }
+  });
+
   test("a sitemap URL's failure is marked as the weaker source", () => {
     expect(crawlErrorToFailureDetail(CrawlError.timeout(URL_ROOT), "sitemap").source).toBe(
       "sitemap",
@@ -193,11 +213,16 @@ function failingFetcher(error: CrawlError): CrawlFetcher {
   return () => Effect.fail(error);
 }
 
-/** A fetcher that answers every URL with one status and no body. */
-function statusFetcher(status: number): CrawlFetcher {
+/** A fetcher that answers every URL with 200 and the given HTML body. */
+function htmlFetcher(body: string): CrawlFetcher {
+  return (url) => statusFetcher(200, body)(url);
+}
+
+/** A fetcher that answers every URL with one status and an optional body. */
+function statusFetcher(status: number, body = ""): CrawlFetcher {
   return (url) =>
     Effect.gen(function* () {
-      yield* applyStatusGuards(url, status, new Headers(), "");
+      yield* applyStatusGuards(url, status, new Headers(), body);
       return {
         url,
         finalUrl: url,
@@ -208,8 +233,8 @@ function statusFetcher(status: number): CrawlFetcher {
         headers: { ...EMPTY_RESPONSE_HEADERS, contentType: "text/html" },
         securityHeaders: EMPTY_SECURITY_HEADERS,
         contentType: "text/html",
-        body: "",
-        sizeBytes: 0,
+        body,
+        sizeBytes: body.length,
         redirectChain: {
           sourceUrl: url,
           finalUrl: url,
@@ -301,6 +326,30 @@ describe("the classification reaches CrawlStats (#1822)", () => {
     expect(stats?.pagesBlocked).toBe(1);
     expect(stats?.rootFailure?.code).toBe("http_4xx");
     expect(stats?.rootFailure?.status).toBe(403);
+  });
+
+  test("later successful page stores cannot erase a recorded failure", async () => {
+    // `updateStats` is a read-modify-write and the storage merge is a plain
+    // spread of the whole stats object, so before #1822's in-memory authority a
+    // worker holding a stale read wrote its own (empty) rootFailure back over a
+    // recorded one. Here one sub-page 500s and several more succeed AFTER it,
+    // each running its own read-modify-write at concurrency 4.
+    const links = ["/p0", "/p1", "/p2", "/p3", "/p4"];
+    const anchors = links.map((h) => `<a href="${ORIGIN}${h}">${h}</a>`).join("");
+    const fetcher: CrawlFetcher = (url) => {
+      if (url === `${ORIGIN}/p0`) {
+        return Effect.fail(CrawlError.network(url, "Server error: 500", 500));
+      }
+      const body = url === URL_ROOT ? `<!doctype html><html><body>${anchors}</body></html>` : "";
+      return htmlFetcher(body)(url);
+    };
+    const stats = await withStubbedRootProbes("", () =>
+      runCrawl(fetcher, { maxPages: 10, concurrency: 4, disableLinkDiscovery: false }),
+    );
+    // The successful stores ran, and the one failure is still on the row.
+    expect(stats?.pagesFetched).toBeGreaterThan(1);
+    expect(stats?.rootFailure?.code).toBe("http_5xx");
+    expect(stats?.rootFailure?.status).toBe(500);
   });
 
   test("a robots.txt that disallows the seed is recorded before any fetch", async () => {

--- a/packages/report/src/failure-notice.ts
+++ b/packages/report/src/failure-notice.ts
@@ -5,7 +5,12 @@
 // squirrelscan outage. Plain strings only (no JSX) so it renders in any
 // consumer; pure so it can be unit-tested without rendering a page.
 
-import type { AuditStatus } from "@squirrelscan/core-contracts";
+import type { AuditFailureReasonCode, AuditStatus } from "@squirrelscan/core-contracts";
+import {
+  AUDIT_FAILURE_CAUSE,
+  AUDIT_FAILURE_NEXT_STEP,
+  classifyAuditFailureReasonText,
+} from "@squirrelscan/core-contracts/failure-reason";
 
 export interface AuditFailureNotice {
   /** Which failure shape — drives the destructive-vs-muted framing. */
@@ -27,6 +32,12 @@ export interface AuditFailureNotice {
  * Build the failure notice for a report status, or `null` for a normal
  * (completed/partial) audit that needs no notice. `target` is the site the
  * local-run hint should reference (a bare domain or URL).
+ *
+ * `reasonCode` (#1822) swaps the failed-tone copy for the class the crawler
+ * actually hit, so a dead DNS record and an expired certificate no longer read
+ * the same. Omitted, or `unknown`, keeps the pre-#1822 wording verbatim: that
+ * is the copy every stored report and every unattributable failure ships with,
+ * and the HTML report's visible copy is pinned to it (#935).
  */
 export function getAuditFailureNotice(
   status: AuditStatus | null | undefined,
@@ -38,6 +49,7 @@ export function getAuditFailureNotice(
    * slowing down does nothing about a WAF — so the notice has to say which.
    */
   rateLimited?: { pages: number; hosts: string[] },
+  reasonCode?: AuditFailureReasonCode,
 ): AuditFailureNotice | null {
   if (status !== "blocked" && status !== "failed") return null;
 
@@ -79,6 +91,17 @@ export function getAuditFailureNotice(
     };
   }
 
+  if (reasonCode && reasonCode !== "unknown") {
+    return {
+      tone: "failed",
+      heading: "We couldn't audit your site",
+      body: [AUDIT_FAILURE_CAUSE[reasonCode], AUDIT_FAILURE_NEXT_STEP[reasonCode]],
+      steps: [],
+      cliIntro: "Or run it locally:",
+      cliCommand,
+    };
+  }
+
   return {
     tone: "failed",
     heading: "We couldn't audit your site",
@@ -90,4 +113,18 @@ export function getAuditFailureNotice(
     cliIntro: "Or run it locally:",
     cliCommand,
   };
+}
+
+/**
+ * The failure class to render a report with (#1822): the stored
+ * `statusReasonCode` when the report has one, otherwise recovered from the
+ * reason text so reports published before #1822 still get class-specific copy.
+ * Never returns undefined: an unattributable failure is `unknown`, which is
+ * still a failure and never an absence of one.
+ */
+export function reportFailureReasonCode(report: {
+  statusReason?: string;
+  statusReasonCode?: AuditFailureReasonCode;
+}): AuditFailureReasonCode {
+  return report.statusReasonCode ?? classifyAuditFailureReasonText(report.statusReason);
 }

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -188,7 +188,11 @@ export type { AffectedPages, RuleAffectedRollup } from "./affected-pages";
 
 // Failed/blocked audit notice copy (#792, #935) — single source of truth for
 // the static HTML report's FailureNotice and the dashboard's report-detail notice.
-export { getAuditFailureNotice, type AuditFailureNotice } from "./failure-notice";
+export {
+  getAuditFailureNotice,
+  reportFailureReasonCode,
+  type AuditFailureNotice,
+} from "./failure-notice";
 
 // Locked cloud-rules audience messaging (#368, #747, #792, #780) — single
 // source of truth reused by every renderer (html/llm/markdown/text) and the

--- a/packages/report/src/output/html.tsx
+++ b/packages/report/src/output/html.tsx
@@ -52,7 +52,7 @@ import {
   isPageUrl,
   isRedundantPageItem,
 } from "../affected-pages";
-import { getAuditFailureNotice } from "../failure-notice";
+import { getAuditFailureNotice, reportFailureReasonCode } from "../failure-notice";
 import { lockedRulesMessage } from "../locked-rules";
 
 export interface HtmlRenderOptions {
@@ -438,7 +438,14 @@ function ScoreFailed({ status }: { status: "failed" | "blocked" }) {
 // only the trailing clause is local — so it can't drift from the shared
 // builder the way a fully hardcoded duplicate would.
 function FailureNotice({ report }: { report: AuditReport }) {
-  const notice = getAuditFailureNotice(report.status, report.baseUrl, report.rateLimited);
+  // #1822: the class the crawl actually failed in, so the notice names DNS,
+  // TLS, a refusal or a timeout instead of one catch-all paragraph.
+  const notice = getAuditFailureNotice(
+    report.status,
+    report.baseUrl,
+    report.rateLimited,
+    reportFailureReasonCode(report),
+  );
   if (!notice) return null;
   return (
     <div className="failure-notice">

--- a/packages/report/src/output/json.ts
+++ b/packages/report/src/output/json.ts
@@ -1,6 +1,8 @@
 // JSON report output
 
+import type { AuditFailureReasonCode } from "@squirrelscan/core-contracts";
 import type { AuditReport, AuditStatus, CheckItem } from "../types";
+import { reportFailureReasonCode } from "../failure-notice";
 import { getScoreGrade } from "../scoring";
 import { getGroupName } from "../categories";
 import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
@@ -57,6 +59,8 @@ interface SlimJsonReport {
    * site?" without parsing `statusReason` prose.
    */
   rateLimited?: { pages: number; hosts: string[] };
+  /** Machine-readable class behind `statusReason` (#1822); absent pre-#1822. */
+  statusReasonCode?: AuditFailureReasonCode;
   score: {
     overall: number | null; // null ⇒ N/A (failed/0-page audit, #586)
     grade: string;
@@ -183,6 +187,12 @@ function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
     },
     status: report.status ?? "completed",
     ...(report.statusReason ? { statusReason: report.statusReason } : {}),
+    // #1822: a programmatic consumer branches on the class, not on the prose.
+    // Derived when the stored report predates the field, so a CI gate reading
+    // it does not have to special-case older reports.
+    ...(report.status === "failed" || report.status === "blocked"
+      ? { statusReasonCode: reportFailureReasonCode(report) }
+      : {}),
     ...(report.rateLimited && report.rateLimited.pages > 0
       ? { rateLimited: report.rateLimited }
       : {}),

--- a/packages/report/src/output/llm.ts
+++ b/packages/report/src/output/llm.ts
@@ -12,6 +12,8 @@ import { editorSummaryView } from "../editor-summary";
 import { seedRedirect } from "../coverage";
 import { LLM_REPORT } from "@squirrelscan/core-contracts/limits";
 import { stripControlChars } from "@squirrelscan/core-contracts/control-chars";
+import { AUDIT_FAILURE_NEXT_STEP_THIRD } from "@squirrelscan/core-contracts/failure-reason";
+import { reportFailureReasonCode } from "../failure-notice";
 
 export interface LlmRenderOptions {
   version?: string;
@@ -155,8 +157,13 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
         `${indent(1)}To get a full audit: allowlist the squirrelscan crawler, turn off bot fight mode for the audit, or run the CLI from a trusted network with \`squirrel audit ${escapeXml(report.baseUrl)}\`.`,
       );
     } else {
+      // #1822: `reason` on the tag is the one-line class; the body says what
+      // that class means and what to do, third person for the agent surface.
+      // `unknown` keeps the pre-#1822 sentence.
+      const code = reportFailureReasonCode(report);
+      lines.push(`${indent(1)}${escapeXml(AUDIT_FAILURE_NEXT_STEP_THIRD[code])}`);
       lines.push(
-        `${indent(1)}No pages could be fetched from the site, so nothing was audited. The site may have been down, unreachable, or timing out. Check that the site is reachable and try again, or run the CLI with \`squirrel audit ${escapeXml(report.baseUrl)}\`.`,
+        `${indent(1)}Run the CLI with \`squirrel audit ${escapeXml(report.baseUrl)}\` to retry locally.`,
       );
     }
     lines.push("</status>");

--- a/packages/report/src/output/markdown.ts
+++ b/packages/report/src/output/markdown.ts
@@ -2,7 +2,9 @@
 
 import type { ReportBranding } from "@squirrelscan/core-contracts";
 import type { AuditReport } from "../types";
+import { AUDIT_FAILURE_NEXT_STEP } from "@squirrelscan/core-contracts/failure-reason";
 import { cacheReasonsLabel, cacheStatsSummaryLine } from "../cache-stats";
+import { reportFailureReasonCode } from "../failure-notice";
 import { getScoreGrade } from "../scoring";
 import { REPORT_SOURCE_PAGES_PREVIEW, REPORT_PAGES_HARD_CAP } from "../constants";
 import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
@@ -209,10 +211,13 @@ export function renderMarkdown(report: AuditReport, options?: MarkdownRenderOpti
       lines.push("- Turn off bot fight mode (or the blocking rule) for the audit.");
       lines.push("- Run the audit from a trusted network.");
     } else {
-      lines.push(
-        report.statusReason ??
-          "No pages could be fetched from this site, so there was nothing to audit. Check that the site is reachable and try again.",
-      );
+      // #1822: reason line, then the next step for that failure class.
+      const code = reportFailureReasonCode(report);
+      if (report.statusReason) {
+        lines.push(report.statusReason);
+        lines.push("");
+      }
+      lines.push(AUDIT_FAILURE_NEXT_STEP[code]);
     }
     lines.push("");
   } else if (report.healthScore) {

--- a/packages/report/src/output/markdown.ts
+++ b/packages/report/src/output/markdown.ts
@@ -214,7 +214,12 @@ export function renderMarkdown(report: AuditReport, options?: MarkdownRenderOpti
       // #1822: reason line, then the next step for that failure class.
       const code = reportFailureReasonCode(report);
       if (report.statusReason) {
-        lines.push(report.statusReason);
+        // ESCAPED, not trusted. The reason embeds a fragment the audited origin
+        // influenced (a certificate error, a redirect target), and this renders
+        // STORED reports of every vintage, including ones published before the
+        // sanitizer in core-contracts existed. A bare `>` here would turn the
+        // rest of the section into a blockquote.
+        lines.push(escapeMarkdownInline(report.statusReason));
         lines.push("");
       }
       lines.push(AUDIT_FAILURE_NEXT_STEP[code]);

--- a/packages/report/src/output/text.ts
+++ b/packages/report/src/output/text.ts
@@ -2,7 +2,9 @@
 
 import type { ReportBranding } from "@squirrelscan/core-contracts";
 import type { AuditReport } from "../types";
+import { AUDIT_FAILURE_NEXT_STEP } from "@squirrelscan/core-contracts/failure-reason";
 import { cacheReasonsLabel, cacheStatsSummaryLine } from "../cache-stats";
+import { reportFailureReasonCode } from "../failure-notice";
 import { getScoreGrade } from "../scoring";
 import { REPORT_TEXT_WRAP_WIDTH } from "../constants";
 import { groupIssuesByCategory, flattenIssuesBySeverity } from "../grouping";
@@ -178,10 +180,12 @@ export function renderText(report: AuditReport, options?: TextRenderOptions): st
         "To get a full audit: allowlist the squirrelscan crawler, turn off bot fight mode for the audit, or run it from a trusted network.",
       );
     } else {
-      write(
-        report.statusReason ??
-          "No pages could be fetched from this site, so there was nothing to audit. Check that the site is reachable and try again.",
-      );
+      // #1822: the reason names the class (DNS, TLS, connection, timeout, a
+      // status, a redirect, robots) and the line under it says what to do about
+      // that class. `unknown` keeps the pre-#1822 paragraph.
+      const code = reportFailureReasonCode(report);
+      if (report.statusReason) write(report.statusReason);
+      write(AUDIT_FAILURE_NEXT_STEP[code]);
     }
     write("");
   } else if (report.healthScore) {

--- a/packages/report/tests/failure-reason-renderers.test.ts
+++ b/packages/report/tests/failure-reason-renderers.test.ts
@@ -32,7 +32,7 @@ function failedReport(
   };
 }
 
-const DNS = failedReport("DNS lookup failed for ejconsultor.es (NXDOMAIN)", "dns");
+const DNS = failedReport("DNS lookup failed for ejconsultor.es: NXDOMAIN", "dns");
 const TLS = failedReport("TLS handshake with ejconsultor.es failed: certificate has expired", "tls");
 const SERVER = failedReport("ejconsultor.es returned 503 Service Unavailable", "http_5xx");
 
@@ -198,5 +198,36 @@ describe("4xx guidance covers both shapes a 4xx entry URL takes (#1822)", () => 
     const out = renderLlm(GONE);
     expect(out).toContain("404 or 410 means the URL does not exist");
     expect(out).not.toContain("This is usually bot protection");
+  });
+});
+
+describe("the reason is escaped before it reaches markdown (#1822)", () => {
+  // The reason embeds a fragment the audited origin influenced, and the
+  // renderers run over STORED reports of every vintage, including ones
+  // published before the sanitizer in core-contracts existed. An unescaped `>`
+  // at the start of the line turns the rest of the section into a blockquote.
+  const HOSTILE = failedReport(
+    "TLS handshake with example.com failed: > swallow [me](http://evil.test) `x`",
+    "tls",
+  );
+
+  test("markdown escapes it, and the next step still renders after it", () => {
+    const out = renderMarkdown(HOSTILE);
+    const section = out.slice(out.indexOf("## Audit failed"));
+    expect(section).toContain(String.raw`\>`);
+    expect(section).toContain(String.raw`\[me\]`);
+    expect(section).not.toContain("\n> ");
+    expect(section).toContain("TLS certificate");
+  });
+
+  test("the llm renderer escapes it as XML, in the attribute and the body", () => {
+    const out = renderLlm(HOSTILE);
+    const block = out.slice(out.indexOf("<status"), out.indexOf("</status>"));
+    expect(block).not.toContain("<img");
+    expect(block).toContain("&gt;");
+  });
+
+  test("a normal reason is unchanged by the escaping", () => {
+    expect(renderMarkdown(DNS)).toContain("DNS lookup failed for ejconsultor.es: NXDOMAIN");
   });
 });

--- a/packages/report/tests/failure-reason-renderers.test.ts
+++ b/packages/report/tests/failure-reason-renderers.test.ts
@@ -1,0 +1,175 @@
+// #1822 - every renderer for a FAILED report must print the specific reason and
+// a next step that differs by failure class. Before this each surface printed
+// one generic "No pages could be fetched" paragraph, so a dead DNS record, an
+// expired certificate and a 503 all read identically.
+
+import { describe, expect, test } from "bun:test";
+
+import type { AuditFailureReasonCode } from "@squirrelscan/core-contracts";
+
+import type { AuditReport } from "../src/types";
+import { getAuditFailureNotice, reportFailureReasonCode } from "../src/failure-notice";
+import { renderText } from "../src/output/text";
+import { renderMarkdown } from "../src/output/markdown";
+import { renderLlm } from "../src/output/llm";
+import { renderJson } from "../src/output/json";
+
+function failedReport(
+  statusReason: string,
+  statusReasonCode?: AuditFailureReasonCode,
+): AuditReport {
+  return {
+    baseUrl: "https://ejconsultor.es",
+    timestamp: "2026-09-03T14:30:00.000Z",
+    totalPages: 0,
+    passed: 0,
+    warnings: 0,
+    failed: 0,
+    ruleResults: {},
+    status: "failed",
+    statusReason,
+    ...(statusReasonCode ? { statusReasonCode } : {}),
+  };
+}
+
+const DNS = failedReport("DNS lookup failed for ejconsultor.es (NXDOMAIN)", "dns");
+const TLS = failedReport("TLS handshake with ejconsultor.es failed: certificate has expired", "tls");
+const SERVER = failedReport("ejconsultor.es returned 503 Service Unavailable", "http_5xx");
+
+describe("text output (#1822)", () => {
+  test("prints the specific reason, not the generic paragraph", () => {
+    const out = renderText(DNS);
+    expect(out).toContain("AUDIT FAILED");
+    expect(out).toContain("DNS lookup failed for ejconsultor.es");
+    expect(out).not.toContain("No pages could be fetched from this site");
+  });
+
+  test("the next step differs between DNS, TLS and a server error", () => {
+    expect(renderText(DNS)).toContain("DNS records");
+    expect(renderText(TLS)).toContain("TLS certificate");
+    expect(renderText(SERVER)).toContain("error logs");
+  });
+
+  test("an unclassified failure keeps the pre-#1822 paragraph", () => {
+    const out = renderText(failedReport("No pages were crawled"));
+    expect(out).toContain("No pages could be fetched from this site");
+  });
+});
+
+describe("markdown output (#1822)", () => {
+  test("prints the reason and a class-specific next step", () => {
+    const out = renderMarkdown(TLS);
+    expect(out).toContain("## Audit failed");
+    expect(out).toContain("TLS handshake with ejconsultor.es failed");
+    expect(out).toContain("TLS certificate");
+  });
+
+  test("a DNS failure and a server error do not read the same", () => {
+    expect(renderMarkdown(DNS)).not.toBe(renderMarkdown(SERVER));
+    expect(renderMarkdown(DNS)).toContain("DNS records");
+    expect(renderMarkdown(SERVER)).toContain("error logs");
+  });
+});
+
+describe("llm output (#1822)", () => {
+  test("the status block carries the reason attribute and third-person guidance", () => {
+    const out = renderLlm(DNS);
+    expect(out).toContain('<status state="failed"');
+    expect(out).toContain("DNS lookup failed for ejconsultor.es");
+    expect(out).toContain("hostname did not resolve");
+    expect(out).toContain("squirrel audit https://ejconsultor.es");
+    // Agent-facing copy carries no em-dashes.
+    expect(out.slice(out.indexOf("<status"), out.indexOf("</status>"))).not.toContain("—");
+  });
+
+  test("a certificate failure and a server error give different guidance", () => {
+    expect(renderLlm(TLS)).toContain("TLS certificate could not be validated");
+    expect(renderLlm(SERVER)).toContain("returned an error of its own");
+  });
+
+  test("an unclassified failure keeps the pre-#1822 sentence", () => {
+    expect(renderLlm(failedReport("No pages were crawled"))).toContain(
+      "No pages could be fetched from the site",
+    );
+  });
+});
+
+describe("json output (#1822)", () => {
+  test("serializes the machine-readable code alongside the reason", () => {
+    const parsed = JSON.parse(renderJson(DNS));
+    expect(parsed.status).toBe("failed");
+    expect(parsed.statusReasonCode).toBe("dns");
+  });
+
+  test("a report stored before #1822 gets its code derived from the reason text", () => {
+    const parsed = JSON.parse(
+      renderJson(failedReport("TLS handshake with example.com failed: self-signed certificate")),
+    );
+    expect(parsed.statusReasonCode).toBe("tls");
+  });
+
+  test("a completed report carries no failure code", () => {
+    const parsed = JSON.parse(
+      renderJson({
+        baseUrl: "https://example.com",
+        timestamp: "2026-09-03T14:30:00.000Z",
+        totalPages: 3,
+        passed: 5,
+        warnings: 0,
+        failed: 0,
+        ruleResults: {},
+      }),
+    );
+    expect(parsed.statusReasonCode).toBeUndefined();
+  });
+});
+
+describe("the shared failure notice (#1822)", () => {
+  test("a coded failure gets class-specific cause and next-step copy", () => {
+    const notice = getAuditFailureNotice("failed", "ejconsultor.es", undefined, "dns");
+    expect(notice?.body[0]).toContain("resolve");
+    expect(notice?.body[1]).toContain("DNS records");
+  });
+
+  test("no code, or `unknown`, keeps the pre-#1822 copy verbatim (#935)", () => {
+    const legacy = getAuditFailureNotice("failed", "example.com");
+    expect(legacy?.body[0]).toBe(
+      "We couldn't fetch any pages from your site, so there was nothing to audit. The site may have been down, unreachable, or timing out when we tried.",
+    );
+    expect(legacy?.body[1]).toBe("Check that the site is reachable and try again.");
+    expect(getAuditFailureNotice("failed", "example.com", undefined, "unknown")).toEqual(legacy!);
+  });
+
+  test("a blocked run is untouched by the code (#792 copy is load-bearing)", () => {
+    expect(getAuditFailureNotice("blocked", "example.com", undefined, "http_4xx")).toEqual(
+      getAuditFailureNotice("blocked", "example.com")!,
+    );
+  });
+
+  test("reportFailureReasonCode prefers the stored code and falls back to the text", () => {
+    expect(reportFailureReasonCode({ statusReasonCode: "tls", statusReason: "anything" })).toBe(
+      "tls",
+    );
+    expect(reportFailureReasonCode({ statusReason: "Crawl request timed out" })).toBe("timeout");
+    // Never undefined: an unreadable reason is still a failure.
+    expect(reportFailureReasonCode({})).toBe("unknown");
+  });
+});
+
+describe("#1822 and #1829 do not fight over the notice (#1822)", () => {
+  test("a rate-limited block keeps its own copy, whatever the class says", () => {
+    const notice = getAuditFailureNotice(
+      "blocked",
+      "example.com",
+      { pages: 4, hosts: ["example.com"] },
+      "http_4xx",
+    );
+    expect(notice?.heading).toBe("Your site rate limited the audit");
+    expect(notice?.body[0]).toContain("throttling, not bot protection");
+  });
+
+  test("a failed audit with no throttling still gets the class-specific copy", () => {
+    const notice = getAuditFailureNotice("failed", "example.com", undefined, "tls");
+    expect(notice?.body[0]).toContain("TLS handshake");
+  });
+});

--- a/packages/report/tests/failure-reason-renderers.test.ts
+++ b/packages/report/tests/failure-reason-renderers.test.ts
@@ -173,3 +173,30 @@ describe("#1822 and #1829 do not fight over the notice (#1822)", () => {
     expect(notice?.body[0]).toContain("TLS handshake");
   });
 });
+
+describe("4xx guidance covers both shapes a 4xx entry URL takes (#1822)", () => {
+  // The nine-code vocabulary folds a refusal and a missing page into one class,
+  // and the wrong half of the advice is useless: a 403 is a wall to open, a 404
+  // is an address to correct. The copy has to name both, because the code alone
+  // cannot tell them apart.
+  const BLOCK = failedReport("example.com returned 403 Forbidden", "http_4xx");
+  const GONE = failedReport("example.com returned 404 Not Found", "http_4xx");
+
+  test("the reason still names the exact status on each", () => {
+    expect(renderText(BLOCK)).toContain("403 Forbidden");
+    expect(renderText(GONE)).toContain("404 Not Found");
+  });
+
+  test("the next step addresses a refusal AND a missing page", () => {
+    const out = renderText(GONE);
+    expect(out).toContain("allowlist the squirrelscan crawler");
+    expect(out).toContain("404 or 410");
+    expect(out).toContain("check that the address is right");
+  });
+
+  test("the agent-facing guidance does not assert bot protection outright", () => {
+    const out = renderLlm(GONE);
+    expect(out).toContain("404 or 410 means the URL does not exist");
+    expect(out).not.toContain("This is usually bot protection");
+  });
+});


### PR DESCRIPTION
## Problem

A crawl that fetched zero pages ended with one string, "No pages were crawled", on every surface: the report, the CLI output, `agent_runs.error`, the failure email and Sentry. The fetcher already knew whether it was a dead resolver, an expired certificate, a socket closed before any response or a 503. `deriveAuditStatusFromPages` only received the page list and a blocked count, so all of it was discarded.

Real case: `ejconsultor.es`, two failed runs. The origin completes a TLS handshake then closes the connection with no HTTP response. The user was told "No pages were crawled" and nothing else.

## What this does

Gives that knowledge a small user-facing vocabulary and threads it end to end.

**`packages/core-contracts/src/failure-reason.ts`** (new leaf module, no deps beyond the local control-char helper): nine failure codes (`dns`, `tls`, `connection`, `timeout`, `http_4xx`, `http_5xx`, `redirect`, `robots`, `unknown`), the reason sentence builder, per-class next steps in both a second-person and a third-person voice, and `classifyAuditFailureReasonText` for the surfaces that only ever see the string.

**`packages/crawler`**: `CrawlStats.rootFailure` records why the entry URL could not be audited, at all four shapes a root failure takes:

- a failed fetch (DNS, TLS, socket, timeout, 5xx), classified from the `CrawlError` type plus the status the guard matched on
- a stored 4xx page, which never reaches the fetch error path at all
- a `robots.txt` that disallows the seed, where no fetch ever happens
- a refused off-site redirect

`CrawlError` now carries `status`. The recorded failure is held in the crawl closure and written on every stats update, because `updateStats` is a read-modify-write and the storage merge is a plain spread: a worker with a stale read used to write its own empty value back over one another worker had just recorded.

**`packages/audit-engine`**: `deriveAuditStatus` reads it and returns `reasonCode` alongside `reason`. It is consulted only in the two no-content branches, so a healthy crawl whose seed happened to 404 is untouched. A crawl that recorded nothing keeps the pre-#1822 sentences and classifies `unknown`.

**`packages/report`**: `text`, `markdown`, `llm`, `json` and the shared failure notice print the specific reason and the next step for that class. The CLI fork (`reconstruct.ts`) and the console output are threaded too, so `squirrel audit` and the cloud agree.

**`docs/guides/failed-audits.mdx`**: every reason and its fix.

## What is deliberately unchanged

A WAF-blocked root (#792) keeps its `blocked` status **and** its exact sentence: the copy is load-bearing for the Sentry classifier and for the renderers' blocked branch. The provider the crawler detected is appended to it, not substituted. A rate-limited root likewise stays `blocked`. Reports stored before this change have neither field and fall back cleanly, with the code recovered from the reason text where a consumer needs one.

## Untrusted input

`detail` and `host` are influenced by the audited origin and end up in an email, a markdown report and a 500-char database column. Absolute URLs in a runtime message are reduced to their host, the characters that would give a fragment markdown or HTML structure are dropped, control characters are stripped and the length is capped. Emphasis markers are left alone on purpose: they are inert in a one-line fragment and stripping them mangles ordinary identifiers.

## Rebased onto #1829

The rate-limit work landed while this was open and touches the same status derivation, so this is rebased on top of it and the two features are kept apart deliberately:

- A throttled crawl keeps its own `blocked` status and its own sentence. Telling a Shopify operator their store has bot protection when it was throttling sends them to the wrong fix, and that distinction is #1829's whole point. This adds only the machine-readable code.
- A throttle dressed as a 503 with a `Retry-After` is still reported as a 429-shaped refusal, not as a server error, so the owner is not sent to their application logs for a rate limit.
- `getAuditFailureNotice` now takes both signals. A rate-limited block keeps #1829's copy whatever the class says.

Both features' suites were re-run against the merged code.

## Tests

Three new files plus additions to the renderer suite: one test per failure class driven from a fake fetch result through the real classification, four end-to-end crawls proving the value reaches the persisted stats, a regression that later successful page stores cannot erase a recorded failure, renderer coverage that DNS, TLS and a server error no longer read the same, and pins on the #792 blocked copy, the #1829 rate-limit copy and the pre-#1822 fallbacks. Golden and streaming engine suites pass unchanged.

Paired with a change on the private side for the failure email, the in-app notification, the MCP tools and the Sentry classifier.
