### PR TITLE
feat(installer): enforce HTTPS-only, TLS 1.2+ and a redirect cap on every curl in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,11 @@ REPO="squirrelscan/squirrelscan"
 # the floor, and --max-redirs bounds the chain. The binary is checksum-verified
 # against the manifest, but the metadata fetches and the bash re-exec have no
 # integrity protection beyond the transport itself (#165).
-# All four options predate curl 7.34 (2013), below every platform we support.
+# --tlsv1.2 is the youngest of the four and landed in curl 7.34 (2013), below
+# every platform we support: the oldest realistic holdout is RHEL 7 at curl
+# 7.29, whose glibc 2.17 is already under the bun standalone binary's floor.
+# An unsupported option exits 2 with "option ...: is unknown", which
+# fetch_with_retry discards, so it would read as three failed download retries.
 CURL_TLS_ARGS=(--proto '=https' --proto-redir '=https' --tlsv1.2 --max-redirs 3)
 
 # Detect if stdout is a terminal for colors
@@ -182,7 +186,10 @@ SELF_INSTALL_KILL_CODES="137 143"
 SELF_INSTALL_KILLED_STEP="self_install_killed"
 
 # Indirected so the tests can point the probe at fixtures instead of the real
-# kernel interfaces; SQUIRREL_ERROR_ENDPOINT above is seamed the same way.
+# kernel interfaces. SQUIRREL_ERROR_ENDPOINT and SQUIRREL_RELEASES_ENDPOINT
+# above are seamed the same way, but since #165 both are HTTPS-only: curl
+# refuses a plain-http override with "Protocol http disabled", so a local
+# stand-in has to serve TLS that the running curl already trusts.
 CGROUP_ROOT="${SQUIRREL_CGROUP_ROOT:-/sys/fs/cgroup}"
 PROC_SELF_CGROUP="${SQUIRREL_PROC_SELF_CGROUP:-/proc/self/cgroup}"
 PROC_MEMINFO="${SQUIRREL_PROC_MEMINFO:-/proc/meminfo}"

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,9 @@ if [ -z "${BASH_VERSION:-}" ]; then
     case "$0" in
       */install.sh | install.sh) exec bash "$0" "$@" ;;
     esac
-    exec bash -c 'curl -fsSL https://install.squirrelscan.com/install.sh | bash'
+    # Hardened by hand rather than via CURL_TLS_ARGS: this runs under /bin/sh
+    # before the bash-only preamble that defines the array (see #165).
+    exec bash -c 'curl -fsSL --proto "=https" --proto-redir "=https" --tlsv1.2 --max-redirs 3 https://install.squirrelscan.com/install.sh | bash'
   fi
   echo "Error: the squirrelscan installer requires bash, and none was found." >&2
   echo "  Install bash, or grab a binary from https://github.com/squirrelscan/squirrelscan/releases" >&2
@@ -34,6 +36,17 @@ set -euo pipefail
 #   GITHUB_TOKEN       - GitHub token to avoid API rate limits (optional)
 
 REPO="squirrelscan/squirrelscan"
+
+# Transport hardening for every curl this script runs. curl's own defaults will
+# happily follow a redirect from https to plain http and will negotiate whatever
+# TLS version the local build still allows, so pin both: --proto bounds the
+# scheme of the initial request, --proto-redir bounds it again on every hop
+# (the two are separate settings — one does not imply the other), --tlsv1.2 sets
+# the floor, and --max-redirs bounds the chain. The binary is checksum-verified
+# against the manifest, but the metadata fetches and the bash re-exec have no
+# integrity protection beyond the transport itself (#165).
+# All four options predate curl 7.34 (2013), below every platform we support.
+CURL_TLS_ARGS=(--proto '=https' --proto-redir '=https' --tlsv1.2 --max-redirs 3)
 
 # Detect if stdout is a terminal for colors
 if [ -t 1 ]; then
@@ -151,7 +164,7 @@ report_error() {
   # immediately (non-blocking); curl is reparented to init so it still gets to
   # finish after the script exits. Tight timeouts are the backstop; stdio
   # discarded so a closed pipe can't SIGPIPE it.
-  ( curl -fsS -m 3 --connect-timeout 2 -X POST \
+  ( curl "${CURL_TLS_ARGS[@]}" -fsS -m 3 --connect-timeout 2 -X POST \
       -H 'Content-Type: application/json' \
       --data "$payload" "$ERROR_ENDPOINT" >/dev/null 2>&1 & ) 2>/dev/null || true
 }
@@ -519,7 +532,7 @@ fetch_with_retry() {
   local timeout_max=120
 
   for i in $(seq 1 $attempts); do
-    if curl -fsSL --connect-timeout "$timeout_connect" --max-time "$timeout_max" "$url" -o "$output" 2>/dev/null; then
+    if curl "${CURL_TLS_ARGS[@]}" -fsSL --connect-timeout "$timeout_connect" --max-time "$timeout_max" "$url" -o "$output" 2>/dev/null; then
       return 0
     fi
     if [ "$i" -lt "$attempts" ]; then
@@ -702,7 +715,7 @@ get_latest_version() {
 
   info "Fetching releases (channel: $channel)..."
 
-  if response=$(curl -fsSL -H "User-Agent: squirrelscan-installer" \
+  if response=$(curl "${CURL_TLS_ARGS[@]}" -fsSL -H "User-Agent: squirrelscan-installer" \
       --connect-timeout 5 --max-time 15 \
       "${RELEASES_ENDPOINT}/${channel}" 2>/dev/null); then
     if [ "$USE_JQ" = true ]; then
@@ -719,7 +732,7 @@ get_latest_version() {
   warn "Release metadata endpoint unavailable, falling back to GitHub API..."
 
   # Build curl args - add auth header if GITHUB_TOKEN is set (avoids rate limits)
-  local curl_args=(-fsSL -H "User-Agent: squirrelscan-installer" --connect-timeout 10 --max-time 30)
+  local curl_args=("${CURL_TLS_ARGS[@]}" -fsSL -H "User-Agent: squirrelscan-installer" --connect-timeout 10 --max-time 30)
   if [ -n "${GITHUB_TOKEN:-}" ]; then
     curl_args+=(-H "Authorization: token $GITHUB_TOKEN")
   fi

--- a/scripts/install-contract.test.ts
+++ b/scripts/install-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { rmSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -8,6 +8,195 @@ const powershellInstaller = await Bun.file(new URL("../install.ps1", import.meta
 const npmPostinstall = await Bun.file(
   new URL("../npm/scripts/postinstall.js", import.meta.url),
 ).text();
+
+// --- curl test double -----------------------------------------------------
+// install.sh pins every curl to HTTPS (#165), so a plaintext loopback server
+// can no longer stand in for an endpoint, and a TLS one would need a CA the
+// child curl trusts — macOS ships a SecureTransport curl that does not read
+// CURL_CA_BUNDLE, so that would pass in CI and fail on half the dev machines.
+// Shim curl on PATH instead. Recording argv is also what proves the hardening
+// flags reach a real invocation rather than merely appearing in the source.
+const CURL_SHIM = `#!/bin/bash
+for a in "$@"; do printf '%s\\0' "$a"; done >> "$SHIM_LOG"
+printf '\\036' >> "$SHIM_LOG"
+
+if [ -n "\${SHIM_FAIL_MATCH:-}" ]; then
+  for a in "$@"; do
+    case "$a" in *"$SHIM_FAIL_MATCH"*) exit 22 ;; esac
+  done
+fi
+
+out=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-o" ]; then out="$a"; fi
+  prev="$a"
+done
+
+if [ -n "$out" ]; then
+  printf '%s' "\${SHIM_BODY:-}" > "$out"
+else
+  printf '%s' "\${SHIM_BODY:-}"
+fi
+exit 0
+`;
+
+// Two sourceable cuts of the installer: everything above the EXIT trap (the
+// reporting preamble), and everything above the final `main "$@"` (the whole
+// script as a function library, which is what the download helpers need).
+const INSTALLER_PREAMBLE = shellInstaller.slice(
+  0,
+  shellInstaller.indexOf("trap report_on_exit EXIT"),
+);
+const INSTALLER_BODY = shellInstaller.slice(0, shellInstaller.lastIndexOf('\nmain "$@"'));
+
+type CurlShimRun = {
+  /** argv of each curl invocation, in the order the script made them. */
+  calls: string[][];
+  stdout: string;
+  stderr: string;
+  code: number;
+};
+
+const parseCurlLog = (raw: string): string[][] =>
+  raw
+    .split("\u001e")
+    .filter((record) => record.length > 0)
+    // Every record is `arg\0arg\0…arg\0`, so the split leaves a trailing "".
+    .map((record) => record.split("\u0000").slice(0, -1));
+
+const runWithCurlShim = async (
+  script: string,
+  {
+    cut = "body",
+    body = "",
+    failMatch = "",
+    env = {},
+    settleMs = 0,
+  }: {
+    cut?: "body" | "preamble";
+    /** What the shim answers with: written to `-o <file>` when given, else stdout. */
+    body?: string;
+    /** The shim exits 22 (curl's HTTP-error code) when any argv contains this. */
+    failMatch?: string;
+    env?: Record<string, string | undefined>;
+    /** How long to wait for a detached (backgrounded) curl to log its argv. */
+    settleMs?: number;
+  } = {},
+): Promise<CurlShimRun> => {
+  const dir = mkdtempSync(join(tmpdir(), "install-curl-shim-"));
+  const log = join(dir, "curl-calls");
+  const shim = join(dir, "curl");
+  const sourced = join(dir, "installer.sh");
+  await Bun.write(shim, CURL_SHIM);
+  chmodSync(shim, 0o755);
+  await Bun.write(sourced, cut === "body" ? INSTALLER_BODY : INSTALLER_PREAMBLE);
+  await Bun.write(log, "");
+
+  try {
+    const proc = Bun.spawn(["bash", "-c", `source "$1"; ${script}`, "--", sourced], {
+      env: {
+        ...process.env,
+        NO_TELEMETRY: "1",
+        PATH: `${dir}:${process.env.PATH ?? ""}`,
+        SHIM_LOG: log,
+        SHIM_BODY: body,
+        SHIM_FAIL_MATCH: failMatch,
+        ...env,
+      } as Record<string, string>,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const code = await proc.exited;
+    for (let waited = 0; waited < settleMs; waited += 50) {
+      if ((await Bun.file(log).text()) !== "") break;
+      await Bun.sleep(50);
+    }
+    return { calls: parseCurlLog(await Bun.file(log).text()), stdout, stderr, code };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+// --- curl transport hardening (#165) --------------------------------------
+// curl's defaults follow a redirect from https straight to plain http and
+// negotiate whatever TLS version the local build still allows.
+const CURL_HARDENING = [
+  ["--proto", "=https"],
+  ["--proto-redir", "=https"],
+  ["--tlsv1.2"],
+  ["--max-redirs", "3"],
+];
+
+/** Which hardening options are absent from a recorded argv, as adjacent pairs. */
+const missingFromArgv = (argv: string[]): string[] => {
+  const joined = `\u0000${argv.join("\u0000")}\u0000`;
+  return CURL_HARDENING.filter(
+    (option) => !joined.includes(`\u0000${option.join("\u0000")}\u0000`),
+  ).map((option) => option.join(" "));
+};
+
+/** The `--data` payload of a recorded argv. */
+const curlDataArg = (argv: string[]): string => argv[argv.indexOf("--data") + 1] ?? "";
+
+/**
+ * Every curl the script actually executes, as (1-based line, folded logical
+ * line). Skips comments, the `command -v curl` presence checks, and the copy
+ * of the one-liner inside user-facing hint text — a curl preceded by an odd
+ * number of double quotes on its line is inside a string, not in command
+ * position. `curl_args=(…)` is not matched: the name is not the bare word.
+ */
+const curlInvocations = (script: string): { line: number; text: string }[] => {
+  const lines = script.split("\n");
+  const found: { line: number; text: string }[] = [];
+  for (const [index, line] of lines.entries()) {
+    if (/^\s*#/.test(line)) continue;
+    const match = /(?<![\w./-])curl(?=\s)/.exec(line);
+    if (!match) continue;
+    if (/command\s+-v\s+curl/.test(line)) continue;
+    if ((line.slice(0, match.index).match(/"/g) ?? []).length % 2 === 1) continue;
+    // Fold bash line continuations so the whole argument list is in view.
+    let text = line;
+    for (let next = index; /\\$/.test(lines[next]) && next + 1 < lines.length; next += 1) {
+      text += `\n${lines[next + 1]}`;
+    }
+    found.push({ line: index + 1, text });
+  }
+  return found;
+};
+
+/** Quoting differs between the array literal and the sh re-exec; ignore it. */
+const unquote = (text: string) => text.replace(/["']/g, "").replace(/\s+/g, " ");
+
+const arrayRefs = (text: string): string[] =>
+  [...text.matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\}/g)].map((match) => match[1]);
+
+/** Whether an argv array is seeded from CURL_TLS_ARGS, or spells the flags out. */
+const arrayIsHardened = (script: string, name: string, seen: Set<string>): boolean => {
+  if (name === "CURL_TLS_ARGS") return true;
+  if (seen.has(name)) return false;
+  seen.add(name);
+  const definition = new RegExp(`(?:^|\\s)(?:local\\s+)?${name}=\\(([^)]*)\\)`, "m").exec(script);
+  if (!definition) return false;
+  const flat = unquote(definition[1]);
+  return (
+    arrayRefs(flat).some((ref) => arrayIsHardened(script, ref, seen)) ||
+    CURL_HARDENING.every((option) => flat.includes(option.join(" ")))
+  );
+};
+
+/** Which hardening options a call site neither spells out nor inherits. */
+const missingHardening = (script: string, invocation: string): string[] => {
+  const flat = unquote(invocation);
+  if (arrayRefs(flat).some((ref) => arrayIsHardened(script, ref, new Set()))) return [];
+  return CURL_HARDENING.filter((option) => !flat.includes(option.join(" "))).map((option) =>
+    option.join(" "),
+  );
+};
 
 describe("installer privacy and supply-chain contracts", () => {
   test("NO_TELEMETRY uses presence semantics in both standalone installers", () => {
@@ -107,48 +296,17 @@ describe("self install killed by a signal", () => {
   });
 
   test("the killed step is what report_error actually POSTs", async () => {
-    const preambleEnd = shellInstaller.indexOf("trap report_on_exit EXIT");
-    const preamble = join(tmpdir(), `install-kill-report-${process.pid}.sh`);
-    await Bun.write(preamble, shellInstaller.slice(0, preambleEnd));
+    const { calls } = await runWithCurlShim(
+      'report_error "$(self_install_step_for_code 137)" 137 "killed" ""; sleep 1',
+      { cut: "preamble", env: { NO_TELEMETRY: undefined }, settleMs: 5000 },
+    );
 
-    const received: Record<string, unknown>[] = [];
-    const server = Bun.serve({
-      port: 0,
-      async fetch(request) {
-        received.push((await request.json()) as Record<string, unknown>);
-        return new Response(null, { status: 204 });
-      },
-    });
-
-    try {
-      const proc = Bun.spawn(
-        [
-          "bash",
-          "-c",
-          'source "$1"; report_error "$(self_install_step_for_code 137)" 137 "killed" ""; sleep 1',
-          "--",
-          preamble,
-        ],
-        {
-          env: {
-            ...process.env,
-            NO_TELEMETRY: undefined,
-            SQUIRREL_ERROR_ENDPOINT: `http://127.0.0.1:${server.port}/error`,
-          } as Record<string, string>,
-        },
-      );
-      await proc.exited;
-      for (let i = 0; i < 100 && received.length === 0; i++) await Bun.sleep(50);
-
-      expect(received).toHaveLength(1);
-      // Distinct from "self_install", which is what makes Sentry fingerprint
-      // OOM kills apart from real self-install failures.
-      expect(received[0].step).toBe("self_install_killed");
-      expect(received[0].exit_code).toBe(137);
-    } finally {
-      server.stop(true);
-      rmSync(preamble, { force: true });
-    }
+    expect(calls).toHaveLength(1);
+    const report = JSON.parse(curlDataArg(calls[0])) as Record<string, unknown>;
+    // Distinct from "self_install", which is what makes Sentry fingerprint
+    // OOM kills apart from real self-install failures.
+    expect(report.step).toBe("self_install_killed");
+    expect(report.exit_code).toBe(137);
   }, 15_000);
 
   test("only SIGKILL claims memory; SIGTERM stays non-committal", async () => {
@@ -437,56 +595,106 @@ describe("self install killed by a signal", () => {
 // watch what report_error actually POSTs.
 describe("install.sh report_error payload", () => {
   test("carries a scrubbed, tail-truncated error_output as valid JSON", async () => {
-    const preambleEnd = shellInstaller.indexOf("trap report_on_exit EXIT");
-    expect(preambleEnd).toBeGreaterThan(0);
-    const preamble = join(tmpdir(), `install-preamble-${process.pid}.sh`);
-    await Bun.write(preamble, shellInstaller.slice(0, preambleEnd));
+    expect(INSTALLER_PREAMBLE.length).toBeGreaterThan(0);
+    const home = process.env.HOME ?? "";
+    const output = `${"noise ".repeat(400)}EPERM: operation not permitted, symlink -> ${home}/.local/bin/squirrel`;
 
-    const received: Record<string, unknown>[] = [];
-    const server = Bun.serve({
-      port: 0,
-      async fetch(request) {
-        received.push((await request.json()) as Record<string, unknown>);
-        return new Response(null, { status: 204 });
+    // The reporter POSTs from a detached subshell, so give it a beat to land.
+    const { calls } = await runWithCurlShim(
+      'report_error self_install 1 "Self install failed with exit code 1" "$REPORT_OUTPUT"; sleep 1',
+      {
+        cut: "preamble",
+        env: { NO_TELEMETRY: undefined, REPORT_OUTPUT: output },
+        settleMs: 5000,
       },
-    });
+    );
 
-    try {
-      const home = process.env.HOME ?? "";
-      const output = `${"noise ".repeat(400)}EPERM: operation not permitted, symlink -> ${home}/.local/bin/squirrel`;
-      // The reporter POSTs from a detached subshell, so give it a beat to land.
-      const proc = Bun.spawn(
-        [
-          "bash",
-          "-c",
-          'source "$1"; report_error self_install 1 "Self install failed with exit code 1" "$2"; sleep 1',
-          "--",
-          preamble,
-          output,
-        ],
-        {
-          env: {
-            ...process.env,
-            NO_TELEMETRY: undefined,
-            SQUIRREL_ERROR_ENDPOINT: `http://127.0.0.1:${server.port}/error`,
-          } as Record<string, string>,
-        },
-      );
-      await proc.exited;
-      for (let i = 0; i < 100 && received.length === 0; i++) await Bun.sleep(50);
-
-      expect(received).toHaveLength(1);
-      const report = received[0];
-      expect(report.step).toBe("self_install");
-      expect(report.script_version).toBe("2");
-      const errorOutput = report.error_output as string;
-      expect(errorOutput.length).toBe(1000); // bounded
-      // Tail kept: the failure is at the END of a command's output.
-      expect(errorOutput).toEndWith("~/.local/bin/squirrel");
-      if (home) expect(errorOutput).not.toContain(home);
-    } finally {
-      server.stop(true);
-      rmSync(preamble, { force: true });
-    }
+    expect(calls).toHaveLength(1);
+    const report = JSON.parse(curlDataArg(calls[0])) as Record<string, unknown>;
+    expect(report.step).toBe("self_install");
+    expect(report.script_version).toBe("2");
+    const errorOutput = report.error_output as string;
+    expect(errorOutput.length).toBe(1000); // bounded
+    // Tail kept: the failure is at the END of a command's output.
+    expect(errorOutput).toEndWith("~/.local/bin/squirrel");
+    if (home) expect(errorOutput).not.toContain(home);
   }, 15_000);
+});
+
+// curl follows a redirect from https to plain http by default and negotiates
+// whatever TLS the local build still allows. The binary is checksum-verified
+// against the manifest, but the metadata fetches and the bash re-exec have
+// nothing but the transport behind them (#165).
+describe("install.sh curl transport hardening", () => {
+  test("the flag set is defined once, with all four options", () => {
+    expect(shellInstaller).toContain(
+      "CURL_TLS_ARGS=(--proto '=https' --proto-redir '=https' --tlsv1.2 --max-redirs 3)",
+    );
+  });
+
+  test("the POSIX-sh re-exec hardens its curl inline, above the array", () => {
+    // This one runs under /bin/sh before the bash-only preamble that defines
+    // CURL_TLS_ARGS, so it cannot use it and has to repeat the flags.
+    expect(shellInstaller).toContain(
+      `exec bash -c 'curl -fsSL --proto "=https" --proto-redir "=https" --tlsv1.2 --max-redirs 3 https://install.squirrelscan.com/install.sh | bash'`,
+    );
+  });
+
+  test("every curl the script executes is hardened, and none escapes the scan", () => {
+    const invocations = curlInvocations(shellInstaller);
+    // Pinned so a refactor that hides a call site from the scan fails loudly
+    // instead of passing vacuously: the fetcher, both release-metadata
+    // fetches, the failure-report POST, and the POSIX-sh re-exec.
+    expect(invocations.map((found) => found.line)).toHaveLength(5);
+    for (const { line, text } of invocations) {
+      expect([line, missingHardening(shellInstaller, text)]).toEqual([line, []]);
+    }
+  });
+
+  test("fetch_with_retry passes the flags to the real command", async () => {
+    const { calls, code } = await runWithCurlShim(
+      'out=$(mktemp); fetch_with_retry "https://example.test/manifest.json" "$out"; rm -f "$out"',
+      { body: "{}" },
+    );
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(missingFromArgv(calls[0])).toEqual([]);
+    expect(calls[0]).toContain("https://example.test/manifest.json");
+  });
+
+  test("get_latest_version passes the flags on the release-metadata fetch", async () => {
+    const { calls, stdout } = await runWithCurlShim("USE_JQ=false; get_latest_version stable", {
+      body: '{"version": "1.2.3"}',
+    });
+    expect(stdout.trim()).toBe("v1.2.3");
+    expect(calls).toHaveLength(1);
+    expect(missingFromArgv(calls[0])).toEqual([]);
+    expect(calls[0]).toContain("https://install.squirrelscan.com/releases/stable");
+  });
+
+  test("get_latest_version passes the flags on the GitHub API fallback too", async () => {
+    // The fallback is the branch a corporate NAT hitting the R2 endpoint takes,
+    // so it is the one least likely to be exercised by hand.
+    const { calls, stdout } = await runWithCurlShim("USE_JQ=false; get_latest_version stable", {
+      body: '[{"tag_name": "v1.2.3", "prerelease": false}]',
+      failMatch: "/releases/stable",
+    });
+    expect(stdout.trim()).toBe("v1.2.3");
+    expect(calls).toHaveLength(2);
+    expect(calls.map(missingFromArgv)).toEqual([[], []]);
+    expect(calls[1]).toContain(
+      "https://api.github.com/repos/squirrelscan/squirrelscan/releases",
+    );
+  });
+
+  test("the failure-report POST passes the flags from its detached subshell", async () => {
+    const { calls } = await runWithCurlShim('report_error fetch_releases 1 "boom" ""; sleep 1', {
+      cut: "preamble",
+      env: { NO_TELEMETRY: undefined },
+      settleMs: 5000,
+    });
+    expect(calls).toHaveLength(1);
+    expect(missingFromArgv(calls[0])).toEqual([]);
+    expect(calls[0]).toContain("https://install.squirrelscan.com/error");
+  });
 });

--- a/scripts/install-contract.test.ts
+++ b/scripts/install-contract.test.ts
@@ -17,8 +17,12 @@ const npmPostinstall = await Bun.file(
 // Shim curl on PATH instead. Recording argv is also what proves the hardening
 // flags reach a real invocation rather than merely appearing in the source.
 const CURL_SHIM = `#!/bin/bash
-for a in "$@"; do printf '%s\\0' "$a"; done >> "$SHIM_LOG"
-printf '\\036' >> "$SHIM_LOG"
+# One redirect for the whole record: a reader that sees the trailing separator
+# knows the argv it is holding is complete.
+{
+  for a in "$@"; do printf '%s\\0' "$a"; done
+  printf '\\036'
+} >> "$SHIM_LOG"
 
 if [ -n "\${SHIM_FAIL_MATCH:-}" ]; then
   for a in "$@"; do
@@ -98,6 +102,14 @@ const runWithCurlShim = async (
       env: {
         ...process.env,
         NO_TELEMETRY: "1",
+        // Keep the ambient environment out of the recorded argv. A GITHUB_TOKEN
+        // reaches get_latest_version's auth header, and a failing expect() on
+        // that argv would print the token into a public CI log.
+        GITHUB_TOKEN: undefined,
+        SQUIRREL_CHANNEL: undefined,
+        SQUIRREL_VERSION: undefined,
+        SQUIRREL_ERROR_ENDPOINT: undefined,
+        SQUIRREL_RELEASES_ENDPOINT: undefined,
         PATH: `${dir}:${process.env.PATH ?? ""}`,
         SHIM_LOG: log,
         SHIM_BODY: body,
@@ -112,11 +124,14 @@ const runWithCurlShim = async (
       new Response(proc.stderr).text(),
     ]);
     const code = await proc.exited;
-    for (let waited = 0; waited < settleMs; waited += 50) {
-      if ((await Bun.file(log).text()) !== "") break;
+    // Wait for a COMPLETE record, not merely a non-empty file: a half-written
+    // one would parse into an argv with no --data and fail as a JSON error.
+    let raw = await Bun.file(log).text();
+    for (let waited = 0; waited < settleMs && !raw.endsWith("\u001e"); waited += 50) {
       await Bun.sleep(50);
+      raw = await Bun.file(log).text();
     }
-    return { calls: parseCurlLog(await Bun.file(log).text()), stdout, stderr, code };
+    return { calls: parseCurlLog(raw), stdout, stderr, code };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -144,27 +159,33 @@ const missingFromArgv = (argv: string[]): string[] => {
 const curlDataArg = (argv: string[]): string => argv[argv.indexOf("--data") + 1] ?? "";
 
 /**
- * Every curl the script actually executes, as (1-based line, folded logical
- * line). Skips comments, the `command -v curl` presence checks, and the copy
- * of the one-liner inside user-facing hint text — a curl preceded by an odd
- * number of double quotes on its line is inside a string, not in command
- * position. `curl_args=(…)` is not matched: the name is not the bare word.
+ * Every curl the script actually executes, as (1-based line, argument text).
+ * Each hit's text starts AT its own curl and runs to the end of the folded
+ * logical line, so a second curl on the line is judged on its own arguments
+ * rather than borrowing the first one's.
+ *
+ * Skipped: whole-line comments, the `command -v curl` presence probes, and the
+ * copy of the published one-liner inside user-facing hint text — a curl behind
+ * an odd number of unescaped double quotes is in a string, not command
+ * position. `curl_args=(…)` never matches: the bare word needs trailing space.
+ * A path-qualified `/usr/bin/curl` does match, deliberately.
  */
 const curlInvocations = (script: string): { line: number; text: string }[] => {
   const lines = script.split("\n");
   const found: { line: number; text: string }[] = [];
   for (const [index, line] of lines.entries()) {
     if (/^\s*#/.test(line)) continue;
-    const match = /(?<![\w./-])curl(?=\s)/.exec(line);
-    if (!match) continue;
-    if (/command\s+-v\s+curl/.test(line)) continue;
-    if ((line.slice(0, match.index).match(/"/g) ?? []).length % 2 === 1) continue;
     // Fold bash line continuations so the whole argument list is in view.
-    let text = line;
+    let folded = line;
     for (let next = index; /\\$/.test(lines[next]) && next + 1 < lines.length; next += 1) {
-      text += `\n${lines[next + 1]}`;
+      folded += `\n${lines[next + 1]}`;
     }
-    found.push({ line: index + 1, text });
+    for (const match of line.matchAll(/(?<![\w-])curl(?=\s)/g)) {
+      const before = line.slice(0, match.index);
+      if (/command\s+-v\s+$/.test(before)) continue;
+      if ((before.replace(/\\"/g, "").match(/"/g) ?? []).length % 2 === 1) continue;
+      found.push({ line: index + 1, text: folded.slice(match.index) });
+    }
   }
   return found;
 };
@@ -175,18 +196,28 @@ const unquote = (text: string) => text.replace(/["']/g, "").replace(/\s+/g, " ")
 const arrayRefs = (text: string): string[] =>
   [...text.matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\}/g)].map((match) => match[1]);
 
-/** Whether an argv array is seeded from CURL_TLS_ARGS, or spells the flags out. */
+/**
+ * Whether an argv array is seeded from CURL_TLS_ARGS, or spells the flags out.
+ * EVERY assignment of the name has to qualify, since a later one that drops the
+ * flags is the one that wins at the call site. A literal `)` inside an array
+ * body (a `$(…)` substitution) truncates the match and reads as unhardened,
+ * which fails loudly rather than passing something through.
+ */
 const arrayIsHardened = (script: string, name: string, seen: Set<string>): boolean => {
   if (name === "CURL_TLS_ARGS") return true;
   if (seen.has(name)) return false;
   seen.add(name);
-  const definition = new RegExp(`(?:^|\\s)(?:local\\s+)?${name}=\\(([^)]*)\\)`, "m").exec(script);
-  if (!definition) return false;
-  const flat = unquote(definition[1]);
-  return (
-    arrayRefs(flat).some((ref) => arrayIsHardened(script, ref, seen)) ||
-    CURL_HARDENING.every((option) => flat.includes(option.join(" ")))
-  );
+  const definitions = [
+    ...script.matchAll(new RegExp(`(?:^|\\s)(?:local\\s+)?${name}=\\(([^)]*)\\)`, "gm")),
+  ];
+  if (definitions.length === 0) return false;
+  return definitions.every((definition) => {
+    const flat = unquote(definition[1]);
+    return (
+      arrayRefs(flat).some((ref) => arrayIsHardened(script, ref, seen)) ||
+      CURL_HARDENING.every((option) => flat.includes(option.join(" ")))
+    );
+  });
 };
 
 /** Which hardening options a call site neither spells out nor inherits. */
@@ -642,13 +673,42 @@ describe("install.sh curl transport hardening", () => {
 
   test("every curl the script executes is hardened, and none escapes the scan", () => {
     const invocations = curlInvocations(shellInstaller);
-    // Pinned so a refactor that hides a call site from the scan fails loudly
-    // instead of passing vacuously: the fetcher, both release-metadata
-    // fetches, the failure-report POST, and the POSIX-sh re-exec.
+    // The count is pinned only so a refactor that hides an EXISTING call site
+    // from the scan fails instead of passing vacuously. It cannot notice a new
+    // call site the scan is blind to; only the scan itself can. Five today:
+    // the fetcher, both release-metadata fetches, the failure-report POST, and
+    // the POSIX-sh re-exec.
     expect(invocations.map((found) => found.line)).toHaveLength(5);
     for (const { line, text } of invocations) {
       expect([line, missingHardening(shellInstaller, text)]).toEqual([line, []]);
     }
+  });
+
+  test.each([
+    ["a path-qualified call", '/usr/bin/curl -fsSL http://evil.test/x'],
+    ["a second call on the line", 'curl "${CURL_TLS_ARGS[@]}" "$u" || curl -fsSL http://evil.test'],
+    ["a call after a probe", 'command -v curl >/dev/null && curl -fsSL http://evil.test'],
+    ["a hardened array named elsewhere", 'echo "${CURL_TLS_ARGS[@]}"; curl -fsSL http://evil.test'],
+  ])("the scan still catches %s", (_label, line) => {
+    // Each of these slipped past an earlier draft of the scan. They are the
+    // shapes a future edit is most likely to reintroduce, so they are pinned
+    // here rather than left to the reviewer's eye.
+    const invocations = curlInvocations(line);
+    expect(invocations.length).toBeGreaterThan(0);
+    expect(
+      invocations.map((found) => missingHardening(shellInstaller, found.text)).flat(),
+    ).not.toEqual([]);
+  });
+
+  test("the scan refuses an array whose later assignment drops the flags", () => {
+    const script = [
+      "CURL_TLS_ARGS=(--proto '=https' --proto-redir '=https' --tlsv1.2 --max-redirs 3)",
+      'local args=("${CURL_TLS_ARGS[@]}" -fsSL)',
+      'args=(-fsSL --proxy "$P")',
+      'curl "${args[@]}" "$url"',
+    ].join("\n");
+    const [invocation] = curlInvocations(script);
+    expect(missingHardening(script, invocation.text)).toHaveLength(4);
   });
 
   test("fetch_with_retry passes the flags to the real command", async () => {
@@ -696,5 +756,42 @@ describe("install.sh curl transport hardening", () => {
     expect(calls).toHaveLength(1);
     expect(missingFromArgv(calls[0])).toEqual([]);
     expect(calls[0]).toContain("https://install.squirrelscan.com/error");
-  });
+    // Same detached-POST shape as the two payload tests, so the same budget:
+    // the script sleeps 1s and the harness can wait 5s more on a loaded runner.
+  }, 15_000);
+
+  // Everything above this point shims curl, so it would pass just as happily
+  // with `--tlsv.1.2` in the array. Nothing else pre-merge would catch that:
+  // `bash -n` does not know curl's options, and the install-test workflow runs
+  // only on release and fetches install.sh from main, not from the tree under
+  // test. So hand the flag set to the real curl once. No network: port 1 is
+  // closed, exit 7 means the options parsed, exit 2 means one did not.
+  test("the real curl on this machine accepts the flag set", async () => {
+    const curl = Bun.which("curl");
+    expect(curl).not.toBeNull();
+    const dir = mkdtempSync(join(tmpdir(), "install-curl-flags-"));
+    const sourced = join(dir, "installer.sh");
+    await Bun.write(sourced, INSTALLER_BODY);
+    try {
+      const proc = Bun.spawn(
+        [
+          "bash",
+          "-c",
+          'source "$1"; curl "${CURL_TLS_ARGS[@]}" -sS -o /dev/null --max-time 5 https://127.0.0.1:1/x',
+          "--",
+          sourced,
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const code = await proc.exited;
+      // The message names the offending option, so assert on it first: it is
+      // the readable half of the failure. The exit code is the backstop.
+      expect(stderr).not.toContain("is unknown");
+      // 2 is curl's "failed to initialize", which is what a bad option exits.
+      expect(code).not.toBe(2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
 });


### PR DESCRIPTION
Closes #165

## Summary

curl follows a redirect from https to plain http by default and negotiates whatever TLS version the local build still allows. The downloaded binary is checksum-verified against the manifest, but the release-metadata fetches and the bash re-exec have nothing behind them but the transport itself.

Every curl the script runs now carries `--proto '=https' --proto-redir '=https' --tlsv1.2 --max-redirs 3`, held in one `CURL_TLS_ARGS` array: `fetch_with_retry`, both fetches in `get_latest_version`, and the failure-report POST in `report_error`. `--proto` and `--proto-redir` are separate settings and one does not imply the other, so the initial scheme and every redirect hop are pinned independently. The POSIX-sh re-exec at the top of the script repeats the flags inline, because it runs under `/bin/sh` above the bash-only preamble that defines the array.

`install.ps1` is untouched: the sibling issue #166 is covered by #207.

### Tests

`scripts/install-contract.test.ts` grows a static scan that fails on any curl call site which neither spells the flags out nor inherits them from `CURL_TLS_ARGS`, plus runtime tests that drive `fetch_with_retry`, `get_latest_version` (both the R2 endpoint and the GitHub API fallback) and `report_error` against a curl test double, which is what proves the flags reach a real argv rather than only the source text. One further test hands the flag set to the *real* curl against a closed loopback port, so a typo like `--tlsv.1.2` cannot pass the suite.

Two existing `report_error` tests move from a plaintext loopback server to that same double. `--proto '=https'` refuses http, and a TLS stand-in would need a CA the child curl trusts, which the SecureTransport curl macOS ships does not read from `CURL_CA_BUNDLE`; that would have passed in CI and failed on half the development machines. Their payload assertions are unchanged, now read off the recorded `--data`.

## Verification

Acceptance criteria, each checked:

| Criterion | Evidence |
|---|---|
| every curl refuses non-HTTPS, including after a redirect | 5 call sites, all carrying `--proto '=https' --proto-redir '=https'`; the scan fails if one does not |
| every curl enforces TLS 1.2 minimum | same 5 sites carry `--tlsv1.2`; the real curl accepts it |
| redirects capped at 3 | same 5 sites carry `--max-redirs 3`; real release assets take exactly 1 hop |
| the one-liner still installs on macOS and Linux (glibc and musl) | end-to-end installs below |

```
bash -n install.sh                                  # clean
shellcheck install.sh                               # clean (2 pre-existing SC2016 notices on awk programs)
bun test scripts/install-contract.test.ts           # 53 pass, 0 fail
detect-secrets-hook --baseline .secrets.baseline …  # clean, baseline unchanged
bun run lint && bun run format:check                # clean
```

End-to-end installs, all exit 0 and the installed binary reports `0.0.90`:

- macOS arm64, both `bash install.sh` and the piped `cat install.sh | bash` form
- `ubuntu:24.04` (glibc, curl 8.5.0/OpenSSL) as a non-root test user
- `alpine:latest` (musl, curl 8.22.0/OpenSSL) as a non-root test user
- both POSIX-sh handoff branches under dash: piped (takes the hardened `curl | bash` re-exec) and `dash /install.sh` (takes `exec bash "$0"`)

Redirect depth against the real endpoints under the hardened flags, confirming the cap of 3 is not tight:

| URL | redirects |
|---|---|
| `install.squirrelscan.com/releases/stable` | 0 |
| `install.squirrelscan.com/install.sh` | 0 |
| `api.github.com/repos/…/releases` | 0 |
| release manifest and all three binaries | 1 |

Mutation-tested: seven separate mutations each turn the suite red, including dropping a flag from the array, dropping the array reference at each of the four bash call sites, unhardening the sh re-exec, adding an unhardened path-qualified curl, and typoing a flag name.

### Reviewed

An adversarial review pass produced the second commit: the scan was letting five shapes of unhardened curl through, the harness could parse a half-written record, and it spread the ambient environment into the child, which put a `GITHUB_TOKEN` into an argv that a failing assertion would print. All fixed, with the scan's blind spots now pinned as their own test cases.

Two follow-ups found in the same pass are deliberately out of scope here: `npm/scripts/postinstall.js` follows redirects by unbounded recursion with no cap (filed as #213), and `install.ps1` has the same gap (#166 / #207).

### Not covered

`test-install.yml` does not gate this PR: it is `workflow_call`/`workflow_dispatch` only, and it fetches `install.sh` from `main` on raw.githubusercontent.com rather than from the tree under test. The platform matrix above was run by hand instead.

## Checklist

- [x] I added or updated tests for behavioral changes.
- [x] I did not include secrets, customer data, or incompatible third-party material.
- [x] Every commit includes a DCO `Signed-off-by` line (`git commit -s`).

