### PR TITLE
feat(audit-engine): emit sub-phase boundaries from the streamed rules pass

### DIFF
--- a/packages/audit-engine/scripts/post-crawl-attribution.ts
+++ b/packages/audit-engine/scripts/post-crawl-attribution.ts
@@ -1,0 +1,106 @@
+// Attribute the post-crawl RSS steps the CLOUD path actually takes (#1860).
+//
+// Production run 01M1XAA5GBR8SHXG10NZZB2PAR (drscholls.com, 150 pages, full,
+// rendered, cloud prefetch on, standard-3) showed the streamed page loop flat
+// (2583 -> 2659 MB across 120 pages) with two ~1 GB steps around it:
+//
+//   (a) +1.1 GB between "rules started" and the first 20-page heartbeat
+//   (b) +1.0 GB between the last page heartbeat and "rules completed"
+//
+// `runStreamingRules` emitted nothing between those points, so neither step
+// could be attributed from the event stream. It now emits sub-phase boundaries;
+// this samples RSS around each one against a real crawl DB.
+//
+// Sampling is SYNCHRONOUS at each boundary: these phases are sync CPU that never
+// yields, so a timer-based sampler records nothing until they finish (an
+// interval sampler reported a peak of 0 the first time this was tried).
+//
+//   bun run scripts/post-crawl-attribution.ts --db /tmp/crawl.sqlite --batch 50
+
+import { getDefaultConfig, type Config } from "@squirrelscan/config";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { Effect } from "effect";
+
+import { runStreamingRules, type PreFetchedAssets, type StreamingRulePhase } from "../src/adapter";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+function arg(name: string, fallback?: string): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  return idx >= 0 ? process.argv[idx + 1] : fallback;
+}
+
+const DB = arg("db", "/tmp/squirrel-bench.sqlite")!;
+const BATCH = Number.parseInt(arg("batch", "50")!, 10);
+const MB = 1024 * 1024;
+
+const EMPTY_ASSETS: PreFetchedAssets = {
+  resourceSizes: { css: [], images: [] },
+  scripts: [],
+  pdfSizes: [],
+  sitemapUrlStatuses: [],
+};
+
+function benchConfig(): Config {
+  const base = getDefaultConfig();
+  return {
+    ...base,
+    cloud: { ...base.cloud, enabled: false },
+    intel: { ...base.intel, enabled: false },
+    external_links: { ...base.external_links, enabled: false },
+  } as Config;
+}
+
+const rss = () => process.memoryUsage().rss;
+
+async function main(): Promise<void> {
+  const storage = new SQLiteStorage(DB);
+  await run(storage.init());
+  const crawls = await run(storage.listCrawls(1));
+  const crawlId = crawls[0]?.id;
+  if (!crawlId) throw new Error(`no crawl in ${DB}`);
+  const pageCount = await run(storage.getPageCount(crawlId));
+
+  console.log(`db=${DB} pages=${pageCount} batch=${BATCH}\n`);
+  Bun.gc(true);
+  const base = rss();
+  console.log(`baseline rss=${(base / MB).toFixed(0)} MB\n`);
+
+  const started = new Map<StreamingRulePhase, number>();
+  const peak = new Map<StreamingRulePhase, number>();
+  let pagesDone = 0;
+
+  const result = await run(
+    runStreamingRules(storage, crawlId, benchConfig(), EMPTY_ASSETS, undefined, {
+      batchSize: BATCH,
+      onPhase: (phase, boundary) => {
+        if (boundary === "start") {
+          started.set(phase, rss());
+          return;
+        }
+        const from = started.get(phase) ?? base;
+        const to = rss();
+        peak.set(phase, to - from);
+        console.log(
+          `${phase.padEnd(12)} ${`${(from / MB).toFixed(0)}`.padStart(6)} -> ${`${(to / MB).toFixed(0)}`.padStart(6)} MB` +
+            `   delta ${((to - from) / MB).toFixed(0).padStart(6)} MB`,
+        );
+      },
+      pageLoopHooks: {
+        heartbeatEveryPages: 20,
+        onProgress: (done) => {
+          pagesDone = done;
+          console.log(`  page-rules heartbeat ${done} pages  rss=${(rss() / MB).toFixed(0)} MB`);
+        },
+      },
+    }),
+  );
+
+  console.log(`\npages scored=${pagesDone} findings-rules=${result.ruleResultsMap.size}`);
+  console.log(`final rss=${(rss() / MB).toFixed(0)} MB (baseline ${(base / MB).toFixed(0)} MB)`);
+  await run(storage.close());
+}
+
+await main();

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -2257,6 +2257,25 @@ function runSitePass(
   });
 }
 
+/**
+ * The sub-phases of {@link runStreamingRules}, in execution order. Named so a
+ * memory or wall-clock step can be attributed to one of them instead of to
+ * "rules" as a whole (#1860).
+ */
+export type StreamingRulePhase =
+  /** Pass 1: the streamed DOM-free scalar universe. */
+  | "universe"
+  /** Steps 2+3: robots/sitemaps/links/cloaking/soft-404, plus siteData assembly. */
+  | "site-fetch"
+  /** Pass 2: the streamed page-rule loop (this one already heartbeats per N pages). */
+  | "page-rules"
+  /** The bounded aggregate view over the crawl (incoming links, page_features). */
+  | "site-query"
+  /** The site-rule pass over the DOM-free universe + collected signals. */
+  | "site-rules"
+  /** Merging + folding the site results and building the report's parsed cache. */
+  | "assemble";
+
 /** {@link runStreamingRules} result: the v1 {@link RuleExecutionResult} plus the folded per-rule tallies and the page-stream DOM-residency high-water mark. */
 export interface StreamingRuleExecutionResult extends RuleExecutionResult {
   /**
@@ -2304,11 +2323,30 @@ export function runStreamingRules(
      * progress marker every N pages; omitted → byte-identical local behavior.
      */
     pageLoopHooks?: PageRuleLoopHooks;
+    /**
+     * Sub-phase boundaries inside the rules pass (#1860).
+     *
+     * The pass emits nothing between "rules started" and "rules completed", and a
+     * production run at 150 pages showed two ~1 GB steps hiding in exactly those
+     * gaps — one before the first page heartbeat, one after the last — which the
+     * event stream could not attribute to anything. Callers hook this to sample
+     * RSS (or time) per sub-phase. The engine deliberately does not sample
+     * anything itself: `process` is the caller's concern.
+     */
+    onPhase?: (phase: StreamingRulePhase, boundary: "start" | "end") => void;
   },
 ): Effect.Effect<StreamingRuleExecutionResult, never, never> {
   return Effect.gen(function* () {
     // Clamped — see streaming.ts; a 0 batch would loop forever over the crawl.
     const batchSize = Math.max(1, opts?.batchSize ?? STREAM_PAGE_BATCH);
+    const onPhase = opts?.onPhase;
+    const phase = <T,>(name: StreamingRulePhase, body: () => Effect.Effect<T, never, never>) =>
+      Effect.gen(function* () {
+        onPhase?.(name, "start");
+        const out = yield* body();
+        onPhase?.(name, "end");
+        return out;
+      });
 
     // Threat-intel scope + runner (mirror of runRulesOnStorage).
     const effectiveScope =
@@ -2317,17 +2355,19 @@ export function runStreamingRules(
 
     // Pass 1: DOM-free scalar universe (one batch of DOMs live at a time).
     const { parsedPages, pageDataMap, totalPageCount, wafBlockedPages, rateLimitedPages } =
-      yield* streamParsedUniverse(storage, crawlId, batchSize);
+      yield* phase("universe", () => streamParsedUniverse(storage, crawlId, batchSize));
 
     // Steps 2+3: site-fetch phase + soft-404 verdict map.
-    const { siteDataForPageRules, soft404Map } = yield* buildStreamingSiteData(
-      storage,
-      crawlId,
-      config,
-      assets,
-      parsedPages,
-      pageDataMap,
-      totalPageCount,
+    const { siteDataForPageRules, soft404Map } = yield* phase("site-fetch", () =>
+      buildStreamingSiteData(
+        storage,
+        crawlId,
+        config,
+        assets,
+        parsedPages,
+        pageDataMap,
+        totalPageCount,
+      ),
     );
 
     // Pass 2: streamed page-rule pass — per-page DOM-drop, merge + fold. The
@@ -2344,7 +2384,8 @@ export function runStreamingRules(
         );
       },
     };
-    const streamed = yield* streamPageRules(storage, crawlId, runner, siteDataForPageRules, {
+    const streamed = yield* phase("page-rules", () =>
+      streamPageRules(storage, crawlId, runner, siteDataForPageRules, {
       batchSize,
       soft404Confirmations: soft404Map,
       collectors: [signalCollector],
@@ -2356,7 +2397,8 @@ export function runStreamingRules(
       pageUniverse: new Set(pageDataMap.keys()),
       totalPages: pageDataMap.size,
       pageLoopHooks: opts?.pageLoopHooks,
-    });
+      }),
+    );
     const collectedSignals: CollectedSiteSignals = { pages: collectedPages };
 
     // Bounded, read-only aggregate view over the crawl (#1022): the site pass's
@@ -2367,19 +2409,24 @@ export function runStreamingRules(
     // failure is a hard error, not a silent empty view (matches the streaming reads).
     // `universe` = v1's assembled site.pages order (parsedPages) so the incoming-link
     // graph's membership/order/sources match v1 exactly (E-E2 (b) reconciliation).
-    const siteQuery = yield* createSiteQuery(storage, crawlId, {
-      universe: parsedPages.map((p) => p.url),
-    }).pipe(Effect.orDie);
+    const siteQuery = yield* phase("site-query", () =>
+      createSiteQuery(storage, crawlId, {
+        universe: parsedPages.map((p) => p.url),
+        pageScanBatchSize: batchSize,
+      }).pipe(Effect.orDie),
+    );
 
     // Step 5: site pass over the DOM-free scalar universe (no re-materialization).
-    const sitePass = yield* runSitePass(
-      runner,
-      siteDataForPageRules,
-      assets,
-      wafBlockedPages,
-      rateLimitedPages,
-      collectedSignals,
-      siteQuery,
+    const sitePass = yield* phase("site-rules", () =>
+      runSitePass(
+        runner,
+        siteDataForPageRules,
+        assets,
+        wafBlockedPages,
+        rateLimitedPages,
+        collectedSignals,
+        siteQuery,
+      ),
     );
 
     // Step 6: assemble. Page rules were already merged + folded by streamPageRules;

--- a/packages/audit-engine/src/site-query.ts
+++ b/packages/audit-engine/src/site-query.ts
@@ -26,9 +26,19 @@ import type {
   StorageError,
 } from "@squirrelscan/core-contracts";
 
-// Page-scan / cursor batch size. Bounds residency to one batch of pages while
-// pre-materializing the incoming-link counts and while walking `pagesMatching`.
-const PAGE_SCAN_BATCH = 500;
+// Cursor batch for the page_features reads, whose rows are small scalars.
+const FEATURE_SCAN_BATCH = 500;
+
+/**
+ * Default batch for the PAGES scan, which is a different animal: `getPages`
+ * returns whole `PageRecord`s, html included, and this scan reads only
+ * `normalizedUrl` and `parsedData`. At 500 that pulled every page of a
+ * 150-page crawl resident at once — roughly 1.5 GB on ~1 MB pages, inside the
+ * window a production run showed a ~1 GB step it could not attribute (#1860).
+ * Callers that know their memory ceiling pass `pageScanBatchSize`; the default
+ * stays modest so a caller that does not is not handed the old behaviour.
+ */
+const PAGE_SCAN_BATCH = 50;
 
 /**
  * Build a {@link SiteQuery} over one crawl's stored pages + page_features rows.
@@ -51,12 +61,27 @@ export function createSiteQuery(
      * (all-HTML-2xx fixtures) → falls back to the raw stored-pages set.
      */
     universe?: readonly string[];
+    /**
+     * Pages pulled per batch by the link-graph scan (#1860). `getPages` returns
+     * whole PageRecords, so this multiplies by the site's page size; the cloud
+     * passes the same batch its other streamed walks use, sized from the
+     * container's memory ceiling. Unset → {@link PAGE_SCAN_BATCH}.
+     */
+    pageScanBatchSize?: number;
   }
 ): Effect.Effect<SiteQuery, StorageError, never> {
   return Effect.gen(function* () {
     // Incoming internal-link counts — reconstructed from parsed page links, NOT
     // link_appearances (which stores only external links; see below).
-    const incoming = yield* buildIncomingLinkCounts(storage, crawlId, opts?.universe);
+    // Clamped like every other streamed batch: `getPages` treats limit 0 as no
+    // limit, which would pull the whole crawl and never advance the offset.
+    const pageScanBatch = Math.max(1, opts?.pageScanBatchSize ?? PAGE_SCAN_BATCH);
+    const incoming = yield* buildIncomingLinkCounts(
+      storage,
+      crawlId,
+      opts?.universe,
+      pageScanBatch,
+    );
 
     // page_features rollups (PR-A read API). All bounded by construction.
     const pageCount = yield* storage.getPageFeaturesCount(crawlId);
@@ -125,7 +150,8 @@ export function createSiteQuery(
 function buildIncomingLinkCounts(
   storage: SQLiteStorage,
   crawlId: string,
-  universe?: readonly string[]
+  universe: readonly string[] | undefined,
+  pageScanBatch: number
 ): Effect.Effect<
   { all: Map<string, number>; contextual: Map<string, number> },
   StorageError,
@@ -152,7 +178,7 @@ function buildIncomingLinkCounts(
         contextualBucket.set(normalizeUrl(url), 0);
       }
     } else {
-      yield* streamPages(storage, crawlId, (page) => {
+      yield* streamPages(storage, crawlId, pageScanBatch, (page) => {
         orderedUrls.push(page.normalizedUrl);
         bucket.set(normalizeUrl(page.normalizedUrl), 0);
         contextualBucket.set(normalizeUrl(page.normalizedUrl), 0);
@@ -162,7 +188,7 @@ function buildIncomingLinkCounts(
     // Pass B: count internal dofollow links whose resolved+normalized target is a
     // crawled page. A second scan keeps at most one page batch resident (vs.
     // holding every page's links). Only pages in the universe are valid sources.
-    yield* streamPages(storage, crawlId, (page) => {
+    yield* streamPages(storage, crawlId, pageScanBatch, (page) => {
       if (universeSet && !universeSet.has(page.normalizedUrl)) return;
       for (const link of parseLinks(page.parsedData)) {
         if (link.isInternal && link.url && !link.isNofollow) {
@@ -206,7 +232,7 @@ function buildPagesByType(
     for (;;) {
       const rows = yield* storage.getPageFeaturesPage(crawlId, {
         after,
-        limit: PAGE_SCAN_BATCH,
+        limit: FEATURE_SCAN_BATCH,
       });
       if (rows.length === 0) break;
       for (const row of rows) {
@@ -216,7 +242,7 @@ function buildPagesByType(
           else byType.set(row.pageType, [row.normalizedUrl]);
         }
       }
-      if (rows.length < PAGE_SCAN_BATCH) break;
+      if (rows.length < FEATURE_SCAN_BATCH) break;
       after = rows[rows.length - 1]!.normalizedUrl;
     }
     return byType;
@@ -227,18 +253,19 @@ function buildPagesByType(
 function streamPages(
   storage: SQLiteStorage,
   crawlId: string,
+  batchSize: number,
   onPage: (page: PageRecord) => void
 ): Effect.Effect<void, StorageError, never> {
   return Effect.gen(function* () {
     let offset = 0;
     for (;;) {
       const batch = yield* storage.getPages(crawlId, {
-        limit: PAGE_SCAN_BATCH,
+        limit: batchSize,
         offset,
       });
       for (const page of batch) onPage(page);
-      if (batch.length < PAGE_SCAN_BATCH) break;
-      offset += PAGE_SCAN_BATCH;
+      if (batch.length < batchSize) break;
+      offset += batchSize;
     }
   });
 }
@@ -264,7 +291,7 @@ async function* iteratePagesMatching(
   for (;;) {
     const rows = await Effect.runPromise(
       storage
-        .getPageFeaturesPage(crawlId, { after, limit: PAGE_SCAN_BATCH })
+        .getPageFeaturesPage(crawlId, { after, limit: FEATURE_SCAN_BATCH })
         // A read failure mid-cursor is a hard error, not a silent truncation.
         .pipe(Effect.orDie)
     );
@@ -272,7 +299,7 @@ async function* iteratePagesMatching(
     for (const row of rows) {
       if (pred(row)) yield row;
     }
-    if (rows.length < PAGE_SCAN_BATCH) return;
+    if (rows.length < FEATURE_SCAN_BATCH) return;
     after = rows[rows.length - 1]!.normalizedUrl;
   }
 }


### PR DESCRIPTION
Investigation support for squirrelscan/repo#1860. Not a fix: this makes the thing measurable and reports what the measurement says.

## Why

The first production run on the streaming path (drscholls.com, 150 pages, full, rendered, cloud prefetch on, standard-3) showed the streamed page loop flat, 2583 to 2659 MB across 120 pages, with two ~1 GB steps around it:

- +1.1 GB between "rules started" and the first 20-page heartbeat
- +1.0 GB between the last page heartbeat and "rules completed"

`runStreamingRules` emitted nothing between those two points, so neither step could be attributed to anything from the event stream.

## What this adds

An `onPhase` hook reporting the pass's sub-phases in order: `universe`, `site-fetch`, `page-rules`, `site-query`, `site-rules`. The engine samples nothing itself, because `process` is the caller's concern and the container already owns RSS sampling.

## What the measurement says

Reproduced on a 153-page crawl of ~1 MB, ~19k-node pages, RSS sampled synchronously at each boundary (a timer-based sampler reads nothing here: these phases are sync CPU that never yields):

| batch | universe | page-rules | site-fetch | site-query | site-rules |
|---|---|---|---|---|---|
| 10 | +233 MB | +324 MB | −1 MB | +74 MB | −3 MB |
| 25 | +501 MB | +404 MB | +1 MB | +43 MB | −1 MB |
| 50 | +673 MB | +730 MB | +2 MB | −58 MB | +2 MB |

Both production steps are the **same term**: one batch's parse working set, sampled at different points in a saw-tooth that rises within a batch and drops when the batch is collected. Nothing new is unbounded; the batch is simply large for pages of this weight.

I want to state one thing plainly, because I guessed wrong before measuring: I expected `createSiteQuery` to be the second step, since its link-graph scan had a hardcoded batch of 500 and pulls whole `PageRecord`s. It is not. It moves memory by tens of MB, and the site pass by single digits. The collected-signals design from #1021 is doing exactly its job.

## The one real change

`createSiteQuery`'s link-graph scan now takes the caller's batch size instead of its own 500. It reads only `normalizedUrl` and `parsedData` but receives whole `PageRecord`s, so 500 of them is a latent whole-crawl read sitting on the one path that must not have one. Measured harmless at 153 pages; bounded now so it stays that way at 5,000. The `page_features` cursors keep 500, since those rows are small scalars.

## Not addressed here

The production run also showed 1.45 GB already resident at crawl end for 150 pages, about 10 MB per page. That is the crawl phase, not the post-crawl pipeline, and it is page-count dependent, so it is the term that decides whether large crawls fit. It needs its own investigation.

`scripts/post-crawl-attribution.ts` is the harness that produced the table. All golden and site-query gates pass unchanged.