### PR TITLE
feat(audit-engine): make the streaming pipeline usable from a cloud audit

### DIFF
--- a/packages/audit-engine/scripts/bench-streaming-memory.ts
+++ b/packages/audit-engine/scripts/bench-streaming-memory.ts
@@ -1,0 +1,279 @@
+// Peak-RSS bench for the resident vs streaming audit pipelines (#1860).
+//
+// Reproduces the shape that OOM-killed the drscholls.com audits (#1862): a
+// 500-page crawl whose pages are ~1 MB of mostly inline script. The golden
+// fixture's own pages are 20-60 KB of text, which parses to a DOM small enough
+// that the resident pipeline looks fine — the wall only appears once each page
+// carries hundreds of KB of script for linkedom to build nodes for. So the
+// fixture is built from the golden model and then INFLATED: a deterministic
+// filler script is appended to each page's stored html.
+//
+// Two modes, run as separate processes so neither heap can flatter the other:
+//
+//   old — getPages -> buildSiteContext -> fetchResourceAssets -> runRulesOnStorage
+//         -> report with an effectively unbounded page batch. This is the pipeline
+//         as it stood before #1860.
+//   new — runStreamingPreRules -> runStreamingRules -> batched report.
+//
+// Network: the synthetic pages carry no sub-resources, and `--max-resources 0`
+// zeroes the sitemap-status and PDF fetch limits, so both modes are fully offline
+// and the only difference measured is residency.
+//
+// Usage (build once, then measure each mode under /usr/bin/time -l):
+//   bun run scripts/bench-streaming-memory.ts build --db /tmp/bench.sqlite --pages 500 --inflate-kb 950
+//   /usr/bin/time -l bun run scripts/bench-streaming-memory.ts old --db /tmp/bench.sqlite
+//   /usr/bin/time -l bun run scripts/bench-streaming-memory.ts new --db /tmp/bench.sqlite
+//
+// The script also samples `process.memoryUsage().rss` on a timer and prints its
+// own peak, because /usr/bin/time -l reports the process maximum resident set
+// size and the in-process sample is the number the container's own heartbeat
+// would have reported. Both are printed; they should agree closely.
+
+import { rmSync } from "node:fs";
+
+import { getDefaultConfig, type Config } from "@squirrelscan/config";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { generateSiteModel, writeCrawlToStorage } from "@squirrelscan/synthetic-site";
+import { Effect } from "effect";
+
+import {
+  buildSiteContext,
+  fetchResourceAssets,
+  generateReportFromStorage,
+  parseHtmlForRules,
+  runRulesOnStorage,
+  runStreamingRules,
+  type PreFetchedAssets,
+} from "../src/adapter";
+import { runStreamingPreRules } from "../src/streaming-pre-rules";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+function arg(name: string, fallback?: string): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  return idx >= 0 ? process.argv[idx + 1] : fallback;
+}
+
+const MODE = process.argv[2] ?? "new";
+const DB = arg("db", "/tmp/squirrel-bench.sqlite")!;
+const PAGES = Number.parseInt(arg("pages", "500")!, 10);
+const INFLATE_KB = Number.parseInt(arg("inflate-kb", "950")!, 10);
+const BATCH = Number.parseInt(arg("batch", "50")!, 10);
+const SCRIPT_SHARE = Number.parseFloat(arg("script-share", "0.8")!);
+// One getPages for the whole crawl — the pre-#1860 report behaviour.
+const UNBOUNDED_BATCH = 1_000_000;
+
+const MB = 1024 * 1024;
+const fmt = (bytes: number) => `${(bytes / MB).toFixed(0)} MB`;
+
+/** Offline config: no cloud, no intel, no integrity probes (no network). */
+function benchConfig(): Config {
+  const base = getDefaultConfig();
+  return {
+    ...base,
+    cloud: { ...base.cloud, enabled: false },
+    intel: { ...base.intel, enabled: false },
+    external_links: { ...base.external_links, enabled: false },
+    integrity: {
+      ...base.integrity,
+      soft404_confirm: { ...(base.integrity?.soft404_confirm ?? {}), enabled: false },
+    },
+  } as Config;
+}
+
+const RESOURCE_OVERRIDES = { resourceCheckMaxItems: 0 };
+
+const EMPTY_ASSETS: PreFetchedAssets = {
+  resourceSizes: { css: [], images: [] },
+  scripts: [],
+  pdfSizes: [],
+  sitemapUrlStatuses: [],
+};
+
+/**
+ * Deterministic page filler shaped like a real script-heavy commerce page.
+ *
+ * This matters more than it looks. A first attempt filled the page with ONE
+ * `<script>` holding ~950 KB of text: the stored html hit 1 MB, but linkedom
+ * built a single text node for it and the parsed document cost only ~0.44 MB per
+ * page — a twelfth of the ~4.7 MB per page measured on drscholls.com (#1862). The
+ * bench then "showed" the resident pipeline using less memory than the streaming
+ * one, because the term the streaming pipeline exists to remove had been filled
+ * with something that does not cost anything to parse.
+ *
+ * linkedom's cost is dominated by NODE COUNT, not by html byte length. So the
+ * filler is half inline script split across many tags and half real markup:
+ * nested divs, spans, attributes and text, the way a product grid is. The bench
+ * prints the achieved per-page DOM cost so this can be checked rather than
+ * assumed.
+ */
+function fillerMarkup(kb: number, seed: string, scriptShare = SCRIPT_SHARE): string {
+  const targetBytes = kb * 1024;
+  const parts: string[] = [];
+  let size = 0;
+
+  // Most of the budget as inline script, split across many small tags (analytics,
+  // config blobs, per-product JSON) rather than one monolith. `scriptShare` is
+  // the dial that sets the achieved DOM cost per page: script text is cheap per
+  // byte, markup is not, so lowering it makes the fixture harsher. The default is
+  // tuned so the fixture lands near the ~4.7 MB/page measured on drscholls.com
+  // (#1862) rather than well past it — a fixture that is 3x harsher than
+  // production would overstate the fix.
+  let i = 0;
+  while (size < targetBytes * scriptShare) {
+    const tag = `<script>window.__q${seed}_${i}={a:${i},b:"t${i}"};</script>`;
+    parts.push(tag);
+    size += tag.length;
+    i++;
+  }
+
+  // The rest as element-dense markup — this is what actually builds nodes.
+  let card = 0;
+  while (size < targetBytes) {
+    const block =
+      `<div class="c${card % 7}" data-id="${card}">` +
+      `<span class="t">P${card}</span>` +
+      `<span class="p">$${card % 90}</span>` +
+      `<ul><li>s${card % 5}</li><li>c${card % 9}</li></ul>` +
+      `</div>`;
+    parts.push(block);
+    size += block.length;
+    card++;
+  }
+
+  return parts.join("");
+}
+
+async function build(): Promise<void> {
+  rmSync(DB, { force: true });
+  rmSync(`${DB}-wal`, { force: true });
+  rmSync(`${DB}-shm`, { force: true });
+
+  const model = generateSiteModel({
+    seed: "bench-streaming-memory-1860",
+    pageCount: PAGES,
+    templateCount: 6,
+    minPageSizeBytes: 20_000,
+    maxPageSizeBytes: 60_000,
+    cleanRatio: 0.35,
+  });
+  const { storage, crawlId } = await writeCrawlToStorage(model, DB);
+
+  // Inflate in batches so the builder itself never holds the whole crawl.
+  let inflated = 0;
+  for (let offset = 0; ; offset += 100) {
+    const batch = await run(storage.getPages(crawlId, { limit: 100, offset }));
+    if (batch.length === 0) break;
+    for (const page of batch) {
+      if (!page.html) continue;
+      const filler = fillerMarkup(INFLATE_KB, page.normalizedUrl.slice(-8).replace(/\W/g, ""));
+      const html = page.html.replace("</body>", `${filler}</body>`);
+      await run(storage.upsertPage(crawlId, { ...page, html }));
+      inflated++;
+    }
+    if (batch.length < 100) break;
+  }
+  // Report the ACHIEVED per-page DOM cost. The whole bench is meaningless if this
+  // is far off the ~4.7 MB/page measured on drscholls.com (#1862) — that is how
+  // the first filler shape slipped through looking plausible (one giant script
+  // text node: 1 MB of html, 0.44 MB of DOM).
+  // Report the fixture's shape so a future reader can tell whether it still
+  // resembles the pages that caused #1862. NODE COUNT is the number that matters:
+  // linkedom's cost tracks nodes, not html bytes, and the first version of this
+  // filler put ~950 KB into a single script text node — 1 MB of html that parsed
+  // to almost no DOM, which made the resident pipeline look cheaper than the
+  // streaming one. Per-page retained MB is deliberately NOT reported: measuring it
+  // from RSS deltas gave readings between 0.7 and 13 MB for the same fixture, so
+  // the honest memory number is the end-to-end peak each mode prints, not a
+  // synthetic per-page figure.
+  const probe = await run(storage.getPages(crawlId, { limit: 5, offset: 0 }));
+  const htmlAvg = probe.reduce((n, pg) => n + (pg.html?.length ?? 0), 0) / Math.max(1, probe.length);
+  const first = probe[0];
+  const nodes = first?.html
+    ? (parseHtmlForRules(first.html, first.normalizedUrl).document?.querySelectorAll("*").length ?? 0)
+    : 0;
+  console.log(
+    `built ${DB}: crawl=${crawlId} pages inflated=${inflated}\n` +
+      `  avg html=${(htmlAvg / 1024).toFixed(0)} KB  nodes/page=${nodes}`,
+  );
+  await run(storage.close());
+}
+
+async function openCrawl(): Promise<{ storage: SQLiteStorage; crawlId: string }> {
+  const storage = new SQLiteStorage(DB);
+  await run(storage.init());
+  const crawls = await run(storage.listCrawls(1));
+  const crawlId = crawls[0]?.id;
+  if (!crawlId) throw new Error(`no crawl in ${DB} — run \`build\` first`);
+  return { storage, crawlId };
+}
+
+async function main(): Promise<void> {
+  if (MODE === "build") {
+    await build();
+    return;
+  }
+
+  let peak = 0;
+  const sample = () => {
+    const rss = process.memoryUsage().rss;
+    if (rss > peak) peak = rss;
+  };
+  const timer = setInterval(sample, 100);
+  const mark = (label: string) => {
+    sample();
+    console.log(`  ${label.padEnd(22)} rss=${fmt(process.memoryUsage().rss)} peak=${fmt(peak)}`);
+  };
+
+  const { storage, crawlId } = await openCrawl();
+  const config = benchConfig();
+  const started = Date.now();
+  console.log(`mode=${MODE} db=${DB} batch=${MODE === "new" ? BATCH : "unbounded"}`);
+
+  if (MODE === "old") {
+    const pages = await run(storage.getPages(crawlId));
+    mark(`getPages(${pages.length})`);
+    const siteContext = await run(buildSiteContext(pages));
+    mark("buildSiteContext");
+    const assets = await run(
+      fetchResourceAssets(storage, crawlId, siteContext, config, RESOURCE_OVERRIDES),
+    );
+    mark("fetchResourceAssets");
+    const rules = await run(
+      runRulesOnStorage(storage, crawlId, siteContext, config, assets, undefined),
+    );
+    mark("runRulesOnStorage");
+    const report = await run(
+      generateReportFromStorage(storage, crawlId, rules, { batchSize: UNBOUNDED_BATCH }),
+    );
+    mark("report");
+    console.log(`  report pages=${report.pages.length} score=${report.healthScore.overall}`);
+  } else {
+    const pre = await run(
+      runStreamingPreRules(storage, crawlId, config, {
+        batchSize: BATCH,
+        resourceOverrides: RESOURCE_OVERRIDES,
+      }),
+    );
+    mark(`preRules(${pre.pageCount})`);
+    const rules = await run(
+      runStreamingRules(storage, crawlId, config, pre.assets ?? EMPTY_ASSETS, undefined, {
+        batchSize: BATCH,
+      }),
+    );
+    mark("runStreamingRules");
+    const report = await run(
+      generateReportFromStorage(storage, crawlId, rules, { batchSize: BATCH }),
+    );
+    mark("report");
+    console.log(`  report pages=${report.pages.length} score=${report.healthScore.overall}`);
+  }
+
+  clearInterval(timer);
+  await run(storage.close());
+  console.log(`PEAK_RSS_MB=${(peak / MB).toFixed(0)} elapsed=${Math.round((Date.now() - started) / 1000)}s`);
+}
+
+await main();

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -106,6 +106,7 @@ import {
   type PageSignalCollector,
   type StreamPageRulesHooks,
 } from "./streaming";
+import { collectDroppedBatch } from "./batch-gc";
 import { resolveCloakingProbes } from "./cloaking-probe";
 import { createSiteQuery } from "./site-query";
 import { confirmSoft404Candidates } from "./soft404-confirm";
@@ -1824,6 +1825,7 @@ function streamParsedUniverse(
       // WAF detection but never `parsed.document`.
       universe.absorb(ctx);
       releaseSiteContextDocuments(ctx);
+      collectDroppedBatch();
 
       if (batch.length < batchSize) break;
     }

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -2289,7 +2289,8 @@ export function runStreamingRules(
   },
 ): Effect.Effect<StreamingRuleExecutionResult, never, never> {
   return Effect.gen(function* () {
-    const batchSize = opts?.batchSize ?? STREAM_PAGE_BATCH;
+    // Clamped — see streaming.ts; a 0 batch would loop forever over the crawl.
+    const batchSize = Math.max(1, opts?.batchSize ?? STREAM_PAGE_BATCH);
 
     // Threat-intel scope + runner (mirror of runRulesOnStorage).
     const effectiveScope =

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -92,6 +92,7 @@ import { logger } from "./adapter-logger";
 import {
   buildV1Report,
   buildRobotsData,
+  type BuildV1ReportOptions,
   type FullAuditReport,
   type RuleExecutionResult,
 } from "./report-stream";
@@ -514,6 +515,122 @@ export interface PreFetchedAssets {
  *
  * This replaces inline resource fetching that previously happened inside runRulesOnStorage().
  */
+/**
+ * The DOM-derived and scalar page signal {@link fetchAssetsFromOccurrences}
+ * needs, accumulated across page batches by {@link createSiteAssetCollector}.
+ * Everything here is bounded by the site's distinct sub-resource URLs, not by
+ * page count × page size, which is what lets the cloud collect it with only one
+ * batch of DOMs live at a time (#1860).
+ */
+export interface SiteAssetOccurrences {
+  css: Map<string, Set<string>>;
+  images: Map<string, Set<string>>;
+  scripts: Map<string, Set<string>>;
+  pdfs: Map<string, Set<string>>;
+  /** Scalars for the sitemap-coverage pass — v1's non-WAF parsed-page list. */
+  coveragePages: Array<{ url: string; finalUrl?: string; statusCode: number }>;
+  /** Every page absorbed, WAF and non-HTML included — v1's `siteContext.length`,
+   * which sizes the script fetcher's per-page budget. */
+  pageCount: number;
+}
+
+function emptySiteAssetOccurrences(): SiteAssetOccurrences {
+  return {
+    css: new Map(),
+    images: new Map(),
+    scripts: new Map(),
+    pdfs: new Map(),
+    coveragePages: [],
+    pageCount: 0,
+  };
+}
+
+/**
+ * Batch-absorbing collector for the asset phase's page signal. `absorb` MUST be
+ * called while the batch's DOMs are live (stylesheet + script srcs are read off
+ * `parsed.document`); everything it retains is DOM-free, so the caller can drop
+ * the batch immediately after. Feeding it the whole site context in one call is
+ * exactly what {@link fetchResourceAssets} does, so the streamed and resident
+ * paths run the same accumulation code.
+ */
+export function createSiteAssetCollector(baseUrl: string): {
+  absorb: (siteContext: SiteContextPage[]) => void;
+  occurrences: SiteAssetOccurrences;
+} {
+  const occurrences = emptySiteAssetOccurrences();
+  let baseOrigin: string | null = null;
+  try {
+    baseOrigin = baseUrl ? new URL(baseUrl).origin : null;
+  } catch {
+    // ignore — no base origin means no same-origin PDF links are collected
+  }
+
+  return {
+    occurrences,
+    absorb(siteContext: SiteContextPage[]): void {
+      // Same filtering as runRulesOnStorage: parsed, non-WAF. Note the page
+      // COUNT below still counts every page, matching v1's siteContext.length.
+      occurrences.pageCount += siteContext.length;
+      const parsedPages: Array<{
+        url: string;
+        finalUrl?: string;
+        statusCode: number;
+        parsed: ParsedPage;
+      }> = [];
+
+      for (const { page, parsed } of siteContext) {
+        if (!parsed) continue;
+        const wafChallenge = detectWafChallengePage({
+          status: page.status,
+          headers: {
+            server: page.headers.server,
+            cfCacheStatus: page.headers.cfCacheStatus,
+            xCache: page.headers.xCache,
+          },
+          html: page.html,
+        });
+        if (wafChallenge.detected) continue;
+
+        parsedPages.push({
+          url: page.normalizedUrl,
+          finalUrl: page.finalUrl,
+          statusCode: page.status,
+          parsed,
+        });
+      }
+
+      for (const page of parsedPages) {
+        occurrences.coveragePages.push({
+          url: page.url,
+          finalUrl: page.finalUrl,
+          statusCode: page.statusCode,
+        });
+      }
+
+      // Needs the DOM (stylesheet + script srcs aren't in stored parsedData).
+      absorbResourceOccurrences(occurrences, parsedPages, baseUrl);
+
+      // PDF links come from parsed scalars.
+      for (const page of parsedPages) {
+        for (const link of page.parsed.links) {
+          if (!link.url) continue;
+          if (!link.url.toLowerCase().endsWith(".pdf")) continue;
+          try {
+            const linkOrigin = new URL(link.url).origin;
+            if (baseOrigin && linkOrigin === baseOrigin) {
+              const sources = occurrences.pdfs.get(link.url) ?? new Set<string>();
+              sources.add(page.url);
+              occurrences.pdfs.set(link.url, sources);
+            }
+          } catch {
+            // Skip malformed URLs
+          }
+        }
+      }
+    },
+  };
+}
+
 export function fetchResourceAssets(
   storage: CrawlStorage,
   crawlId: string,
@@ -522,36 +639,36 @@ export function fetchResourceAssets(
   overrides?: ResourceCheckOverrides,
 ): Effect.Effect<PreFetchedAssets, never, never> {
   return Effect.gen(function* () {
+    const crawl = yield* storage
+      .getCrawl(crawlId)
+      .pipe(Effect.catchAll(() => Effect.succeed(null)));
+    const collector = createSiteAssetCollector(crawl?.baseUrl ?? "");
+    collector.absorb(siteContext);
+    return yield* fetchAssetsFromOccurrences(
+      storage,
+      crawlId,
+      collector.occurrences,
+      config,
+      overrides,
+    );
+  });
+}
+
+/**
+ * The asset phase's network tail: sitemap coverage, then the bounded CSS /
+ * image / script / PDF / sitemap-status fetches. Split out of
+ * {@link fetchResourceAssets} (#1860) so the cloud can drive the collection half
+ * one page batch at a time and still land in exactly this code.
+ */
+export function fetchAssetsFromOccurrences(
+  storage: CrawlStorage,
+  crawlId: string,
+  occurrences: SiteAssetOccurrences,
+  config: Config,
+  overrides?: ResourceCheckOverrides,
+): Effect.Effect<PreFetchedAssets, never, never> {
+  return Effect.gen(function* () {
     const assetsSpan = logger.traceStart("fetchResourceAssets");
-
-    // Build parsedPages from siteContext (same filtering as runRulesOnStorage)
-    const parsedPages: Array<{
-      url: string;
-      finalUrl?: string;
-      statusCode: number;
-      parsed: ParsedPage;
-    }> = [];
-
-    for (const { page, parsed } of siteContext) {
-      if (!parsed) continue;
-      const wafChallenge = detectWafChallengePage({
-        status: page.status,
-        headers: {
-          server: page.headers.server,
-          cfCacheStatus: page.headers.cfCacheStatus,
-          xCache: page.headers.xCache,
-        },
-        html: page.html,
-      });
-      if (wafChallenge.detected) continue;
-
-      parsedPages.push({
-        url: page.normalizedUrl,
-        finalUrl: page.finalUrl,
-        statusCode: page.status,
-        parsed,
-      });
-    }
 
     const crawl = yield* storage
       .getCrawl(crawlId)
@@ -609,46 +726,14 @@ export function fetchResourceAssets(
     };
 
     if (sitemapDiscovery.discovered.length > 0) {
-      const coverage = computeSitemapCoverageData(
-        parsedPages.map((page) => ({
-          url: page.url,
-          finalUrl: page.finalUrl,
-          statusCode: page.statusCode,
-        })),
-        sitemapDiscovery,
-      );
+      const coverage = computeSitemapCoverageData(occurrences.coveragePages, sitemapDiscovery);
       // Cap to keep resource-check URLs within reasonable bounds
       sitemapDiscovery.orphanPages = coverage.orphanPages.slice(0, REPORT_LIMITS.maxPages);
       sitemapDiscovery.missingPages = coverage.missingPages.slice(0, REPORT_LIMITS.maxPages);
     }
 
-    // Collect resource URLs from parsed pages
-    const resourceOccurrences = collectResourceOccurrences(parsedPages, baseUrl);
-
-    // Collect PDF URLs from parsed page links
-    const pdfUrls = new Map<string, Set<string>>();
-    let baseOrigin: string | null = null;
-    try {
-      baseOrigin = baseUrl ? new URL(baseUrl).origin : null;
-    } catch {
-      // ignore
-    }
-    for (const page of parsedPages) {
-      for (const link of page.parsed.links) {
-        if (!link.url) continue;
-        if (!link.url.toLowerCase().endsWith(".pdf")) continue;
-        try {
-          const linkOrigin = new URL(link.url).origin;
-          if (baseOrigin && linkOrigin === baseOrigin) {
-            const sources = pdfUrls.get(link.url) ?? new Set<string>();
-            sources.add(page.url);
-            pdfUrls.set(link.url, sources);
-          }
-        } catch {
-          // Skip malformed URLs
-        }
-      }
-    }
+    const resourceOccurrences = occurrences;
+    const pdfUrls = occurrences.pdfs;
 
     // Prior-crawl sub-resource records, keyed by URL, enable browser-like cache
     // reuse for CSS/images (#107). Empty on a first/cold audit. Mirrors the page
@@ -701,7 +786,7 @@ export function fetchResourceAssets(
     };
 
     const scriptFetchOptions: Parameters<typeof fetchScriptContents>[1] = {
-      pageCount: siteContext.length,
+      pageCount: occurrences.pageCount,
       ...(maxResources != null ? { maxScripts: maxResources } : {}),
       ...(overrides?.resourceCheckTimeoutMs != null
         ? { timeoutMs: overrides.resourceCheckTimeoutMs }
@@ -1564,6 +1649,22 @@ type StreamParsedPage = {
   redirectChain?: RedirectChain;
 };
 
+/**
+ * The per-page identity the streamed universe retains, in place of the whole
+ * {@link PageRecord}. Deliberately just the three scalars the post-Pass-1 steps
+ * read (`buildStreamingSiteData`'s soft-404 confirm pass), because a PageRecord
+ * carries `html` (≈1 MB on a script-heavy page) and `parsedData` — keeping one
+ * per page put the O(pages × html) term straight back into a pipeline whose
+ * whole point is bounding residency (#1860). `parsed` is the SAME object the
+ * matching `parsedPages` entry holds, so it costs nothing extra.
+ */
+interface StreamPageIdentity {
+  normalizedUrl: string;
+  status: number;
+  fetcherId?: string | null;
+  parsed: ParsedPage;
+}
+
 interface ParsedUniverse {
   parsedPages: StreamParsedPage[];
   wafBlockedPages: Array<{ url: string; provider: string | null }>;
@@ -1571,91 +1672,123 @@ interface ParsedUniverse {
   /** Pages excluded from scoring because the host was throttling (#1829). */
   rateLimitedPages: Array<{ url: string; status: number }>;
   rateLimitedPageSet: Set<string>;
-  pageDataMap: Map<
-    string,
-    { page: PageRecord; parsed: ParsedPage; headers: Record<string, string> }
-  >;
+  pageDataMap: Map<string, StreamPageIdentity>;
 }
 
 /**
- * Assemble the `site.pages` universe from a parsed site context, EXACTLY as
- * `runRulesOnStorage` does: HTML pages first (WAF-challenge pages excluded and
- * collected for the advisory site check), then 4xx/5xx error pages appended with
+ * Assemble the `site.pages` universe, EXACTLY as `runRulesOnStorage` does: HTML
+ * pages first (WAF-challenge and rate-limited pages excluded and collected for
+ * their advisory site checks), then 4xx/5xx error pages appended with
  * `EMPTY_PARSED_PAGE`. Reads only `page.html` + parsed scalars (never
  * `parsed.document`), so a DOM-dropped context yields the same universe — which
- * is what lets Pass 1 null each batch's DOMs before calling this. Duplicated from
- * v1's inline block to keep v1 untouched; the golden-diff gates against drift.
+ * is what lets Pass 1 null each batch's DOMs before feeding it here.
+ *
+ * Batch-absorbing (`absorb` per batch, then one `build`) rather than taking the
+ * whole site context, so Pass 1 never has to hold every `PageRecord` resident
+ * just to assemble the universe. Order is preserved because HTML and error
+ * entries are buffered separately and concatenated once, and the error-page
+ * `!pageDataMap.has` test is deferred to `build`, where the map is complete —
+ * the two places batching could otherwise diverge from v1's two-loop original.
+ * Duplicated from v1's inline block to keep v1 untouched; the golden-diff gates
+ * against drift.
  */
-function assembleParsedUniverse(siteContext: SiteContextPage[]): ParsedUniverse {
-  const parsedPages: StreamParsedPage[] = [];
+function createParsedUniverseAccumulator(): {
+  absorb: (siteContext: SiteContextPage[]) => void;
+  build: () => ParsedUniverse;
+} {
+  const htmlPages: StreamParsedPage[] = [];
+  // v1 appends its 4xx/5xx entries AFTER every HTML page, so they are buffered
+  // separately and concatenated in `build` — which is what makes absorbing the
+  // crawl one batch at a time produce v1's exact `site.pages` order.
+  const errorPages: StreamParsedPage[] = [];
   const wafBlockedPages: Array<{ url: string; provider: string | null }> = [];
   const wafBlockedPageSet = new Set<string>();
   const rateLimitedPages: Array<{ url: string; status: number }> = [];
   const rateLimitedPageSet = new Set<string>();
   const pageDataMap: ParsedUniverse["pageDataMap"] = new Map();
-
-  for (const { page, parsed } of siteContext) {
-    if (!parsed) continue; // non-HTML / failed parse — v1 skips these too
-    // Mirrors v1's rate-limit exclusion (#1829); the golden diff gates drift.
-    if (isRateLimitStatus(page.status)) {
-      rateLimitedPages.push({ url: page.normalizedUrl, status: page.status });
-      rateLimitedPageSet.add(page.normalizedUrl);
-      continue;
-    }
-    const wafChallenge = detectWafChallengePage({
-      status: page.status,
-      headers: {
-        server: page.headers.server,
-        cfCacheStatus: page.headers.cfCacheStatus,
-        xCache: page.headers.xCache,
-      },
-      html: page.html,
-    });
-    if (wafChallenge.detected) {
-      wafBlockedPages.push({ url: page.normalizedUrl, provider: wafChallenge.provider });
-      wafBlockedPageSet.add(page.normalizedUrl);
-      continue;
-    }
-
-    const headers = buildHeadersMap(page);
-    parsedPages.push({
-      url: page.normalizedUrl,
-      finalUrl: page.finalUrl,
-      statusCode: page.status,
-      parsed,
-      headers,
-      redirectChain: page.redirectChain,
-    });
-    pageDataMap.set(page.normalizedUrl, { page, parsed, headers });
-  }
-
-  // Error pages (4xx/5xx) carry no HTML but their status codes feed broken-link
-  // detection — appended after the HTML pages exactly as v1 does.
-  for (const { page } of siteContext) {
-    if (
-      page.status >= 400 &&
-      !pageDataMap.has(page.normalizedUrl) &&
-      !wafBlockedPageSet.has(page.normalizedUrl) &&
-      !rateLimitedPageSet.has(page.normalizedUrl)
-    ) {
-      parsedPages.push({
-        url: page.normalizedUrl,
-        finalUrl: page.finalUrl,
-        statusCode: page.status,
-        parsed: EMPTY_PARSED_PAGE,
-        headers: {},
-        redirectChain: page.redirectChain,
-      });
-    }
-  }
+  // v1's second loop tests `!pageDataMap.has(url)` against the map as it stands
+  // AFTER the whole first loop. Batching means a later batch can still add to
+  // that map, so the error-page decision is deferred to `build`.
+  const errorCandidates: StreamParsedPage[] = [];
 
   return {
-    parsedPages,
-    wafBlockedPages,
-    wafBlockedPageSet,
-    rateLimitedPages,
-    rateLimitedPageSet,
-    pageDataMap,
+    absorb(siteContext: SiteContextPage[]): void {
+      for (const { page, parsed } of siteContext) {
+        // Error-page candidates are collected for EVERY page (parsed or not),
+        // mirroring v1's second loop, which iterates the whole site context.
+        if (page.status >= 400) {
+          errorCandidates.push({
+            url: page.normalizedUrl,
+            finalUrl: page.finalUrl,
+            statusCode: page.status,
+            parsed: EMPTY_PARSED_PAGE,
+            headers: {},
+            redirectChain: page.redirectChain,
+          });
+        }
+
+        if (!parsed) continue; // non-HTML / failed parse — v1 skips these too
+        // Mirrors v1's rate-limit exclusion (#1829); the golden diff gates drift.
+        if (isRateLimitStatus(page.status)) {
+          rateLimitedPages.push({ url: page.normalizedUrl, status: page.status });
+          rateLimitedPageSet.add(page.normalizedUrl);
+          continue;
+        }
+        const wafChallenge = detectWafChallengePage({
+          status: page.status,
+          headers: {
+            server: page.headers.server,
+            cfCacheStatus: page.headers.cfCacheStatus,
+            xCache: page.headers.xCache,
+          },
+          html: page.html,
+        });
+        if (wafChallenge.detected) {
+          wafBlockedPages.push({ url: page.normalizedUrl, provider: wafChallenge.provider });
+          wafBlockedPageSet.add(page.normalizedUrl);
+          continue;
+        }
+
+        const headers = buildHeadersMap(page);
+        htmlPages.push({
+          url: page.normalizedUrl,
+          finalUrl: page.finalUrl,
+          statusCode: page.status,
+          parsed,
+          headers,
+          redirectChain: page.redirectChain,
+        });
+        // Scalars only — NOT the PageRecord (see StreamPageIdentity).
+        pageDataMap.set(page.normalizedUrl, {
+          normalizedUrl: page.normalizedUrl,
+          status: page.status,
+          fetcherId: page.fetcherId,
+          parsed,
+        });
+      }
+    },
+
+    build(): ParsedUniverse {
+      // Error pages (4xx/5xx) carry no HTML but their status codes feed
+      // broken-link detection — appended after the HTML pages exactly as v1 does.
+      for (const candidate of errorCandidates) {
+        if (
+          !pageDataMap.has(candidate.url) &&
+          !wafBlockedPageSet.has(candidate.url) &&
+          !rateLimitedPageSet.has(candidate.url)
+        ) {
+          errorPages.push(candidate);
+        }
+      }
+      return {
+        parsedPages: [...htmlPages, ...errorPages],
+        wafBlockedPages,
+        wafBlockedPageSet,
+        rateLimitedPages,
+        rateLimitedPageSet,
+        pageDataMap,
+      };
+    },
   };
 }
 
@@ -1672,7 +1805,7 @@ function streamParsedUniverse(
   batchSize: number,
 ): Effect.Effect<ParsedUniverse & { totalPageCount: number }, never, never> {
   return Effect.gen(function* () {
-    const siteContext: SiteContextPage[] = [];
+    const universe = createParsedUniverseAccumulator();
     let totalPageCount = 0;
 
     for (let offset = 0; ; offset += batchSize) {
@@ -1684,15 +1817,18 @@ function streamParsedUniverse(
       totalPageCount += batch.length;
 
       const ctx = yield* buildSiteContext(batch);
-      // Drop this batch's DOMs before the next — `assembleParsedUniverse` and the
-      // site-fetch phase read only page.html + parsed scalars, never `.document`.
+      // Absorb THEN drop, and never retain `ctx` past the iteration: the
+      // accumulator keeps only parsed scalars, so this batch's PageRecords (each
+      // holding the page's full html) become garbage at the end of the loop body.
+      // Absorbing before the release is safe — the universe reads page.html for
+      // WAF detection but never `parsed.document`.
+      universe.absorb(ctx);
       releaseSiteContextDocuments(ctx);
-      for (const entry of ctx) siteContext.push(entry);
 
       if (batch.length < batchSize) break;
     }
 
-    return { ...assembleParsedUniverse(siteContext), totalPageCount };
+    return { ...universe.build(), totalPageCount };
   });
 }
 
@@ -1871,10 +2007,10 @@ function buildStreamingSiteData(
     // flagged candidates; a failed/absent re-fetch degrades to `unconfirmed`.
     yield* Effect.promise(() =>
       confirmSoft404Candidates(
-        Array.from(pageDataMap.values(), ({ page, parsed }) => ({
+        Array.from(pageDataMap.values(), (page) => ({
           url: page.normalizedUrl,
           statusCode: page.status,
-          parsed,
+          parsed: page.parsed,
           rendered: isRenderedFetch(page.fetcherId),
         })),
         {
@@ -1943,6 +2079,7 @@ function runSitePass(
   siteData: SiteData,
   assets: PreFetchedAssets,
   wafBlockedPages: ReadonlyArray<{ url: string; provider: string | null }>,
+  rateLimitedPages: ReadonlyArray<{ url: string; status: number }>,
   collectedSignals: CollectedSiteSignals,
   siteQuery: SiteQuery,
 ): Effect.Effect<
@@ -2012,6 +2149,50 @@ function runSitePass(
       siteResult.checks.push(wafCheck);
       siteRuleResults.set(wafRuleResult.meta.id, [wafCheck]);
       siteRuleRunResults.set(wafRuleResult.meta.id, wafRuleResult);
+    }
+
+    // #1829, verbatim from runRulesOnStorage and in v1's position (after the WAF
+    // notice, before the asset-degradation note). This was MISSING from the
+    // streaming twin: #1829 landed after the #1021 golden gate was written and
+    // the golden fixtures carry no 429/430 pages, so the gate never caught it —
+    // a throttled cloud crawl silently lost the advisory on this path.
+    if (rateLimitedPages.length > 0) {
+      const sampledPages = rateLimitedPages.slice(0, 5).map((page) => page.url);
+      const statuses = Array.from(new Set(rateLimitedPages.map((page) => page.status))).sort(
+        (a, b) => a - b,
+      );
+
+      const rateLimitCheck: CheckResult = {
+        name: "Rate-limited pages",
+        status: "info",
+        message: `${rateLimitedPages.length} page(s) were rate limited (${statuses.join(", ")}); their status is unverified and they were excluded from page-level rule scoring.`,
+        pages: sampledPages,
+        details: {
+          totalRateLimitedPages: rateLimitedPages.length,
+          statuses,
+          sampledPages,
+        },
+      };
+
+      const rateLimitRuleResult: RuleRunResult = {
+        meta: {
+          id: "crawl/rate-limited-pages",
+          name: "Rate-Limited Pages",
+          description:
+            "Pages the origin answered with rate limiting (429/430), so their real status could not be verified.",
+          solution:
+            "Slow the crawl down for this host: set `[crawler] per_host_concurrency = 1` and `per_host_delay_ms = 500` in squirrel.toml, and raise `max_backoff_ms` if the host needs longer recovery windows.",
+          category: "crawl",
+          scope: "site",
+          severity: "info",
+          weight: 0,
+        },
+        checks: [rateLimitCheck],
+      };
+
+      siteResult.checks.push(rateLimitCheck);
+      siteRuleResults.set(rateLimitRuleResult.meta.id, [rateLimitCheck]);
+      siteRuleRunResults.set(rateLimitRuleResult.meta.id, rateLimitRuleResult);
     }
 
     if (assets.degradation?.degraded) {
@@ -2099,6 +2280,12 @@ export function runStreamingRules(
     batchSize?: number;
     hooks?: StreamPageRulesHooks;
     signal?: AbortSignal;
+    /**
+     * #1252 page-loop hooks, forwarded to {@link streamPageRules}. The cloud
+     * passes them so the sync page-rule CPU yields to the event loop and emits a
+     * progress marker every N pages; omitted → byte-identical local behavior.
+     */
+    pageLoopHooks?: PageRuleLoopHooks;
   },
 ): Effect.Effect<StreamingRuleExecutionResult, never, never> {
   return Effect.gen(function* () {
@@ -2110,7 +2297,7 @@ export function runStreamingRules(
     const runner = createRunner(config, effectiveScope);
 
     // Pass 1: DOM-free scalar universe (one batch of DOMs live at a time).
-    const { parsedPages, pageDataMap, totalPageCount, wafBlockedPages } =
+    const { parsedPages, pageDataMap, totalPageCount, wafBlockedPages, rateLimitedPages } =
       yield* streamParsedUniverse(storage, crawlId, batchSize);
 
     // Steps 2+3: site-fetch phase + soft-404 verdict map.
@@ -2144,6 +2331,12 @@ export function runStreamingRules(
       collectors: [signalCollector],
       hooks: opts?.hooks,
       signal: opts?.signal,
+      // v1's page-rule universe verbatim (its `pageDataMap` keys), so the streamed
+      // pass can't drift from it — notably it excludes rate-limited pages, which
+      // `isAuditablePage` alone does not (#1829).
+      pageUniverse: new Set(pageDataMap.keys()),
+      totalPages: pageDataMap.size,
+      pageLoopHooks: opts?.pageLoopHooks,
     });
     const collectedSignals: CollectedSiteSignals = { pages: collectedPages };
 
@@ -2165,6 +2358,7 @@ export function runStreamingRules(
       siteDataForPageRules,
       assets,
       wafBlockedPages,
+      rateLimitedPages,
       collectedSignals,
       siteQuery,
     );
@@ -2208,7 +2402,9 @@ export function runStreamingRules(
 // "./adapter") and every existing "./adapter" importer stay byte-identical.
 export {
   emptyRuleExecutionResult,
+  V1_REPORT_PAGE_BATCH,
   type AuditSummary,
+  type BuildV1ReportOptions,
   type FullAuditReport,
   type PageAudit,
   type RuleExecutionResult,
@@ -2225,8 +2421,9 @@ export function generateReportFromStorage(
   storage: CrawlStorage,
   crawlId: string,
   ruleResults: RuleExecutionResult,
+  options?: BuildV1ReportOptions,
 ): Effect.Effect<FullAuditReport, never, never> {
-  return buildV1Report(storage, crawlId, ruleResults);
+  return buildV1Report(storage, crawlId, ruleResults, options);
 }
 
 // ============================================
@@ -2247,6 +2444,50 @@ export interface ExternalLinkCheckProgress {
  * @param linkCache - Optional injectable link cache (CLI provides SQLite-backed; cloud passes null)
  * @param bulkChecker - Optional cloud bulk checker (paid dead_links service), tried first per url
  */
+interface ExternalLinkOccurrence {
+  pageUrl: string;
+  text: string;
+  position: LinkPosition;
+  isNofollow: boolean;
+}
+
+/** Per-href external-link appearances, accumulated across page batches. */
+export type ExternalLinkOccurrences = Map<string, ExternalLinkOccurrence[]>;
+
+/**
+ * Collect one batch's external-link appearances into `target`. MUST be called
+ * with the batch's DOMs live: link POSITION (nav/header/footer/body) is not in
+ * stored parsedData, so this is the one pre-rules step that genuinely needs a
+ * parsed document per page. Split out of {@link checkExternalLinksOnStorage}
+ * (#1860) so the cloud can accumulate over batches instead of holding every
+ * page's DOM resident to make one pass.
+ */
+export function absorbExternalLinkOccurrences(
+  target: ExternalLinkOccurrences,
+  siteContext: SiteContextPage[],
+): void {
+  for (const { page, parsed } of siteContext) {
+    if (!parsed || !parsed.document) continue; // Skip non-HTML or failed parses
+
+    // Extract links from pre-parsed document (no additional parsing)
+    // We need position info which isn't stored in parsedData
+    const links = extractLinks(parsed.document, page.finalUrl);
+
+    for (const link of links) {
+      if (!link.isInternal && link.href) {
+        const occurrences = target.get(link.href) ?? [];
+        occurrences.push({
+          pageUrl: page.normalizedUrl,
+          text: link.text,
+          position: link.position,
+          isNofollow: link.isNofollow,
+        });
+        target.set(link.href, occurrences);
+      }
+    }
+  }
+}
+
 export function checkExternalLinksOnStorage(
   storage: CrawlStorage,
   crawlId: string,
@@ -2256,39 +2497,38 @@ export function checkExternalLinksOnStorage(
   linkCache?: LinkCache | null,
   bulkChecker?: (urls: string[]) => Promise<Map<string, ExternalCheckResult>>,
 ): Effect.Effect<ExternalCheckResult[], never, never> {
+  if (!config.enabled) return Effect.succeed([]);
+  const externalLinkOccurrences: ExternalLinkOccurrences = new Map();
+  absorbExternalLinkOccurrences(externalLinkOccurrences, siteContext);
+  return checkCollectedExternalLinks(
+    storage,
+    crawlId,
+    externalLinkOccurrences,
+    config,
+    onProgress,
+    linkCache,
+    bulkChecker,
+  );
+}
+
+/**
+ * The external-link phase's network + persistence tail, over occurrences already
+ * collected by {@link absorbExternalLinkOccurrences}. Same body
+ * {@link checkExternalLinksOnStorage} always ran; split so both the resident and
+ * the streamed collection paths land here (#1860).
+ */
+export function checkCollectedExternalLinks(
+  storage: CrawlStorage,
+  crawlId: string,
+  externalLinkOccurrences: ExternalLinkOccurrences,
+  config: ExternalLinksConfig,
+  onProgress?: (progress: ExternalLinkCheckProgress) => void,
+  linkCache?: LinkCache | null,
+  bulkChecker?: (urls: string[]) => Promise<Map<string, ExternalCheckResult>>,
+): Effect.Effect<ExternalCheckResult[], never, never> {
   return Effect.gen(function* () {
     if (!config.enabled) {
       return [];
-    }
-
-    // Extract all external links from site context (no DOM parsing needed)
-    interface ExternalLinkOccurrence {
-      pageUrl: string;
-      text: string;
-      position: LinkPosition;
-      isNofollow: boolean;
-    }
-    const externalLinkOccurrences = new Map<string, ExternalLinkOccurrence[]>();
-
-    for (const { page, parsed } of siteContext) {
-      if (!parsed || !parsed.document) continue; // Skip non-HTML or failed parses
-
-      // Extract links from pre-parsed document (no additional parsing)
-      // We need position info which isn't stored in parsedData
-      const links = extractLinks(parsed.document, page.finalUrl);
-
-      for (const link of links) {
-        if (!link.isInternal && link.href) {
-          const occurrences = externalLinkOccurrences.get(link.href) ?? [];
-          occurrences.push({
-            pageUrl: page.normalizedUrl,
-            text: link.text,
-            position: link.position,
-            isNofollow: link.isNofollow,
-          });
-          externalLinkOccurrences.set(link.href, occurrences);
-        }
-      }
     }
 
     if (externalLinkOccurrences.size === 0) {
@@ -2384,10 +2624,29 @@ function collectResourceOccurrences(
   }>,
   baseUrl: string,
 ): ResourceOccurrenceMap {
+  const target: ResourceOccurrenceMap = {
+    css: new Map<string, Set<string>>(),
+    images: new Map<string, Set<string>>(),
+    scripts: new Map<string, Set<string>>(),
+  };
+  absorbResourceOccurrences(target, pages, baseUrl);
+  return target;
+}
+
+/** {@link collectResourceOccurrences}' body, accumulating into `target` so the
+ * streamed pre-rules pass can feed it one page batch at a time (DOMs live) and
+ * the whole-array entry point stays a one-shot call into the same code. */
+function absorbResourceOccurrences(
+  target: ResourceOccurrenceMap,
+  pages: Array<{
+    url: string;
+    finalUrl?: string;
+    parsed: ParsedPage;
+  }>,
+  baseUrl: string,
+): void {
   const baseHost = getHostname(baseUrl).toLowerCase();
-  const css = new Map<string, Set<string>>();
-  const images = new Map<string, Set<string>>();
-  const scripts = new Map<string, Set<string>>();
+  const { css, images, scripts } = target;
 
   for (const page of pages) {
     const pageUrl = page.finalUrl ?? page.url;
@@ -2427,8 +2686,6 @@ function collectResourceOccurrences(
       scripts.set(script.src, sources);
     }
   }
-
-  return { css, images, scripts };
 }
 
 function computeSitemapCoverageData(

--- a/packages/audit-engine/src/batch-gc.ts
+++ b/packages/audit-engine/src/batch-gc.ts
@@ -1,0 +1,43 @@
+// Per-batch collector nudge for the streaming pipeline (#1860).
+//
+// Dropping a batch's DOMs makes them garbage; it does not make them GONE. JSC
+// grows the heap in preference to collecting, so a streamed walk that parses
+// and releases 50 pages at a time still climbs: the pages are unreachable, but
+// the collector has not run, and a container with a hard memory ceiling is
+// killed on garbage exactly as readily as on live data.
+//
+// Measured on a 200-page crawl of ~1 MB, ~19k-node pages, batch of 50, peak RSS
+// sampled inside the loop (a setInterval sampler never fires — the walk is sync
+// CPU and does not yield):
+//
+//   no nudge          1424 MB
+//   Bun.gc(false)     1481 MB   (opportunistic: no help at all)
+//   Bun.gc(true)      1148 MB   (synchronous: the bound actually holds)
+//
+// 1148 MB is ~= one batch's live working set, which is the residency bound the
+// streaming design promises. Without the synchronous collect the walk drifts
+// above it by however much the collector happens to be behind — which is not a
+// property anything in the pipeline controls.
+//
+// So: a SYNCHRONOUS collect, once per batch, not the opportunistic one. The cost
+// is a full GC every `batchSize` pages (tens of milliseconds on a heap this
+// size, a few dozen times across an audit that runs for minutes) in exchange for
+// the peak being a function of batch size rather than of collector timing.
+
+/** Bun's GC hook, when running under Bun. Undefined elsewhere (Workers, node). */
+type GcHost = { Bun?: { gc?: (synchronous: boolean) => void } };
+
+/**
+ * Collect the batch just dropped. Best-effort and never throws: on a runtime
+ * without `Bun.gc` this is a no-op and the pipeline still behaves correctly,
+ * just with the collector's own timing deciding the peak.
+ */
+export function collectDroppedBatch(): void {
+  const gc = (globalThis as GcHost).Bun?.gc;
+  if (!gc) return;
+  try {
+    gc(true);
+  } catch {
+    // A runtime that exposes the hook but refuses the call — nothing to do.
+  }
+}

--- a/packages/audit-engine/src/cloud-prefetch-run.ts
+++ b/packages/audit-engine/src/cloud-prefetch-run.ts
@@ -535,10 +535,15 @@ export function createCloudPrefetchCollector(siteUrl: string): {
         if (home && !sample.includes(home)) sample.push(home);
       }
       // The batches these entries came from were released long ago; re-parse.
+      // Deterministic: `buildSiteContext` never yields a non-null `parsed`
+      // without html, so every retained entry can be rebuilt identically.
       ensureSiteContextDocuments(sample);
       const metadataPages = buildMetadataPayload(sample, siteUrl);
       // Release again — the sample is not read past this point, and the caller
-      // may still have a long network phase ahead of it.
+      // may still have a long network phase ahead of it. NOTE this mutates
+      // entries the caller handed to `absorb`; both callers release the whole
+      // context immediately after anyway, but a future caller that still needs
+      // those DOMs must re-materialize them.
       releaseSiteContextDocuments(sample);
 
       const urls = [...blocklistUrls];

--- a/packages/audit-engine/src/cloud-prefetch-run.ts
+++ b/packages/audit-engine/src/cloud-prefetch-run.ts
@@ -28,7 +28,12 @@ import {
   type CloudPrefetchResult,
   type CloudSitePayloads,
 } from "./cloud-prefetch";
-import { renderedPageUrlsFrom, releaseSiteContextDocuments, type SiteContextPage } from "./adapter";
+import {
+  ensureSiteContextDocuments,
+  renderedPageUrlsFrom,
+  releaseSiteContextDocuments,
+  type SiteContextPage,
+} from "./adapter";
 
 // The parsed page's linkedom Document, without adding a direct linkedom dep here.
 type Document = NonNullable<NonNullable<SiteContextPage["parsed"]>["document"]>;
@@ -209,35 +214,53 @@ function isHttpUrl(url: string): boolean {
 
 function collectBlocklistUrls(siteContext: SiteContextPage[]): string[] {
   const urls = new Set<string>();
+  absorbBlocklistUrls(urls, siteContext);
+  return [...urls];
+}
+
+/** {@link collectBlocklistUrls}' body, accumulating into `urls` so the streamed
+ * pre-rules pass can feed it batch by batch. The BL_MAX_URLS cap is a Set-size
+ * test, so stopping and resuming across batches sees exactly the sequence one
+ * whole-array pass would. */
+function absorbBlocklistUrls(urls: Set<string>, siteContext: SiteContextPage[]): void {
   for (const { page, parsed } of siteContext) {
     if (!parsed || page.status < 200 || page.status >= 300) continue;
     const pageHost = getHostname(page.url);
     for (const link of parsed.links) {
-      if (urls.size >= BL_MAX_URLS) return [...urls];
+      if (urls.size >= BL_MAX_URLS) return;
       if (!link.isInternal && isHttpUrl(link.url)) urls.add(link.url);
     }
     for (const image of parsed.images) {
-      if (urls.size >= BL_MAX_URLS) return [...urls];
+      if (urls.size >= BL_MAX_URLS) return;
       if (isHttpUrl(image.src) && getHostname(image.src) !== pageHost) urls.add(image.src);
     }
     const doc = parsed.document;
     if (!doc) continue;
     for (const script of doc.querySelectorAll("script[src]")) {
-      if (urls.size >= BL_MAX_URLS) return [...urls];
+      if (urls.size >= BL_MAX_URLS) return;
       const src = (script as Element).getAttribute("src");
       if (src && isHttpUrl(src) && getHostname(src) !== pageHost) urls.add(src);
     }
   }
-  return [...urls];
 }
 
 function collectBlocklistSelectors(siteContext: SiteContextPage[]): string[] {
-  const selectors = new Set<string>();
-  let pagesScanned = 0;
+  const state = { selectors: new Set<string>(), pagesScanned: 0 };
+  absorbBlocklistSelectors(state, siteContext);
+  return [...state.selectors];
+}
+
+/** {@link collectBlocklistSelectors}' body over carried state, so the page-scan
+ * budget (BL_MAX_SELECTOR_PAGES) spans batches instead of resetting per batch. */
+function absorbBlocklistSelectors(
+  state: { selectors: Set<string>; pagesScanned: number },
+  siteContext: SiteContextPage[],
+): void {
+  const { selectors } = state;
   for (const { page, parsed } of siteContext) {
-    if (selectors.size >= BL_MAX_SELECTORS || pagesScanned >= BL_MAX_SELECTOR_PAGES) break;
+    if (selectors.size >= BL_MAX_SELECTORS || state.pagesScanned >= BL_MAX_SELECTOR_PAGES) return;
     if (!parsed?.document || page.status < 200 || page.status >= 300) continue;
-    pagesScanned++;
+    state.pagesScanned++;
     let elements: Iterable<Element>;
     try {
       elements = parsed.document.querySelectorAll("[class], [id]");
@@ -256,7 +279,6 @@ function collectBlocklistSelectors(siteContext: SiteContextPage[]): string[] {
       }
     }
   }
-  return [...selectors];
 }
 
 export function buildBlocklistPayload(
@@ -339,8 +361,19 @@ function cleanSeed(text: string): string | null {
 }
 
 function collectSeeds(siteContext: SiteContextPage[]): string[] {
-  const seeds: string[] = [];
-  const seen = new Set<string>();
+  const state = { seeds: [] as string[], seen: new Set<string>() };
+  absorbSeeds(state, siteContext);
+  return state.seeds;
+}
+
+/** {@link collectSeeds}' body over carried state, so the seed cap and the
+ * dedupe set span batches (#1860). */
+function absorbSeeds(
+  state: { seeds: string[]; seen: Set<string> },
+  siteContext: SiteContextPage[],
+): void {
+  const { seeds, seen } = state;
+  if (seeds.length >= SERVICE_LIMITS.gapsMaxSeeds) return;
   for (const { page, parsed } of siteContext) {
     if (!parsed || page.status < 200 || page.status >= 300) continue;
     const candidates = [parsed.meta.title ?? "", ...parsed.h1.texts];
@@ -351,10 +384,9 @@ function collectSeeds(siteContext: SiteContextPage[]): string[] {
       if (seen.has(key)) continue;
       seen.add(key);
       seeds.push(seed);
-      if (seeds.length >= SERVICE_LIMITS.gapsMaxSeeds) return seeds;
+      if (seeds.length >= SERVICE_LIMITS.gapsMaxSeeds) return;
     }
   }
-  return seeds;
 }
 
 export function buildGapsPayloads(
@@ -362,8 +394,17 @@ export function buildGapsPayloads(
   baseUrl: string,
   config: Config,
 ): GapsPayloads {
+  return buildGapsPayloadsFromSeeds(collectSeeds(siteContext), baseUrl, config);
+}
+
+/** {@link buildGapsPayloads} over seeds gathered elsewhere — the streamed
+ * pre-rules pass accumulates them batch by batch (#1860). */
+export function buildGapsPayloadsFromSeeds(
+  seeds: string[],
+  baseUrl: string,
+  config: Config,
+): GapsPayloads {
   const domain = apexDomain(baseUrl);
-  const seeds = collectSeeds(siteContext);
   if (!domain || seeds.length === 0) return {};
   const keywordOpts = gapsOptions(config, "gaps/keywords");
   const contentOpts = gapsOptions(config, "gaps/content");
@@ -405,6 +446,111 @@ export const gateStage1 = (meta: SiteMetadata, service: CloudServiceId): boolean
   }
 };
 
+/** Everything {@link runContainerCloudPrefetchFromPayloads} needs from the crawl's
+ * pages, all of it bounded by a cap rather than by page count. */
+export interface CloudPrefetchPayloadSet {
+  pages: CloudPagePayload[];
+  metadataPages: SiteMetadataPagePayload[];
+  blocklist: { urls: string[]; selectors: string[] } | null;
+  gapsSeeds: string[];
+  renderedPageUrls: Set<string>;
+}
+
+/**
+ * Batch-absorbing collector for the cloud-prefetch payloads (#1860). Every
+ * payload but the site-metadata sample accumulates straight out of each batch
+ * (with the DOMs live for blocklist srcs and selectors), so nothing page-scaled
+ * is retained.
+ *
+ * The metadata sample is the exception: {@link buildMetadataPayload} picks the
+ * homepage plus the first `metadataMaxPages` usable pages and shares one JSON-LD
+ * byte budget across them, so it has to run once over an ordered sample. This
+ * retains exactly that sample — the first `metadataMaxPages` usable entries plus
+ * the first entry matching each home predicate — and re-materializes their DOMs
+ * at `build` time. That reproduces `buildMetadataPayload`'s pick exactly: the
+ * home predicates are evaluated in crawl order, so an entry that matches one of
+ * them later than the retained prefix could only have matched had no earlier
+ * entry matched it, which is the same entry `findIndex` selects over the full
+ * list. Retention is `metadataMaxPages + 2` pages, not O(pages).
+ *
+ * `absorb` MUST be called with the batch's DOMs live. `build` may be called
+ * after the batches have been released; it re-parses the retained sample's HTML,
+ * which `ensureSiteContextDocuments` guarantees is deterministic.
+ */
+export function createCloudPrefetchCollector(siteUrl: string): {
+  absorb: (siteContext: SiteContextPage[]) => void;
+  build: () => CloudPrefetchPayloadSet;
+} {
+  const pages: CloudPagePayload[] = [];
+  const renderedPageUrls = new Set<string>();
+  const blocklistUrls = new Set<string>();
+  const selectorState = { selectors: new Set<string>(), pagesScanned: 0 };
+  const seedState = { seeds: [] as string[], seen: new Set<string>() };
+
+  // Retained metadata sample (see the doc above) — bounded, never page-scaled.
+  const metadataPrefix: SiteContextPage[] = [];
+  let primaryHome: SiteContextPage | undefined;
+  let rootHome: SiteContextPage | undefined;
+
+  const baseOrigin = getOrigin(siteUrl);
+  const isRoot = (u: string): boolean => {
+    const path = getPathname(u);
+    return getOrigin(u) === baseOrigin && (path === "" || path === "/");
+  };
+
+  return {
+    absorb(siteContext: SiteContextPage[]): void {
+      for (const payload of buildCloudPagePayloads(siteContext)) pages.push(payload);
+      for (const url of renderedPageUrlsFrom(siteContext)) renderedPageUrls.add(url);
+      absorbBlocklistUrls(blocklistUrls, siteContext);
+      absorbBlocklistSelectors(selectorState, siteContext);
+      absorbSeeds(seedState, siteContext);
+
+      for (const entry of siteContext) {
+        // Same "usable" test buildMetadataPayload applies.
+        if (entry.parsed?.document == null) continue;
+        if (entry.page.status < 200 || entry.page.status >= 300) continue;
+        if (metadataPrefix.length < SERVICE_LIMITS.metadataMaxPages) metadataPrefix.push(entry);
+        if (
+          !primaryHome &&
+          (entry.page.finalUrl === siteUrl || entry.page.url === siteUrl)
+        ) {
+          primaryHome = entry;
+        }
+        if (!rootHome && (isRoot(entry.page.finalUrl || entry.page.url) || isRoot(entry.page.url))) {
+          rootHome = entry;
+        }
+      }
+    },
+
+    build(): CloudPrefetchPayloadSet {
+      // Dedupe by identity, preserving encounter order: a home already inside the
+      // retained prefix must not appear twice, or buildMetadataPayload's
+      // `usable.filter(p => p !== home)` would leave a duplicate in `rest`.
+      const sample: SiteContextPage[] = [...metadataPrefix];
+      for (const home of [primaryHome, rootHome]) {
+        if (home && !sample.includes(home)) sample.push(home);
+      }
+      // The batches these entries came from were released long ago; re-parse.
+      ensureSiteContextDocuments(sample);
+      const metadataPages = buildMetadataPayload(sample, siteUrl);
+      // Release again — the sample is not read past this point, and the caller
+      // may still have a long network phase ahead of it.
+      releaseSiteContextDocuments(sample);
+
+      const urls = [...blocklistUrls];
+      const selectors = [...selectorState.selectors];
+      return {
+        pages,
+        metadataPages,
+        blocklist: urls.length === 0 && selectors.length === 0 ? null : { urls, selectors },
+        gapsSeeds: seedState.seeds,
+        renderedPageUrls,
+      };
+    },
+  };
+}
+
 export interface ContainerPrefetchInput {
   client: CloudServicesClient;
   /** Full config — drives rule selection (config.rules) + prefetch (config.cloud). */
@@ -434,15 +580,47 @@ export async function runContainerCloudPrefetch(
   input: ContainerPrefetchInput,
 ): Promise<CloudPrefetchResult | null> {
   if (input.remainingBudget <= 0) return null;
+  if (selectCloudRules(input.config).length === 0) return null;
+
+  const collector = createCloudPrefetchCollector(input.siteUrl);
+  collector.absorb(input.siteContext);
+  const payloads = collector.build();
+
+  // Payloads built — nothing reads the DOMs again until the rules phase
+  // (runRulesOnStorage re-materializes idempotently), so drop them for the
+  // network waits. Mirrors the CLI's onPayloadsBuilt release; matters more
+  // here since the container runs under a fixed memory ceiling (#858).
+  releaseSiteContextDocuments(input.siteContext);
+
+  return runContainerCloudPrefetchFromPayloads(
+    {
+      client: input.client,
+      config: input.config,
+      siteUrl: input.siteUrl,
+      auditId: input.auditId,
+      remainingBudget: input.remainingBudget,
+      crawlRendered: input.crawlRendered,
+    },
+    payloads,
+  );
+}
+
+/**
+ * {@link runContainerCloudPrefetch} over payloads collected elsewhere — the
+ * streamed pre-rules pass builds them batch by batch (#1860) rather than from a
+ * whole-crawl site context. Same request body either way.
+ */
+export async function runContainerCloudPrefetchFromPayloads(
+  input: Omit<ContainerPrefetchInput, "siteContext">,
+  payloads: CloudPrefetchPayloadSet,
+): Promise<CloudPrefetchResult | null> {
+  if (input.remainingBudget <= 0) return null;
   const rules = selectCloudRules(input.config);
   if (rules.length === 0) return null;
 
-  const pages = buildCloudPagePayloads(input.siteContext);
-  const metadataPages = buildMetadataPayload(input.siteContext, input.siteUrl);
-  const blocklist = buildBlocklistPayload(input.siteContext);
   const sitePayloads: CloudSitePayloads = {
-    ...(blocklist ? { "blocklist-check": blocklist } : {}),
-    ...buildGapsPayloads(input.siteContext, input.siteUrl, input.config),
+    ...(payloads.blocklist ? { "blocklist-check": payloads.blocklist } : {}),
+    ...buildGapsPayloadsFromSeeds(payloads.gapsSeeds, input.siteUrl, input.config),
     // Archive Indexing (#789) — payload is just the site URL.
     "archive-indexing": { url: input.siteUrl },
   };
@@ -452,22 +630,12 @@ export async function runContainerCloudPrefetch(
     ? Math.max(0, Math.floor(input.remainingBudget))
     : 0;
 
-  // Per-page render provenance (#673/#964): the render service skips pages the crawl already rendered, so an
-  // "auto" hybrid crawl doesn't pay to re-render its upgraded pages. Built before the document release below.
-  const renderedPageUrls = renderedPageUrlsFrom(input.siteContext);
-
-  // Payloads built — nothing reads the DOMs again until the rules phase
-  // (runRulesOnStorage re-materializes idempotently), so drop them for the
-  // network waits. Mirrors the CLI's onPayloadsBuilt release; matters more
-  // here since the container runs under a fixed memory ceiling (#858).
-  releaseSiteContextDocuments(input.siteContext);
-
   return prefetchCloudData({
     client: input.client,
     config: { ...input.config.cloud, max_credits_per_audit: cap },
     rules,
-    pages,
-    metadataPages,
+    pages: payloads.pages,
+    metadataPages: payloads.metadataPages,
     sitePayloads,
     gate: gateStage1,
     siteUrl: input.siteUrl,
@@ -476,8 +644,9 @@ export async function runContainerCloudPrefetch(
     // Sourced from the container's actual render decision (see ContainerPrefetchInput.crawlRendered) —
     // config.cloud.rendering is unset on this path, so reading it here would leave render charged+discarded.
     crawlRendered: input.crawlRendered,
-    // Per-page skip for the pages an "auto" crawl already rendered (charge-free, rule-discarded otherwise).
-    renderedPageUrls,
+    // Per-page render provenance (#673/#964): the render service skips pages the crawl already rendered, so an
+    // "auto" hybrid crawl doesn't pay to re-render its upgraded pages.
+    renderedPageUrls: payloads.renderedPageUrls,
     // No `confirm` — the dashboard spendAck already consented; the cap bounds spend.
   });
 }

--- a/packages/audit-engine/src/cloud-prefetch-run.ts
+++ b/packages/audit-engine/src/cloud-prefetch-run.ts
@@ -459,8 +459,11 @@ export interface CloudPrefetchPayloadSet {
 /**
  * Batch-absorbing collector for the cloud-prefetch payloads (#1860). Every
  * payload but the site-metadata sample accumulates straight out of each batch
- * (with the DOMs live for blocklist srcs and selectors), so nothing page-scaled
- * is retained.
+ * (with the DOMs live for blocklist srcs and selectors), so no DOM and no page
+ * html is retained. `pages` IS one payload per 2xx page — a 6 KB excerpt plus
+ * headings, so a few MB on a 500-page crawl — which is what v1 built too; the
+ * change is that it is now live for the whole pre-rules phase rather than only
+ * at prefetch time.
  *
  * The metadata sample is the exception: {@link buildMetadataPayload} picks the
  * homepage plus the first `metadataMaxPages` usable pages and shares one JSON-LD

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -17,6 +17,13 @@ export {
   isRenderedFetch,
   renderedPageUrlsFrom,
   setAdapterLogger,
+  // Pre-rules collection seams (#1860) — the DOM-needing halves of the asset and
+  // external-link phases, split so they can be fed one page batch at a time.
+  absorbExternalLinkOccurrences,
+  checkCollectedExternalLinks,
+  createSiteAssetCollector,
+  fetchAssetsFromOccurrences,
+  V1_REPORT_PAGE_BATCH,
 } from "./adapter";
 export type {
   SiteContextPage,
@@ -25,11 +32,19 @@ export type {
   PreFetchedAssets,
   ResourceCheckOverrides,
   ExternalLinkCheckProgress,
+  ExternalLinkOccurrences,
+  SiteAssetOccurrences,
+  BuildV1ReportOptions,
   FullAuditReport,
   PageAudit,
   AuditSummary,
   AdapterLogger,
 } from "./adapter";
+
+// Streamed pre-rules phase (#1860) — one batched walk that feeds the asset,
+// external-link, tech-detect, intel and cloud-prefetch collectors together.
+export { runStreamingPreRules, PRE_RULES_PAGE_BATCH } from "./streaming-pre-rules";
+export type { StreamPreRulesOptions, StreamPreRulesResult } from "./streaming-pre-rules";
 
 export {
   calculateHealthScore,

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -41,11 +41,6 @@ export type {
   AdapterLogger,
 } from "./adapter";
 
-// Streamed pre-rules phase (#1860) — one batched walk that feeds the asset,
-// external-link, tech-detect, intel and cloud-prefetch collectors together.
-export { runStreamingPreRules, PRE_RULES_PAGE_BATCH } from "./streaming-pre-rules";
-export type { StreamPreRulesOptions, StreamPreRulesResult } from "./streaming-pre-rules";
-
 export {
   calculateHealthScore,
   deriveAuditStatus,
@@ -120,6 +115,7 @@ export * from "./runner";
 export {
   localIntelContext,
   buildFullIntelContext,
+  buildFullIntelContextFromUrls,
   mapIntelConfig,
   collectIntelUrls,
 } from "./intel";
@@ -193,3 +189,8 @@ export { isHtmlContentType } from "./adapter";
 // Streaming rules engine (#1021, PR-E) — batched page-rule pass with DOM-drop.
 export { streamPageRules, STREAM_PAGE_BATCH } from "./streaming";
 export type { PageSignalCollector, StreamPageRulesHooks, StreamPageRulesResult } from "./streaming";
+
+// Streamed pre-rules phase (#1860) — one batched walk that feeds the asset,
+// external-link, tech-detect, intel and cloud-prefetch collectors together.
+export { runStreamingPreRules, PRE_RULES_PAGE_BATCH } from "./streaming-pre-rules";
+export type { StreamPreRulesOptions, StreamPreRulesResult } from "./streaming-pre-rules";

--- a/packages/audit-engine/src/intel.ts
+++ b/packages/audit-engine/src/intel.ts
@@ -67,11 +67,24 @@ export async function buildFullIntelContext(
   config: Config,
   input: { siteContext: SiteContextPage[]; baseUrl?: string; kv?: KvStore },
 ): Promise<IntelContext> {
-  const intelConfig = mapIntelConfig(config);
-  if (!intelConfig) return buildIntelContext();
-  const resolved = await prefetchIntel(intelConfig, {
+  return buildFullIntelContextFromUrls(config, {
     urls: collectIntelUrls(input.siteContext, input.baseUrl),
     kv: input.kv,
   });
+}
+
+/**
+ * {@link buildFullIntelContext} over URLs gathered elsewhere — the streamed
+ * pre-rules pass accumulates them batch by batch rather than from a whole-crawl
+ * site context (#1860). Same seeding order: base URL first, then each page's
+ * `url` and `finalUrl` in crawl order.
+ */
+export async function buildFullIntelContextFromUrls(
+  config: Config,
+  input: { urls: string[]; kv?: KvStore },
+): Promise<IntelContext> {
+  const intelConfig = mapIntelConfig(config);
+  if (!intelConfig) return buildIntelContext();
+  const resolved = await prefetchIntel(intelConfig, { urls: input.urls, kv: input.kv });
   return buildIntelContext({ resolved });
 }

--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -308,25 +308,40 @@ export interface FullAuditReport extends AuditReport {
   sitemapUrlStatuses?: SitemapUrlStatusData[];
 }
 
+/** Default page batch for v1's summary + pageAudits pass (#1860). */
+export const V1_REPORT_PAGE_BATCH = 100;
+
+export interface BuildV1ReportOptions {
+  batchSize?: number;
+  /** Fired after each page batch with the running count. The container wires its
+   * liveness heartbeat here so a large-crawl report tail keeps the run alive
+   * (aligns #1252) instead of going silent for the whole assembly. */
+  onBatch?: (info: { pagesDone: number }) => void;
+}
+
 /**
  * Build a FullAuditReport from crawler storage — the v1 (non-streaming) path.
  *
  * Moved verbatim from adapter.generateReportFromStorage (#1021, PR-F); adapter's
  * exported generateReportFromStorage is now a one-line delegate to this. Keeping
  * it byte-identical is the 518-page golden-diff gate.
+ *
+ * #1860: the one whole-crawl `getPages` this used to make is now a batched walk
+ * (see the pass below). Output is unchanged — the batching is a residency fix,
+ * not a report change — and the golden baseline gates that.
  */
 export function buildV1Report(
   storage: CrawlStorage,
   crawlId: string,
   ruleResults: RuleExecutionResult,
+  options?: BuildV1ReportOptions,
 ): Effect.Effect<FullAuditReport, never, never> {
   return Effect.gen(function* () {
     const reportSpan = logger.traceStart("generateReportFromStorage");
+    const batchSize = options?.batchSize ?? V1_REPORT_PAGE_BATCH;
     const crawl = yield* storage
       .getCrawl(crawlId)
       .pipe(Effect.catchAll(() => Effect.succeed(null)));
-
-    const pages = yield* storage.getPages(crawlId).pipe(Effect.catchAll(() => Effect.succeed([])));
 
     const links = yield* storage.getLinks(crawlId).pipe(Effect.catchAll(() => Effect.succeed([])));
 
@@ -362,22 +377,6 @@ export function buildV1Report(
       redirectChains: [],
       securityIssues: [],
     };
-
-    // Use cached parsed pages for summary (optimization: no redundant parsing)
-    const summaryParseSpan = logger.traceStart("summary:useCachedParsed");
-    for (const page of pages) {
-      const parsed = ruleResults.parsedPages.get(page.normalizedUrl);
-      if (!parsed) continue;
-
-      if (!parsed.meta.title) summary.missingTitles.push(page.normalizedUrl);
-      if (!parsed.meta.description) summary.missingDescriptions.push(page.normalizedUrl);
-      if (!parsed.og.title && !parsed.og.image) summary.missingOgTags.push(page.normalizedUrl);
-      if (!parsed.twitter.card) summary.missingTwitterCards.push(page.normalizedUrl);
-      if (!parsed.schema.types.length) summary.missingSchemas.push(page.normalizedUrl);
-      if (parsed.h1.count > 1) summary.multipleH1s.push(page.normalizedUrl);
-      if (parsed.content.isThinContent) summary.thinContentPages.push(page.normalizedUrl);
-    }
-    logger.traceEnd(summaryParseSpan, { pageCount: pages.length });
 
     // Check missing alt text (batch query when available)
     const imageAppearancesSpan = logger.traceStart("imageAppearances");
@@ -421,12 +420,42 @@ export function buildV1Report(
       results: ruleResults.ruleResultsMap,
     });
 
-    // Build page audits (optimization: use cached parsed pages)
+    // Build the summary + page audits in ONE batched pass over the crawl's pages
+    // (#1860). Batched rather than one `getPages(crawlId)` because a PageRecord
+    // carries the page's full html: on a 500-page crawl of ~1 MB pages the
+    // resident array alone was ~600 MB, landing on top of the rules phase's peak.
+    // `getPages` orders by normalized_url ASC with or without LIMIT/OFFSET, so
+    // walking it in batches visits exactly the sequence the resident array did —
+    // same summary entries, same pageAudits order, byte-identical report.
     const pageAuditsSpan = logger.traceStart("pageAudits:useCachedParsed");
     const pageAudits: PageAudit[] = [];
-    for (const page of pages) {
+    // Statuses only — all `deriveAuditStatusFromPages` and the rate-limit count
+    // read, and 8 bytes a page instead of a megabyte.
+    const pageStatuses: Array<{ status: number }> = [];
+    let pagesCrawled = 0;
+    for (let offset = 0; ; offset += batchSize) {
+      // Fail-loud: a mid-stream read failure must not masquerade as end-of-crawl
+      // and silently truncate the report's page set (matches streamPageRules).
+      const batch = yield* storage
+        .getPages(crawlId, { limit: batchSize, offset })
+        .pipe(Effect.orDie);
+      if (batch.length === 0) break;
+
+      for (const page of batch) {
+      pagesCrawled++;
+      pageStatuses.push({ status: page.status });
       const parsed = ruleResults.parsedPages.get(page.normalizedUrl) ?? null;
       const pageChecks = ruleResults.pageResults.get(page.normalizedUrl) ?? [];
+
+      if (parsed) {
+        if (!parsed.meta.title) summary.missingTitles.push(page.normalizedUrl);
+        if (!parsed.meta.description) summary.missingDescriptions.push(page.normalizedUrl);
+        if (!parsed.og.title && !parsed.og.image) summary.missingOgTags.push(page.normalizedUrl);
+        if (!parsed.twitter.card) summary.missingTwitterCards.push(page.normalizedUrl);
+        if (!parsed.schema.types.length) summary.missingSchemas.push(page.normalizedUrl);
+        if (parsed.h1.count > 1) summary.multipleH1s.push(page.normalizedUrl);
+        if (parsed.content.isThinContent) summary.thinContentPages.push(page.normalizedUrl);
+      }
 
       // Get links for this page using per-page index lookup
       const pageLinkAppearances = hasSqliteStorage
@@ -497,8 +526,12 @@ export function buildV1Report(
         fetcherId: page.fetcherId,
         fallbackReason: page.fallbackReason,
       });
+      }
+
+      options?.onBatch?.({ pagesDone: pagesCrawled });
+      if (batch.length < batchSize) break;
     }
-    logger.traceEnd(pageAuditsSpan, { pageCount: pages.length });
+    logger.traceEnd(pageAuditsSpan, { pageCount: pagesCrawled });
 
     // Calculate totals from the per-rule map so rule meta is in reach:
     // warn checks in severity-"info" rules are recommendations — surfaced in
@@ -531,7 +564,7 @@ export function buildV1Report(
       // Present only when the crawler refused an off-site seed redirect (#1418).
       ...(refusedSeedRedirect ? { finalUrl: refusedSeedRedirect } : {}),
       timestamp: new Date().toISOString(),
-      totalPages: pages.length,
+      totalPages: pagesCrawled,
       passed,
       warnings,
       failed,
@@ -583,13 +616,13 @@ export function buildV1Report(
     // too. The reason names the host that throttled us.
     const rateLimitedCount =
       (crawl?.stats?.pagesRateLimited ?? 0) +
-      pages.filter((page) => isRateLimitStatus(page.status)).length;
+      pageStatuses.filter((page) => isRateLimitStatus(page.status)).length;
     const rateLimitedHosts = rateLimitedHostsFor(result.baseUrl, rateLimitedCount);
     if (rateLimitedCount > 0) {
       result.rateLimited = { pages: rateLimitedCount, hosts: rateLimitedHosts };
     }
     const runStatus = deriveAuditStatusFromPages(
-      pages,
+      pageStatuses,
       crawl?.stats?.pagesBlocked ?? 0,
       {
         errors: crawl?.stats?.pagesRateLimited ?? 0,
@@ -623,7 +656,7 @@ export function buildV1Report(
 
     sanitizeReportRuleResults(result.ruleResults);
 
-    logger.traceEnd(reportSpan, { totalPages: pages.length });
+    logger.traceEnd(reportSpan, { totalPages: pagesCrawled });
     return result;
   });
 }

--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -436,8 +436,14 @@ export function buildV1Report(
     const pageStatuses: Array<{ status: number }> = [];
     let pagesCrawled = 0;
     for (let offset = 0; ; offset += batchSize) {
-      // Fail-loud: a mid-stream read failure must not masquerade as end-of-crawl
-      // and silently truncate the report's page set (matches streamPageRules).
+      // Fail-loud, and a deliberate change from the single resident read this
+      // replaced. That read degraded to `[]` on failure, which produced a
+      // `totalPages: 0` report — wrong, but visibly wrong. Degrading a BATCHED
+      // read the same way is worse: it would end the walk at an arbitrary offset
+      // and publish a confident report over a truncated page set. So a mid-walk
+      // read failure now kills the run instead. The cost is that a caller which
+      // used to get a failed-looking report for an unreadable crawl now gets a
+      // rejected promise (matches streamPageRules and site-query.ts).
       const batch = yield* storage
         .getPages(crawlId, { limit: batchSize, offset })
         .pipe(Effect.orDie);

--- a/packages/audit-engine/src/report-stream.ts
+++ b/packages/audit-engine/src/report-stream.ts
@@ -338,7 +338,9 @@ export function buildV1Report(
 ): Effect.Effect<FullAuditReport, never, never> {
   return Effect.gen(function* () {
     const reportSpan = logger.traceStart("generateReportFromStorage");
-    const batchSize = options?.batchSize ?? V1_REPORT_PAGE_BATCH;
+    // Clamped — a 0 batch is an infinite loop (LIMIT 0 is unlimited in SQLite
+    // and the offset never advances). See streaming-pre-rules.ts.
+    const batchSize = Math.max(1, options?.batchSize ?? V1_REPORT_PAGE_BATCH);
     const crawl = yield* storage
       .getCrawl(crawlId)
       .pipe(Effect.catchAll(() => Effect.succeed(null)));
@@ -442,90 +444,90 @@ export function buildV1Report(
       if (batch.length === 0) break;
 
       for (const page of batch) {
-      pagesCrawled++;
-      pageStatuses.push({ status: page.status });
-      const parsed = ruleResults.parsedPages.get(page.normalizedUrl) ?? null;
-      const pageChecks = ruleResults.pageResults.get(page.normalizedUrl) ?? [];
+        pagesCrawled++;
+        pageStatuses.push({ status: page.status });
+        const parsed = ruleResults.parsedPages.get(page.normalizedUrl) ?? null;
+        const pageChecks = ruleResults.pageResults.get(page.normalizedUrl) ?? [];
 
-      if (parsed) {
-        if (!parsed.meta.title) summary.missingTitles.push(page.normalizedUrl);
-        if (!parsed.meta.description) summary.missingDescriptions.push(page.normalizedUrl);
-        if (!parsed.og.title && !parsed.og.image) summary.missingOgTags.push(page.normalizedUrl);
-        if (!parsed.twitter.card) summary.missingTwitterCards.push(page.normalizedUrl);
-        if (!parsed.schema.types.length) summary.missingSchemas.push(page.normalizedUrl);
-        if (parsed.h1.count > 1) summary.multipleH1s.push(page.normalizedUrl);
-        if (parsed.content.isThinContent) summary.thinContentPages.push(page.normalizedUrl);
-      }
+        if (parsed) {
+          if (!parsed.meta.title) summary.missingTitles.push(page.normalizedUrl);
+          if (!parsed.meta.description) summary.missingDescriptions.push(page.normalizedUrl);
+          if (!parsed.og.title && !parsed.og.image) summary.missingOgTags.push(page.normalizedUrl);
+          if (!parsed.twitter.card) summary.missingTwitterCards.push(page.normalizedUrl);
+          if (!parsed.schema.types.length) summary.missingSchemas.push(page.normalizedUrl);
+          if (parsed.h1.count > 1) summary.multipleH1s.push(page.normalizedUrl);
+          if (parsed.content.isThinContent) summary.thinContentPages.push(page.normalizedUrl);
+        }
 
-      // Get links for this page using per-page index lookup
-      const pageLinkAppearances = hasSqliteStorage
-        ? yield* (storage as import("@squirrelscan/crawler").SQLiteStorage)
-            .getLinkAppearancesForPage(crawlId, page.normalizedUrl)
-            .pipe(Effect.catchAll(() => Effect.succeed([])))
-        : [];
-      const pageLinks = pageLinkAppearances.map((a) => ({
-        url: a.href,
-        text: a.anchorText,
-        isInternal: linkByHref.get(a.href)?.isInternal ?? false,
-      }));
+        // Get links for this page using per-page index lookup
+        const pageLinkAppearances = hasSqliteStorage
+          ? yield* (storage as import("@squirrelscan/crawler").SQLiteStorage)
+              .getLinkAppearancesForPage(crawlId, page.normalizedUrl)
+              .pipe(Effect.catchAll(() => Effect.succeed([])))
+          : [];
+        const pageLinks = pageLinkAppearances.map((a) => ({
+          url: a.href,
+          text: a.anchorText,
+          isInternal: linkByHref.get(a.href)?.isInternal ?? false,
+        }));
 
-      // Get images for this page using per-page index lookup
-      const pageImageAppearances = hasSqliteStorage
-        ? yield* (storage as import("@squirrelscan/crawler").SQLiteStorage)
-            .getImageAppearancesForPage(crawlId, page.normalizedUrl)
-            .pipe(Effect.catchAll(() => Effect.succeed([])))
-        : [];
-      const pageImages = pageImageAppearances.map((a) => ({
-        src: a.src,
-        alt: a.alt ?? null,
-        width: null,
-        height: null,
-      }));
+        // Get images for this page using per-page index lookup
+        const pageImageAppearances = hasSqliteStorage
+          ? yield* (storage as import("@squirrelscan/crawler").SQLiteStorage)
+              .getImageAppearancesForPage(crawlId, page.normalizedUrl)
+              .pipe(Effect.catchAll(() => Effect.succeed([])))
+          : [];
+        const pageImages = pageImageAppearances.map((a) => ({
+          src: a.src,
+          alt: a.alt ?? null,
+          width: null,
+          height: null,
+        }));
 
-      pageAudits.push({
-        url: page.normalizedUrl,
-        statusCode: page.status,
-        loadTime: page.loadTimeMs,
-        meta: parsed?.meta ?? {
-          title: null,
-          description: null,
-          canonical: null,
-          robots: null,
-        },
-        og: parsed?.og ?? {
-          title: null,
-          description: null,
-          url: null,
-          type: null,
-          image: null,
-          siteName: null,
-        },
-        twitter: parsed?.twitter ?? {
-          card: null,
-          title: null,
-          description: null,
-          image: null,
-        },
-        schema: parsed?.schema ?? {
-          types: [],
-          valid: true,
-          errors: [],
-          raw: null,
-        },
-        links: pageLinks,
-        images: pageImages,
-        h1Count: parsed?.h1.count ?? 0,
-        h1Text: parsed?.h1.texts ?? [],
-        // #1003: bound oversize item ids/items-arrays and cap a page's own
-        // checks count at maxChecksPerPage — the cloud path publishes pages[]
-        // unstripped, so an over-cap single page hit the schema's silent
-        // slice. A page's checks mix many DIFFERENT rules, so this must NOT
-        // fold by (name,status) like capChecksForPublish does (see its doc).
-        checks: capMixedRuleChecksForPublish(pageChecks, REPORT_LIMITS.maxChecksPerPage),
-        redirectChain: page.redirectChain,
-        fetcherId: page.fetcherId,
-        fallbackReason: page.fallbackReason,
-      });
+        pageAudits.push({
+          url: page.normalizedUrl,
+          statusCode: page.status,
+          loadTime: page.loadTimeMs,
+          meta: parsed?.meta ?? {
+            title: null,
+            description: null,
+            canonical: null,
+            robots: null,
+          },
+          og: parsed?.og ?? {
+            title: null,
+            description: null,
+            url: null,
+            type: null,
+            image: null,
+            siteName: null,
+          },
+          twitter: parsed?.twitter ?? {
+            card: null,
+            title: null,
+            description: null,
+            image: null,
+          },
+          schema: parsed?.schema ?? {
+            types: [],
+            valid: true,
+            errors: [],
+            raw: null,
+          },
+          links: pageLinks,
+          images: pageImages,
+          h1Count: parsed?.h1.count ?? 0,
+          h1Text: parsed?.h1.texts ?? [],
+          // #1003: bound oversize item ids/items-arrays and cap a page's own
+          // checks count at maxChecksPerPage — the cloud path publishes pages[]
+          // unstripped, so an over-cap single page hit the schema's silent
+          // slice. A page's checks mix many DIFFERENT rules, so this must NOT
+          // fold by (name,status) like capChecksForPublish does (see its doc).
+          checks: capMixedRuleChecksForPublish(pageChecks, REPORT_LIMITS.maxChecksPerPage),
+          redirectChain: page.redirectChain,
+          fetcherId: page.fetcherId,
+          fallbackReason: page.fallbackReason,
+        });
       }
 
       options?.onBatch?.({ pagesDone: pagesCrawled });
@@ -721,7 +723,8 @@ export function buildV2Report(
 ): Effect.Effect<FullAuditReport, never, never> {
   return Effect.gen(function* () {
     const reportSpan = logger.traceStart("buildV2Report");
-    const batchSize = options?.batchSize ?? V2_REPORT_BATCH;
+    // Clamped for the same reason as buildV1Report's walk above.
+    const batchSize = Math.max(1, options?.batchSize ?? V2_REPORT_BATCH);
     const maxSummaryItems = REPORT_LIMITS.maxSummaryItems;
 
     const crawl = yield* storage

--- a/packages/audit-engine/src/streaming-pre-rules.ts
+++ b/packages/audit-engine/src/streaming-pre-rules.ts
@@ -1,0 +1,195 @@
+// Streamed pre-rules phase (#1860) — the half of a cloud audit that sits between
+// the crawl and `runStreamingRules`.
+//
+// `runStreamingRules` already bounds the RULES phase to one batch of live DOMs,
+// but wiring it into `runCloudAudit` alone would not have bounded anything: the
+// runtime built ONE `buildSiteContext` over every crawled page and handed that
+// same resident array, DOMs and all, to the external-link check, the resource
+// asset pass and the cloud prefetch. Three of the four consumers genuinely need
+// a parsed document per page (link position, stylesheet/script srcs, blocklist
+// srcs + selectors), so the DOMs stayed live from the end of the crawl until the
+// prefetch released them — the 2.2 GB of linkedom that OOM-killed a 500-page
+// audit of ~1 MB pages (#1862).
+//
+// This runs those consumers' COLLECTION halves together in one batched walk of
+// the pages table: parse a batch, absorb it into every collector while its DOMs
+// are live, drop the batch, repeat. What each collector retains is bounded by
+// the site's distinct sub-resource URLs and by explicit payload caps, never by
+// page count × page size. The network halves (link checking, asset fetching) then
+// run once over the collected occurrences, exactly as before.
+//
+// Parity: every collector here is the SAME code the whole-array entry point runs
+// (`fetchResourceAssets`, `checkExternalLinksOnStorage`,
+// `runContainerCloudPrefetch` all delegate into these accumulators), so there is
+// no second implementation to drift. `tests/streaming-pre-rules-golden.test.ts`
+// pins that by running both paths over one crawl and deep-comparing the outputs.
+
+import { Effect } from "effect";
+
+import type { ExternalLinksConfig, Config } from "@squirrelscan/config";
+import type { PageRecord } from "@squirrelscan/core-contracts";
+import type { SQLiteStorage } from "@squirrelscan/crawler";
+
+import {
+  absorbExternalLinkOccurrences,
+  buildSiteContext,
+  checkCollectedExternalLinks,
+  createSiteAssetCollector,
+  fetchAssetsFromOccurrences,
+  releaseSiteContextDocuments,
+  type ExternalLinkCheckProgress,
+  type ExternalLinkOccurrences,
+  type PreFetchedAssets,
+  type ResourceCheckOverrides,
+} from "./adapter";
+import { createCloudPrefetchCollector, type CloudPrefetchPayloadSet } from "./cloud-prefetch-run";
+import type { ExternalCheckResult, LinkCache } from "./external-checker";
+
+/** Default page batch for the pre-rules walk. Smaller than STREAM_PAGE_BATCH
+ * because this is the pass whose peak is `batchSize` live DOMs of the site's
+ * heaviest pages, and the cloud sizes it from the container's memory ceiling. */
+export const PRE_RULES_PAGE_BATCH = 50;
+
+export interface StreamPreRulesOptions {
+  batchSize?: number;
+  resourceOverrides?: ResourceCheckOverrides;
+  /**
+   * External-link checking. Omit (or pass a config with `enabled: false`) to skip
+   * it — the collection loop then does not gather occurrences at all, which is
+   * the only part of this pass that is not otherwise free.
+   */
+  externalLinks?: {
+    config: ExternalLinksConfig;
+    onProgress?: (progress: ExternalLinkCheckProgress) => void;
+    linkCache?: LinkCache | null;
+    bulkChecker?: (urls: string[]) => Promise<Map<string, ExternalCheckResult>>;
+  };
+  /**
+   * Site URL to collect cloud-prefetch payloads for. Omit when the run has no
+   * cloud client, so no payload work is done.
+   */
+  cloudPrefetchSiteUrl?: string;
+  /**
+   * Base URL seeded into the threat-intel candidate URLs, matching
+   * `collectIntelUrls(siteContext, baseUrl)`. Omit to seed nothing.
+   */
+  intelBaseUrl?: string;
+  /** Fired after each page batch with the running count — the container's
+   * liveness heartbeat, so a long pre-rules pass is never silent. */
+  onBatch?: (info: { pagesDone: number }) => void;
+}
+
+export interface StreamPreRulesResult {
+  assets: PreFetchedAssets;
+  /** Empty when external-link checking is off, exactly as v1 returns. */
+  externalLinkResults: ExternalCheckResult[];
+  /**
+   * The crawl's FIRST stored page (normalized_url ASC) — v1's `pages[0]`, which
+   * the cloud runtime feeds to tech detection. Retained whole (one PageRecord,
+   * so one page's html) because tech detect reads its url, html and headers.
+   * Null for a crawl with no pages.
+   */
+  techDetectPage: PageRecord | null;
+  /** `collectIntelUrls` order: base URL first, then each page's url + finalUrl. */
+  intelUrls: string[];
+  /** Null when `cloudPrefetchSiteUrl` was not supplied. */
+  cloudPrefetchPayloads: CloudPrefetchPayloadSet | null;
+  /** Pages walked — v1's `pages.length`. */
+  pageCount: number;
+}
+
+/**
+ * Run the pre-rules phase over a crawl's stored pages with DOM residency bounded
+ * to one batch. See the module header for why this exists and what guarantees
+ * parity with the resident path.
+ */
+export function runStreamingPreRules(
+  storage: SQLiteStorage,
+  crawlId: string,
+  config: Config,
+  options?: StreamPreRulesOptions,
+): Effect.Effect<StreamPreRulesResult, never, never> {
+  return Effect.gen(function* () {
+    const batchSize = options?.batchSize ?? PRE_RULES_PAGE_BATCH;
+    const crawl = yield* storage
+      .getCrawl(crawlId)
+      .pipe(Effect.catchAll(() => Effect.succeed(null)));
+    const baseUrl = crawl?.baseUrl ?? "";
+
+    const assetCollector = createSiteAssetCollector(baseUrl);
+    const externalLinksEnabled = options?.externalLinks?.config.enabled === true;
+    const externalLinkOccurrences: ExternalLinkOccurrences = new Map();
+    const prefetchCollector = options?.cloudPrefetchSiteUrl
+      ? createCloudPrefetchCollector(options.cloudPrefetchSiteUrl)
+      : null;
+
+    // Seeded and ordered exactly as collectIntelUrls does.
+    const intelUrlSet = new Set<string>();
+    if (options?.intelBaseUrl) intelUrlSet.add(options.intelBaseUrl);
+
+    let techDetectPage: PageRecord | null = null;
+    let pageCount = 0;
+
+    for (let offset = 0; ; offset += batchSize) {
+      // Fail-loud: a mid-walk read failure must not read as end-of-crawl and
+      // silently shrink the asset/link/payload universe (matches streamPageRules).
+      const batch = yield* storage
+        .getPages(crawlId, { limit: batchSize, offset })
+        .pipe(Effect.orDie);
+      if (batch.length === 0) break;
+
+      // `getPages` orders by normalized_url ASC, so the first row of the first
+      // batch is v1's `pages[0]`.
+      if (techDetectPage === null) techDetectPage = batch[0] ?? null;
+      pageCount += batch.length;
+
+      for (const page of batch) {
+        if (page.url) intelUrlSet.add(page.url);
+        if (page.finalUrl) intelUrlSet.add(page.finalUrl);
+      }
+
+      const ctx = yield* buildSiteContext(batch);
+      // Every absorb below runs with this batch's DOMs live; the batch is dropped
+      // immediately after, which is the whole residency bound.
+      assetCollector.absorb(ctx);
+      if (externalLinksEnabled) absorbExternalLinkOccurrences(externalLinkOccurrences, ctx);
+      prefetchCollector?.absorb(ctx);
+      releaseSiteContextDocuments(ctx);
+
+      options?.onBatch?.({ pagesDone: pageCount });
+      if (batch.length < batchSize) break;
+    }
+
+    // Network halves, in v1's order: external links are checked and PERSISTED
+    // first because `buildStreamingSiteData` later reads the link + appearance
+    // rows they write.
+    const externalLinkResults = options?.externalLinks
+      ? yield* checkCollectedExternalLinks(
+          storage,
+          crawlId,
+          externalLinkOccurrences,
+          options.externalLinks.config,
+          options.externalLinks.onProgress,
+          options.externalLinks.linkCache ?? null,
+          options.externalLinks.bulkChecker,
+        )
+      : [];
+
+    const assets = yield* fetchAssetsFromOccurrences(
+      storage,
+      crawlId,
+      assetCollector.occurrences,
+      config,
+      options?.resourceOverrides,
+    );
+
+    return {
+      assets,
+      externalLinkResults,
+      techDetectPage,
+      intelUrls: [...intelUrlSet],
+      cloudPrefetchPayloads: prefetchCollector ? prefetchCollector.build() : null,
+      pageCount,
+    };
+  });
+}

--- a/packages/audit-engine/src/streaming-pre-rules.ts
+++ b/packages/audit-engine/src/streaming-pre-rules.ts
@@ -42,6 +42,7 @@ import {
   type PreFetchedAssets,
   type ResourceCheckOverrides,
 } from "./adapter";
+import { collectDroppedBatch } from "./batch-gc";
 import { createCloudPrefetchCollector, type CloudPrefetchPayloadSet } from "./cloud-prefetch-run";
 import type { ExternalCheckResult, LinkCache } from "./external-checker";
 
@@ -166,6 +167,9 @@ export function runStreamingPreRules(
       if (externalLinksEnabled) absorbExternalLinkOccurrences(externalLinkOccurrences, ctx);
       prefetchCollector?.absorb(ctx);
       releaseSiteContextDocuments(ctx);
+      // Dropped is not collected — see batch-gc.ts. Without this the walk's peak
+      // is set by how far behind the collector happens to be, not by batchSize.
+      collectDroppedBatch();
 
       options?.onBatch?.({ pagesDone: pageCount });
       if (batch.length < batchSize) break;

--- a/packages/audit-engine/src/streaming-pre-rules.ts
+++ b/packages/audit-engine/src/streaming-pre-rules.ts
@@ -110,7 +110,11 @@ export function runStreamingPreRules(
   options?: StreamPreRulesOptions,
 ): Effect.Effect<StreamPreRulesResult, never, never> {
   return Effect.gen(function* () {
-    const batchSize = options?.batchSize ?? PRE_RULES_PAGE_BATCH;
+    // Math.max, not `??` alone: `??` lets a 0 through, and SQLite reads
+    // `LIMIT 0` as no limit (sqlite.ts guards with `if (options?.limit)`), so a
+    // zero batch would return the WHOLE table every iteration while `offset +=
+    // 0` never advanced — an infinite loop that re-absorbs the crawl forever.
+    const batchSize = Math.max(1, options?.batchSize ?? PRE_RULES_PAGE_BATCH);
     const crawl = yield* storage
       .getCrawl(crawlId)
       .pipe(Effect.catchAll(() => Effect.succeed(null)));
@@ -123,7 +127,10 @@ export function runStreamingPreRules(
       ? createCloudPrefetchCollector(options.cloudPrefetchSiteUrl)
       : null;
 
-    // Seeded and ordered exactly as collectIntelUrls does.
+    // Seeded and ordered exactly as collectIntelUrls does. Threat-intel is opt-in
+    // and off by default, so the caller omits `intelBaseUrl` when it is off and
+    // the per-page accumulation below is skipped entirely.
+    const collectIntelUrls = options?.intelBaseUrl !== undefined;
     const intelUrlSet = new Set<string>();
     if (options?.intelBaseUrl) intelUrlSet.add(options.intelBaseUrl);
 
@@ -143,9 +150,13 @@ export function runStreamingPreRules(
       if (techDetectPage === null) techDetectPage = batch[0] ?? null;
       pageCount += batch.length;
 
-      for (const page of batch) {
-        if (page.url) intelUrlSet.add(page.url);
-        if (page.finalUrl) intelUrlSet.add(page.finalUrl);
+      // Only when a base URL was supplied, i.e. the caller actually wants intel
+      // candidates; otherwise this is two Set writes per page for nothing.
+      if (collectIntelUrls) {
+        for (const page of batch) {
+          if (page.url) intelUrlSet.add(page.url);
+          if (page.finalUrl) intelUrlSet.add(page.finalUrl);
+        }
       }
 
       const ctx = yield* buildSiteContext(batch);

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -26,6 +26,7 @@ import type { RuleRunner } from "@squirrelscan/rules";
 import { mergeRuleRunResult } from "@squirrelscan/rules";
 
 import { buildSiteContext, buildHeadersMap, isRenderedFetch } from "./adapter";
+import { collectDroppedBatch } from "./batch-gc";
 import { extractPageFeatures, isAuditablePage } from "./page-features";
 import type { PageRuleLoopHooks } from "./page-rule-executor";
 import { foldRuleResultIntoTallies, type RuleTally } from "./scoring";
@@ -260,6 +261,9 @@ export function streamPageRules(
       // guarantees a future early-continue that skips the explicit drop still can't
       // leak a live DOM past the batch boundary (the residency invariant).
       for (const { parsed } of parsedBatch) if (parsed) parsed.document = null;
+      // Collect the batch we just dropped, so peak residency tracks batchSize
+      // rather than the collector's timing (see batch-gc.ts).
+      collectDroppedBatch();
 
       batchIndex++;
       opts?.hooks?.onBatch?.({

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -24,6 +24,7 @@ import { mergeRuleRunResult } from "@squirrelscan/rules";
 
 import { buildSiteContext, buildHeadersMap, isRenderedFetch } from "./adapter";
 import { extractPageFeatures, isAuditablePage } from "./page-features";
+import type { PageRuleLoopHooks } from "./page-rule-executor";
 import { foldRuleResultIntoTallies, type RuleTally } from "./scoring";
 
 /** Default page batch — bounds DOM residency to ≤ this many live docs at once. */
@@ -45,6 +46,11 @@ export interface PageSignalCollector {
 export interface StreamPageRulesHooks {
   /** Emitted after each batch with cumulative page count + wall-time, for the flatness gate. */
   onBatch?: (info: { batchIndex: number; pagesDone: number; batchMs: number }) => void;
+}
+
+/** Yield to a macrotask so timers/heartbeats queued during sync work can fire. */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
 export interface StreamPageRulesResult {
@@ -94,12 +100,45 @@ export function streamPageRules(
     hooks?: StreamPageRulesHooks;
     soft404Confirmations?: ReadonlyMap<string, ParsedPage["soft404Confirmation"]>;
     signal?: AbortSignal;
+    /**
+     * The page-rule universe as normalized URLs — v1's `pageDataMap` key set.
+     * When supplied, ONLY these pages run, which is what keeps the streamed pass
+     * on exactly v1's set instead of re-deriving it from a second predicate that
+     * can drift. It already had: `isAuditablePage` excludes non-HTML and WAF
+     * challenge pages but NOT rate-limited ones (#1829 landed after #1021), so
+     * without this a stored 429/430 page was scored here and skipped by v1, and
+     * its page_features row polluted the siteQuery rollups. `runStreamingRules`
+     * always passes it; the per-rule golden fixtures (all HTML 2xx) omit it and
+     * fall back to the `isAuditablePage` gate, for which the two agree.
+     */
+    pageUniverse?: ReadonlySet<string>;
+    /**
+     * #1252 cooperative-yield + heartbeat hooks, the same ones v1's
+     * {@link SerialPageRuleExecutor} takes. The cloud MUST pass them: page rules
+     * are sync CPU, and without a macrotask yield the single thread never returns
+     * to the timers phase, so the rules deadline, the post-crawl backstop AND the
+     * container's 30s liveness heartbeat all starve and the stale reaper kills a
+     * healthy-but-slow run (#1251). Omitted → byte-identical local behavior.
+     */
+    pageLoopHooks?: PageRuleLoopHooks;
+    /**
+     * Total pages the loop expects to run, for the heartbeat's `(done, total)`.
+     * v1 reports `tasks.length` (its page-rule universe size); pass the same
+     * number — the universe set's size — so a progress marker means the same
+     * thing on both paths. Unset → the running done count is reported as total.
+     */
+    totalPages?: number;
   }
 ): Effect.Effect<StreamPageRulesResult, never, never> {
   return Effect.gen(function* () {
     const batchSize = opts?.batchSize ?? STREAM_PAGE_BATCH;
     const collectors = opts?.collectors ?? [];
     const soft404 = opts?.soft404Confirmations;
+    const universe = opts?.pageUniverse;
+    const yieldEveryMs = opts?.pageLoopHooks?.yieldEveryMs;
+    const heartbeatEvery = Math.max(1, opts?.pageLoopHooks?.heartbeatEveryPages ?? 1);
+    const onLoopProgress = opts?.pageLoopHooks?.onProgress;
+    let lastYieldAt = Date.now();
 
     const pageResults = new Map<string, CheckResultLike[]>();
     const pageRuleResults = new Map<string, Map<string, CheckResultLike[]>>();
@@ -129,7 +168,11 @@ export function streamPageRules(
       for (const { page, parsed } of parsedBatch) {
         if (!parsed) continue; // non-HTML / failed parse — v1 skips these too
         // WAF-challenge pages are excluded from page-level scoring (v1 parity).
-        if (!isAuditablePage(page)) {
+        // With a `pageUniverse` that set is v1's own, so WAF *and* rate-limited
+        // pages are excluded together; without one this falls back to the
+        // WAF-only predicate (see the option's doc).
+        const inUniverse = universe ? universe.has(page.normalizedUrl) : isAuditablePage(page);
+        if (!inUniverse) {
           parsed.document = null;
           continue;
         }
@@ -186,6 +229,19 @@ export function streamPageRules(
         // Drop this page's DOM before moving on — the residency bound.
         parsed.document = null;
         pagesDone++;
+
+        // #1252 parity with SerialPageRuleExecutor: heartbeat every N pages, then
+        // a cooperative macrotask yield once enough sync time has elapsed, so the
+        // rules deadline and the container liveness heartbeat can actually fire.
+        // The DOM is already dropped above, so the yield never holds one open.
+        if (onLoopProgress && pagesDone % heartbeatEvery === 0) {
+          onLoopProgress(pagesDone, opts?.totalPages ?? pagesDone);
+        }
+        if (yieldEveryMs != null && yieldEveryMs > 0 && Date.now() - lastYieldAt >= yieldEveryMs) {
+          yield* Effect.promise(() => yieldToEventLoop());
+          lastYieldAt = Date.now();
+          opts?.signal?.throwIfAborted();
+        }
       }
 
       // Defensive backstop: every path in the per-page loop above already nulls
@@ -202,6 +258,13 @@ export function streamPageRules(
       });
 
       if (batch.length < batchSize) break;
+    }
+
+    // Final marker when the last page didn't land on a heartbeat boundary —
+    // mirrors SerialPageRuleExecutor's tail so the last progress event a slow
+    // cloud run emits is the real total, not the last multiple of N.
+    if (onLoopProgress && (pagesDone === 0 || pagesDone % heartbeatEvery !== 0)) {
+      onLoopProgress(pagesDone, opts?.totalPages ?? pagesDone);
     }
 
     return {

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -4,8 +4,11 @@
 // `runStreamingRules` (site-fetch phase + site pass + RuleExecutionResult
 // assembly) is built on top of it.
 //
-// Dark: nothing wires this into a production audit path yet. v1 (runRulesOnStorage)
-// is untouched; v2 is flag-gated and golden-diff-gated (blueprint §5).
+// No longer dark: the CLOUD audit path runs on this as of #1860. The CLI still
+// runs v1 (runRulesOnStorage), which is untouched, so the two paths must be kept
+// byte-identical by the golden diffs (blueprint §5) — and note those gates only
+// cover cases their fixtures contain. #1829's rate-limited-page handling landed
+// after they were written and diverged here unnoticed until #1860.
 //
 // Page rules are per-page independent (verified: no page rule reads other pages —
 // the 8 touching ctx.site read only scripts/resourceSizes/siteMetadata), so
@@ -131,7 +134,9 @@ export function streamPageRules(
   }
 ): Effect.Effect<StreamPageRulesResult, never, never> {
   return Effect.gen(function* () {
-    const batchSize = opts?.batchSize ?? STREAM_PAGE_BATCH;
+    // Clamped: a 0 batch means `LIMIT 0` (no limit in SQLite) plus `offset += 0`,
+    // i.e. an infinite loop over the whole crawl. See streaming-pre-rules.ts.
+    const batchSize = Math.max(1, opts?.batchSize ?? STREAM_PAGE_BATCH);
     const collectors = opts?.collectors ?? [];
     const soft404 = opts?.soft404Confirmations;
     const universe = opts?.pageUniverse;
@@ -166,6 +171,10 @@ export function streamPageRules(
       peakLiveDocs = Math.max(peakLiveDocs, parsedBatch.filter((p) => p.parsed?.document).length);
 
       for (const { page, parsed } of parsedBatch) {
+        // Per-page interruption checkpoint, matching SerialPageRuleExecutor's.
+        // Checking only per batch would let a `rulesPhaseTimeoutMs` breach run a
+        // whole batch of heavy pages to completion before it took effect.
+        opts?.signal?.throwIfAborted();
         if (!parsed) continue; // non-HTML / failed parse — v1 skips these too
         // WAF-challenge pages are excluded from page-level scoring (v1 parity).
         // With a `pageUniverse` that set is v1's own, so WAF *and* rate-limited
@@ -233,7 +242,9 @@ export function streamPageRules(
         // #1252 parity with SerialPageRuleExecutor: heartbeat every N pages, then
         // a cooperative macrotask yield once enough sync time has elapsed, so the
         // rules deadline and the container liveness heartbeat can actually fire.
-        // The DOM is already dropped above, so the yield never holds one open.
+        // This page's DOM is dropped above; the REST of the batch still holds
+        // live documents across the yield, so the residency bound over a yield is
+        // the batch, not zero.
         if (onLoopProgress && pagesDone % heartbeatEvery === 0) {
           onLoopProgress(pagesDone, opts?.totalPages ?? pagesDone);
         }

--- a/packages/audit-engine/tests/rate-limited-pages-e2e.test.ts
+++ b/packages/audit-engine/tests/rate-limited-pages-e2e.test.ts
@@ -19,7 +19,12 @@ import type { Config } from "@squirrelscan/config";
 import type { PageRecord } from "@squirrelscan/core-contracts";
 import { SQLiteStorage } from "@squirrelscan/crawler";
 
-import { buildSiteContext, runRulesOnStorage, type PreFetchedAssets } from "../src/adapter";
+import {
+  buildSiteContext,
+  runRulesOnStorage,
+  runStreamingRules,
+  type PreFetchedAssets,
+} from "../src/adapter";
 
 const BASE = "https://shop.example.com";
 
@@ -122,8 +127,12 @@ interface AuditResult {
   checksFor: (ruleId: string) => { name: string; status: string; items?: unknown[] }[];
 }
 
+/** Which engine path `auditPages` drives. Both must behave identically: #1829's
+ * exclusion is a property of the audit, not of one of the two rule runners. */
+type EnginePath = "v1" | "streaming";
+
 /** Store the given pages, then run the real rules over them via the real adapter. */
-async function auditPages(pages: SeedPage[]): Promise<AuditResult> {
+async function auditPages(pages: SeedPage[], engine: EnginePath = "v1"): Promise<AuditResult> {
   const storage = new SQLiteStorage(":memory:");
   return run(
     Effect.gen(function* () {
@@ -151,9 +160,17 @@ async function auditPages(pages: SeedPage[]): Promise<AuditResult> {
         yield* storage.upsertPage(crawlId, pageRecord(crawlId, page));
       }
 
-      const stored = yield* storage.getPages(crawlId);
-      const siteContext = yield* buildSiteContext(stored);
-      const result = yield* runRulesOnStorage(storage, crawlId, siteContext, CONFIG, EMPTY_ASSETS);
+      let result;
+      if (engine === "streaming") {
+        // batchSize 1 so the exclusion is exercised at every batch boundary.
+        result = yield* runStreamingRules(storage, crawlId, CONFIG, EMPTY_ASSETS, undefined, {
+          batchSize: 1,
+        });
+      } else {
+        const stored = yield* storage.getPages(crawlId);
+        const siteContext = yield* buildSiteContext(stored);
+        result = yield* runRulesOnStorage(storage, crawlId, siteContext, CONFIG, EMPTY_ASSETS);
+      }
 
       // `pageResults` is keyed by page URL, so its keys ARE the set of pages the
       // page rules were run over — the most direct statement of what was scored.
@@ -247,5 +264,82 @@ describe("#1829 — rate-limited pages are excluded from page-level scoring", ()
       (c) => c.name === "Rate-limited pages",
     );
     expect(notice?.status).toBe("info");
+  });
+});
+
+// #1860: the streaming engine shipped dark in July 2026 and #1829 landed after
+// it, so `runStreamingRules` was never updated for either half of this fix. Both
+// halves were genuinely broken on that path — `isAuditablePage` excludes WAF
+// pages but says nothing about 429/430, so the streamed page loop GRADED a
+// throttled page v1 skips, and `runSitePass` never emitted the advisory. The
+// #1021 golden gate could not catch it: its fixtures contain no rate-limited
+// pages, so both paths agreed on a case that never arose. Now that the cloud
+// runs on this path, these are the assertions that keep it honest.
+describe("#1829 on the streaming path — same exclusion, same advisory (#1860)", () => {
+  test("the control: at status 200 the streamed path grades and indicts", async () => {
+    const { gradedUrls, findingsFor } = await auditPages(
+      [
+        { path: "/", status: 200 },
+        { path: "/suspect", status: 200, body: INDICTABLE_BODY },
+      ],
+      "streaming",
+    );
+
+    expect(gradedUrls).toContain(`${BASE}/suspect`);
+    expect(findingsFor(`${BASE}/suspect`).length).toBeGreaterThan(0);
+  });
+
+  test("a 429 page is not graded by the streamed page loop either", async () => {
+    const { gradedUrls, findingsFor } = await auditPages(
+      [
+        { path: "/", status: 200 },
+        { path: "/suspect", status: 429, body: INDICTABLE_BODY },
+      ],
+      "streaming",
+    );
+
+    expect(gradedUrls).toContain(`${BASE}/`);
+    expect(gradedUrls).not.toContain(`${BASE}/suspect`);
+    expect(findingsFor(`${BASE}/suspect`)).toEqual([]);
+  });
+
+  test("a 430 page is excluded the same way on the streamed path", async () => {
+    const { gradedUrls } = await auditPages(
+      [
+        { path: "/", status: 200 },
+        { path: "/suspect", status: 430, body: INDICTABLE_BODY },
+      ],
+      "streaming",
+    );
+
+    expect(gradedUrls).not.toContain(`${BASE}/suspect`);
+  });
+
+  test("the streamed site pass emits the rate-limited advisory", async () => {
+    const { checksFor } = await auditPages(
+      [
+        { path: "/", status: 200 },
+        { path: "/throttled", status: 429, body: "Too Many Requests" },
+      ],
+      "streaming",
+    );
+
+    const notice = checksFor("crawl/rate-limited-pages").find(
+      (c) => c.name === "Rate-limited pages",
+    );
+    expect(notice?.status).toBe("info");
+  });
+
+  test("v1 and the streamed path agree on the graded set for a throttled crawl", async () => {
+    const seed: SeedPage[] = [
+      { path: "/", status: 200 },
+      { path: "/a", status: 200, body: INDICTABLE_BODY },
+      { path: "/throttled", status: 429, body: INDICTABLE_BODY },
+      { path: "/gone", status: 404, body: "Not Found" },
+    ];
+    const v1 = await auditPages(seed, "v1");
+    const streamed = await auditPages(seed, "streaming");
+
+    expect([...streamed.gradedUrls].sort()).toEqual([...v1.gradedUrls].sort());
   });
 });

--- a/packages/audit-engine/tests/streaming-pre-rules-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-pre-rules-golden.test.ts
@@ -1,0 +1,429 @@
+// GOLDEN INVARIANT (#1860): the streamed pre-rules phase collects EXACTLY what
+// the resident whole-crawl pass collected.
+//
+// `runStreamingPreRules` exists to stop a cloud audit holding every page's
+// linkedom DOM live between the crawl and the rules phase (#1862: 500 pages of
+// ~1 MB HTML = 2.2 GB of DOM, OOM). It gets there by feeding each collector one
+// page batch at a time instead of one whole-crawl array. Batching is only safe if
+// every collector's caps, dedupe sets and early-exits carry ACROSS batches — a
+// cap that reset per batch, or a "first N pages" sample taken per batch, would
+// silently change what the cloud sends to the paid prefetch services.
+//
+// So each test below runs one collector twice over the same crawl — once with the
+// whole site context, once batch by batch — and asserts the outputs are equal;
+// the prefetch collector is additionally compared against the pre-existing
+// whole-array builders it now delegates from, which is what pins it to the shape
+// the cloud has always sent.
+//
+// The end-to-end test uses a hand-built crawl with no sitemap and no sub-resource
+// markup, so `fetchAssetsFromOccurrences` has nothing to fetch and the whole file
+// stays hermetic (no network).
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { Config } from "@squirrelscan/config";
+import type { PageRecord, ResponseHeaders, SecurityHeaders } from "@squirrelscan/core-contracts";
+import type { SQLiteStorage } from "@squirrelscan/crawler";
+import { SQLiteStorage as SQLiteStorageImpl } from "@squirrelscan/crawler";
+import { generateSiteModel, writeCrawlToStorage } from "@squirrelscan/synthetic-site";
+
+import {
+  absorbExternalLinkOccurrences,
+  buildSiteContext,
+  createSiteAssetCollector,
+  releaseSiteContextDocuments,
+  renderedPageUrlsFrom,
+  type ExternalLinkOccurrences,
+  type SiteAssetOccurrences,
+  type SiteContextPage,
+} from "../src/adapter";
+import {
+  buildBlocklistPayload,
+  buildCloudPagePayloads,
+  buildGapsPayloads,
+  buildMetadataPayload,
+  createCloudPrefetchCollector,
+} from "../src/cloud-prefetch-run";
+import { collectIntelUrls } from "../src/intel";
+import { runStreamingPreRules } from "../src/streaming-pre-rules";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const CONFIG = {
+  rule_options: {},
+  rules: { enable: ["*"] },
+  cloud: {},
+  crawler: {},
+  external_links: { enabled: false, concurrency: 1, timeout_ms: 1000, cache_ttl_days: 1 },
+} as unknown as Config;
+
+const SITE_URL = "http://synthetic.test";
+
+/** Minimal non-null crawl stats — the crawls table requires the column. */
+const CRAWL_STATS = {
+  pagesTotal: 0,
+  pagesFetched: 0,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+/** Occurrence maps compare as sorted plain arrays — Map/Set don't deep-equal usefully. */
+function assetShape(occ: SiteAssetOccurrences) {
+  const flat = (m: Map<string, Set<string>>) =>
+    [...m.entries()].map(([k, v]) => [k, [...v].sort()] as const).sort();
+  return {
+    css: flat(occ.css),
+    images: flat(occ.images),
+    scripts: flat(occ.scripts),
+    pdfs: flat(occ.pdfs),
+    coveragePages: occ.coveragePages,
+    pageCount: occ.pageCount,
+  };
+}
+
+function linkShape(occ: ExternalLinkOccurrences) {
+  return [...occ.entries()].map(([href, list]) => [href, list] as const).sort();
+}
+
+/** Read the crawl's pages in `size` chunks, parsed, as the streamed pass does. */
+async function batches(
+  storage: SQLiteStorage,
+  crawlId: string,
+  size: number,
+): Promise<SiteContextPage[][]> {
+  const out: SiteContextPage[][] = [];
+  for (let offset = 0; ; offset += size) {
+    const batch = await run(storage.getPages(crawlId, { limit: size, offset }));
+    if (batch.length === 0) break;
+    out.push(await run(buildSiteContext(batch)));
+    if (batch.length < size) break;
+  }
+  return out;
+}
+
+async function residentContext(
+  storage: SQLiteStorage,
+  crawlId: string,
+): Promise<SiteContextPage[]> {
+  return run(buildSiteContext(await run(storage.getPages(crawlId))));
+}
+
+const T = 30_000;
+
+describe("streamed pre-rules collectors — batched === resident (#1860)", () => {
+  test("asset occurrences are identical whether absorbed whole or in batches", async () => {
+    const model = generateSiteModel({ seed: 11, pageCount: 60 });
+    const { storage, crawlId } = await writeCrawlToStorage(model, ":memory:");
+    await injectRichPages(storage, crawlId, 12);
+
+    const resident = createSiteAssetCollector(SITE_URL);
+    resident.absorb(await residentContext(storage, crawlId));
+
+    const streamed = createSiteAssetCollector(SITE_URL);
+    for (const batch of await batches(storage, crawlId, 7)) {
+      streamed.absorb(batch);
+      releaseSiteContextDocuments(batch);
+    }
+
+    expect(assetShape(streamed.occurrences)).toEqual(assetShape(resident.occurrences));
+    // Guard against a vacuous pass: EVERY map the collector fills must be
+    // non-empty, or "batched === resident" would just be "empty === empty".
+    // The synthetic model renders no sub-resource markup at all, which is why
+    // injectRichPages exists.
+    expect(resident.occurrences.css.size).toBeGreaterThan(0);
+    expect(resident.occurrences.images.size).toBeGreaterThan(0);
+    expect(resident.occurrences.scripts.size).toBeGreaterThan(0);
+    expect(resident.occurrences.pdfs.size).toBeGreaterThan(0);
+    expect(resident.occurrences.coveragePages.length).toBeGreaterThan(0);
+    // pageCount counts EVERY stored page (the model's redirect hops included),
+    // matching v1's siteContext.length.
+    expect(resident.occurrences.pageCount).toBe(
+      (await run(storage.getPages(crawlId))).length,
+    );
+
+    await run(storage.close());
+  }, T);
+
+  test("external-link occurrences are identical whether absorbed whole or in batches", async () => {
+    const model = generateSiteModel({ seed: 13, pageCount: 60 });
+    const { storage, crawlId } = await writeCrawlToStorage(model, ":memory:");
+    await injectRichPages(storage, crawlId, 12);
+
+    const resident: ExternalLinkOccurrences = new Map();
+    absorbExternalLinkOccurrences(resident, await residentContext(storage, crawlId));
+
+    const streamed: ExternalLinkOccurrences = new Map();
+    for (const batch of await batches(storage, crawlId, 7)) {
+      absorbExternalLinkOccurrences(streamed, batch);
+      releaseSiteContextDocuments(batch);
+    }
+
+    expect(linkShape(streamed)).toEqual(linkShape(resident));
+    // Non-vacuity: the injected pages carry external anchors, and each shared
+    // href must accumulate an appearance per page (the part batching could drop).
+    expect(resident.size).toBeGreaterThan(0);
+    expect(resident.get(SHARED_EXTERNAL_HREF)?.length).toBe(12);
+
+    await run(storage.close());
+  }, T);
+
+  test("cloud-prefetch payloads match the whole-array builders, batched or not", async () => {
+    const model = generateSiteModel({ seed: 17, pageCount: 60 });
+    const { storage, crawlId } = await writeCrawlToStorage(model, ":memory:");
+    // Blocklist URLs come from off-host links, images and script srcs; the
+    // synthetic model renders none, so without these the blocklist comparison
+    // would be null === null.
+    await injectRichPages(storage, crawlId, 12);
+
+    // The legacy whole-array builders, over a fully resident context — the shape
+    // the cloud has always sent to /v1/services/*.
+    const ctx = await residentContext(storage, crawlId);
+    const legacy = {
+      pages: buildCloudPagePayloads(ctx),
+      metadataPages: buildMetadataPayload(ctx, SITE_URL),
+      blocklist: buildBlocklistPayload(ctx),
+      gaps: buildGapsPayloads(ctx, SITE_URL, CONFIG),
+      rendered: [...renderedPageUrlsFrom(ctx)],
+    };
+
+    const streamed = createCloudPrefetchCollector(SITE_URL);
+    for (const batch of await batches(storage, crawlId, 7)) {
+      streamed.absorb(batch);
+      releaseSiteContextDocuments(batch);
+    }
+    const built = streamed.build();
+
+    expect(built.pages).toEqual(legacy.pages);
+    expect(built.metadataPages).toEqual(legacy.metadataPages);
+    expect(built.blocklist).toEqual(legacy.blocklist);
+    expect([...built.renderedPageUrls]).toEqual(legacy.rendered);
+    // Seeds reach the wire through buildGapsPayloadsFromSeeds; compare the
+    // assembled payload rather than the intermediate list.
+    expect(
+      built.gapsSeeds.length > 0
+        ? {
+            "keyword-gaps": {
+              ...(legacy.gaps["keyword-gaps"] ?? {}),
+              seedKeywords: built.gapsSeeds,
+            },
+          }
+        : {},
+    ).toEqual(
+      legacy.gaps["keyword-gaps"] ? { "keyword-gaps": legacy.gaps["keyword-gaps"] } : {},
+    );
+
+    // Vacuity guards: the sample and the blocklist must be non-trivial, and the
+    // metadata sample must be the CAPPED sample rather than every page — that cap
+    // is exactly what the batched collector could have got wrong.
+    expect(built.pages.length).toBeGreaterThan(0);
+    expect(built.metadataPages.length).toBeGreaterThan(0);
+    expect(built.metadataPages.length).toBeLessThan(built.pages.length);
+    expect(built.blocklist?.urls.length).toBeGreaterThan(0);
+    expect(built.blocklist?.selectors.length ?? 0).toBeGreaterThanOrEqual(0);
+    expect(built.gapsSeeds.length).toBeGreaterThan(0);
+    expect(built.renderedPageUrls.size).toBe(0);
+
+    await run(storage.close());
+  }, T);
+
+  test("metadata sample still picks the homepage when it sorts past the retained prefix", async () => {
+    // `getPages` orders by normalized_url, so a homepage at "/" sorts FIRST and
+    // the interesting case (home beyond the first metadataMaxPages usable pages)
+    // never arises from a natural crawl. Force it: give every page a path that
+    // sorts before the home URL, so home lands last.
+    const storage = new SQLiteStorageImpl(":memory:");
+    await run(storage.init());
+    const crawlId = await run(
+      storage.createCrawl({
+        baseUrl: SITE_URL,
+        seedUrl: SITE_URL,
+        originalUrl: SITE_URL,
+        startedAt: Date.now(),
+        status: "running",
+        config: {},
+        stats: CRAWL_STATS,
+      } as never),
+    );
+
+    const paths = ["/a", "/b", "/c", "/d", "/e", "/f", "/g", "/h", ""];
+    for (const path of paths) {
+      await run(storage.upsertPage(crawlId, htmlPage(`${SITE_URL}${path}`, path || "home")));
+    }
+
+    const ctx = await residentContext(storage, crawlId);
+    const legacy = buildMetadataPayload(ctx, SITE_URL);
+
+    const streamed = createCloudPrefetchCollector(SITE_URL);
+    for (const batch of await batches(storage, crawlId, 3)) {
+      streamed.absorb(batch);
+      releaseSiteContextDocuments(batch);
+    }
+
+    expect(streamed.build().metadataPages).toEqual(legacy);
+    // The point of the fixture: home really is last in crawl order, and really is
+    // the sample's first entry.
+    expect(legacy[0]?.url).toBe(SITE_URL);
+
+    await run(storage.close());
+  }, T);
+});
+
+describe("runStreamingPreRules end to end (#1860)", () => {
+  test("reports v1's pages[0], intel URL order and page count", async () => {
+    // Hand-built: no sitemap and no sub-resource markup, so the asset phase has
+    // nothing to fetch and the test never touches the network.
+    const storage = new SQLiteStorageImpl(":memory:");
+    await run(storage.init());
+    const crawlId = await run(
+      storage.createCrawl({
+        baseUrl: SITE_URL,
+        seedUrl: SITE_URL,
+        originalUrl: SITE_URL,
+        startedAt: Date.now(),
+        status: "running",
+        config: {},
+        stats: CRAWL_STATS,
+      } as never),
+    );
+    for (const path of ["/c", "/a", "/b"]) {
+      await run(storage.upsertPage(crawlId, htmlPage(`${SITE_URL}${path}`, path)));
+    }
+
+    const result = await run(
+      runStreamingPreRules(storage, crawlId, CONFIG, {
+        batchSize: 2,
+        cloudPrefetchSiteUrl: SITE_URL,
+        intelBaseUrl: SITE_URL,
+      }),
+    );
+
+    expect(result.pageCount).toBe(3);
+    // normalized_url ASC ⇒ "/a" is v1's pages[0], not the insertion-order "/c".
+    expect(result.techDetectPage?.url).toBe(`${SITE_URL}/a`);
+    // Base URL first, then each page's url + finalUrl in crawl order — the exact
+    // order collectIntelUrls produces.
+    const ctx = await residentContext(storage, crawlId);
+    expect(result.intelUrls).toEqual(collectIntelUrls(ctx, SITE_URL));
+    // Nothing to fetch, so the asset phase is empty and undegraded.
+    expect(result.assets.resourceSizes.css).toEqual([]);
+    expect(result.assets.scripts).toEqual([]);
+    expect(result.assets.degradation).toBeUndefined();
+    // External links off ⇒ no results, exactly as v1 returns.
+    expect(result.externalLinkResults).toEqual([]);
+    expect(result.cloudPrefetchPayloads?.pages.length).toBe(3);
+
+    await run(storage.close());
+  }, T);
+
+  test("collects no prefetch payloads when no site URL is given", async () => {
+    const storage = new SQLiteStorageImpl(":memory:");
+    await run(storage.init());
+    const crawlId = await run(
+      storage.createCrawl({
+        baseUrl: SITE_URL,
+        seedUrl: SITE_URL,
+        originalUrl: SITE_URL,
+        startedAt: Date.now(),
+        status: "running",
+        config: {},
+        stats: CRAWL_STATS,
+      } as never),
+    );
+    await run(storage.upsertPage(crawlId, htmlPage(`${SITE_URL}/a`, "a")));
+
+    const result = await run(runStreamingPreRules(storage, crawlId, CONFIG, { batchSize: 2 }));
+    expect(result.cloudPrefetchPayloads).toBeNull();
+
+    await run(storage.close());
+  }, T);
+});
+
+const EMPTY_HEADERS: ResponseHeaders = {
+  contentType: "text/html",
+  contentEncoding: null,
+  cacheControl: null,
+  vary: null,
+  etag: null,
+  server: null,
+  lastModified: null,
+  link: null,
+  serverTiming: null,
+  age: null,
+  xCache: null,
+  cfCacheStatus: null,
+  xVercelCache: null,
+  altSvc: null,
+  acceptRanges: null,
+};
+
+const EMPTY_SECURITY_HEADERS: SecurityHeaders = {
+  hsts: null,
+  csp: null,
+  xFrameOptions: null,
+  xContentTypeOptions: null,
+  referrerPolicy: null,
+  permissionsPolicy: null,
+  xRobotsTag: null,
+};
+
+const SHARED_EXTERNAL_HREF = "https://external.example/shared";
+
+/**
+ * Pages that actually carry the markup the asset + external-link collectors read.
+ * The synthetic generator renders none of it (no `img`, `script` or stylesheet
+ * `link`, and only internal anchors), so without these the parity assertions
+ * would compare two empty maps. Each page gets its own stylesheet, script, image
+ * and same-origin PDF link plus a per-page and a SHARED external anchor, so the
+ * occurrence maps exercise both distinct keys and multi-page accumulation.
+ */
+async function injectRichPages(
+  storage: SQLiteStorage,
+  crawlId: string,
+  count: number,
+): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    const url = `${SITE_URL}/rich/${String(i).padStart(3, "0")}`;
+    const html =
+      `<!doctype html><html lang="en"><head><title>rich ${i}</title>` +
+      `<link rel="stylesheet" href="${SITE_URL}/assets/site-${i % 3}.css">` +
+      `<script src="${SITE_URL}/assets/app-${i % 4}.js"></script>` +
+      `</head><body><h1>rich ${i}</h1>` +
+      `<img src="${SITE_URL}/img/hero-${i % 5}.png" alt="hero ${i}">` +
+      `<a href="${SITE_URL}/docs/manual-${i % 2}.pdf">manual</a>` +
+      `<a href="https://external.example/page-${i}">out ${i}</a>` +
+      `<a href="${SHARED_EXTERNAL_HREF}">shared</a>` +
+      `</body></html>`;
+    await run(storage.upsertPage(crawlId, { ...htmlPage(url, `rich ${i}`), html }));
+  }
+}
+
+/** A minimal 200 HTML page with no sub-resources of any kind. */
+function htmlPage(url: string, title: string): PageRecord {
+  const html = `<!doctype html><html lang="en"><head><title>${title}</title><meta name="description" content="${title} page"></head><body><h1>${title}</h1><p>Body copy for ${title}.</p></body></html>`;
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: Buffer.byteLength(html, "utf8"),
+    loadTimeMs: 1,
+    fetchedAt: Date.now(),
+    etag: null,
+    lastModified: null,
+    contentHash: "test",
+    html,
+    parsedData: null,
+    headers: EMPTY_HEADERS,
+    securityHeaders: EMPTY_SECURITY_HEADERS,
+  };
+}


### PR DESCRIPTION
Engine-side prep so a cloud audit can run on the streaming pipeline instead of the resident one. The private tracker issue is squirrelscan/repo#1860; the incident is a 500-page audit of ~1 MB pages peaking at 3.9 GB and OOM-killing the container three times.

## Why this was needed at all

`runStreamingRules` has been in the tree since July and already bounds the rules phase to one batch of live DOMs. It could not be adopted as-is, because the rules phase was never where the audit went resident. The pre-rules phase built **one** `buildSiteContext` over every crawled page and handed that array to three consumers that each need a live parsed document per page:

| consumer | why it needs a DOM |
|---|---|
| `checkExternalLinksOnStorage` | link position (nav/header/footer/body) is not in stored `parsedData` |
| `fetchResourceAssets` | stylesheet and script `src`s are read off the document |
| `runContainerCloudPrefetch` | blocklist script srcs and selectors, metadata sample |

So every page's DOM stayed live from the end of the crawl until the prefetch released them, no matter which rule runner ran afterwards.

## What changed

**Collection split from network tail.** Each of those three consumers is now a batch-absorbing collector plus its unchanged network half. The existing whole-array entry points delegate into the same accumulators, so there is one implementation, not two that can drift.

- `createSiteAssetCollector` + `fetchAssetsFromOccurrences`
- `absorbExternalLinkOccurrences` + `checkCollectedExternalLinks`
- `createCloudPrefetchCollector` + `runContainerCloudPrefetchFromPayloads`

**`runStreamingPreRules`** drives them in one batched walk of the pages table: parse a batch, absorb it with the DOMs live, drop it, repeat. What each collector keeps is bounded by the site's distinct sub-resource URLs and by the existing payload caps, never by page count times page size.

The site-metadata sample is the one thing that cannot be absorbed and forgotten, since `buildMetadataPayload` picks the homepage plus the first `metadataMaxPages` usable pages and shares one JSON-LD byte budget across them. The collector retains exactly that sample (`metadataMaxPages + 2` pages) and re-materializes their DOMs at build time.

## Four bugs fixed along the way

**No page-loop hooks.** `runStreamingRules` took no `PageRuleLoopHooks`. A cloud run on it would have had no macrotask yield and no per-N-pages progress, so the rules deadline, the post-crawl backstop and the container's 30s liveness heartbeat would all starve and the stale reaper would kill healthy-but-slow runs. That is #1251/#1252 again.

**Two #1829 parity bugs.** `isAuditablePage` excludes WAF challenge pages but says nothing about 429/430, so the streamed page loop **graded** throttled pages that v1 skips, and wrote their `page_features` rows into the siteQuery rollups. `runSitePass` also never emitted the `crawl/rate-limited-pages` advisory. #1829 landed after the #1021 golden gate, and the golden fixtures carry no rate-limited pages, so the gate agreed on a case that never arose. The page loop now takes v1's universe set rather than re-deriving membership from a second predicate.

**`PageRecord` retention.** `streamParsedUniverse` dropped DOMs but retained a whole `PageRecord` per page in `pageDataMap`, which put the O(pages x html) term straight back into a pipeline whose point is bounding residency. It now keeps the three scalars the later steps actually read.

## Dropped is not collected

Benchmarking end to end found the streaming path peaking **higher** than the resident one: 2443 MB against 1513 MB on a 200-page crawl. Dropping a batch's DOMs makes them garbage, not gone, and JSC grows the heap in preference to collecting, so the walk climbed on unreachable pages. A container with a hard ceiling is killed on garbage as readily as on live data. Measured on that crawl, peak RSS sampled inside the loop:

| per-batch nudge | peak |
|---|---|
| none | 1424 MB |
| `Bun.gc(false)` | 1481 MB |
| `Bun.gc(true)` | 1148 MB |

1148 MB is about one batch's live working set, which is what the design promises, so the three streamed walks now collect synchronously once per batch (guarded; a no-op off Bun).

## Numbers

Synthetic crawl, ~983 KB of HTML per page, ~18.9k DOM nodes per page, batch of 50, on a 16 GB Mac.

| pages | resident | streaming |
|---|---|---|
| 200 | 1513 MB, 240s | 1361 MB, 168s |
| 500 | 2219 MB, **did not finish in 60 min** | 1088 MB, 428s |

Two things to read off that. Peak: the streaming path's peak at 500 pages is *lower* than at 200, because it tracks batch size rather than page count, which is the whole property. Time: the resident path never finished a 500-page crawl the streaming path completed in seven minutes, which is the same wall the incident hit when its rules phase slowed to 7 pages/min and timed out at 290 of 476 pages.

Metric notes, since they matter more than usual here. The 200-page figures and streaming@500 are the peak of `process.memoryUsage().rss`, the metric the container heartbeat reports and the one that read 3.9 GB during the incident; resident@500 is an external `ps` poll, since that run never reached its own final report. macOS compresses pages under pressure, so the resident arm's RSS *falls* while it is still holding everything and the numbers above flatter it; a Linux container has no such compressor. `/usr/bin/time -l`'s own two figures disagree with each other by 3-5x in both directions, which is why neither is used.

Benchmarking also turned up a real bug in the first version of this change: dropping a batch's DOMs makes them garbage, not gone, and JSC grows the heap in preference to collecting, so the streaming path initially peaked **higher** than the resident one (2443 MB against 1513 MB at 200 pages). Measured per-batch nudges, peak RSS sampled inside the loop:

| per-batch nudge | peak |
|---|---|
| none | 1424 MB |
| `Bun.gc(false)` | 1481 MB |
| `Bun.gc(true)` | 1148 MB |

1148 MB is about one batch's live working set, so the three streamed walks now collect synchronously once per batch (guarded; a no-op off Bun). That is also where the speedup comes from: the heap stops growing.

Reproduce with `packages/audit-engine/scripts/bench-streaming-memory.ts` (`build`, then `old` / `new`). The fixture's node count is printed at build time on purpose: an earlier version filled pages with one giant `<script>`, which reached 1 MB of HTML but parsed to 0.44 MB of DOM instead of the ~4.7 MB per page measured in the incident, and made the resident path look cheaper than it is.

## Report tail

`buildV1Report`'s single whole-crawl `getPages` is now a batched walk. `getPages` orders by `normalized_url ASC` with or without LIMIT/OFFSET, so it visits the same sequence and the report is unchanged; what changes is that only one batch of `PageRecord`s is resident. One deliberate behaviour change: a mid-walk read failure now kills the run (`Effect.orDie`) where the single read degraded to an empty page list. Degrading a batched read the same way would end the walk at an arbitrary offset and publish a confident report over a truncated page set. `buildV2Report` was not adopted for the cloud: it returns `pages: []`, which the publish path reads.

## Gates

Existing golden diffs all still pass, plus two new suites:

- `tests/streaming-pre-rules-golden.test.ts` runs each new collector twice over one crawl, whole-array and batch by batch, and asserts equality; the prefetch collector is additionally compared against the whole-array builders it now delegates from. The synthetic generator renders no sub-resource markup and no external anchors, so the fixture injects pages that do, and every assertion has a non-vacuity guard.
- The streaming twin of the #1829 end-to-end assertions in `tests/rate-limited-pages-e2e.test.ts`. All four fail if either parity fix is reverted (verified).

Whole `packages/audit-engine` suite green; `apps/cli` typechecks and its report tests pass.
