### PR TITLE
build(ci): upgrade to Bun 1.4.0

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Bun version to install
     # exact pin: "latest" makes setup-bun resolve the version via api.github.com,
     # which takes all CI down whenever GitHub's API degrades (2026-07-16 outage)
-    default: 1.3.14
+    default: 1.4.0
 
 runs:
   using: composite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing to squirrelscan. Bug fixes, rules, tests, documentation,
 
 ## Development
 
-Use Bun 1.3.14 or the version in `package.json`.
+Use Bun 1.4.0 or the version in `package.json`.
 
 ```bash
 bun install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Use the audit-website skill to audit this site and fix all issues but only crawl
 
 The complete local CLI, crawler, audit engine, rules, report generators, CLI-facing cloud clients, and documentation site are open source in this repository. The hosted API, website, dashboard, and cloud worker implementations are separate private services.
 
-Prerequisites: [Bun 1.3.14](https://bun.sh/) and Git.
+Prerequisites: [Bun 1.4.0](https://bun.sh/) and Git.
 
 ```bash
 git clone https://github.com/squirrelscan/squirrelscan.git

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -49,7 +49,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/semver": "^7.7.1",
     "@types/xml2js": "^0.4.14",
-    "bun-types": "^1.3.14",
+    "bun-types": "^1.4.0",
     "eslint-plugin-github": "^6.0.0",
     "eslint-plugin-sonarjs": "^4.1.0",
     "oxfmt": "^0.21.0",

--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -90,6 +90,7 @@ import {
 } from "@/self/settings";
 import { trackTelemetryEvent, trackError } from "@/self/telemetry";
 import { safeExit } from "@/self/updater";
+import { CWD_UNAVAILABLE, cwdOr } from "@/utils/cwd";
 import { configureLogger, logger, setLogInterceptor } from "@/utils/logger";
 import { getProjectNameContext, parseUserUrl } from "@/utils/url";
 
@@ -789,7 +790,7 @@ export const audit = defineCommand({
       verbose: args.verbose,
       debug: args.debug,
       trace: args.trace,
-      cwd: process.cwd(),
+      cwd: cwdOr(CWD_UNAVAILABLE),
       version: packageVersion,
       bunVersion: Bun.version,
       platform: platform(),
@@ -1473,8 +1474,13 @@ export const audit = defineCommand({
         });
       };
       removeSignalHandlers = (): void => {
-        process.off("SIGINT", onSignal);
-        process.off("SIGTERM", onSignal);
+        // Cast: bun-types >=1.4 declares off/removeListener("memoryPressure")
+        // directly on Process, which hides the inherited EventEmitter overloads
+        // (@types/node only spells out signal names for on/once). The cast
+        // restores them; drop it once bun-types keeps the base signatures.
+        const emitter = process as NodeJS.EventEmitter;
+        emitter.off("SIGINT", onSignal);
+        emitter.off("SIGTERM", onSignal);
       };
       process.once("SIGINT", onSignal);
       process.once("SIGTERM", onSignal);

--- a/apps/cli/src/cli/commands/crawl.ts
+++ b/apps/cli/src/cli/commands/crawl.ts
@@ -13,6 +13,7 @@ import {
 import { runCrawl, type CrawlerEvent } from "@/controllers/crawl";
 import { warnIfSessionUnreadable } from "@/self/credentials";
 import { loadUserSettings, updateSettings } from "@/self/settings";
+import { CWD_UNAVAILABLE, cwdOr } from "@/utils/cwd";
 import { logger, setLogInterceptor } from "@/utils/logger";
 import { getProjectNameContext, parseUserUrl } from "@/utils/url";
 
@@ -84,7 +85,7 @@ export const crawl = defineCommand({
       url: args.url,
       maxPages: args["max-pages"],
       refresh: args.refresh,
-      cwd: process.cwd(),
+      cwd: cwdOr(CWD_UNAVAILABLE),
       version: packageVersion,
       bunVersion: Bun.version,
       platform: platform(),

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -45,6 +45,7 @@ import {
 } from "@squirrelscan/config";
 
 import { safeExit } from "@/self/updater";
+import { cwdOr } from "@/utils/cwd";
 
 // ============================================
 // CLI-SPECIFIC CONFIG FUNCTIONS
@@ -115,10 +116,12 @@ function deepMerge<T extends Record<string, unknown>>(
 }
 
 // Find config file walking up directory tree, stopping at home dir
-export function findConfigFile(
-  startDir: string = process.cwd()
-): string | null {
-  let dir = startDir;
+export function findConfigFile(startDir?: string): string | null {
+  // Not a default parameter: on Bun 1.4 an unresolvable cwd throws, and this
+  // function's contract is "no config found", not "crash the command".
+  const dir0 = startDir ?? cwdOr("");
+  if (!dir0) return null;
+  let dir = dir0;
   const home = homedir();
 
   while (true) {

--- a/apps/cli/src/self/paths.ts
+++ b/apps/cli/src/self/paths.ts
@@ -106,7 +106,21 @@ export function getContentStorePath(): string {
 // EACCES (or any other stat error) now surfaces as err() so callers can warn
 // loudly instead of treating settings as missing (#1057).
 export function findLocalSettingsPath(): Result<string | null> {
-  let dir = process.cwd();
+  // Bun 1.4 surfaces the underlying getcwd(3) failure (EACCES when an ancestor
+  // dir lost +x under us); 1.3 returned a cached path instead. Uncaught, that
+  // turns the err() contract above back into the throw #1057 removed.
+  let dir: string;
+  try {
+    dir = process.cwd();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return err(
+      commandError(
+        code ?? "FILE_READ_ERROR",
+        `Failed to resolve the current directory: ${(error as Error).message}`
+      )
+    );
+  }
   const root = parse(dir).root;
   const home = homedir();
 

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -701,7 +701,12 @@ export function reexecIntoUpdatedBinary(
     // Always restore the previous disposition: a leaked handler would leave
     // the fallback command (or a test process) ignoring Ctrl-C.
     const release = () => {
-      for (const [signal, handler] of handlers) process.off(signal, handler);
+      // Cast: bun-types >=1.4 declares off/removeListener("memoryPressure")
+      // directly on Process, which hides the inherited EventEmitter overloads
+      // (@types/node only spells out signal names for on/once). The cast
+      // restores them; drop it once bun-types keeps the base signatures.
+      const emitter = process as NodeJS.EventEmitter;
+      for (const [signal, handler] of handlers) emitter.off(signal, handler);
     };
 
     let settled = false;

--- a/apps/cli/src/utils/cwd.ts
+++ b/apps/cli/src/utils/cwd.ts
@@ -1,0 +1,20 @@
+// Bun 1.4 propagates the underlying getcwd(3) failure from `process.cwd()`
+// (EACCES once an ancestor of the process's cwd loses +x under us); Bun 1.3
+// returned a cached path and never threw. That turned a call every command
+// makes on its way in — including one that only fills a debug-log field — into
+// a way to abort the whole run, so callers that cannot act on the error read
+// the cwd through here instead.
+//
+// Callers that must report the errno (findLocalSettingsPath in self/paths.ts)
+// keep their own try/catch so the code survives into their Result.
+export function cwdOr(fallback: string): string {
+  try {
+    return process.cwd();
+  } catch {
+    return fallback;
+  }
+}
+
+// What the log field shows when the cwd can no longer be resolved. A literal
+// rather than "" so a log line reads as "we could not tell" instead of "root".
+export const CWD_UNAVAILABLE = "<unavailable>";

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "apps/cli": {
       "name": "@squirrelscan/cli",
-      "version": "0.0.89",
+      "version": "0.0.90",
       "bin": {
         "squirrelscan": "./build/squirrelscan",
       },
@@ -51,7 +51,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/semver": "^7.7.1",
         "@types/xml2js": "^0.4.14",
-        "bun-types": "^1.3.14",
+        "bun-types": "^1.4.0",
         "eslint-plugin-github": "^6.0.0",
         "eslint-plugin-sonarjs": "^4.1.0",
         "oxfmt": "^0.21.0",
@@ -73,7 +73,7 @@
       "name": "@squirrelscan/api-client",
       "version": "0.0.1",
       "devDependencies": {
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "@types/node": "^24.13.1",
       },
     },
@@ -97,7 +97,7 @@
       },
       "devDependencies": {
         "@squirrelscan/synthetic-site": "workspace:*",
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "@types/node": "^24.13.1",
       },
     },
@@ -139,7 +139,7 @@
         "zod": "^3.25.76",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "@types/node": "^24.13.1",
       },
     },
@@ -151,7 +151,7 @@
         "@squirrelscan/utils": "workspace:*",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "@types/node": "^24.13.1",
       },
     },
@@ -213,9 +213,9 @@
         "effect": "^3.21.3",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "@types/node": "^24.13.1",
-        "bun-types": "^1.3.14",
+        "bun-types": "^1.4.0",
         "eslint-plugin-github": "^6.0.0",
         "eslint-plugin-sonarjs": "^4.1.0",
         "oxfmt": "^0.21.0",
@@ -248,7 +248,7 @@
         "user-agents": "^1.1.675",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "@types/node": "^24.13.1",
       },
     },
@@ -826,56 +826,6 @@
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.2", "", { "os": "android", "cpu": "arm" }, "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg=="],
-
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw=="],
-
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A=="],
-
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA=="],
-
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw=="],
-
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg=="],
-
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg=="],
-
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.2", "", { "os": "linux", "cpu": "arm" }, "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA=="],
-
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA=="],
-
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ=="],
-
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg=="],
-
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ=="],
-
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A=="],
-
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w=="],
-
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg=="],
-
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q=="],
-
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg=="],
-
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A=="],
-
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg=="],
-
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg=="],
-
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.2", "", { "os": "none", "cpu": "arm64" }, "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA=="],
-
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg=="],
-
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q=="],
-
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg=="],
-
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
-
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@scalar/agent-chat": ["@scalar/agent-chat@0.12.22", "", { "dependencies": { "@ai-sdk/vue": "3.0.33", "@scalar/api-client": "3.13.7", "@scalar/components": "0.27.9", "@scalar/helpers": "0.9.2", "@scalar/icons": "0.7.5", "@scalar/json-magic": "0.12.19", "@scalar/openapi-types": "0.9.3", "@scalar/schemas": "0.7.4", "@scalar/themes": "0.17.1", "@scalar/types": "0.16.4", "@scalar/use-toasts": "0.10.4", "@scalar/validation": "0.6.2", "@scalar/workspace-store": "0.55.6", "@vueuse/core": "13.9.0", "ai": "6.0.33", "js-base64": "^3.7.8", "neverpanic": "0.0.8", "truncate-json": "3.0.1", "vue": "^3.5.30" } }, "sha512-TQ4K8DOPMzRSwFWEVuJp7a+JQoiPD4WxbG0d7sJilC1dgtdDS6efRmadh87eRa17N+06xWfx5EcXg8hDrfKAFw=="],
@@ -1046,7 +996,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -1326,7 +1276,7 @@
 
     "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -2513,8 +2463,6 @@
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
     "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
-
-    "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squirrelscan-monorepo",
   "private": true,
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "workspaces": ["apps/*", "docs", "packages/*"],
   "scripts": {
     "dev": "cd apps/cli && bun run dev",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -6,7 +6,7 @@
     ".": "./src/index.ts"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "@types/node": "^24.13.1"
   },
   "scripts": {

--- a/packages/audit-engine/package.json
+++ b/packages/audit-engine/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@squirrelscan/synthetic-site": "workspace:*",
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "@types/node": "^24.13.1"
   },
   "private": true,

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -28,7 +28,7 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "@types/node": "^24.13.1"
   },
   "private": true,

--- a/packages/fetchers/package.json
+++ b/packages/fetchers/package.json
@@ -14,7 +14,7 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "@types/node": "^24.13.1"
   },
   "private": true,

--- a/packages/synthetic-site/package.json
+++ b/packages/synthetic-site/package.json
@@ -23,9 +23,9 @@
     "effect": "^3.21.3"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "@types/node": "^24.13.1",
-    "bun-types": "^1.3.14",
+    "bun-types": "^1.4.0",
     "eslint-plugin-github": "^6.0.0",
     "eslint-plugin-sonarjs": "^4.1.0",
     "oxfmt": "^0.21.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,7 @@
     "user-agents": "^1.1.675"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "@types/node": "^24.13.1"
   },
   "scripts": {


### PR DESCRIPTION
Upgrades every Bun pin in this repo from 1.3.14 to **1.4.0**, Bun's Rust port. Part of squirrelscan/repo#1840. The private monorepo half lands separately.

## Pins moved

| Where | From | To |
|---|---|---|
| `.github/actions/setup-bun/action.yml` default | 1.3.14 | 1.4.0 |
| `package.json` `packageManager` | bun@1.3.14 | bun@1.4.0 |
| `@types/bun` / `bun-types` (7 manifests) | ^1.3.14 | ^1.4.0 |
| `README.md`, `CONTRIBUTING.md` prerequisite | 1.3.14 | 1.4.0 |

`grep -rn 1.3.14` over the repo now returns nothing outside `CHANGELOG.md`.

## Two compatibility breaks, both fixed here

**`process.cwd()` throws on 1.4.** The Rust port propagates the underlying `getcwd(3)` failure (EACCES once an ancestor of the process's cwd loses `+x`); 1.3.14 returned a cached path and never threw. `findLocalSettingsPath()` opened with a bare `process.cwd()`, so on 1.4 it threw instead of returning `err()` and silently undid the #1057 contract. Its own EACCES test is what caught this.

The same call also sits behind two debug-log fields (`audit`, `crawl` command start) and config discovery (`findConfigFile`), where an unresolvable cwd should not abort the command. Those now read it through a new `cwdOr()` helper. `init`, `getLocalSettingsPath()` and `getLocalSettingsDir()` deliberately keep throwing: they cannot do their job without a cwd, and citty renders the error.

**`process.off("SIGINT", h)` stopped typechecking.** `bun-types@1.4.0` declares `off`/`removeListener`/`addListener("memoryPressure")` directly on `interface Process`. A member on the derived interface hides the base member, and `@types/node` spells out signal-name overloads for `on`/`once` only, so `"memoryPressure"` became the only accepted event. `process.removeListener` is hidden the same way, so it is not a workaround. Casting to `NodeJS.EventEmitter` restores the base signatures; `off` is an alias of `removeListener`, so runtime behaviour is unchanged. Grep `memoryPressure` to find the casts and delete them once bun-types keeps the base signatures.

## Lockfile

Churn beyond the type version lines is two things, both expected:

- the stale `apps/cli` version field, corrected 0.0.89 to 0.0.90 to match `apps/cli/package.json`
- `rollup` and its 25 platform binaries, which 1.4 no longer installs. `rollup` is an **optional peer** of `@rollup/pluginutils` and no manifest requests it, so 1.3.14 was over-installing. `bun install --frozen-lockfile` passes on 1.4.0 and `notices:check` still reports the same 149 packages.

## Validation

Everything below ran locally on macOS arm64 with 1.4.0, and the test suites were re-run on 1.3.14 to confirm the branch does not break anyone who has not upgraded yet.

- `format:check`, `lint`, `typecheck` (16 workspaces), `notices:check`, `sync-plugin-manifests --check`, `test:release`, `check:psl-freshness`: all pass
- CLI suite, 153 files: **1922 pass / 0 fail on both 1.4.0 and 1.3.14**
- audit engine, 44 files: **328 pass / 0 fail**. `golden-baseline` and `report-stream-v2-golden` peak over this machine's local memory guard and were left to CI
- rules (20 files) and crawler (20 files): pass on both
- `docs:check` (387 pages, no errors) and `docs:build` (390 pages) both succeed
- `bun build --compile` for the host and for `--target=bun-darwin-arm64`: binary runs, reports 0.0.90

`bun audit` (the Dependency audit job) currently fails on `POST /-/npm/v1/security/advisories/bulk 503`. That is npm's endpoint: plain `curl` gets the same 503, and 1.3.14 fails identically. Not related to this change.

## Benchmarks, 1.3.14 vs 1.4.0

Same machine, same source tree, alternating runs.

| Measure | 1.3.14 | 1.4.0 |
|---|---|---|
| `bun install` cold, empty cache, no node_modules | 8.43 s | 8.72 s |
| `bun install` warm cache, no node_modules | 2.01 s | 2.29 s |
| `bun install` fully warm | 0.04 s | 0.09 s |
| CLI suite, 153 files | 30.7 s | 29.2 s |
| audit engine, 44 files | 114.4 s | 113.9 s |
| rules, 20 files | 0.94 s | 0.60 s |
| crawler, 20 files | 9.04 s | 8.69 s |
| `docs:build`, 390 pages | 32.5 / 33.5 s | 31.6 / 33.8 s |
| `bun build --compile --minify` | 0.27 s | 0.30 s |
| compiled binary size | 71 140 706 B | 71 621 618 B |
| CLI startup, `--version`, mean of 10 | 148.4 ms | 137.9 ms |
| CLI suite peak RSS | 1121 MB | 1363 MB |

Install and build are a wash. Test wall-clock is flat to slightly better, with the small rule-heavy suites clearly faster. The binary grows 0.5 MB (+0.7%) and starts about 7% quicker.

Peak RSS is the one number worth watching: it moves around run to run on the CLI suite and 1.4 read higher on the heaviest audit-engine goldens. Nothing here OOMed, but the PGlite-backed suites that are sensitive to this live in the private repo and are measured in that PR.

## Audit parity

`squirrel audit --max-pages 5 --offline --refresh`, binaries built from this same commit with each Bun:

| Site | 1.3.14 | 1.4.0 |
|---|---|---|
| squirrelscan.com | 75, grade C, 603/7/34 | identical |
| docs.squirrelscan.com | 50, grade F, 560/8/82 | identical |
| allbirds.com | 41, 432/54/130 | 42, 434/54/128 |

The first two match byte for byte across the full score object. allbirds.com drifts, but so does 1.3.14 against itself: three consecutive runs of the same 1.3.14 binary gave overall 41, 41, 42 and warnings 130, 128, 129. The 1.4.0 result sits inside that spread, so the variance is the live third-party site, not Bun.


## Bun 1.4 breaking changes, checked one by one

From oven-sh/bun#28792. Every item verified against this repo, not assumed. Measurements are from running the same probe under both Bun versions.

**`--compile` no longer auto-loads tsconfig.json / package.json from cwd.** Not affected, no `--compile-autoload-*` flag needed. Every `package.json` reference in the CLI is a static ESM import that the bundler inlines; a search for runtime reads (`readFileSync`/`Bun.file` on a manifest, or a literal `"tsconfig.json"`) finds none. Verified empirically: both the 1.3.14-built and 1.4.0-built binaries, run from a directory containing a decoy `package.json` with `"version": "9.9.9"` and a `tsconfig.json` whose `paths` point nowhere, still report the embedded `0.0.90`.

**Default lockfileVersion 2, and `isolated` linker for new monorepos.** Not affected, and checked rather than assumed: after a full 1.4.0 install the lockfile header still reads `"lockfileVersion": 1, "configVersion": 1`. No `linker` or `isolated` key appears anywhere in it, there is no `bunfig.toml` in the repo, and `node_modules` keeps the hoisted shape (flat top-level packages plus the `.bun` store). `configVersion: 1` is what pins an existing repo to hoisted, exactly as the changelog describes.

**x64 is baseline-only, `-march=haswell` dropped, old URLs alias.** Not affected. The `build-all` matrix already maps `linux-x64`, `linux-x64-musl` and `windows-x64` to their `-baseline` targets. All seven release targets compile clean on 1.4.0:

| target | 1.3.14 | 1.4.0 | delta |
|---|---|---|---|
| darwin-arm64 | 71 140 706 | 71 621 618 | +0.7% |
| darwin-x64 | 76 808 272 | 78 355 872 | +2.0% |
| linux-x64-baseline | 101 271 680 | 90 186 952 | -10.9% |
| linux-arm64 | 101 296 272 | 90 097 656 | -11.1% |
| linux-x64-musl-baseline | 98 068 768 | 83 932 632 | -14.4% |
| linux-arm64-musl | 96 907 128 | 83 102 832 | -14.2% |
| windows-x64-baseline | 105 391 616 | 96 469 504 | -8.5% |

`--target=bun-darwin-x64` is not baseline-mapped and still resolves, so the aliasing holds.

**Node target 26.3.0, NODE_MODULE_VERSION 147, native addons need rebuilding.** Not affected. Nothing in either tree is compiled from source. Every `.node` file present belongs to a prebuilt per-platform package (lightningcss, oxfmt, oxc-parser, tailwind oxide, sharp, rollup, rolldown, fsevents), all N-API and therefore ABI-stable across a Node version bump. `bindings` and `node-gyp-build` appear in the lockfile only as dependencies of `@vercel/nft`, a static analyser that looks for those names in source rather than loading addons. Exercised in practice: oxfmt, oxlint and every app build (vite, lightningcss, tailwind oxide, rolldown) run clean on 1.4.0.

**`bun:ffi` is now JSC-native, `CString` lost `.ptr`/`.byteLength`/`.arrayBuffer()`.** Not affected. Neither repo imports `bun:ffi`, calls `dlopen`, or constructs a `CString`.

**`bun test`: `resetAllMocks()` now calls mockReset, `toContain()` uses `===`, deepEquals distinguishes boxed primitives.** Not affected on all three. There is no call to `resetAllMocks`, `clearAllMocks` or `restoreAllMocks` anywhere in either repo; the six direct `.mockReset()` / `.mockClear()` calls have unchanged semantics. Of 2329 `toContain()` calls, none passes an object or array literal, so `===` versus deep equality cannot change an outcome. No boxed primitive (`new String`/`Number`/`Boolean`) is constructed anywhere. Backed by the suites: 1922 CLI, 328 audit engine and 4111 private API tests pass on 1.4.0.

**fetch: network errors reject as TypeError, `redirect:"error"` narrowed, idle timeout is an absolute header deadline, HTTP/1.0 pooling, duplicate headers joined.** The one item with a real behaviour change, and our classification survives it. `redirect:"error"` is used nowhere; every call site uses `redirect:"manual"` on purpose, since workerd throws on `"error"` (#685). No call passes Bun's own `timeout`, `proxy`, `protocol` or `tls` fetch options, so the idle-timeout change has no surface here; all deadlines go through `AbortSignal.timeout()`, which is unchanged. Nothing sets a `Connection` header on a client fetch. Measured side by side:

| probe | 1.3.14 | 1.4.0 |
|---|---|---|
| refused, constructor / name | `Error` / `Error` | `TypeError` / `TypeError` |
| refused, `instanceof Error` | true | true |
| refused, `.code` | `ConnectionRefused` | `ConnectionRefused` |
| DNS failure, message | `Unable to connect. Is the computer able to access the url?` | `getaddrinfo ENOTFOUND <host>` |
| DNS failure, `.code` | `ConnectionRefused` | `ENOTFOUND` |
| self-signed TLS | `self signed certificate` / `DEPTH_ZERO_SELF_SIGNED_CERT` | identical |
| abort via `AbortSignal.timeout` | `DOMException` / `TimeoutError` | identical |
| duplicate response headers | joined `"a, b"` | identical |
| `set-cookie` via `get` / `getSetCookie` | `"c1=1, c2=2"` / `["c1=1","c2=2"]` | identical |
| `redirect:"manual"` on a 301 | 301 plus `location` | identical |

Running the crawler's own classifier over those four errors gives **NETWORK, NETWORK, TLS, TIMEOUT on both versions**. `TypeError` extends `Error`, so the `error instanceof Error && error.name === "AbortError"` guards are unaffected, and `isTlsError` still matches because it walks `message` and `code` through the cause chain and both are unchanged for TLS.

The DNS message change is an improvement worth naming: 1.3.14 reported a DNS failure as a connection refusal, and 1.4.0 is the first version where the two are distinguishable. That is also how it surfaced a pre-existing bug, filed separately.

**`node:http` `response.writeHeader()` removed, `dns.lookup()` uses the system resolver on Linux, `fs.open()` with an options object as flags throws.** Not affected. No `writeHeader(` call, no `node:dns` import or `dns.lookup` call, and no `fs.open(` with an options object anywhere in either repo.

**New experimental features, deliberately left off.** `fetch({protocol: "http2" | "http3"})`, the TLS session resumption cache, and fetch proxy headers are all available in 1.4.0 and none is enabled by this PR. A search confirms no `"http2"`, `"http3"` or `protocol:` fetch option appears in either repo. HTTP/2 or HTTP/3 for the crawler is worth evaluating on its own, with its own benchmarks, not smuggled into a runtime bump.
