### PR TITLE
feat(rules): add content/unrendered-markup, literal markdown or escaped HTML in rendered copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Site Integrity | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | Security | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | Links | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
-| Content | 18 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| Content | 19 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | Performance | 30 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | Images | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | Structured Data | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus rating markup that is not about the page it sits on |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **279 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **280 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 279 rules across 21 categories**
+**Total: 280 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **280 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **281 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more
@@ -43,7 +43,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Site Integrity | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | Security | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | Links | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
-| Content | 19 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| Content | 20 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | Performance | 30 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | Images | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | Structured Data | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus rating markup that is not about the page it sits on |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 280 rules across 21 categories**
+**Total: 281 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/agent-setup/index.mdx
+++ b/docs/agent-setup/index.mdx
@@ -92,7 +92,7 @@ other MCP client works too: see [MCP clients](/developers/mcp-clients).
 <div class="agent-facts">
   <div class="agent-fact">
     <span class="agent-fact-key">Audit</span>
-    <span class="agent-fact-val">279 rules across SEO, performance, security, accessibility, and agent experience.</span>
+    <span class="agent-fact-val">280 rules across SEO, performance, security, accessibility, and agent experience.</span>
   </div>
   <div class="agent-fact">
     <span class="agent-fact-key">Read</span>

--- a/docs/agent-setup/index.mdx
+++ b/docs/agent-setup/index.mdx
@@ -92,7 +92,7 @@ other MCP client works too: see [MCP clients](/developers/mcp-clients).
 <div class="agent-facts">
   <div class="agent-fact">
     <span class="agent-fact-key">Audit</span>
-    <span class="agent-fact-val">280 rules across SEO, performance, security, accessibility, and agent experience.</span>
+    <span class="agent-fact-val">281 rules across SEO, performance, security, accessibility, and agent experience.</span>
   </div>
   <div class="agent-fact">
     <span class="agent-fact-key">Read</span>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -250,7 +250,8 @@
                   "rules/content/mojibake",
                   "rules/content/thin-vs-site-norm",
                   "rules/content/title-pattern-outlier",
-                  "rules/content/date-agreement"
+                  "rules/content/date-agreement",
+                  "rules/content/unrendered-markup"
                 ]
               },
               {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="279 rules, 21 categories"
+    title="280 rules, 21 categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule categories
 
-squirrelscan runs **279 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **280 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -226,7 +226,7 @@ squirrelscan runs **279 rules** across **21 categories**, plus opt-in cloud gap 
 | **Site Integrity** | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | **Security** | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | **Links** | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
-| **Content** | 18 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| **Content** | 19 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | **Performance** | 30 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | **Structured Data** | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have and rating markup that is not about the page it sits on |
@@ -242,7 +242,7 @@ squirrelscan runs **279 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 279 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 280 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="280 rules, 21 categories"
+    title="281 rules, 21 categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule categories
 
-squirrelscan runs **280 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **281 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -226,7 +226,7 @@ squirrelscan runs **280 rules** across **21 categories**, plus opt-in cloud gap 
 | **Site Integrity** | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | **Security** | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | **Links** | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
-| **Content** | 19 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| **Content** | 20 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | **Performance** | 30 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | **Structured Data** | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have and rating markup that is not about the page it sits on |
@@ -242,7 +242,7 @@ squirrelscan runs **280 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 280 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 281 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -65,6 +65,9 @@ Text quality, readability, and content structure
   <Card title="Title Template Consistency" icon="triangle-exclamation" href="/rules/content/title-pattern-outlier">
     Finds pages whose title breaks the template the rest of the site follows
   </Card>
+  <Card title="Unrendered Markup" icon="triangle-exclamation" href="/rules/content/unrendered-markup">
+    Detects literal markdown or escaped HTML leaking into rendered copy
+  </Card>
   <Card title="Word Count" icon="triangle-exclamation" href="/rules/content/word-count">
     Checks content length for thin content issues
   </Card>

--- a/docs/rules/content/unrendered-markup.mdx
+++ b/docs/rules/content/unrendered-markup.mdx
@@ -43,10 +43,11 @@ Displaying markup is not the same as leaking it, and this rule is mostly a list 
 - `<code>`, `<pre>`, `<samp>`, `<kbd>` and `<textarea>`, because a visitor reads them as a quoted literal. A tutorial showing `**bold**` in a code span is doing its job, and an editor pre-filled with a post's markdown source is not a defect.
 - Any element a syntax highlighter marks as its own: the whole class tokens `highlight`, `hljs`, `shiki`, `chroma`, `codehilite`, `code-block`, `preformatted` and their siblings, any `language-*` or `lang-*` class, and the `data-language` family of attributes. Whole tokens, so a `highlight-box` callout is still judged as prose.
 
-Four more limits keep the rule quiet on pages that talk about markup rather than mangle it.
+Five more limits keep the rule quiet on pages that talk about markup rather than mangle it.
 
 - **Underscore emphasis must contain a space.** `__init__` and `__main__` are flanked exactly like bold and appear in ordinary prose, so `__bold__` on its own is not reported. `**bold**` still is.
 - **A markdown link needs a URL-shaped target.** `array[i](arg)` and `[see note] (below)` are not links.
+- **A single `#` needs a capitalised word after it.** `#` is also the number sign, so `# of seats` in a table header is not a heading, and neither is the URL fragment MDN prints under a specification link. `##` and deeper have no second reading and are taken as written, so `## my-package` still counts.
 - **Escaped tags must be lowercase.** `<Article>` and `<Header>` are component names a page is showing on purpose. Markup that leaked from a template came from HTML a server emitted, which is lowercase.
 - **At least one escaped tag must carry a true closing form or a recognised attribute with a value.** A page that writes `<pre>` or `<meta name>` in a sentence is documenting an element. A leak brings `</p>` or `class="row"` with it. A self-closing `<br/>` is not a closing form, `</path/to/file>` is a path rather than a closing tag, and `c=1` is not an attribute, so `if a<b then c=1>0` stays clean.
 
@@ -57,6 +58,8 @@ Two classes are known and deliberate.
 Prose full of identifiers stays clean: `CLOUDFLARE_API_TOKEN`, `some_file_name.ts`, `max_pages`, `width * height` and `2 * 3` are none of them emphasis, because both emphasis forms require CommonMark-style flanking.
 
 Backticks alone never trip the rule. They are the one markdown character people put on a page on purpose and often, in a prompt written to be copied into an agent, a chat transcript, or a changelog. Inline code spans are reported in the detail once another family has fired, and never before.
+
+Text is read block by block, so a match is never assembled out of two elements that each hold half of it. A heading ending in `*` followed by a link starting with `*` is two stray asterisks, not emphasis.
 
 The residual case is a page whose subject is HTML source, displayed in a container the rule cannot recognise. A tutorial that shows `<p>This is a paragraph.</p>` inside a plain `<div>` with a bespoke class is indistinguishable from a page that leaked it. Wrap such examples in `<pre>` or `<code>`, which is also what makes them selectable and copyable for readers.
 

--- a/docs/rules/content/unrendered-markup.mdx
+++ b/docs/rules/content/unrendered-markup.mdx
@@ -1,0 +1,89 @@
+---
+title: "Unrendered Markup"
+description: "Detects literal markdown or escaped HTML leaking into rendered copy"
+---
+
+Detects literal markdown or escaped HTML leaking into rendered copy
+
+| | |
+|---|---|
+| **Rule ID** | `content/unrendered-markup` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 5/10 |
+
+## Solution
+
+Something rendered a value as plain text that was authored as markup. Find the field, not the page: a CMS that stores markdown and a template that prints it without a markdown-to-HTML pass produces literal `**bold**` and `[text](url)` everywhere that field appears, and fixing one page leaves the rest broken. Visible `<p>` or `<a href` means the opposite mistake: HTML was escaped twice, usually by escaping a value that a templating engine (Jinja, Twig, Blade, JSX) had already escaped, so remove the manual escape rather than marking the value safe. Visible `&nbsp;` or `&amp;` means the entity itself was encoded a second time on the way in, which is normally an import or a rich-text editor round-trip, so re-import the affected content. If the markup is meant to be on display, put it in `<code>` or `<pre>`, which this rule skips.
+
+## What it checks
+
+Three families, in visible text only:
+
+| Kind | Example on screen | Meaning |
+|---|---|---|
+| `markdown-emphasis` | `**unlimited audits**` | a markdown field printed as plain text |
+| `markdown-link` | `[our docs](https://example.com/d)` | the same, for links and images |
+| `markdown-heading` | a line starting `## ` | the same, for headings |
+| `markdown-code-fence` | a line of three backticks | the same, for fenced code |
+| `markdown-inline-code` | `` `squirrel audit` `` | corroborating only, see below |
+| `escaped-html-tag` | `<p>Prices exclude tax.</p>` | HTML escaped twice |
+| `double-encoded-entity` | `&nbsp;`, `&amp;` | an entity encoded a second time |
+
+The check reads the text a visitor sees, decoded, never the raw HTML. That matters for the HTML families: the page source says `&lt;p&gt;`, and the browser paints `<p>`, so the rule looks for the painted form.
+
+**Severity depends on certainty.** Visible tags and entities fail, because nothing outside a code block renders them on purpose. Literal markdown warns at one or two occurrences and fails at three or more, where it stops looking like a typo and starts looking like a template that never ran its markdown pass.
+
+## What is excluded
+
+Displaying markup is not the same as leaking it, and this rule is mostly a list of ways to tell the two apart.
+
+- `<script>`, `<style>`, `<noscript>` and `<template>`, because a visitor never reads them.
+- `<code>`, `<pre>`, `<samp>`, `<kbd>` and `<textarea>`, because a visitor reads them as a quoted literal. A tutorial showing `**bold**` in a code span is doing its job, and an editor pre-filled with a post's markdown source is not a defect.
+- Any element a syntax highlighter marks as its own: the whole class tokens `highlight`, `hljs`, `shiki`, `chroma`, `codehilite`, `code-block`, `preformatted` and their siblings, any `language-*` or `lang-*` class, and the `data-language` family of attributes. Whole tokens, so a `highlight-box` callout is still judged as prose.
+
+Four more limits keep the rule quiet on pages that talk about markup rather than mangle it.
+
+- **Underscore emphasis must contain a space.** `__init__` and `__main__` are flanked exactly like bold and appear in ordinary prose, so `__bold__` on its own is not reported. `**bold**` still is.
+- **A markdown link needs a URL-shaped target.** `array[i](arg)` and `[see note] (below)` are not links.
+- **Escaped tags must be lowercase.** `<Article>` and `<Header>` are component names a page is showing on purpose. Markup that leaked from a template came from HTML a server emitted, which is lowercase.
+- **At least one escaped tag must carry a closing form or an attribute with a value.** A page that writes `<pre>` or `<meta name>` in a sentence is documenting an element. A leak brings `</p>` or `class="row"` with it.
+
+## False positives
+
+Two classes are known and deliberate.
+
+Prose full of identifiers stays clean: `CLOUDFLARE_API_TOKEN`, `some_file_name.ts`, `max_pages`, `width * height` and `2 * 3` are none of them emphasis, because both emphasis forms require CommonMark-style flanking.
+
+Backticks alone never trip the rule. They are the one markdown character people put on a page on purpose and often, in a prompt written to be copied into an agent, a chat transcript, or a changelog. Inline code spans are reported in the detail once another family has fired, and never before.
+
+The residual case is a page whose subject is HTML source, displayed in a container the rule cannot recognise. A tutorial that shows `<p>This is a paragraph.</p>` inside a plain `<div>` with a bespoke class is indistinguishable from a page that leaked it. Wrap such examples in `<pre>` or `<code>`, which is also what makes them selectable and copyable for readers.
+
+## Related rules
+
+[content/mojibake](/rules/content/mojibake) covers the neighbouring problem: bytes decoded with the wrong encoding. The two overlap by one level on entities. Mojibake reports a visible `&amp;nbsp;`, which means the source was encoded three times; this rule reports a visible `&nbsp;`, which means twice.
+
+## Enable / disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/unrendered-markup"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/unrendered-markup"]
+disable = ["*"]
+```

--- a/docs/rules/content/unrendered-markup.mdx
+++ b/docs/rules/content/unrendered-markup.mdx
@@ -19,7 +19,7 @@ Something rendered a value as plain text that was authored as markup. Find the f
 
 ## What it checks
 
-Three families, in visible text only:
+Seven kinds, in three families, in visible text only:
 
 | Kind | Example on screen | Meaning |
 |---|---|---|
@@ -48,7 +48,7 @@ Four more limits keep the rule quiet on pages that talk about markup rather than
 - **Underscore emphasis must contain a space.** `__init__` and `__main__` are flanked exactly like bold and appear in ordinary prose, so `__bold__` on its own is not reported. `**bold**` still is.
 - **A markdown link needs a URL-shaped target.** `array[i](arg)` and `[see note] (below)` are not links.
 - **Escaped tags must be lowercase.** `<Article>` and `<Header>` are component names a page is showing on purpose. Markup that leaked from a template came from HTML a server emitted, which is lowercase.
-- **At least one escaped tag must carry a closing form or an attribute with a value.** A page that writes `<pre>` or `<meta name>` in a sentence is documenting an element. A leak brings `</p>` or `class="row"` with it.
+- **At least one escaped tag must carry a true closing form or a recognised attribute with a value.** A page that writes `<pre>` or `<meta name>` in a sentence is documenting an element. A leak brings `</p>` or `class="row"` with it. A self-closing `<br/>` is not a closing form, `</path/to/file>` is a path rather than a closing tag, and `c=1` is not an attribute, so `if a<b then c=1>0` stays clean.
 
 ## False positives
 
@@ -62,7 +62,9 @@ The residual case is a page whose subject is HTML source, displayed in a contain
 
 ## Related rules
 
-[content/mojibake](/rules/content/mojibake) covers the neighbouring problem: bytes decoded with the wrong encoding. The two overlap by one level on entities. Mojibake reports a visible `&amp;nbsp;`, which means the source was encoded three times; this rule reports a visible `&nbsp;`, which means twice.
+[content/mojibake](/rules/content/mojibake) covers the neighbouring problem: bytes decoded with the wrong encoding. The two sit one encoding level apart on entities. Mojibake reports a visible `&amp;nbsp;`, meaning the source was encoded three times; this rule reports a visible `&nbsp;`, meaning twice.
+
+They do overlap on triple-encoded text, and deliberately so. A page showing `&amp;nbsp;` trips mojibake on the whole sequence and this rule on the `&amp;` inside it, and both findings are true: the entity was encoded once too many, and a reader is looking at raw markup. Expect one finding from each rule on such a page.
 
 ## Enable / disable
 

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules reference"
-description: "All 280 audit rules organized by score group and category"
+description: "All 281 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **280 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **281 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -23,7 +23,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Internal and external link health and structure (15 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (19 rules)
+    Text quality, readability, and content structure (20 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (12 rules)

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules reference"
-description: "All 279 audit rules organized by score group and category"
+description: "All 280 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **279 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **280 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -23,7 +23,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Internal and external link health and structure (15 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (18 rules)
+    Text quality, readability, and content structure (19 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (12 rules)

--- a/docs/rules/seo/index.mdx
+++ b/docs/rules/seo/index.mdx
@@ -25,7 +25,7 @@ are skipped when you're not logged in.
     Internal and external link health and structure (15 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (19 rules)
+    Text quality, readability, and content structure (20 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (12 rules)

--- a/docs/rules/seo/index.mdx
+++ b/docs/rules/seo/index.mdx
@@ -25,7 +25,7 @@ are skipped when you're not logged in.
     Internal and external link health and structure (15 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (18 rules)
+    Text quality, readability, and content structure (19 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (12 rules)

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -124,6 +124,19 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // content/unrendered-markup; anything else means a rule id
       // leaked in, so fix that rather than this number.
       expect(v1.perRuleTally.length).toBe(281);
+      // Each +500 above is only "all passes" if nothing warned. healthScore
+      // staying at 48 does not prove that — a handful of weight-5 warnings in a
+      // 20-rule category would not move it — so pin the tally directly.
+      const unrendered = v1.perRuleTally.find((t) => t.ruleId === "content/unrendered-markup");
+      expect(unrendered).toEqual({
+        ruleId: "content/unrendered-markup",
+        pass: 500,
+        warn: 0,
+        fail: 0,
+        info: 0,
+        skipped: 0,
+        total: 500,
+      });
     },
     180_000,
   );

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -106,7 +106,11 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // speaks, so like content/hidden-text it emits one check across the 500
       // fixture pages that have a document (#1350). All 500 PASS, which is why
       // healthScore.overall is still 48: the synthetic site writes real copy.
-      expect(v1.findings.length).toBe(98721);
+      // 98721 -> 99221: content/unrendered-markup (#1352) is the same shape and
+      // adds the same 500 — one check on each page with a document, the other
+      // 18 having none. All 500 pass too: the fixture's copy carries no literal
+      // markdown, so healthScore.overall is still 48.
+      expect(v1.findings.length).toBe(99221);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
@@ -116,9 +120,10 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // 274 -> 275 crawl/sitemap-lastmod-drift, 275 -> 276
       // content/date-agreement, 276 -> 277 links/no-contextual-inbound,
       // 277 -> 278 social/asset-divergence, 278 -> 279 perf/asset-compression,
-      // 279 -> 280 content/placeholder-text; anything else means a rule id
+      // 279 -> 280 content/placeholder-text, 280 -> 281
+      // content/unrendered-markup; anything else means a rule id
       // leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(280);
+      expect(v1.perRuleTally.length).toBe(281);
     },
     180_000,
   );

--- a/packages/parser/src/extractors/dom-text.ts
+++ b/packages/parser/src/extractors/dom-text.ts
@@ -10,6 +10,9 @@ import type { Element, Node } from "linkedom";
 const ELEMENT_NODE = 1;
 const TEXT_NODE = 3;
 
+/** Stack marker: a boundary element's children are done, close it. */
+const BOUNDARY_CLOSE = Symbol("boundary-close");
+
 /**
  * Concatenate `root`'s descendant text in document order, skipping any subtree
  * whose root element is excluded by `isExcluded`. Output is identical to
@@ -23,13 +26,20 @@ const TEXT_NODE = 3;
  * back as `Ã©`. Callers that scan the result for character sequences must pass a
  * separator, or they will see sequences that exist in neither fragment.
  *
- * `isBoundary` (optional) additionally emits `separator` on ENTERING a matching
- * element. `.textContent` joins adjacent blocks with nothing at all, so
+ * `isBoundary` (optional) wraps each matching element's text in `separator`, on
+ * BOTH sides. `.textContent` joins adjacent blocks with nothing at all, so
  * `<td>Author</td><td>undefined</td>` reads back as `Authorundefined` and no
- * word-boundary pattern can see either cell. Entering is enough to separate
- * siblings: the next block's own entry closes the previous one. Callers that
- * judge WORDS rather than characters want this; callers reproducing
- * `.textContent` must leave it off.
+ * word-boundary pattern can see either cell, while `<p>a</p><p>b</p>` reads as
+ * `ab` and a line-anchored pattern finds a line start only at offset 0.
+ *
+ * Entering alone looks sufficient — the next block's own entry closes the
+ * previous one — but that only holds between two BLOCKS. A block followed by
+ * INLINE content has nothing to close it, so `<h3>Price *</h3><a>terms* apply</a>`
+ * reads back as `*terms*`, emphasis present in neither element. Closing on the
+ * way out is what makes the separation unconditional.
+ *
+ * Callers that judge words or characters want this; callers reproducing
+ * `.textContent` exactly must leave it off, and nothing changes for them.
  */
 export function collectTextExcluding(
   root: Node,
@@ -40,12 +50,19 @@ export function collectTextExcluding(
   const out: string[] = [];
   // Explicit stack of remaining child lists; index tracks position in each.
   // Pushing children in reverse preserves document order on a LIFO stack.
-  const stack: Node[] = [];
+  const stack: (Node | typeof BOUNDARY_CLOSE)[] = [];
   const initial = root.childNodes;
   for (let i = initial.length - 1; i >= 0; i--) stack.push(initial[i] as Node);
 
   while (stack.length > 0) {
-    const node = stack.pop() as Node;
+    const entry = stack.pop() as Node | typeof BOUNDARY_CLOSE;
+    // A boundary element pushes this before its children, so it pops after them
+    // and closes the boundary. See the note above on why entering is not enough.
+    if (entry === BOUNDARY_CLOSE) {
+      out.push(separator);
+      continue;
+    }
+    const node = entry;
     const type = node.nodeType;
     if (type === TEXT_NODE) {
       out.push((node as { data?: string }).data ?? "");
@@ -54,7 +71,10 @@ export function collectTextExcluding(
         if (separator) out.push(separator);
         continue;
       }
-      if (separator && isBoundary?.(node as Element)) out.push(separator);
+      if (separator && isBoundary?.(node as Element) === true) {
+        out.push(separator);
+        stack.push(BOUNDARY_CLOSE);
+      }
       const children = node.childNodes;
       for (let i = children.length - 1; i >= 0; i--) {
         stack.push(children[i] as Node);

--- a/packages/parser/tests/dom-text.test.ts
+++ b/packages/parser/tests/dom-text.test.ts
@@ -50,8 +50,13 @@ describe("collectTextExcluding separator", () => {
   });
 });
 
+// The boundary is emitted on BOTH sides of a matching element. Entering alone
+// separates two adjacent BLOCKS, which is all content/placeholder-text needs,
+// but leaves a block glued to inline content that follows it — where
+// content/unrendered-markup then reads a match belonging to neither element.
 describe("collectTextExcluding — block boundaries", () => {
   const isTd = tagExcluder(new Set(["td"]));
+  const isBlock = tagExcluder(new Set(["p", "li", "div"]));
 
   test("without isBoundary, adjacent cells fuse into one word", () => {
     // `.textContent` semantics, and the reason the option exists.
@@ -60,20 +65,60 @@ describe("collectTextExcluding — block boundaries", () => {
     );
   });
 
-  test("isBoundary emits the separator on ENTERING a matching element", () => {
+  test("isBoundary wraps each matching element, so cells never fuse", () => {
     expect(
       collectTextExcluding(body("<tr><td>Author</td><td>undefined</td></tr>"), isCode, "\n", isTd),
-    ).toBe("\nAuthor\nundefined");
+    ).toBe("\nAuthor\n\nundefined\n");
   });
 
   test("a boundary separates, it never joins", () => {
     // Text already flowing through one element must not gain a break inside it.
     expect(collectTextExcluding(body("<td>two words</td>"), isCode, "\n", isTd)).toBe(
-      "\ntwo words",
+      "\ntwo words\n",
     );
   });
 
   test("an empty separator disables boundaries as well as skip markers", () => {
     expect(collectTextExcluding(body("<tr><td>a</td><td>b</td></tr>"), isCode, "", isTd)).toBe("ab");
+  });
+
+  test("omitted, sibling blocks glue together", () => {
+    expect(collectTextExcluding(body("<p>a</p><p>b</p>"), isCode, "\n")).toBe("ab");
+  });
+
+  test("nested blocks each contribute their own pair", () => {
+    expect(collectTextExcluding(body("<div>x<p>y</p></div>"), isCode, "\n", isBlock)).toBe(
+      "\nx\ny\n\n",
+    );
+  });
+
+  test("non-matching elements are transparent", () => {
+    expect(collectTextExcluding(body("<p>a<span>b</span>c</p>"), isCode, "\n", isBlock)).toBe(
+      "\nabc\n",
+    );
+  });
+
+  test("excluded subtrees still emit exactly one separator", () => {
+    expect(collectTextExcluding(body("<p>a<code>x</code>b</p>"), isCode, "\n", isBlock)).toBe(
+      "\na\nb\n",
+    );
+  });
+
+  test("a boundary element that is ALSO excluded is only excluded", () => {
+    // Exclusion wins, and contributes one separator rather than three.
+    const both = tagExcluder(new Set(["div"]));
+    expect(collectTextExcluding(body("a<div>x</div>b"), both, "\n", both)).toBe("a\nb");
+  });
+
+  test("text on both sides of a block cannot glue across it", () => {
+    // The closing half of the boundary is what this pins: `*` before a block and
+    // `*` after it must not read back as a matched pair.
+    expect(collectTextExcluding(body("a *<p>b</p>c* d"), isCode, "\n", isBlock)).toBe(
+      "a *\nb\nc* d",
+    );
+  });
+
+  test("the root itself never emits a boundary", () => {
+    expect(collectTextExcluding(body("plain"), isCode, "\n", () => true)).toBe("plain");
   });
 });

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -21,6 +21,7 @@ import { readingLevelRule } from "./reading-level";
 import { staleCopyrightRule } from "./stale-copyright";
 import { thinVsSiteNormRule } from "./thin-vs-site-norm";
 import { titlePatternOutlierRule } from "./title-pattern-outlier";
+import { unrenderedMarkupRule } from "./unrendered-markup";
 import { wordCountRule } from "./word-count";
 
 export const rules: Rule[] = [
@@ -44,6 +45,7 @@ export const rules: Rule[] = [
   titlePatternOutlierRule,
   dateAgreementRule,
   placeholderTextRule,
+  unrenderedMarkupRule,
 ];
 
 export {
@@ -66,5 +68,6 @@ export {
   staleCopyrightRule,
   thinVsSiteNormRule,
   titlePatternOutlierRule,
+  unrenderedMarkupRule,
   wordCountRule,
 };

--- a/packages/rules/src/content/unrendered-markup.ts
+++ b/packages/rules/src/content/unrendered-markup.ts
@@ -1,0 +1,455 @@
+// content/unrendered-markup - Markup that failed to render and leaked into visible copy
+
+import { getAttrCI } from "@squirrelscan/utils";
+
+import { collectTextExcluding } from "@squirrelscan/parser/extractors";
+
+import type { Element } from "linkedom";
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+
+/** Never read by a visitor at all. */
+const SCRIPT_LIKE_TAGS = ["script", "style", "noscript", "template"] as const;
+
+/**
+ * Markup that says "what follows is a literal, not prose". A documentation page
+ * showing `**bold**` inside one of these is doing its job, not mis-rendering, so
+ * every one of them is excluded before a single pattern runs. `<textarea>` joins
+ * the usual four because an editor pre-filled with a post's markdown source is
+ * the single most common way real markdown appears on a page on purpose.
+ */
+const CODE_LIKE_TAGS = ["code", "pre", "samp", "kbd", "textarea"] as const;
+
+/**
+ * Class tokens every mainstream syntax highlighter stamps on its container.
+ * Matched as WHOLE tokens, never as substrings: a marketing page's
+ * `class="highlight-box"` callout is prose and must still be judged, while
+ * Rouge's `class="highlight"` wrapper is a code block and must not be.
+ *
+ * Some highlighters (Rouge, Chroma, Pygments) put the marker on a `<div>` that
+ * WRAPS the `<pre>`, so the tag list alone would still read the language label
+ * and line numbers they inject as prose.
+ */
+const HIGHLIGHT_CLASS_TOKENS = new Set([
+  "highlight",
+  "highlighter-rouge",
+  "codehilite",
+  "chroma",
+  "hljs",
+  "shiki",
+  "astro-code",
+  "expressive-code",
+  "torchlight",
+  "prismjs",
+  "code-block",
+  "codeblock",
+  "sourcecode",
+  "line-numbers",
+  // A site that styles source-on-display without reaching for <pre>. Generic
+  // enough to be a promise about the content, not one site's class name:
+  // commonmark.org's syntax table marks every cell of markdown source this way.
+  "preformatted",
+  "pre",
+]);
+
+/** `class="language-ts"` / `class="lang-ts"`: the same marker, spelled per-language. */
+const HIGHLIGHT_CLASS_PREFIXES = ["language-", "lang-"] as const;
+
+/** Attributes a highlighter or MDX renderer writes on the block it owns. */
+const HIGHLIGHT_ATTRIBUTES = ["data-language", "data-lang", "data-highlighted", "data-code"];
+
+const SCRIPT_OR_CODE_TAGS = new Set<string>([...SCRIPT_LIKE_TAGS, ...CODE_LIKE_TAGS]);
+
+/** True for any element whose subtree is source-on-display rather than prose. */
+export function isCodeLikeElement(el: Element): boolean {
+  const tag = el.tagName?.toLowerCase();
+  if (tag && SCRIPT_OR_CODE_TAGS.has(tag)) return true;
+
+  // getAttribute is case-SENSITIVE on this parser, so read both class spellings
+  // the same way every other rule does.
+  const className = getAttrCI(el, "class");
+  if (className) {
+    for (const token of className.split(/\s+/)) {
+      if (!token) continue;
+      const lower = token.toLowerCase();
+      if (HIGHLIGHT_CLASS_TOKENS.has(lower)) return true;
+      for (const prefix of HIGHLIGHT_CLASS_PREFIXES) {
+        if (lower.startsWith(prefix) && lower.length > prefix.length) return true;
+      }
+    }
+  }
+
+  for (const attr of HIGHLIGHT_ATTRIBUTES) {
+    if (getAttrCI(el, attr) !== null) return true;
+  }
+  return false;
+}
+
+/**
+ * A newline, never a space, stands in for each skipped subtree.
+ *
+ * Skipping glues neighbours together: `**<code>x</code>**` would read back as
+ * `****` and be counted as emphasis that exists in neither fragment. A newline
+ * also stops a line-anchored pattern (`## `, ```` ``` ````) from starting mid-line
+ * where an excluded block actually ended.
+ */
+const SKIPPED_SUBTREE_BOUNDARY = "\n";
+
+/**
+ * Work cap. Prose beyond this is not scanned: the rule is a yes/no signal about
+ * whether a template mis-rendered, and no real page needs half a megabyte of
+ * prose to demonstrate that. Bounds the cost on a hostile or generated page.
+ */
+const MAX_SCANNED_CHARS = 500_000;
+
+/** Per family, so one pathological page cannot allocate an unbounded match list. */
+const MAX_MATCHES_PER_KIND = 500;
+
+/**
+ * Markdown emphasis, ASTERISK form. The delimiters must be FLANKED the way
+ * CommonMark requires — opener preceded by start/whitespace/opening punctuation
+ * and followed by non-whitespace, closer preceded by non-whitespace and followed
+ * by end/whitespace/closing punctuation.
+ *
+ * Flanking is the whole point: a naive "two paired asterisks" rule reads
+ * `2 * 3 * 4` as emphasis and `width * height` as bold. Both fail here because
+ * the character after the opening `*` is a space.
+ */
+const MD_EMPHASIS_ASTERISK_RE =
+  /(?:^|[\s([{'"])(\*{1,2})(?=[^\s*])([^*\n]{1,200})\1(?=$|[\s.,;:!?)\]}'"])/gm;
+
+/**
+ * Markdown emphasis, UNDERSCORE form — deliberately stricter than the asterisk
+ * form: the emphasized run must contain whitespace, which `INNER_HAS_SPACE`
+ * checks on the capture rather than in the pattern.
+ *
+ * Flanking alone already rejects `CLOUDFLARE_API_TOKEN` and `some_file_name.ts`,
+ * whose underscores are intraword. It does NOT reject `__init__`, `__main__` or
+ * `__all__`, which are flanked exactly like bold and appear in ordinary Python
+ * prose outside a code span. Requiring a space inside costs single-word
+ * `__bold__` and buys silence on every dunder; a page that really lost its
+ * markdown almost always leaks phrases and asterisks too.
+ *
+ * The whitespace test is JS, not regex, on purpose: spelling it as
+ * `[^_\n]{0,198}[ \t][^_\n]{0,198}` puts two quantifiers over the same
+ * characters, and every run that fails to close then re-partitions itself.
+ */
+const MD_EMPHASIS_UNDERSCORE_RE =
+  /(?:^|[\s([{'"])(_{1,2})(?=[^\s_])([^_\n]{1,200})\1(?=$|[\s.,;:!?)\]}'"])/gm;
+
+const INNER_HAS_SPACE = (m: RegExpExecArray): boolean => /[ \t]/.test(m[2] ?? "");
+
+/**
+ * Markdown link or image: `[text](url)`, `![alt](url)`.
+ *
+ * The target must LOOK like a URL. That single condition is what separates a
+ * leaked link from ordinary bracketed prose — `f[x](y)`, `[see note] (below)`
+ * and `array[i](arg)` all fail it, while `[docs](https://…)`, `[home](/)` and
+ * `[top](#top)` do not.
+ */
+const MD_LINK_RE =
+  /!?\[[^\]\n]{0,200}\]\((?:https?:\/\/|mailto:|\/|#|www\.|[\w.-]{1,60}\.[a-z]{2,10}[/?#])[^)\s]{0,300}\)/g;
+
+/**
+ * A leading `#` run at the start of a line. `[ \t]` never `\s`, so the class
+ * cannot swallow the newline the `m` anchor depends on.
+ *
+ * The trailing letter requirement keeps `#1 in the market` and `# 404` out; a
+ * line that opens with hashes, a space and a word is a heading nobody rendered.
+ *
+ * There is deliberately no `$`: anchoring the tail to end-of-line would make a
+ * heading longer than the bound fail and then re-try every shorter length,
+ * which is both slow and a silent miss on exactly the long headings a broken
+ * template produces.
+ */
+const MD_HEADING_RE = /^[ \t]{0,3}#{1,6}[ \t]+(?=[^\s#\d])[^\n]{1,100}/gm;
+
+/** A fence line: three or more backticks or tildes, optionally with an info string. */
+const MD_FENCE_RE = /^[ \t]{0,3}(?:`{3,}|~{3,})[^\n]{0,60}/gm;
+
+/**
+ * Inline code span. Backticks are near-absent from ordinary prose, so flanking
+ * plus a non-space interior is enough; the run is bounded to keep it linear.
+ */
+const MD_INLINE_CODE_RE = /(?:^|[\s([{'"])`(?=[^\s`])([^`\n]{1,200})`(?=$|[\s.,;:!?)\]}'"])/gm;
+
+/**
+ * HTML tags a reader can SEE. The page source said `&lt;p&gt;`; `.textContent`
+ * decodes that, so by the time the text reaches here it is a literal `<p>`.
+ * Scanning the raw HTML for `&lt;` instead would be the same rule written
+ * backwards, and would fire on every escaped example inside a code block.
+ *
+ * One bounded character class, not two adjacent quantifiers: `[^<>]{0,200}`
+ * cannot match the closing `>`, so it stops at the first one and never
+ * re-partitions a long run the way `\s*[^>]*` would.
+ *
+ * LOWERCASE tag names only. Escaped markup that leaked out of a template came
+ * from HTML a server actually emitted, which is lowercase. A capitalised
+ * `<Article>` or `<Video>` is a JSX, Astro or Vue COMPONENT name that a page is
+ * displaying on purpose — astro.build puts a whole row of them in its hero.
+ */
+const ESCAPED_TAG_RE = /<(\/?)([a-z][a-z0-9]{0,9})([^<>]{0,200})>/g;
+
+/**
+ * Tags whose bare form is unambiguous evidence. `b`, `i`, `u`, `s` and `q` are
+ * absent on purpose: `x<b>y` occurs in mathematical prose, and one comparison
+ * chain must not accuse a page of leaking markup.
+ */
+const VISIBLE_HTML_TAGS = new Set([
+  "p", "div", "span", "br", "hr", "ul", "ol", "li", "dl", "dt", "dd",
+  "strong", "em", "h1", "h2", "h3", "h4", "h5", "h6",
+  "table", "thead", "tbody", "tfoot", "tr", "td", "th", "caption",
+  "section", "article", "header", "footer", "aside", "nav", "main",
+  "form", "input", "button", "select", "option", "label", "textarea",
+  "img", "picture", "source", "video", "audio", "iframe", "embed", "object",
+  "blockquote", "figure", "figcaption", "pre", "code", "script", "style",
+  "link", "meta", "svg", "path", "html", "head", "body", "title",
+  "details", "summary", "canvas", "template", "abbr",
+]);
+
+/** These need an attribute or a closing slash before they count. */
+const AMBIGUOUS_HTML_TAGS = new Set(["a", "b", "i", "u", "s", "q"]);
+
+/**
+ * Named entities that survived one decode too few. A curated list, not
+ * `&[a-z]+;`: the generic shape reads `Johnson&Johnson;` as an entity, and a
+ * rule that accuses a page of broken encoding cannot afford that. Numeric
+ * references are unambiguous and handled separately.
+ */
+const KNOWN_ENTITY_NAMES = [
+  "nbsp", "amp", "lt", "gt", "quot", "apos", "hellip", "mdash", "ndash",
+  "copy", "reg", "trade", "laquo", "raquo", "ldquo", "rdquo", "lsquo", "rsquo",
+  "bull", "middot", "deg", "plusmn", "times", "divide", "frac12", "frac14",
+  "euro", "pound", "yen", "cent", "sect", "para", "dagger", "permil", "prime",
+  "ne", "le", "ge", "larr", "rarr", "harr", "infin", "sup2", "sup3",
+  "eacute", "egrave", "agrave", "uuml", "ouml", "auml", "ccedil", "ntilde", "szlig",
+  "shy", "ensp", "emsp", "thinsp", "zwnj", "zwj",
+] as const;
+
+const DOUBLE_ENCODED_ENTITY_RE = new RegExp(
+  `&(?:${KNOWN_ENTITY_NAMES.join("|")}|#\\d{1,7}|#[xX][0-9a-fA-F]{1,6});`,
+  "g",
+);
+
+export type UnrenderedMarkupKind =
+  | "markdown-emphasis"
+  | "markdown-link"
+  | "markdown-heading"
+  | "markdown-code-fence"
+  | "markdown-inline-code"
+  | "escaped-html-tag"
+  | "double-encoded-entity";
+
+export interface UnrenderedMarkupFinding {
+  kind: UnrenderedMarkupKind;
+  /** A short, single-line excerpt of the first occurrence. */
+  sample: string;
+  count: number;
+}
+
+/** Kinds that mean a reader is looking at raw markup, not at a formatting glyph. */
+const RAW_MARKUP_KINDS = new Set<UnrenderedMarkupKind>([
+  "escaped-html-tag",
+  "double-encoded-entity",
+]);
+
+/**
+ * Corroborating only: present in the detail when something else fires, never
+ * able to accuse a page by itself.
+ *
+ * A visible backtick is the one markdown character people put on a page
+ * deliberately and often — a prompt written to be copied into an agent, a chat
+ * transcript, a changelog entry. Vercel's docs landing page carries six of them
+ * in a copyable prompt and is not mis-rendering anything. A template that
+ * really lost its markdown pass leaks headings, links or emphasis as well.
+ */
+const CORROBORATING_KINDS = new Set<UnrenderedMarkupKind>(["markdown-inline-code"]);
+
+/** Reports get these verbatim, so no newline and no unbounded site-controlled string. */
+function toSample(match: string): string {
+  const flat = match.replace(/\s+/g, " ").trim();
+  return flat.length > 80 ? `${flat.slice(0, 79)}…` : flat;
+}
+
+/**
+ * Matches of `re` in `text` that satisfy `accept`, capped, with `re`'s
+ * lastIndex left clean for the next page (these regexes are module-level and
+ * `g`-flagged, so a stale lastIndex would silently skip the head of the text).
+ */
+function collect(
+  re: RegExp,
+  text: string,
+  accept?: (m: RegExpExecArray) => boolean,
+): string[] {
+  re.lastIndex = 0;
+  const out: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    if (!accept || accept(match)) {
+      out.push(match[0]);
+      if (out.length >= MAX_MATCHES_PER_KIND) break;
+    }
+    // A zero-length match would spin forever; none of these patterns can produce
+    // one, but the guard costs nothing and the alternative is a hung audit.
+    if (match.index === re.lastIndex) re.lastIndex++;
+  }
+  re.lastIndex = 0;
+  return out;
+}
+
+function push(
+  out: UnrenderedMarkupFinding[],
+  kind: UnrenderedMarkupKind,
+  matches: string[],
+): void {
+  if (matches.length === 0) return;
+  out.push({ kind, sample: toSample(matches[0] as string), count: matches.length });
+}
+
+/**
+ * Visible HTML tags in `text`, reported only when at least one of them could
+ * not have been written on purpose.
+ *
+ * A bare tag NAME is how a page talks about an element: MDN's reference for the
+ * `pre` element says `<pre>` in its breadcrumb and `<meta name>` and
+ * `<meta http-equiv>` in its see-also list, none of them inside a code span.
+ * Markup that actually leaked out of a template looks different — it brings the
+ * closing tag with it (`<p>…</p>`) or an attribute with a VALUE
+ * (`<div class="row">`, `<a href="/x">`), because that is what a server emits
+ * and what nobody types into a sentence.
+ *
+ * One such tag vouches for the rest, so a leak of `<p>text</p><br><br>` is
+ * counted in full while a page of bare element names is silent.
+ */
+function findEscapedTags(text: string): string[] {
+  const candidates: { text: string; closing: boolean; valued: boolean }[] = [];
+  ESCAPED_TAG_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ESCAPED_TAG_RE.exec(text)) !== null) {
+    const closing = match[1] === "/";
+    const name = match[2] ?? "";
+    const rest = match[3] ?? "";
+    // An attribute list has to start at a boundary, so `<pathological>` cannot
+    // read as `<path>` followed by noise.
+    const attrs = rest.length > 0 && /^[\s/]/.test(rest);
+    if (rest.length > 0 && !attrs) continue;
+    const ambiguous = AMBIGUOUS_HTML_TAGS.has(name);
+    if (!VISIBLE_HTML_TAGS.has(name) && !ambiguous) continue;
+    // `x<b>y` is a comparison chain in mathematical prose. An ambiguous opening
+    // tag needs an attribute before it outweighs that reading.
+    if (ambiguous && !closing && !attrs) continue;
+    candidates.push({ text: match[0], closing, valued: attrs && rest.includes("=") });
+    if (candidates.length >= MAX_MATCHES_PER_KIND) break;
+  }
+  ESCAPED_TAG_RE.lastIndex = 0;
+
+  if (!candidates.some((c) => c.closing || c.valued)) return [];
+  return candidates.map((c) => c.text);
+}
+
+/** Every family of unrendered markup present in `text`, with a sample and a count. */
+export function findUnrenderedMarkup(text: string): UnrenderedMarkupFinding[] {
+  const scanned = text.length > MAX_SCANNED_CHARS ? text.slice(0, MAX_SCANNED_CHARS) : text;
+  const out: UnrenderedMarkupFinding[] = [];
+
+  const emphasis = [
+    ...collect(MD_EMPHASIS_ASTERISK_RE, scanned),
+    ...collect(MD_EMPHASIS_UNDERSCORE_RE, scanned, INNER_HAS_SPACE),
+  ];
+  push(out, "markdown-emphasis", emphasis);
+  push(out, "markdown-link", collect(MD_LINK_RE, scanned));
+  push(out, "markdown-heading", collect(MD_HEADING_RE, scanned));
+  push(out, "markdown-code-fence", collect(MD_FENCE_RE, scanned));
+  push(out, "markdown-inline-code", collect(MD_INLINE_CODE_RE, scanned));
+
+  push(out, "escaped-html-tag", findEscapedTags(scanned));
+
+  push(out, "double-encoded-entity", collect(DOUBLE_ENCODED_ENTITY_RE, scanned));
+
+  return out;
+}
+
+export const unrenderedMarkupRule: Rule = {
+  meta: {
+    id: "content/unrendered-markup",
+    name: "Unrendered Markup",
+    description: "Detects literal markdown or escaped HTML leaking into rendered copy",
+    solution:
+      'Something rendered a value as plain text that was authored as markup. Find the field, not the page: a CMS that stores markdown and a template that prints it without a markdown-to-HTML pass produces literal `**bold**` and `[text](url)` everywhere that field appears, and fixing one page leaves the rest broken. Visible `<p>` or `<a href` means the opposite mistake — HTML was escaped twice, usually by escaping a value that a templating engine (Jinja, Twig, Blade, JSX) had already escaped, so remove the manual escape rather than marking the value safe. Visible `&nbsp;` or `&amp;` means the entity itself was encoded a second time on the way in, which is normally an import or a rich-text editor round-trip, so re-import the affected content. If the markup is meant to be on display, put it in `<code>` or `<pre>`, which this rule skips.',
+    category: "content",
+    scope: "page",
+    severity: "warning",
+    weight: 5,
+    skipOnSoft404: true,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const checks: CheckResult[] = [];
+    const doc = ctx.parsed.document;
+    if (!doc) {
+      checks.push({
+        name: "unrendered-markup",
+        status: "skipped",
+        message: "No document available",
+        skipReason: "Parse error",
+      });
+      return { checks };
+    }
+
+    const body = doc.querySelector("body");
+    if (!body) {
+      checks.push({
+        name: "unrendered-markup",
+        status: "skipped",
+        message: "No body element to read visible text from",
+        skipReason: "no-body",
+      });
+      return { checks };
+    }
+
+    // Prose only, and never the raw HTML: the rule asks what a VISITOR sees, so
+    // it has to read the same decoded text a browser paints. Code-like subtrees
+    // come out first because a documentation page showing `**bold**` on purpose
+    // is the single largest false-positive class this rule has — without the
+    // exclusion it fires on its own documentation.
+    const text = collectTextExcluding(body, isCodeLikeElement, SKIPPED_SUBTREE_BOUNDARY);
+    const found = findUnrenderedMarkup(text);
+
+    const hasRawMarkup = found.some((f) => RAW_MARKUP_KINDS.has(f.kind));
+    const markdownCount = found
+      .filter((f) => !RAW_MARKUP_KINDS.has(f.kind) && !CORROBORATING_KINDS.has(f.kind))
+      .reduce((sum, f) => sum + f.count, 0);
+
+    // Backticks alone say nothing: they are the one markdown character pages
+    // display on purpose. Everything else is reported, and the corroborating
+    // family rides along in the detail once something real has fired.
+    if (!hasRawMarkup && markdownCount === 0) {
+      checks.push({
+        name: "unrendered-markup",
+        status: "pass",
+        message: "No unrendered markup in visible text",
+      });
+      return { checks };
+    }
+
+    const total = found.reduce((sum, f) => sum + f.count, 0);
+    const kinds = found.map((f) => f.kind).join(", ");
+
+    // Visible tags and entities are not a judgement call: nothing renders them
+    // on purpose outside a code block, and those are already excluded. Literal
+    // markdown is judged by weight instead — one stray asterisk pair is a typo,
+    // three or more is a template that never ran its markdown pass.
+    const status = hasRawMarkup || markdownCount >= 3 ? "fail" : "warn";
+
+    checks.push({
+      name: "unrendered-markup",
+      status,
+      message: `${total} unrendered markup occurrence(s) in visible text (${kinds}): example ${found[0]?.sample}`,
+      value: total,
+      details: {
+        kinds: found.map((f) => ({ kind: f.kind, sample: f.sample, count: f.count })),
+      },
+    });
+    return { checks };
+  },
+};

--- a/packages/rules/src/content/unrendered-markup.ts
+++ b/packages/rules/src/content/unrendered-markup.ts
@@ -73,7 +73,7 @@ const BLOCK_TAGS = new Set([
   "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form",
   "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "li", "main",
   "nav", "ol", "p", "section", "summary", "table", "tbody", "td", "tfoot",
-  "th", "thead", "tr", "ul",
+  "th", "thead", "tr", "ul", "option", "optgroup", "caption", "legend", "menu",
 ]);
 
 /** True for any element a browser starts on a new line. */
@@ -187,17 +187,20 @@ const MD_LINK_RE =
  * which is both slow and a silent miss on exactly the long headings a broken
  * template produces.
  */
-const MD_HEADING_RE = /^[ \t]{0,3}#{1,6}[ \t]+(?=[^\s#\d])([^\n]{1,100})/gm;
+const MD_HEADING_RE = /^[ \t]{0,3}(#{1,6})[ \t]+(?=[^\s#\d])([^\n]{1,100})/gm;
 
 /**
- * A heading is prose; a URL fragment is a slug. MDN's specification table
- * renders `HTML<br /># the-pre-element` — a real line, really starting with a
- * hash, that is the fragment of the link above it rather than a heading nobody
- * rendered. One lowercase hyphenated or underscored token with no spaces is
- * that shape, and is never a heading a CMS lost.
+ * A SINGLE `#` is also the number sign, and now that every block starts a line
+ * the number sign starts plenty of them: `<th># of seats</th>` is a column
+ * header, and MDN's specification table renders `HTML<br /># the-pre-element`,
+ * a real line showing the link's fragment. Both are lowercase after the hash.
+ *
+ * `##` and deeper have no such second reading, so they are taken as written —
+ * which keeps `## my-package` and `## getting-started`, headings a changelog
+ * really can lose.
  */
-const NOT_A_SLUG = (m: RegExpExecArray): boolean =>
-  !/^[a-z0-9]+(?:[-_][a-z0-9]+)+$/.test((m[1] ?? "").trim());
+const HEADING_IS_PROSE = (m: RegExpExecArray): boolean =>
+  (m[1] ?? "").length > 1 || /^[A-Z]/.test((m[2] ?? "").trim());
 
 /** A fence line: three or more backticks or tildes, optionally with an info string. */
 const MD_FENCE_RE = /^[ \t]{0,3}(?:`{3,}|~{3,})[^\n]{0,60}/gm;
@@ -244,9 +247,12 @@ export const MAX_TAG_NAME_LENGTH = Math.max(
  * Scanning the raw HTML for `&lt;` instead would be the same rule written
  * backwards, and would fire on every escaped example inside a code block.
  *
- * One bounded character class, not two adjacent quantifiers: `[^<>]{0,200}`
+ * One bounded character class, not two adjacent quantifiers: `[^<>\n]{0,200}`
  * cannot match the closing `>`, so it stops at the first one and never
- * re-partitions a long run the way `\s*[^>]*` would.
+ * re-partitions a long run the way `\s*[^>]*` would. It excludes the newline
+ * for a second reason: a block boundary is a newline, so allowing one here
+ * would let `<p>x&lt;p</p><span>&gt;y</span>` assemble a `<p>` out of two
+ * blocks that each hold half of it.
  *
  * LOWERCASE tag names only. Escaped markup that leaked out of a template came
  * from HTML a server actually emitted, which is lowercase. A capitalised
@@ -254,7 +260,7 @@ export const MAX_TAG_NAME_LENGTH = Math.max(
  * displaying on purpose — astro.build puts a whole row of them in its hero.
  */
 const ESCAPED_TAG_RE = new RegExp(
-  `<(/?)([a-z][a-z0-9]{0,${MAX_TAG_NAME_LENGTH - 1}})([^<>]{0,200})>`,
+  `<(/?)([a-z][a-z0-9]{0,${MAX_TAG_NAME_LENGTH - 1}})([^<>\n]{0,200})>`,
   "g",
 );
 
@@ -272,6 +278,13 @@ const KNOWN_ATTRIBUTES = new Set([
   "height", "colspan", "rowspan", "for", "action", "method", "placeholder",
   "datetime", "label", "cite", "download", "referrerpolicy", "integrity",
   "crossorigin", "http-equiv", "property", "itemprop", "viewbox", "xmlns",
+  // Legacy presentational attributes. A mangled rich-text or email import
+  // produces exactly this shape — no closing tags, nothing modern — and would
+  // otherwise have nothing to vouch for it. Single-letter SVG names (d, x, y)
+  // are deliberately absent: `if a<b then d=1>0` would read as an attribute
+  // again, which is the false positive this allowlist exists to prevent.
+  "align", "valign", "bgcolor", "cellpadding", "cellspacing", "nowrap",
+  "frameborder", "allowfullscreen", "scrolling", "poster", "srcdoc", "border",
 ]);
 
 /**
@@ -407,9 +420,16 @@ function push(
  * One such tag vouches for the rest, so a leak of `<p>text</p><br><br>` is
  * counted in full while a page of bare element names is silent.
  */
+const closing = (m: RegExpExecArray): boolean => m[1] === "/";
+
 function findEscapedTags(text: string): string[] {
   const candidates: string[] = [];
-  let vouched = false;
+  // Index of the tag that made the family reportable. It is moved to the front
+  // so the report's example line shows real evidence — `<div class="row">`, not
+  // the bare `<pre>` that happened to appear first. An INDEX, not the string:
+  // the same tag text usually repeats, and removing it by value would drop
+  // every copy and undercount the family.
+  let vouchingAt = -1;
   ESCAPED_TAG_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = ESCAPED_TAG_RE.exec(text)) !== null) {
@@ -428,20 +448,22 @@ function findEscapedTags(text: string): string[] {
     // whose "attributes" are the rest of the path. A real closing tag has
     // nothing after the name.
     const closesCleanly = closing(match) && rest.trim().length === 0;
-    if (closesCleanly || hasRecognisedAttribute(rest)) vouched = true;
+    if (vouchingAt < 0 && (closesCleanly || hasRecognisedAttribute(rest))) {
+      vouchingAt = candidates.length;
+    }
     candidates.push(match[0]);
     // Stop once the list is full AND something has vouched: breaking earlier
     // could drop the one tag that would have made the family reportable.
-    if (candidates.length >= MAX_MATCHES_PER_KIND && vouched) break;
+    if (candidates.length >= MAX_MATCHES_PER_KIND && vouchingAt >= 0) break;
     if (candidates.length >= MAX_MATCHES_PER_KIND * 4) break;
   }
   ESCAPED_TAG_RE.lastIndex = 0;
 
-  if (!vouched) return [];
-  return candidates.slice(0, MAX_MATCHES_PER_KIND);
+  if (vouchingAt < 0) return [];
+  const [vouching] = candidates.splice(vouchingAt, 1);
+  return [vouching as string, ...candidates].slice(0, MAX_MATCHES_PER_KIND);
 }
 
-const closing = (m: RegExpExecArray): boolean => m[1] === "/";
 
 /** Every family of unrendered markup present in `text`, with a sample and a count. */
 export function findUnrenderedMarkup(text: string): UnrenderedMarkupFinding[] {
@@ -456,7 +478,7 @@ export function findUnrenderedMarkup(text: string): UnrenderedMarkupFinding[] {
   ].slice(0, MAX_MATCHES_PER_KIND);
   push(out, "markdown-emphasis", emphasis);
   push(out, "markdown-link", collect(MD_LINK_RE, scanned));
-  push(out, "markdown-heading", collect(MD_HEADING_RE, scanned, NOT_A_SLUG));
+  push(out, "markdown-heading", collect(MD_HEADING_RE, scanned, HEADING_IS_PROSE));
   push(out, "markdown-code-fence", collect(MD_FENCE_RE, scanned));
   push(out, "markdown-inline-code", collect(MD_INLINE_CODE_RE, scanned));
 

--- a/packages/rules/src/content/unrendered-markup.ts
+++ b/packages/rules/src/content/unrendered-markup.ts
@@ -85,10 +85,10 @@ export function isBlockElement(el: Element): boolean {
 /**
  * True for any element whose subtree is source-on-display rather than prose.
  *
- * One pass over `attributes`, not five: this runs on every element of every
- * crawled page, and `getAttrCI` walks the whole list per call. getAttribute
- * itself is case-SENSITIVE on this parser, which is why the names are folded
- * here rather than looked up directly.
+ * Attribute names are folded here rather than looked up by name because
+ * getAttribute is case-SENSITIVE on this parser. Reading them in ONE pass
+ * matters: the by-name helper walks the whole attribute list per call, so the
+ * five lookups this needs cost five walks of every element of every page.
  */
 export function isCodeLikeElement(el: Element): boolean {
   const tag = el.tagName?.toLowerCase();
@@ -341,7 +341,11 @@ export type UnrenderedMarkupKind =
 
 export interface UnrenderedMarkupFinding {
   kind: UnrenderedMarkupKind;
-  /** A short, single-line excerpt of the first occurrence. */
+  /**
+   * A short, single-line excerpt of the occurrence worth showing: the first
+   * one, except for `escaped-html-tag`, where it is the tag that made the
+   * family reportable rather than whichever bare mention came first.
+   */
   sample: string;
   count: number;
 }
@@ -495,7 +499,7 @@ export const unrenderedMarkupRule: Rule = {
     name: "Unrendered Markup",
     description: "Detects literal markdown or escaped HTML leaking into rendered copy",
     solution:
-      'Something rendered a value as plain text that was authored as markup. Find the field, not the page: a CMS that stores markdown and a template that prints it without a markdown-to-HTML pass produces literal `**bold**` and `[text](url)` everywhere that field appears, and fixing one page leaves the rest broken. Visible `<p>` or `<a href` means the opposite mistake — HTML was escaped twice, usually by escaping a value that a templating engine (Jinja, Twig, Blade, JSX) had already escaped, so remove the manual escape rather than marking the value safe. Visible `&nbsp;` or `&amp;` means the entity itself was encoded a second time on the way in, which is normally an import or a rich-text editor round-trip, so re-import the affected content. If the markup is meant to be on display, put it in `<code>` or `<pre>`, which this rule skips.',
+      'Something rendered a value as plain text that was authored as markup. Find the field, not the page: a CMS that stores markdown and a template that prints it without a markdown-to-HTML pass produces literal `**bold**` and `[text](url)` everywhere that field appears, and fixing one page leaves the rest broken. Visible `<p>` or `<a href` means the opposite mistake: HTML was escaped twice, usually by escaping a value that a templating engine (Jinja, Twig, Blade, JSX) had already escaped, so remove the manual escape rather than marking the value safe. Visible `&nbsp;` or `&amp;` means the entity itself was encoded a second time on the way in, which is normally an import or a rich-text editor round-trip, so re-import the affected content. If the markup is meant to be on display, put it in `<code>` or `<pre>`, which this rule skips.',
     category: "content",
     scope: "page",
     severity: "warning",

--- a/packages/rules/src/content/unrendered-markup.ts
+++ b/packages/rules/src/content/unrendered-markup.ts
@@ -1,7 +1,5 @@
 // content/unrendered-markup - Markup that failed to render and leaked into visible copy
 
-import { getAttrCI } from "@squirrelscan/utils";
-
 import { collectTextExcluding } from "@squirrelscan/parser/extractors";
 
 import type { Element } from "linkedom";
@@ -49,27 +47,58 @@ const HIGHLIGHT_CLASS_TOKENS = new Set([
   // enough to be a promise about the content, not one site's class name:
   // commonmark.org's syntax table marks every cell of markdown source this way.
   "preformatted",
-  "pre",
 ]);
 
 /** `class="language-ts"` / `class="lang-ts"`: the same marker, spelled per-language. */
 const HIGHLIGHT_CLASS_PREFIXES = ["language-", "lang-"] as const;
 
 /** Attributes a highlighter or MDX renderer writes on the block it owns. */
-const HIGHLIGHT_ATTRIBUTES = ["data-language", "data-lang", "data-highlighted", "data-code"];
+const HIGHLIGHT_ATTRIBUTES = new Set([
+  "data-language",
+  "data-lang",
+  "data-highlighted",
+  "data-code",
+]);
 
 const SCRIPT_OR_CODE_TAGS = new Set<string>([...SCRIPT_LIKE_TAGS, ...CODE_LIKE_TAGS]);
 
-/** True for any element whose subtree is source-on-display rather than prose. */
+/**
+ * Elements a browser lays out on their own line. Their text has to be kept
+ * apart, or `<p>a</p><p>b</p>` reads back as `ab` and every line-anchored
+ * pattern here (a leading `## `, a fence) can only ever match at offset 0 —
+ * which on a real page means after the header and nav, never.
+ */
+const BLOCK_TAGS = new Set([
+  "address", "article", "aside", "blockquote", "br", "dd", "details", "dialog",
+  "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form",
+  "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "li", "main",
+  "nav", "ol", "p", "section", "summary", "table", "tbody", "td", "tfoot",
+  "th", "thead", "tr", "ul",
+]);
+
+/** True for any element a browser starts on a new line. */
+export function isBlockElement(el: Element): boolean {
+  const tag = el.tagName?.toLowerCase();
+  return !!tag && BLOCK_TAGS.has(tag);
+}
+
+/**
+ * True for any element whose subtree is source-on-display rather than prose.
+ *
+ * One pass over `attributes`, not five: this runs on every element of every
+ * crawled page, and `getAttrCI` walks the whole list per call. getAttribute
+ * itself is case-SENSITIVE on this parser, which is why the names are folded
+ * here rather than looked up directly.
+ */
 export function isCodeLikeElement(el: Element): boolean {
   const tag = el.tagName?.toLowerCase();
   if (tag && SCRIPT_OR_CODE_TAGS.has(tag)) return true;
 
-  // getAttribute is case-SENSITIVE on this parser, so read both class spellings
-  // the same way every other rule does.
-  const className = getAttrCI(el, "class");
-  if (className) {
-    for (const token of className.split(/\s+/)) {
+  for (const attr of el.attributes) {
+    const name = attr.name.toLowerCase();
+    if (HIGHLIGHT_ATTRIBUTES.has(name)) return true;
+    if (name !== "class") continue;
+    for (const token of attr.value.split(/\s+/)) {
       if (!token) continue;
       const lower = token.toLowerCase();
       if (HIGHLIGHT_CLASS_TOKENS.has(lower)) return true;
@@ -77,10 +106,6 @@ export function isCodeLikeElement(el: Element): boolean {
         if (lower.startsWith(prefix) && lower.length > prefix.length) return true;
       }
     }
-  }
-
-  for (const attr of HIGHLIGHT_ATTRIBUTES) {
-    if (getAttrCI(el, attr) !== null) return true;
   }
   return false;
 }
@@ -148,7 +173,7 @@ const INNER_HAS_SPACE = (m: RegExpExecArray): boolean => /[ \t]/.test(m[2] ?? ""
  * `[top](#top)` do not.
  */
 const MD_LINK_RE =
-  /!?\[[^\]\n]{0,200}\]\((?:https?:\/\/|mailto:|\/|#|www\.|[\w.-]{1,60}\.[a-z]{2,10}[/?#])[^)\s]{0,300}\)/g;
+  /!?\[[^\]\n]{0,80}\]\((?:https?:\/\/|mailto:|\/|#|www\.|[\w.-]{1,60}\.[a-z]{2,10}[/?#])[^)\s]{0,300}\)/g;
 
 /**
  * A leading `#` run at the start of a line. `[ \t]` never `\s`, so the class
@@ -162,7 +187,17 @@ const MD_LINK_RE =
  * which is both slow and a silent miss on exactly the long headings a broken
  * template produces.
  */
-const MD_HEADING_RE = /^[ \t]{0,3}#{1,6}[ \t]+(?=[^\s#\d])[^\n]{1,100}/gm;
+const MD_HEADING_RE = /^[ \t]{0,3}#{1,6}[ \t]+(?=[^\s#\d])([^\n]{1,100})/gm;
+
+/**
+ * A heading is prose; a URL fragment is a slug. MDN's specification table
+ * renders `HTML<br /># the-pre-element` — a real line, really starting with a
+ * hash, that is the fragment of the link above it rather than a heading nobody
+ * rendered. One lowercase hyphenated or underscored token with no spaces is
+ * that shape, and is never a heading a CMS lost.
+ */
+const NOT_A_SLUG = (m: RegExpExecArray): boolean =>
+  !/^[a-z0-9]+(?:[-_][a-z0-9]+)+$/.test((m[1] ?? "").trim());
 
 /** A fence line: three or more backticks or tildes, optionally with an info string. */
 const MD_FENCE_RE = /^[ \t]{0,3}(?:`{3,}|~{3,})[^\n]{0,60}/gm;
@@ -172,23 +207,6 @@ const MD_FENCE_RE = /^[ \t]{0,3}(?:`{3,}|~{3,})[^\n]{0,60}/gm;
  * plus a non-space interior is enough; the run is bounded to keep it linear.
  */
 const MD_INLINE_CODE_RE = /(?:^|[\s([{'"])`(?=[^\s`])([^`\n]{1,200})`(?=$|[\s.,;:!?)\]}'"])/gm;
-
-/**
- * HTML tags a reader can SEE. The page source said `&lt;p&gt;`; `.textContent`
- * decodes that, so by the time the text reaches here it is a literal `<p>`.
- * Scanning the raw HTML for `&lt;` instead would be the same rule written
- * backwards, and would fire on every escaped example inside a code block.
- *
- * One bounded character class, not two adjacent quantifiers: `[^<>]{0,200}`
- * cannot match the closing `>`, so it stops at the first one and never
- * re-partitions a long run the way `\s*[^>]*` would.
- *
- * LOWERCASE tag names only. Escaped markup that leaked out of a template came
- * from HTML a server actually emitted, which is lowercase. A capitalised
- * `<Article>` or `<Video>` is a JSX, Astro or Vue COMPONENT name that a page is
- * displaying on purpose — astro.build puts a whole row of them in its hero.
- */
-const ESCAPED_TAG_RE = /<(\/?)([a-z][a-z0-9]{0,9})([^<>]{0,200})>/g;
 
 /**
  * Tags whose bare form is unambiguous evidence. `b`, `i`, `u`, `s` and `q` are
@@ -209,6 +227,74 @@ const VISIBLE_HTML_TAGS = new Set([
 
 /** These need an attribute or a closing slash before they count. */
 const AMBIGUOUS_HTML_TAGS = new Set(["a", "b", "i", "u", "s", "q"]);
+
+/**
+ * The name bound is DERIVED, never a literal. `blockquote` and `figcaption` are
+ * ten characters, so a hand-written `{0,9}` tail sits exactly on the limit and
+ * the next longer name added to the set above would compile, review clean, and
+ * silently never match.
+ */
+export const MAX_TAG_NAME_LENGTH = Math.max(
+  ...[...VISIBLE_HTML_TAGS, ...AMBIGUOUS_HTML_TAGS].map((t) => t.length),
+);
+
+/**
+ * HTML tags a reader can SEE. The page source said `&lt;p&gt;`; `.textContent`
+ * decodes that, so by the time the text reaches here it is a literal `<p>`.
+ * Scanning the raw HTML for `&lt;` instead would be the same rule written
+ * backwards, and would fire on every escaped example inside a code block.
+ *
+ * One bounded character class, not two adjacent quantifiers: `[^<>]{0,200}`
+ * cannot match the closing `>`, so it stops at the first one and never
+ * re-partitions a long run the way `\s*[^>]*` would.
+ *
+ * LOWERCASE tag names only. Escaped markup that leaked out of a template came
+ * from HTML a server actually emitted, which is lowercase. A capitalised
+ * `<Article>` or `<Video>` is a JSX, Astro or Vue COMPONENT name that a page is
+ * displaying on purpose — astro.build puts a whole row of them in its hero.
+ */
+const ESCAPED_TAG_RE = new RegExp(
+  `<(/?)([a-z][a-z0-9]{0,${MAX_TAG_NAME_LENGTH - 1}})([^<>]{0,200})>`,
+  "g",
+);
+
+/**
+ * Attribute names a browser would recognise. A curated list for the same reason
+ * the entity list is curated: the generic shape reads any `word=value` as an
+ * attribute, so `if a<b then c=1>0 holds` parses as `<b>` with an attribute
+ * `c="1"` and the rule calls an inequality plus an equation a rendering bug —
+ * at `fail`, the hardest status it has.
+ */
+const KNOWN_ATTRIBUTES = new Set([
+  "class", "id", "style", "title", "lang", "dir", "role", "hidden", "tabindex",
+  "href", "src", "srcset", "sizes", "alt", "rel", "target", "type", "name",
+  "value", "content", "charset", "media", "loading", "decoding", "width",
+  "height", "colspan", "rowspan", "for", "action", "method", "placeholder",
+  "datetime", "label", "cite", "download", "referrerpolicy", "integrity",
+  "crossorigin", "http-equiv", "property", "itemprop", "viewbox", "xmlns",
+]);
+
+/**
+ * Each `name=` in an attribute list. Bounded and over disjoint classes, so the
+ * scan stays linear over the 200 characters `ESCAPED_TAG_RE` can hand it.
+ */
+const ATTRIBUTE_NAME_RE = /[\s/]([a-z][a-z0-9:_.-]{0,40})[ \t]{0,4}=/gi;
+
+/** True when `rest` assigns a value to an attribute a browser would recognise. */
+function hasRecognisedAttribute(rest: string): boolean {
+  ATTRIBUTE_NAME_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  let found = false;
+  while ((m = ATTRIBUTE_NAME_RE.exec(rest)) !== null) {
+    const name = (m[1] ?? "").toLowerCase();
+    if (KNOWN_ATTRIBUTES.has(name) || name.startsWith("data-") || name.startsWith("aria-")) {
+      found = true;
+      break;
+    }
+  }
+  ATTRIBUTE_NAME_RE.lastIndex = 0;
+  return found;
+}
 
 /**
  * Named entities that survived one decode too few. A curated list, not
@@ -314,7 +400,7 @@ function push(
  * `pre` element says `<pre>` in its breadcrumb and `<meta name>` and
  * `<meta http-equiv>` in its see-also list, none of them inside a code span.
  * Markup that actually leaked out of a template looks different — it brings the
- * closing tag with it (`<p>…</p>`) or an attribute with a VALUE
+ * closing tag with it (`<p>…</p>`) or assigns a value to a RECOGNISED attribute
  * (`<div class="row">`, `<a href="/x">`), because that is what a server emits
  * and what nobody types into a sentence.
  *
@@ -322,11 +408,11 @@ function push(
  * counted in full while a page of bare element names is silent.
  */
 function findEscapedTags(text: string): string[] {
-  const candidates: { text: string; closing: boolean; valued: boolean }[] = [];
+  const candidates: string[] = [];
+  let vouched = false;
   ESCAPED_TAG_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = ESCAPED_TAG_RE.exec(text)) !== null) {
-    const closing = match[1] === "/";
     const name = match[2] ?? "";
     const rest = match[3] ?? "";
     // An attribute list has to start at a boundary, so `<pathological>` cannot
@@ -337,28 +423,40 @@ function findEscapedTags(text: string): string[] {
     if (!VISIBLE_HTML_TAGS.has(name) && !ambiguous) continue;
     // `x<b>y` is a comparison chain in mathematical prose. An ambiguous opening
     // tag needs an attribute before it outweighs that reading.
-    if (ambiguous && !closing && !attrs) continue;
-    candidates.push({ text: match[0], closing, valued: attrs && rest.includes("=") });
-    if (candidates.length >= MAX_MATCHES_PER_KIND) break;
+    if (ambiguous && !closing(match) && !attrs) continue;
+    // A path in angle brackets — `</path/to/file>` — parses as a closing tag
+    // whose "attributes" are the rest of the path. A real closing tag has
+    // nothing after the name.
+    const closesCleanly = closing(match) && rest.trim().length === 0;
+    if (closesCleanly || hasRecognisedAttribute(rest)) vouched = true;
+    candidates.push(match[0]);
+    // Stop once the list is full AND something has vouched: breaking earlier
+    // could drop the one tag that would have made the family reportable.
+    if (candidates.length >= MAX_MATCHES_PER_KIND && vouched) break;
+    if (candidates.length >= MAX_MATCHES_PER_KIND * 4) break;
   }
   ESCAPED_TAG_RE.lastIndex = 0;
 
-  if (!candidates.some((c) => c.closing || c.valued)) return [];
-  return candidates.map((c) => c.text);
+  if (!vouched) return [];
+  return candidates.slice(0, MAX_MATCHES_PER_KIND);
 }
+
+const closing = (m: RegExpExecArray): boolean => m[1] === "/";
 
 /** Every family of unrendered markup present in `text`, with a sample and a count. */
 export function findUnrenderedMarkup(text: string): UnrenderedMarkupFinding[] {
   const scanned = text.length > MAX_SCANNED_CHARS ? text.slice(0, MAX_SCANNED_CHARS) : text;
   const out: UnrenderedMarkupFinding[] = [];
 
+  // Two patterns, ONE family budget: capping each `collect` separately would let
+  // the emphasis family reach twice MAX_MATCHES_PER_KIND.
   const emphasis = [
     ...collect(MD_EMPHASIS_ASTERISK_RE, scanned),
     ...collect(MD_EMPHASIS_UNDERSCORE_RE, scanned, INNER_HAS_SPACE),
-  ];
+  ].slice(0, MAX_MATCHES_PER_KIND);
   push(out, "markdown-emphasis", emphasis);
   push(out, "markdown-link", collect(MD_LINK_RE, scanned));
-  push(out, "markdown-heading", collect(MD_HEADING_RE, scanned));
+  push(out, "markdown-heading", collect(MD_HEADING_RE, scanned, NOT_A_SLUG));
   push(out, "markdown-code-fence", collect(MD_FENCE_RE, scanned));
   push(out, "markdown-inline-code", collect(MD_INLINE_CODE_RE, scanned));
 
@@ -412,7 +510,12 @@ export const unrenderedMarkupRule: Rule = {
     // come out first because a documentation page showing `**bold**` on purpose
     // is the single largest false-positive class this rule has — without the
     // exclusion it fires on its own documentation.
-    const text = collectTextExcluding(body, isCodeLikeElement, SKIPPED_SUBTREE_BOUNDARY);
+    const text = collectTextExcluding(
+      body,
+      isCodeLikeElement,
+      SKIPPED_SUBTREE_BOUNDARY,
+      isBlockElement,
+    );
     const found = findUnrenderedMarkup(text);
 
     const hasRawMarkup = found.some((f) => RAW_MARKUP_KINDS.has(f.kind));
@@ -432,8 +535,14 @@ export const unrenderedMarkupRule: Rule = {
       return { checks };
     }
 
-    const total = found.reduce((sum, f) => sum + f.count, 0);
-    const kinds = found.map((f) => f.kind).join(", ");
+    // Headline the evidence that DECIDED the status. Counting the corroborating
+    // family here would report "6 occurrences" at `warn` on a page whose only
+    // real finding is one bold phrase, and would put a backtick span in the
+    // example line — the exact thing the family is promised never to do.
+    const accusing = found.filter((f) => !CORROBORATING_KINDS.has(f.kind));
+    const total = accusing.reduce((sum, f) => sum + f.count, 0);
+    const kinds = accusing.map((f) => f.kind).join(", ");
+    const example = accusing[0]!.sample;
 
     // Visible tags and entities are not a judgement call: nothing renders them
     // on purpose outside a code block, and those are already excluded. Literal
@@ -444,7 +553,7 @@ export const unrenderedMarkupRule: Rule = {
     checks.push({
       name: "unrendered-markup",
       status,
-      message: `${total} unrendered markup occurrence(s) in visible text (${kinds}): example ${found[0]?.sample}`,
+      message: `${total} unrendered markup occurrence(s) in visible text (${kinds}): example ${example}`,
       value: total,
       details: {
         kinds: found.map((f) => ({ kind: f.kind, sample: f.sample, count: f.count })),

--- a/packages/rules/tests/content-unrendered-markup.test.ts
+++ b/packages/rules/tests/content-unrendered-markup.test.ts
@@ -130,6 +130,25 @@ describe("findUnrenderedMarkup: escaped HTML and entities", () => {
     expect(kinds('<input type="text" required>')).toContain("escaped-html-tag");
   });
 
+  test("legacy presentational attributes vouch too", () => {
+    // A mangled rich-text or email import: no closing tags, nothing modern. The
+    // allowlist has to reach these or the whole family goes unreported.
+    expect(kinds('<td align="center" bgcolor="#fff">Total<td valign="top">')).toContain(
+      "escaped-html-tag",
+    );
+    // But not at the cost of the inequality the allowlist exists to protect.
+    expect(kinds("if a<b then d=1>0 holds")).not.toContain("escaped-html-tag");
+  });
+
+  test("the vouching tag leads the list, without dropping its duplicates", () => {
+    // Moving it by value rather than index would delete every copy of `</p>`.
+    const found = findUnrenderedMarkup("<p>a</p><p>b</p>");
+    expect(found.find((f) => f.kind === "escaped-html-tag")?.count).toBe(4);
+    // A bare tag first, a real one after: the sample must be the real one.
+    const mixed = findUnrenderedMarkup('<pre><div class="row">x</div>');
+    expect(mixed.find((f) => f.kind === "escaped-html-tag")?.sample).toBe('<div class="row">');
+  });
+
   test("a path in angle brackets is not a closing tag", () => {
     expect(kinds("The config lives at </path/to/file> on disk")).not.toContain(
       "escaped-html-tag",
@@ -186,14 +205,22 @@ describe("findUnrenderedMarkup: identifiers and arithmetic stay clean", () => {
     expect(findUnrenderedMarkup("Order #4821 has shipped")).toEqual([]);
   });
 
-  test("a URL fragment on its own line is not a heading", () => {
-    // MDN's specification table renders `HTML<br /># the-pre-element`: a real
-    // line that really starts with a hash, showing the link's fragment.
+  test("a lone hash is the number sign, not a heading", () => {
+    // Every block now starts a line, so the number sign starts plenty of them.
+    expect(findUnrenderedMarkup("# of seats")).toEqual([]);
+    expect(findUnrenderedMarkup("# of licences")).toEqual([]);
+    expect(findUnrenderedMarkup("# and more")).toEqual([]);
+    // MDN renders `HTML<br /># the-pre-element`: a real line showing a fragment.
     expect(findUnrenderedMarkup("HTML\n# the-pre-element")).toEqual([]);
     expect(findUnrenderedMarkup("# some_anchor_name")).toEqual([]);
-    // A one-word heading is still a heading.
+  });
+
+  test("a capitalised or multi-hash heading survives that test", () => {
     expect(kinds("## Pricing")).toContain("markdown-heading");
     expect(kinds("# Getting started")).toContain("markdown-heading");
+    // `##` has no second reading as the number sign, so it is taken as written.
+    expect(kinds("## my-package")).toContain("markdown-heading");
+    expect(kinds("### getting-started")).toContain("markdown-heading");
   });
 
   test("ordinary marketing copy is clean", () => {
@@ -474,12 +501,13 @@ describe("unrenderedMarkupRule: adversarial input stays linear", () => {
 });
 
 // Sibling blocks are concatenated with nothing between them unless a boundary is
-// asked for, so `<p>a</p><p>b</p>` reads back as `ab`. Every line-anchored
-// pattern here would then match only at offset 0 — which, on a page with a
-// header, is never. These fixtures all put the markup AFTER chrome.
-describe("unrenderedMarkupRule: line-anchored patterns on a real page shape", () => {
+// asked for, so `<p>a</p><p>b</p>` reads back as `ab`. Two failure modes follow,
+// and each fixture here targets one: a line-anchored pattern that can only match
+// at offset 0, and a match GLUED together from two blocks that share neither
+// half. Every fixture puts the markup after chrome, so none of them passes by
+// sitting at the body's first byte.
+describe("unrenderedMarkupRule: block boundaries on a real page shape", () => {
   test("a leaked heading is found after the site chrome", () => {
-    expect(run(page("<p>## Pricing</p>"))[0]?.status).toBe("warn");
     expect(run(page(`${NAV}<main><p>## Pricing</p></main>`))[0]?.status).toBe("warn");
   });
 
@@ -496,16 +524,37 @@ describe("unrenderedMarkupRule: line-anchored patterns on a real page shape", ()
     ).toBe("warn");
   });
 
+  // The inverse failure: a boundary opened but never closed glues a block to
+  // whatever inline content follows it, inventing a match in neither half.
+  const glued: [string, string][] = [
+    ["heading then inline link", '<h3>Price *</h3><a href="/x">terms* apply</a>'],
+    ["block then bare text", "<p>Save on *big</p> sale* today"],
+    ["div then button", "<div>Save *</div><button>now* only</button>"],
+    ["split escaped tag", '<p>x&lt;p</p><span> class="a"&gt;y</span>'],
+    ["adjacent options", "<select><option>Sort by *</option><option>price* asc</option></select>"],
+  ];
+
+  test.each(glued)("%s cannot glue into a match", (_, body) => {
+    expect(run(page(`${NAV}<main>${body}</main>`))[0]?.status).toBe("pass");
+  });
+
+  test("a tag whole within one block is still reported", () => {
+    // The boundary must suppress assembled matches, not real ones sitting
+    // entirely inside a single block.
+    expect(
+      run(page(`${NAV}<main><p>x</p><span>&lt;p&gt;y&lt;/p&gt;</span></main>`))[0]?.status,
+    ).toBe("fail");
+  });
+
   test("a heading split across blocks does not invent a match", () => {
-    // The boundary must not glue `##` in one block to a word in the next.
     expect(run(page(`${NAV}<main><p>Rated ##</p><p>Pricing details</p></main>`))[0]?.status).toBe(
       "pass",
     );
   });
 
   test("chrome itself is judged, not skipped", () => {
-    expect(run(page(`<header><p>## Menu</p></header><main><p>Copy.</p></main>`))[0]?.status).toBe(
-      "warn",
-    );
+    expect(
+      run(page(`<header><nav><p>## Menu</p></nav></header><main><p>Copy.</p></main>`))[0]?.status,
+    ).toBe("warn");
   });
 });

--- a/packages/rules/tests/content-unrendered-markup.test.ts
+++ b/packages/rules/tests/content-unrendered-markup.test.ts
@@ -1,0 +1,406 @@
+// content/unrendered-markup: markdown and escaped HTML a reader can actually see.
+//
+// The rule accuses a page of a rendering bug, so the false-positive fixtures
+// carry more weight here than the detection ones. Three classes matter: a
+// documentation page that displays markdown source on purpose, prose full of
+// snake_case identifiers and file paths, and arithmetic written with asterisks.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "@squirrelscan/parser/dom";
+
+import {
+  findUnrenderedMarkup,
+  isCodeLikeElement,
+  unrenderedMarkupRule,
+} from "../src/content/unrendered-markup";
+import type { ParsedPage, RuleContext } from "../src/types";
+
+function run(html: string) {
+  const { document } = parseHTML(html);
+  const ctx: RuleContext = {
+    page: { url: "https://example.com/", html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: { document } as unknown as ParsedPage,
+    options: {},
+  };
+  return unrenderedMarkupRule.run(ctx).checks;
+}
+
+const page = (body: string) => `<html><head><title>t</title></head><body>${body}</body></html>`;
+
+const kinds = (text: string) => findUnrenderedMarkup(text).map((f) => f.kind);
+
+describe("findUnrenderedMarkup: literal markdown", () => {
+  test("asterisk emphasis, bold and italic", () => {
+    expect(kinds("We are **the best** at this")).toContain("markdown-emphasis");
+    expect(kinds("This is *important* to know")).toContain("markdown-emphasis");
+  });
+
+  test("underscore emphasis when the run is a phrase", () => {
+    expect(kinds("Read the __getting started__ guide")).toContain("markdown-emphasis");
+    expect(kinds("A _short phrase_ here")).toContain("markdown-emphasis");
+  });
+
+  test("link and image syntax", () => {
+    expect(kinds("See [our docs](https://docs.example.com/start) for more")).toContain(
+      "markdown-link",
+    );
+    expect(kinds("Go [home](/) now")).toContain("markdown-link");
+    expect(kinds("Jump to [the top](#top)")).toContain("markdown-link");
+    expect(kinds("![a squirrel](/img/mascot.png)")).toContain("markdown-link");
+  });
+
+  test("a leading heading marker in a text node", () => {
+    expect(kinds("## Pricing\nOur plans start at ten dollars.")).toContain("markdown-heading");
+    expect(kinds("### Frequently asked questions")).toContain("markdown-heading");
+    expect(kinds("# Welcome to the site")).toContain("markdown-heading");
+  });
+
+  test("an unrendered code fence", () => {
+    expect(kinds("```js\nconst a = 1\n```")).toContain("markdown-code-fence");
+    expect(kinds("~~~\nplain\n~~~")).toContain("markdown-code-fence");
+  });
+
+  test("an inline code span", () => {
+    expect(kinds("Run `squirrel audit` to start")).toContain("markdown-inline-code");
+  });
+
+  test("counts every occurrence, not just the first", () => {
+    const found = findUnrenderedMarkup("**one** and **two** and **three**");
+    expect(found.find((f) => f.kind === "markdown-emphasis")?.count).toBe(3);
+  });
+});
+
+describe("findUnrenderedMarkup: escaped HTML and entities", () => {
+  // The page source said `&lt;p&gt;`; textContent hands the rule a literal `<p>`.
+  test("visible structural tags", () => {
+    expect(kinds("<p>Welcome to the store</p>")).toContain("escaped-html-tag");
+    expect(kinds('<div class="row">Contents</div>')).toContain("escaped-html-tag");
+    expect(kinds('Read <a href="/terms">the terms</a> first')).toContain("escaped-html-tag");
+  });
+
+  test("a closing ambiguous tag counts, a bare opening one does not", () => {
+    expect(kinds("end of the quote</a> follows")).toContain("escaped-html-tag");
+    // `x<b>y` is a comparison chain in mathematical prose, not leaked markup.
+    expect(kinds("when x<b>y the value grows")).not.toContain("escaped-html-tag");
+  });
+
+  test("double-encoded named and numeric entities", () => {
+    expect(kinds("Ten&nbsp;dollars")).toContain("double-encoded-entity");
+    expect(kinds("Fish &amp; chips")).toContain("double-encoded-entity");
+    expect(kinds("He said &quot;yes&quot;")).toContain("double-encoded-entity");
+    expect(kinds("Caf&#233; open now")).toContain("double-encoded-entity");
+  });
+
+  test("a capitalised component name is not a leaked tag", () => {
+    // astro.build renders exactly this row in its hero. Escaped markup that
+    // really leaked came from HTML a server emitted, and that is lowercase.
+    expect(kinds("<Logo><NavLinks><Hero><Article><Video>")).not.toContain("escaped-html-tag");
+    expect(kinds("Compose <Header> and <Footer> in your layout")).not.toContain("escaped-html-tag");
+  });
+
+  test("bare element names are documentation, not a leak", () => {
+    // MDN's reference for the pre element, outside any code span: a breadcrumb
+    // and a see-also list. No closing form, no attribute with a value.
+    expect(kinds("Elements <pre>\nThe <pre> element\n<meta name> and <meta http-equiv>")).not.toContain(
+      "escaped-html-tag",
+    );
+    expect(kinds("Compose <header>, <main> and <footer> in the layout")).not.toContain(
+      "escaped-html-tag",
+    );
+  });
+
+  test("one leaked tag vouches for the bare ones beside it", () => {
+    const found = findUnrenderedMarkup("<p>Line one</p><br><br>");
+    expect(found.find((f) => f.kind === "escaped-html-tag")?.count).toBe(4);
+  });
+
+  test("a company name with an ampersand is not an entity", () => {
+    // The generic `&[a-z]+;` shape reads this as a named entity. A curated list
+    // does not, which is the point of having one.
+    expect(kinds("Johnson&Johnson; a long history")).not.toContain("double-encoded-entity");
+    expect(kinds("AT&T; the carrier")).not.toContain("double-encoded-entity");
+  });
+});
+
+describe("findUnrenderedMarkup: identifiers and arithmetic stay clean", () => {
+  test("snake_case identifiers are not emphasis", () => {
+    expect(findUnrenderedMarkup("Set CLOUDFLARE_API_TOKEN in the environment")).toEqual([]);
+    expect(findUnrenderedMarkup("Edit some_file_name.ts to continue")).toEqual([]);
+    expect(findUnrenderedMarkup("The max_pages option caps the crawl")).toEqual([]);
+    expect(findUnrenderedMarkup("Both user_id and org_id are required")).toEqual([]);
+  });
+
+  test("Python dunders are not emphasis", () => {
+    // Flanked exactly like bold, and common in prose outside a code span. This
+    // is why the underscore form insists on a space inside the run.
+    expect(findUnrenderedMarkup("Define __init__ on the class")).toEqual([]);
+    expect(findUnrenderedMarkup("The __main__ guard runs it")).toEqual([]);
+  });
+
+  test("arithmetic and footnote asterisks are not emphasis", () => {
+    expect(findUnrenderedMarkup("Area is width * height * depth")).toEqual([]);
+    expect(findUnrenderedMarkup("Compute 2 * 3 * 4 first")).toEqual([]);
+    expect(findUnrenderedMarkup("Prices exclude tax*")).toEqual([]);
+  });
+
+  test("bracketed prose without a URL target is not a link", () => {
+    expect(findUnrenderedMarkup("The array[i](arg) call returns early")).toEqual([]);
+    expect(findUnrenderedMarkup("See [note] (below) for detail")).toEqual([]);
+    expect(findUnrenderedMarkup("Apply f[x](y) to the input")).toEqual([]);
+  });
+
+  test("hash-prefixed prose is not a heading", () => {
+    expect(findUnrenderedMarkup("#1 in customer satisfaction")).toEqual([]);
+    expect(findUnrenderedMarkup("Order #4821 has shipped")).toEqual([]);
+  });
+
+  test("ordinary marketing copy is clean", () => {
+    expect(
+      findUnrenderedMarkup(
+        "We build tools for developers. Our pricing is simple: ten dollars a month, " +
+          "cancel any time. Read about the team, or get in touch — we reply within a day.",
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("isCodeLikeElement", () => {
+  const el = (html: string) => parseHTML(`<body>${html}</body>`).document.querySelector("body")!
+    .firstElementChild!;
+
+  test("the code-like tags", () => {
+    for (const tag of ["code", "pre", "samp", "kbd", "textarea", "script", "style", "noscript"]) {
+      expect(isCodeLikeElement(el(`<${tag}>x</${tag}>`))).toBe(true);
+    }
+  });
+
+  test("syntax-highlighter containers, by whole class token", () => {
+    expect(isCodeLikeElement(el('<div class="highlight">x</div>'))).toBe(true);
+    expect(isCodeLikeElement(el('<div class="wrap hljs dark">x</div>'))).toBe(true);
+    expect(isCodeLikeElement(el('<div class="language-ts">x</div>'))).toBe(true);
+    expect(isCodeLikeElement(el('<div data-language="bash">x</div>'))).toBe(true);
+    // Case-insensitive attribute read, matching every other rule in the package.
+    expect(isCodeLikeElement(el('<div CLASS="shiki">x</div>'))).toBe(true);
+  });
+
+  test("a callout that merely contains the word is prose", () => {
+    expect(isCodeLikeElement(el('<div class="highlight-box">x</div>'))).toBe(false);
+    expect(isCodeLikeElement(el('<div class="codeblocks-intro">x</div>'))).toBe(false);
+    expect(isCodeLikeElement(el("<p>x</p>"))).toBe(false);
+  });
+});
+
+describe("unrenderedMarkupRule", () => {
+  test("pass on a clean page", () => {
+    const checks = run(page("<h1>Welcome</h1><p>We sell excellent coffee beans.</p>"));
+    expect(checks[0]?.status).toBe("pass");
+  });
+
+  test("warn on one or two stray markdown occurrences", () => {
+    const checks = run(page("<p>We are **the best** at coffee.</p>"));
+    expect(checks[0]?.status).toBe("warn");
+    expect(checks[0]?.value).toBe(1);
+  });
+
+  test("fail once markdown is systemic", () => {
+    const checks = run(
+      page("<p>**one** and **two** and **three** and [docs](https://example.com/d)</p>"),
+    );
+    expect(checks[0]?.status).toBe("fail");
+  });
+
+  test("fail on visible escaped HTML even once", () => {
+    // Source: `&lt;p&gt;Welcome&lt;/p&gt;` — nothing renders that on purpose.
+    const checks = run(page("<p>&lt;p&gt;Welcome&lt;/p&gt;</p>"));
+    expect(checks[0]?.status).toBe("fail");
+    const kindList = (checks[0]?.details as { kinds: { kind: string }[] }).kinds.map((k) => k.kind);
+    expect(kindList).toContain("escaped-html-tag");
+  });
+
+  test("fail on a visible double-encoded entity", () => {
+    const checks = run(page("<p>Ten&amp;nbsp;dollars a month</p>"));
+    expect(checks[0]?.status).toBe("fail");
+  });
+
+  test("visible backticks alone do not accuse the page", () => {
+    // Vercel's docs landing page carries a copyable agent prompt written in
+    // markdown. Six visible code spans, nothing else, nothing broken.
+    const prompt =
+      "<p>Install the CLI globally (`npm i -g vercel`) and log in with `vercel login`. " +
+      "Then run `vercel link`, `vercel env pull` and `vercel deploy`.</p>";
+    expect(run(page(prompt))[0]?.status).toBe("pass");
+  });
+
+  test("backticks corroborate once something real fires", () => {
+    const checks = run(page("<p>## Setup</p><p>Run `vercel deploy` to ship</p>"));
+    expect(checks[0]?.status).not.toBe("pass");
+    const kindList = (checks[0]?.details as { kinds: { kind: string }[] }).kinds.map((k) => k.kind);
+    expect(kindList).toContain("markdown-inline-code");
+    expect(kindList).toContain("markdown-heading");
+  });
+
+  test("a bare escaped div with its closing tag counts", () => {
+    // The issue names `&lt;div&gt;` explicitly. It carries a closing form here,
+    // which is what separates a leak from a page documenting the element.
+    expect(run(page("<p>&lt;div&gt;Contents&lt;/div&gt;</p>"))[0]?.status).toBe("fail");
+  });
+
+  test("skipped when the document is missing", () => {
+    const ctx: RuleContext = {
+      page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+      parsed: { document: null } as unknown as ParsedPage,
+      options: {},
+    };
+    const checks = unrenderedMarkupRule.run(ctx).checks;
+    expect(checks[0]?.status).toBe("skipped");
+    expect(checks[0]?.skipReason).toBe("Parse error");
+  });
+
+  test("skipped when there is no body", () => {
+    const { document } = parseHTML("<html><head><title>t</title></head></html>");
+    document.querySelector("body")?.remove();
+    const ctx: RuleContext = {
+      page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+      parsed: { document } as unknown as ParsedPage,
+      options: {},
+    };
+    const checks = unrenderedMarkupRule.run(ctx).checks;
+    expect(checks[0]?.status).toBe("skipped");
+    expect(checks[0]?.skipReason).toBe("no-body");
+  });
+
+  test("the message names a real example, flattened to one line", () => {
+    const checks = run(page("<p>Read [our docs](https://docs.example.com/start) today</p>"));
+    expect(checks[0]?.message).toContain("[our docs](https://docs.example.com/start)");
+    expect(checks[0]?.message).not.toContain("\n");
+  });
+});
+
+describe("unrenderedMarkupRule: the documentation page that displays markdown", () => {
+  // The load-bearing fixture. A docs page teaching markdown shows every pattern
+  // this rule detects, on purpose, inside code markup. It must stay clean.
+  const docsPage = page(`
+    <h1>Writing with markdown</h1>
+    <p>Wrap a phrase in asterisks to emphasise it:</p>
+    <pre><code class="language-md">**bold text** and *italic text*
+## A heading
+[a link](https://example.com/page)
+\`\`\`js
+const a = 1;
+\`\`\`
+</code></pre>
+    <p>Inline, write <code>\`squirrel audit\`</code> to show a command.</p>
+    <p>Escaped HTML is written as <code>&amp;lt;p&amp;gt;</code> and renders as
+      <code>&lt;p&gt;text&lt;/p&gt;</code>.</p>
+    <div class="highlight"><pre><span>&lt;div class="row"&gt;</span></pre></div>
+    <div data-language="html"><span>&lt;a href="/x"&gt;link&lt;/a&gt;</span></div>
+    <textarea>## Draft post
+
+Some **bold** copy the author is still editing.</textarea>
+  `);
+
+  test("stays clean", () => {
+    const checks = run(docsPage);
+    expect(checks[0]?.status).toBe("pass");
+  });
+
+  test("the same page fails once one line escapes its code block", () => {
+    // Same document, one paragraph moved out of <code>: the exclusion is doing
+    // the work, not the patterns.
+    const leaked = docsPage.replace(
+      "<p>Wrap a phrase in asterisks to emphasise it:</p>",
+      "<p>Wrap a phrase in **asterisks** to [emphasise](https://example.com/e) it</p>",
+    );
+    expect(run(leaked)[0]?.status).toBe("warn");
+  });
+
+  // "Stays clean" is only evidence if the SAME markup, outside the container,
+  // is a real detection. Each row carries both spellings.
+  const containers: [string, string, string][] = [
+    [
+      "pre + code",
+      '<pre><code class="language-md">**bold** and *italic*\n## Heading\n[a](https://e.com/p)</code></pre>',
+      "<p>**bold** and *italic*</p><p>## Heading</p><p>[a](https://e.com/p)</p>",
+    ],
+    [
+      "escaped html in code",
+      "<p><code>&lt;p&gt;text&lt;/p&gt;</code></p>",
+      "<p>&lt;p&gt;text&lt;/p&gt;</p>",
+    ],
+    [
+      "rouge highlight wrapper",
+      '<div class="highlight"><span>&lt;div class="row"&gt;here&lt;/div&gt;</span></div>',
+      '<div><span>&lt;div class="row"&gt;here&lt;/div&gt;</span></div>',
+    ],
+    [
+      "data-language wrapper",
+      '<div data-language="html"><span>&lt;a href="/x"&gt;l&lt;/a&gt;</span></div>',
+      '<div><span>&lt;a href="/x"&gt;l&lt;/a&gt;</span></div>',
+    ],
+    [
+      "textarea draft",
+      "<textarea>## Draft\n\nSome **bold** copy.</textarea>",
+      "<p>## Draft</p><p>Some **bold** copy.</p>",
+    ],
+    [
+      "commonmark-style preformatted cell",
+      '<table><tr><td class="preformatted">[Link](http://a.com)</td><td class="preformatted">*Italic*</td></tr></table>',
+      "<table><tr><td>[Link](http://a.com)</td><td>*Italic*</td></tr></table>",
+    ],
+  ];
+
+  test.each(containers)("%s is silent, and the same markup outside it is not", (_, inside, outside) => {
+    expect(run(page(inside))[0]?.status).toBe("pass");
+    expect(run(page(outside))[0]?.status).not.toBe("pass");
+  });
+
+  test("a skipped subtree does not glue its neighbours into a match", () => {
+    // Without a boundary between excluded subtrees, `**` + `**` reads back as
+    // bold text that exists in neither fragment.
+    const checks = run(page("<p>**<code>x</code>**</p>"));
+    expect(checks[0]?.status).toBe("pass");
+  });
+});
+
+describe("unrenderedMarkupRule: adversarial input stays linear", () => {
+  const budgetMs = 2000;
+
+  const timed = (text: string) => {
+    const started = performance.now();
+    findUnrenderedMarkup(text);
+    return performance.now() - started;
+  };
+
+  test("a long run of underscores and spaces", () => {
+    // The shape that would re-partition itself if the space test lived in the
+    // pattern instead of in JS.
+    expect(timed(`_${"a b ".repeat(16_000)}`)).toBeLessThan(budgetMs);
+  });
+
+  test("a long run of asterisks", () => {
+    expect(timed("*".repeat(64_000))).toBeLessThan(budgetMs);
+    expect(timed(`*${"a ".repeat(32_000)}`)).toBeLessThan(budgetMs);
+  });
+
+  test("a long unterminated tag and bracket run", () => {
+    expect(timed(`<div ${"x".repeat(64_000)}`)).toBeLessThan(budgetMs);
+    expect(timed(`[${"a".repeat(64_000)}`)).toBeLessThan(budgetMs);
+    expect(timed(`[x](${"a".repeat(64_000)}`)).toBeLessThan(budgetMs);
+  });
+
+  test("a long backtick and hash run", () => {
+    expect(timed(`\`${"a ".repeat(32_000)}`)).toBeLessThan(budgetMs);
+    expect(timed(`## ${"word ".repeat(13_000)}`)).toBeLessThan(budgetMs);
+    expect(timed(`&${"a".repeat(64_000)}`)).toBeLessThan(budgetMs);
+  });
+
+  test("a page far past the scan cap still returns", () => {
+    const huge = `${"clean prose. ".repeat(50_000)}**bold**`;
+    expect(timed(huge)).toBeLessThan(budgetMs);
+  });
+
+  test("counts are capped rather than unbounded", () => {
+    const found = findUnrenderedMarkup("**a** ".repeat(2_000));
+    expect(found.find((f) => f.kind === "markdown-emphasis")?.count).toBe(500);
+  });
+});

--- a/packages/rules/tests/content-unrendered-markup.test.ts
+++ b/packages/rules/tests/content-unrendered-markup.test.ts
@@ -11,6 +11,7 @@ import { parseHTML } from "@squirrelscan/parser/dom";
 import {
   findUnrenderedMarkup,
   isCodeLikeElement,
+  MAX_TAG_NAME_LENGTH,
   unrenderedMarkupRule,
 } from "../src/content/unrendered-markup";
 import type { ParsedPage, RuleContext } from "../src/types";
@@ -28,6 +29,10 @@ function run(html: string) {
 const page = (body: string) => `<html><head><title>t</title></head><body>${body}</body></html>`;
 
 const kinds = (text: string) => findUnrenderedMarkup(text).map((f) => f.kind);
+
+// Every real page opens with chrome. Fixtures that start at the body's first
+// byte hide the boundary bug below, so the page-level tests wear this.
+const NAV = '<header><nav><a href="/">Home</a><a href="/pricing">Pricing</a></nav></header>';
 
 describe("findUnrenderedMarkup: literal markdown", () => {
   test("asterisk emphasis, bold and italic", () => {
@@ -114,6 +119,33 @@ describe("findUnrenderedMarkup: escaped HTML and entities", () => {
     expect(found.find((f) => f.kind === "escaped-html-tag")?.count).toBe(4);
   });
 
+  test("a stray equals sign in prose is not an attribute", () => {
+    // `<b then c=1>` parses as a tag with an attribute under any rule that just
+    // looks for "=", and `b` is a tag. An inequality plus an equation would then
+    // be reported at fail, the rule's hardest status.
+    expect(kinds("if a<b then c=1>0 holds")).not.toContain("escaped-html-tag");
+    expect(kinds("set x<i where i=3>2 to continue")).not.toContain("escaped-html-tag");
+    // A recognised attribute with a value still counts.
+    expect(kinds('<div class="row">hi</div>')).toContain("escaped-html-tag");
+    expect(kinds('<input type="text" required>')).toContain("escaped-html-tag");
+  });
+
+  test("a path in angle brackets is not a closing tag", () => {
+    expect(kinds("The config lives at </path/to/file> on disk")).not.toContain(
+      "escaped-html-tag",
+    );
+  });
+
+  test("the tag-name bound is derived from the tag sets, never a literal", () => {
+    // A hand-written {0,9} tail sits exactly on `blockquote` and `figcaption`,
+    // so the next longer name added would silently never match.
+    expect(MAX_TAG_NAME_LENGTH).toBeGreaterThanOrEqual("blockquote".length);
+    expect(kinds("<blockquote>quoted</blockquote>")).toContain("escaped-html-tag");
+    expect(kinds('<figcaption class="c">a photo</figcaption>')).toContain("escaped-html-tag");
+    // And the boundary filter still refuses to read `<pathological>` as `<path>`.
+    expect(kinds("<pathological>x</pathological>")).not.toContain("escaped-html-tag");
+  });
+
   test("a company name with an ampersand is not an entity", () => {
     // The generic `&[a-z]+;` shape reads this as a named entity. A curated list
     // does not, which is the point of having one.
@@ -152,6 +184,16 @@ describe("findUnrenderedMarkup: identifiers and arithmetic stay clean", () => {
   test("hash-prefixed prose is not a heading", () => {
     expect(findUnrenderedMarkup("#1 in customer satisfaction")).toEqual([]);
     expect(findUnrenderedMarkup("Order #4821 has shipped")).toEqual([]);
+  });
+
+  test("a URL fragment on its own line is not a heading", () => {
+    // MDN's specification table renders `HTML<br /># the-pre-element`: a real
+    // line that really starts with a hash, showing the link's fragment.
+    expect(findUnrenderedMarkup("HTML\n# the-pre-element")).toEqual([]);
+    expect(findUnrenderedMarkup("# some_anchor_name")).toEqual([]);
+    // A one-word heading is still a heading.
+    expect(kinds("## Pricing")).toContain("markdown-heading");
+    expect(kinds("# Getting started")).toContain("markdown-heading");
   });
 
   test("ordinary marketing copy is clean", () => {
@@ -232,7 +274,7 @@ describe("unrenderedMarkupRule", () => {
   });
 
   test("backticks corroborate once something real fires", () => {
-    const checks = run(page("<p>## Setup</p><p>Run `vercel deploy` to ship</p>"));
+    const checks = run(page(`${NAV}<main><p>## Setup</p><p>Run \`vercel deploy\` to ship</p></main>`));
     expect(checks[0]?.status).not.toBe("pass");
     const kindList = (checks[0]?.details as { kinds: { kind: string }[] }).kinds.map((k) => k.kind);
     expect(kindList).toContain("markdown-inline-code");
@@ -304,7 +346,7 @@ Some **bold** copy the author is still editing.</textarea>
     expect(checks[0]?.status).toBe("pass");
   });
 
-  test("the same page fails once one line escapes its code block", () => {
+  test("the same page warns once one line escapes its code block", () => {
     // Same document, one paragraph moved out of <code>: the exclusion is doing
     // the work, not the patterns.
     const leaked = docsPage.replace(
@@ -363,7 +405,12 @@ Some **bold** copy the author is still editing.</textarea>
 });
 
 describe("unrenderedMarkupRule: adversarial input stays linear", () => {
-  const budgetMs = 2000;
+  // Every fixture is DENSE in its trigger character. A single trigger in 64 KB
+  // exercises one start position and cannot detect catastrophic backtracking:
+  // a deliberately bad link pattern measured 0.1 ms on `"[" + "a".repeat(64_000)`
+  // and 5.2 seconds on `"[ ".repeat(32_000)`. The budget is tight for the same
+  // reason — a 2 second ceiling passes patterns that are already a live DoS.
+  const budgetMs = 400;
 
   const timed = (text: string) => {
     const started = performance.now();
@@ -371,36 +418,94 @@ describe("unrenderedMarkupRule: adversarial input stays linear", () => {
     return performance.now() - started;
   };
 
-  test("a long run of underscores and spaces", () => {
-    // The shape that would re-partition itself if the space test lived in the
-    // pattern instead of in JS.
-    expect(timed(`_${"a b ".repeat(16_000)}`)).toBeLessThan(budgetMs);
+  const dense: [string, string][] = [
+    ["emphasis openers", `*${"a ".repeat(32_000)}`],
+    ["dense asterisks", "* ".repeat(32_000)],
+    ["asterisk run", "*".repeat(64_000)],
+    ["underscore phrases", `_${"a b ".repeat(16_000)}`],
+    ["dense underscores", "_ ".repeat(32_000)],
+    ["dense brackets", "[ ".repeat(32_000)],
+    ["dense near-links", `${"[x](".repeat(16_000)}`],
+    ["dense url-ish targets", `${"[x](a.".repeat(10_000)}`],
+    ["dense tag openers", "<a ".repeat(21_000)],
+    ["dense long tag names", `${`<${"a".repeat(210)}`.repeat(300)}`],
+    ["dense attribute runs", `${'<div class="'.repeat(5_000)}`],
+    ["dense backticks", "` ".repeat(32_000)],
+    ["dense hashes", `${"## word\n".repeat(8_000)}`],
+    ["dense hash-only lines", `${"###\n".repeat(16_000)}`],
+    ["dense ampersands", "&nbs".repeat(16_000)],
+    ["ampersand run", `&${"a".repeat(64_000)}`],
+    ["dense fences", `${"``\n".repeat(21_000)}`],
+    ["mixed triggers", `${"*[<&`_# ".repeat(8_000)}`],
+  ];
+
+  test.each(dense)("%s", (_, text) => {
+    expect(timed(text)).toBeLessThan(budgetMs);
   });
 
-  test("a long run of asterisks", () => {
-    expect(timed("*".repeat(64_000))).toBeLessThan(budgetMs);
-    expect(timed(`*${"a ".repeat(32_000)}`)).toBeLessThan(budgetMs);
+  test("the whole scan of a hostile page stays under budget", () => {
+    // 500 KB of the worst shape measured, at the scan cap.
+    expect(timed(`${"[".repeat(199)}](www.${"a".repeat(300)}`.repeat(700))).toBeLessThan(budgetMs);
   });
 
-  test("a long unterminated tag and bracket run", () => {
-    expect(timed(`<div ${"x".repeat(64_000)}`)).toBeLessThan(budgetMs);
-    expect(timed(`[${"a".repeat(64_000)}`)).toBeLessThan(budgetMs);
-    expect(timed(`[x](${"a".repeat(64_000)}`)).toBeLessThan(budgetMs);
-  });
-
-  test("a long backtick and hash run", () => {
-    expect(timed(`\`${"a ".repeat(32_000)}`)).toBeLessThan(budgetMs);
-    expect(timed(`## ${"word ".repeat(13_000)}`)).toBeLessThan(budgetMs);
-    expect(timed(`&${"a".repeat(64_000)}`)).toBeLessThan(budgetMs);
-  });
-
-  test("a page far past the scan cap still returns", () => {
-    const huge = `${"clean prose. ".repeat(50_000)}**bold**`;
-    expect(timed(huge)).toBeLessThan(budgetMs);
+  test("the scan cap truncates rather than merely finishing quickly", () => {
+    // Asserting only elapsed time would pass with the cap deleted.
+    expect(findUnrenderedMarkup(`${"x".repeat(499_000)} **bold** `)).not.toEqual([]);
+    expect(findUnrenderedMarkup(`${"x".repeat(500_100)} **bold** `)).toEqual([]);
   });
 
   test("counts are capped rather than unbounded", () => {
     const found = findUnrenderedMarkup("**a** ".repeat(2_000));
     expect(found.find((f) => f.kind === "markdown-emphasis")?.count).toBe(500);
+  });
+
+  test("the emphasis family honours ONE budget, not one per pattern", () => {
+    // Two patterns feed this family; capping each separately would allow 1000.
+    const found = findUnrenderedMarkup(`${"**a** ".repeat(600)}${"_a b_ ".repeat(600)}`);
+    expect(found.find((f) => f.kind === "markdown-emphasis")?.count).toBe(500);
+  });
+
+  test("a vouching tag past the cap still reports the family", () => {
+    // Breaking at MAX_MATCHES_PER_KIND before anything vouched would drop the
+    // whole family on a page whose first 500 tags are bare.
+    const found = findUnrenderedMarkup(`${"<br>".repeat(600)}<p>real leak</p>`);
+    expect(found.find((f) => f.kind === "escaped-html-tag")?.count).toBe(500);
+  });
+});
+
+// Sibling blocks are concatenated with nothing between them unless a boundary is
+// asked for, so `<p>a</p><p>b</p>` reads back as `ab`. Every line-anchored
+// pattern here would then match only at offset 0 — which, on a page with a
+// header, is never. These fixtures all put the markup AFTER chrome.
+describe("unrenderedMarkupRule: line-anchored patterns on a real page shape", () => {
+  test("a leaked heading is found after the site chrome", () => {
+    expect(run(page("<p>## Pricing</p>"))[0]?.status).toBe("warn");
+    expect(run(page(`${NAV}<main><p>## Pricing</p></main>`))[0]?.status).toBe("warn");
+  });
+
+  test("a leaked fence is found after the site chrome", () => {
+    expect(run(page(`${NAV}<main><p>\`\`\`js</p><p>const a = 1</p></main>`))[0]?.status).toBe(
+      "warn",
+    );
+  });
+
+  test("emphasis in adjacent list items is not lost at the seam", () => {
+    // Glued, `*a b*</li><li>*c d*` runs together and the flanking fails on both.
+    expect(
+      run(page(`${NAV}<main><ul><li>*a b*</li><li>*c d*</li></ul></main>`))[0]?.status,
+    ).toBe("warn");
+  });
+
+  test("a heading split across blocks does not invent a match", () => {
+    // The boundary must not glue `##` in one block to a word in the next.
+    expect(run(page(`${NAV}<main><p>Rated ##</p><p>Pricing details</p></main>`))[0]?.status).toBe(
+      "pass",
+    );
+  });
+
+  test("chrome itself is judged, not skipped", () => {
+    expect(run(page(`<header><p>## Menu</p></header><main><p>Copy.</p></main>`))[0]?.status).toBe(
+      "warn",
+    );
   });
 });

--- a/packages/rules/tests/placeholder-text.test.ts
+++ b/packages/rules/tests/placeholder-text.test.ts
@@ -427,6 +427,10 @@ describe("placeholderTextRule — what a reader never sees", () => {
   });
 });
 
+// The block boundary wraps each matching element on BOTH sides (#1352 found that
+// opening it alone leaves a block glued to the inline content after it), so the
+// expected strings below carry a closing separator too. What each test asserts
+// is unchanged: subtrees become a break, inline elements do not.
 describe("getRenderedProseText", () => {
   const prose = (body: string) => {
     const { document } = parseHTML(page(body));
@@ -434,11 +438,13 @@ describe("getRenderedProseText", () => {
   };
 
   test("script-like and code-like subtrees become a boundary", () => {
-    expect(prose("<p>a<script>x</script>b<code>y</code>c</p>")).toBe("\na\nb\nc");
+    expect(prose("<p>a<script>x</script>b<code>y</code>c</p>")).toBe("\na\nb\nc\n");
   });
 
   test("<template> content is inert markup, not text", () => {
-    expect(prose('<p>a</p><template id="t"><li>{{ x }}</li></template><p>b</p>')).toBe("\na\n\nb");
+    expect(prose('<p>a</p><template id="t"><li>{{ x }}</li></template><p>b</p>')).toBe(
+      "\na\n\n\nb\n",
+    );
   });
 
   test("every code-container class is excluded", () => {
@@ -470,9 +476,9 @@ describe("getRenderedProseText", () => {
   });
 
   test("block elements are separated, inline elements are not", () => {
-    expect(prose("<p>your <b>company</b> name</p>")).toBe("\nyour company name");
+    expect(prose("<p>your <b>company</b> name</p>")).toBe("\nyour company name\n");
     expect(prose("<tr><td>Author</td><td>undefined</td></tr>")).toBe(
-      "\n\nAuthor\nundefined",
+      "\n\nAuthor\n\nundefined\n\n",
     );
   });
 });


### PR DESCRIPTION
Refs squirrelscan/repo#1352

## Summary

Adds `content/unrendered-markup`, a per-page rule that detects markup which failed to render and leaked into the copy a visitor reads: literal markdown (emphasis, links, headings, fences), visible escaped HTML, and double-encoded entities.

The rule reads decoded prose from the DOM, never raw HTML, with script-like and code-like subtrees excluded. Excluding those is the rule rather than a refinement, because a documentation site displaying markdown source is doing its job. `<code>`, `<pre>`, `<samp>`, `<kbd>` and `<textarea>` come out, along with whole-token syntax-highlighter classes (`highlight`, `hljs`, `shiki`, `chroma`, `codehilite`, `preformatted`, any `language-*`) and the `data-language` attribute family. Whole tokens, so a `highlight-box` callout is still judged as prose.

**A note on the acceptance criteria.** The issue says the rule registers in `loader.ts`. `loader.ts` registers namespaces, not rules; a new content rule is registered in `packages/rules/src/content/index.ts`, which is what `loadAllRules()` reads. The criterion's intent is met and no `loader.ts` change is needed. The issue also names `stripHtmlForText`; that helper takes a string and cannot exclude `<pre>`/`<code>`, so the rule uses `collectTextExcluding`, the non-mutating DOM extraction that `content/mojibake` adopted for exactly this problem.

**A shared helper changed, and #214 changed it too.** `collectTextExcluding` gained an optional fourth parameter, `isBoundary`. Without it, sibling blocks concatenate with nothing between them, `<p>a</p><p>b</p>` reads back as `ab`, and every line-anchored pattern here can only match at offset 0, which on a real page means never. The parameter defaults to undefined, so existing call sites are unchanged, and the 518-page canonical golden gate confirms zero divergence for every other rule.

`content/placeholder-text` (#214) added the same parameter independently, emitting the separator on ENTERING a matching element only. That is enough between two blocks, which is all that rule needs, but not when a block is followed by inline content: `<h3>Price *</h3><a>terms* apply</a>` still reads back as `*terms*`, emphasis present in neither element. This branch keeps the symmetric version, which serves both rules, and merges the two test suites into one describe block. The consequence is that extracted text now carries a closing separator as well, which moved three exact-string expectations in `packages/rules/tests/placeholder-text.test.ts`. Only the strings moved: each test still asserts what its name says, and every rule-outcome assertion in that suite is untouched and green.

**Rule counts after the rebase.** Both branches bumped the published counts 279 to 280 with byte-identical edits, so git merged them as one change and raised no conflict, leaving every literal at 280 while the loader returned 281. Corrected across all five documentation surfaces; both per-category tables and all four score-group card sets sum to 281, with content at 20.

## Precision

This rule accuses a page of a rendering bug, so it was measured against real sites rather than fixtures alone. **83 of 85 real pages clean**, worst per-page rule time 10 ms. Each false positive found in the wild became a rule and a test:

| Real page | What it does | Rule that fixed it |
|---|---|---|
| commonmark.org | markdown source in `td class="preformatted"` | `preformatted` joins the highlighter class tokens |
| vercel.com/docs | a copyable agent prompt full of backticks | backticks corroborate, never accuse alone |
| astro.build | `<Article>`, `<Video>` in the hero | escaped tags must be lowercase; those are component names |
| MDN `/pre` | `<pre>` and `<meta name>` in a breadcrumb | one tag must close cleanly or carry a recognised valued attribute |
| MDN `/pre` | `# the-pre-element`, a URL fragment on its own line | a lone `#` is the number sign unless a capital follows |

Prose full of identifiers stays clean: `CLOUDFLARE_API_TOKEN`, `some_file_name.ts`, `max_pages`, `__init__`, `2 * 3`, `width * height`, `array[i](arg)`, `Johnson&Johnson;` and `if a<b then c=1>0` are all covered by tests. Both emphasis forms require CommonMark flanking, and the underscore form additionally requires a space inside the run, which is what silences Python dunders.

**The residual is two w3schools tutorials** that display HTML source in a bespoke `w3-code` div. That is reported honestly rather than tuned away: silencing every `*-code` class token would also silence `promo-code` and `discount-code`, which are prose. The docs page names this case and tells authors to use `<pre>` or `<code>`.

## Verification

```
packages/rules       bun test tests/content-unrendered-markup.test.ts   84 pass
packages/parser      bun test tests/dom-text.test.ts                    14 pass
packages/rules       bun test (5 neighbouring content + limit suites)  145 pass
packages/audit-engine  bun test tests/*golden*  (canonical + 4 more)    14 pass
tsgo --noEmit        parser, rules, audit-engine, apps/cli              all clean
bun run lint         root                                               clean
docs                 bun run check && bun run build                     clean, 389 pages
```

Real-site sweep: 85 pages fetched, 83 clean. End to end through the CLI: a served page with a mis-rendered markdown field reports the finding and ignores the `<pre><code>` block on the same page; the same page with its markdown correctly rendered is silent.

The golden merge gate moved as a new rule id should. `findings` 98721 to 99221, which is one check on each of the 500 pages that have a document, and `perRuleTally` 280 to 281. The pin asserts the rule's tally directly (`pass: 500, warn: 0, fail: 0`) rather than inferring "no false positives" from an unmoved health score, so the gate proves zero false positives across 500 synthetic pages.

Two independent review passes ran over the diff (the `codex` MCP was unavailable on this account, so both were fresh-eyes model reviews). Every finding is fixed and each has a regression test. The timing tests were rewritten after one pass showed the original fixtures carried a single trigger character each and could not detect backtracking at all: a deliberately bad pattern measured 0.1 ms on the old fixture and 5.2 seconds on a dense one. There are now 18 dense-trigger fixtures at a 400 ms budget.

## Follow-up for the gitlink bump

A rule change makes the private monorepo's generated catalogue stale. That bump needs `cd apps/api && bun run generate:rule-catalog` plus the `totalRules` literal and its header comment in `apps/web/src/components/rules.tsx`, or `Test - API` goes red on the rule-count and catalogue drift guards.

## Checklist

- [x] I added or updated tests for behavioral changes.
- [x] I did not include secrets, customer data, or incompatible third-party material.
- [x] Every commit includes a DCO `Signed-off-by` line (`git commit -s`).
