### PR TITLE
feat(rules): add content/dev-leakage, localhost, staging and preview hosts on a production origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Combine your coding agent with a deterministic and extensible audit tool.
 
 ## Features
 
-- **281 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
+- **282 Rules, 21 Categories** - Comprehensive coverage across SEO, accessibility, performance, and security
 - **Fast crawler** - Highly optimized memory efficient crawler
 - **Agent Experience** - Audit agent experience to assist agents in using your site
 - **Security Audit** - Detect phishing kits, leaked credentials, and more
@@ -43,7 +43,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Site Integrity | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | Security | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | Links | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
-| Content | 20 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| Content | 21 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | Performance | 30 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | Images | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | Structured Data | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus rating markup that is not about the page it sits on |
@@ -59,7 +59,7 @@ Ordered by how much a failure usually costs you, not by how many rules each one 
 | Analytics | 2 | Google Tag Manager presence and consent-mode wiring |
 | Blocking | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 281 rules across 21 categories**
+**Total: 282 rules across 21 categories**
 
 See the [rules reference](https://docs.squirrelscan.com/rules) for full details.
 

--- a/docs/agent-setup/index.mdx
+++ b/docs/agent-setup/index.mdx
@@ -92,7 +92,7 @@ other MCP client works too: see [MCP clients](/developers/mcp-clients).
 <div class="agent-facts">
   <div class="agent-fact">
     <span class="agent-fact-key">Audit</span>
-    <span class="agent-fact-val">281 rules across SEO, performance, security, accessibility, and agent experience.</span>
+    <span class="agent-fact-val">282 rules across SEO, performance, security, accessibility, and agent experience.</span>
   </div>
   <div class="agent-fact">
     <span class="agent-fact-key">Read</span>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -251,7 +251,8 @@
                   "rules/content/thin-vs-site-norm",
                   "rules/content/title-pattern-outlier",
                   "rules/content/date-agreement",
-                  "rules/content/unrendered-markup"
+                  "rules/content/unrendered-markup",
+                  "rules/content/dev-leakage"
                 ]
               },
               {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -106,7 +106,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 <Columns cols={2}>
   <Card
-    title="281 rules, 21 categories"
+    title="282 rules, 21 categories"
     icon="list-check"
   >
     Comprehensive coverage across SEO, accessibility, performance, and security.
@@ -216,7 +216,7 @@ Same audit engine, same report, four front doors: your terminal, your coding age
 
 ## Rule categories
 
-squirrelscan runs **281 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
+squirrelscan runs **282 rules** across **21 categories**, plus opt-in cloud gap analysis. Ordered by how much a failure usually costs you, not by how many rules each one has.
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|
@@ -226,7 +226,7 @@ squirrelscan runs **281 rules** across **21 categories**, plus opt-in cloud gap 
 | **Site Integrity** | 9 | Signs the site has been compromised: injected doorway pages, phishing kit signatures, obfuscated scripts, brand impersonation, cloaking, known-malicious URLs |
 | **Security** | 16 | Transport and header hygiene: HTTPS and HSTS, CSP, cookie flags, mixed content, subresource integrity, leaked secrets, unprotected and downgraded forms |
 | **Links** | 15 | Internal and external link health: broken and dead links, redirect chains, anchor-text quality, orphan and dead-end pages, pages linked only from sitewide chrome, HTTPS downgrades |
-| **Content** | 20 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
+| **Content** | 21 | Text quality and honesty: duplicate titles and descriptions, title-template consistency, readability, word count against the site's own norm, freshness, heading hierarchy, keyword stuffing, hidden text, encoding damage |
 | **Performance** | 30 | Core Web Vitals and delivery: LCP, CLS and INP hints, TTFB, compression, caching, render-blocking resources, DOM size, font delivery, legacy and unminified JS/CSS |
 | **Images** | 15 | Alt text, modern formats, responsive `srcset`, intrinsic dimensions and aspect-ratio mismatches, lazy loading above versus below the fold, file weight |
 | **Structured Data** | 12 | JSON-LD validity and rich-result eligibility for Article, Product, FAQ, Review, Breadcrumb, Organization, LocalBusiness, Video and site search, plus pages missing the markup their same-type siblings have and rating markup that is not about the page it sits on |
@@ -242,7 +242,7 @@ squirrelscan runs **281 rules** across **21 categories**, plus opt-in cloud gap 
 | **Analytics** | 2 | Google Tag Manager presence and consent-mode wiring |
 | **Blocking** | 3 | Content, links and trackers that ad blockers and privacy filters strip for a large share of your visitors |
 
-**Total: 281 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
+**Total: 282 rules across 21 categories.** Gap analysis (keyword and content gaps) is a cloud opt-in and is not counted above.
 
 See the [rules reference](/rules) for full details.
 

--- a/docs/rules/content/dev-leakage.mdx
+++ b/docs/rules/content/dev-leakage.mdx
@@ -1,0 +1,84 @@
+---
+title: "Development Host Leakage"
+description: "Detects localhost, private, staging and preview hosts on a production page"
+---
+
+Detects localhost, private, staging and preview hosts on a production page
+
+| | |
+|---|---|
+| **Rule ID** | `content/dev-leakage` |
+| **Category** | [Content](/rules/content) |
+| **Scope** | Per-page |
+| **Severity** | warning |
+| **Weight** | 6/10 |
+
+## Solution
+
+A URL that was correct in development shipped to production. Find where it is stored, not just the page it appears on: a link or image pointing at localhost, a private address, or a preview deployment is usually a hard-coded value in a template, a CMS field written while working locally, or a base-URL environment variable that never got a production value, so the same URL is on every page that renders that component. Replace the origin with a relative path where the target is on this site, which is what makes the link correct in every environment at once. For a staging or preview host, point the link at the production equivalent and check whether the staging site is publicly indexable while you are there. For an `http://` link back to your own site, make it relative or `https://`, since the redirect it currently costs every visitor is avoidable.
+
+## What it checks
+
+Five kinds, in `href` and `src` attributes and in the copy a visitor reads:
+
+| Kind | Example | Meaning |
+|---|---|---|
+| `localhost` | `http://localhost:3000/api` | a dev server address shipped to production |
+| `private-ip` | `http://192.168.1.10/logo.png` | an address only reachable inside one network |
+| `dev-subdomain` | `https://staging.example.com/pricing` | a non-production tier of this site's own domain |
+| `preview-host` | `https://example-git-main.vercel.app/` | an ephemeral deployment that will stop resolving |
+| `insecure-self-link` | `http://example.com/pricing` | this site's own URL, spelled without TLS |
+
+`localhost` covers the whole `127.0.0.0/8` block, the IPv6 loopback `[::1]`, the unspecified address `0.0.0.0`, and any `*.localhost` name. `private-ip` covers the three RFC 1918 blocks: `10.0.0.0/8`, `172.16.0.0/12` and `192.168.0.0/16`. Preview hosts are `vercel.app`, `netlify.app`, `pages.dev`, `ngrok.io`, `ngrok.app`, `ngrok-free.app` and `trycloudflare.com`.
+
+**Severity depends on whether the reference is live.** A dev host in an `href` or `src` is something a visitor can click or a browser will try to load, and it fails. A dev host that only appears in copy is embarrassing rather than broken, and it warns.
+
+## What is excluded
+
+The rule is mostly a list of ways to tell a leaked URL apart from a URL a page is talking about on purpose.
+
+- **Code samples.** `<code>`, `<pre>`, `<samp>` and `<kbd>` subtrees, `<template>` content, and the container classes syntax highlighters and in-page editors use (`hljs`, `shiki`, `prism`, `code-block`, `cm-editor`, `monaco-editor`, any `language-*`) are all dropped before the copy is read. A getting-started page printing `http://localhost:5173` in a code block stays clean. A live `<a href>` is still judged wherever it sits, including inside a `<pre>`, because a clickable link is clickable regardless of its surroundings.
+- **A bare `localhost` in a sentence.** "The app also runs on localhost during development" is a sentence people write. A scheme, a port or a path is required before a bare `localhost` counts, so `localhost:5173` and `http://localhost` do. A qualified name like `api.acme.localhost` has no second reading and counts on its own.
+- **A bare address in `10.0.0.0/8`.** Four dotted numbers starting at 10 is also how enterprise software spells a version, so `Contoso Server 10.0.0.1` is not reported. With a scheme, a port or a path it is unmistakably a host and is. The `192.168.*`, `172.16-31.*` and `127.*` blocks have no such reading and count bare.
+- **A bare platform name.** "We deploy to pages.dev" names a platform. `abc123.pages.dev` names a deployment, so at least one leading label is required.
+- **Non-production audits.** If the audited origin is itself a localhost, private, preview or `staging.`/`dev.`/`test.` host, the rule skips the page rather than passing it. Auditing a preview deploy would otherwise report every internal link on it as leakage. Both the seed URL and the page's own URL are checked, so a page that redirected onto a preview host skips too.
+
+## Subdomain matching
+
+`staging.`, `dev.` and `test.` are matched against the audited site's **registrable domain**, resolved through the Public Suffix List, not by a string suffix test. Two things follow.
+
+`notdev.example.com`, `webdev.example.com` and `development.example.com` are not reported, because the leftmost label has to be exactly `staging`, `dev` or `test`. Somebody else's `dev.other.com` is not reported either, because its registrable domain is not this site's. Multi-label public suffixes resolve correctly, so `dev.example.co.uk` is a dev tier of `example.co.uk` rather than of `co.uk`.
+
+## Preview hosts that are not yours
+
+Plenty of production sites live on `vercel.app` and `pages.dev`, and a page may legitimately link to somebody else's project there. A preview host whose leftmost label carries this site's own name (`example-git-main.vercel.app` for `example.com`) is treated as this site's own deployment and fails. One that does not is still reported, because linking production content at an ephemeral platform host is worth knowing about, but it only warns.
+
+## Related rules
+
+[links/https-downgrade](/rules/links/https-downgrade) counts every `http://` anchor on an HTTPS page, including links to other people's sites, and owns the transport-security story. This rule looks at the same attribute from a different angle and deliberately stays narrower: it reports an `http://` URL only when it points back at **your own** registrable domain, where the fix is a template or a config value rather than a decision about whether to link somewhere at all. That kind never escalates this rule past `warn` and never decides its status by itself, so an HTTPS page whose only finding is a self-referential `http://` link gets one warning here and one from `links/https-downgrade`, describing the same href as two different problems: an avoidable redirect, and a baked-in absolute URL.
+
+[links/invalid-links](/rules/links/invalid-links) reports URLs that do not parse. There is no overlap: `http://localhost:3000/api` is a perfectly well-formed URL, so it never appears there, and a value this rule cannot parse is skipped rather than reported, so a malformed href is never counted twice. Broken-link rules would catch a dev host only when it happens to be unreachable from the crawler, which is the wrong signal at the wrong time: `staging.example.com` usually resolves, and `abc123.vercel.app` resolves right up until the deployment is garbage-collected.
+
+## Enable / disable
+
+### Disable this rule
+
+```toml squirrel.toml
+[rules]
+disable = ["content/dev-leakage"]
+```
+
+### Disable all Content rules
+
+```toml squirrel.toml
+[rules]
+disable = ["content/*"]
+```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/dev-leakage"]
+disable = ["*"]
+```

--- a/docs/rules/content/dev-leakage.mdx
+++ b/docs/rules/content/dev-leakage.mdx
@@ -19,7 +19,7 @@ A URL that was correct in development shipped to production. Find where it is st
 
 ## What it checks
 
-Five kinds, in `href` and `src` attributes and in the copy a visitor reads:
+Five kinds, in every `href` and `src` on the page and in the copy a visitor reads. The head is included: a `<link rel="canonical">` at localhost de-indexes the page and a stylesheet or script at localhost breaks it outright, so those are the highest-impact findings the rule has.
 
 | Kind | Example | Meaning |
 |---|---|---|
@@ -41,7 +41,7 @@ The rule is mostly a list of ways to tell a leaked URL apart from a URL a page i
 - **A bare `localhost` in a sentence.** "The app also runs on localhost during development" is a sentence people write. A scheme, a port or a path is required before a bare `localhost` counts, so `localhost:5173` and `http://localhost` do. A qualified name like `api.acme.localhost` has no second reading and counts on its own.
 - **A bare address in `10.0.0.0/8`.** Four dotted numbers starting at 10 is also how enterprise software spells a version, so `Contoso Server 10.0.0.1` is not reported. With a scheme, a port or a path it is unmistakably a host and is. The `192.168.*`, `172.16-31.*` and `127.*` blocks have no such reading and count bare.
 - **A bare platform name.** "We deploy to pages.dev" names a platform. `abc123.pages.dev` names a deployment, so at least one leading label is required.
-- **Non-production audits.** If the audited origin is itself a localhost, private, preview or `staging.`/`dev.`/`test.` host, the rule skips the page rather than passing it. Auditing a preview deploy would otherwise report every internal link on it as leakage. Both the seed URL and the page's own URL are checked, so a page that redirected onto a preview host skips too.
+- **Non-production audits.** If the audited origin is itself a localhost, private, preview or `staging.`/`dev.`/`test.` host, the rule skips the page rather than passing it. Auditing a preview deploy would otherwise report every internal link on it as leakage. Both the seed URL and the URL the page finally resolved to are checked, so a page that redirected onto a preview host skips too. A tier word only counts when it really is a tier: `dev.to`, `test.com` and `staging.com` are registrable domains in their own right, and sites hosted on them are audited normally.
 
 ## Subdomain matching
 
@@ -52,6 +52,8 @@ The rule is mostly a list of ways to tell a leaked URL apart from a URL a page i
 ## Preview hosts that are not yours
 
 Plenty of production sites live on `vercel.app` and `pages.dev`, and a page may legitimately link to somebody else's project there. A preview host whose leftmost label carries this site's own name (`example-git-main.vercel.app` for `example.com`) is treated as this site's own deployment and fails. One that does not is still reported, because linking production content at an ephemeral platform host is worth knowing about, but it only warns.
+
+The name has to be a whole hyphen-separated segment of the label, never a substring. Vercel, Netlify and Cloudflare all build the label out of hyphen-joined parts, so a project's own name is always a segment; a substring test would instead read `sandbox-demo.vercel.app` as `box.com`'s own deployment and fail a link its owner cannot do anything about.
 
 ## Related rules
 

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -26,6 +26,9 @@ Text quality, readability, and content structure
   <Card title="Date Agreement" icon="triangle-exclamation" href="/rules/content/date-agreement">
     Checks the visible date, schema dates and URL/title year agree
   </Card>
+  <Card title="Development Host Leakage" icon="triangle-exclamation" href="/rules/content/dev-leakage">
+    Detects localhost, private, staging and preview hosts on a production page
+  </Card>
   <Card title="Duplicate Description" icon="triangle-exclamation" href="/rules/content/duplicate-description">
     Checks for duplicate meta descriptions across the site
   </Card>

--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Rules reference"
-description: "All 281 audit rules organized by score group and category"
+description: "All 282 audit rules organized by score group and category"
 ---
 
-squirrelscan includes **281 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
+squirrelscan includes **282 rules** across **21 categories**, plus opt-in cloud gap analysis. Every category rolls up into one of four score groups: **SEO**, **Performance**, **Security**, and **Agents**. These are the four scores you see on reports and in the dashboard, alongside the overall health score.
 
 Most rules run locally for free. A handful of [cloud rules](/cloud/rules) use AI analysis, full filter lists, or live search data - they require login and are skipped when you're not logged in. Cloud rules carry a notice banner on their doc pages.
 
@@ -23,7 +23,7 @@ Search visibility: crawling, indexing, content, markup, and accessibility.
     Internal and external link health and structure (15 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (20 rules)
+    Text quality, readability, and content structure (21 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (12 rules)

--- a/docs/rules/seo/index.mdx
+++ b/docs/rules/seo/index.mdx
@@ -25,7 +25,7 @@ are skipped when you're not logged in.
     Internal and external link health and structure (15 rules)
   </Card>
   <Card title="Content" icon="folder" href="/rules/content">
-    Text quality, readability, and content structure (20 rules)
+    Text quality, readability, and content structure (21 rules)
   </Card>
   <Card title="Structured Data" icon="folder" href="/rules/schema">
     Structured data and rich snippet eligibility (12 rules)

--- a/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-rules-canonical-golden.test.ts
@@ -64,7 +64,13 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // rich, at-scale one, not a degenerate crawl. Exact pins double as a
       // rule-surface drift tripwire (see golden-baseline.test.ts for the same fixture).
       expect(v1.meta.pageCount).toBeGreaterThanOrEqual(GOLDEN_BASELINE_PAGE_COUNT);
-      expect(v1.healthScore.overall).toBe(48);
+      // 48 -> 49 (#1353). Every earlier +500 landed on a category whose score was
+      // already far enough from a rounding boundary to absorb it; this one is not.
+      // content/dev-leakage passes on all 500 pages, which lifts the content
+      // category's pass ratio just past the point where the weighted overall
+      // rounds up. A MOVE here is only correct alongside a deliberate rule
+      // addition — if this number shifts on its own, a rule started failing.
+      expect(v1.healthScore.overall).toBe(49);
       // 97711 -> 98211: content/hidden-text emits one page check across the 500
       // fixture pages that have a document, and passes on every one of them. The
       // overall score is unmoved.
@@ -109,8 +115,12 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // 98721 -> 99221: content/unrendered-markup (#1352) is the same shape and
       // adds the same 500 — one check on each page with a document, the other
       // 18 having none. All 500 pass too: the fixture's copy carries no literal
-      // markdown, so healthScore.overall is still 48.
-      expect(v1.findings.length).toBe(99221);
+      // markdown, so healthScore.overall was still 48 at that point.
+      // 99221 -> 99721: content/dev-leakage (#1353) is the same shape again and
+      // adds the same 500. All 500 pass: the fixture's origin is
+      // `http://synthetic.test`, which is neither a dev host nor HTTPS, so
+      // neither the host families nor the http-self-link kind can fire.
+      expect(v1.findings.length).toBe(99721);
       // Tripwire: EXTENDING a rule must never add a tally key, so a change here
       // is only correct alongside a deliberate new rule id. 266 -> 267 is
       // content/hidden-text, 267 -> 268 content/thin-vs-site-norm, 268 -> 269
@@ -121,15 +131,25 @@ describe("runStreamingRules — canonical 518-page v1↔v2 merge gate", () => {
       // content/date-agreement, 276 -> 277 links/no-contextual-inbound,
       // 277 -> 278 social/asset-divergence, 278 -> 279 perf/asset-compression,
       // 279 -> 280 content/placeholder-text, 280 -> 281
-      // content/unrendered-markup; anything else means a rule id
-      // leaked in, so fix that rather than this number.
-      expect(v1.perRuleTally.length).toBe(281);
+      // content/unrendered-markup, 281 -> 282 content/dev-leakage; anything
+      // else means a rule id leaked in, so fix that rather than this number.
+      expect(v1.perRuleTally.length).toBe(282);
       // Each +500 above is only "all passes" if nothing warned. healthScore
       // staying at 48 does not prove that — a handful of weight-5 warnings in a
       // 20-rule category would not move it — so pin the tally directly.
       const unrendered = v1.perRuleTally.find((t) => t.ruleId === "content/unrendered-markup");
       expect(unrendered).toEqual({
         ruleId: "content/unrendered-markup",
+        pass: 500,
+        warn: 0,
+        fail: 0,
+        info: 0,
+        skipped: 0,
+        total: 500,
+      });
+      const devLeakage = v1.perRuleTally.find((t) => t.ruleId === "content/dev-leakage");
+      expect(devLeakage).toEqual({
+        ruleId: "content/dev-leakage",
         pass: 500,
         warn: 0,
         fail: 0,

--- a/packages/rules/src/content/dev-leakage.ts
+++ b/packages/rules/src/content/dev-leakage.ts
@@ -1,0 +1,644 @@
+// content/dev-leakage - development, staging and preview hosts left on a production origin
+//
+// The shape of the bug: a URL that was correct on someone's laptop, or on a
+// preview deploy, got baked into content or into a template and shipped. The
+// reader sees `http://localhost:3000/api`, a link to `staging.example.com`, or
+// an image served from a Vercel preview that will 404 the moment the deployment
+// is garbage-collected.
+
+import { getDomain } from "tldts";
+
+import type { Element } from "linkedom";
+
+import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
+import { getRenderedProseText } from "./text-content";
+
+/**
+ * Platforms whose hostnames are, by construction, a deployment rather than a
+ * brand. A production page pointing at one of these is pointing at something
+ * ephemeral.
+ *
+ * `ngrok.app` and `ngrok-free.app` ride along with the issue's `ngrok.io`: same
+ * vendor, and `.io` is the legacy domain every current tunnel has moved off, so
+ * matching only the old one would miss the tunnels people actually open today.
+ *
+ * `pages.dev` and `vercel.app` also host plenty of REAL production sites, which
+ * is why the seed skip below exists and why a preview host that does not look
+ * like this site's own project only ever warns.
+ */
+const PREVIEW_HOST_SUFFIXES = [
+  "vercel.app",
+  "netlify.app",
+  "pages.dev",
+  "ngrok.io",
+  "ngrok.app",
+  "ngrok-free.app",
+  "trycloudflare.com",
+] as const;
+
+/** Leftmost labels that name a non-production tier of the site's own domain. */
+const DEV_SUBDOMAIN_LABELS = new Set(["staging", "dev", "test"]);
+
+/**
+ * Work cap on the prose scan. This rule is a yes/no signal about whether a dev
+ * URL shipped, and no real page needs half a megabyte of copy to demonstrate
+ * that. Bounds the cost on a hostile or machine-generated page.
+ */
+const MAX_SCANNED_CHARS = 500_000;
+
+/** Elements whose attributes are read. Bounds the DOM pass on a hostile page. */
+const MAX_ELEMENTS_SCANNED = 50_000;
+
+/** Per kind, so one pathological page cannot allocate an unbounded hit list. */
+const MAX_HITS_PER_KIND = 200;
+
+/** Reports get these verbatim, so no newline and no unbounded site-controlled string. */
+const MAX_SAMPLE_LENGTH = 120;
+
+export type DevLeakageKind =
+  | "localhost"
+  | "private-ip"
+  | "dev-subdomain"
+  | "preview-host"
+  | "insecure-self-link";
+
+/** Where the reference was found: a live `href`/`src`, or copy a reader sees. */
+export type DevLeakageSource = "attribute" | "text";
+
+export interface DevLeakageHit {
+  kind: DevLeakageKind;
+  source: DevLeakageSource;
+  /** Lowercased host that triggered the hit. */
+  host: string;
+  /** Short, single-line excerpt safe to put in a report. */
+  sample: string;
+  /**
+   * True when the host is unambiguously an artifact of THIS site: a loopback or
+   * private address, a non-production tier of the site's own apex, or a preview
+   * deployment that carries the site's own name. False only for a preview-
+   * platform host that could belong to anyone.
+   */
+  own: boolean;
+}
+
+/** The audited origin, resolved once per page. */
+export interface SiteOrigin {
+  /** Registrable domain (eTLD+1) of the page, lowercased. */
+  apex: string;
+  /** Leftmost label of `apex`, or "" when it is too short to match a preview on. */
+  apexLabel: string;
+  /** The page's own host, lowercased. */
+  host: string;
+  /** True when the page itself was served over HTTPS. */
+  secure: boolean;
+}
+
+/**
+ * eTLD+1 via the Public Suffix List, the same helper shape `integrity/signals`
+ * uses. A string suffix test is not a substitute: `notdev.example.com` ends with
+ * `dev.example.com`, and `example.co.uk` is not a subdomain of `co.uk`.
+ *
+ * `allowPrivateDomains` is on so PRIVATE-section suffixes count as public and
+ * `a.vercel.app` and `b.vercel.app` resolve to DISTINCT registrable domains
+ * instead of collapsing to `vercel.app`. That is what stops a site hosted on
+ * `acme.pages.dev` from treating every other tenant of `pages.dev` as its own.
+ *
+ * Falls back to the lowercased, trailing-dot-stripped host whenever tldts
+ * cannot derive one (an IP literal, `localhost`, a bare public suffix), so both
+ * sides of a comparison still normalize identically.
+ */
+export function registrableDomain(host: string): string {
+  const normalized = host.replace(/\.$/, "").toLowerCase();
+  return getDomain(normalized, { allowPrivateDomains: true }) ?? normalized;
+}
+
+/** The four octets of a dotted-quad, or null if `host` is not one. */
+function ipv4Octets(host: string): number[] | null {
+  const parts = host.split(".");
+  if (parts.length !== 4) return null;
+  const octets: number[] = [];
+  for (const part of parts) {
+    // Length first: `Number("")` is 0 and `Number(" 1")` is 1, so the numeric
+    // test alone would accept `10...` and `10. 0.0.1` as addresses.
+    if (part.length === 0 || part.length > 3 || !/^\d+$/.test(part)) return null;
+    const value = Number(part);
+    if (value > 255) return null;
+    octets.push(value);
+  }
+  return octets;
+}
+
+/** `localhost`, any `*.localhost`, the IPv6 loopback, or `127.0.0.0/8`. */
+export function isLoopbackHost(host: string): boolean {
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1" || host === "[::1]") return true;
+  // 0.0.0.0 is the unspecified address, not loopback, but it reaches a page only
+  // by being copied out of a dev server's "listening on" line, which is the same
+  // bug with the same fix.
+  if (host === "0.0.0.0") return true;
+  const octets = ipv4Octets(host);
+  return octets !== null && octets[0] === 127;
+}
+
+/** RFC 1918: `10/8`, `172.16/12`, `192.168/16`. */
+export function isPrivateIpHost(host: string): boolean {
+  const octets = ipv4Octets(host);
+  if (!octets) return false;
+  const [a, b] = octets as [number, number, number, number];
+  if (a === 10) return true;
+  if (a === 192 && b === 168) return true;
+  return a === 172 && b >= 16 && b <= 31;
+}
+
+/** A host on one of the ephemeral-deployment platforms. */
+export function isPreviewHost(host: string): boolean {
+  return PREVIEW_HOST_SUFFIXES.some((s) => host === s || host.endsWith(`.${s}`));
+}
+
+/**
+ * True when `host` is a `staging.`/`dev.`/`test.` tier of `apex`.
+ *
+ * Both halves are load-bearing. The registrable-domain equality is what keeps
+ * `dev.someoneelse.com` out; the leftmost-label test is what keeps
+ * `notdev.example.com` and `development.example.com` out, since neither is the
+ * site's dev tier and a suffix test would call both one.
+ */
+export function isDevSubdomainOf(host: string, apex: string): boolean {
+  if (!apex || host === apex) return false;
+  if (registrableDomain(host) !== apex) return false;
+  const leftmost = host.split(".")[0] ?? "";
+  return DEV_SUBDOMAIN_LABELS.has(leftmost);
+}
+
+/**
+ * True when a preview host carries the audited site's own name, e.g.
+ * `acme-git-main-team.vercel.app` for `acme.com`.
+ *
+ * Everything on `vercel.app` and `pages.dev` looks alike from the outside, and
+ * a production page may legitimately link to somebody else's project there. The
+ * name test is what separates "your own preview deployment leaked" (a bug you
+ * can act on) from "you linked to a site that happens to be on Vercel".
+ */
+export function looksLikeOwnPreview(host: string, apexLabel: string): boolean {
+  // Two characters match far too much — `wp-abc.vercel.app` would "contain" the
+  // apex label of `wp.com`.
+  if (apexLabel.length < 3) return false;
+  const leftmost = host.split(".")[0] ?? "";
+  return leftmost.includes(apexLabel);
+}
+
+/** True for a host that means "this audit is not of a production origin". */
+export function isNonProductionSeedHost(host: string): boolean {
+  if (isLoopbackHost(host) || isPrivateIpHost(host) || isPreviewHost(host)) return true;
+  // A seed whose OWN leftmost label names a tier: auditing `staging.example.com`
+  // is auditing staging, and every internal link on it is a staging link.
+  return DEV_SUBDOMAIN_LABELS.has(host.split(".")[0] ?? "");
+}
+
+/** Which family `host` belongs to, and whether it is this site's own artifact. */
+export function classifyHost(
+  host: string,
+  site: SiteOrigin,
+): { kind: DevLeakageKind; own: boolean } | null {
+  if (isLoopbackHost(host)) return { kind: "localhost", own: true };
+  if (isPrivateIpHost(host)) return { kind: "private-ip", own: true };
+  if (isPreviewHost(host)) {
+    return { kind: "preview-host", own: looksLikeOwnPreview(host, site.apexLabel) };
+  }
+  if (isDevSubdomainOf(host, site.apex)) return { kind: "dev-subdomain", own: true };
+  return null;
+}
+
+/** Resolve the audited origin from a page URL. */
+export function siteOriginOf(pageUrl: string): SiteOrigin | null {
+  let url: URL;
+  try {
+    url = new URL(pageUrl);
+  } catch {
+    return null;
+  }
+  const host = url.hostname.toLowerCase();
+  const apex = registrableDomain(host);
+  return {
+    apex,
+    apexLabel: apex.split(".")[0] ?? "",
+    host,
+    secure: url.protocol === "https:",
+  };
+}
+
+function toSample(raw: string): string {
+  const flat = raw.replace(/\s+/g, " ").trim();
+  return flat.length > MAX_SAMPLE_LENGTH ? `${flat.slice(0, MAX_SAMPLE_LENGTH - 1)}…` : flat;
+}
+
+/** Escape a host for literal use inside a RegExp. */
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
+}
+
+// ---------------------------------------------------------------------------
+// Prose scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * The character before a host has to be one that cannot be part of one, or
+ * `notdev.example.com` matches on `dev.example.com` and `v10.0.0.1` matches on
+ * `10.0.0.1`. Consumed rather than looked behind: the capture groups carry
+ * everything the report needs, so nothing depends on `match[0]`.
+ */
+const LEFT_BOUNDARY = String.raw`(?:^|[^A-Za-z0-9.\-_])`;
+
+/** Nothing may follow the host that could have been part of it. */
+const RIGHT_BOUNDARY = String.raw`(?![A-Za-z0-9.\-])`;
+
+const OPTIONAL_SCHEME = String.raw`(?:(https?):\/\/)?`;
+const OPTIONAL_PORT = String.raw`(?::(\d{1,5}))?`;
+
+/**
+ * A path, if one follows. One bounded character class, never two adjacent
+ * quantifiers, so a long run cannot re-partition itself. Closing punctuation is
+ * excluded so a URL at the end of a parenthetical does not swallow the bracket.
+ */
+const OPTIONAL_PATH = String.raw`((?:\/[^\s<>"'\)\]]{0,200})?)`;
+
+/** Up to ten leading labels, each ending in a literal dot, so partitioning is unique. */
+const LEADING_LABELS = String.raw`(?:[a-z0-9-]{1,63}\.){0,10}`;
+
+const LOCALHOST_TEXT_RE = new RegExp(
+  `${LEFT_BOUNDARY}${OPTIONAL_SCHEME}(${LEADING_LABELS}localhost)${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
+  "gi",
+);
+
+const IPV4_TEXT_RE = new RegExp(
+  `${LEFT_BOUNDARY}${OPTIONAL_SCHEME}(\\d{1,3}(?:\\.\\d{1,3}){3})${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
+  "gi",
+);
+
+/**
+ * At least one leading label is REQUIRED. A page that writes "we deploy to
+ * pages.dev" is naming a platform, not leaking a deployment; `abc123.pages.dev`
+ * is a deployment.
+ */
+const PREVIEW_TEXT_RE = new RegExp(
+  `${LEFT_BOUNDARY}${OPTIONAL_SCHEME}((?:[a-z0-9-]{1,63}\\.){1,10}(?:${PREVIEW_HOST_SUFFIXES.map(
+    escapeForRegExp,
+  ).join("|")}))${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
+  "gi",
+);
+
+/** `http://` spelled out in copy, host left open so the apex test can judge it. */
+const INSECURE_URL_TEXT_RE = new RegExp(
+  `${LEFT_BOUNDARY}(http):\\/\\/([a-z0-9][a-z0-9.\\-]{0,253})${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
+  "gi",
+);
+
+interface UrlishMatch {
+  scheme: string | undefined;
+  host: string;
+  port: string | undefined;
+  path: string;
+  /** Scheme, host, port and path reassembled — the text a reader actually sees. */
+  text: string;
+}
+
+/**
+ * Every URL-shaped occurrence of `re` in `text`.
+ *
+ * `re` is module-level and `g`-flagged, so `lastIndex` is reset on both sides:
+ * a stale one would silently skip the head of the next page's text.
+ */
+function scanUrlish(re: RegExp, text: string, limit: number): UrlishMatch[] {
+  re.lastIndex = 0;
+  const out: UrlishMatch[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const host = (match[2] ?? "").toLowerCase();
+    const scheme = match[1]?.toLowerCase();
+    const port = match[3];
+    const path = match[4] ?? "";
+    out.push({
+      scheme,
+      host,
+      port,
+      path,
+      text: `${scheme ? `${scheme}://` : ""}${host}${port ? `:${port}` : ""}${path}`,
+    });
+    if (out.length >= limit) break;
+    // None of these patterns can match empty, but a zero-length match would spin
+    // forever and the alternative to this guard is a hung audit.
+    if (match.index === re.lastIndex) re.lastIndex++;
+  }
+  re.lastIndex = 0;
+  return out;
+}
+
+/** True when the occurrence was written as a URL rather than as a bare word. */
+const hasUrlContext = (m: UrlishMatch): boolean =>
+  m.scheme !== undefined || m.port !== undefined || m.path.length > 0;
+
+/**
+ * Every dev-host reference in `text`, which must already be VISIBLE prose with
+ * code-like subtrees removed.
+ *
+ * Two families need URL context before they count, because a bare occurrence of
+ * either has an innocent second reading in ordinary prose:
+ *
+ * - A bare `localhost`. "Open the app on localhost" is a sentence people write;
+ *   `localhost:3000` and `http://localhost` are not. A qualified host
+ *   (`api.acme.localhost`) has no second reading and counts on its own.
+ * - A bare address in `10.0.0.0/8`. Four dotted numbers starting at 10 is also
+ *   how enterprise software spells a version, and a rule that calls a version
+ *   number a leak is worse than one that misses it. `192.168.*`, `172.16-31.*`
+ *   and `127.*` have no such reading and count bare.
+ */
+export function findDevHostsInText(text: string, site: SiteOrigin): DevLeakageHit[] {
+  const scanned = text.length > MAX_SCANNED_CHARS ? text.slice(0, MAX_SCANNED_CHARS) : text;
+  const hits: DevLeakageHit[] = [];
+
+  const add = (kind: DevLeakageKind, own: boolean, m: UrlishMatch): void => {
+    hits.push({ kind, source: "text", host: m.host, sample: toSample(m.text), own });
+  };
+
+  for (const m of scanUrlish(LOCALHOST_TEXT_RE, scanned, MAX_HITS_PER_KIND)) {
+    const qualified = m.host !== "localhost";
+    if (!qualified && !hasUrlContext(m)) continue;
+    add("localhost", true, m);
+  }
+
+  for (const m of scanUrlish(IPV4_TEXT_RE, scanned, MAX_HITS_PER_KIND * 2)) {
+    if (isLoopbackHost(m.host)) {
+      add("localhost", true, m);
+      continue;
+    }
+    if (!isPrivateIpHost(m.host)) continue;
+    if (m.host.startsWith("10.") && !hasUrlContext(m)) continue;
+    add("private-ip", true, m);
+  }
+
+  for (const m of scanUrlish(PREVIEW_TEXT_RE, scanned, MAX_HITS_PER_KIND)) {
+    add("preview-host", looksLikeOwnPreview(m.host, site.apexLabel), m);
+  }
+
+  if (site.apex) {
+    const devSubdomainRe = new RegExp(
+      `${LEFT_BOUNDARY}${OPTIONAL_SCHEME}((?:staging|dev|test)\\.${LEADING_LABELS}${escapeForRegExp(
+        site.apex,
+      )})${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
+      "gi",
+    );
+    for (const m of scanUrlish(devSubdomainRe, scanned, MAX_HITS_PER_KIND)) {
+      add("dev-subdomain", true, m);
+    }
+  }
+
+  // Only on an HTTPS page, and only for the site's own domain: a printed
+  // `http://` URL for somebody else's site is their transport problem, and
+  // `links/https-downgrade` already owns the page-level downgrade story.
+  if (site.secure && site.apex) {
+    for (const m of scanUrlish(INSECURE_URL_TEXT_RE, scanned, MAX_HITS_PER_KIND)) {
+      if (registrableDomain(m.host) !== site.apex) continue;
+      // A dev host that happens to be reachable over http is already reported as
+      // what it is; saying it twice would double-count the same string.
+      if (classifyHost(m.host, site)) continue;
+      add("insecure-self-link", true, m);
+    }
+  }
+
+  return hits;
+}
+
+// ---------------------------------------------------------------------------
+// Attribute scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * Every `href`/`src` value on the page, in document order.
+ *
+ * Attribute names are folded from `el.attributes` rather than looked up by
+ * name: `getAttribute` follows the HTML case rules only through the parser's
+ * patched DOM, and reading the list once is cheaper than two by-name lookups
+ * per element, each of which walks that same list.
+ */
+export function collectUrlAttributes(root: Element): string[] {
+  const out: string[] = [];
+  let seen = 0;
+  for (const el of root.querySelectorAll("*")) {
+    if (++seen > MAX_ELEMENTS_SCANNED) break;
+    for (const attr of el.attributes) {
+      const name = attr.name.toLowerCase();
+      if (name !== "href" && name !== "src") continue;
+      const value = attr.value?.trim();
+      if (value) out.push(value);
+    }
+  }
+  return out;
+}
+
+/**
+ * The dev-leakage hit for one `href`/`src` value, or null.
+ *
+ * A value that will not parse is skipped rather than reported: a malformed URL
+ * is `links/invalid-links`'s finding, and restating it here would put the same
+ * defect in two categories under two different names.
+ */
+export function classifyUrlAttribute(
+  raw: string,
+  pageUrl: string,
+  site: SiteOrigin,
+): DevLeakageHit | null {
+  let url: URL;
+  try {
+    url = new URL(raw, pageUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  const host = url.hostname.toLowerCase();
+  // The canonical form, never the raw attribute: `url.href` is what the browser
+  // would actually request, and it is percent-encoded, so a site-controlled
+  // attribute cannot smuggle markup or a newline into the report through it.
+  const sample = toSample(url.href);
+
+  const classified = classifyHost(host, site);
+  if (classified) {
+    return { kind: classified.kind, source: "attribute", host, sample, own: classified.own };
+  }
+  if (site.secure && url.protocol === "http:" && registrableDomain(host) === site.apex) {
+    return { kind: "insecure-self-link", source: "attribute", host, sample, own: true };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+/** One row per kind, with the count and the first sample, in report order. */
+export interface DevLeakageSummaryRow {
+  kind: DevLeakageKind;
+  sample: string;
+  count: number;
+  /** True when at least one occurrence of this kind came from an `href`/`src`. */
+  inAttribute: boolean;
+}
+
+/**
+ * `insecure-self-link` is the one kind `links/https-downgrade` also speaks
+ * about, so it is never allowed to decide this rule's status on its own and
+ * never escalates to `fail`. See the doc page for the full overlap story.
+ */
+const SOFT_KINDS = new Set<DevLeakageKind>(["insecure-self-link"]);
+
+export function summarize(hits: DevLeakageHit[]): DevLeakageSummaryRow[] {
+  const rows = new Map<DevLeakageKind, DevLeakageSummaryRow>();
+  for (const hit of hits) {
+    const existing = rows.get(hit.kind);
+    if (!existing) {
+      rows.set(hit.kind, {
+        kind: hit.kind,
+        sample: hit.sample,
+        count: 1,
+        inAttribute: hit.source === "attribute",
+      });
+      continue;
+    }
+    existing.count += 1;
+    // Prefer an attribute sample: a live reference is stronger evidence than a
+    // mention, and it is the one a reader can click to reproduce the bug.
+    if (hit.source === "attribute" && !existing.inAttribute) {
+      existing.inAttribute = true;
+      existing.sample = hit.sample;
+    }
+  }
+  return [...rows.values()];
+}
+
+export const devLeakageRule: Rule = {
+  meta: {
+    id: "content/dev-leakage",
+    name: "Development Host Leakage",
+    description: "Detects localhost, private, staging and preview hosts on a production page",
+    solution:
+      "A URL that was correct in development shipped to production. Find where it is stored, not just the page it appears on: a link or image pointing at localhost, a private address, or a preview deployment is usually a hard-coded value in a template, a CMS field written while working locally, or a base-URL environment variable that never got a production value, so the same URL is on every page that renders that component. Replace the origin with a relative path where the target is on this site, which is what makes the link correct in every environment at once. For a staging or preview host, point the link at the production equivalent and check whether the staging site is publicly indexable while you are there. For an `http://` link back to your own site, make it relative or `https://`, since the redirect it currently costs every visitor is avoidable.",
+    category: "content",
+    scope: "page",
+    severity: "warning",
+    weight: 6,
+    skipOnSoft404: true,
+  },
+
+  run(ctx: RuleContext): RuleResult {
+    const checks: CheckResult[] = [];
+    const name = "dev-leakage";
+    const doc = ctx.parsed.document;
+    if (!doc) {
+      checks.push({
+        name,
+        status: "skipped",
+        message: "No document available",
+        skipReason: "Parse error",
+      });
+      return { checks };
+    }
+
+    const site = siteOriginOf(ctx.page.url);
+    if (!site) {
+      checks.push({
+        name,
+        status: "skipped",
+        message: "Page URL could not be parsed",
+        skipReason: "unparseable-page-url",
+      });
+      return { checks };
+    }
+
+    // The audited origin, which is the SEED when the runner supplied site data
+    // and the page's own URL otherwise. Both are checked: a seed on a preview
+    // host means the whole audit is of a preview, and a page that redirected
+    // onto one means this page is.
+    const seedHost = ctx.site?.baseUrl ? siteOriginOf(ctx.site.baseUrl)?.host : undefined;
+    const nonProductionHost = [seedHost, site.host].find(
+      (h): h is string => h !== undefined && isNonProductionSeedHost(h),
+    );
+    if (nonProductionHost) {
+      checks.push({
+        name,
+        status: "skipped",
+        message: `Audited origin is itself a non-production host (${nonProductionHost}), so its own URLs are not leakage`,
+        skipReason: "non-production-origin",
+      });
+      return { checks };
+    }
+
+    const body = doc.querySelector("body");
+    if (!body) {
+      checks.push({
+        name,
+        status: "skipped",
+        message: "No body element to read visible text from",
+        skipReason: "no-body",
+      });
+      return { checks };
+    }
+
+    const hits: DevLeakageHit[] = [];
+    for (const raw of collectUrlAttributes(body)) {
+      const hit = classifyUrlAttribute(raw, ctx.page.url, site);
+      if (hit) hits.push(hit);
+    }
+    // Prose only, and never the raw HTML. `getRenderedProseText` drops `<code>`,
+    // `<pre>`, `<template>` and highlighter containers, which is what lets a
+    // tutorial print `http://localhost:3000` in a code sample and stay clean —
+    // the single largest false-positive class this rule has.
+    hits.push(...findDevHostsInText(getRenderedProseText(body), site));
+
+    if (hits.length === 0) {
+      checks.push({
+        name,
+        status: "pass",
+        message: "No development, private or preview hosts referenced",
+      });
+      return { checks };
+    }
+
+    const rows = summarize(hits);
+    const total = rows.reduce((sum, r) => sum + r.count, 0);
+    const kinds = rows.map((r) => r.kind).join(", ");
+
+    // A live `href`/`src` at a host that is unmistakably this site's own dev
+    // artifact is a broken reference a visitor can hit right now, so it fails. A
+    // mention in copy is embarrassing rather than broken, and a preview host
+    // that could belong to anyone is a judgement call, so both warn.
+    const broken = hits.some(
+      (h) => h.source === "attribute" && h.own && !SOFT_KINDS.has(h.kind),
+    );
+    const status = broken ? "fail" : "warn";
+
+    // Lead with the row that decided the status, so the example line is the
+    // clickable reference rather than whichever mention came first.
+    const leading =
+      rows.find((r) => r.inAttribute && !SOFT_KINDS.has(r.kind)) ?? (rows[0] as DevLeakageSummaryRow);
+
+    checks.push({
+      name,
+      status,
+      message: `${total} development host reference(s) on a production page (${kinds}): example ${leading.sample}`,
+      value: total,
+      items: rows.map((r) => ({
+        id: r.sample,
+        label: r.kind,
+        meta: { count: r.count, inAttribute: r.inAttribute },
+      })),
+      details: {
+        kinds: rows.map((r) => ({
+          kind: r.kind,
+          sample: r.sample,
+          count: r.count,
+          inAttribute: r.inAttribute,
+        })),
+      },
+    });
+    return { checks };
+  },
+};

--- a/packages/rules/src/content/dev-leakage.ts
+++ b/packages/rules/src/content/dev-leakage.ts
@@ -52,6 +52,13 @@ const MAX_ELEMENTS_SCANNED = 50_000;
 /** Per kind, so one pathological page cannot allocate an unbounded hit list. */
 const MAX_HITS_PER_KIND = 200;
 
+/**
+ * The same budget for the attribute pass, which has no per-kind regex cap to
+ * inherit one from. A page of 30,000 localhost anchors still renders as a
+ * single row, so nothing is lost by stopping early.
+ */
+const MAX_ATTRIBUTE_HITS = MAX_HITS_PER_KIND * 5;
+
 /** Reports get these verbatim, so no newline and no unbounded site-controlled string. */
 const MAX_SAMPLE_LENGTH = 120;
 
@@ -180,19 +187,32 @@ export function isDevSubdomainOf(host: string, apex: string): boolean {
  * can act on) from "you linked to a site that happens to be on Vercel".
  */
 export function looksLikeOwnPreview(host: string, apexLabel: string): boolean {
-  // Two characters match far too much — `wp-abc.vercel.app` would "contain" the
-  // apex label of `wp.com`.
+  // Two characters match far too much even as a whole segment.
   if (apexLabel.length < 3) return false;
   const leftmost = host.split(".")[0] ?? "";
-  return leftmost.includes(apexLabel);
+  // WHOLE hyphen-separated segments, never a substring. Vercel, Netlify and
+  // Cloudflare all build the label out of hyphen-joined parts
+  // (`<project>-git-<branch>-<team>`), so the site's own name is always a
+  // segment. A substring test instead reads `sandbox-demo.vercel.app` as
+  // `box.com`'s own deployment, `shopify-theme.vercel.app` as `shop.com`'s and
+  // `my-nextjs-demo.vercel.app` as `next.com`'s — and this flag is what raises
+  // the finding to `fail`, the hardest status the rule has, on a link the site
+  // owner cannot act on.
+  return leftmost.split("-").includes(apexLabel);
 }
 
 /** True for a host that means "this audit is not of a production origin". */
 export function isNonProductionSeedHost(host: string): boolean {
   if (isLoopbackHost(host) || isPrivateIpHost(host) || isPreviewHost(host)) return true;
-  // A seed whose OWN leftmost label names a tier: auditing `staging.example.com`
-  // is auditing staging, and every internal link on it is a staging link.
-  return DEV_SUBDOMAIN_LABELS.has(host.split(".")[0] ?? "");
+  // A seed that is a tier of its OWN apex: auditing `staging.example.com` is
+  // auditing staging, and every internal link on it is a staging link.
+  //
+  // Routed through the same PSL helper rather than a bare leftmost-label test,
+  // because `dev.to`, `test.com` and `staging.com` ARE registrable domains —
+  // real production sites whose apex happens to start with a tier word. A bare
+  // label test disables the whole rule on every one of them, and disagrees with
+  // itself the moment the same site is reached as `www.dev.to`.
+  return isDevSubdomainOf(host, registrableDomain(host));
 }
 
 /** Which family `host` belongs to, and whether it is this site's own artifact. */
@@ -227,8 +247,29 @@ export function siteOriginOf(pageUrl: string): SiteOrigin | null {
   };
 }
 
+/**
+ * Markdown link syntax, percent-encoded. URL canonicalization is NOT enough on
+ * its own: `new URL()` leaves `[`, `]`, `(` and `)` untouched in a path, so a
+ * site-controlled href like `/[click here](https://evil.example/pwn)` survives
+ * into the message and the markdown renderer turns it into a clickable link
+ * pointing wherever the audited page chose. Percent-encoding is lossless — the
+ * URL still resolves and still reads — and the escape is done here rather than
+ * in the renderer because every rule that puts a URL in a message would
+ * otherwise have to remember to ask for it.
+ */
+const MARKDOWN_ACTIVE = /[[\]()]/g;
+const MARKDOWN_ACTIVE_ESCAPES: Record<string, string> = {
+  "[": "%5B",
+  "]": "%5D",
+  "(": "%28",
+  ")": "%29",
+};
+
 function toSample(raw: string): string {
-  const flat = raw.replace(/\s+/g, " ").trim();
+  const flat = raw
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(MARKDOWN_ACTIVE, (c) => MARKDOWN_ACTIVE_ESCAPES[c] ?? c);
   return flat.length > MAX_SAMPLE_LENGTH ? `${flat.slice(0, MAX_SAMPLE_LENGTH - 1)}…` : flat;
 }
 
@@ -249,8 +290,15 @@ function escapeForRegExp(value: string): string {
  */
 const LEFT_BOUNDARY = String.raw`(?:^|[^A-Za-z0-9.\-_])`;
 
-/** Nothing may follow the host that could have been part of it. */
-const RIGHT_BOUNDARY = String.raw`(?![A-Za-z0-9.\-])`;
+/**
+ * Nothing may follow the host that could have been part of it.
+ *
+ * A trailing dot is only disqualifying when MORE host follows it, so
+ * `dev.example.com.au` cannot match as `dev.example.com` while
+ * "Bound to 192.168.1.10." — a host at the end of a sentence, which is how copy
+ * usually mentions one — still does.
+ */
+const RIGHT_BOUNDARY = String.raw`(?![A-Za-z0-9\-])(?!\.[A-Za-z0-9])`;
 
 const OPTIONAL_SCHEME = String.raw`(?:(https?):\/\/)?`;
 const OPTIONAL_PORT = String.raw`(?::(\d{1,5}))?`;
@@ -287,9 +335,15 @@ const PREVIEW_TEXT_RE = new RegExp(
   "gi",
 );
 
-/** `http://` spelled out in copy, host left open so the apex test can judge it. */
+/**
+ * `http://` spelled out in copy, host left open so the apex test can judge it.
+ *
+ * Spelled as labels rather than as one `[a-z0-9.-]` run so the host cannot end
+ * on a dot: a flat class is greedy and would capture the full stop in
+ * "…point at http://example.com." into the reported sample.
+ */
 const INSECURE_URL_TEXT_RE = new RegExp(
-  `${LEFT_BOUNDARY}(http):\\/\\/([a-z0-9][a-z0-9.\\-]{0,253})${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
+  `${LEFT_BOUNDARY}(http):\\/\\/((?:[a-z0-9-]{1,63}\\.){1,10}[a-z0-9-]{1,63})${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
   "gi",
 );
 
@@ -412,8 +466,11 @@ export function findDevHostsInText(text: string, site: SiteOrigin): DevLeakageHi
 // Attribute scanning
 // ---------------------------------------------------------------------------
 
+/** Cap on the collected list itself, so the DOM pass cannot allocate unbounded. */
+const MAX_URL_ATTRIBUTES = 2_000;
+
 /**
- * Every `href`/`src` value on the page, in document order.
+ * Every `href`/`src` value under `root`, in document order.
  *
  * Attribute names are folded from `el.attributes` rather than looked up by
  * name: `getAttribute` follows the HTML case rules only through the parser's
@@ -431,6 +488,7 @@ export function collectUrlAttributes(root: Element): string[] {
       const value = attr.value?.trim();
       if (value) out.push(value);
     }
+    if (out.length >= MAX_URL_ATTRIBUTES) break;
   }
   return out;
 }
@@ -542,7 +600,13 @@ export const devLeakageRule: Rule = {
       return { checks };
     }
 
-    const site = siteOriginOf(ctx.page.url);
+    // The URL the browser ENDED on, which is both what relative `href`s resolve
+    // against and what decides whether this page sits on a production origin. A
+    // page that redirected from the apex onto a preview host is a preview page,
+    // and reading `ctx.page.url` would judge the pre-redirect URL — the same
+    // reason `security/form-https` and the link adapter prefer `finalUrl`.
+    const pageUrl = ctx.page.finalUrl ?? ctx.page.url;
+    const site = siteOriginOf(pageUrl) ?? siteOriginOf(ctx.page.url);
     if (!site) {
       checks.push({
         name,
@@ -552,11 +616,14 @@ export const devLeakageRule: Rule = {
       });
       return { checks };
     }
+    // A `finalUrl` that will not parse must not silently become the base for
+    // every relative href on the page.
+    const baseUrl = siteOriginOf(pageUrl) ? pageUrl : ctx.page.url;
 
     // The audited origin, which is the SEED when the runner supplied site data
-    // and the page's own URL otherwise. Both are checked: a seed on a preview
-    // host means the whole audit is of a preview, and a page that redirected
-    // onto one means this page is.
+    // and this page's own final URL otherwise. Both are checked: a seed on a
+    // preview host means the whole audit is of a preview, and a page that
+    // redirected onto one means this page is.
     const seedHost = ctx.site?.baseUrl ? siteOriginOf(ctx.site.baseUrl)?.host : undefined;
     const nonProductionHost = [seedHost, site.host].find(
       (h): h is string => h !== undefined && isNonProductionSeedHost(h),
@@ -571,27 +638,25 @@ export const devLeakageRule: Rule = {
       return { checks };
     }
 
-    const body = doc.querySelector("body");
-    if (!body) {
-      checks.push({
-        name,
-        status: "skipped",
-        message: "No body element to read visible text from",
-        skipReason: "no-body",
-      });
-      return { checks };
-    }
-
     const hits: DevLeakageHit[] = [];
-    for (const raw of collectUrlAttributes(body)) {
-      const hit = classifyUrlAttribute(raw, ctx.page.url, site);
-      if (hit) hits.push(hit);
+    // The WHOLE document, head included. A `<link rel="canonical">` at localhost
+    // de-indexes the page and a `<script src>` or stylesheet at localhost breaks
+    // it outright, so the head carries this rule's highest-impact findings and
+    // scanning only the body would pass every one of them.
+    const root = doc.documentElement ?? doc.querySelector("body");
+    if (root) {
+      for (const raw of collectUrlAttributes(root)) {
+        const hit = classifyUrlAttribute(raw, baseUrl, site);
+        if (hit) hits.push(hit);
+        if (hits.length >= MAX_ATTRIBUTE_HITS) break;
+      }
     }
     // Prose only, and never the raw HTML. `getRenderedProseText` drops `<code>`,
     // `<pre>`, `<template>` and highlighter containers, which is what lets a
     // tutorial print `http://localhost:3000` in a code sample and stay clean —
     // the single largest false-positive class this rule has.
-    hits.push(...findDevHostsInText(getRenderedProseText(body), site));
+    const body = doc.querySelector("body");
+    if (body) hits.push(...findDevHostsInText(getRenderedProseText(body), site));
 
     if (hits.length === 0) {
       checks.push({
@@ -625,9 +690,15 @@ export const devLeakageRule: Rule = {
       status,
       message: `${total} development host reference(s) on a production page (${kinds}): example ${leading.sample}`,
       value: total,
+      // `id` is the KIND, never the URL. `report/affected-pages` reads an item
+      // id that starts with `http` as a page of the site being audited, so a
+      // leaked `http://localhost:3000/api` id would be counted as an affected
+      // page AND make the row itself redundant, suppressing the kind and count
+      // in every renderer. `content/placeholder-text` sets the same shape.
       items: rows.map((r) => ({
-        id: r.sample,
+        id: r.kind,
         label: r.kind,
+        snippet: r.sample,
         meta: { count: r.count, inAttribute: r.inAttribute },
       })),
       details: {

--- a/packages/rules/src/content/dev-leakage.ts
+++ b/packages/rules/src/content/dev-leakage.ts
@@ -59,6 +59,13 @@ const MAX_HITS_PER_KIND = 200;
  */
 const MAX_ATTRIBUTE_HITS = MAX_HITS_PER_KIND * 5;
 
+/**
+ * Candidates the named-host scan will look at. Host-SHAPED, not host: every
+ * abbreviation and file name in prose reaches this scan and is discarded by
+ * `classifyHost`, so the budget is on the candidates rather than on the hits.
+ */
+const MAX_NAMED_HOST_MATCHES = 20_000;
+
 /** Reports get these verbatim, so no newline and no unbounded site-controlled string. */
 const MAX_SAMPLE_LENGTH = 120;
 
@@ -157,6 +164,11 @@ export function isPrivateIpHost(host: string): boolean {
   return a === 172 && b >= 16 && b <= 31;
 }
 
+/** True for the platform's own bare domain, e.g. `pages.dev` itself. */
+export function isPreviewSuffix(host: string): boolean {
+  return PREVIEW_HOST_SUFFIXES.some((s) => host === s);
+}
+
 /** A host on one of the ephemeral-deployment platforms. */
 export function isPreviewHost(host: string): boolean {
   return PREVIEW_HOST_SUFFIXES.some((s) => host === s || host.endsWith(`.${s}`));
@@ -172,9 +184,12 @@ export function isPreviewHost(host: string): boolean {
  */
 export function isDevSubdomainOf(host: string, apex: string): boolean {
   if (!apex || host === apex) return false;
-  if (registrableDomain(host) !== apex) return false;
+  // Label test BEFORE the PSL lookup. Every named host in the page's prose
+  // reaches this function, and `getDomain` is the expensive half; almost none of
+  // them start with a tier label, so this ordering is what keeps the scan cheap.
   const leftmost = host.split(".")[0] ?? "";
-  return DEV_SUBDOMAIN_LABELS.has(leftmost);
+  if (!DEV_SUBDOMAIN_LABELS.has(leftmost)) return false;
+  return registrableDomain(host) === apex;
 }
 
 /**
@@ -273,11 +288,6 @@ function toSample(raw: string): string {
   return flat.length > MAX_SAMPLE_LENGTH ? `${flat.slice(0, MAX_SAMPLE_LENGTH - 1)}…` : flat;
 }
 
-/** Escape a host for literal use inside a RegExp. */
-function escapeForRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
-}
-
 // ---------------------------------------------------------------------------
 // Prose scanning
 // ---------------------------------------------------------------------------
@@ -324,26 +334,24 @@ const IPV4_TEXT_RE = new RegExp(
 );
 
 /**
- * At least one leading label is REQUIRED. A page that writes "we deploy to
- * pages.dev" is naming a platform, not leaking a deployment; `abc123.pages.dev`
- * is a deployment.
- */
-const PREVIEW_TEXT_RE = new RegExp(
-  `${LEFT_BOUNDARY}${OPTIONAL_SCHEME}((?:[a-z0-9-]{1,63}\\.){1,10}(?:${PREVIEW_HOST_SUFFIXES.map(
-    escapeForRegExp,
-  ).join("|")}))${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
-  "gi",
-);
-
-/**
- * `http://` spelled out in copy, host left open so the apex test can judge it.
+ * Any dotted, named host in the text. Deliberately carries NO hostname literal
+ * of its own: every judgement about WHICH hosts matter is made afterwards by
+ * `classifyHost`, the same function the attribute path uses.
  *
- * Spelled as labels rather than as one `[a-z0-9.-]` run so the host cannot end
- * on a dot: a flat class is greedy and would capture the full stop in
- * "…point at http://example.com." into the reported sample.
+ * Written this way for three reasons. It is one classification path instead of
+ * two, so the text and attribute halves cannot drift. It removes the per-page
+ * `RegExp` this used to compile from the audited apex. And a suffix list
+ * interpolated into an unanchored pattern is exactly the shape of a host-
+ * matching bypass — the pattern matches anywhere in a string, so a reader (and
+ * CodeQL) has to reason about whether the boundaries around it really pin the
+ * host down. Comparing a parsed host against a list has no such question.
+ *
+ * The final label is ALPHABETIC, which is what keeps dotted-quad addresses out:
+ * they have their own scan below with its own rule about bare occurrences, and
+ * matching them here would bypass it.
  */
-const INSECURE_URL_TEXT_RE = new RegExp(
-  `${LEFT_BOUNDARY}(http):\\/\\/((?:[a-z0-9-]{1,63}\\.){1,10}[a-z0-9-]{1,63})${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
+const NAMED_HOST_TEXT_RE = new RegExp(
+  `${LEFT_BOUNDARY}${OPTIONAL_SCHEME}((?:[a-z0-9-]{1,63}\\.){1,10}[a-z]{2,24})${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
   "gi",
 );
 
@@ -430,33 +438,31 @@ export function findDevHostsInText(text: string, site: SiteOrigin): DevLeakageHi
     add("private-ip", true, m);
   }
 
-  for (const m of scanUrlish(PREVIEW_TEXT_RE, scanned, MAX_HITS_PER_KIND)) {
-    add("preview-host", looksLikeOwnPreview(m.host, site.apexLabel), m);
-  }
-
-  if (site.apex) {
-    const devSubdomainRe = new RegExp(
-      `${LEFT_BOUNDARY}${OPTIONAL_SCHEME}((?:staging|dev|test)\\.${LEADING_LABELS}${escapeForRegExp(
-        site.apex,
-      )})${RIGHT_BOUNDARY}${OPTIONAL_PORT}${OPTIONAL_PATH}`,
-      "gi",
-    );
-    for (const m of scanUrlish(devSubdomainRe, scanned, MAX_HITS_PER_KIND)) {
-      add("dev-subdomain", true, m);
+  // One pass over every named host, classified by the same function the
+  // attribute path uses. The cap is generous because the scan matches ordinary
+  // prose too — an abbreviation like "e.g" is host-shaped — and almost all of
+  // those are discarded a line later.
+  for (const m of scanUrlish(NAMED_HOST_TEXT_RE, scanned, MAX_NAMED_HOST_MATCHES)) {
+    const classified = classifyHost(m.host, site);
+    if (classified) {
+      // A bare platform name is not a deployment: "we deploy to pages.dev" names
+      // Cloudflare, `abc123.pages.dev` names something that will stop resolving.
+      // The attribute path has no such reading, so this lives here.
+      if (classified.kind === "preview-host" && isPreviewSuffix(m.host)) continue;
+      add(classified.kind, classified.own, m);
+      if (hits.length >= MAX_HITS_PER_KIND * 2) break;
+      continue;
     }
-  }
-
-  // Only on an HTTPS page, and only for the site's own domain: a printed
-  // `http://` URL for somebody else's site is their transport problem, and
-  // `links/https-downgrade` already owns the page-level downgrade story.
-  if (site.secure && site.apex) {
-    for (const m of scanUrlish(INSECURE_URL_TEXT_RE, scanned, MAX_HITS_PER_KIND)) {
-      if (registrableDomain(m.host) !== site.apex) continue;
-      // A dev host that happens to be reachable over http is already reported as
-      // what it is; saying it twice would double-count the same string.
-      if (classifyHost(m.host, site)) continue;
-      add("insecure-self-link", true, m);
-    }
+    // Only on an HTTPS page, and only for the site's own domain: a printed
+    // `http://` URL for somebody else's site is their transport problem, and
+    // `links/https-downgrade` already owns the page-level downgrade story. The
+    // `classified` check above means a dev host reachable over http is reported
+    // as what it is rather than counted twice.
+    if (!site.secure || !site.apex) continue;
+    if (m.scheme !== "http") continue;
+    if (registrableDomain(m.host) !== site.apex) continue;
+    add("insecure-self-link", true, m);
+    if (hits.length >= MAX_HITS_PER_KIND * 2) break;
   }
 
   return hits;

--- a/packages/rules/src/content/index.ts
+++ b/packages/rules/src/content/index.ts
@@ -6,6 +6,7 @@ import { articleLinksRule } from "./article-links";
 import { authorInfoRule } from "./author-info";
 import { brokenHtmlRule } from "./broken-html";
 import { dateAgreementRule } from "./date-agreement";
+import { devLeakageRule } from "./dev-leakage";
 import { duplicateDescriptionRule } from "./duplicate-description";
 import { duplicateTitleRule } from "./duplicate-title";
 import { freshnessRule } from "./freshness";
@@ -46,6 +47,7 @@ export const rules: Rule[] = [
   dateAgreementRule,
   placeholderTextRule,
   unrenderedMarkupRule,
+  devLeakageRule,
 ];
 
 export {
@@ -54,6 +56,7 @@ export {
   brokenHtmlRule,
   contentQualityRule,
   dateAgreementRule,
+  devLeakageRule,
   duplicateDescriptionRule,
   duplicateTitleRule,
   freshnessRule,

--- a/packages/rules/tests/content-dev-leakage.test.ts
+++ b/packages/rules/tests/content-dev-leakage.test.ts
@@ -1,0 +1,521 @@
+// content/dev-leakage: development, staging and preview hosts on a production page.
+//
+// The rule accuses a page of shipping a URL that only ever worked on somebody's
+// laptop, so the fixtures that keep it quiet carry as much weight as the ones
+// that trip it. Three classes matter: a tutorial printing `localhost` inside a
+// code sample, a host that merely ENDS with a dev label (`notdev.example.com`),
+// and an audit whose own seed is a preview deploy.
+
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "@squirrelscan/parser/dom";
+
+import {
+  classifyHost,
+  classifyUrlAttribute,
+  devLeakageRule,
+  findDevHostsInText,
+  isDevSubdomainOf,
+  isLoopbackHost,
+  isNonProductionSeedHost,
+  isPreviewHost,
+  isPrivateIpHost,
+  looksLikeOwnPreview,
+  siteOriginOf,
+  summarize,
+  type SiteOrigin,
+} from "../src/content/dev-leakage";
+import { loadAllRules } from "../src/loader";
+import type { CheckResult, ParsedPage, RuleContext, SiteData } from "../src/types";
+
+const page = (body: string) => `<html><head><title>t</title></head><body>${body}</body></html>`;
+
+// Every real page opens with chrome. Fixtures that start at the body's first
+// byte hide the left-boundary bug the host patterns depend on.
+const NAV = '<header><nav><a href="/">Home</a><a href="/pricing">Pricing</a></nav></header>';
+
+function run(
+  body: string,
+  opts: { url?: string; baseUrl?: string } = {},
+): CheckResult[] {
+  const url = opts.url ?? "https://example.com/about";
+  const html = page(body);
+  const { document } = parseHTML(html);
+  const ctx: RuleContext = {
+    page: { url, html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: { document } as unknown as ParsedPage,
+    ...(opts.baseUrl ? { site: { baseUrl: opts.baseUrl } as unknown as SiteData } : {}),
+    options: {},
+  };
+  return devLeakageRule.run(ctx).checks;
+}
+
+const only = (checks: CheckResult[]): CheckResult => {
+  expect(checks).toHaveLength(1);
+  return checks[0] as CheckResult;
+};
+
+const site = (host = "example.com", secure = true): SiteOrigin =>
+  siteOriginOf(`${secure ? "https" : "http"}://${host}/`) as SiteOrigin;
+
+const textKinds = (text: string, origin = site()) =>
+  findDevHostsInText(text, origin).map((h) => h.kind);
+
+// ---------------------------------------------------------------------------
+// Host classification
+// ---------------------------------------------------------------------------
+
+describe("host families", () => {
+  test("loopback covers the whole 127/8 block, the IPv6 form and *.localhost", () => {
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("api.acme.localhost")).toBe(true);
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("127.53.2.9")).toBe(true);
+    expect(isLoopbackHost("0.0.0.0")).toBe(true);
+    expect(isLoopbackHost("[::1]")).toBe(true);
+    // A host that merely CONTAINS the word is somebody's domain.
+    expect(isLoopbackHost("mylocalhost.com")).toBe(false);
+    expect(isLoopbackHost("localhost.example.com")).toBe(false);
+    expect(isLoopbackHost("128.0.0.1")).toBe(false);
+  });
+
+  test("private ranges are the three RFC 1918 blocks and nothing adjacent", () => {
+    expect(isPrivateIpHost("10.0.0.5")).toBe(true);
+    expect(isPrivateIpHost("192.168.1.10")).toBe(true);
+    expect(isPrivateIpHost("172.16.0.1")).toBe(true);
+    expect(isPrivateIpHost("172.31.255.254")).toBe(true);
+    // The 172 block stops at 31; 172.15 and 172.32 are public space.
+    expect(isPrivateIpHost("172.15.0.1")).toBe(false);
+    expect(isPrivateIpHost("172.32.0.1")).toBe(false);
+    expect(isPrivateIpHost("192.169.1.1")).toBe(false);
+    expect(isPrivateIpHost("11.0.0.1")).toBe(false);
+  });
+
+  test("an out-of-range or malformed octet is not an address", () => {
+    expect(isPrivateIpHost("10.0.0.256")).toBe(false);
+    expect(isPrivateIpHost("10.0.0")).toBe(false);
+    expect(isPrivateIpHost("10.0.0.1.2")).toBe(false);
+    expect(isPrivateIpHost("10..0.1")).toBe(false);
+    expect(isPrivateIpHost("10.0.0.x")).toBe(false);
+  });
+
+  test("preview platforms match the host and any subdomain of it", () => {
+    expect(isPreviewHost("acme-git-main.vercel.app")).toBe(true);
+    expect(isPreviewHost("deploy-preview-7--acme.netlify.app")).toBe(true);
+    expect(isPreviewHost("abc123.pages.dev")).toBe(true);
+    expect(isPreviewHost("1a2b.ngrok.io")).toBe(true);
+    expect(isPreviewHost("1a2b.ngrok-free.app")).toBe(true);
+    expect(isPreviewHost("quiet-fox.trycloudflare.com")).toBe(true);
+    // A brand that merely ends in the same letters is not the platform.
+    expect(isPreviewHost("notvercel.app")).toBe(false);
+    expect(isPreviewHost("mypages.dev")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PSL: the acceptance criterion that `notdev.example.com` must not match
+// ---------------------------------------------------------------------------
+
+describe("dev subdomains resolve through the registrable domain, not a suffix test", () => {
+  test("the site's own dev tiers match", () => {
+    expect(isDevSubdomainOf("dev.example.com", "example.com")).toBe(true);
+    expect(isDevSubdomainOf("staging.example.com", "example.com")).toBe(true);
+    expect(isDevSubdomainOf("test.example.com", "example.com")).toBe(true);
+    // Deeper tiers still belong to the same apex.
+    expect(isDevSubdomainOf("staging.app.example.com", "example.com")).toBe(true);
+  });
+
+  test("a host that merely ends with the dev label does not", () => {
+    expect(isDevSubdomainOf("notdev.example.com", "example.com")).toBe(false);
+    expect(isDevSubdomainOf("webdev.example.com", "example.com")).toBe(false);
+    expect(isDevSubdomainOf("development.example.com", "example.com")).toBe(false);
+    expect(isDevSubdomainOf("latest.example.com", "example.com")).toBe(false);
+  });
+
+  test("somebody else's dev tier is not this site's", () => {
+    expect(isDevSubdomainOf("dev.other.com", "example.com")).toBe(false);
+    expect(isDevSubdomainOf("dev.example.com.au", "example.com")).toBe(false);
+  });
+
+  test("a multi-label public suffix resolves to the right apex", () => {
+    // A string suffix test would call `example.co.uk` a subdomain of `co.uk`.
+    expect(isDevSubdomainOf("dev.example.co.uk", "example.co.uk")).toBe(true);
+    expect(isDevSubdomainOf("dev.example.co.uk", "co.uk")).toBe(false);
+  });
+
+  test("the apex itself is never its own dev tier", () => {
+    expect(isDevSubdomainOf("example.com", "example.com")).toBe(false);
+  });
+});
+
+describe("preview ownership", () => {
+  test("a preview carrying the site's own name is the site's own", () => {
+    expect(looksLikeOwnPreview("acme.vercel.app", "acme")).toBe(true);
+    expect(looksLikeOwnPreview("acme-git-main-acme.vercel.app", "acme")).toBe(true);
+  });
+
+  test("an unrelated tenant of the same platform is not", () => {
+    expect(looksLikeOwnPreview("someones-portfolio.vercel.app", "acme")).toBe(false);
+  });
+
+  test("a two-letter apex label never claims ownership", () => {
+    expect(looksLikeOwnPreview("wp-demo.vercel.app", "wp")).toBe(false);
+  });
+});
+
+describe("classifyHost", () => {
+  test("names the family and whether it is this site's own artifact", () => {
+    const s = site("acme.com");
+    expect(classifyHost("localhost", s)).toEqual({ kind: "localhost", own: true });
+    expect(classifyHost("10.0.0.5", s)).toEqual({ kind: "private-ip", own: true });
+    expect(classifyHost("dev.acme.com", s)).toEqual({ kind: "dev-subdomain", own: true });
+    expect(classifyHost("acme-git-main.vercel.app", s)).toEqual({
+      kind: "preview-host",
+      own: true,
+    });
+    expect(classifyHost("someone-else.vercel.app", s)).toEqual({
+      kind: "preview-host",
+      own: false,
+    });
+    expect(classifyHost("example.com", s)).toBeNull();
+    expect(classifyHost("cdn.acme.com", s)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Visible copy
+// ---------------------------------------------------------------------------
+
+describe("findDevHostsInText", () => {
+  test("a dev URL written out in copy", () => {
+    expect(textKinds("Point your client at http://localhost:3000/api")).toContain("localhost");
+    expect(textKinds("Internal only: 192.168.1.10/admin")).toContain("private-ip");
+    expect(textKinds("Preview at acme-git-main.vercel.app")).toContain("preview-host");
+    expect(textKinds("Copy is drafted on staging.example.com first")).toContain("dev-subdomain");
+  });
+
+  test("a bare `localhost` in a sentence is not a leak; a qualified one is", () => {
+    // "run it on localhost" is a sentence people write on purpose.
+    expect(textKinds("The app also runs on localhost during development")).toHaveLength(0);
+    expect(textKinds("Open localhost:5173 to see it")).toContain("localhost");
+    expect(textKinds("Open http://localhost to see it")).toContain("localhost");
+    expect(textKinds("Try api.acme.localhost for the internal build")).toContain("localhost");
+  });
+
+  test("a bare 10.x quad is a version number as often as an address", () => {
+    expect(textKinds("Requires Contoso Server 10.0.0.1 or later")).toHaveLength(0);
+    expect(textKinds("Requires Contoso Server v10.0.0.1 or later")).toHaveLength(0);
+    // With URL context it is unmistakably a host.
+    expect(textKinds("Hit http://10.0.0.1 from the VPN")).toContain("private-ip");
+    expect(textKinds("Hit 10.0.0.1:8080 from the VPN")).toContain("private-ip");
+    // The other two blocks and loopback have no second reading.
+    expect(textKinds("Bound to 192.168.1.10 on the office LAN")).toContain("private-ip");
+    expect(textKinds("Bound to 127.0.0.1 on the office LAN")).toContain("localhost");
+  });
+
+  test("a bare platform name is not a deployment", () => {
+    expect(textKinds("We deploy to pages.dev and vercel.app")).toHaveLength(0);
+    expect(textKinds("We deploy to acme.pages.dev")).toContain("preview-host");
+  });
+
+  test("the left boundary keeps lookalike hosts out", () => {
+    expect(textKinds("Visit notdev.example.com for the writeup")).toHaveLength(0);
+    expect(textKinds("Our mylocalhost.com mirror is fine")).toHaveLength(0);
+    expect(textKinds("Build 1.10.0.0.1 shipped")).toHaveLength(0);
+  });
+
+  test("an http self-link on an HTTPS page, and nobody else's http link", () => {
+    expect(textKinds("Old bookmarks point at http://example.com/pricing")).toContain(
+      "insecure-self-link",
+    );
+    expect(textKinds("See http://other.com/pricing for theirs")).toHaveLength(0);
+  });
+
+  test("an http self-link is not reported from an HTTP page", () => {
+    expect(textKinds("Old bookmarks point at http://example.com/pricing", site("example.com", false)))
+      .toHaveLength(0);
+  });
+
+  test("a dev host reachable over http is reported once, as what it is", () => {
+    const kinds = textKinds("Try http://dev.example.com/preview");
+    expect(kinds).toEqual(["dev-subdomain"]);
+  });
+
+  test("the sample is the URL as written, flattened to one line", () => {
+    const hits = findDevHostsInText("Point at http://localhost:3000/api/v1 now", site());
+    expect(hits[0]?.sample).toBe("http://localhost:3000/api/v1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attributes
+// ---------------------------------------------------------------------------
+
+describe("classifyUrlAttribute", () => {
+  const s = site("example.com");
+  const at = (raw: string) => classifyUrlAttribute(raw, "https://example.com/about", s);
+
+  test("an absolute dev URL is a hit and reports the canonical form", () => {
+    expect(at("http://localhost:3000/api")).toMatchObject({
+      kind: "localhost",
+      source: "attribute",
+      host: "localhost",
+      sample: "http://localhost:3000/api",
+      own: true,
+    });
+  });
+
+  test("a relative URL resolves onto the page's own production origin", () => {
+    expect(at("/pricing")).toBeNull();
+    expect(at("https://example.com/pricing")).toBeNull();
+  });
+
+  test("an http self-link on an HTTPS page", () => {
+    expect(at("http://example.com/pricing")).toMatchObject({ kind: "insecure-self-link" });
+    // Somebody else's http link belongs to links/https-downgrade, not here.
+    expect(at("http://other.com/pricing")).toBeNull();
+  });
+
+  test("a non-HTTP scheme is out of scope", () => {
+    expect(at("mailto:hi@example.com")).toBeNull();
+    expect(at("javascript:void(0)")).toBeNull();
+    expect(at("tel:+61000")).toBeNull();
+  });
+
+  test("a value that will not parse is links/invalid-links' finding, not this one", () => {
+    expect(at("http://")).toBeNull();
+    expect(at("ht!tp://[bad")).toBeNull();
+  });
+
+  test("the canonical form is percent-encoded, so a hostile attribute cannot inject", () => {
+    const hit = at('http://localhost:3000/a"><img src=x onerror=1>');
+    expect(hit?.sample).not.toContain('"');
+    expect(hit?.sample).not.toContain("<");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule outcomes: pass, warn, fail, skipped
+// ---------------------------------------------------------------------------
+
+describe("devLeakageRule outcomes", () => {
+  test("pass: an ordinary production page", () => {
+    const check = only(
+      run(
+        `${NAV}<main><h1>Pricing</h1><p>Plans start at ten dollars.</p>` +
+          `<a href="/contact">Contact us</a><img src="/img/hero.png" alt="hero">` +
+          `<a href="https://example.com/docs">Docs</a></main>`,
+      ),
+    );
+    expect(check.status).toBe("pass");
+  });
+
+  test("fail: a live href at a localhost origin", () => {
+    const check = only(
+      run(`${NAV}<main><a href="http://localhost:3000/api/health">Health check</a></main>`),
+    );
+    expect(check.status).toBe("fail");
+    expect(check.message).toContain("localhost");
+    expect(check.value).toBe(1);
+  });
+
+  test("fail: an img src on a private address", () => {
+    const check = only(run(`${NAV}<main><img src="http://192.168.1.10/logo.png" alt=""></main>`));
+    expect(check.status).toBe("fail");
+    expect(check.message).toContain("private-ip");
+  });
+
+  test("fail: a link to the site's own staging tier", () => {
+    const check = only(run(`${NAV}<main><a href="https://staging.example.com/x">Draft</a></main>`));
+    expect(check.status).toBe("fail");
+    expect(check.message).toContain("dev-subdomain");
+  });
+
+  test("fail: an asset served from the site's own preview deployment", () => {
+    const check = only(
+      run(`${NAV}<main><img src="https://example-git-main.vercel.app/a.png" alt=""></main>`, {
+        url: "https://example.com/about",
+      }),
+    );
+    expect(check.status).toBe("fail");
+    expect(check.message).toContain("preview-host");
+  });
+
+  test("warn: a preview host that could belong to anyone", () => {
+    const check = only(
+      run(`${NAV}<main><a href="https://someones-portfolio.vercel.app/">A friend</a></main>`),
+    );
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain("preview-host");
+  });
+
+  test("warn: a dev host mentioned in copy but never linked", () => {
+    const check = only(
+      run(`${NAV}<main><p>The API also listens on http://localhost:3000 in development.</p></main>`),
+    );
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain("localhost");
+  });
+
+  test("warn: an http link back to the site's own origin never escalates", () => {
+    // links/https-downgrade owns the page-level downgrade story; this rule
+    // reports the same href as a baked-in dev URL and stops at warn.
+    const check = only(run(`${NAV}<main><a href="http://example.com/pricing">Pricing</a></main>`));
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain("insecure-self-link");
+  });
+
+  test("skipped: the seed is itself a preview deploy", () => {
+    const check = only(
+      run(`${NAV}<main><a href="https://acme.vercel.app/pricing">Pricing</a></main>`, {
+        url: "https://acme.vercel.app/about",
+        baseUrl: "https://acme.vercel.app/",
+      }),
+    );
+    expect(check.status).toBe("skipped");
+    expect(check.skipReason).toBe("non-production-origin");
+  });
+
+  test("skipped: the audit is of a local dev server", () => {
+    const check = only(
+      run(`${NAV}<main><a href="http://localhost:3000/api">API</a></main>`, {
+        url: "http://localhost:3000/about",
+      }),
+    );
+    expect(check.status).toBe("skipped");
+    expect(check.skipReason).toBe("non-production-origin");
+  });
+
+  test("skipped: the seed is a staging tier even when this page redirected onto the apex", () => {
+    const check = only(
+      run(`${NAV}<main><a href="https://staging.example.com/x">Draft</a></main>`, {
+        url: "https://example.com/about",
+        baseUrl: "https://staging.example.com/",
+      }),
+    );
+    expect(check.status).toBe("skipped");
+  });
+
+  test("skipped: no document", () => {
+    const ctx = {
+      page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
+      parsed: { document: null } as unknown as ParsedPage,
+      options: {},
+    } as RuleContext;
+    const check = only(devLeakageRule.run(ctx).checks);
+    expect(check.status).toBe("skipped");
+  });
+
+  test("skipped: the page URL will not parse", () => {
+    const check = only(run(`${NAV}<main><p>hi</p></main>`, { url: "not a url" }));
+    expect(check.status).toBe("skipped");
+    expect(check.skipReason).toBe("unparseable-page-url");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The no-false-positive fixture the acceptance criteria call for
+// ---------------------------------------------------------------------------
+
+describe("code samples stay clean", () => {
+  test("a production page whose code sample mentions localhost passes", () => {
+    const check = only(
+      run(
+        `${NAV}<main><h1>Getting started</h1>` +
+          `<p>Start the dev server, then open the address it prints.</p>` +
+          `<pre><code>bun run dev\n# Listening on http://localhost:5173</code></pre>` +
+          `<p>Set <code>BASE_URL=http://127.0.0.1:8080</code> to point at the API.</p>` +
+          `</main>`,
+      ),
+    );
+    expect(check.status).toBe("pass");
+  });
+
+  test("a highlighted block, a CodeMirror editor and an inert template are code too", () => {
+    const check = only(
+      run(
+        `${NAV}<main>` +
+          // What Rouge and Chroma emit: a wrapper div around a real <pre>.
+          `<div class="highlight"><pre><code>curl http://localhost:9000/health</code></pre></div>` +
+          // What CodeMirror emits: plain divs, no <pre> or <code> anywhere.
+          `<div class="cm-editor"><div>fetch("http://192.168.0.9/v1")</div></div>` +
+          `<div class="language-bash"><div>curl http://10.1.2.3:9000/health</div></div>` +
+          // Inert: the browser never renders it, so a visitor never reads it.
+          `<template><span>http://staging.example.com</span></template>` +
+          `</main>`,
+      ),
+    );
+    expect(check.status).toBe("pass");
+  });
+
+  test("but an href inside a code block is still a live reference", () => {
+    // Excluding code from the PROSE scan must not excuse a real anchor: a
+    // clickable link is a clickable link wherever it sits in the markup.
+    const check = only(
+      run(`${NAV}<main><pre><a href="http://localhost:3000/x">run</a></pre></main>`),
+    );
+    expect(check.status).toBe("fail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reporting shape and registration
+// ---------------------------------------------------------------------------
+
+describe("reporting", () => {
+  test("kinds are folded to one row each, counted, and lead with the live reference", () => {
+    const check = only(
+      run(
+        `${NAV}<main>` +
+          `<p>Mentioned once: http://localhost:4000 and again http://localhost:4001.</p>` +
+          `<a href="http://192.168.1.10/admin">Admin</a>` +
+          `</main>`,
+      ),
+    );
+    expect(check.status).toBe("fail");
+    expect(check.value).toBe(3);
+    const rows = (check.details?.kinds ?? []) as Array<{ kind: string; count: number }>;
+    expect(rows.find((r) => r.kind === "localhost")?.count).toBe(2);
+    expect(rows.find((r) => r.kind === "private-ip")?.count).toBe(1);
+    // The example line is the clickable one, not whichever mention came first.
+    expect(check.message).toContain("http://192.168.1.10/admin");
+  });
+
+  test("summarize prefers an attribute sample over an earlier text one", () => {
+    const rows = summarize([
+      { kind: "localhost", source: "text", host: "localhost", sample: "localhost:1", own: true },
+      {
+        kind: "localhost",
+        source: "attribute",
+        host: "localhost",
+        sample: "http://localhost:2/",
+        own: true,
+      },
+    ]);
+    expect(rows).toEqual([
+      { kind: "localhost", sample: "http://localhost:2/", count: 2, inAttribute: true },
+    ]);
+  });
+});
+
+describe("registration", () => {
+  test("the loader exposes the rule under its id", () => {
+    const rule = loadAllRules().get("content/dev-leakage");
+    expect(rule).toBeDefined();
+    expect(rule?.meta.category).toBe("content");
+    expect(rule?.meta.scope).toBe("page");
+  });
+});
+
+describe("seed classification", () => {
+  test("every non-production host family is recognised as a seed", () => {
+    expect(isNonProductionSeedHost("localhost")).toBe(true);
+    expect(isNonProductionSeedHost("127.0.0.1")).toBe(true);
+    expect(isNonProductionSeedHost("192.168.1.10")).toBe(true);
+    expect(isNonProductionSeedHost("acme.vercel.app")).toBe(true);
+    expect(isNonProductionSeedHost("staging.example.com")).toBe(true);
+    expect(isNonProductionSeedHost("dev.example.com")).toBe(true);
+    expect(isNonProductionSeedHost("example.com")).toBe(false);
+    expect(isNonProductionSeedHost("www.example.com")).toBe(false);
+    expect(isNonProductionSeedHost("notdev.example.com")).toBe(false);
+  });
+});

--- a/packages/rules/tests/content-dev-leakage.test.ts
+++ b/packages/rules/tests/content-dev-leakage.test.ts
@@ -242,6 +242,17 @@ describe("findDevHostsInText", () => {
     expect(textKinds("Bound to 127.0.0.1 on the office LAN")).toContain("localhost");
   });
 
+  test("ordinary prose full of dotted words stays clean", () => {
+    // The named-host scan is deliberately generic, so abbreviations, file names
+    // and third-party domains all reach it and must all be discarded.
+    expect(
+      textKinds(
+        "See e.g. the notes in README.md and config.yaml, or our partners at " +
+          "acme.io, shop.co.uk and example.com. Docs live at https://example.com/docs.",
+      ),
+    ).toHaveLength(0);
+  });
+
   test("a bare platform name is not a deployment", () => {
     expect(textKinds("We deploy to pages.dev and vercel.app")).toHaveLength(0);
     expect(textKinds("We deploy to acme.pages.dev")).toContain("preview-host");

--- a/packages/rules/tests/content-dev-leakage.test.ts
+++ b/packages/rules/tests/content-dev-leakage.test.ts
@@ -35,13 +35,22 @@ const NAV = '<header><nav><a href="/">Home</a><a href="/pricing">Pricing</a></na
 
 function run(
   body: string,
-  opts: { url?: string; baseUrl?: string } = {},
+  opts: { url?: string; baseUrl?: string; finalUrl?: string; head?: string } = {},
 ): CheckResult[] {
   const url = opts.url ?? "https://example.com/about";
-  const html = page(body);
+  const html = opts.head
+    ? `<html><head><title>t</title>${opts.head}</head><body>${body}</body></html>`
+    : page(body);
   const { document } = parseHTML(html);
   const ctx: RuleContext = {
-    page: { url, html, statusCode: 200, loadTime: 0, headers: {} },
+    page: {
+      url,
+      html,
+      statusCode: 200,
+      loadTime: 0,
+      headers: {},
+      ...(opts.finalUrl ? { finalUrl: opts.finalUrl } : {}),
+    },
     parsed: { document } as unknown as ParsedPage,
     ...(opts.baseUrl ? { site: { baseUrl: opts.baseUrl } as unknown as SiteData } : {}),
     options: {},
@@ -157,6 +166,27 @@ describe("preview ownership", () => {
     expect(looksLikeOwnPreview("someones-portfolio.vercel.app", "acme")).toBe(false);
   });
 
+  test("a label that merely CONTAINS the apex label is not", () => {
+    // Whole hyphen-separated segments only. A substring test reads every one of
+    // these as the site's own deployment and escalates the finding to `fail`.
+    expect(looksLikeOwnPreview("sandbox-demo.vercel.app", "box")).toBe(false);
+    expect(looksLikeOwnPreview("shopify-theme.vercel.app", "shop")).toBe(false);
+    expect(looksLikeOwnPreview("my-nextjs-demo.vercel.app", "next")).toBe(false);
+    expect(looksLikeOwnPreview("moneyapp.vercel.app", "one")).toBe(false);
+    expect(looksLikeOwnPreview("blog-application.pages.dev", "app")).toBe(false);
+    // The segment itself still matches.
+    expect(looksLikeOwnPreview("blog-app.pages.dev", "app")).toBe(true);
+  });
+
+  test("a stranger's preview warns rather than fails, even on a short apex", () => {
+    const check = only(
+      run(`${NAV}<main><a href="https://sandbox-demo.vercel.app/">Partner demo</a></main>`, {
+        url: "https://box.com/x",
+      }),
+    );
+    expect(check.status).toBe("warn");
+  });
+
   test("a two-letter apex label never claims ownership", () => {
     expect(looksLikeOwnPreview("wp-demo.vercel.app", "wp")).toBe(false);
   });
@@ -215,6 +245,27 @@ describe("findDevHostsInText", () => {
   test("a bare platform name is not a deployment", () => {
     expect(textKinds("We deploy to pages.dev and vercel.app")).toHaveLength(0);
     expect(textKinds("We deploy to acme.pages.dev")).toContain("preview-host");
+  });
+
+  test("a host at the end of a sentence still counts", () => {
+    // The most common way copy mentions a host is with a full stop after it.
+    expect(textKinds("Bound to 192.168.1.10.")).toContain("private-ip");
+    expect(textKinds("Bound to 127.0.0.1.")).toContain("localhost");
+    expect(textKinds("Preview at acme-git-main.vercel.app.")).toContain("preview-host");
+    expect(textKinds("Draft on staging.example.com.")).toContain("dev-subdomain");
+    expect(textKinds("(see acme.vercel.app)")).toContain("preview-host");
+  });
+
+  test("but a dot followed by MORE host is a different domain", () => {
+    // `dev.example.com.au` must not match as `dev.example.com`.
+    expect(textKinds("Read dev.example.com.au for theirs")).toHaveLength(0);
+  });
+
+  test("the sentence's full stop stays out of the reported sample", () => {
+    const hits = findDevHostsInText("Old links point at http://example.com. Next.", site());
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.host).toBe("example.com");
+    expect(hits[0]?.sample).toBe("http://example.com");
   });
 
   test("the left boundary keeps lookalike hosts out", () => {
@@ -395,6 +446,54 @@ describe("devLeakageRule outcomes", () => {
     expect(check.status).toBe("skipped");
   });
 
+  test("fail: the head is scanned, where the worst leaks live", () => {
+    // A canonical at localhost de-indexes the page; a stylesheet or script at
+    // localhost breaks it outright. Body copy here is entirely clean.
+    const check = only(
+      run(`${NAV}<main><p>Plans start at ten dollars.</p></main>`, {
+        head:
+          '<link rel="canonical" href="http://localhost:3000/about">' +
+          '<link rel="stylesheet" href="http://localhost:3000/a.css">' +
+          '<script src="http://localhost:3000/app.js"></script>',
+      }),
+    );
+    expect(check.status).toBe("fail");
+    expect(check.value).toBe(3);
+  });
+
+  test("skipped: the page redirected onto a preview host", () => {
+    const check = only(
+      run(`${NAV}<main><a href="/pricing">Pricing</a></main>`, {
+        url: "https://example.com/about",
+        finalUrl: "https://example-git-main.vercel.app/about",
+      }),
+    );
+    expect(check.status).toBe("skipped");
+    expect(check.skipReason).toBe("non-production-origin");
+  });
+
+  test("the redirected-to URL decides whether the page is secure", () => {
+    // Seeded over http, redirected to https: the self-link kind is live now.
+    const check = only(
+      run(`${NAV}<main><a href="http://example.com/pricing">Pricing</a></main>`, {
+        url: "http://example.com/about",
+        finalUrl: "https://example.com/about",
+      }),
+    );
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain("insecure-self-link");
+  });
+
+  test("an unparseable finalUrl falls back to the page URL rather than disabling the rule", () => {
+    const check = only(
+      run(`${NAV}<main><a href="http://localhost:3000/api">API</a></main>`, {
+        url: "https://example.com/about",
+        finalUrl: "not a url",
+      }),
+    );
+    expect(check.status).toBe("fail");
+  });
+
   test("skipped: no document", () => {
     const ctx = {
       page: { url: "https://example.com/", html: "", statusCode: 200, loadTime: 0, headers: {} },
@@ -480,6 +579,47 @@ describe("reporting", () => {
     expect(check.message).toContain("http://192.168.1.10/admin");
   });
 
+  test("item ids are kinds, never URLs", () => {
+    // report/affected-pages reads an item id starting with `http` as a page of
+    // the audited site, which would both inflate the affected-page count and
+    // suppress the row as redundant.
+    const check = only(
+      run(`${NAV}<main><a href="http://localhost:3000/api">API</a></main>`),
+    );
+    expect(check.items).toEqual([
+      {
+        id: "localhost",
+        label: "localhost",
+        snippet: "http://localhost:3000/api",
+        meta: { count: 1, inAttribute: true },
+      },
+    ]);
+  });
+
+  test("markdown link syntax in a hostile href cannot survive into the report", () => {
+    // Canonicalizing is not enough: new URL() leaves brackets and parentheses
+    // alone, and the renderer would turn them into a clickable attacker link.
+    const check = only(
+      run(
+        `${NAV}<main><a href="http://localhost/[click here](https://evil.example/pwn)">x</a></main>`,
+      ),
+    );
+    const sample = (check.items?.[0]?.snippet ?? "") as string;
+    expect(sample).not.toContain("[");
+    expect(sample).not.toContain("]");
+    expect(sample).not.toContain("(");
+    expect(sample).not.toContain(")");
+    expect(sample).toContain("%5Bclick%20here%5D");
+  });
+
+  test("a very long site-controlled URL is truncated", () => {
+    const long = `http://localhost:3000/${"a".repeat(500)}`;
+    const check = only(run(`${NAV}<main><a href="${long}">x</a></main>`));
+    const sample = (check.items?.[0]?.snippet ?? "") as string;
+    expect(sample.length).toBeLessThanOrEqual(120);
+    expect(sample.endsWith("…")).toBe(true);
+  });
+
   test("summarize prefers an attribute sample over an earlier text one", () => {
     const rows = summarize([
       { kind: "localhost", source: "text", host: "localhost", sample: "localhost:1", own: true },
@@ -517,5 +657,24 @@ describe("seed classification", () => {
     expect(isNonProductionSeedHost("example.com")).toBe(false);
     expect(isNonProductionSeedHost("www.example.com")).toBe(false);
     expect(isNonProductionSeedHost("notdev.example.com")).toBe(false);
+  });
+
+  test("a real site whose APEX starts with a tier word is production", () => {
+    // dev.to, test.com and staging.com are registrable domains, not tiers of
+    // anything. A bare leftmost-label test disables the whole rule on them.
+    expect(isNonProductionSeedHost("dev.to")).toBe(false);
+    expect(isNonProductionSeedHost("test.com")).toBe(false);
+    expect(isNonProductionSeedHost("staging.com")).toBe(false);
+    // …and agrees with itself when the same site is reached as www.
+    expect(isNonProductionSeedHost("www.dev.to")).toBe(false);
+  });
+
+  test("the rule still runs on a site hosted at dev.to", () => {
+    const check = only(
+      run(`${NAV}<main><a href="http://localhost:3000/api">API</a></main>`, {
+        url: "https://dev.to/some-post",
+      }),
+    );
+    expect(check.status).toBe("fail");
   });
 });


### PR DESCRIPTION
Adds `content/dev-leakage`, a per-page rule that flags URLs which were only ever correct on a laptop or a preview deploy. Closes squirrelscan/repo#1353 (private tracker).

## What it detects

Five kinds, read from every `href`/`src` on the page (head included) and from the copy a visitor sees:

| Kind | Example | Status |
|---|---|---|
| `localhost` | `http://localhost:3000/api`, `127.x`, `[::1]`, `0.0.0.0`, `*.localhost` | fail in an attribute, warn in copy |
| `private-ip` | `10/8`, `172.16/12`, `192.168/16` | fail in an attribute, warn in copy |
| `dev-subdomain` | `staging.`/`dev.`/`test.` tier of the audited apex | fail in an attribute, warn in copy |
| `preview-host` | `vercel.app`, `netlify.app`, `pages.dev`, `ngrok.io`, `ngrok.app`, `ngrok-free.app`, `trycloudflare.com` | fail if it carries the site's own name, else warn |
| `insecure-self-link` | `http://` back to the site's own registrable domain | warn, never more |

The rule **skips** rather than passes when the audited origin is itself non-production, so auditing a preview deploy does not report every internal link as leakage. Both the seed and the URL the page finally resolved to are checked.

## Overlap decision

**`links/invalid-links`** reports URLs that do not parse. There is no overlap and none is possible: `http://localhost:3000/api` is a perfectly well-formed URL, so it never reaches that rule, and a value this rule cannot parse is skipped rather than reported, so a malformed `href` is never counted in two categories. That is the deliberate part of the resolution: this rule reports the dev-leakage *category*, and it never restates a broken-link result. The issue's own framing holds up on inspection: broken-link rules only catch a dev host when it happens to be unreachable from the crawler, which is the wrong signal at the wrong time, because `staging.example.com` usually resolves and `abc123.vercel.app` resolves right up until the deployment is garbage-collected.

**`links/https-downgrade`** counts every `http://` anchor on an HTTPS page, third-party links included, and owns the transport-security story. This rule looks at the same attribute from a different angle and stays deliberately narrower in three ways: it only fires on the site's **own** registrable domain, where the fix is a template or a config value rather than a decision about whether to link somewhere; the `insecure-self-link` kind never escalates the rule past `warn`; and it never decides the rule's status by itself. So an HTTPS page whose only finding is a self-referential `http://` link gets one warning here and one from `links/https-downgrade`, describing the same `href` as two different problems: an avoidable redirect, and a baked-in absolute URL. That duplication is intentional and bounded, and it is written up in the rule's doc page under "Related rules".

## Correctness notes

- Subdomain matching goes through the PSL registrable domain (`tldts`, `allowPrivateDomains: true`), never a string suffix, so `notdev.example.com`, `webdev.example.com` and `dev.other.com` stay clean and `dev.example.co.uk` resolves against `example.co.uk` rather than `co.uk`.
- The prose scan uses `getRenderedProseText`, so `<code>`, `<pre>`, `<template>` and highlighter/editor containers are excluded: a getting-started page printing `http://localhost:5173` in a code sample passes. A live `<a href>` inside a `<pre>` is still judged.
- Two false-positive classes need URL context before a bare occurrence counts: `localhost` on its own ("the app also runs on localhost"), and a bare `10.x` quad, which is also how enterprise software spells a version. `192.168.*`, `172.16-31.*` and `127.*` count bare.
- Preview ownership matches whole hyphen-separated segments of the label, never a substring, so `sandbox-demo.vercel.app` is not read as `box.com`'s own deployment.
- The prose scan carries no hostname literal at all. It matches any dotted named host with a generic pattern and hands each capture to `classifyHost`, the same function the attribute path uses. That is one classification path instead of two, no per-page `RegExp` compiled from the audited apex, and it clears CodeQL's `js/regex/missing-regexp-anchor` on the merits rather than by suppression: a suffix list interpolated into an unanchored pattern is the shape of a host-matching bypass, and comparing a parsed host against a list raises no such question.
- Report samples are the canonical `url.href` with markdown link syntax percent-encoded. Canonicalizing alone is not enough: `new URL()` leaves `[`, `]`, `(`, `)` untouched, so a hostile `href` would otherwise render as a clickable attacker-chosen link.
- All five text scanners were timed against adversarial inputs up to 620 KB (long label runs, dotted-digit runs, hyphen runs, near-miss preview suffixes). Worst case 3.2 ms.

## Testing

- `packages/rules/tests/content-dev-leakage.test.ts`: 62 tests covering pass, warn, fail and skipped, the preview-seed and localhost-seed skip paths, the code-sample no-false-positive fixture, and regressions for every review finding.
- `bunx tsgo --noEmit` clean in `packages/rules` and `packages/audit-engine`.
- Every audit-engine golden and streaming test run individually and green.

## Golden gate and counts

Rule count 281 to 282, content 20 to 21, bumped on all six published surfaces (README, `docs/index.mdx`, `docs/agent-setup`, `docs/rules/index.mdx`, `docs/rules/seo/index.mdx`, `docs/rules/content/index.mdx`) plus `docs.json` nav and the new rule page.

The canonical 518-page golden gate moves `findings` 99221 to 99721 (+500 passes), `perRuleTally` 281 to 282, and `healthScore.overall` **48 to 49**. The score move is new: every earlier `+500` landed on a category far enough from a rounding boundary to absorb it, and this one tips it. Worth flagging that the fixture is weak evidence for this particular rule, since its origin is `http://synthetic.test`, so `site.secure` is false and the `insecure-self-link` kind is structurally disabled there.

## Follow-up, not in this PR

Sub-tier hosts are missed by design in both paths: only the leftmost label is matched, so `app.dev.example.com` and `www.staging.example.com` are clean. The tier vocabulary is also just `staging`/`dev`/`test`, with no `qa`, `uat`, `preprod` or `sandbox`. Both match the acceptance criteria as written; I will file an issue rather than widen the rule here.
