### PR TITLE
perf(audit-engine): stop the streamed universe retaining every page's text

### DIFF
--- a/packages/audit-engine/scripts/retention-census.ts
+++ b/packages/audit-engine/scripts/retention-census.ts
@@ -1,0 +1,146 @@
+// Retention census for the streaming pipeline (#1860).
+//
+// Peak RSS tells you IF a pipeline is bounded; it does not tell you WHICH
+// structure is unbounded. This walks the objects `runStreamingRules` returns and
+// the universe it holds, and reports each one's size and its size per page, so
+// an O(pages) term can be named and priced rather than guessed at.
+//
+// Sizes are JSON byte lengths, used as a stable proxy for retained size. They
+// understate the real heap (object headers, Map overhead, UTF-16 strings) by
+// roughly 2-3x, and they are directly comparable between structures and between
+// page counts, which is what matters for finding the terms that scale.
+//
+//   bun run scripts/retention-census.ts --db /tmp/bench.sqlite
+//
+// Run it at two page counts and compare the per-page columns: a bounded term's
+// TOTAL stays flat, an O(pages) term's per-page figure stays flat instead.
+
+import { getDefaultConfig, type Config } from "@squirrelscan/config";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { Effect } from "effect";
+
+import { runStreamingRules, type PreFetchedAssets } from "../src/adapter";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+function arg(name: string, fallback?: string): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  return idx >= 0 ? process.argv[idx + 1] : fallback;
+}
+
+const DB = arg("db", "/tmp/squirrel-bench.sqlite")!;
+const BATCH = Number.parseInt(arg("batch", "50")!, 10);
+
+const EMPTY_ASSETS: PreFetchedAssets = {
+  resourceSizes: { css: [], images: [] },
+  scripts: [],
+  pdfSizes: [],
+  sitemapUrlStatuses: [],
+};
+
+function benchConfig(): Config {
+  const base = getDefaultConfig();
+  return {
+    ...base,
+    cloud: { ...base.cloud, enabled: false },
+    intel: { ...base.intel, enabled: false },
+    external_links: { ...base.external_links, enabled: false },
+    integrity: {
+      ...base.integrity,
+      soft404_confirm: { ...(base.integrity?.soft404_confirm ?? {}), enabled: false },
+    },
+  } as Config;
+}
+
+/** JSON byte length, tolerant of cycles and of a live DOM (never serialized). */
+function sizeOf(value: unknown): number {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(value, (key, v) => {
+      // A linkedom Document would serialize the whole tree; it is also exactly
+      // what this pipeline is supposed to have dropped, so report its presence
+      // rather than its size.
+      if (key === "document") return v == null ? null : "<LIVE DOCUMENT>";
+      if (typeof v === "object" && v !== null) {
+        if (seen.has(v as object)) return "<cycle>";
+        seen.add(v as object);
+        if (v instanceof Map) return Object.fromEntries(v);
+        if (v instanceof Set) return [...v];
+      }
+      return v;
+    })?.length ?? 0;
+  } catch {
+    return -1;
+  }
+}
+
+const MB = 1024 * 1024;
+
+async function main(): Promise<void> {
+  const storage = new SQLiteStorage(DB);
+  await run(storage.init());
+  const crawls = await run(storage.listCrawls(1));
+  const crawlId = crawls[0]?.id;
+  if (!crawlId) throw new Error(`no crawl in ${DB}`);
+  const pageCount = await run(storage.getPageCount(crawlId));
+
+  const result = await run(
+    runStreamingRules(storage, crawlId, benchConfig(), EMPTY_ASSETS, undefined, {
+      batchSize: BATCH,
+    }),
+  );
+
+  // Every structure the streamed rules pass hands back or holds open. `parsedPages`
+  // is the site-rule universe (the `siteData.pages` array); it is the same object
+  // set as parsedPagesCache, so it is reported once and noted.
+  const rows: Array<[string, unknown]> = [
+    ["parsedPages (site universe + cache)", result.parsedPages],
+    ["ruleResultsMap", result.ruleResultsMap],
+    ["pageResults", result.pageResults],
+    ["pageRuleResults", result.pageRuleResults],
+    ["siteResults", result.siteResults],
+    ["siteRuleResults", result.siteRuleResults],
+    ["tallies", result.tallies],
+  ];
+
+  console.log(`db=${DB} pages=${pageCount} batch=${BATCH}`);
+  console.log(`${"structure".padEnd(38)} ${"total".padStart(10)} ${"per page".padStart(10)}`);
+  let total = 0;
+  for (const [name, value] of rows) {
+    const bytes = sizeOf(value);
+    total += Math.max(0, bytes);
+    console.log(
+      `${name.padEnd(38)} ${`${(bytes / MB).toFixed(1)} MB`.padStart(10)} ${`${Math.round(bytes / pageCount)} B`.padStart(10)}`,
+    );
+  }
+  console.log(
+    `${"TOTAL".padEnd(38)} ${`${(total / MB).toFixed(1)} MB`.padStart(10)} ${`${Math.round(total / pageCount)} B`.padStart(10)}`,
+  );
+
+  // Break the universe down: which FIELD of a retained ParsedPage is the weight.
+  const parsed = [...result.parsedPages.values()];
+  const fields = ["content", "links", "images", "schemas", "headings", "schema", "meta", "og"];
+  console.log(`\nretained ParsedPage, by field (${parsed.length} pages):`);
+  for (const f of fields) {
+    const bytes = parsed.reduce(
+      (n, p) => n + sizeOf((p as unknown as Record<string, unknown>)[f]),
+      0,
+    );
+    console.log(
+      `  ${f.padEnd(14)} ${`${(bytes / MB).toFixed(1)} MB`.padStart(10)} ${`${Math.round(bytes / parsed.length)} B/page`.padStart(14)}`,
+    );
+  }
+  const textBytes = parsed.reduce((n, p) => n + (p.content?.textContent?.length ?? 0), 0);
+  console.log(
+    `  ${"of which textContent".padEnd(14)} ${`${(textBytes / MB).toFixed(1)} MB`.padStart(10)} ${`${Math.round(textBytes / parsed.length)} B/page`.padStart(14)}`,
+  );
+  const liveDocs = parsed.filter((p) => p.document != null).length;
+  console.log(`  live documents retained: ${liveDocs} (must be 0)`);
+
+  console.log(`\nrss now: ${(process.memoryUsage().rss / MB).toFixed(0)} MB`);
+  await run(storage.close());
+}
+
+await main();

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -1750,6 +1750,22 @@ function createParsedUniverseAccumulator(): {
           continue;
         }
 
+        // Drop the page's extracted TEXT before retaining the parse (#1860).
+        //
+        // This is the single largest thing the streamed universe holds: measured
+        // over a 509-page crawl of ~1 MB pages, the retained ParsedPage set is
+        // 40.5 KB per page and `content.textContent` is 39.1 KB of it — 97%.
+        // Nothing that reads this universe wants it. Site rules take their text
+        // from `ctx.collectedSignals` or from their own DOM walk; the four rules
+        // that do read `content.textContent` read it off `ctx.parsed`, the PAGE
+        // context, which Pass 2 re-parses fresh; and the report's summary and
+        // page audits read only meta/og/twitter/schema/h1 and the `isThinContent`
+        // flag, all of which survive. Every other `content` field is kept.
+        //
+        // The golden diff is the check on that reasoning: a site rule that did
+        // read this text would produce different findings than v1 and fail.
+        if (parsed.content?.textContent) parsed.content.textContent = "";
+
         const headers = buildHeadersMap(page);
         htmlPages.push({
           url: page.normalizedUrl,

--- a/packages/audit-engine/tests/streaming-pre-rules-golden.test.ts
+++ b/packages/audit-engine/tests/streaming-pre-rules-golden.test.ts
@@ -34,6 +34,8 @@ import {
   createSiteAssetCollector,
   releaseSiteContextDocuments,
   renderedPageUrlsFrom,
+  runStreamingRules,
+  type PreFetchedAssets,
   type ExternalLinkOccurrences,
   type SiteAssetOccurrences,
   type SiteContextPage,
@@ -61,6 +63,13 @@ const CONFIG = {
 } as unknown as Config;
 
 const SITE_URL = "http://synthetic.test";
+
+const EMPTY_ASSETS: PreFetchedAssets = {
+  resourceSizes: { css: [], images: [] },
+  scripts: [],
+  pdfSizes: [],
+  sitemapUrlStatuses: [],
+};
 
 /** Minimal non-null crawl stats — the crawls table requires the column. */
 const CRAWL_STATS = {
@@ -427,3 +436,45 @@ function htmlPage(url: string, title: string): PageRecord {
     securityHeaders: EMPTY_SECURITY_HEADERS,
   };
 }
+
+// #1860 P0: the streamed universe must stay O(1) per page in the fields it
+// retains, not just DOM-free. A 5,000-10,000 page audit is the target, and the
+// retained ParsedPage set is the structure that decides whether that fits.
+//
+// `content.textContent` is the whole page's extracted text and was 97% of the
+// retained universe (39.1 KB of 40.5 KB per page on a 509-page crawl of ~1 MB
+// pages). Nothing that reads this universe wants it: site rules take text from
+// `ctx.collectedSignals` or their own DOM walk, the four rules reading
+// `content.textContent` read it off `ctx.parsed` (the page context, re-parsed
+// fresh per batch), and the report reads only meta/og/twitter/schema/h1 and the
+// `isThinContent` flag. So it is dropped — and this test is what stops it
+// silently coming back, or a future site rule quietly depending on it.
+describe("streamed universe retention (#1860)", () => {
+  test("the retained universe carries no page text and no live documents", async () => {
+    const model = generateSiteModel({ seed: 23, pageCount: 40 });
+    const { storage, crawlId } = await writeCrawlToStorage(model, ":memory:");
+
+    const result = await run(
+      runStreamingRules(storage, crawlId, CONFIG, EMPTY_ASSETS, undefined, { batchSize: 7 }),
+    );
+
+    const retained = [...result.parsedPages.values()];
+    expect(retained.length).toBeGreaterThan(0);
+    for (const parsed of retained) {
+      expect(parsed.content.textContent).toBe("");
+      // The residency invariant the whole pipeline rests on.
+      expect(parsed.document).toBeNull();
+    }
+
+    // The rest of `content` must SURVIVE — the report's summary reads
+    // isThinContent, and dropping the lot would silently change every report.
+    const anyThin = retained.some((p) => typeof p.content.isThinContent === "boolean");
+    expect(anyThin).toBeTrue();
+    expect(retained.some((p) => p.content.wordCount > 0)).toBeTrue();
+    // And the fields site rules actually read must survive too.
+    expect(retained.some((p) => p.meta.title !== null)).toBeTrue();
+    expect(retained.some((p) => p.links.length > 0)).toBeTrue();
+
+    await run(storage.close());
+  }, T);
+});


### PR DESCRIPTION
Follow-up to #221. The private tracker issue squirrelscan/repo#1860 moved to P0 with a harder target: cloud audit RSS bounded by batch size, not page count, so a 5,000-10,000 page audit of ~1 MB pages fits well under 2 GB. #221 bounded DOM residency. That makes the retained per-page cost the thing that decides whether the pipeline fits, so I measured it.

## What the census found

`scripts/retention-census.ts` (added here) walks what `runStreamingRules` returns and holds open, and reports bytes per structure and per page. Over a 509-page crawl of ~1 MB, ~18.9k-node pages:

| structure | total | per page |
|---|---|---|
| parsedPages (site universe + report cache) | 19.7 MB | 40.5 KB |
| ruleResultsMap | 14.6 MB | 30.0 KB |
| pageResults | 14.4 MB | 29.6 KB |
| pageRuleResults | 16.6 MB | 34.2 KB |
| tallies | 0.2 MB | 0.4 KB |

Broken down by field, the universe was almost entirely one thing:

| field | per page |
|---|---|
| content | 39.2 KB |
| of which `textContent` | **39.1 KB** |
| links | 598 B |
| headings | 515 B |
| meta | 246 B |
| everything else | under 100 B each |

97% of what the site pass carries across the whole crawl is the full extracted text of every page.

## Nothing reads it

- Site rules take their text from `ctx.collectedSignals` (captured page-time, while the DOM was live) or from their own DOM walk. The four rules that do read `content.textContent` read it off `ctx.parsed`, the PAGE context, which Pass 2 re-parses fresh per batch.
- The report's summary and page audits read meta/og/twitter/schema/h1 and the `isThinContent` flag. All survive; every other `content` field is kept.
- The cloud-prefetch excerpt is collected during the pre-rules walk from its own parses, not from this universe.

So it is dropped at the point the universe is assembled. 19.7 MB to 1.0 MB at 509 pages; 40.5 KB to 2.1 KB per page.

## Why this is safe

The v1-vs-v2 byte-identity golden diff is the real check on the reasoning above, not the reasoning itself: a site rule that did read this text would produce different findings from v1 and fail the gate. All 31 golden and streaming tests pass, including the 518-page baseline, the site-query universe diff, and the report-stream v2 diff.

Added on top of that, a retention test that fails if the text comes back or a live document survives into the universe, and that asserts the rest of `content` and the fields site rules read are still there. Verified by reverting the drop: it fails.

## What is still O(pages)

Named so the next step is priced rather than guessed at. From the same census: `ruleResultsMap` 30.0 KB/page, `pageResults` 29.6 KB/page, `pageRuleResults` 34.2 KB/page. Those three share `CheckResult` objects, so the real retained figure is well below their sum, but it is the dominant remaining term. Bounding it is the #1021 PR-F story (score from the folded tallies, publish from a capped per-rule sample) and is deliberately not in this PR.