### PR TITLE
feat(rules): add content/placeholder-text, template leftovers in visible copy

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -243,6 +243,7 @@
                   "rules/content/author-info",
                   "rules/content/meta-in-body",
                   "rules/content/mime-type",
+                  "rules/content/placeholder-text",
                   "rules/content/article-links",
                   "rules/content/quality",
                   "rules/content/stale-copyright",

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -50,6 +50,9 @@ Text quality, readability, and content structure
   <Card title="MIME Type Validation" icon="triangle-exclamation" href="/rules/content/mime-type">
     Detects Content-Type header mismatches with file extensions
   </Card>
+  <Card title="Placeholder Text" icon="triangle-exclamation" href="/rules/content/placeholder-text">
+    Detects template leftovers and filler copy that shipped to production
+  </Card>
   <Card title="Reading Level" icon="circle-info" href="/rules/content/reading-level">
     Analyzes content readability using Flesch-Kincaid
   </Card>

--- a/docs/rules/content/placeholder-text.mdx
+++ b/docs/rules/content/placeholder-text.mdx
@@ -1,0 +1,98 @@
+---
+title: "Placeholder Text"
+description: "Detects template leftovers and filler copy that shipped to production"
+---
+
+Detects template leftovers and filler copy that shipped to production
+
+| | |
+|---|---|
+| **Rule ID** | `content/placeholder-text` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 6/10 |
+
+## Solution
+
+Each family points at a different break in the publishing pipeline. Lorem ipsum and theme boilerplate mean a page was published before its copy was written: replace the text, and add the affected fields to whatever check gates publishing. Unrendered template syntax means the templating engine never ran over that string, usually because the value was interpolated into an already-escaped fragment or the template was served as static HTML: render it server-side, or delete the stale copy. A visible `undefined`, `NaN`, `null` or `[object Object]` means the value was missing and the code concatenated it into the copy anyway: guard the field at the point of render rather than in CSS. `TODO` and `FIXME` markers mean a draft shipped: finish or remove the note, since search engines and readers see it exactly as written.
+
+## What it checks
+
+Five families, in visible text only:
+
+| Kind | Example | Meaning |
+|---|---|---|
+| `lorem-ipsum` | `Lorem ipsum dolor sit amet` | latin filler was never replaced |
+| `boilerplate-copy` | `Your Company Name`, `Insert text here` | theme or page-builder filler |
+| `unrendered-template` | `{{ user.name }}`, `{% for x in y %}`, `<%= title %>`, `${total}`, `[[slug]]` | the template engine never ran |
+| `stringified-object` | `[object Object]` | an object was concatenated into a string |
+| `js-artifact` | `Rating: NaN`, a table cell reading `undefined` | a missing value was rendered anyway |
+| `todo-marker` | `TODO: write this`, `FIXME(alice)` | a draft note shipped |
+
+**Severity depends on certainty.** Lorem ipsum, unrendered template syntax and `[object Object]` are machine-generated and nothing legitimate produces them, so they fail. The rest warn, including the bare words `undefined`, `null` and `NaN`: an API reference whose defaults column reads `null` is ordinary, and telling it apart from a value that failed to render is not possible from the text alone.
+
+## What is not visible text
+
+The check reads rendered prose, never raw HTML, so a framework attribute such as `v-bind:title="{{ x }}"` is not reported. Four kinds of markup are excluded:
+
+- `<script>`, `<style>` and `<noscript>`, because a visitor never reads them.
+- `<code>`, `<pre>`, `<samp>` and `<kbd>`, because a visitor reads them as a quoted literal. This page is the proof: every example above is inside a code span, and this page passes its own rule.
+- `<template>`, because its content is inert markup for JavaScript to clone. Without this exclusion every Vue, Alpine, Handlebars and htmx page would report its own component templates.
+- Containers belonging to an in-page code editor or syntax highlighter, matched by class: `hljs`, `shiki`, `prism`, `torchlight`, `codeblock`, `code-block`, and anything starting `language-`, `cm-` or `monaco-`. CodeMirror and Monaco build their view from plain divs and spans with no `<pre>` or `<code>` anywhere, so a tag-only test reads a Liquid tutorial as a page full of unrendered Liquid.
+
+Text is read with a line break at every block boundary, so a value alone in a table cell or list item is seen as a value alone on its line. A page with no body is skipped rather than passed, and a [soft 404](/rules/crawl/soft-404) is skipped so one broken error template cannot spray warnings across a crawl.
+
+## False positives
+
+Each family is deliberately narrower than its name suggests, because every one of them is also a legitimate thing to write.
+
+**Lorem ipsum** needs corroboration: three distinct marker words, or the opening phrase `dolor sit amet`. The `Lorem ipsum` bigram alone is never enough at any position, so a page that mentions the filler, the way Jinja's documentation describes its `lipsum()` helper, stays clean. Words that are real in other languages, including `dolor`, `sit`, `amet`, `elit` and `sed`, are not markers at all, so Spanish and Latin copy stays clean.
+
+**Boilerplate copy** matches whole-word phrases, never single words and never substrings. `Request a sample of our placeholder API`, `we resample textures` and the headings `Placeholder Text` and `Example text` are all ordinary and stay clean.
+
+**JavaScript artifacts** match only the JavaScript spellings, case-sensitively, as standalone words. `NULL` in SQL prose, a sentence beginning `Undefined`, and identifiers such as `nullable` or `non-null` never match. Beyond that, the word has to sit where a **value** sits, not where a noun sits. It is reported only when it is alone on its line, which is what `<h1>{title}</h1>` renders as when the title is missing, or when a label such as `:` or `>` introduces it. A comma does not count as a label, and neither does a pipe: both read as prose far more often than as a list. All of these stay clean:
+
+```text
+This triggers undefined behaviour in C++.
+The function returns undefined when the key is missing.
+We reject the null hypothesis.
+Comparison with NaN
+If an operand is a quiet NaN, there is no exception.
+Accepts a string, null, or undefined.
+The parameter accepts string | null | undefined
+TypeError: null/undefined has no properties
+Reject the [null] hypothesis.
+```
+
+The cost of that strictness is deliberate: `Posted by undefined` at the end of a line is the same shape as `Comparison with NaN`, so the ambiguous shape is left alone.
+
+**Comment markers** match `TODO` and `FIXME` in annotation form: followed by `:` or `(`, preceded by a comment sigil such as `//`, or introducing a lowercase sentence on the same line. A bare standalone `TODO` is left alone, because it is the name of a column on every task board ever shipped. `XXX` is narrower still and needs the comment sigil, because `Super Bowl XXX: the box score` and `Rated XXX (explicit)` fit annotation form exactly. Redacted digits such as `555-XXX-XXXX` and `$XXX,XXX` are not markers either.
+
+## Known limit
+
+A page whose SUBJECT is one of these values is reported, as a warning. A JavaScript language reference that lists `null`, `undefined` and `NaN` as navigation entries, an API reference whose defaults column reads `null`, or an article whose visible heading is the bare word all look exactly like a page whose values failed to render, and no amount of reading the text can tell them apart. That is why this family warns rather than fails. Disable the rule for those pages.
+
+## Enable / disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/placeholder-text"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/placeholder-text"]
+disable = ["*"]
+```

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -102,7 +102,11 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // harness supplies empty resourceSizes/scripts pools, so the rule has no
       // sub-resource to judge — which is why the pass/warn/fail tallies and
       // healthScore.overall (48) are all UNMOVED and only the raw count shifts.
-      expect(v1.findings.length).toBe(98221);
+      // 98221 -> 98721: content/placeholder-text is page-scoped and always
+      // speaks, so like content/hidden-text it emits one check across the 500
+      // fixture pages that have a document (#1350). All 500 PASS, which is why
+      // healthScore.overall is still 48: the synthetic site writes real copy.
+      expect(v1.findings.length).toBe(98721);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
@@ -111,10 +115,10 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // 272 -> 273 schema/rating-scope, 273 -> 274 crawl/sitemap-lastmod-churn,
       // 274 -> 275 crawl/sitemap-lastmod-drift, 275 -> 276
       // content/date-agreement, 276 -> 277 links/no-contextual-inbound,
-      // 277 -> 278 social/asset-divergence, 278 -> 279 perf/asset-compression;
-      // anything else means a rule id leaked in, so fix that rather than this
-      // number.
-      expect(v1.perRuleTally.length).toBe(279);
+      // 277 -> 278 social/asset-divergence, 278 -> 279 perf/asset-compression,
+      // 279 -> 280 content/placeholder-text; anything else means a rule id
+      // leaked in, so fix that rather than this number.
+      expect(v1.perRuleTally.length).toBe(280);
     },
     180_000,
   );

--- a/packages/parser/src/extractors/dom-text.ts
+++ b/packages/parser/src/extractors/dom-text.ts
@@ -22,11 +22,20 @@ const TEXT_NODE = 3;
  * removing an element GLUES its neighbours together, so `Ã<code>x</code>©` reads
  * back as `Ã©`. Callers that scan the result for character sequences must pass a
  * separator, or they will see sequences that exist in neither fragment.
+ *
+ * `isBoundary` (optional) additionally emits `separator` on ENTERING a matching
+ * element. `.textContent` joins adjacent blocks with nothing at all, so
+ * `<td>Author</td><td>undefined</td>` reads back as `Authorundefined` and no
+ * word-boundary pattern can see either cell. Entering is enough to separate
+ * siblings: the next block's own entry closes the previous one. Callers that
+ * judge WORDS rather than characters want this; callers reproducing
+ * `.textContent` must leave it off.
  */
 export function collectTextExcluding(
   root: Node,
   isExcluded: (el: Element) => boolean,
-  separator = ""
+  separator = "",
+  isBoundary?: (el: Element) => boolean
 ): string {
   const out: string[] = [];
   // Explicit stack of remaining child lists; index tracks position in each.
@@ -45,6 +54,7 @@ export function collectTextExcluding(
         if (separator) out.push(separator);
         continue;
       }
+      if (separator && isBoundary?.(node as Element)) out.push(separator);
       const children = node.childNodes;
       for (let i = children.length - 1; i >= 0; i--) {
         stack.push(children[i] as Node);

--- a/packages/parser/tests/dom-text.test.ts
+++ b/packages/parser/tests/dom-text.test.ts
@@ -49,3 +49,31 @@ describe("collectTextExcluding separator", () => {
     expect(el.querySelectorAll("code").length).toBe(1);
   });
 });
+
+describe("collectTextExcluding — block boundaries", () => {
+  const isTd = tagExcluder(new Set(["td"]));
+
+  test("without isBoundary, adjacent cells fuse into one word", () => {
+    // `.textContent` semantics, and the reason the option exists.
+    expect(collectTextExcluding(body("<tr><td>Author</td><td>undefined</td></tr>"), isCode)).toBe(
+      "Authorundefined",
+    );
+  });
+
+  test("isBoundary emits the separator on ENTERING a matching element", () => {
+    expect(
+      collectTextExcluding(body("<tr><td>Author</td><td>undefined</td></tr>"), isCode, "\n", isTd),
+    ).toBe("\nAuthor\nundefined");
+  });
+
+  test("a boundary separates, it never joins", () => {
+    // Text already flowing through one element must not gain a break inside it.
+    expect(collectTextExcluding(body("<td>two words</td>"), isCode, "\n", isTd)).toBe(
+      "\ntwo words",
+    );
+  });
+
+  test("an empty separator disables boundaries as well as skip markers", () => {
+    expect(collectTextExcluding(body("<tr><td>a</td><td>b</td></tr>"), isCode, "", isTd)).toBe("ab");
+  });
+});

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -15,6 +15,7 @@ import { keywordStuffingRule } from "./keyword-stuffing";
 import { metaInBodyRule } from "./meta-in-body";
 import { mojibakeRule } from "./mojibake";
 import { mimeTypeRule } from "./mime-type";
+import { placeholderTextRule } from "./placeholder-text";
 import { contentQualityRule } from "./quality";
 import { readingLevelRule } from "./reading-level";
 import { staleCopyrightRule } from "./stale-copyright";
@@ -42,6 +43,7 @@ export const rules: Rule[] = [
   thinVsSiteNormRule,
   titlePatternOutlierRule,
   dateAgreementRule,
+  placeholderTextRule,
 ];
 
 export {
@@ -59,6 +61,7 @@ export {
   metaInBodyRule,
   mimeTypeRule,
   mojibakeRule,
+  placeholderTextRule,
   readingLevelRule,
   staleCopyrightRule,
   thinVsSiteNormRule,

--- a/packages/rules/src/content/placeholder-text.ts
+++ b/packages/rules/src/content/placeholder-text.ts
@@ -1,0 +1,584 @@
+// content/placeholder-text - Template leftovers that shipped to production.
+//
+// Six families of "this was never meant to be read": latin filler, theme
+// boilerplate, template syntax that never rendered, a stringified object, the
+// bare JavaScript values, and source-comment markers. All six are judged against
+// PROSE only, because every one of them is a legitimate thing for a page to
+// QUOTE — this rule's own documentation shows `{{var}}` and `[object Object]`
+// on purpose, and must stay clean. That constraint is a test, not a hope: see
+// "this rule's own documentation page stays clean" in the test file.
+
+import type { CheckItem } from "@squirrelscan/core-contracts";
+
+import { getRenderedProseText } from "./text-content";
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+
+export type PlaceholderKind =
+  | "lorem-ipsum"
+  | "boilerplate-copy"
+  | "unrendered-template"
+  | "stringified-object"
+  | "js-artifact"
+  | "todo-marker";
+
+export interface PlaceholderFinding {
+  kind: PlaceholderKind;
+  /** Distinct matched strings, deduped, in first-seen order. */
+  samples: string[];
+  /** Total occurrences, including repeats of the same sample. */
+  count: number;
+}
+
+/** Regex metacharacter escape for literals spliced into an alternation. */
+const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/* -------------------------------------------------------------------------- */
+/* Normalisation                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Collapse HORIZONTAL whitespace runs to one space and newline runs to one
+ * newline, so every pattern below can join words with a LITERAL space and carry
+ * no quantifier at all. Two payoffs: phrases still match when the markup wrapped
+ * a word in a `<span>`, and no pattern in this file contains adjacent unbounded
+ * whitespace quantifiers (the `\s*X?\s*` shape that backtracks quadratically).
+ *
+ * Newlines survive because they are load-bearing: `getRenderedProseText` emits
+ * one in place of every skipped subtree, and the TODO heuristic below uses "same
+ * line" to tell a marker that introduces a sentence from a bare UI label.
+ */
+export function normalizeProse(text: string): string {
+  return (
+    text
+      // Horizontal runs first, so the second pass only ever sees single spaces.
+      .replace(/[^\S\n]+/g, " ")
+      // A newline ABSORBS the spaces on either side of it, so a boundary reads as
+      // exactly one "\n". Written as an optional single space plus a simple class
+      // star rather than `\s*\n\s*`: the latter lets the leading quantifier eat
+      // the newline it is looking for, which is the shape that backtracks
+      // quadratically on a long whitespace run with no newline in it.
+      .replace(/ ?\n[ \n]*/g, "\n")
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* 1. Lorem ipsum                                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Only tokens with no life outside the filler text. Deliberately EXCLUDED:
+ * `dolor` (Spanish for pain), `sit`, `amet`, `elit`, `velit`, `sint` and `sed` —
+ * each is a real word in a real language, and one of them alone is not evidence.
+ */
+const LOREM_TOKENS = [
+  "lorem",
+  "ipsum",
+  "consectetur",
+  "consectetuer",
+  "adipiscing",
+  "adipisicing",
+  "eiusmod",
+  "incididunt",
+  "ullamco",
+  "laboris",
+  "cupidatat",
+  "proident",
+  "occaecat",
+  "excepteur",
+  "nostrud",
+  "exercitation",
+  "reprehenderit",
+  "aliquip",
+  "pariatur",
+  "laborum",
+] as const;
+
+const LOREM_TOKEN_RE = new RegExp(`\\b(?:${LOREM_TOKENS.join("|")})\\b`, "gi");
+
+/** The opening of the standard passage. Nothing else on earth says this. */
+const LOREM_PHRASE_RE = /\bdolor sit amet\b/i;
+
+/**
+ * Latin filler needs corroboration, because a page is allowed to talk ABOUT it:
+ * three distinct marker tokens, or the standard opening phrase. The bigram alone
+ * is NOT enough at any position. Every heading and every bolded lede begins a
+ * line once block boundaries are in the text, so "at the head of a block" would
+ * flag `<h2>Lorem ipsum explained</h2>` and this rule's own documentation.
+ *
+ * The cost is a bare `<h1>Lorem ipsum</h1>` with no filler under it, which real
+ * placeholder pages almost never are.
+ */
+function findLorem(text: string): PlaceholderFinding | undefined {
+  const matches = [...text.matchAll(LOREM_TOKEN_RE)].map((m) => m[0]);
+  if (matches.length === 0) return undefined;
+
+  const distinct = [...new Set(matches.map((m) => m.toLowerCase()))];
+  if (distinct.length < 3 && !LOREM_PHRASE_RE.test(text)) return undefined;
+
+  return { kind: "lorem-ipsum", samples: distinct.slice(0, 5), count: matches.length };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2. Boilerplate copy                                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Phrases shipped by themes and page builders that a human was supposed to
+ * replace. Every entry has to be a phrase, never a single word: "sample" and
+ * "placeholder" are ordinary English, "sample text" as a sentence is not.
+ *
+ * `placeholder text` and `example text` are deliberately absent. They are the
+ * ordinary way to NAME this subject, so they flag this rule's own documentation
+ * and every article about page builders.
+ */
+const BOILERPLATE_PHRASES = [
+  "your company name",
+  "your business name",
+  "company name here",
+  "your name here",
+  "your text here",
+  "your logo here",
+  "your headline here",
+  "insert text here",
+  "insert your text here",
+  "enter text here",
+  "add your text here",
+  "type your text here",
+  "sample text",
+  "dummy text",
+  "replace this text",
+  "edit this text",
+  "click here to edit",
+  "this is a placeholder",
+] as const;
+
+/**
+ * Words joined by a LITERAL space, never `\s`. Two consequences, both wanted: the
+ * pattern carries no quantifier at all, so matching is strictly linear; and a
+ * phrase cannot span the newline that stands in for a skipped subtree, so
+ * `your <code>x</code> company name` is not "your company name".
+ */
+const BOILERPLATE_RE = new RegExp(
+  `\\b(?:${BOILERPLATE_PHRASES.map((p) => p.split(" ").map(escapeRe).join(" ")).join("|")})\\b`,
+  "gi",
+);
+
+/* -------------------------------------------------------------------------- */
+/* 3. Unrendered template syntax                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Delimiter pairs that reached the reader. Every body is a NEGATED class or a
+ * bounded lazy run, so none of them can nest or backtrack super-linearly: the
+ * engine gives up after at most 200 characters per start position.
+ */
+const TEMPLATE_PATTERNS: readonly RegExp[] = [
+  /\{\{[^{}]{1,200}\}\}/g, // {{ var }} — Handlebars, Vue, Angular, Jinja, Liquid
+  /\{%[^{}]{1,200}%\}/g, // {% for x in y %} — Jinja, Liquid, Twig statement tags
+  /<%[\s\S]{1,200}?%>/g, // <%= var %> — EJS, ERB, ASP
+  /\$\{[^{}]{1,200}\}/g, // ${var} — JS template literals, shell, Gradle
+  /\[\[[^[\]]{1,200}\]\]/g, // [[var]] — Polymer, wiki links, some CMSes
+];
+
+/**
+ * One leftover, one occurrence. `<%= ${x} %>` matches two patterns over the same
+ * span, and reporting `count: 2` for a single stale expression overstates every
+ * page that nests one delimiter inside another.
+ */
+function findTemplateSyntax(text: string): PlaceholderFinding | undefined {
+  const spans: { start: number; end: number; text: string }[] = [];
+  for (const re of TEMPLATE_PATTERNS) {
+    for (const m of text.matchAll(re)) {
+      spans.push({ start: m.index, end: m.index + m[0].length, text: m[0] });
+    }
+  }
+  if (spans.length === 0) return undefined;
+
+  // Widest first, so a nested match is always tested against its container.
+  spans.sort((a, b) => a.start - b.start || b.end - a.end);
+  const kept: typeof spans = [];
+  for (const span of spans) {
+    if (kept.some((k) => k.start <= span.start && span.end <= k.end)) continue;
+    kept.push(span);
+  }
+
+  return {
+    kind: "unrendered-template",
+    samples: [...new Set(kept.map((k) => k.text))].slice(0, 5),
+    count: kept.length,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4. JavaScript artifacts                                                    */
+/* -------------------------------------------------------------------------- */
+
+/** `[object Object]` and its siblings. Never anything but a stringify accident. */
+const OBJECT_TAG_RE = /\[object [A-Z][A-Za-z]{0,30}\]/g;
+
+/**
+ * Case-SENSITIVE and standalone. `NULL` in SQL prose, `Undefined` at the start of
+ * a sentence, `foo.null` and `non-null` all stay clean; only the JavaScript
+ * spellings match. `$` is NOT a boundary here: `Price: $undefined` is the very
+ * artifact this family is for, and the currency sign is what proves it.
+ */
+const JS_VALUE_RE = /(?<![\w.\-])(?:undefined|null|NaN)(?![\w\-])/g;
+
+/**
+ * The collocations that make one of those words ordinary technical English. A
+ * match keeps only when NEITHER neighbour is on a list, so "the null hypothesis"
+ * and "behaviour is undefined" are out before the slot test below ever runs.
+ * These lists are the cheap first pass, not the guarantee.
+ */
+const PROSE_BEFORE = new Set([
+  "a", "an", "the", "is", "was", "be", "been", "being", "are", "were", "if",
+  "unless", "when", "whether", "not", "non", "or", "and", "of", "any", "no",
+  "all", "some", "every", "returns", "return", "returning", "yields", "yield",
+  "produces", "equals", "equal", "becomes", "become", "than", "to", "from", "as",
+  "versus", "vs", "checks", "check", "checking", "against", "into", "with",
+  "without", "allow", "allows", "allowed", "permit", "permits", "treat",
+  "treats", "treated", "means", "meaning", "explicit", "implicit", "literal",
+  "nullable", "possibly", "always", "never", "either", "neither", "both",
+]);
+
+const PROSE_AFTER = new Set([
+  "behavior", "behaviour", "behaviors", "behaviours", "variable", "variables",
+  "reference", "references", "function", "functions", "value", "values",
+  "property", "properties", "method", "methods", "symbol", "symbols", "index",
+  "indices", "state", "states", "term", "terms", "type", "types", "name",
+  "names", "error", "errors", "key", "keys", "result", "results", "field",
+  "fields", "column", "columns", "row", "rows", "entry", "entries", "case",
+  "cases", "check", "checks", "checking", "safety", "coalescing", "pointer",
+  "pointers", "hypothesis", "character", "characters", "byte", "bytes", "set",
+  "sets", "string", "strings", "island", "and", "or", "terminated",
+  "terminator", "default", "instead", "rather", "when", "if", "unless",
+  "because", "since", "means", "here", "in", "at", "for", "is", "was", "are",
+  "were", "has", "have", "had", "refers", "denotes", "indicates", "represents",
+  "behaves", "evaluates", "coerces",
+]);
+
+/**
+ * Delimiters that mean the page is NAMING the word rather than printing a value.
+ * `the [null] hypothesis` is an editorial insertion and `a "null" result` is a
+ * quotation; neither is a value that leaked into the copy.
+ */
+const QUOTE_CHARS = new Set([
+  '"', "'", "`", "[", "]", "(", ")", "{", "}", "\u201c", "\u201d", "\u2018", "\u2019", "\u00ab", "\u00bb",
+]);
+
+/**
+ * Punctuation that INTRODUCES a value, so it only counts on the LEFT: a value
+ * sits after the colon in `Rating: NaN`, never before it. Reading these on both
+ * sides is what makes `Stated null: Ability = 0` look like a finding when it is
+ * a label whose NAME ends in the word.
+ *
+ * `=` is deliberately absent: without a space it is far more often a query
+ * string (`?title=NaN&oldid=1`) than a label. `/` is absent for the same reason
+ * in reverse, since `null/undefined has no properties` reads as "or".
+ */
+const VALUE_INTRODUCER = /[:>\u2192$\u00a3\u20ac\u00a5#]/;
+
+
+
+/** Nearest non-space character before `index`, or "" at the start of the text. */
+function edgeBefore(text: string, index: number): string {
+  // Runs are already collapsed, so at most one space can separate the two.
+  const i = text.charAt(index - 1) === " " ? index - 2 : index - 1;
+  return i < 0 ? "" : text.charAt(i);
+}
+
+/** Nearest non-space character after `end`, or "" at the end of the text. */
+function edgeAfter(text: string, end: number): string {
+  const i = text.charAt(end) === " " ? end + 1 : end;
+  return i >= text.length ? "" : text.charAt(i);
+}
+
+/** Start or end of a line. */
+const isLineEdge = (ch: string): boolean => ch === "" || ch === "\n";
+
+/**
+ * The token OCCUPIES a slot: it is the whole line, the way `<h1>{title}</h1>`
+ * renders when the title is missing, or the whole cell of a table.
+ *
+ * A line edge on ONE side is deliberately not enough. `Posted by undefined` and
+ * `Comparison with NaN` are the same shape in flat text, so treating a trailing
+ * line edge as evidence reports every heading on every page that discusses these
+ * words. This is the rule's precision/recall trade, made in favour of precision
+ * because this family FAILS an audit.
+ */
+const occupiesLine = (before: string, after: string): boolean =>
+  isLineEdge(before) && isLineEdge(after);
+
+/**
+ * A label introduces it: `Rating: NaN`, `Home > undefined`, `Price: $undefined`.
+ * LEFT side only, because a value follows its label and never precedes it.
+ *
+ * List separators are NOT slots. `,` reads as a clause break far more often than
+ * as a list: `Accepts a string, null, or undefined` and `The three falsy values
+ * are 0, null, and NaN` are English sentences. `|` is a TypeScript union in
+ * every API reference on the web. A genuine list item gets its own line from the
+ * block boundaries, so `occupiesLine` already covers it.
+ */
+const isSlotBefore = (ch: string): boolean => VALUE_INTRODUCER.test(ch);
+
+/** The word immediately before `index`, lowercased, or "" when there is none. */
+function wordBefore(text: string, index: number): string {
+  const m = /([A-Za-z]+)[ \t]?$/.exec(text.slice(Math.max(0, index - 40), index));
+  return m ? m[1]!.toLowerCase() : "";
+}
+
+/** The word immediately after `end`, lowercased, or "" when there is none. */
+function wordAfter(text: string, end: number): string {
+  const m = /^[ \t]?([A-Za-z]+)/.exec(text.slice(end, end + 40));
+  return m ? m[1]!.toLowerCase() : "";
+}
+
+/** `[object X]` needs no corroboration: nothing but a stringify accident says it. */
+function findStringifiedObjects(text: string): PlaceholderFinding | undefined {
+  const hits = [...text.matchAll(OBJECT_TAG_RE)].map((m) => m[0]);
+  if (hits.length === 0) return undefined;
+  return {
+    kind: "stringified-object",
+    samples: [...new Set(hits)].slice(0, 5),
+    count: hits.length,
+  };
+}
+
+function findJsArtifacts(text: string): PlaceholderFinding | undefined {
+  const hits: string[] = [];
+
+  for (const m of text.matchAll(JS_VALUE_RE)) {
+    const start = m.index;
+    const end = start + m[0].length;
+    if (PROSE_BEFORE.has(wordBefore(text, start))) continue;
+    if (PROSE_AFTER.has(wordAfter(text, end))) continue;
+
+    // A word GLUED to a slash is a compound, not a value: `null/undefined has no
+    // properties` and `and/or` read the same way, and neither is a leak.
+    if (text.charAt(start - 1) === "/" || text.charAt(end) === "/") continue;
+
+    const before = edgeBefore(text, start);
+    const after = edgeAfter(text, end);
+    if (QUOTE_CHARS.has(before) || QUOTE_CHARS.has(after)) continue;
+    // The decisive test, and the one that survives contact with a page whose
+    // SUBJECT is the word: a value sits at a slot boundary, prose does not. An
+    // article on the null hypothesis has ordinary words on both sides of every
+    // occurrence, so no collocation list has to be complete for it to stay clean.
+    if (!occupiesLine(before, after) && !isSlotBefore(before)) continue;
+
+    hits.push(m[0]);
+  }
+
+  if (hits.length === 0) return undefined;
+  return { kind: "js-artifact", samples: [...new Set(hits)].slice(0, 5), count: hits.length };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5. Source-comment markers                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `TODO`/`FIXME` in ANNOTATION form: followed by `:` or `(`, or introducing a
+ * lowercase sentence ON THE SAME LINE. A bare standalone `TODO` is a legitimate
+ * label — it is the name of a column on every task board ever shipped — so it is
+ * deliberately not matched.
+ *
+ * `XXX` is absent from this form on purpose. `Super Bowl XXX: the box score` and
+ * `Chapter XXX: aftermath` are Roman numerals, and `Rated XXX (explicit)` is a
+ * content label; all three fit annotation form exactly. It survives only behind
+ * a comment sigil below, where nothing else can be meant.
+ *
+ * The bounded `[ \t]{0,4}` runs are horizontal-only: a newline stands in for a
+ * skipped subtree and for every block boundary, so letting one bridge would let
+ * the next paragraph pose as the marker's sentence.
+ */
+const MARKER_ANNOTATION_RE = /(?<![\w])(?:TODO|FIXME)(?![\w])(?=[ \t]{0,4}[:(]|[ \t]{1,4}[a-z])/g;
+const MARKER_COMMENT_RE =
+  /(?:(?:\/\/|\/\*)[ \t]{0,4}|#[ \t]{1,4})(TODO|FIXME|XXX)(?![\w])/g;
+
+/**
+ * `XXX` doubles as a redaction: `$XXX,XXX` and `555-XXX-XXXX` are censored
+ * digits, not a leftover marker. Reject a match glued to the punctuation that
+ * builds those runs.
+ */
+const REDACTION_NEIGHBOUR = /[$#\d]/;
+function isRedactedXxx(text: string, start: number, end: number): boolean {
+  if (text.slice(start, end).indexOf("XXX") === -1) return false;
+  const before = text.slice(Math.max(0, start - 2), start);
+  const after = text.slice(end, end + 2);
+  return (
+    (/[-,./]$/.test(before) && REDACTION_NEIGHBOUR.test(before.charAt(0))) ||
+    /^[-,./](?:[Xx\d])/.test(after) ||
+    /[$#]$/.test(before)
+  );
+}
+
+function findMarkers(text: string): PlaceholderFinding | undefined {
+  // Keyed by the MARKER's own offset, because `// TODO: x` is in annotation form
+  // AND in comment form. Counting both would report one leftover as two, the
+  // same double-count trap `content/mojibake` hit with its prefix sequences.
+  const byOffset = new Map<number, string>();
+
+  for (const m of text.matchAll(MARKER_ANNOTATION_RE)) {
+    const start = m.index;
+    if (isRedactedXxx(text, start, start + m[0].length)) continue;
+    byOffset.set(start, m[0]);
+  }
+
+  for (const m of text.matchAll(MARKER_COMMENT_RE)) {
+    const marker = m[1]!;
+    const start = m.index + m[0].lastIndexOf(marker);
+    if (isRedactedXxx(text, start, start + marker.length)) continue;
+    // The sigil form is the more informative sample, so it wins the slot.
+    byOffset.set(start, m[0].trim());
+  }
+
+  if (byOffset.size === 0) return undefined;
+  const hits = [...byOffset.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+  return { kind: "todo-marker", samples: [...new Set(hits)].slice(0, 5), count: hits.length };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Aggregation                                                                */
+/* -------------------------------------------------------------------------- */
+
+/** Collect every distinct match of `patterns` in `text`, or undefined when there are none. */
+function findByPatterns(
+  kind: PlaceholderKind,
+  text: string,
+  patterns: readonly RegExp[],
+): PlaceholderFinding | undefined {
+  const hits: string[] = [];
+  for (const re of patterns) for (const m of text.matchAll(re)) hits.push(m[0]);
+  if (hits.length === 0) return undefined;
+  return { kind, samples: [...new Set(hits)].slice(0, 5), count: hits.length };
+}
+
+/**
+ * Every placeholder family present in `text`. `text` must already be VISIBLE
+ * prose: pass raw HTML and the template family will fire on every framework
+ * attribute on the page.
+ */
+export function findPlaceholders(text: string): PlaceholderFinding[] {
+  const prose = normalizeProse(text);
+  const found: (PlaceholderFinding | undefined)[] = [
+    findLorem(prose),
+    findByPatterns("boilerplate-copy", prose, [BOILERPLATE_RE]),
+    findTemplateSyntax(prose),
+    findStringifiedObjects(prose),
+    findJsArtifacts(prose),
+    findMarkers(prose),
+  ];
+  return found.filter((f): f is PlaceholderFinding => f !== undefined);
+}
+
+/**
+ * Families no site ever ships on purpose, where the finding is its own proof.
+ *
+ * `js-artifact` is NOT one of them, even though it names the same bug class. A
+ * defaults table whose cell reads `null`, and an API reference whose heading is
+ * the bare word, are indistinguishable from a value that failed to render, and
+ * both are ordinary on developer sites. Reporting those as a hard failure would
+ * be wrong more often than it was right, so the three bare words warn and only
+ * `[object X]`, which nothing legitimate produces, fails.
+ */
+const CERTAIN_KINDS = new Set<PlaceholderKind>([
+  "lorem-ipsum",
+  "unrendered-template",
+  "stringified-object",
+]);
+
+const KIND_LABELS: Record<PlaceholderKind, string> = {
+  "lorem-ipsum": "lorem ipsum filler",
+  "boilerplate-copy": "theme boilerplate",
+  "unrendered-template": "unrendered template syntax",
+  "stringified-object": "stringified object in copy",
+  "js-artifact": "JavaScript value in copy",
+  "todo-marker": "source-comment marker",
+};
+
+const MAX_SAMPLE_CHARS = 60;
+
+const truncate = (s: string): string =>
+  s.length <= MAX_SAMPLE_CHARS ? s : `${s.slice(0, MAX_SAMPLE_CHARS - 1)}…`;
+
+export const placeholderTextRule: Rule = {
+  meta: {
+    id: "content/placeholder-text",
+    name: "Placeholder Text",
+    description: "Detects template leftovers and filler copy that shipped to production",
+    solution:
+      "Each family points at a different break in the publishing pipeline. Lorem ipsum and theme boilerplate mean a page was published before its copy was written: replace the text, and add the affected fields to whatever check gates publishing. Unrendered template syntax means the templating engine never ran over that string, usually because the value was interpolated into an already-escaped fragment or the template was served as static HTML: render it server-side, or delete the stale copy. A visible undefined, NaN, null or [object Object] means the value was missing and the code concatenated it into the copy anyway: guard the field at the point of render rather than in CSS. TODO and FIXME markers mean a draft shipped: finish or remove the note, since search engines and readers see it exactly as written.",
+    category: "content",
+    scope: "page",
+    severity: "warning",
+    weight: 6,
+    skipOnSoft404: true,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const checks: CheckResult[] = [];
+    const doc = ctx.parsed.document;
+    if (!doc) {
+      checks.push({
+        name: "placeholder-content",
+        status: "skipped",
+        message: "No document available",
+        skipReason: "Parse error",
+      });
+      return { checks };
+    }
+
+    const body = doc.querySelector("body");
+    if (!body) {
+      checks.push({
+        name: "placeholder-content",
+        status: "skipped",
+        message: "No body element to read visible text from",
+        skipReason: "no-body",
+      });
+      return { checks };
+    }
+
+    // Rendered prose, never raw HTML. Code-like and <template> subtrees are out
+    // by construction: a docs page SHOWING `{{ name }}` is documenting the
+    // syntax, and a <template> is markup the browser never renders. Without
+    // both exclusions this rule fails its own documentation and every Vue page.
+    const found = findPlaceholders(getRenderedProseText(body));
+
+    if (found.length === 0) {
+      checks.push({
+        name: "placeholder-content",
+        status: "pass",
+        message: "No placeholder or template leftovers in visible text",
+      });
+      return { checks };
+    }
+
+    const total = found.reduce((sum, f) => sum + f.count, 0);
+    const certain = found.some((f) => CERTAIN_KINDS.has(f.kind));
+    const items: CheckItem[] = found.map((f) => ({
+      id: f.kind,
+      label: KIND_LABELS[f.kind],
+      snippet: f.samples.map(truncate).join(" | "),
+      meta: { count: f.count },
+    }));
+
+    checks.push({
+      name: "placeholder-content",
+      status: certain ? "fail" : "warn",
+      // Naming the family and a sample is what makes this findable: "placeholder
+      // text detected" sends the reader hunting through the whole page.
+      message: `${total} placeholder occurrence(s) in visible text: ${found
+        .map((f) => `${KIND_LABELS[f.kind]} (${truncate(f.samples[0]!)})`)
+        .join(", ")}`,
+      value: total,
+      items,
+      details: {
+        kinds: found.map((f) => ({ kind: f.kind, count: f.count, samples: f.samples })),
+      },
+    });
+    return { checks };
+  },
+};

--- a/packages/rules/src/content/text-content.ts
+++ b/packages/rules/src/content/text-content.ts
@@ -56,3 +56,83 @@ const SKIPPED_SUBTREE_BOUNDARY = "\n";
 export function getProseTextExcludingCode(element: Element): string {
   return collectTextExcluding(element, isScriptOrCodeLike, SKIPPED_SUBTREE_BOUNDARY);
 }
+
+/**
+ * Markup the browser parses but never renders. `<template>` content is inert —
+ * it exists to be cloned by JavaScript — yet linkedom keeps it in `childNodes`,
+ * so a plain text walk reads it as if a visitor saw it. Every Vue, Alpine,
+ * Handlebars and htmx page carries unrendered `{{ }}` in there, which is
+ * exactly what a placeholder rule is looking for and exactly what it must not
+ * report.
+ */
+const NON_RENDERED_TAGS = ["template"] as const;
+
+/**
+ * Container classes used by in-page code editors and syntax highlighters. They
+ * make the same promise `<code>` makes — what follows is source, read it as a
+ * literal — but CodeMirror and Monaco build their view out of plain divs and
+ * spans with no `<pre>` or `<code>` anywhere in the chain. Without this a Liquid
+ * or Handlebars tutorial reads as a page full of unrendered template syntax.
+ */
+const CODE_CONTAINER_CLASSES = new Set([
+  "hljs",
+  "shiki",
+  "prism",
+  "torchlight",
+  "codeblock",
+  "code-block",
+  "cm-editor",
+  "monaco-editor",
+]);
+
+/** Prefixes of the same thing, where the suffix names the language or the part. */
+const CODE_CONTAINER_PREFIXES = ["language-", "cm-", "monaco-"] as const;
+
+const isCodeContainerClass = (token: string): boolean =>
+  CODE_CONTAINER_CLASSES.has(token) || CODE_CONTAINER_PREFIXES.some((p) => token.startsWith(p));
+
+const isTagExcluded = tagExcluder(
+  new Set<string>([...SCRIPT_LIKE_TAGS, ...CODE_LIKE_TAGS, ...NON_RENDERED_TAGS]),
+);
+
+function isScriptCodeOrUnrendered(el: Element): boolean {
+  if (isTagExcluded(el)) return true;
+  const className = el.getAttribute?.("class");
+  if (!className) return false;
+  // split() over classList: linkedom exposes both, and the split is the cheaper
+  // of the two on an element that usually has no interesting class at all.
+  return className.split(/\s+/).some(isCodeContainerClass);
+}
+
+/**
+ * Elements a browser lays out on their own line. A reader sees a break between
+ * two table cells; `.textContent` does not, and joins them into one word. Rules
+ * that judge WORDS have to see the break, or `<td>Author</td><td>undefined</td>`
+ * is the single token `Authorundefined`.
+ */
+const BLOCK_TAGS = new Set([
+  "address", "article", "aside", "blockquote", "br", "caption", "dd", "details",
+  "dialog", "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer",
+  "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "li",
+  "main", "nav", "ol", "option", "p", "section", "summary", "table", "tbody",
+  "td", "tfoot", "th", "thead", "tr", "ul",
+]);
+
+const isBlockElement = tagExcluder(BLOCK_TAGS);
+
+/**
+ * `element`'s RENDERED prose: `getProseTextExcludingCode` minus `<template>`
+ * subtrees and code containers, with a newline where each skipped subtree was
+ * AND at every block boundary.
+ *
+ * For rules that judge only what a visitor's eyes land on. Kept separate from
+ * `getProseTextExcludingCode` so existing callers keep their exact behaviour.
+ */
+export function getRenderedProseText(element: Element): string {
+  return collectTextExcluding(
+    element,
+    isScriptCodeOrUnrendered,
+    SKIPPED_SUBTREE_BOUNDARY,
+    isBlockElement,
+  );
+}

--- a/packages/rules/tests/placeholder-text.test.ts
+++ b/packages/rules/tests/placeholder-text.test.ts
@@ -1,0 +1,478 @@
+// content/placeholder-text: template leftovers a reader can actually see.
+//
+// Every family here is something a page is also allowed to QUOTE, so the
+// no-false-positive fixtures (a docs page showing template syntax, a technical
+// page writing "undefined behaviour", a task board with a TODO column) carry
+// more weight than any of the detection cases.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "@squirrelscan/parser/dom";
+
+import { findPlaceholders, normalizeProse, placeholderTextRule } from "../src/content/placeholder-text";
+import { getRenderedProseText } from "../src/content/text-content";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+function run(html: string) {
+  const { document } = parseHTML(html);
+  const ctx: RuleContext = {
+    page: { url: "https://example.com/", html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: { document } as unknown as ParsedPage,
+    options: {},
+  };
+  return placeholderTextRule.run(ctx).checks;
+}
+
+const page = (body: string) => `<html><head><title>t</title></head><body>${body}</body></html>`;
+
+const kinds = (text: string) => findPlaceholders(text).map((f) => f.kind);
+
+describe("normalizeProse", () => {
+  test("collapses horizontal whitespace but keeps newlines", () => {
+    expect(normalizeProse("a  \t b\n\n\nc")).toBe("a b\nc");
+  });
+
+  test("a newline absorbs the spaces around it, so a boundary is exactly one \\n", () => {
+    expect(normalizeProse("your \n company \t name")).toBe("your\ncompany name");
+  });
+
+  test("a phrase must not span a boundary", () => {
+    // "\n" is what stands in for a skipped subtree, so `your <code>x</code>
+    // company name` is not the boilerplate phrase.
+    expect(kinds("your\ncompany name")).toEqual([]);
+    expect(kinds("your company name")).toContain("boilerplate-copy");
+  });
+});
+
+describe("findPlaceholders — lorem ipsum", () => {
+  test("the bigram is enough on its own", () => {
+    expect(kinds("Lorem ipsum dolor sit amet")).toContain("lorem-ipsum");
+  });
+
+  test("three distinct marker tokens corroborate each other", () => {
+    expect(kinds("consectetur adipiscing eiusmod")).toContain("lorem-ipsum");
+  });
+
+  test("the bigram alone is never enough, at any position", () => {
+    // Block boundaries put a "\n" before every heading and every bolded lede, so
+    // "opens a block" would flag this rule's own documentation.
+    expect(kinds("Generates some lorem ipsum for the template.")).toEqual([]);
+    expect(kinds("\nLorem ipsum explained\n")).toEqual([]);
+    expect(kinds("\nLorem ipsum needs corroboration: three distinct words.")).toEqual([]);
+  });
+
+  test("one stray token is not evidence", () => {
+    // A single Latin-looking word is how a page about Cicero gets flagged.
+    expect(kinds("The word nostrud appears once in this sentence.")).not.toContain("lorem-ipsum");
+  });
+
+  test("Spanish and Latin prose stay clean", () => {
+    // `dolor`, `sit`, `amet`, `elit` and `sed` are deliberately not markers.
+    expect(kinds("El dolor de cabeza es sed de agua, sit down.")).toEqual([]);
+  });
+});
+
+describe("findPlaceholders — boilerplate copy", () => {
+  test("theme filler is caught", () => {
+    expect(kinds("Welcome to Your Company Name")).toContain("boilerplate-copy");
+    expect(kinds("Insert text here to get started")).toContain("boilerplate-copy");
+    expect(kinds("Sample text for the hero")).toContain("boilerplate-copy");
+  });
+
+  test("the single words on their own are ordinary English", () => {
+    expect(kinds("Request a sample of our placeholder API for your company.")).toEqual([]);
+  });
+
+  test("a phrase must be whole words, not a substring", () => {
+    expect(kinds("We resample textures at load time.")).toEqual([]);
+    expect(kinds("Order a free sample textile swatch.")).toEqual([]);
+    expect(kinds("Your company names are stored separately.")).toEqual([]);
+  });
+
+  test("the ordinary way to NAME this subject is not filler", () => {
+    // Otherwise the rule flags its own documentation page and every article
+    // about page builders.
+    expect(kinds("Placeholder Text")).toEqual([]);
+    expect(kinds("Example text for the docs")).toEqual([]);
+  });
+});
+
+describe("findPlaceholders — unrendered template syntax", () => {
+  test("every delimiter pair is caught", () => {
+    expect(kinds("Hello {{ name }}")).toContain("unrendered-template");
+    expect(kinds("{% for item in items %}")).toContain("unrendered-template");
+    expect(kinds("Hello <%= user.name %>")).toContain("unrendered-template");
+    expect(kinds("Total: ${cart.total}")).toContain("unrendered-template");
+    expect(kinds("See [[page-title]]")).toContain("unrendered-template");
+  });
+
+  test("one leftover nesting two delimiters counts once", () => {
+    const [found] = findPlaceholders("<%= ${x} %>");
+    expect(found?.kind).toBe("unrendered-template");
+    expect(found?.count).toBe(1);
+    expect(found?.samples).toEqual(["<%= ${x} %>"]);
+  });
+
+  test("ordinary punctuation and prices are not template syntax", () => {
+    expect(kinds("Costs $19.99, or {see the table} for details [1].")).toEqual([]);
+  });
+});
+
+describe("findPlaceholders — JavaScript artifacts", () => {
+  test("a value that occupies its own line is caught", () => {
+    // What `<h1>{title}</h1>` renders as when the title is missing.
+    expect(kinds("Author\nundefined\nPublished")).toContain("js-artifact");
+  });
+
+  test("a value that follows its label is caught", () => {
+    expect(kinds("Rating: NaN")).toContain("js-artifact");
+    expect(kinds("Author: null")).toContain("js-artifact");
+    expect(kinds("Price: $undefined")).toContain("js-artifact");
+    expect(kinds("Home > undefined")).toContain("js-artifact");
+  });
+
+  test("[object Object] needs no corroboration at all", () => {
+    expect(kinds("Tags: [object Object]")).toContain("stringified-object");
+    expect(kinds("the value [object Array] appeared")).toContain("stringified-object");
+  });
+
+  test("a leading comma is a clause break, not a list slot", () => {
+    // The shape of every API reference and every JS tutorial written in prose.
+    expect(kinds("Accepts a string, null, or undefined.")).toEqual([]);
+    expect(kinds("The three falsy values are 0, null, and NaN.")).toEqual([]);
+    expect(kinds("Valid JSON values are true, false, null.")).toEqual([]);
+    expect(kinds("In JavaScript, NaN, Infinity and -Infinity are special.")).toEqual([]);
+  });
+
+  test("a pipe is a TypeScript union, not a list slot", () => {
+    expect(kinds("The parameter accepts string | null | undefined")).toEqual([]);
+  });
+
+  test("a word at the end of a line is NOT a slot", () => {
+    // `Posted by undefined` and `Comparison with NaN` are the same shape in flat
+    // text. This family fails an audit, so the trade is made for precision.
+    expect(kinds("Comparison with NaN")).toEqual([]);
+    expect(kinds("Operations generating NaN")).toEqual([]);
+  });
+
+  test("a trailing comma is a sentence, not a list", () => {
+    expect(kinds("If an operand is a quiet NaN, there is no exception.")).toEqual([]);
+  });
+
+  test("a preceding section number is not a label", () => {
+    expect(kinds("See 30.3 NaN Boxing in Crafting Interpreters.")).toEqual([]);
+  });
+
+  test("quoting delimiters mean the page is naming the word", () => {
+    expect(kinds("Reject the [null] hypothesis")).toEqual([]);
+    expect(kinds('The literal "null" is written like this')).toEqual([]);
+  });
+
+  test("a word glued to a slash is a compound", () => {
+    // MDN: `TypeError: null/undefined has no properties`.
+    expect(kinds("TypeError: null/undefined has no properties")).toEqual([]);
+  });
+
+  test("technical English about the same words stays clean", () => {
+    // The whole reason for the collocation lists.
+    expect(kinds("This triggers undefined behaviour in C++.")).toEqual([]);
+    expect(kinds("We reject the null hypothesis.")).toEqual([]);
+    expect(kinds("The function returns undefined when the key is missing.")).toEqual([]);
+    expect(kinds("A null pointer dereference is not the same as a null value.")).toEqual([]);
+  });
+
+  test("only the JavaScript spellings match", () => {
+    // SQL prose and sentence-initial capitals are not artifacts.
+    expect(kinds("Set the column to NULL. Undefined stays empty. Nan is a name.")).toEqual([]);
+  });
+
+  test("the word must stand alone", () => {
+    expect(kinds("Use the nullable flag or undefinedValue helper.")).toEqual([]);
+  });
+});
+
+describe("findPlaceholders — source-comment markers", () => {
+  test("a marker in both forms at once is counted once", () => {
+    // `// TODO: x` is a comment sigil AND an annotation. One leftover, one count.
+    const [found] = findPlaceholders("// TODO: fix this");
+    expect(found?.kind).toBe("todo-marker");
+    expect(found?.count).toBe(1);
+    expect(found?.samples).toEqual(["// TODO"]);
+  });
+
+  test("a shell comment sigil is a marker", () => {
+    expect(kinds("# TODO tidy the config")).toContain("todo-marker");
+  });
+
+  test("annotation form is caught", () => {
+    expect(kinds("TODO: write the about page")).toContain("todo-marker");
+    expect(kinds("FIXME(alice) broken link")).toContain("todo-marker");
+    expect(kinds("// TODO polish this")).toContain("todo-marker");
+    expect(kinds("// XXX remove before launch")).toContain("todo-marker");
+  });
+
+  test("XXX needs a comment sigil, because bare XXX is a Roman numeral", () => {
+    expect(kinds("Super Bowl XXX: the box score")).toEqual([]);
+    expect(kinds("Chapter XXX: aftermath")).toEqual([]);
+    expect(kinds("Rated XXX (explicit)")).toEqual([]);
+  });
+
+  test("redaction runs behind a sigil are still not markers", () => {
+    // Reaches the redaction guard, which the annotation form no longer can.
+    expect(kinds("Reach us on # XXX-XXXX today")).toEqual([]);
+  });
+
+  test("a marker introducing a lowercase sentence is caught", () => {
+    expect(kinds("TODO finish the pricing copy")).toContain("todo-marker");
+  });
+
+  test("a bare TODO label on a task board is not a leftover", () => {
+    // Every kanban column in the world is named this.
+    expect(kinds("TODO\nIn Progress\nDone")).toEqual([]);
+  });
+
+  test("redacted digits are not markers", () => {
+    expect(kinds("Call 555-XXX-XXXX or send $XXX,XXX.")).toEqual([]);
+  });
+
+  test("a hashtag is not a comment sigil", () => {
+    expect(kinds("Shipping it today #TODO")).toEqual([]);
+  });
+
+  test("lowercase prose is not a marker", () => {
+    expect(kinds("Add it to your todo list and fix me later.")).toEqual([]);
+  });
+});
+
+describe("findPlaceholders — counts and samples", () => {
+  test("distinct samples are deduped, count is total occurrences", () => {
+    const [found] = findPlaceholders("{{ a }} and {{ a }} and {{ b }}");
+    expect(found?.kind).toBe("unrendered-template");
+    expect(found?.count).toBe(3);
+    expect(found?.samples).toEqual(["{{ a }}", "{{ b }}"]);
+  });
+});
+
+describe("findPlaceholders — adversarial input", () => {
+  // The ReDoS guard. Every pattern is a negated class or a bounded lazy run, so
+  // an unclosed delimiter followed by a huge run must fail fast, not backtrack.
+  test("long unterminated delimiters and whitespace runs finish quickly", () => {
+    const inputs = [
+      // Many start positions, each of which must fail fast. The single-long-run
+      // shapes below only ever exercise ONE expensive position.
+      "<%".repeat(100_000),
+      "{{".repeat(100_000),
+      "{%".repeat(100_000),
+      "${".repeat(100_000),
+      "[[".repeat(100_000),
+      `${"<%".padEnd(201, "a")}`.repeat(2_000),
+      "// TODO: x ".repeat(20_000),
+      ", null".repeat(20_000),
+      `{{${"a".repeat(200_000)}`,
+      `\${${"a".repeat(200_000)}`,
+      `[[${"a".repeat(200_000)}`,
+      `<%${" ".repeat(200_000)}`,
+      `${"{".repeat(100_000)}${"}".repeat(100_000)}`,
+      `TODO${" ".repeat(200_000)}x`,
+      `${"undefined ".repeat(20_000)}`,
+    ];
+    const started = performance.now();
+    for (const input of inputs) findPlaceholders(input);
+    expect(performance.now() - started).toBeLessThan(5_000);
+  });
+});
+
+describe("placeholderTextRule", () => {
+  test("a clean page passes", () => {
+    expect(run(page("<p>Ordinary copy about ordinary things.</p>"))[0]?.status).toBe("pass");
+  });
+
+  test("machine-generated leftovers fail", () => {
+    const [check] = run(page("<p>Hello {{ user.name }}</p>"));
+    expect(check?.status).toBe("fail");
+    expect(check?.message).toMatch(/unrendered template syntax/i);
+    expect(check?.value).toBe(1);
+  });
+
+  test("human filler only warns", () => {
+    // A page could just about mean to write these, so they are not a failure.
+    const [check] = run(page("<h1>Your Company Name</h1>\n<p>TODO: write this</p>"));
+    expect(check?.status).toBe("warn");
+    expect(check?.items?.map((i) => i.id).sort()).toEqual(["boilerplate-copy", "todo-marker"]);
+  });
+
+  test("a certain family among warnings escalates the whole check", () => {
+    const [check] = run(page("<h1>Sample text</h1>\n<p>Tags: [object Object]</p>"));
+    expect(check?.status).toBe("fail");
+  });
+
+  test("a bare JavaScript value warns, it does not fail", () => {
+    // An API reference whose defaults column reads `null` is ordinary. Only
+    // [object X], which nothing legitimate produces, is a failure.
+    const [check] = run(page("<table><tr><td>onError</td><td>null</td></tr></table>"));
+    expect(check?.status).toBe("warn");
+    expect(check?.items?.[0]?.id).toBe("js-artifact");
+  });
+
+  test("no document is skipped, not passed", () => {
+    const ctx = {
+      page: { url: "https://example.com/", html: "", statusCode: 500, loadTime: 0, headers: {} },
+      parsed: { document: null } as unknown as ParsedPage,
+      options: {},
+    } as RuleContext;
+    const [check] = placeholderTextRule.run(ctx).checks;
+    expect(check?.status).toBe("skipped");
+    expect(check?.skipReason).toBe("Parse error");
+  });
+
+  test("a document with no body is skipped", () => {
+    const { document } = parseHTML("<html><head><title>t</title></head></html>");
+    document.querySelector("body")?.remove();
+    const ctx = {
+      page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+      parsed: { document } as unknown as ParsedPage,
+      options: {},
+    } as RuleContext;
+    const [check] = placeholderTextRule.run(ctx).checks;
+    expect(check?.status).toBe("skipped");
+    expect(check?.skipReason).toBe("no-body");
+  });
+});
+
+describe("placeholderTextRule — what a reader never sees", () => {
+  test("a docs page that shows template syntax in a code block stays clean", () => {
+    // The fixture that matters: this rule's own documentation.
+    const [check] = run(
+      page(`
+        <h1>Templating</h1>
+        <p>Interpolate a value with the double-brace form:</p>
+        <pre><code>&lt;h1&gt;Hello {{ user.name }}&lt;/h1&gt;</code></pre>
+        <p>The ERB equivalent is <code>&lt;%= user.name %&gt;</code>,
+        and in a shell script you would write <code>\${USER}</code>.</p>
+        <p>A missing value renders as <code>undefined</code> or
+        <samp>[object Object]</samp>. Press <kbd>XXX</kbd> to continue.</p>
+      `),
+    );
+    expect(check?.status).toBe("pass");
+  });
+
+  test("this rule's own documentation page stays clean", () => {
+    // The design constraint stated at the top of the rule module, asserted.
+    const [check] = run(
+      page(`
+        <h1>Placeholder Text</h1>
+        <p>Detects template leftovers and filler copy that shipped to production.</p>
+        <h2>False positives</h2>
+        <p><strong>Lorem ipsum</strong> needs corroboration: three distinct marker
+        words, or the opening phrase.</p>
+        <p><strong>JavaScript artifacts</strong> match only the JavaScript
+        spellings. A page may write about undefined behaviour, the null
+        hypothesis, or a quiet NaN, and stay clean.</p>
+        <table>
+          <tr><th>Kind</th><th>Example</th></tr>
+          <tr><td>unrendered-template</td><td><code>{{ user.name }}</code></td></tr>
+          <tr><td>js-artifact</td><td><code>Rating: NaN</code></td></tr>
+        </table>
+        <pre><code>disable = ["content/placeholder-text"]</code></pre>
+      `),
+    );
+    expect(check?.status).toBe("pass");
+  });
+
+  test("script and style contents are not visible text", () => {
+    const [check] = run(
+      page('<script>var s = "{{ name }}";</script><style>/* TODO: colours */</style><p>Clean.</p>'),
+    );
+    expect(check?.status).toBe("pass");
+  });
+
+  test("an inert <template> is markup the browser never renders", () => {
+    // linkedom keeps template children in childNodes, so a plain text walk would
+    // read every Vue/Alpine/Handlebars page as full of unrendered syntax.
+    const [check] = run(
+      page('<p>Clean.</p><template id="row"><li>{{ item.name }}</li></template>'),
+    );
+    expect(check?.status).toBe("pass");
+  });
+
+  test("a phrase is not glued together across a skipped subtree", () => {
+    // The `<code>` becomes a newline, and phrases match on literal spaces only.
+    const [check] = run(page("<p>Set your <code>x</code> company name in config.</p>"));
+    expect(check?.status).toBe("pass");
+  });
+
+  test("inline markup inside a phrase does not hide it", () => {
+    // `<b>` is not excluded, so the text nodes concatenate with their own spaces.
+    const [check] = run(page("<p>Welcome to Your <b>Company</b> Name</p>"));
+    expect(check?.status).toBe("warn");
+  });
+
+  test("adjacent blocks are separated even with no whitespace between them", () => {
+    // `.textContent` joins these into "HeadingTODO: write this", where no
+    // word-boundary pattern can see the marker at all.
+    expect(run(page("<h1>Heading</h1><p>TODO: write this</p>"))[0]?.status).toBe("warn");
+  });
+
+  test("a value alone in a table cell is a value alone on its line", () => {
+    // The shape a missing field actually takes, and the reason block boundaries
+    // matter: every cell here sits on one source line.
+    const [check] = run(page("<table><tr><td>Author</td><td>undefined</td></tr></table>"));
+    expect(check?.items?.[0]?.id).toBe("js-artifact");
+    expect(check?.value).toBe(1);
+  });
+
+  test("a block boundary does not fuse two words into a placeholder", () => {
+    // The boundary must SEPARATE, never join: `<p>your</p><p>company name</p>`
+    // is not the boilerplate phrase.
+    expect(run(page("<p>your</p><p>company name</p>"))[0]?.status).toBe("pass");
+  });
+});
+
+describe("getRenderedProseText", () => {
+  const prose = (body: string) => {
+    const { document } = parseHTML(page(body));
+    return getRenderedProseText(document.querySelector("body") as never);
+  };
+
+  test("script-like and code-like subtrees become a boundary", () => {
+    expect(prose("<p>a<script>x</script>b<code>y</code>c</p>")).toBe("\na\nb\nc");
+  });
+
+  test("<template> content is inert markup, not text", () => {
+    expect(prose('<p>a</p><template id="t"><li>{{ x }}</li></template><p>b</p>')).toBe("\na\n\nb");
+  });
+
+  test("every code-container class is excluded", () => {
+    // Each entry is load-bearing: a typo here ships a false positive on the
+    // FAILING unrendered-template family, and nothing else would notice.
+    for (const cls of [
+      "hljs",
+      "shiki",
+      "prism",
+      "torchlight",
+      "codeblock",
+      "code-block",
+      "cm-editor",
+      "monaco-editor",
+      "language-liquid",
+      "cm-content",
+      "monaco-scroller",
+    ]) {
+      expect(prose(`<p>a</p><div class="${cls}">{{ page_title }}</div>`)).not.toContain("{{");
+    }
+  });
+
+  test("a class-list match works on any token, not just the first", () => {
+    expect(prose('<div class="Card_7q5 cm-editor cm-static">{{ x }}</div>')).not.toContain("{{");
+  });
+
+  test("an ordinary class is not a code container", () => {
+    expect(prose('<div class="highlight-banner">{{ x }}</div>')).toContain("{{ x }}");
+  });
+
+  test("block elements are separated, inline elements are not", () => {
+    expect(prose("<p>your <b>company</b> name</p>")).toBe("\nyour company name");
+    expect(prose("<tr><td>Author</td><td>undefined</td></tr>")).toBe(
+      "\n\nAuthor\nundefined",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new per-page audit rule `content/placeholder-text`: template leftovers and filler copy that reached production. Six families, all judged against visible prose:

| Kind | Example | Status |
|---|---|---|
| `lorem-ipsum` | `Lorem ipsum dolor sit amet` | fail |
| `unrendered-template` | `{{ user.name }}`, `{% for x in y %}`, `<%= title %>`, `${total}`, `[[slug]]` | fail |
| `stringified-object` | `[object Object]` | fail |
| `boilerplate-copy` | `Your Company Name`, `Insert text here` | warn |
| `js-artifact` | `Rating: NaN`, a table cell reading `undefined` | warn |
| `todo-marker` | `TODO: write this`, `FIXME(alice)` | warn |

Severity follows certainty. The three failing families are machine-generated and nothing legitimate produces them. The bare words `undefined`, `null` and `NaN` only warn, because an API reference whose defaults column reads `null` is ordinary and text alone cannot tell it from a value that failed to render.

Every family is also a legitimate thing for a page to quote, so most of the work here is precision:

- **Prose only.** A new `getRenderedProseText` drops `script`/`style`/`noscript`, `code`/`pre`/`samp`/`kbd`, `<template>` (linkedom keeps its children in `childNodes`, so every Vue and Handlebars page reads as full of unrendered syntax without this), and the container classes of in-page code editors. CodeMirror and Monaco render no `<pre>` or `<code>` anywhere, which is why shopify.dev's Liquid reference fired before that exclusion.
- **Block boundaries.** Text is read with a line break at every block edge, so a value alone in a table cell is seen as alone on its line. `.textContent` joins `<td>Author</td><td>undefined</td>` into one word that no word-boundary pattern can see.
- **A value must sit in a value slot**: alone on its line, or after a label such as `:` or `>`. A comma is not a label, so `Accepts a string, null, or undefined` is prose. Neither is a pipe, so a TypeScript union is prose.
- **Lorem needs three distinct markers or `dolor sit amet`.** The bigram alone is never enough, or every `Lorem ipsum explained` heading would fire.
- **Boilerplate matches whole-word phrases**, and deliberately omits `placeholder text` and `example text`, which are the ordinary way to name this subject.
- **`XXX` needs a comment sigil**, because `Super Bowl XXX: the box score` fits annotation form exactly. A bare `TODO` is left alone too: it is the name of a column on every task board ever shipped.

`collectTextExcluding` in `packages/parser` gains an optional `isBoundary` predicate. It is guarded by both `separator &&` and `?.`, and every existing caller passes three arguments or fewer, so no existing behaviour changes.

Refs squirrelscan/repo#1350

## Verification

Rule and helper tests, 62 cases:

```
bun test packages/rules/tests/placeholder-text.test.ts
 62 pass  0 fail  115 expect() calls
```

Neighbours and the shared walk:

```
bun test packages/rules/tests/mojibake.test.ts \
  packages/rules/tests/content-no-dom-mutation.test.ts \
  packages/parser/tests/dom-text.test.ts \
  packages/rules/tests/content-quality-text.test.ts
 106 pass  0 fail   (with placeholder-text)
```

Full audit-engine golden set green, including the canonical 518-page merge gate. Its two pinned counts move as expected for a page-scoped rule that always speaks: findings `98221 -> 98721` (+500, one passing check per fixture page) and `perRuleTally 279 -> 280`. `healthScore.overall` is unmoved at 48, so all 500 checks pass.

`tsgo --noEmit` clean in `packages/rules`, `packages/parser`, `packages/audit-engine` and `apps/cli`. `make validate` clean in `docs/`.

Smoked through the real CLI against a local fixture page, which reports all six families with the right severities and leaves the `<code>`, `<pre>` and `<template>` content alone.

Smoked against real sites, which is what drove most of the precision work above:

```
PASS  vuejs.org, handlebarsjs.com, shopify.dev/docs/api/liquid,
      jinja.palletsprojects.com, docs.astro.build, tailwindcss.com,
      en.wikipedia.org/wiki/Null_hypothesis, squirrelscan.com,
      gov.uk, news.ycombinator.com
WARN  en.wikipedia.org/wiki/NaN, MDN's `undefined` reference
      (both list the bare word as a heading or nav entry)
FAIL  en.wikipedia.org/wiki/Lorem_ipsum (it reproduces the filler)
```

The two warnings are the documented known limit: a page whose subject IS one of these values looks exactly like a page whose values failed to render.

## Checklist

- [x] I added or updated tests for behavioral changes.
- [x] I did not include secrets, customer data, or incompatible third-party material.
- [x] Every commit includes a DCO `Signed-off-by` line (`git commit -s`).
