### PR TITLE
fix(core-contracts): raise runPerPageMs to 7200 so a 500-page full audit gets the 1h budget

### DIFF
--- a/packages/core-contracts/src/limits.ts
+++ b/packages/core-contracts/src/limits.ts
@@ -33,8 +33,13 @@ export const AUDIT_RUNTIME = {
   // worker-agent, so before this these were duplicated literals; drift between
   // the two would mean the reaper reaps a run before/after the container is
   // actually guaranteed dead.
-  //   full budget ÷ its 500-page preset — page-count scaling for oversized runs.
-  runPerPageMs: 4_800,
+  //   Was 4_800 (full budget ÷ its 500-page preset), which gave a 500-page full
+  //   audit exactly the 2400s base. A 474-page rendered crawl of ~1MB Shopify
+  //   pages needs ~27min to crawl + ~16min of rules on the container (#1864) and
+  //   timed out at 310/474 pages with memory to spare (#1862). 7_200 lets the
+  //   500-page preset reach the 1h ceiling; quick/surface presets are unchanged
+  //   (25 × 7.2s = 180s < 240s base, 100 × 7.2s = 720s < 900s base).
+  runPerPageMs: 7_200,
   // 1h ceiling so a wedged crawl can't pin a container indefinitely.
   maxRunTimeoutMs: 3_600_000,
   // Gap the DO leaves between the runtime cap and container SIGKILL. Wider


### PR DESCRIPTION
## Why

A 500-page full-coverage cloud audit of a site with ~1 MB HTML pages (drscholls.com, Shopify, ~820 KB inline script per page) takes ~27 min to crawl with rendering and ~16 min in the rules phase on the container. `runPerPageMs = 4_800` pinned the 500-page preset to exactly the 2400 s `full` base, so the run timed out at 310/474 pages after the memory problem (private #1862) had already been fixed.

## What

`runPerPageMs: 4_800 → 7_200`. A 500-page full audit now scales to the existing 1 h ceiling (`maxRunTimeoutMs`). `quick` (25 × 7.2 s = 180 s) and `surface` (100 × 7.2 s = 720 s) stay below their base budgets, so nothing changes for them. Crawl-phase budget scales with the same extra (worker-agent `CRAWL_PHASE_EXTRA_FRACTION = 0.75`): 1800 s + 900 s = 45 min for the 500-page preset, above the observed 27 min crawl. The container hard-kill (runtime + 180 s) and the API reaper (`staleRunThresholdMs` 75 min) already assume the 1 h cap.

The rule cost itself is tracked in private #1864; this PR only stops the budget from being the thing that fails.

## Verification

No public test pins the constant (grep `runPerPageMs`/`4_800` in packages/ and apps/ is only the definition). Private worker-agent/api timeout tests are updated in the gitlink-bump PR.