### PR TITLE
fix(audit-engine): bound the complete-store finalize to rules, not findings

### DIFF
--- a/packages/audit-engine/scripts/bench-complete-store-fold.ts
+++ b/packages/audit-engine/scripts/bench-complete-store-fold.ts
@@ -1,0 +1,147 @@
+// Complete-store finalize memory bench (#1873).
+//
+// Measures the two ways of scoring a chunked publish off the COMPLETE findings:
+//
+//   --mode=materialized  the pre-#1873 path: every page_findings row resident as a
+//                        PageFindingRecord[] (loadIngestedFindings), then
+//                        reconstructCompleteResults → buildScoringResultsFromMerged
+//                        → calculateHealthScore. This is what Cloudflare killed
+//                        with `exceededMemory` at 43,470 findings.
+//   --mode=bounded       the #1873 path: findings arrive one page at a time from a
+//                        cursor and are folded into per-rule tallies, then
+//                        calculateHealthScoreFromTallies.
+//
+// Peak memory is only honest as a fresh process's max RSS (a JSC heapUsed delta
+// reported a 4 MiB JSON.parse as +0.00 MiB — see the publish-zod-clamp
+// measurement), so run each mode under /usr/bin/time and compare `maximum
+// resident set size`:
+//
+//   /usr/bin/time -l bun run scripts/bench-complete-store-fold.ts --mode=materialized
+//   /usr/bin/time -l bun run scripts/bench-complete-store-fold.ts --mode=bounded
+//
+// Defaults reproduce the #1873 acceptance shape: 60,000 findings over 500 pages.
+// The absolute numbers are Bun/JSC on the host, not workerd/V8 in a 128 MB
+// isolate — the RATIO is what transfers.
+
+import type { CheckResult, PageFindingRecord } from "@squirrelscan/core-contracts";
+import type { RuleRunResult } from "@squirrelscan/rules/types";
+
+import { foldCompleteStoreTallies } from "../src/complete-store-fold";
+import { reconstructCompleteResults } from "../src/reconstruct";
+import {
+  buildScoringResultsFromMerged,
+  calculateHealthScore,
+  calculateHealthScoreFromTallies,
+} from "../src/scoring";
+
+const arg = (name: string, fallback: number): number => {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? Number(hit.slice(name.length + 3)) : fallback;
+};
+const mode =
+  process.argv.find((a) => a.startsWith("--mode="))?.slice("--mode=".length) ?? "bounded";
+const PAGES = arg("pages", 500);
+const FINDINGS = arg("findings", 60_000);
+const RULES = arg("rules", 40);
+
+const ruleId = (r: number) => `content/rule-${r}`;
+const pageUrl = (p: number) => `https://bench.test/section-${p % 20}/page-${p}?variant=${p % 3}`;
+
+const meta = (r: number): RuleRunResult["meta"] => ({
+  id: ruleId(r),
+  name: `Bench rule ${r}`,
+  description: "A page-scope rule used to size the finalize fold",
+  category: "content",
+  scope: "page",
+  severity: r % 5 === 0 ? "error" : "warning",
+  weight: 10,
+});
+
+/** The staged shell: rule META plus a bounded display sample, as the container stages it. */
+const ruleResults: Record<string, { meta: RuleRunResult["meta"]; checks: CheckResult[] }> = {};
+for (let r = 0; r < RULES; r++) ruleResults[ruleId(r)] = { meta: meta(r), checks: [] };
+
+const crawledUrls = new Set<string>();
+for (let p = 0; p < PAGES; p++) crawledUrls.add(pageUrl(p));
+
+// Rows shaped like the real read: message/value/expected from the finding_defs
+// join, plus the serialized item payload flattenChecks stamps.
+const PER_PAGE = Math.ceil(FINDINGS / PAGES);
+function rowsForPage(p: number): PageFindingRecord[] {
+  const url = pageUrl(p);
+  const out: PageFindingRecord[] = [];
+  for (let i = 0; i < PER_PAGE; i++) {
+    const r = i % RULES;
+    out.push({
+      siteKey: "web_bench",
+      normalizedUrl: url,
+      ruleId: ruleId(r),
+      checkName: `check-${i % 3}`,
+      locator: `item-${i}`,
+      status: i % 4 === 0 ? "warn" : "fail",
+      severity: r % 5 === 0 ? "error" : "warning",
+      message: `The element at position ${i} on this page does not satisfy rule ${r}`,
+      value: `observed-value-${i}`,
+      expected: `expected-value-${i}`,
+      payload: JSON.stringify({
+        items: [{ id: `item-${i}`, label: `Element #${i} in the document body`, sourcePages: [url] }],
+        details: { additional: i % 7 },
+        i,
+      }),
+      fingerprint: `fp-${p}-${i}`,
+      firstSeenAt: 1_700_000_000_000,
+      lastSeenCrawlId: "audit_bench",
+      lastSeenAt: 1_700_000_000_000,
+      provenance: "fresh",
+      state: "open",
+    });
+  }
+  return out;
+}
+
+const started = Date.now();
+let overall: number | null = null;
+
+if (mode === "materialized") {
+  // What loadIngestedFindings returned: the whole audit in one array.
+  const ingestedFindings: PageFindingRecord[] = [];
+  for (let p = 0; p < PAGES; p++) ingestedFindings.push(...rowsForPage(p));
+  const freshResults = reconstructCompleteResults({
+    ruleResults,
+    ingestedFindings,
+    crawledUrls,
+  });
+  const union = buildScoringResultsFromMerged({
+    freshResults,
+    carriedFindings: [],
+    carriedPageUrls: new Set(),
+    ruleMetaIndex: new Map(Object.entries(ruleResults).map(([id, r]) => [id, r.meta])),
+  });
+  overall = calculateHealthScore({ results: union }).overall;
+} else {
+  // What the cursor yields: one page at a time, dropped after each fold.
+  async function* findingPages(): AsyncGenerator<PageFindingRecord[]> {
+    for (let p = 0; p < PAGES; p++) yield rowsForPage(p);
+  }
+  const tallies = await foldCompleteStoreTallies({
+    ruleResults,
+    findingPages: findingPages(),
+    crawledUrls,
+    carriedFindings: [],
+    carriedPageUrls: new Set(),
+    ruleMetaIndex: new Map(Object.entries(ruleResults).map(([id, r]) => [id, r.meta])),
+  });
+  overall = calculateHealthScoreFromTallies(tallies, new Map()).overall;
+}
+
+console.log(
+  JSON.stringify({
+    mode,
+    pages: PAGES,
+    findings: PER_PAGE * PAGES,
+    rules: RULES,
+    overall,
+    elapsedMs: Date.now() - started,
+    rssMb: Number((process.memoryUsage().rss / 1024 / 1024).toFixed(1)),
+  }),
+);

--- a/packages/audit-engine/src/complete-store-fold.ts
+++ b/packages/audit-engine/src/complete-store-fold.ts
@@ -1,0 +1,257 @@
+// Bounded complete-store scoring fold (#1873).
+//
+// #1023 R-D3 made the chunked publish score off the COMPLETE per-page findings,
+// but by MATERIALIZING them: load every page_findings row → reconstruct every
+// per-page CheckResult → build the union map → score it. Every one of those steps
+// holds the whole audit at once, so a 43,470-finding publish killed the 128 MB API
+// isolate (`exceededMemory`, #1873) after the audit had already been paid for.
+//
+// This module computes the SAME score from the SAME evidence with memory bounded
+// by (rules × checks) instead of by finding count: findings arrive ONE PAGE at a
+// time, are folded into per-rule `IssueTally` (the #1021 streaming machinery), and
+// are dropped. `calculateHealthScoreFromTallies` over the result is the
+// byte-identical twin of `calculateHealthScore` over the materialized union — see
+// complete-store-parity.test.ts, which asserts exactly that on every fixture.
+//
+// THE INVARIANT THAT MAKES IT BYTE-IDENTICAL: `addChecksToTally`'s item-aware keys
+// are `${checkName}\u0000${pageUrl}`, and its per-key state (the fail-unit sum, its
+// ISSUE_PENALTY_ITEM_CAP clamp, the `details.additional` max, the distinct warn-key
+// count) is LOCAL TO ONE CALL. Folding incrementally therefore matches folding the
+// concatenated array if and only if no (checkName, pageUrl) bucket is ever split
+// across two calls. Two consequences, both load-bearing:
+//   1. `findingPages` MUST yield a page's findings whole (one page per item), never
+//      half a page — a split page would clamp and count one bucket twice;
+//   2. carried findings on a page that ALSO has fresh findings are folded together
+//      WITH that page, not in the trailing carried pass. In complete mode a carried
+//      finding normally sits on an un-crawled page (the merge resolves anything on
+//      a crawled page), so the overlap only arises for a page missing from the
+//      crawled set — but "normally" is not "never", and the cost of handling it is
+//      one map lookup.
+
+import type { CheckResult, PageFindingRecord } from "@squirrelscan/core-contracts";
+import type { RuleRunResult } from "@squirrelscan/rules/types";
+
+import { reconstructPageRuleChecks } from "./reconstruct";
+import {
+  addChecksToTally,
+  carriedFindingToCheck,
+  emptyTally,
+  type CarriedFinding,
+  type RuleTally,
+} from "./scoring";
+import type { SkippedPassCounts } from "./stream-findings";
+
+/**
+ * This audit's complete findings, delivered ONE PAGE AT A TIME. Each yielded array
+ * holds every ingested finding for a single `normalizedUrl`; a page must never be
+ * split across two items (see the module header). The API implements this as a
+ * keyset cursor over page_findings that buffers to page boundaries, so no more
+ * than one page's rows are resident at a time.
+ */
+export type FindingPageSource = AsyncIterable<readonly PageFindingRecord[]>;
+
+export interface CompleteStoreTallyInput {
+  /**
+   * The published (sampled/slimmed) shell's `ruleResults` — the source of rule
+   * META, the set of rules that ran, and SITE-scope rules' checks (which are
+   * scored verbatim; findings never carry them). Page-scope rules' checks are
+   * ignored here: they are superseded by the complete findings.
+   */
+  ruleResults: Record<string, { meta: RuleRunResult["meta"]; checks: CheckResult[] }>;
+  /** Complete per-(page,rule,check,locator) findings, page at a time. */
+  findingPages: FindingPageSource;
+  /**
+   * Full crawled-URL set (NORMALIZED) for this run — the `syntheticPassCount`
+   * denominator, and the set a finding's page must be in to count as DIRTY.
+   */
+  crawledUrls: Set<string>;
+  /** (#1305) Passing sibling checks on dirty pages; see reconstructCompleteResults. */
+  skippedPassCounts?: SkippedPassCounts;
+  /** Issues on un-crawled, still-active pages carried forward by the merge. */
+  carriedFindings: readonly CarriedFinding[];
+  /** Normalized URLs of pages carried forward (un-crawled but still active). */
+  carriedPageUrls: Set<string>;
+  /** ruleId -> meta for rules absent from `ruleResults` (carried-only rules). */
+  ruleMetaIndex: Map<string, RuleRunResult["meta"]>;
+}
+
+/**
+ * Fold this audit's complete findings + the merge's carried findings into per-rule
+ * tallies — the bounded twin of
+ * `buildScoringResultsFromMerged({ freshResults: reconstructCompleteResults(…), … })`.
+ *
+ * MUST run BEFORE the merge's persistence writes: `computeMerge` stamps RESOLVED
+ * rows with this run's crawlId, so a fold that ran after them would read a
+ * just-resolved finding back as fresh evidence of failure.
+ */
+export async function foldCompleteStoreTallies(
+  input: CompleteStoreTallyInput
+): Promise<Map<string, RuleTally>> {
+  const {
+    ruleResults,
+    findingPages,
+    crawledUrls,
+    skippedPassCounts,
+    carriedFindings,
+    carriedPageUrls,
+    ruleMetaIndex,
+  } = input;
+
+  const tallies = new Map<string, RuleTally>();
+  const metaOf = (ruleId: string): RuleRunResult["meta"] | undefined =>
+    ruleResults[ruleId]?.meta ?? ruleMetaIndex.get(ruleId);
+  const entryFor = (ruleId: string, meta: RuleRunResult["meta"]): RuleTally => {
+    let entry = tallies.get(ruleId);
+    if (!entry) {
+      entry = { meta, tally: emptyTally() };
+      tallies.set(ruleId, entry);
+    }
+    return entry;
+  };
+  const advisory = (meta: RuleRunResult["meta"]): boolean => meta.severity === "info";
+
+  // Carried findings indexed two ways, both bounded by the carried set (the
+  // findings a previous audit left open on pages this run did not re-crawl):
+  //  - byPage: to fold a page's carried checks in the SAME call as its fresh ones;
+  //  - pagesByRule: the clean-carried-pass denominator, which must survive the
+  //    page pass (it counts every carried page a rule has NO finding on).
+  const carriedByPage = new Map<string, Map<string, CarriedFinding[]>>();
+  const carriedPagesByRule = new Map<string, Set<string>>();
+  for (const f of carriedFindings) {
+    const meta = metaOf(f.ruleId);
+    // Unknown rule — cannot be scored (no meta); site-scope rules never carry
+    // per-page findings. Both mirror buildScoringResultsFromMerged's guards.
+    if (meta?.scope !== "page") continue;
+    let byRule = carriedByPage.get(f.normalizedUrl);
+    if (!byRule) {
+      byRule = new Map();
+      carriedByPage.set(f.normalizedUrl, byRule);
+    }
+    const list = byRule.get(f.ruleId);
+    if (list) list.push(f);
+    else byRule.set(f.ruleId, [f]);
+    let pages = carriedPagesByRule.get(f.ruleId);
+    if (!pages) {
+      pages = new Set();
+      carriedPagesByRule.set(f.ruleId, pages);
+    }
+    pages.add(f.normalizedUrl);
+  }
+
+  // Pages this run has a finding on, per rule — the fresh-clean denominator's
+  // subtrahend. Counted (not collected) so it stays O(rules), and counted only for
+  // CRAWLED pages, matching reconstructCompleteResults' `crawledUrls \ failingPages`.
+  const dirtyPagesByRule = new Map<string, number>();
+
+  for await (const page of findingPages) {
+    if (page.length === 0) continue;
+    const normalizedUrl = page[0]!.normalizedUrl;
+    const freshByRule = reconstructPageRuleChecks(page);
+    const carriedForPage = carriedByPage.get(normalizedUrl);
+    // Consumed: this page's carried findings are folded here, so the trailing
+    // carried pass must not fold them a second time.
+    if (carriedForPage) carriedByPage.delete(normalizedUrl);
+    const isCrawled = crawledUrls.has(normalizedUrl);
+
+    const ruleIds = new Set<string>(freshByRule.keys());
+    if (carriedForPage) for (const ruleId of carriedForPage.keys()) ruleIds.add(ruleId);
+
+    for (const ruleId of ruleIds) {
+      const meta = metaOf(ruleId);
+      // A finding whose rule is absent from the shell cannot be scored (no meta);
+      // a site-scope rule never has per-page findings. Mirrors the unknown-rule
+      // guards in reconstructCompleteResults / buildScoringResultsFromMerged.
+      if (meta?.scope !== "page") continue;
+      const fresh = freshByRule.get(ruleId);
+      const carried = carriedForPage?.get(ruleId);
+      const checks: CheckResult[] = carried
+        ? [...(fresh ?? []), ...carried.map((f) => carriedFindingToCheck(f, normalizedUrl))]
+        : (fresh ?? []);
+      addChecksToTally(entryFor(ruleId, meta).tally, checks, advisory(meta), 0);
+      if (fresh && fresh.length > 0 && isCrawled) {
+        dirtyPagesByRule.set(ruleId, (dirtyPagesByRule.get(ruleId) ?? 0) + 1);
+      }
+    }
+  }
+
+  // Trailing pass 1 — every rule the shell carries.
+  for (const [ruleId, r] of Object.entries(ruleResults)) {
+    if (r.meta.scope !== "page") {
+      // Site-scope rule: findings never carry these (flattenChecks skips
+      // no-pageUrl checks), so it is scored from the shell's checks verbatim —
+      // the same ones reconstructCompleteResults passes through.
+      addChecksToTally(entryFor(ruleId, r.meta).tally, r.checks, advisory(r.meta), 0);
+      continue;
+    }
+    const entry = entryFor(ruleId, r.meta);
+    // Fresh clean pages: crawled pages with NO finding for this rule. See the
+    // SKIP-AS-PASS approximation documented on reconstructCompleteResults — a page
+    // the rule skipped has no finding and is counted here as a pass, exactly as
+    // the #918 carried-clean model already does.
+    const clean = crawledUrls.size - (dirtyPagesByRule.get(ruleId) ?? 0);
+    // (#1305) Passing SIBLING checks on dirty pages, with the round-5 SECURITY
+    // CLAMP: skippedPassCounts is untrusted finalize-body input, and an inflated
+    // count added straight into the pass numerator would drive a genuinely-failing
+    // rule's passRate toward 1.0 — the exact #1179 integrity class this feature
+    // fixes. A check cannot pass on more pages than were crawled, so bounding the
+    // per-rule sum to the crawl universe only ever reduces an over-count.
+    let skippedPasses = 0;
+    const perCheck = skippedPassCounts?.[ruleId];
+    if (perCheck) for (const n of Object.values(perCheck)) skippedPasses += n;
+    skippedPasses = Math.min(skippedPasses, crawledUrls.size);
+    addChecksToTally(
+      entry.tally,
+      [],
+      advisory(r.meta),
+      clean + skippedPasses + cleanCarriedPasses(ruleId, carriedPageUrls, carriedPagesByRule)
+    );
+  }
+
+  // Trailing pass 2 — carried findings whose page was never streamed (the normal
+  // case: an un-crawled page), plus carried-only rules absent from the shell.
+  for (const [normalizedUrl, byRule] of carriedByPage) {
+    for (const [ruleId, findings] of byRule) {
+      const meta = metaOf(ruleId)!; // indexed above only when page-scope meta exists
+      addChecksToTally(
+        entryFor(ruleId, meta).tally,
+        findings.map((f) => carriedFindingToCheck(f, normalizedUrl)),
+        advisory(meta),
+        0
+      );
+    }
+  }
+  // Carried-only rules (page-scope, absent from the shell) get no fresh-clean
+  // count — reconstructCompleteResults never runs for them — but they DO get the
+  // carried-clean passes buildScoringResultsFromMerged gives them.
+  for (const ruleId of carriedPagesByRule.keys()) {
+    if (ruleResults[ruleId]) continue; // already handled in trailing pass 1
+    const meta = metaOf(ruleId);
+    if (meta?.scope !== "page") continue;
+    addChecksToTally(
+      entryFor(ruleId, meta).tally,
+      [],
+      advisory(meta),
+      cleanCarriedPasses(ruleId, carriedPageUrls, carriedPagesByRule)
+    );
+  }
+
+  return tallies;
+}
+
+/**
+ * Carried pages with NO finding for this rule — the carried half of the pass-ratio
+ * denominator (#918). Folded to a count, never to synthetic "pass" CheckResults,
+ * so a partial re-audit of a large site cannot materialize
+ * (page-scope rules × carried pages) objects.
+ */
+function cleanCarriedPasses(
+  ruleId: string,
+  carriedPageUrls: Set<string>,
+  carriedPagesByRule: Map<string, Set<string>>
+): number {
+  const dirty = carriedPagesByRule.get(ruleId);
+  if (!dirty || dirty.size === 0) return carriedPageUrls.size;
+  let clean = 0;
+  for (const url of carriedPageUrls) if (!dirty.has(url)) clean++;
+  return clean;
+}

--- a/packages/audit-engine/src/complete-store-fold.ts
+++ b/packages/audit-engine/src/complete-store-fold.ts
@@ -67,6 +67,15 @@ export interface CompleteStoreTallyInput {
   crawledUrls: Set<string>;
   /** (#1305) Passing sibling checks on dirty pages; see reconstructCompleteResults. */
   skippedPassCounts?: SkippedPassCounts;
+  /**
+   * Normalized URLs that returned 404/410 this run. Their fresh checks are NOT
+   * scored: the page is gone, so it is not one of the "known non-removed" pages
+   * the union covers. This mirrors the materialized path's `freshForUnion` filter
+   * in runCloudSmartAudits — a removed page can still carry ingested findings (the
+   * crawl rendered it before the status was known), and folding those would count
+   * a deleted page against the score.
+   */
+  removedUrls?: Set<string>;
   /** Issues on un-crawled, still-active pages carried forward by the merge. */
   carriedFindings: readonly CarriedFinding[];
   /** Normalized URLs of pages carried forward (un-crawled but still active). */
@@ -95,6 +104,7 @@ export async function foldCompleteStoreTallies(
     carriedFindings,
     carriedPageUrls,
     ruleMetaIndex,
+    removedUrls,
   } = input;
 
   const tallies = new Map<string, RuleTally>();
@@ -152,6 +162,11 @@ export async function foldCompleteStoreTallies(
     // carried pass must not fold them a second time.
     if (carriedForPage) carriedByPage.delete(normalizedUrl);
     const isCrawled = crawledUrls.has(normalizedUrl);
+    // 404/410 this run: the page is gone, so its fresh checks leave the union
+    // (mirroring freshForUnion). Carried findings are folded regardless — the
+    // merge stales anything on a removed page, so in practice there are none, but
+    // the shape then matches the materialized path rather than relying on that.
+    const isRemoved = removedUrls?.has(normalizedUrl) ?? false;
 
     const ruleIds = new Set<string>(freshByRule.keys());
     if (carriedForPage) for (const ruleId of carriedForPage.keys()) ruleIds.add(ruleId);
@@ -162,11 +177,12 @@ export async function foldCompleteStoreTallies(
       // a site-scope rule never has per-page findings. Mirrors the unknown-rule
       // guards in reconstructCompleteResults / buildScoringResultsFromMerged.
       if (meta?.scope !== "page") continue;
-      const fresh = freshByRule.get(ruleId);
+      const fresh = isRemoved ? undefined : freshByRule.get(ruleId);
       const carried = carriedForPage?.get(ruleId);
       const checks: CheckResult[] = carried
         ? [...(fresh ?? []), ...carried.map((f) => carriedFindingToCheck(f, normalizedUrl))]
         : (fresh ?? []);
+      if (checks.length === 0) continue;
       addChecksToTally(entryFor(ruleId, meta).tally, checks, advisory(meta), 0);
       if (fresh && fresh.length > 0 && isCrawled) {
         dirtyPagesByRule.set(ruleId, (dirtyPagesByRule.get(ruleId) ?? 0) + 1);

--- a/packages/audit-engine/src/complete-store-fold.ts
+++ b/packages/audit-engine/src/complete-store-fold.ts
@@ -42,11 +42,11 @@ import {
 import type { SkippedPassCounts } from "./stream-findings";
 
 /**
- * This audit's complete findings, delivered ONE PAGE AT A TIME. Each yielded array
- * holds every ingested finding for a single `normalizedUrl`; a page must never be
- * split across two items (see the module header). The API implements this as a
- * keyset cursor over page_findings that buffers to page boundaries, so no more
- * than one page's rows are resident at a time.
+ * This audit's complete findings, delivered a page at a time. A yielded array may
+ * hold several WHOLE pages, but a single page must never be SPLIT across two
+ * items — that is what the fold's byte-identity rests on (see the module header).
+ * The API implements this as a keyset cursor over page_findings that buffers to
+ * page boundaries, so no more than one page's rows are resident at a time.
  */
 export type FindingPageSource = AsyncIterable<readonly PageFindingRecord[]>;
 
@@ -153,9 +153,10 @@ export async function foldCompleteStoreTallies(
   // CRAWLED pages, matching reconstructCompleteResults' `crawledUrls \ failingPages`.
   const dirtyPagesByRule = new Map<string, number>();
 
-  for await (const page of findingPages) {
-    if (page.length === 0) continue;
-    const normalizedUrl = page[0]!.normalizedUrl;
+  /** Fold ONE page: its reconstructed fresh checks plus any carried findings that
+   * sit on the same page, in a single addChecksToTally call per rule so no
+   * (checkName, pageUrl) bucket is ever split. */
+  const foldPage = (normalizedUrl: string, page: readonly PageFindingRecord[]): void => {
     const freshByRule = reconstructPageRuleChecks(page);
     const carriedForPage = carriedByPage.get(normalizedUrl);
     // Consumed: this page's carried findings are folded here, so the trailing
@@ -188,6 +189,16 @@ export async function foldCompleteStoreTallies(
         dirtyPagesByRule.set(ruleId, (dirtyPagesByRule.get(ruleId) ?? 0) + 1);
       }
     }
+  };
+
+  for await (const batch of findingPages) {
+    if (batch.length === 0) continue;
+    // Re-group by page rather than trusting a batch to hold exactly one. What the
+    // invariant needs is that a page is never SPLIT across two items; a batch
+    // carrying several WHOLE pages is harmless, and grouping here means such a
+    // producer cannot silently attribute one page's findings to another page's
+    // crawled/removed state.
+    for (const [normalizedUrl, page] of groupByPage(batch)) foldPage(normalizedUrl, page);
   }
 
   // Trailing pass 1 — every rule the shell carries.
@@ -252,6 +263,19 @@ export async function foldCompleteStoreTallies(
   }
 
   return tallies;
+}
+
+/** Split a batch of findings into per-page groups, preserving arrival order. */
+function groupByPage(
+  batch: readonly PageFindingRecord[]
+): Map<string, PageFindingRecord[]> {
+  const byPage = new Map<string, PageFindingRecord[]>();
+  for (const f of batch) {
+    const rows = byPage.get(f.normalizedUrl);
+    if (rows) rows.push(f);
+    else byPage.set(f.normalizedUrl, [f]);
+  }
+  return byPage;
 }
 
 /**

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -56,6 +56,7 @@ export {
   addTally,
   emptyTally,
   ruleScoreFromTally,
+  carriedFindingToCheck,
 } from "./scoring";
 export type { AuditStatusSignals } from "./scoring";
 export type {
@@ -92,8 +93,12 @@ export type {
   CloudSmartAuditsInput,
   CloudSmartAuditsResult,
 } from "./merge-promise";
-export { reconstructCompleteResults } from "./reconstruct";
+export { reconstructCompleteResults, reconstructPageRuleChecks } from "./reconstruct";
 export type { ReconstructCompleteInput } from "./reconstruct";
+// Bounded complete-store scoring fold (#1873) — the memory-safe twin of
+// reconstructCompleteResults + buildScoringResultsFromMerged.
+export { foldCompleteStoreTallies } from "./complete-store-fold";
+export type { CompleteStoreTallyInput, FindingPageSource } from "./complete-store-fold";
 // Chunked-publish producer: flatten a report to complete streamable findings (#1023).
 export { buildStreamFindings, buildSkippedPassCounts } from "./stream-findings";
 export type { StreamFindingLine, SkippedPassCounts } from "./stream-findings";

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -30,9 +30,16 @@ import {
   type MergedState,
   type MergeResolutionInput,
 } from "./merge-core";
-import { reconstructCompleteResults } from "./reconstruct";
+import {
+  foldCompleteStoreTallies,
+  type FindingPageSource,
+} from "./complete-store-fold";
 import type { SkippedPassCounts } from "./stream-findings";
-import { buildScoringResultsFromMerged, type CarriedFinding } from "./scoring";
+import {
+  buildScoringResultsFromMerged,
+  type CarriedFinding,
+  type RuleTally,
+} from "./scoring";
 
 /** 404/410 = page gone → stale its findings (not carry). */
 const REMOVED_STATUSES = new Set([404, 410]);
@@ -80,6 +87,14 @@ export interface MergeFindingsPromiseInput {
   sampledCheckPages?: Map<string, Set<string>>;
   /** (#1185) Pre-indexed publish resolution signal — see {@link ComputeMergeInput.resolution}. */
   resolution?: MergeResolutionInput;
+  /**
+   * (#1873) Prior OPEN findings, already loaded by the caller — skips the
+   * `store.getFindings(siteKey, ["open"])` read. The complete-store finalize uses
+   * it to pass the findings this audit did NOT re-observe: the chunk ingest has
+   * already upserted every re-observed finding under this run's crawlId, so the
+   * store read would return the whole audit a second time.
+   */
+  priorFindings?: PageFindingRecord[];
 }
 
 /**
@@ -87,8 +102,8 @@ export interface MergeFindingsPromiseInput {
  * via the store, then run the pure {@link computeMerge}.
  */
 export async function mergeFindingsPromise(input: MergeFindingsPromiseInput): Promise<MergedState> {
-  const { store, siteKey, now, ...rest } = input;
-  const priorFindings = await store.getFindings(siteKey, ["open"]);
+  const { store, siteKey, now, priorFindings: preloaded, ...rest } = input;
+  const priorFindings = preloaded ?? (await store.getFindings(siteKey, ["open"]));
   const priorPages = await store.getSitePages(siteKey);
   return computeMerge({
     ...rest,
@@ -129,8 +144,21 @@ export interface CloudSmartAuditsInput {
    * page's absence from the fresh set authoritative — so both are skipped.
    */
   completeStore?: {
-    /** Complete per-(page,rule,check,locator) findings for this audit. */
-    ingestedFindings: PageFindingRecord[];
+    /**
+     * (#1873) Complete per-(page,rule,check,locator) findings for this audit,
+     * delivered ONE PAGE AT A TIME and folded into per-rule tallies rather than
+     * materialized — a 43k-finding audit does not fit in the 128 MB API isolate.
+     * See {@link FindingPageSource} for the page-boundary contract.
+     */
+    findingPages: FindingPageSource;
+    /**
+     * (#1873) Prior OPEN findings for the site EXCLUDING the rows this audit's
+     * chunk ingest wrote. Required in complete mode: those rows are the fresh
+     * evidence (already persisted, and folded from `findingPages`), so loading
+     * them as "prior" would both double the isolate's memory and make the merge
+     * reason about this run's own findings as if a previous run had left them.
+     */
+    priorOpenFindings: PageFindingRecord[];
     /** Full crawled-URL list (`resolutionSignal.crawledUrls`); normalized here. */
     crawledUrls: string[];
     /**
@@ -145,8 +173,25 @@ export interface CloudSmartAuditsInput {
 }
 
 export interface CloudSmartAuditsResult {
-  /** UNION rule results (fresh + carried) for authoritative scoring + report. */
+  /**
+   * UNION rule results (fresh + carried) for authoritative scoring + report.
+   *
+   * (#1873) In COMPLETE-STORE mode this is the REPORT surface only: page-scope
+   * rules carry the staged shell's bounded checks (the container's
+   * `slimPageChecksForShell` aggregates, which keep every affected page as
+   * `details.occurrences` + `pagesTruncated`) plus the carried replays — NOT one
+   * check per affected page. The authoritative numbers come from
+   * {@link scoringTallies} instead, which sees every page.
+   */
   unionRuleResults: Map<string, RuleRunResult>;
+  /**
+   * (#1873) Per-rule folded tallies over the COMPLETE findings — present ONLY in
+   * complete-store mode. When set, the caller MUST take the health score
+   * (`calculateHealthScoreFromTallies`) and the passed/warnings/failed totals from
+   * these, not from {@link unionRuleResults}: the tallies count every affected
+   * page, the union map only lists the shell's sample.
+   */
+  scoringTallies?: Map<string, RuleTally>;
   /** Coverage line data for surfacing. */
   coverage: {
     auditedPages: number;
@@ -229,14 +274,15 @@ export async function runCloudSmartAudits(
     for (const u of completeStore.crawledUrls) crawledUrls.add(normalizeUrl(u));
     for (const u of statusByUrl.keys()) crawledUrls.add(u);
     for (const u of removedUrls) crawledUrls.delete(u);
-    // Reconstruct AFTER crawledUrls is final — the per-rule syntheticPassCount
-    // denominator (crawled − failing pages) is measured against it.
-    freshResults = reconstructCompleteResults({
-      ruleResults: input.ruleResults,
-      ingestedFindings: completeStore.ingestedFindings,
-      crawledUrls,
-      skippedPassCounts: completeStore.skippedPassCounts,
-    });
+    // (#1873) NOT reconstructed here. The complete findings are folded into
+    // per-rule tallies page at a time (below, after the merge), so nothing
+    // audit-sized is ever resident. `freshResults` keeps the SHELL's rules: they
+    // are the report surface and the site-scope rules' checks, exactly what the
+    // materialized reconstruction passed through untouched.
+    freshResults = new Map<string, RuleRunResult>();
+    for (const [ruleId, r] of Object.entries(input.ruleResults)) {
+      freshResults.set(ruleId, { meta: r.meta, checks: r.checks });
+    }
   } else {
     // A published report arrives already folded (#910): an over-cap per-rule
     // check array is collapsed into per-issue-class aggregates that carry every
@@ -286,22 +332,31 @@ export async function runCloudSmartAudits(
   // Flatten fresh page-scope fail/warn checks into findings, grouped per page
   // (flattenChecks stamps one normalizedUrl across the checks it's given). Skip
   // pages removed this run — they're gone, not active issues.
+  // (#1873) Complete mode flattens NOTHING: the chunk ingest already persisted
+  // this run's findings (same rows, same PK, and the store's LEAST(first_seen)
+  // conflict rule already preserved the earliest first-seen), so re-deriving them
+  // from the shell would both re-materialize the audit and re-write rows that are
+  // already correct. The merge below therefore sees an empty fresh set and treats
+  // the prior OPEN findings the caller passed — which EXCLUDE this run's ingest —
+  // as the only rows needing a resolve/carry/stale decision.
   const freshFindings: FlatFinding[] = [];
-  for (const [ruleId, r] of freshResults) {
-    const byUrl = new Map<string, CheckResult[]>();
-    for (const c of r.checks) {
-      if (!c.pageUrl) continue; // site-scope check — not a per-page finding
-      const u = normalizeUrl(c.pageUrl);
-      if (removedUrls.has(u)) continue;
-      let arr = byUrl.get(u);
-      if (!arr) {
-        arr = [];
-        byUrl.set(u, arr);
+  if (!completeStore) {
+    for (const [ruleId, r] of freshResults) {
+      const byUrl = new Map<string, CheckResult[]>();
+      for (const c of r.checks) {
+        if (!c.pageUrl) continue; // site-scope check — not a per-page finding
+        const u = normalizeUrl(c.pageUrl);
+        if (removedUrls.has(u)) continue;
+        let arr = byUrl.get(u);
+        if (!arr) {
+          arr = [];
+          byUrl.set(u, arr);
+        }
+        arr.push(c);
       }
-      arr.push(c);
-    }
-    for (const [u, checks] of byUrl) {
-      freshFindings.push(...flattenChecks(u, ruleId, checks));
+      for (const [u, checks] of byUrl) {
+        freshFindings.push(...flattenChecks(u, ruleId, checks));
+      }
     }
   }
 
@@ -345,24 +400,8 @@ export async function runCloudSmartAudits(
     now,
     sampledCheckPages,
     resolution,
+    priorFindings: completeStore?.priorOpenFindings,
   });
-
-  // Persist: removed pages (transactional stale) first, then the rest. One tx
-  // for the whole removed set rather than one round-trip per url (#288).
-  const removedPages = Array.from(removedUrls, (url) => ({
-    normalizedUrl: url,
-    lastStatus: statusByUrl.get(url) ?? 404,
-  }));
-  await store.markPagesRemoved(siteKey, removedPages, crawlId);
-  await store.upsertFindings(merged.persisted.filter((f) => !removedUrls.has(f.normalizedUrl)));
-  await store.upsertSitePages(merged.sitePages.filter((p) => !removedUrls.has(p.normalizedUrl)));
-  // Best-effort hygiene — only ever prunes terminal rows, never open/carried, so
-  // it can't affect the merged report. NEVER fail the audit on a prune error.
-  try {
-    await store.compactFindings(siteKey);
-  } catch {
-    // degrade to "no pruning this run"
-  }
 
   // Carried pages = every active page NOT (re-)crawled this run (incl. clean
   // ones, so the union scorer can emit synthetic passes for them).
@@ -398,6 +437,43 @@ export async function runCloudSmartAudits(
     carriedLastSeen.set(carriedKey(f.normalizedUrl, f.ruleId, f.checkName), f.lastSeenAt);
   }
 
+  // (#1873) COMPLETE mode: fold this audit's findings into per-rule tallies, page
+  // at a time, straight off the store.
+  //
+  // ORDER IS LOAD-BEARING — this MUST run before the persistence block below.
+  // `computeMerge` stamps RESOLVED rows with THIS run's crawlId, and the fold's
+  // source selects by that crawlId, so folding after the writes would read a
+  // finding the merge just resolved back as fresh evidence that the page fails.
+  let scoringTallies: Map<string, RuleTally> | undefined;
+  if (completeStore) {
+    scoringTallies = await foldCompleteStoreTallies({
+      ruleResults: input.ruleResults,
+      findingPages: completeStore.findingPages,
+      crawledUrls,
+      skippedPassCounts: completeStore.skippedPassCounts,
+      carriedFindings,
+      carriedPageUrls,
+      ruleMetaIndex,
+    });
+  }
+
+  // Persist: removed pages (transactional stale) first, then the rest. One tx
+  // for the whole removed set rather than one round-trip per url (#288).
+  const removedPages = Array.from(removedUrls, (url) => ({
+    normalizedUrl: url,
+    lastStatus: statusByUrl.get(url) ?? 404,
+  }));
+  await store.markPagesRemoved(siteKey, removedPages, crawlId);
+  await store.upsertFindings(merged.persisted.filter((f) => !removedUrls.has(f.normalizedUrl)));
+  await store.upsertSitePages(merged.sitePages.filter((p) => !removedUrls.has(p.normalizedUrl)));
+  // Best-effort hygiene — only ever prunes terminal rows, never open/carried, so
+  // it can't affect the merged report. NEVER fail the audit on a prune error.
+  try {
+    await store.compactFindings(siteKey);
+  } catch {
+    // degrade to "no pruning this run"
+  }
+
   // Drop checks for removed (404/410) pages from the fresh results before union
   // scoring — removed pages are not "known non-removed" pages. Site-scope checks
   // (no pageUrl) pass through untouched.
@@ -431,6 +507,7 @@ export async function runCloudSmartAudits(
 
   return {
     unionRuleResults,
+    ...(scoringTallies ? { scoringTallies } : {}),
     coverage: {
       auditedPages: crawledUrls.size,
       knownPages: merged.activePageUrls.size,

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -454,6 +454,9 @@ export async function runCloudSmartAudits(
       carriedFindings,
       carriedPageUrls,
       ruleMetaIndex,
+      // Same exclusion the union scoring applies below via `freshForUnion`: a
+      // page that 404/410'd this run is not one of the known non-removed pages.
+      removedUrls,
     });
   }
 

--- a/packages/audit-engine/src/reconstruct.ts
+++ b/packages/audit-engine/src/reconstruct.ts
@@ -157,6 +157,31 @@ function reconstructRuleChecks(findings: PageFindingRecord[]): CheckResult[] {
 }
 
 /**
+ * Reconstruct ONE page's checks, per rule, from that page's complete findings —
+ * the bounded (#1873) entry point into the same {@link reconstructRuleChecks}
+ * inverse {@link reconstructCompleteResults} uses for the whole audit.
+ *
+ * `findings` must be the findings of a SINGLE page. Feeding it a page at a time
+ * yields byte-identical checks to reconstructing the whole audit at once:
+ * reconstructRuleChecks groups by (normalizedUrl, checkName) first, so a page's
+ * groups never span pages, and the per-rule concatenation order is preserved when
+ * pages arrive in the loader's `normalizedUrl` order.
+ */
+export function reconstructPageRuleChecks(
+  findings: readonly PageFindingRecord[],
+): Map<string, CheckResult[]> {
+  const byRule = new Map<string, PageFindingRecord[]>();
+  for (const f of findings) {
+    const list = byRule.get(f.ruleId);
+    if (list) list.push(f);
+    else byRule.set(f.ruleId, [f]);
+  }
+  const out = new Map<string, CheckResult[]>();
+  for (const [ruleId, rows] of byRule) out.set(ruleId, reconstructRuleChecks(rows));
+  return out;
+}
+
+/**
  * Reconstruct the COMPLETE `freshResults` map for the complete-store finalize
  * path. Page-scope rules' checks come from `ingestedFindings` (every affected
  * page); site-scope rules keep their sampled checks. Each page-scope rule is

--- a/packages/audit-engine/src/scoring.ts
+++ b/packages/audit-engine/src/scoring.ts
@@ -118,6 +118,38 @@ export interface MergedScoringInput {
  * Site-scope rules are page-independent — their fresh checks pass through
  * unchanged (a site rule runs over whatever pages this run crawled).
  */
+/**
+ * Replay ONE carried finding as a union check. Extracted so the bounded
+ * complete-store fold (#1873) builds carried checks with byte-identical shape to
+ * the materialized union built here — the two must stay one construction, or the
+ * two scoring paths diverge on carried detail.
+ *
+ * The captured payload (items/details/pages) is replayed so a carried finding
+ * renders with the same per-item detail as a fresh one. (#1652) The
+ * never-rendered case is stamped HERE, at the one place a union check is
+ * created, so every consumer (report rendering, the hosted rescore, issue-sync)
+ * inherits it without a second lookup — and deliberately WITHOUT `lastSeenAt`:
+ * nothing has ever observed this finding, so there is no date to show.
+ */
+export function carriedFindingToCheck(
+  f: CarriedFinding,
+  normalizedUrl: string
+): CheckResult {
+  const payload = parseCarriedPayload(f.payload);
+  return {
+    name: f.checkName,
+    status: f.status === "fail" ? "fail" : "warn",
+    message: f.message,
+    pageUrl: normalizedUrl,
+    value: f.value ?? undefined,
+    expected: f.expected ?? undefined,
+    ...(payload.items ? { items: payload.items } : {}),
+    ...(payload.details ? { details: payload.details } : {}),
+    ...(payload.pages ? { pages: payload.pages } : {}),
+    ...(f.neverRendered ? { provenance: "unrendered" as const } : {}),
+  };
+}
+
 export function buildScoringResultsFromMerged(
   input: MergedScoringInput
 ): Map<string, RuleRunResult> {
@@ -186,26 +218,7 @@ export function buildScoringResultsFromMerged(
     if (carriedForRule) {
       for (const [url, findings] of carriedForRule) {
         for (const f of findings) {
-          // Replay the captured payload (items/details/pages) so carried
-          // findings render with the same per-item detail as fresh ones.
-          const payload = parseCarriedPayload(f.payload);
-          result.checks.push({
-            name: f.checkName,
-            status: f.status === "fail" ? "fail" : "warn",
-            message: f.message,
-            pageUrl: url,
-            value: f.value ?? undefined,
-            expected: f.expected ?? undefined,
-            ...(payload.items ? { items: payload.items } : {}),
-            ...(payload.details ? { details: payload.details } : {}),
-            ...(payload.pages ? { pages: payload.pages } : {}),
-            // (#1652) Stamp the never-rendered case HERE, at the one place the
-            // union check is created, so every consumer of the union (report
-            // rendering, the hosted rescore, issue-sync) inherits it without a
-            // second lookup — and deliberately WITHOUT `lastSeenAt`: nothing has
-            // ever observed this finding, so there is no date to show.
-            ...(f.neverRendered ? { provenance: "unrendered" as const } : {}),
-          });
+          result.checks.push(carriedFindingToCheck(f, url));
         }
       }
     }

--- a/packages/audit-engine/src/smart-audits.ts
+++ b/packages/audit-engine/src/smart-audits.ts
@@ -34,15 +34,31 @@ export type {
 } from "./merge-promise";
 
 export {
+  addChecksToTally,
   buildScoringResultsFromMerged,
   calculateHealthScore,
+  // (#1873) The tally scorer is the bounded twin of calculateHealthScore — the
+  // complete-store finalize scores from folded tallies so a 43k-finding audit
+  // never has to be resident in the API isolate.
+  calculateHealthScoreFromTallies,
+  carriedFindingToCheck,
+  emptyTally,
   getScoreColor,
   getScoreGrade,
 } from "./scoring";
-export type { CarriedFinding, MergedScoringInput, ScoringContext } from "./scoring";
+export type {
+  CarriedFinding,
+  IssueTally,
+  MergedScoringInput,
+  RuleTally,
+  ScoringContext,
+} from "./scoring";
 
-export { reconstructCompleteResults } from "./reconstruct";
+export { reconstructCompleteResults, reconstructPageRuleChecks } from "./reconstruct";
 export type { ReconstructCompleteInput } from "./reconstruct";
+
+export { foldCompleteStoreTallies } from "./complete-store-fold";
+export type { CompleteStoreTallyInput, FindingPageSource } from "./complete-store-fold";
 
 export { buildStreamFindings, buildSkippedPassCounts } from "./stream-findings";
 export type { StreamFindingLine, SkippedPassCounts } from "./stream-findings";

--- a/packages/audit-engine/tests/complete-store-parity.test.ts
+++ b/packages/audit-engine/tests/complete-store-parity.test.ts
@@ -758,6 +758,61 @@ describe("(d) bounded fold == the materialized reconstruction (#1873)", () => {
     }
   });
 
+  test("a page that 404'd this run leaves the score, exactly as freshForUnion drops it", async () => {
+    // A removed page can still carry ingested findings — the crawl rendered it
+    // before the 404 was known — and the materialized path filtered those checks
+    // out of the union before scoring. Folding them instead would count a deleted
+    // page against the site.
+    const native = nativeChecks(10, 3);
+    const crawled = native.map((c) => c.pageUrl!);
+    const removed = url(0); // a FAILING page, so dropping it actually moves the score
+    const ingested = toIngested(native, "web_gone", "audit_1");
+    const shell = sampledReport(native);
+
+    const bounded = await runCloudSmartAudits({
+      store: new MemStore(),
+      siteKey: "web_gone",
+      crawlId: "audit_1",
+      ruleResults: shell,
+      pageStatuses: crawled.map((u) => ({ url: u, status: u === removed ? 404 : 200 })),
+      completeStore: completeInput(ingested, crawled),
+    });
+
+    // Reference: the materialized path — crawledUrls loses the removed page, then
+    // freshForUnion drops any check still sitting on it.
+    const crawledUrls = new Set(crawled);
+    crawledUrls.delete(removed);
+    const freshResults = reconstructCompleteResults({
+      ruleResults: shell,
+      ingestedFindings: ingested,
+      crawledUrls,
+    });
+    const freshForUnion = new Map(
+      Array.from(freshResults, ([ruleId, r]) => [
+        ruleId,
+        {
+          meta: r.meta,
+          checks: r.checks.filter((c) => c.pageUrl !== removed),
+          ...(r.syntheticPassCount !== undefined
+            ? { syntheticPassCount: r.syntheticPassCount }
+            : {}),
+        },
+      ]),
+    );
+    const union = buildScoringResultsFromMerged({
+      freshResults: freshForUnion,
+      carriedFindings: [],
+      carriedPageUrls: new Set<string>(),
+      ruleMetaIndex: new Map([[pageMeta.id, pageMeta]]),
+    });
+    expect(completeHealthScore(bounded)).toEqual(calculateHealthScore({ results: union }));
+
+    // 3 pages failed, one of them is gone: 2 fails scored over the 9 live pages.
+    const tally = bounded.scoringTallies!.get(pageMeta.id)!.tally;
+    expect(tally.failed).toBe(2);
+    expect(tally.passed).toBe(7);
+  });
+
   test("carried findings on un-crawled pages fold identically to the union replay", async () => {
     // 10 crawled pages (2 failing) + 5 still-active pages this run did not crawl,
     // 2 of which carry an open finding. Exercises every carried term at once:

--- a/packages/audit-engine/tests/complete-store-parity.test.ts
+++ b/packages/audit-engine/tests/complete-store-parity.test.ts
@@ -27,10 +27,19 @@ import {
 } from "@squirrelscan/rules/fold";
 import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
 
+import type { FindingPageSource } from "../src/complete-store-fold";
 import { findingKey, flattenChecks } from "../src/merge-core";
-import { runCloudSmartAudits, type SmartAuditStore } from "../src/merge-promise";
+import {
+  runCloudSmartAudits,
+  type CloudSmartAuditsResult,
+  type SmartAuditStore,
+} from "../src/merge-promise";
 import { reconstructCompleteResults } from "../src/reconstruct";
-import { calculateHealthScore } from "../src/scoring";
+import {
+  buildScoringResultsFromMerged,
+  calculateHealthScore,
+  calculateHealthScoreFromTallies,
+} from "../src/scoring";
 import { findingFingerprint } from "../src/fingerprint";
 import { buildSkippedPassCounts, buildStreamFindings } from "../src/stream-findings";
 
@@ -174,6 +183,80 @@ function sampledReport(native: CheckResult[]) {
   return { [pageMeta.id]: { meta: pageMeta, checks: sampled } };
 }
 
+/**
+ * (#1873) Page-at-a-time source, mirroring the API's keyset cursor: rows in
+ * page_findings PK order (normalizedUrl, ruleId, checkName, locator), yielded one
+ * whole page at a time. The page-boundary contract is what keeps the incremental
+ * fold byte-identical to folding the concatenated array.
+ */
+async function* pageSource(findings: PageFindingRecord[]): FindingPageSource {
+  const sorted = [...findings].sort((a, b) => {
+    const k1 = findingKey(a.normalizedUrl, a.ruleId, a.checkName, a.locator);
+    const k2 = findingKey(b.normalizedUrl, b.ruleId, b.checkName, b.locator);
+    return k1 < k2 ? -1 : k1 > k2 ? 1 : 0;
+  });
+  const byPage = new Map<string, PageFindingRecord[]>();
+  for (const f of sorted) {
+    const rows = byPage.get(f.normalizedUrl);
+    if (rows) rows.push(f);
+    else byPage.set(f.normalizedUrl, [f]);
+  }
+  for (const rows of byPage.values()) yield rows;
+}
+
+/** completeStore input from a materialized ingest array (the store the API reads). */
+function completeInput(
+  ingested: PageFindingRecord[],
+  crawled: string[],
+  skippedPassCounts?: Record<string, Record<string, number>>,
+) {
+  return {
+    findingPages: pageSource(ingested),
+    // These fixtures run against an empty store, so nothing predates this audit.
+    priorOpenFindings: [] as PageFindingRecord[],
+    crawledUrls: crawled,
+    ...(skippedPassCounts ? { skippedPassCounts } : {}),
+  };
+}
+
+/**
+ * The published score on the complete path (#1873): folded per-rule tallies, NOT
+ * the union map — which now carries only the shell's bounded display sample.
+ * `unionRuleResults` still supplies the robots/sitemap penalty rules verbatim.
+ */
+function completeHealthScore(result: CloudSmartAuditsResult) {
+  return calculateHealthScoreFromTallies(result.scoringTallies!, result.unionRuleResults);
+}
+
+/**
+ * The PRE-#1873 materialized complete path — reconstruct every page, build the
+ * union, score it — kept as the reference the bounded fold is measured against.
+ */
+function materializedCompleteScore(
+  ruleResults: Record<string, { meta: typeof pageMeta; checks: CheckResult[] }>,
+  ingested: PageFindingRecord[],
+  crawled: string[],
+  skippedPassCounts?: Record<string, Record<string, number>>,
+) {
+  const crawledUrls = new Set(crawled);
+  const freshResults = reconstructCompleteResults({
+    ruleResults,
+    ingestedFindings: ingested,
+    crawledUrls,
+    skippedPassCounts,
+  });
+  const ruleMetaIndex = new Map(
+    Object.entries(ruleResults).map(([ruleId, r]) => [ruleId, r.meta]),
+  );
+  const union = buildScoringResultsFromMerged({
+    freshResults,
+    carriedFindings: [],
+    carriedPageUrls: new Set<string>(),
+    ruleMetaIndex,
+  });
+  return calculateHealthScore({ results: union });
+}
+
 async function runSample(siteKey: string, native: CheckResult[], crawled: string[]) {
   const store = new MemStore();
   return runCloudSmartAudits({
@@ -199,7 +282,7 @@ async function runComplete(siteKey: string, native: CheckResult[], crawled: stri
     // The shell still carries the (sampled) ruleResults — the source of rule META.
     ruleResults: sampledReport(native),
     pageStatuses: crawled.map((u) => ({ url: u, status: 200 })),
-    completeStore: { ingestedFindings: ingested, crawledUrls: crawled, skippedPassCounts },
+    completeStore: completeInput(ingested, crawled, skippedPassCounts),
   });
 }
 
@@ -338,13 +421,14 @@ describe("multi-checkName rule: passing sibling on a partial-fail page (#1305)",
       crawlId: "audit_1",
       ruleResults,
       pageStatuses: crawled.map((u) => ({ url: u, status: 200 })),
-      completeStore: { ingestedFindings: ingested, crawledUrls: crawled, skippedPassCounts },
+      completeStore: completeInput(ingested, crawled, skippedPassCounts),
     });
 
-    // The passing sibling is counted (1), not lost.
-    expect(complete.unionRuleResults.get(faqMeta.id)!.syntheticPassCount).toBe(1);
+    // The passing sibling is counted (1), not lost: the rule's tally is the warn
+    // (0.5) plus one synthetic pass, exactly the sampled path's 1.5/2.
+    expect(complete.scoringTallies!.get(faqMeta.id)!.tally.passed).toBe(1);
     // Byte-identical to the sampled path (both 1.5/2 = 75%). Fails pre-#1305 (0.5/1).
-    expect(calculateHealthScore({ results: complete.unionRuleResults })).toEqual(
+    expect(completeHealthScore(complete)).toEqual(
       calculateHealthScore({ results: sample.unionRuleResults }),
     );
   });
@@ -396,7 +480,7 @@ describe("(a) sample==complete: byte-identical published score", () => {
       const sample = await runSample("web_s", native, crawled);
       const complete = await runComplete("web_c", native, crawled);
       const sScore = calculateHealthScore({ results: sample.unionRuleResults });
-      const cScore = calculateHealthScore({ results: complete.unionRuleResults });
+      const cScore = completeHealthScore(complete);
       expect(cScore).toEqual(sScore); // full HealthScore, not just .overall
       // coverage matches too (denominator + known-page count).
       expect(complete.coverage.auditedPages).toBe(sample.coverage.auditedPages);
@@ -417,25 +501,23 @@ describe("(b) sample<complete: complete scores LOWER (more failing pages counted
     const sample = await runSample("web_s", native, crawled);
     const complete = await runComplete("web_c", native, crawled);
     const sOverall = calculateHealthScore({ results: sample.unionRuleResults }).overall!;
-    const cOverall = calculateHealthScore({ results: complete.unionRuleResults }).overall!;
+    const cOverall = completeHealthScore(complete).overall!;
 
     // Direction: complete counts every failing page → strictly lower score.
     expect(cOverall).toBeLessThan(sOverall);
 
-    // The sample lost failing pages: its union has ≤100 fail checks; the complete
-    // union has all 600.
+    // The sample lost failing pages: its union has ≤100 fail checks. The complete
+    // path counts all 600 in its TALLY — (#1873) not as 600 materialized checks.
     const sFails = sample.unionRuleResults
       .get(pageMeta.id)!
       .checks.filter((c) => c.status === "fail").length;
-    const cFails = complete.unionRuleResults
-      .get(pageMeta.id)!
-      .checks.filter((c) => c.status === "fail").length;
     expect(sFails).toBeLessThanOrEqual(DEFAULT_PUBLISH_SAMPLE.maxPagesPerCheck);
-    expect(cFails).toBe(600);
+    const cTally = complete.scoringTallies!.get(pageMeta.id)!.tally;
+    expect(cTally.failed).toBe(600);
 
-    // The complete denominator is the true crawl, so its passRate = 100/700.
-    const cRule = complete.unionRuleResults.get(pageMeta.id)!;
-    expect(cRule.syntheticPassCount).toBe(100); // 700 crawled − 600 failing
+    // The complete denominator is the true crawl, so its passRate = 100/700: the
+    // 100 clean pages arrive as synthetic passes, never as pass CheckResults.
+    expect(cTally.passed).toBe(100); // 700 crawled − 600 failing
   });
 });
 
@@ -491,21 +573,26 @@ describe("skip-as-pass divergence (measured, bounded, expected direction)", () =
       crawlId: "a1",
       ruleResults,
       pageStatuses: crawled.map((u) => ({ url: u, status: 200 })),
-      completeStore: { ingestedFindings: ingested, crawledUrls: crawled },
+      completeStore: completeInput(ingested, crawled),
     });
     const s = calculateHealthScore({ results: sample.unionRuleResults });
-    const c = calculateHealthScore({ results: complete.unionRuleResults });
-    return { s, c, sampleRule: sample.unionRuleResults.get(skipMeta.id)!, completeRule: complete.unionRuleResults.get(skipMeta.id)! };
+    const c = completeHealthScore(complete);
+    return {
+      s,
+      c,
+      sampleRule: sample.unionRuleResults.get(skipMeta.id)!,
+      completeTally: complete.scoringTallies!.get(skipMeta.id)!.tally,
+    };
   }
 
   test("skip-heavy rule (20 fail, 100 pass, 80 skipped of 200) — complete inflates, bounded", async () => {
-    const { s, c, sampleRule, completeRule } = await scores(20, 100, 80);
+    const { s, c, sampleRule, completeTally } = await scores(20, 100, 80);
     // Per-rule pass-ratio: sample = 100/120 = 0.833; complete = 180/200 = 0.90.
     const sampleTotal = sampleRule.checks.length + (sampleRule.syntheticPassCount ?? 0);
-    const completeTotal = completeRule.checks.length + (completeRule.syntheticPassCount ?? 0);
+    const completeTotal = completeTally.passed + completeTally.warnings + completeTally.failed;
     expect(sampleTotal).toBe(120); // evaluated only
     expect(completeTotal).toBe(200); // + 80 skipped counted as passes
-    expect(completeRule.syntheticPassCount).toBe(180);
+    expect(completeTally.passed).toBe(180);
 
     // eslint-disable-next-line no-console
     console.log(
@@ -555,10 +642,10 @@ describe("container producer (buildStreamFindings) → server reconstruct", () =
       crawlId: "audit_1",
       ruleResults: sampledReport(native),
       pageStatuses: crawled.map((u) => ({ url: u, status: 200 })),
-      completeStore: { ingestedFindings: ingested, crawledUrls: crawled },
+      completeStore: completeInput(ingested, crawled),
     });
     const sample = await runSample("web_ps", native, crawled);
-    expect(calculateHealthScore({ results: complete.unionRuleResults })).toEqual(
+    expect(completeHealthScore(complete)).toEqual(
       calculateHealthScore({ results: sample.unionRuleResults }),
     );
     // Producer dedupes by PK so the streamed count equals the store row count
@@ -577,5 +664,188 @@ describe("(c) complete crawledUrls == the unsampled crawled set", () => {
     const complete = await runComplete("web_c", native, crawled);
     expect(complete.coverage.auditedPages).toBe(crawled.length); // == crawledUrls
     expect(complete.completeStore).toBe(true);
+  });
+});
+
+// ── (d) THE #1873 GATE: bounded fold == materialized reconstruction ──────────
+// #1023 R-D3 scored the complete store by materializing it (reconstruct every
+// page → union map → calculateHealthScore), which OOM'd the 128 MB API isolate at
+// 43k findings (#1873). The bounded fold replaced it. These assert the two produce
+// the SAME HealthScore — not merely the same overall number — on every fixture,
+// so the memory fix cannot silently move a customer's score.
+describe("(d) bounded fold == the materialized reconstruction (#1873)", () => {
+  for (const [total, fail] of [
+    [100, 30],
+    [100, 0],
+    [100, 100],
+    [50, 17],
+    [700, 600],
+  ] as const) {
+    test(`${total} pages, ${fail} failing → identical to the materialized path`, async () => {
+      const native = nativeChecks(total, fail);
+      const crawled = native.map((c) => c.pageUrl!);
+      const ingested = toIngested(native, "web_d", "audit_1");
+      const shell = sampledReport(native);
+      const bounded = await runCloudSmartAudits({
+        store: new MemStore(),
+        siteKey: "web_d",
+        crawlId: "audit_1",
+        ruleResults: shell,
+        pageStatuses: crawled.map((u) => ({ url: u, status: 200 })),
+        completeStore: completeInput(ingested, crawled),
+      });
+      expect(completeHealthScore(bounded)).toEqual(
+        materializedCompleteScore(shell, ingested, crawled),
+      );
+    });
+  }
+
+  test("multi-item checks (per-key unit cap + additional) survive page-at-a-time folding", async () => {
+    // The fold's byte-identity rests on (checkName, pageUrl) buckets never being
+    // split across calls: items and `details.additional` feed a per-key SUM and
+    // MAX that are local to one addChecksToTally call. Items per page + a
+    // remainder is exactly the shape that would diverge if a page were split.
+    const native: CheckResult[] = [];
+    for (let i = 0; i < 40; i++) {
+      native.push({
+        name: "img-alt",
+        status: i % 3 === 0 ? "warn" : "fail",
+        message: "missing alt",
+        pageUrl: url(i),
+        items: Array.from({ length: 1 + (i % 7) }, (_, k) => ({ id: `img-${k}`, label: `#${k}` })),
+        details: { additional: i % 5 },
+      });
+    }
+    const crawled = Array.from({ length: 60 }, (_, i) => url(i));
+    const ingested = toIngested(native, "web_units", "audit_1");
+    const shell = sampledReport(native);
+    const bounded = await runCloudSmartAudits({
+      store: new MemStore(),
+      siteKey: "web_units",
+      crawlId: "audit_1",
+      ruleResults: shell,
+      pageStatuses: crawled.map((u) => ({ url: u, status: 200 })),
+      completeStore: completeInput(ingested, crawled),
+    });
+    expect(completeHealthScore(bounded)).toEqual(
+      materializedCompleteScore(shell, ingested, crawled),
+    );
+  });
+
+  test("skippedPassCounts (#1305) and its security clamp fold identically", async () => {
+    const native: CheckResult[] = [
+      { name: "faq-questions", status: "warn", message: "1 invalid", pageUrl: url(0) },
+      { name: "faq-questions", status: "fail", message: "broken", pageUrl: url(1) },
+    ];
+    const crawled = [url(0), url(1), url(2)];
+    const ingested = toIngested(native, "web_skip", "audit_1");
+    const shell = sampledReport(native);
+    for (const counts of [
+      { [pageMeta.id]: { "faq-valid": 2 } },
+      { [pageMeta.id]: { "faq-valid": 1_000_000_000 } }, // clamped to crawled.size
+    ]) {
+      const bounded = await runCloudSmartAudits({
+        store: new MemStore(),
+        siteKey: "web_skip",
+        crawlId: "audit_1",
+        ruleResults: shell,
+        pageStatuses: crawled.map((u) => ({ url: u, status: 200 })),
+        completeStore: completeInput(ingested, crawled, counts),
+      });
+      expect(completeHealthScore(bounded)).toEqual(
+        materializedCompleteScore(shell, ingested, crawled, counts),
+      );
+    }
+  });
+
+  test("carried findings on un-crawled pages fold identically to the union replay", async () => {
+    // 10 crawled pages (2 failing) + 5 still-active pages this run did not crawl,
+    // 2 of which carry an open finding. Exercises every carried term at once:
+    // the replayed carried checks, and the 3 clean carried pages that must keep
+    // counting in the pass denominator (#918).
+    const native = nativeChecks(10, 2);
+    const crawled = native.map((c) => c.pageUrl!);
+    const ingested = toIngested(native, "web_carry", "audit_1");
+    const shell = sampledReport(native);
+
+    const store = new MemStore();
+    const carriedPages = Array.from({ length: 5 }, (_, i) => `https://x.test/old/${i}`);
+    const seeded: PageFindingRecord[] = carriedPages.slice(0, 2).map((u) => ({
+      siteKey: "web_carry",
+      normalizedUrl: u,
+      ruleId: pageMeta.id,
+      checkName: "has-meta-description",
+      locator: "",
+      status: "fail",
+      severity: pageMeta.severity,
+      message: "Missing meta description",
+      value: null,
+      expected: null,
+      payload: null,
+      fingerprint: findingFingerprint("fail", "Missing meta description", null, null),
+      firstSeenAt: 1_600_000_000_000,
+      lastSeenCrawlId: "audit_0",
+      lastSeenAt: 1_600_000_000_000,
+      provenance: "fresh",
+      state: "open",
+    }));
+    await store.upsertFindings(seeded);
+    await store.upsertSitePages(
+      carriedPages.map((u) => ({
+        siteKey: "web_carry",
+        normalizedUrl: u,
+        lastStatus: 200,
+        state: "active" as const,
+        lastSeenCrawlId: "audit_0",
+        lastSeenAt: 1_600_000_000_000,
+      })),
+    );
+
+    const bounded = await runCloudSmartAudits({
+      store,
+      siteKey: "web_carry",
+      crawlId: "audit_1",
+      ruleResults: shell,
+      pageStatuses: crawled.map((u) => ({ url: u, status: 200 })),
+      completeStore: {
+        findingPages: pageSource(ingested),
+        // Mirrors the API: prior OPEN rows EXCLUDING this audit's own ingest.
+        priorOpenFindings: (await store.getFindings("web_carry", ["open"])).filter(
+          (f) => f.lastSeenCrawlId !== "audit_1",
+        ),
+        crawledUrls: crawled,
+      },
+    });
+
+    // Reference: the materialized union with the same carried inputs.
+    const freshResults = reconstructCompleteResults({
+      ruleResults: shell,
+      ingestedFindings: ingested,
+      crawledUrls: new Set(crawled),
+    });
+    const union = buildScoringResultsFromMerged({
+      freshResults,
+      carriedFindings: seeded.map((f) => ({
+        normalizedUrl: f.normalizedUrl,
+        ruleId: f.ruleId,
+        checkName: f.checkName,
+        status: f.status,
+        message: f.message,
+        value: f.value,
+        expected: f.expected,
+        payload: f.payload,
+        neverRendered: false,
+      })),
+      carriedPageUrls: new Set(carriedPages),
+      ruleMetaIndex: new Map([[pageMeta.id, pageMeta]]),
+    });
+    expect(completeHealthScore(bounded)).toEqual(calculateHealthScore({ results: union }));
+
+    // And the carried terms really are there: 2 fresh + 2 carried fails, 8 fresh
+    // clean + 3 clean carried pages.
+    const tally = bounded.scoringTallies!.get(pageMeta.id)!.tally;
+    expect(tally.failed).toBe(4);
+    expect(tally.passed).toBe(11);
+    expect(bounded.coverage.carriedFindings).toBe(2);
   });
 });

--- a/packages/rules/src/fold.ts
+++ b/packages/rules/src/fold.ts
@@ -794,7 +794,22 @@ function foldGroup(group: CheckResult[], limits: FoldLimits): CheckResult {
     })
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
-  const details: Record<string, unknown> = { aggregated: true, occurrences: group.length };
+  // Occurrence total, independent of how many OBJECTS this group holds (#1873).
+  // A constituent that is itself an aggregate already stands for `occurrences`
+  // findings, so counting objects would replace a true 600 with "1 aggregate + 3
+  // carried checks" = 4 — and issue-sync reads this as the tracker's occurrence
+  // count. Summing is exact here (unlike the pagesTruncated floor above): a
+  // per-page check is one occurrence, an aggregate's count is its own disjoint
+  // fold, and `unfoldAggregateCheck` DELETES `occurrences` when it expands one,
+  // so the unfold → re-fold path still sums to the per-page count.
+  let occurrences = 0;
+  for (const check of group) {
+    const prior = check.details?.occurrences;
+    occurrences +=
+      typeof prior === "number" && Number.isFinite(prior) && prior > 0 ? Math.floor(prior) : 1;
+  }
+
+  const details: Record<string, unknown> = { aggregated: true, occurrences };
   if (additional + droppedIds.size > 0) details.additional = additional + droppedIds.size;
   if (pagesTotal > pages.length) details.pagesTruncated = pagesTotal;
 

--- a/packages/rules/tests/fold.test.ts
+++ b/packages/rules/tests/fold.test.ts
@@ -181,6 +181,40 @@ describe("foldOverflowChecks", () => {
     );
     expect(foldOverflowChecks(checks, SMALL)).toHaveLength(SMALL.maxChecks);
   });
+
+  test("re-folding an aggregate keeps its TRUE occurrence total, not the object count (#1873)", () => {
+    // The complete-store finalize appends carried per-page checks to the staged
+    // shell's already-folded aggregates and re-folds. Counting objects would tell
+    // issue-sync this rule had 7 occurrences when the aggregate alone stands for
+    // 600 — and `occurrences` IS the tracker's count.
+    const aggregate = failCheck({
+      message: "1 thing broken (+599 more pages)",
+      pages: Array.from({ length: 3 }, (_, i) => `https://example.com/old/${i}`),
+      details: { aggregated: true, occurrences: 600, pagesTruncated: 600 },
+    });
+    const carried = Array.from({ length: 6 }, (_, i) =>
+      failCheck({ pageUrl: `https://example.com/new/${i}` }),
+    );
+
+    const folded = foldOverflowChecks([aggregate, ...carried], SMALL);
+    expect(folded).toHaveLength(1);
+    expect(folded[0]!.details?.occurrences).toBe(606); // 600 + 6, not 7
+    // The affected-page floor still comes from the constituent's marker.
+    expect(folded[0]!.details?.pagesTruncated).toBe(600);
+  });
+
+  test("unfold then re-fold still counts one occurrence per page (#1873)", () => {
+    // unfoldAggregateCheck deletes `occurrences` precisely so the expanded checks
+    // count as one each; this pins that the sum above cannot double-count them.
+    const aggregate = failCheck({
+      message: "1 thing broken (+5 more pages)",
+      pages: Array.from({ length: 6 }, (_, i) => `https://example.com/p/${i}`),
+      details: { aggregated: true, occurrences: 6 },
+    });
+    const refolded = foldOverflowChecks(unfoldAggregateCheck(aggregate), SMALL);
+    expect(refolded).toHaveLength(1);
+    expect(refolded[0]!.details?.occurrences).toBe(6);
+  });
 });
 
 // #910 acceptance: the exact drmadnani.com failure mode — images/alt-text


### PR DESCRIPTION
## What

The chunked publish path scores off the COMPLETE per-page findings a cloud audit streams into the finding store. It got there by materializing them: every row resident at once, reconstructed into per-page `CheckResult`s, unioned, then scored. On a 469-page audit that streamed 43,470 findings, the finalize step exceeded the hosting worker's 128 MB isolate and the run failed at the very last step, after the audit had already been paid for.

This replaces the materialization with an incremental fold. Findings arrive one page at a time and fold into per-rule `IssueTally` (the streaming-scoring machinery already used by the engine), and `calculateHealthScoreFromTallies` produces the score. Peak memory now tracks rules x checks instead of finding count.

## How

- `reconstructPageRuleChecks` reconstructs one page's checks, sharing the same inverse-of-`flattenChecks` code the whole-audit reconstruction uses.
- `foldCompleteStoreTallies` is the bounded twin of `reconstructCompleteResults` + `buildScoringResultsFromMerged`: the same synthetic-pass denominators, the same passing-sibling counts and their security clamp, the same carried replays.
- `runCloudSmartAudits` takes the findings as a page source and returns `scoringTallies`. In complete mode it flattens nothing, because the chunk ingest already persisted this run's rows with the store's earliest-first-seen conflict rule, and the caller passes the prior OPEN findings EXCLUDING this audit. That exclusion is a correctness requirement, and it is also what keeps the prior read bounded by the delta rather than by the whole store.
- `carriedFindingToCheck` is extracted so both scoring paths build a carried check from one construction.

## Why it is safe

Byte-identity is the gate. The parity harness now asserts the folded `HealthScore` equals the materialized one on every fixture, including:

- multi-item checks with a remainder, the shape that would diverge if a page were ever split across two folds (the per-key unit cap and the `additional` max are local to one fold call);
- the passing-sibling counts and their clamp;
- carried findings on un-crawled pages, covering the replayed carried checks and the clean-carried passes.

The page-boundary contract on the finding source is documented on the type and in the module header, because it is what the identity rests on.

## Measured

`scripts/bench-complete-store-fold.ts`, max RSS of a fresh process (Bun/JSC on a host, so the ratio transfers, not the absolutes):

| shape | materialized | bounded |
|---|---|---|
| 60,000 findings / 500 pages | 180.4 MiB | 53.0 MiB |
| 43,617 findings / 469 pages | 137.8 MiB | 51.6 MiB |

The bounded path stays flat as findings grow (20k 54.4 MiB, 60k 57.4 MiB, 150k 64.8 MiB) where the materialized one scales with them. Note the materialized peak at the real incident's size already exceeds 128 MB on the host, which is the failure being fixed.

## Tests

`bun test tests/complete-store-parity.test.ts` (23 pass), plus the merge, cloud-merge, advisory-scoring, streaming-scoring-golden and fingerprint-parity suites (40 pass). Typecheck clean.