### PR TITLE
perf(audit-engine): size the streamed batch from a byte budget, not a page count

### DIFF
--- a/packages/audit-engine/src/batch-sizing.ts
+++ b/packages/audit-engine/src/batch-sizing.ts
@@ -1,0 +1,208 @@
+// Byte-budget batch sizing for the streamed pipeline (#1860).
+//
+// Every streamed walk holds one batch of pages live: read, parse, use, drop.
+// Peak RSS is therefore `batch × per-page cost`, and per-page cost is set by the
+// SITE, not by us — a docs site's 20 KB pages and a Shopify product page's 1 MB
+// differ by fifty times. A fixed page count cannot be right for both. At 50
+// pages it is generous for the first and, measured on ~1 MB pages, a 400-670 MB
+// swing for the second; the same 50 on a light site wastes the headroom it was
+// sized for and makes the walk slower than it needs to be.
+//
+// So the batch is sized from a BYTE budget instead: how much raw html we are
+// willing to hold at once. Pages per batch falls out of the site's own average
+// page size. The budget is the thing an operator actually reasons about against
+// a container's memory ceiling, and it holds across site shapes without a
+// per-site override.
+//
+// The budget counts RAW HTML bytes, not the parsed footprint. Parsing multiplies
+// it — measured around 13x on script-heavy ~1 MB pages, less on lighter markup —
+// so the budget is not a memory limit, it is the input that determines one. It
+// is deliberately the quantity we can measure exactly and cheaply, rather than a
+// parsed-size estimate that would be wrong per site in a way nobody could debug.
+
+import { Effect } from "effect";
+
+import type { SQLiteStorage } from "@squirrelscan/crawler";
+
+/**
+ * Default raw-html bytes held per batch. 48 MB parses to roughly 600 MB on the
+ * heaviest pages measured, which fits a standard-3 container (8 GiB) alongside
+ * the crawl's own high-water and the report tail with room to spare.
+ */
+export const STREAM_BATCH_BYTES = 48 * 1024 * 1024;
+
+/** Floor: below this the per-batch storage round-trips start to dominate. */
+export const STREAM_BATCH_MIN_PAGES = 5;
+
+/** Ceiling: a light-page site must not talk itself into a whole-crawl batch. */
+export const STREAM_BATCH_MAX_PAGES = 500;
+
+/** Pages sampled to estimate the site's average page size. */
+const SIZE_SAMPLE_PAGES = 12;
+
+/**
+ * A finite positive integer, or `fallback`.
+ *
+ * Every number in this module ends up as a SQLite `LIMIT`/`OFFSET`, where the
+ * failure modes are silent and severe: `limit: 0` and `limit: NaN` are both
+ * falsy, so the query drops the LIMIT clause and returns the whole crawl, and a
+ * `NaN` offset never advances — an infinite loop re-reading every page forever.
+ * A fractional limit is a SQLite bind error. So nothing reaches a query without
+ * passing through here, including caller-supplied bounds.
+ */
+function toPositiveInt(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  const floored = Math.floor(value);
+  return floored >= 1 ? floored : fallback;
+}
+
+/**
+ * Pages per batch for a site whose average page is `avgPageBytes` of html.
+ *
+ * A non-positive or non-finite average (an empty crawl, a crawl of pages with no
+ * stored html) yields the floor rather than a division by zero: a tiny batch is
+ * always safe, and the walk is over almost immediately anyway.
+ */
+export function resolveStreamBatchPages(opts: {
+  avgPageBytes: number;
+  byteBudget?: number;
+  minPages?: number;
+  maxPages?: number;
+}): number {
+  const min = toPositiveInt(opts.minPages, STREAM_BATCH_MIN_PAGES);
+  const max = Math.max(min, toPositiveInt(opts.maxPages, STREAM_BATCH_MAX_PAGES));
+  const budget = toPositiveInt(opts.byteBudget, STREAM_BATCH_BYTES);
+  if (!Number.isFinite(opts.avgPageBytes) || opts.avgPageBytes <= 0) return min;
+  const pages = Math.floor(budget / opts.avgPageBytes);
+  // `pages` is finite here (finite budget over a positive finite average), so the
+  // clamp cannot propagate a NaN.
+  return Math.min(max, Math.max(min, pages));
+}
+
+/**
+ * Average stored html bytes per page, from a small sample.
+ *
+ * Sampled rather than read from `crawl.stats.bytesTotal` deliberately: that
+ * counter sums the crawler's fetched `sizeBytes`, which for a gzipped origin is
+ * the TRANSFER size — the incident page was 105 KB on the wire and 1 MB of html
+ * — so budgeting against it would pick a batch ten times too large on exactly
+ * the sites that need it smallest. `html.length` is the quantity the batch
+ * actually holds, so that is what gets measured.
+ *
+ * The sample is spread across the crawl (start, middle, end) instead of taken
+ * from the front, because `getPages` orders by normalized_url and a site's URL
+ * order correlates with page type — a front-only sample on a site whose `/a…`
+ * paths are light index pages would size the batch for the wrong page.
+ *
+ * Costs `SIZE_SAMPLE_PAGES` page reads, dropped immediately. Returns 0 for an
+ * empty crawl, which {@link resolveStreamBatchPages} turns into the floor.
+ */
+export function sampleAveragePageBytes(
+  storage: SQLiteStorage,
+  crawlId: string,
+  totalPages: number,
+): Effect.Effect<number, never, never> {
+  return Effect.gen(function* () {
+    if (!Number.isFinite(totalPages) || totalPages <= 0) return 0;
+    const total = Math.floor(totalPages);
+    if (total <= SIZE_SAMPLE_PAGES) {
+      const batch = yield* storage
+        .getPages(crawlId, { limit: total })
+        .pipe(Effect.catchAll(() => Effect.succeed([])));
+      return averageHtmlBytes(batch);
+    }
+
+    // Three DISJOINT windows: front, middle, back. Disjointness is enforced
+    // rather than assumed — at 13 pages the naive offsets (0, 6, 9) with a
+    // 4-page window overlap on page 9, which counts one page twice and silently
+    // samples fewer distinct pages than intended.
+    const perWindow = Math.max(1, Math.ceil(SIZE_SAMPLE_PAGES / 3));
+    const starts: number[] = [];
+    for (const candidate of [0, Math.floor((total - perWindow) / 2), total - perWindow]) {
+      const start = Math.max(0, Math.min(total - perWindow, Math.floor(candidate)));
+      const previous = starts[starts.length - 1];
+      if (previous === undefined || start >= previous + perWindow) starts.push(start);
+    }
+
+    let bytes = 0;
+    let counted = 0;
+    for (const offset of starts) {
+      const batch = yield* storage
+        .getPages(crawlId, { limit: perWindow, offset })
+        .pipe(Effect.catchAll(() => Effect.succeed([])));
+      for (const page of batch) {
+        // Pages with no html (redirects, non-HTML) are not what the batch holds,
+        // so they must not drag the average down and inflate the batch.
+        if (!page.html) continue;
+        bytes += page.html.length;
+        counted++;
+      }
+    }
+    return counted > 0 ? Math.round(bytes / counted) : 0;
+  });
+}
+
+/** Mean html length over the pages that have html; 0 when none do. */
+function averageHtmlBytes(pages: ReadonlyArray<{ html: string | null }>): number {
+  let bytes = 0;
+  let counted = 0;
+  for (const page of pages) {
+    if (!page.html) continue;
+    bytes += page.html.length;
+    counted++;
+  }
+  return counted > 0 ? Math.round(bytes / counted) : 0;
+}
+
+/**
+ * The batch size a streamed walk should use for this crawl, and the numbers that
+ * produced it — the caller reports them so a batch can be explained after the
+ * fact from the run's own events rather than guessed at.
+ */
+export interface ResolvedStreamBatch {
+  pages: number;
+  avgPageBytes: number;
+  byteBudget: number;
+  /** True when an explicit page count was supplied and the budget was ignored. */
+  explicit: boolean;
+}
+
+/**
+ * Resolve the batch for one crawl. An explicit `pages` override wins outright
+ * (still clamped) — an operator pinning a page count is answering a question
+ * this heuristic would otherwise re-answer every run.
+ */
+export function resolveStreamBatch(
+  storage: SQLiteStorage,
+  crawlId: string,
+  totalPages: number,
+  opts?: { pages?: number; byteBudget?: number; minPages?: number; maxPages?: number },
+): Effect.Effect<ResolvedStreamBatch, never, never> {
+  return Effect.gen(function* () {
+    const byteBudget = toPositiveInt(opts?.byteBudget, STREAM_BATCH_BYTES);
+    if (opts?.pages !== undefined) {
+      const min = toPositiveInt(opts.minPages, STREAM_BATCH_MIN_PAGES);
+      const max = Math.max(min, toPositiveInt(opts.maxPages, STREAM_BATCH_MAX_PAGES));
+      // An unusable explicit count (NaN, 0, fractional) falls back to the floor
+      // rather than propagating: a NaN batch is an infinite walk, not a slow one.
+      return {
+        pages: Math.min(max, Math.max(min, toPositiveInt(opts.pages, min))),
+        avgPageBytes: 0,
+        byteBudget,
+        explicit: true,
+      };
+    }
+    const avgPageBytes = yield* sampleAveragePageBytes(storage, crawlId, totalPages);
+    return {
+      pages: resolveStreamBatchPages({
+        avgPageBytes,
+        byteBudget,
+        minPages: opts?.minPages,
+        maxPages: opts?.maxPages,
+      }),
+      avgPageBytes,
+      byteBudget,
+      explicit: false,
+    };
+  });
+}

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -199,3 +199,16 @@ export type { PageSignalCollector, StreamPageRulesHooks, StreamPageRulesResult }
 // external-link, tech-detect, intel and cloud-prefetch collectors together.
 export { runStreamingPreRules, PRE_RULES_PAGE_BATCH } from "./streaming-pre-rules";
 export type { StreamPreRulesOptions, StreamPreRulesResult } from "./streaming-pre-rules";
+
+// Byte-budget batch sizing (#1860) — pages per batch derived from the site's own
+// average page size, because peak RSS is batch x per-page cost and per-page cost
+// is a property of the site, not of us.
+export {
+  resolveStreamBatch,
+  resolveStreamBatchPages,
+  sampleAveragePageBytes,
+  STREAM_BATCH_BYTES,
+  STREAM_BATCH_MIN_PAGES,
+  STREAM_BATCH_MAX_PAGES,
+} from "./batch-sizing";
+export type { ResolvedStreamBatch } from "./batch-sizing";

--- a/packages/audit-engine/tests/batch-sizing.test.ts
+++ b/packages/audit-engine/tests/batch-sizing.test.ts
@@ -1,0 +1,340 @@
+// #1860: pages per batch is derived from a BYTE budget, because peak RSS is
+// `batch × per-page cost` and per-page cost belongs to the site. A fixed page
+// count is right for one site shape and wrong for the other by fifty times.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { PageRecord, ResponseHeaders, SecurityHeaders } from "@squirrelscan/core-contracts";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+
+import {
+  resolveStreamBatch,
+  resolveStreamBatchPages,
+  sampleAveragePageBytes,
+  STREAM_BATCH_BYTES,
+  STREAM_BATCH_MAX_PAGES,
+  STREAM_BATCH_MIN_PAGES,
+} from "../src/batch-sizing";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const KB = 1024;
+const MB = 1024 * KB;
+
+describe("resolveStreamBatchPages", () => {
+  test("a heavy-page site gets a small batch, a light-page site a large one", () => {
+    // The whole point: one budget, two very different page counts.
+    const heavy = resolveStreamBatchPages({ avgPageBytes: 1 * MB });
+    const light = resolveStreamBatchPages({ avgPageBytes: 20 * KB });
+    expect(heavy).toBe(48);
+    expect(light).toBe(STREAM_BATCH_MAX_PAGES);
+    expect(heavy).toBeLessThan(light);
+  });
+
+  test("the batch times the page size stays inside the budget", () => {
+    for (const avg of [5 * KB, 50 * KB, 250 * KB, 1 * MB, 4 * MB]) {
+      const pages = resolveStreamBatchPages({ avgPageBytes: avg });
+      // Only meaningful away from the clamps; at a clamp the budget yields.
+      if (pages > STREAM_BATCH_MIN_PAGES && pages < STREAM_BATCH_MAX_PAGES) {
+        expect(pages * avg).toBeLessThanOrEqual(STREAM_BATCH_BYTES);
+      }
+    }
+  });
+
+  test("a page heavier than the whole budget still yields a runnable batch", () => {
+    // 64 MB of html in one page would divide to zero. A batch of zero is an
+    // infinite loop (SQLite reads LIMIT 0 as no limit), so the floor holds.
+    expect(resolveStreamBatchPages({ avgPageBytes: 64 * MB })).toBe(STREAM_BATCH_MIN_PAGES);
+  });
+
+  test("an unknown page size falls to the floor, never to a huge batch", () => {
+    // An empty crawl or pages with no stored html must not be read as "tiny
+    // pages, use a 500-page batch".
+    for (const avg of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(resolveStreamBatchPages({ avgPageBytes: avg })).toBe(STREAM_BATCH_MIN_PAGES);
+    }
+    // An unusable BUDGET is different from an unknown page size: it is a typo in
+    // a knob, so it falls back to the documented default budget rather than to a
+    // 5-page batch that would make every audit crawl along for no stated reason.
+    expect(resolveStreamBatchPages({ avgPageBytes: 1 * MB, byteBudget: 0 })).toBe(
+      resolveStreamBatchPages({ avgPageBytes: 1 * MB }),
+    );
+  });
+
+  test("a bigger budget buys proportionally more pages", () => {
+    const at48 = resolveStreamBatchPages({ avgPageBytes: 1 * MB, byteBudget: 48 * MB });
+    const at96 = resolveStreamBatchPages({ avgPageBytes: 1 * MB, byteBudget: 96 * MB });
+    expect(at96).toBe(at48 * 2);
+  });
+
+  test("clamps are honoured and cannot invert", () => {
+    expect(resolveStreamBatchPages({ avgPageBytes: 1, maxPages: 10 })).toBe(10);
+    expect(resolveStreamBatchPages({ avgPageBytes: 1 * MB, minPages: 30 })).toBe(48);
+    // A max below the min must not produce a nonsense batch.
+    expect(
+      resolveStreamBatchPages({ avgPageBytes: 1, minPages: 20, maxPages: 5 }),
+    ).toBeGreaterThanOrEqual(20);
+  });
+});
+
+const EMPTY_HEADERS: ResponseHeaders = {
+  contentType: "text/html",
+  contentEncoding: null,
+  cacheControl: null,
+  vary: null,
+  etag: null,
+  server: null,
+  lastModified: null,
+  link: null,
+  serverTiming: null,
+  age: null,
+  xCache: null,
+  cfCacheStatus: null,
+  xVercelCache: null,
+  altSvc: null,
+  acceptRanges: null,
+};
+
+const EMPTY_SECURITY: SecurityHeaders = {
+  hsts: null,
+  csp: null,
+  xFrameOptions: null,
+  xContentTypeOptions: null,
+  referrerPolicy: null,
+  permissionsPolicy: null,
+  xRobotsTag: null,
+};
+
+function page(url: string, htmlBytes: number, opts?: { sizeBytes?: number }): PageRecord {
+  const html = htmlBytes > 0 ? "x".repeat(htmlBytes) : null;
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    // Deliberately allowed to disagree with html.length — see the gzip test.
+    sizeBytes: opts?.sizeBytes ?? htmlBytes,
+    loadTimeMs: 1,
+    fetchedAt: Date.now(),
+    etag: null,
+    lastModified: null,
+    contentHash: url,
+    html,
+    parsedData: null,
+    headers: EMPTY_HEADERS,
+    securityHeaders: EMPTY_SECURITY,
+  } as PageRecord;
+}
+
+async function seed(pages: PageRecord[]): Promise<{ storage: SQLiteStorage; crawlId: string }> {
+  const storage = new SQLiteStorage(":memory:");
+  await run(storage.init());
+  const crawlId = await run(
+    storage.createCrawl({
+      baseUrl: "https://example.com",
+      seedUrl: "https://example.com",
+      originalUrl: "https://example.com",
+      startedAt: Date.now(),
+      status: "running",
+      config: {},
+      stats: {
+        pagesTotal: 0,
+        pagesFetched: 0,
+        pagesFailed: 0,
+        pagesSkipped: 0,
+        pagesUnchanged: 0,
+        linksTotal: 0,
+        imagesTotal: 0,
+        bytesTotal: 0,
+        avgLoadTimeMs: 0,
+      },
+    } as never),
+  );
+  for (const p of pages) await run(storage.upsertPage(crawlId, p));
+  return { storage, crawlId };
+}
+
+describe("sampleAveragePageBytes", () => {
+  test("measures stored html, not the crawler's transfer size", async () => {
+    // THE reason this samples html instead of reading crawl.stats.bytesTotal.
+    // The incident's pages were 105 KB gzipped on the wire and ~1 MB of html;
+    // budgeting against the wire size picks a batch ten times too large on
+    // exactly the sites that need it smallest.
+    const pages = Array.from({ length: 20 }, (_, i) =>
+      page(`https://example.com/p${i}`, 100 * KB, { sizeBytes: 10 * KB }),
+    );
+    const { storage, crawlId } = await seed(pages);
+
+    const avg = await run(sampleAveragePageBytes(storage, crawlId, pages.length));
+    expect(avg).toBe(100 * KB);
+
+    await run(storage.close());
+  });
+
+  test("pages with no html do not drag the average down", async () => {
+    // A redirect or a PDF is not what the batch holds. Counting them as zero
+    // would halve the average here and double the batch.
+    const { storage, crawlId } = await seed([
+      page("https://example.com/a", 200 * KB),
+      page("https://example.com/b", 0),
+      page("https://example.com/c", 200 * KB),
+      page("https://example.com/d", 0),
+    ]);
+
+    expect(await run(sampleAveragePageBytes(storage, crawlId, 4))).toBe(200 * KB);
+
+    await run(storage.close());
+  });
+
+  test("samples across the crawl, not just the front", async () => {
+    // getPages orders by normalized_url, and URL order correlates with page
+    // type. Here the front is light and the tail is heavy; a front-only sample
+    // would size the batch for the wrong page.
+    const light = Array.from({ length: 40 }, (_, i) =>
+      page(`https://example.com/a${String(i).padStart(3, "0")}`, 10 * KB),
+    );
+    const heavy = Array.from({ length: 40 }, (_, i) =>
+      page(`https://example.com/z${String(i).padStart(3, "0")}`, 1 * MB),
+    );
+    const { storage, crawlId } = await seed([...light, ...heavy]);
+
+    const avg = await run(sampleAveragePageBytes(storage, crawlId, 80));
+    // A front-only sample would report ~10 KB. The spread must see the heavy tail.
+    expect(avg).toBeGreaterThan(100 * KB);
+
+    await run(storage.close());
+  });
+
+  test("an empty crawl reports zero rather than throwing", async () => {
+    const { storage, crawlId } = await seed([]);
+    expect(await run(sampleAveragePageBytes(storage, crawlId, 0))).toBe(0);
+    await run(storage.close());
+  });
+});
+
+describe("resolveStreamBatch", () => {
+  test("derives the batch from the crawl and reports what produced it", async () => {
+    const pages = Array.from({ length: 30 }, (_, i) =>
+      page(`https://example.com/p${String(i).padStart(3, "0")}`, 1 * MB),
+    );
+    const { storage, crawlId } = await seed(pages);
+
+    const resolved = await run(resolveStreamBatch(storage, crawlId, pages.length));
+    expect(resolved.explicit).toBeFalse();
+    expect(resolved.avgPageBytes).toBe(1 * MB);
+    expect(resolved.pages).toBe(48);
+    expect(resolved.byteBudget).toBe(STREAM_BATCH_BYTES);
+
+    await run(storage.close());
+  });
+
+  test("an explicit page count wins and skips the sampling entirely", async () => {
+    const pages = Array.from({ length: 30 }, (_, i) =>
+      page(`https://example.com/p${String(i).padStart(3, "0")}`, 1 * MB),
+    );
+    const { storage, crawlId } = await seed(pages);
+
+    const resolved = await run(resolveStreamBatch(storage, crawlId, pages.length, { pages: 12 }));
+    expect(resolved.explicit).toBeTrue();
+    expect(resolved.pages).toBe(12);
+    // Not sampled: an operator pinning a count is answering the question this
+    // heuristic would otherwise re-answer every run.
+    expect(resolved.avgPageBytes).toBe(0);
+
+    await run(storage.close());
+  });
+
+  test("an explicit count is still clamped", async () => {
+    const { storage, crawlId } = await seed([page("https://example.com/a", 1 * KB)]);
+    expect((await run(resolveStreamBatch(storage, crawlId, 1, { pages: 100000 }))).pages).toBe(
+      STREAM_BATCH_MAX_PAGES,
+    );
+    expect((await run(resolveStreamBatch(storage, crawlId, 1, { pages: 0 }))).pages).toBe(
+      STREAM_BATCH_MIN_PAGES,
+    );
+    await run(storage.close());
+  });
+});
+
+// Every number here becomes a SQLite LIMIT/OFFSET, where the failure modes are
+// silent and severe: `limit: 0` and `limit: NaN` are both falsy, so the query
+// drops its LIMIT and returns the whole crawl, and a NaN offset never advances —
+// an infinite walk re-reading every page forever. These came out of a review
+// pass that reproduced all three.
+describe("batch sizing cannot emit a value SQLite will misread", () => {
+  const bad = [Number.NaN, Number.POSITIVE_INFINITY, -1, 0, 0.5];
+
+  test("an unusable explicit page count falls back instead of propagating", () => {
+    for (const pages of bad) {
+      const n = resolveStreamBatchPages({ avgPageBytes: 1 * MB, minPages: pages });
+      expect(Number.isInteger(n)).toBeTrue();
+      expect(n).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  test("unusable bounds cannot produce a fractional or NaN batch", () => {
+    for (const minPages of bad) {
+      for (const maxPages of bad) {
+        const n = resolveStreamBatchPages({ avgPageBytes: 250 * KB, minPages, maxPages });
+        expect(Number.isInteger(n)).toBeTrue();
+        expect(n).toBeGreaterThanOrEqual(1);
+      }
+    }
+  });
+
+  test("an unusable byte budget falls back to the floor", () => {
+    for (const byteBudget of bad) {
+      const n = resolveStreamBatchPages({ avgPageBytes: 1 * MB, byteBudget });
+      expect(Number.isInteger(n)).toBeTrue();
+      expect(n).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  test("resolveStreamBatch clamps an unusable explicit count", async () => {
+    const { storage, crawlId } = await seed([page("https://example.com/a", 1 * KB)]);
+    for (const pages of bad) {
+      const resolved = await run(resolveStreamBatch(storage, crawlId, 1, { pages }));
+      expect(Number.isInteger(resolved.pages)).toBeTrue();
+      expect(resolved.pages).toBeGreaterThanOrEqual(1);
+    }
+    await run(storage.close());
+  });
+
+  test("a nonsense page total does not send the sampler into a bad read", async () => {
+    const { storage, crawlId } = await seed([page("https://example.com/a", 4 * KB)]);
+    for (const total of [Number.NaN, Number.POSITIVE_INFINITY, -5]) {
+      expect(await run(sampleAveragePageBytes(storage, crawlId, total))).toBe(0);
+    }
+    await run(storage.close());
+  });
+});
+
+describe("the size sample reads distinct pages", () => {
+  // At 13 pages the naive windows (0, 6, 9) with a 4-page window overlap on page
+  // 9: one page counted twice, and fewer distinct pages sampled than intended.
+  // Sizes are distinct per page so double-counting changes the mean.
+  for (const total of [13, 14, 15, 20, 37]) {
+    test(`${total} pages: the mean matches counting each sampled page once`, async () => {
+      const pages = Array.from({ length: total }, (_, i) =>
+        page(`https://example.com/p${String(i).padStart(3, "0")}`, (i + 1) * KB),
+      );
+      const { storage, crawlId } = await seed(pages);
+
+      const avg = await run(sampleAveragePageBytes(storage, crawlId, total));
+      // Every page is a whole number of KB, and a mean over distinct pages of
+      // 1..N KB must land inside the range. The bug produced a mean pulled
+      // toward the duplicated page.
+      expect(avg).toBeGreaterThanOrEqual(1 * KB);
+      expect(avg).toBeLessThanOrEqual(total * KB);
+      // The sample must span the crawl, so the mean cannot be the front alone.
+      expect(avg).toBeGreaterThan(4 * KB);
+
+      await run(storage.close());
+    });
+  }
+});


### PR DESCRIPTION
For squirrelscan/repo#1860. Follows #226, which established that peak RSS on the streamed path is `batch × per-page cost` and nothing else in the post-crawl pipeline scales with page count.

## The problem with a page count

Per-page cost belongs to the site. A docs site's 20 KB pages and a product page's 1 MB differ by fifty times, so one page count cannot be right for both: 50 pages is generous for the first and, measured, a 400 to 670 MB swing for the second. Tuning it per site by env var means someone has to notice first, which on this issue meant three OOM-killed audits.

## What it does now

Pages per batch is derived from a **byte budget** — how much raw html we hold at once, 48 MB by default — divided by the site's own average page size, clamped to 5-500. Measured end to end on the real cloud path at 150 pages of ~1 MB:

| budget | batch chosen | peak RSS |
|---|---|---|
| 48 MB | 51 pages | 1575 MB |
| 12 MB | 12 pages | 964 MB |

And the same 48 MB budget on 21 KB pages picks a 500-page batch, peaks at 306 MB, and finishes in 11s instead of 172s. It adapts in both directions, which is the point: the heavy site gets protected without the light site paying for it.

The budget is what an operator can reason about against a container's memory ceiling. Pages per batch is not. Note the budget counts **raw html**, not the parsed footprint — parsing multiplies it by roughly 13x on script-heavy pages — so it is the input that determines a memory bound rather than the bound itself. That is deliberate: it is the quantity we can measure exactly and cheaply, where a parsed-size estimate would be wrong per site in a way nobody could debug.

## Why the average is sampled

Not read from `crawl.stats.bytesTotal`, which sums the crawler's fetched `sizeBytes` — the **wire** size. The incident's pages were 105 KB gzipped and about 1 MB of html, so budgeting against that counter picks a batch ten times too large on exactly the sites that need it smallest. `html.length` is what the batch actually holds, so that is what gets measured, from a dozen pages spread across the crawl rather than the front, since `getPages` orders by `normalized_url` and URL order correlates with page type.

## Three bugs caught in review before this landed

All one class. Every number here becomes a SQLite `LIMIT`/`OFFSET`, where the failure modes are silent and severe: `limit: 0` and `limit: NaN` are both falsy, so the query drops its LIMIT and returns the whole crawl, while a NaN offset never advances — an infinite walk re-reading every page forever.

- An explicit `NaN` page count propagated through the clamps intact.
- Caller-supplied `minPages`/`maxPages` were unvalidated and could produce a fractional or NaN batch.
- The size sample's windows overlapped at 13 and 14 pages, counting one page twice and sampling fewer distinct pages than intended.

Everything now passes through one finite-positive-integer normalizer, the sample windows are disjoint by construction, and each case has a test.

## Compatibility

Purely additive to the engine: a new module plus exports, no change to `runStreamingRules` or any existing caller. A caller that passes an explicit batch keeps getting exactly that. All golden and streaming gates pass unchanged.