### PR TITLE
ci: split the whole-tree test run into named suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-bun
+      # First: it takes ~20ms and it is the check that explains itself. Fails if
+      # a test file lands outside every suite, if two suites would run the same
+      # file, if a named suite points at a package that no longer exists, or if
+      # the CLI tests job stops matching scripts/test-suites.ts.
+      - name: Check every test suite is wired into CI
+        run: bun run scripts/test-suites.ts --check
       - name: Check formatting
         run: bun run format:check
       - name: Lint
@@ -38,6 +44,43 @@ jobs:
       - name: Check plugin manifests are in sync
         run: bun run scripts/sync-plugin-manifests.ts --check
 
+  # ---------------------------------------------------------------------------
+  # Which test suites run where (#1670):
+  #
+  #   CLI tests (this job)  every test file in the repo, one step per suite.
+  #                         This job was a single bare `bun test`, which walks the
+  #                         WHOLE tree — packages/* already gated every PR, just
+  #                         invisibly, under a job named for apps/cli. The steps
+  #                         below run exactly that set; a red step now names the
+  #                         package. `rest` is the complement of the named suites,
+  #                         so a new package is covered the day it lands.
+  #   Audit engine golden   packages/audit-engine golden/streaming/redirect/deadline
+  #                         files, again, on their own — a corpus regression is
+  #                         unreadable inside a 400-file log.
+  #   Release tooling       scripts/release-version.test.ts, again, next to the
+  #                         changelog shell test.
+  #   release.yml           still one bare whole-tree `bun test` before a release.
+  #
+  # The last three deliberately re-run files the steps below already cover.
+  #
+  # "Every test file" means what bun discovers: *.test.* / *.spec.* / *_test.* /
+  # *_spec.* with a js/ts extension, any case, outside dot-directories.
+  # scripts/test-suites.ts owns that definition and the split; the quality job's
+  # --check step fails if the two ever disagree.
+  #
+  # Do NOT swap these for `bun run test`: that script is `cd apps/cli && bun test`
+  # and would drop every package. The job name is fixed by the "CLI tests"
+  # required status check in the repo ruleset; renaming it means updating the
+  # ruleset in the same change or every PR blocks on a check that never reports.
+  #
+  # Wall time, measured on run 33955204147 (400 files, 251.6s total):
+  #   audit-engine 143.0s · crawler 60.9s · cli 24.5s · rest 20.4s
+  #   rules 2.5s · report 0.2s
+  # Sequential steps keep that total unchanged. Cheapest first, so a fast suite
+  # still reports if the slow one exhausts timeout-minutes. A parallel matrix
+  # would cut the job to ~160s but renames the check per suite, hence a ruleset
+  # edit; not worth it for one job on the critical path.
+  # ---------------------------------------------------------------------------
   cli-tests:
     name: CLI tests
     needs: quality
@@ -45,8 +88,29 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/setup-bun
-      - run: bun test
+      - id: setup
+        uses: ./.github/actions/setup-bun
+      # Every suite runs even when an earlier one is red, the way the single bare
+      # `bun test` reported every failure at once; each still fails the job. The
+      # setup guard keeps a broken toolchain to one red step instead of six.
+      - name: Report tests
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        run: bun run scripts/test-suites.ts --run report
+      - name: Rules tests
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        run: bun run scripts/test-suites.ts --run rules
+      - name: Remaining package and script tests
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        run: bun run scripts/test-suites.ts --run rest
+      - name: apps/cli tests
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        run: bun run scripts/test-suites.ts --run cli
+      - name: Crawler tests
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        run: bun run scripts/test-suites.ts --run crawler
+      - name: Audit engine tests
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        run: bun run scripts/test-suites.ts --run audit-engine
 
   installer-scripts:
     name: Installer script syntax

--- a/scripts/test-suites.test.ts
+++ b/scripts/test-suites.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  TEST_FILE,
+  bunFilter,
+  checkCoverage,
+  planSuites,
+  selectedBy,
+  suiteNames,
+  suiteRoot,
+  suitesRunBy,
+  testFilesIn,
+} from "./test-suites.ts";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** A ci.yml stand-in that runs exactly the named suites. */
+function workflowRunning(names: string[]): string {
+  return names.map((n) => `      - run: bun run scripts/test-suites.ts --run ${n}\n`).join("");
+}
+
+/** One test file per suite, so the default fixture is a valid partition. */
+const files = [
+  "apps/cli/a.test.ts",
+  "packages/audit-engine/a.test.ts",
+  "packages/crawler/a.test.ts",
+  "packages/rules/a.test.ts",
+  "packages/report/a.test.ts",
+  "scripts/a.test.ts",
+];
+
+describe("testFilesIn", () => {
+  test("keeps every naming bun treats as a test file, whatever the case", () => {
+    const tracked = ["a/x.test.ts", "a/y.spec.tsx", "a/z_test.mts", "a/Cloudflare.Test.ts"];
+    expect(testFilesIn(tracked)).toEqual(tracked);
+  });
+
+  test("drops files bun would never run", () => {
+    // Dot-directories are skipped by bun, so counting them as covered would
+    // certify a file that never executes.
+    expect(testFilesIn([".github/scripts/verify.test.ts"])).toEqual([]);
+    expect(testFilesIn(["packages/a/src/index.ts", "packages/a/tests/helper.ts"])).toEqual([]);
+    // Anchored: `e.test.helper.ts` is not a test file to bun either.
+    expect(testFilesIn(["packages/a/e.test.helper.ts"])).toEqual([]);
+  });
+
+  test("the regex is case-insensitive, because bun's discovery is", () => {
+    expect(TEST_FILE.test("Cloudflare.Test.ts")).toBe(true);
+  });
+});
+
+describe("suiteRoot", () => {
+  test("attributes apps/ and packages/ files to their workspace", () => {
+    expect(suiteRoot("packages/rules/tests/a.test.ts")).toBe("packages/rules");
+    expect(suiteRoot("apps/cli/tests/a.test.ts")).toBe("apps/cli");
+  });
+
+  test("attributes everything else to its top-level directory", () => {
+    expect(suiteRoot("scripts/release-version.test.ts")).toBe("scripts");
+    expect(suiteRoot("npm/scripts/postinstall.test.ts")).toBe("npm");
+  });
+
+  test("attributes a repo-root test file to itself, so bun can still target it", () => {
+    expect(suiteRoot("smoke.test.ts")).toBe("smoke.test.ts");
+    expect(selectedBy(["smoke.test.ts"], ["smoke.test.ts"])).toEqual(["smoke.test.ts"]);
+  });
+});
+
+describe("bunFilter and selectedBy", () => {
+  test("anchors the filter to a real path", () => {
+    expect(bunFilter("packages/report")).toBe("./packages/report");
+  });
+
+  test("a package whose name extends another's is NOT selected", () => {
+    // The reason for the `./`: bare `bun test packages/report` selects
+    // packages/report-v2 too, by substring.
+    const tree = ["packages/report/a.test.ts", "packages/report-v2/a.test.ts"];
+    expect(selectedBy(["packages/report"], tree)).toEqual(["packages/report/a.test.ts"]);
+  });
+
+  test("a nested directory sharing a top-level name is NOT selected", () => {
+    const tree = ["scripts/a.test.ts", "apps/cli/scripts/b.test.ts"];
+    expect(selectedBy(["scripts"], tree)).toEqual(["scripts/a.test.ts"]);
+  });
+});
+
+describe("planSuites", () => {
+  test("puts an unnamed package in rest, not in a named suite", () => {
+    const plan = planSuites(["packages/rules/a.test.ts", "packages/brand-new/a.test.ts"]);
+    expect(plan.find((s) => s.name === "rest")?.roots).toEqual(["packages/brand-new"]);
+    expect(plan.find((s) => s.name === "rules")?.roots).toEqual(["packages/rules"]);
+  });
+
+  test("the suites partition the tree: every file selected, by exactly one suite", () => {
+    const tree = [...files, "packages/newthing/a.test.ts", "npm/scripts/a.test.ts"];
+    const plan = planSuites(tree);
+    const runs = tree.map((f) => plan.filter((s) => selectedBy(s.roots, [f]).length === 1));
+    expect(runs.map((suites) => suites.length)).toEqual(tree.map(() => 1));
+  });
+});
+
+describe("suitesRunBy", () => {
+  test("reads the suite names ci.yml actually runs", () => {
+    expect(suitesRunBy(workflowRunning(["cli", "rest"]))).toEqual(["cli", "rest"]);
+  });
+
+  test("ignores a commented-out step, which runs nothing", () => {
+    const yaml = `${workflowRunning(["cli"])}      # - run: bun run scripts/test-suites.ts --run rest\n`;
+    expect(suitesRunBy(yaml)).toEqual(["cli"]);
+  });
+});
+
+describe("checkCoverage", () => {
+  test("passes when ci.yml runs every suite once", () => {
+    expect(checkCoverage(files, workflowRunning(suiteNames()))).toEqual([]);
+  });
+
+  test("fails when ci.yml drops a suite", () => {
+    const dropped = suiteNames().filter((n) => n !== "rest");
+    expect(checkCoverage(files, workflowRunning(dropped))).toContain(
+      'ci.yml never runs suite "rest"',
+    );
+  });
+
+  test("fails when ci.yml runs a suite twice", () => {
+    expect(checkCoverage(files, workflowRunning([...suiteNames(), "rules"]))).toContain(
+      'ci.yml runs suite "rules" 2 times',
+    );
+  });
+
+  test("fails on a suite name ci.yml invents", () => {
+    expect(checkCoverage(files, workflowRunning([...suiteNames(), "nope"]))).toContain(
+      'ci.yml runs unknown suite "nope"',
+    );
+  });
+
+  test("fails when a suite resolves to no directories, which would run the whole tree", () => {
+    // Nothing outside the named suites, so `rest` is empty and a bare `bun test`
+    // in that step would silently widen to every package.
+    const named = files.filter((f) => !f.startsWith("scripts/"));
+    expect(checkCoverage(named, workflowRunning(suiteNames()))).toContain(
+      'suite "rest" resolves to no directories',
+    );
+  });
+
+  test("fails when a named suite has gone stale, e.g. its package was renamed", () => {
+    // packages/audit-engine -> packages/engine. The rename is invisible to the
+    // complement (rest just absorbs it), but the named suite now runs nothing,
+    // and bun exits non-zero on a filter matching no files.
+    const renamed = files.map((f) => f.replace("packages/audit-engine/", "packages/engine/"));
+    expect(checkCoverage(renamed, workflowRunning(suiteNames()))).toContain(
+      'suite "audit-engine" points at packages/audit-engine/, which has no test files',
+    );
+  });
+
+  test("names the file when two suites would both run it", () => {
+    // `apps/stray.test.ts` makes `apps` a rest root, which also selects apps/cli.
+    const overlapping = [...files, "apps/stray.test.ts"];
+    expect(checkCoverage(overlapping, workflowRunning(suiteNames()))).toContain(
+      'suites "cli" and "rest" both run apps/cli/a.test.ts',
+    );
+  });
+
+  test("does NOT fail on a package whose name merely extends a named suite's", () => {
+    // packages/report-v2 is a substring collision, but `./packages/report` does
+    // not select it, so this is a legal tree and the gate must stay green.
+    const extended = [...files, "packages/report-v2/a.test.ts"];
+    expect(checkCoverage(extended, workflowRunning(suiteNames()))).toEqual([]);
+  });
+
+  test("does NOT fail on a nested scripts/ directory inside a named suite", () => {
+    const nested = [...files, "apps/cli/scripts/gen.test.ts"];
+    expect(checkCoverage(nested, workflowRunning(suiteNames()))).toEqual([]);
+  });
+});
+
+describe("the real repository", () => {
+  test("ci.yml runs every suite, and every test file has exactly one", async () => {
+    const workflow = await Bun.file(join(repoRoot, ".github/workflows/ci.yml")).text();
+    const tracked = Bun.spawnSync(["git", "ls-files", "-z"], { cwd: repoRoot });
+    const tree = testFilesIn(tracked.stdout.toString().split("\0"));
+
+    expect(tree.length).toBeGreaterThan(300);
+    expect(checkCoverage(tree, workflow)).toEqual([]);
+  });
+});

--- a/scripts/test-suites.ts
+++ b/scripts/test-suites.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+/**
+ * Split the whole-tree unit test run into named CI suites (#1670).
+ *
+ * CI's "CLI tests" job used to be a single bare `bun test`. Bare `bun test` walks
+ * the WHOLE tree, so packages/* were already gating every PR — but under a job
+ * called "CLI tests", with one 400-file log, so nobody could tell. This module is
+ * the single source of truth for the split: ci.yml runs one `--run <suite>` step
+ * per suite, and a red step names the package.
+ *
+ * `rest` is the COMPLEMENT of the named suites, computed from the tree rather than
+ * hand-kept, so a new package is covered the day it lands. `--check` (run in the
+ * quality job) fails if a test file escapes every suite, if two suites would run
+ * the same file, if a named suite has gone stale, or if ci.yml stops running one
+ * of them.
+ *
+ * Note `bun run test` is apps/cli ONLY — it is not, and must not become, the CI
+ * entry point.
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const workflow = join(repoRoot, ".github/workflows/ci.yml");
+
+// Suites that get their own step, so a red step names the package. ci.yml orders
+// the steps cheapest-first; this order only shapes --list and error messages.
+const NAMED_SUITES: { name: string; roots: string[] }[] = [
+  { name: "audit-engine", roots: ["packages/audit-engine"] },
+  { name: "crawler", roots: ["packages/crawler"] },
+  { name: "cli", roots: ["apps/cli"] },
+  { name: "rules", roots: ["packages/rules"] },
+  { name: "report", roots: ["packages/report"] },
+];
+const REST_SUITE = "rest";
+
+// Mirrors bun's own test-file convention: *.test.* / *.spec.* / *_test.* / *_spec.*
+// with a js/ts extension. Case-insensitive because bun's discovery is: it runs
+// `Cloudflare.Test.ts`, so a case-sensitive regex here would hide a real file.
+export const TEST_FILE = /(?:\.|_)(?:test|spec)\.(?:m|c)?[jt]sx?$/i;
+
+// bun never descends into dot-directories, so a test file under one cannot run
+// and must not be counted as covered.
+const HIDDEN_PATH = /(?:^|\/)\./;
+
+/** Every tracked test file bun could run, repo-relative. */
+export function testFilesIn(tracked: string[]): string[] {
+  return tracked.filter((f) => f !== "" && TEST_FILE.test(f) && !HIDDEN_PATH.test(f));
+}
+
+function trackedFiles(): string[] {
+  const out = Bun.spawnSync(["git", "ls-files", "-z"], { cwd: repoRoot });
+  if (out.exitCode !== 0) throw new Error(`git ls-files failed: ${out.stderr.toString()}`);
+  // -z, so a path with a space or quote arrives verbatim rather than git-quoted.
+  return out.stdout.toString().split("\0");
+}
+
+/**
+ * The directory a test file is attributed to: `apps/<x>` and `packages/<x>` keep
+ * their workspace, anything else groups under its top-level directory.
+ */
+export function suiteRoot(file: string): string {
+  const parts = file.split("/");
+  if ((parts[0] === "apps" || parts[0] === "packages") && parts.length > 2) {
+    return `${parts[0]}/${parts[1]}`;
+  }
+  return parts[0] ?? "";
+}
+
+/** Resolve every suite against a set of test files. `rest` is the complement. */
+export function planSuites(files: string[]): { name: string; roots: string[] }[] {
+  const claimed = new Set(NAMED_SUITES.flatMap((s) => s.roots));
+  const restRoots = [...new Set(files.map(suiteRoot))].filter((r) => !claimed.has(r)).sort();
+  return [...NAMED_SUITES, { name: REST_SUITE, roots: restRoots }];
+}
+
+/**
+ * How a root is handed to bun. The `./` matters: a bare filter is a path
+ * SUBSTRING, so `scripts` also selects `apps/cli/scripts/` and `packages/report`
+ * also selects `packages/report-v2`. `./scripts` resolves as a real path instead,
+ * which is what makes each file land in exactly one suite.
+ */
+export function bunFilter(root: string): string {
+  return `./${root}`;
+}
+
+/** The files `bun test ./<root>` would select. */
+export function selectedBy(roots: string[], files: string[]): string[] {
+  return files.filter((f) => roots.some((root) => f === root || f.startsWith(`${root}/`)));
+}
+
+/** Suite names ci.yml is expected to run. */
+export function suiteNames(): string[] {
+  return [...NAMED_SUITES.map((s) => s.name), REST_SUITE];
+}
+
+/**
+ * Suite names ci.yml actually runs, parsed from its `--run <suite>` steps.
+ * Comment lines are skipped: a commented-out step runs nothing and must not
+ * count as coverage, and the job's own comment block names this script.
+ */
+export function suitesRunBy(workflowYaml: string): string[] {
+  const names: string[] = [];
+  for (const line of workflowYaml.split("\n")) {
+    if (/^\s*#/.test(line)) continue;
+    const match = line.match(/test-suites\.ts\s+--run\s+([a-z0-9-]+)/);
+    if (match) names.push(match[1] as string);
+  }
+  return names;
+}
+
+/**
+ * Reasons ci.yml and the tree disagree. Empty means the split is sound: every
+ * test file runs in exactly one suite, and ci.yml runs each suite exactly once.
+ */
+export function checkCoverage(files: string[], workflowYaml: string): string[] {
+  const problems: string[] = [];
+  const plan = planSuites(files);
+
+  for (const suite of plan) {
+    // No roots would make `bun test` run with no filter at all — the whole tree,
+    // in a step claiming to be one package.
+    if (suite.roots.length === 0) {
+      problems.push(`suite "${suite.name}" resolves to no directories`);
+      continue;
+    }
+    // A renamed or deleted package leaves a named suite pointing at nothing. bun
+    // exits non-zero on a filter that matches no files, so this would surface as
+    // an opaque failure in the test job rather than here.
+    for (const root of suite.roots) {
+      if (selectedBy([root], files).length === 0) {
+        problems.push(`suite "${suite.name}" points at ${root}/, which has no test files`);
+      }
+    }
+  }
+
+  // Two suites running the same file is wasted time rather than lost coverage,
+  // but it means the split has stopped being a partition, so treat it as drift.
+  const owners = new Map<string, string>();
+  for (const suite of plan) {
+    for (const file of selectedBy(suite.roots, files)) {
+      const owner = owners.get(file);
+      if (owner === undefined) owners.set(file, suite.name);
+      else problems.push(`suites "${owner}" and "${suite.name}" both run ${file}`);
+    }
+  }
+  for (const file of files) {
+    if (!owners.has(file)) problems.push(`no suite runs ${file}`);
+  }
+
+  const expected = suiteNames();
+  const actual = suitesRunBy(workflowYaml);
+  for (const name of expected) {
+    const runs = actual.filter((a) => a === name).length;
+    if (runs === 0) problems.push(`ci.yml never runs suite "${name}"`);
+    else if (runs > 1) problems.push(`ci.yml runs suite "${name}" ${runs} times`);
+  }
+  for (const name of actual) {
+    if (!expected.includes(name)) problems.push(`ci.yml runs unknown suite "${name}"`);
+  }
+  return problems;
+}
+
+async function main(): Promise<number> {
+  const [flag, value] = process.argv.slice(2);
+
+  if (flag === "--list") {
+    console.log(suiteNames().join("\n"));
+    return 0;
+  }
+
+  if (flag === "--check") {
+    const problems = checkCoverage(testFilesIn(trackedFiles()), await Bun.file(workflow).text());
+    if (problems.length === 0) {
+      console.log(`test suites cover every test file (${suiteNames().join(", ")})`);
+      return 0;
+    }
+    for (const p of problems) console.error(`error: ${p}`);
+    console.error(
+      "\nFix scripts/test-suites.ts and the unit test steps in .github/workflows/ci.yml.",
+    );
+    return 1;
+  }
+
+  if (flag === "--run") {
+    const suite = planSuites(testFilesIn(trackedFiles())).find((s) => s.name === value);
+    if (!suite) {
+      console.error(`error: unknown suite "${value}". Known: ${suiteNames().join(", ")}`);
+      return 1;
+    }
+    // Guarded by --check, but re-asserted here: bare `bun test` would silently
+    // widen this step to the whole tree.
+    if (suite.roots.length === 0) {
+      console.error(`error: suite "${value}" resolves to no directories`);
+      return 1;
+    }
+    const filters = suite.roots.map(bunFilter);
+    console.log(`bun test ${filters.join(" ")}`);
+    const proc = Bun.spawn(["bun", "test", ...filters], {
+      cwd: repoRoot,
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+    // `exited`, not `exitCode`: a signal-killed run (an OOM kill, say) reports
+    // exitCode null but resolves `exited` to 137, so the step still fails.
+    return await proc.exited;
+  }
+
+  console.error("usage: bun run scripts/test-suites.ts --list | --check | --run <suite>");
+  return 1;
+}
+
+if (import.meta.main) process.exit(await main());


### PR DESCRIPTION
Refs squirrelscan/repo#1670.

## The issue's premise was wrong, and that is the finding

squirrelscan/repo#1670 says "packages/* test suites never run in public-repo CI". They do, and they always have. The `CLI tests` job ran a **bare** `bun test`, and a bare `bun test` walks the whole tree, unlike `bun run test` (which is `cd apps/cli && bun test`).

Evidence from the last green run before this branch, [run 33955204147](https://github.com/squirrelscan/squirrelscan/actions/runs/33955204147), job `CLI tests`:

```
Ran 5111 tests across 400 files. [251.62s]
 5107 pass
 0 fail
```

Those 400 files, counted from the per-file group markers in that log:

| suite | files | time |
|---|---|---|
| apps/cli | 153 | 24.5s |
| packages/rules | 87 | 2.5s |
| packages/audit-engine | 46 | 143.0s |
| packages/crawler | 43 | 60.9s |
| packages/report | 30 | 0.2s |
| the other 11 packages, npm, scripts | 41 | 20.4s |

So a failure in `packages/rules` **already** failed the PR. What was missing was legibility: it happened under a job named for apps/cli, in one 400-file log, with nothing stating the arrangement or stopping it from silently changing.

## What changed

**Before:** one step, `bun test`, in a job called `CLI tests`.

**After:** one step per suite in the same job, so a red step names the package. Same file set, verified below.

`scripts/test-suites.ts` is the single source of truth. `rest` is the **complement** of the named suites computed from the tree, not a hand-kept list, so a new package is covered the day it lands. `--check` runs in the quality job (first, ~20ms) and fails if:

- a test file escapes every suite,
- two suites would run the same file,
- a named suite points at a package that no longer exists (a rename would otherwise leave the step running nothing while `rest` quietly absorbed the files),
- ci.yml stops running a suite, runs one twice, or invents a name. Commented-out steps do not count as coverage.

Roots are handed to bun as `./<root>`. A bare filter is a path **substring**, verified: `bun test report` matches 48 files across the tree, `bun test scripts` picks up `apps/cli/scripts/` as well, and `packages/report` would also select a future `packages/report-v2`. `./scripts` matches 3 files where `scripts` matches 4.

## Acceptance criteria

1. **packages/rules, packages/crawler, packages/audit-engine run and fail the PR.** They already did; now each is its own named step. Failure propagation re-verified by planting a failing test in `packages/report`: the step exits 1.
2. **The golden/streaming engine jobs stay separate.** `engine-tests` and `release-tooling` are untouched. Both deliberately re-run files the new steps also cover, and the comment now says so, along with `release.yml`, which still runs its own bare whole-tree `bun test`.
3. **A comment in ci.yml states which suites run where.** Above the job, including why the job cannot be renamed and what "every test file" means.
4. **Wall time.** Unchanged: the same files, same order of magnitude, six sequential steps at ~20ms of wrapper overhead each. Steps run cheapest-first so a fast suite still reports if the slow one exhausts `timeout-minutes`.

## The job could not be renamed

`CLI tests` is a **required status check** in this repo's ruleset (`Protect main`, id 19657274), alongside `Format, lint, and typecheck`, `Audit engine golden tests` and others. Renaming the job, or moving to a `strategy.matrix` (which renames checks to `Unit tests (cli)` and so on), makes the required check never report and blocks every PR until someone edits the ruleset. So the job keeps its name and the split lives in steps.

A matrix would cut this job from ~275s to ~160s of wall time, and since `engine-tests` already runs 179s in parallel it would take the whole workflow off this job's critical path. That is a real win, but it needs a ruleset edit landed in the same change. Happy to follow up if you want it.

## Verification

Locally, per suite, file counts matching the CI table exactly:

| suite | result |
|---|---|
| report | 325 pass, 0 fail, 30 files |
| rules | 1609 pass, 0 fail, 87 files |
| rest | 550 pass, 0 fail, 42 files |
| cli | 1922 pass, 1 skip, 0 fail, 153 files, 24.7s |
| crawler | 370 tests, 43 files |
| audit-engine | see below |
| scripts/test-suites.test.ts | 23 pass, 0 fail |

`actionlint` clean, `bun run format:check` clean, `--check` green.

**audit-engine** was verified in two halves rather than as one run: its 29 non-golden files pass in 0.72s, and the 17 golden/streaming/deadline files are exactly what the already-green `engine-tests` job runs. The combined 46-file run peaks over 1.3GB, above my local test watchdog's ceiling, so CI is the arbiter for the union. It is a strict subset of the 400 files that run in one process today, so it should not be new pressure.

**One thing to know:** `packages/crawler` has a pre-existing, load-dependent flake. Running its 43 files on a loaded machine failed once in each of two runs, a different test each time (`trailing-slash-canonical-crawl` and `seed-redirect-pinning`), and passed clean on the third. Both pass in isolation. This branch touches nothing in that package, and CI has been green, but the timing-sensitive redirect tests are worth knowing about. Filed separately.