### PR TITLE
fix(audit-engine): item findings carry their own message, not the page's count

### DIFF
--- a/packages/audit-engine/src/merge-core.ts
+++ b/packages/audit-engine/src/merge-core.ts
@@ -8,11 +8,13 @@
 // `computeMerge`, so the algorithm lives in EXACTLY one place (no drift).
 
 import type {
+  CheckItem,
   CheckResult,
   FindingProvenance,
   PageFindingRecord,
   SitePageRecord,
 } from "@squirrelscan/core-contracts";
+import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
 import { resolutionUrlHash } from "@squirrelscan/core-contracts/resolution";
 
 import { findingFingerprint } from "./fingerprint";
@@ -168,13 +170,162 @@ export function findingKey(
 export const fingerprint = findingFingerprint;
 
 /**
+ * Max chars of the page-invariant check text kept in front of the item id, so a
+ * pathologically long rule message cannot crowd the id out of the store's
+ * `maxMediumString` clamp on the `message` column. Real rule messages are well
+ * under this (the longest on a 401-page production audit is ~110 chars).
+ */
+const ITEM_MESSAGE_PREFIX_MAX = 240;
+
+/**
+ * Reduce a page-scope check's message to the part that does NOT depend on the
+ * page: drop a leading count, then neutralise any digit run left behind.
+ *
+ * A page-scope check's message COUNTS that page's items ("26 cross-origin
+ * resources without Subresource Integrity"), which is why it cannot ride on an
+ * item row verbatim. `N` as the placeholder is not invented here — the report's
+ * own grouping already shows exactly that for a merged group whose members'
+ * messages differ only in digits (`packages/report/src/grouping.ts`), so the two
+ * surfaces read alike.
+ *
+ * Anchored and non-overlapping: the leading `\s*` and the trailing `\s+` are
+ * separated by a mandatory digit and the class between them excludes whitespace,
+ * so there is no ambiguity for a backtracker to explore (#150/#175/#177).
+ *
+ * KNOWN LIMIT: a leading number that is WORDING rather than a count is eaten the
+ * same way ("404 Not Found" → "Not Found"). No rule in the catalog opens an
+ * item-bearing check's message that way today, and the alternative — keeping the
+ * number and writing "N cross-origin resources …" on every item row — is worse
+ * copy for the shapes that actually occur. Public #229 is the gate that would
+ * catch a future rule reintroducing it.
+ */
+function pageInvariantCheckText(message: string, max: number): string {
+  const stripped = message.replace(/^\s*\d[\d,._]*\s+/, "").trim();
+  // Nothing but a number ("26", "2.5") — there is no wording to keep, and the
+  // caller falls back to the check name. Tested BEFORE the substitution, because
+  // afterwards the placeholder `N` is itself a letter.
+  if (!/\p{L}/u.test(stripped)) return "";
+  return sliceWholeChars(stripped.replace(/\d+/g, "N").trim(), max);
+}
+
+/** `slice` on a UTF-16 code-unit boundary can cut a surrogate PAIR in half and
+ * leave a lone surrogate, which is not valid text to hand a database or a JSON
+ * encoder. Drop the orphan. */
+function sliceWholeChars(s: string, max: number): string {
+  if (s.length <= max) return s;
+  const cut = s.slice(0, max);
+  const last = cut.charCodeAt(cut.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? cut.slice(0, -1) : cut;
+}
+
+/**
+ * Page-invariant, ITEM-scoped message for an item finding (#1881).
+ *
+ * WHY: `findingFingerprint` hashes [status, message, value, expected] and is
+ * nominally URL-free, so `finding_defs` (keyed by site + fingerprint) is meant to
+ * hold ONE row per distinct defect. Copying the parent check's message onto every
+ * item row defeats that, because a page-scope check's message is a COUNT of that
+ * page's items: one Shopify CDN script missing SRI on 401 pages stored 25 distinct
+ * messages ("26 cross-origin resources without Subresource Integrity" on one page,
+ * "24 ..." on another) and therefore 25 fingerprints for one defect. On a real
+ * 401-page audit that inflated distinct (rule, check, locator, status, message,
+ * value, expected) from 2,606 to 4,201.
+ *
+ * Reads as `<page-invariant check text>: <item id>`, e.g.
+ * `cross-origin resources without Subresource Integrity: https://cdn.shopify.com/…/globo.js`.
+ * The id alone would also be page-invariant and is what the fingerprint really
+ * needs, but this column is a display string wherever a reader does not rebuild a
+ * CheckResult first, and a bare URL is not a finding description.
+ *
+ * `item.label` deliberately does NOT feed this. It is free-form per-check text
+ * and several rules stamp per-PAGE numbers into it (content/keyword-stuffing
+ * emits `"everyday" (2.3%)`, a density that moves page to page), which would
+ * re-create the very split this fixes. The label is not lost: it rides in the
+ * payload's `items[0]`, which every reader that rebuilds a CheckResult replays.
+ *
+ * Derived generically here rather than edited into ~280 rules. Measured on a real
+ * 45,663-row site: distinct (rule, check, locator, status) is 4,068 and adding
+ * this message takes it to 4,069, so the text contributes one tuple in 45k rows.
+ * That is empirical, not a proof — a rule that put some OTHER page-varying token
+ * in its message (a URL, a page title) would still split, which is a rule bug and
+ * is what public #229 exists to catch.
+ */
+export function itemFindingMessage(check: CheckResult, item: CheckItem): string {
+  const id = item.id.trim();
+  // The ID is the discriminator, so it gets first claim on the store's
+  // `maxMediumString` clamp: budget the prefix against what the id leaves behind,
+  // or a long URL would be truncated away and two distinct items would display
+  // identically. Still a pure function of (check message, item id), so this does
+  // not weaken page-invariance.
+  const budget = Math.min(
+    ITEM_MESSAGE_PREFIX_MAX,
+    Math.max(0, REPORT_LIMITS.maxMediumString - id.length - 2)
+  );
+  // A message with no wording in it ("26") yields "" — fall back to the check
+  // name, which is page-invariant too.
+  const text = pageInvariantCheckText(check.message, budget) || sliceWholeChars(check.name, budget);
+  // An empty id makes the locator "" (colliding with a whole-check row) — a
+  // degenerate case, but still never the parent's page-level message.
+  if (id === "") return text;
+  return text === "" ? id : `${text}: ${id}`;
+}
+
+/**
+ * Serialize one item finding's payload, adding the aggregate stash only when the
+ * result still fits `maxFindingPayload`.
+ *
+ * WHY A BUDGET: the chunk ingest DROPS a payload over that cap whole, and
+ * `details` is load-bearing for scoring (`details.additional` feeds the density
+ * penalty), so letting the stash tip a near-cap payload over the line would
+ * inflate the health score — the #1179 class. The stash is display detail, so it
+ * is the part that yields, and a row that loses it reads its own message exactly
+ * like a pre-#1881 row.
+ *
+ * The budget only ever REMOVES the stash. It never trims `items`/`details`/`pages`
+ * to make room, because this function also feeds the CLI's local SQLite store,
+ * which persists the payload with no cap at all — dropping detail here to work
+ * around a transport limit would destroy data that the local path would have
+ * kept. Shrinking an already-over-cap payload for transport belongs at the
+ * transport boundary (`clampFindingPayload` in the API's chunk ingest), not here.
+ */
+function itemFindingPayload(
+  check: CheckResult,
+  item: CheckItem,
+  i: number,
+  value: string | null,
+  expected: string | null
+): string {
+  const base = { items: [item], details: check.details, pages: check.pages, i };
+  const withAggregate = JSON.stringify({
+    ...base,
+    // Short keys: this rides on EVERY item row. `v`/`e` are omitted when the
+    // check carried none, and `m` is the marker a reader keys the whole restore
+    // on — a pre-#1881 row has no `m`, and a whole-check row never writes one.
+    m: check.message,
+    ...(value !== null ? { v: value } : {}),
+    ...(expected !== null ? { e: expected } : {}),
+  });
+  if (withAggregate.length <= REPORT_LIMITS.maxFindingPayload) return withAggregate;
+  // Byte-identical to the pre-#1881 payload, so an over-cap finding is no worse
+  // off than it was — the ingest drops it exactly as before, and the local store
+  // keeps every field exactly as before.
+  return JSON.stringify(base);
+}
+
+/**
  * Flatten a page's CheckResults into per-finding rows. Only failing/warning
  * checks become persisted findings — `pass`/`info`/`skipped` checks are not
  * issues to carry (the union scorer re-derives pass denominators from the
  * active-page set, so we never need to persist passes).
  *
  * A check with `items[]` yields one finding per item (locator = item.id); a
- * check without items yields a single whole-check finding (locator = "").
+ * check without items yields a single whole-check finding (locator = "") and
+ * keeps the check's page-level message/value/expected verbatim.
+ *
+ * (#1881) An ITEM finding's message/value/expected describe the ITEM, not the
+ * page — see {@link itemFindingMessage}. The check's page-level trio is stashed
+ * in the payload as `m`/`v`/`e` so a reader rebuilding a CheckResult
+ * (`carriedFindingToCheck`, `reconstructRuleChecks`) restores it unchanged.
  *
  * Each item finding's payload carries `i` = the item's index within the check's
  * `items[]` — its EMISSION order. The page_findings PK is keyed by `locator`
@@ -204,15 +355,15 @@ export function flattenChecks(
           checkName: check.name,
           locator: item.id,
           status: check.status,
-          message: check.message,
-          value,
-          expected,
-          payload: JSON.stringify({
-            items: [item],
-            details: check.details,
-            pages: check.pages,
-            i,
-          }),
+          // (#1881) ITEM-scoped, so the fingerprint follows the defect rather
+          // than the page's item count. `value`/`expected` are the same
+          // page-level aggregate the message was, so they are dropped from the
+          // row for the same reason; all three are stashed in the payload below
+          // and restored by every reader that rebuilds a CheckResult.
+          message: itemFindingMessage(check, item),
+          value: null,
+          expected: null,
+          payload: itemFindingPayload(check, item, i, value, expected),
         });
       }
     } else {

--- a/packages/audit-engine/src/merge.ts
+++ b/packages/audit-engine/src/merge.ts
@@ -25,6 +25,7 @@ export {
   fingerprint,
   findingKey,
   flattenChecks,
+  itemFindingMessage,
 } from "./merge-core";
 export type {
   ComputeMergeInput,

--- a/packages/audit-engine/src/reconstruct.ts
+++ b/packages/audit-engine/src/reconstruct.ts
@@ -65,6 +65,15 @@ interface ParsedPayload {
   /** Emission-order index of this item within its check (flattenChecks stamps
    * it on every item finding). See {@link reconstructRuleChecks}. */
   i?: number;
+  /** (#1881) Parent check's PAGE-LEVEL message. An item row's own `message`
+   * column describes the item (so its fingerprint follows the defect, not the
+   * page's item count), so the aggregate text lives here. Absent on pre-#1881
+   * rows, whose `message` column still holds the page-level text. */
+  m?: string;
+  /** (#1881) Parent check's page-level `value`; absent when it had none. */
+  v?: string;
+  /** (#1881) Parent check's page-level `expected`; absent when it had none. */
+  e?: string;
 }
 
 /** Emission-order key for an item finding's payload; findings without a stamped
@@ -120,26 +129,48 @@ function reconstructRuleChecks(findings: PageFindingRecord[]): CheckResult[] {
     // flattenChecks emits EITHER one whole-check finding (locator "") OR one per
     // item (locator = item.id) for a given check — never both — so a group is
     // homogeneous and this split is exhaustive.
-    const itemFindings = group.filter((f) => f.locator !== "");
+    // Parse each row's payload exactly ONCE: the aggregate scan, details/pages
+    // and the item-order sort all read it.
+    const parsed = group.map((f) => parsePayload(f.payload));
+    const payload = parsed[0]!;
+    const itemIdx: number[] = [];
+    for (let k = 0; k < group.length; k++) if (group[k]!.locator !== "") itemIdx.push(k);
 
-    const payload = parsePayload(first.payload);
+    // (#1881) An item row's message/value/expected describe the ITEM; the parent
+    // check's page-level trio was stashed in the payload, so restore it here and
+    // the rebuilt CheckResult is byte-identical to the one flattenChecks was
+    // given. The presence of `m` is the ONLY marker used, deliberately:
+    //  - a pre-#1881 row has no `m` and its own `message` IS the page-level text;
+    //  - a whole-check row never writes one (its payload can still carry
+    //    details/pages, so payload presence alone would misfire);
+    //  - an item whose id is "" lands in a locator-"" group, so gating on the
+    //    locator would drop ITS aggregate — `m` catches it either way.
+    // Scanned over the WHOLE group, not just the first row: the payload size
+    // budget is decided per item, so an item with a long `sourcePages` list can
+    // drop its stash while its siblings keep theirs, and reading only `group[0]`
+    // would make the restore depend on row order.
+    // When `m` is present the row's own value/expected are null by construction,
+    // so `v`/`e` being absent means the source check carried none.
+    const aggregate = parsed.find((p) => typeof p.m === "string");
+    const message = typeof aggregate?.m === "string" ? aggregate.m : first.message;
+    const value = aggregate ? (aggregate.v ?? null) : first.value;
+    const expected = aggregate ? (aggregate.e ?? null) : first.expected;
     const check: CheckResult = {
       name: first.checkName,
       status,
-      message: first.message,
+      message,
       pageUrl: first.normalizedUrl,
     };
-    if (first.value != null) check.value = first.value;
-    if (first.expected != null) check.expected = first.expected;
+    if (value != null) check.value = value;
+    if (expected != null) check.expected = expected;
 
-    if (itemFindings.length > 0) {
-      // Restore the ORIGINAL item emission order. `itemFindings` arrives in
+    if (itemIdx.length > 0) {
+      // Restore the ORIGINAL item emission order. Item findings arrive in
       // loadIngestedFindings' `locator` (item id) sort order, which scrambles
       // unpadded numeric ids ("parse-10" < "parse-2"), so we re-sort by the
       // emission index (`i`) flattenChecks stamped into each item's payload.
       // Array.sort is stable, so item findings missing `i` keep their load order.
-      const parsed = itemFindings.map((f) => parsePayload(f.payload));
-      const order = itemFindings.map((_, idx) => idx);
+      const order = [...itemIdx];
       order.sort((a, b) => emissionIndex(parsed[a]!) - emissionIndex(parsed[b]!));
       const items: CheckItem[] = [];
       for (const idx of order) {

--- a/packages/audit-engine/src/scoring.ts
+++ b/packages/audit-engine/src/scoring.ts
@@ -139,10 +139,17 @@ export function carriedFindingToCheck(
   return {
     name: f.checkName,
     status: f.status === "fail" ? "fail" : "warn",
-    message: f.message,
+    // (#1881) Restore the parent check's page-level text for an item row, so the
+    // replayed union check renders exactly as it did before item rows became
+    // item-scoped. Report grouping keys on the message, so reading the item's own
+    // text here would split one carried aggregate into one group per item. `m`
+    // is the sole marker (see reconstructRuleChecks): when it is present the
+    // row's own value/expected are null by construction, so an absent `v`/`e`
+    // means the source check carried none.
+    message: payload.m ?? f.message,
     pageUrl: normalizedUrl,
-    value: f.value ?? undefined,
-    expected: f.expected ?? undefined,
+    value: (payload.m !== undefined ? payload.v : f.value) ?? undefined,
+    expected: (payload.m !== undefined ? payload.e : f.expected) ?? undefined,
     ...(payload.items ? { items: payload.items } : {}),
     ...(payload.details ? { details: payload.details } : {}),
     ...(payload.pages ? { pages: payload.pages } : {}),
@@ -249,6 +256,14 @@ interface CarriedPayload {
   items?: CheckResult["items"];
   details?: CheckResult["details"];
   pages?: CheckResult["pages"];
+  /** (#1881) Parent check's PAGE-LEVEL message/value/expected, stashed by
+   * `flattenChecks` because an item row's own columns describe the ITEM (so its
+   * fingerprint follows the defect, not the page's item count). Absent on
+   * pre-#1881 rows and on whole-check rows, whose columns already hold the
+   * page-level text. */
+  m?: string;
+  v?: string;
+  e?: string;
 }
 
 /** Safely parse a carried finding's stored payload JSON. */

--- a/packages/audit-engine/tests/item-finding-identity.test.ts
+++ b/packages/audit-engine/tests/item-finding-identity.test.ts
@@ -1,0 +1,458 @@
+// #1881 — an item finding's identity must describe the ITEM, not the page.
+//
+// `findingFingerprint` hashes [status, message, value, expected] and is
+// deliberately URL-free, so `finding_defs` (site + fingerprint) can hold one row
+// per distinct defect. Before this, `flattenChecks` copied the parent check's
+// PAGE-LEVEL message/value/expected onto every item row, and a page-scope check's
+// message is a count of that page's items — so one Shopify CDN script missing SRI
+// on 401 pages stored 25 different messages ("26 cross-origin resources without
+// Subresource Integrity" here, "24 ..." there) and 25 fingerprints for one defect.
+//
+// The gates below are the invariant, its two round-trips, and the pre-#1881
+// compatibility fallback.
+
+import { describe, expect, test } from "bun:test";
+
+import type { CheckResult, PageFindingRecord } from "@squirrelscan/core-contracts";
+import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
+
+import { fingerprint, flattenChecks, itemFindingMessage } from "../src/merge";
+import { carriedFindingToCheck } from "../src/scoring";
+import { reconstructPageRuleChecks } from "../src/reconstruct";
+
+/** The SRI shape that produced the drscholls inflation: the same cross-origin
+ * assets on every page, but a page-varying COUNT of them in the check message. */
+function sriCheck(count: number): CheckResult {
+  const items = Array.from({ length: count }, (_, k) => ({
+    id: `https://cdn.shopify.com/extensions/globo-${k}.js`,
+    label: k % 3 === 0 ? "stylesheet" : "script",
+  }));
+  return {
+    name: "sri",
+    status: "warn",
+    message: `${count} cross-origin ${count === 1 ? "resource" : "resources"} without Subresource Integrity`,
+    value: String(count),
+    expected: "0",
+    items,
+  };
+}
+
+/** Turn a FlatFinding into the stored row shape the readers consume. */
+function toRecord(f: ReturnType<typeof flattenChecks>[number]): PageFindingRecord {
+  return {
+    siteKey: "SITE",
+    normalizedUrl: f.normalizedUrl,
+    ruleId: f.ruleId,
+    checkName: f.checkName,
+    locator: f.locator,
+    status: f.status as PageFindingRecord["status"],
+    severity: "warning",
+    message: f.message,
+    value: f.value,
+    expected: f.expected,
+    payload: f.payload,
+    fingerprint: fingerprint(f.status, f.message, f.value, f.expected),
+    firstSeenAt: 1,
+    lastSeenCrawlId: "crawl-1",
+    lastSeenAt: 1,
+    provenance: "fresh",
+    state: "open",
+  };
+}
+
+describe("#1881 item findings carry their own identity", () => {
+  test("the SAME item on two pages fingerprints identically under different page-level counts", () => {
+    // Page A sees 26 cross-origin assets, page B sees 24 — the exact drscholls
+    // split. `globo-0.js` is one defect and must hash to one value.
+    const a = flattenChecks("https://x/a", "security/sri", [sriCheck(26)]);
+    const b = flattenChecks("https://x/b", "security/sri", [sriCheck(24)]);
+
+    const pick = (rows: typeof a, locator: string) => rows.find((f) => f.locator === locator)!;
+    const itemA = pick(a, "https://cdn.shopify.com/extensions/globo-0.js");
+    const itemB = pick(b, "https://cdn.shopify.com/extensions/globo-0.js");
+
+    expect(itemA.message).toBe(
+      "cross-origin resources without Subresource Integrity: https://cdn.shopify.com/extensions/globo-0.js",
+    );
+    expect(itemA.message).toBe(itemB.message);
+    expect(fingerprint(itemA.status, itemA.message, itemA.value, itemA.expected)).toBe(
+      fingerprint(itemB.status, itemB.message, itemB.value, itemB.expected),
+    );
+
+    // Pre-#1881 this was 24 vs 26 distinct fingerprints across the two pages;
+    // now the union is exactly the 26 assets page A carries.
+    const fps = new Set(
+      [...a, ...b].map((f) => fingerprint(f.status, f.message, f.value, f.expected)),
+    );
+    expect(fps.size).toBe(26);
+  });
+
+  test("an item row's message/value/expected carry no page-derived text", () => {
+    // The invariant that makes distinct (rule, check, locator, status, message,
+    // value, expected) collapse to distinct (rule, check, locator, status). The
+    // message is a function of (page-invariant check text, item id) — the check's
+    // WORDING is still an input, only its per-page numbers are removed.
+    const rows = [24, 25, 26].flatMap((n, i) =>
+      flattenChecks(`https://x/${i}`, "security/sri", [sriCheck(n)]),
+    );
+    const byLocator = new Map<string, Set<string>>();
+    for (const r of rows) {
+      const seen = byLocator.get(r.locator) ?? new Set<string>();
+      seen.add(JSON.stringify([r.status, r.message, r.value, r.expected]));
+      byLocator.set(r.locator, seen);
+    }
+    for (const [locator, seen] of byLocator) {
+      expect({ locator, variants: seen.size }).toEqual({ locator, variants: 1 });
+    }
+    // The message is a function of (page-invariant check text, item id) — the
+    // page's own count never survives into it.
+    expect(rows.every((r) => r.message.endsWith(`: ${r.locator}`))).toBe(true);
+    expect(rows.every((r) => !/\d/.test(r.message.slice(0, r.message.length - r.locator.length)))).toBe(
+      true,
+    );
+    expect(rows.every((r) => r.value === null && r.expected === null)).toBe(true);
+  });
+
+  test("a per-page number in item.label does NOT reach the row identity", () => {
+    // content/keyword-stuffing stamps a per-page density into `label`
+    // (`"everyday" (2.3%)`), so the label is page-varying and must stay out of
+    // the message — it rides in the payload's item instead.
+    const check = (density: string): CheckResult => ({
+      name: "keyword-stuffing",
+      status: "warn",
+      message: "1 word(s) may be overused",
+      items: [{ id: "everyday", label: `"everyday" (${density}%)` }],
+    });
+    const a = flattenChecks("https://x/a", "content/keyword-stuffing", [check("2.3")])[0]!;
+    const b = flattenChecks("https://x/b", "content/keyword-stuffing", [check("4.8")])[0]!;
+
+    expect(a.message).toBe("word(s) may be overused: everyday");
+    expect(fingerprint(a.status, a.message, a.value, a.expected)).toBe(
+      fingerprint(b.status, b.message, b.value, b.expected),
+    );
+    // Not lost — the label is still replayed from the payload.
+    expect(JSON.parse(a.payload!).items[0].label).toBe('"everyday" (2.3%)');
+  });
+
+  test("the page-invariant text drops leading counts and neutralises embedded numbers", () => {
+    // These are the real shapes production rules emit. The transform is what
+    // makes the message page-invariant, so pin it directly rather than only
+    // through flattenChecks.
+    const msg = (m: string) =>
+      itemFindingMessage({ name: "c", status: "warn", message: m }, { id: "ID" });
+
+    expect(msg("26 cross-origin resources without Subresource Integrity")).toBe(
+      "cross-origin resources without Subresource Integrity: ID",
+    );
+    expect(msg("2 cookie(s) missing the Secure flag")).toBe(
+      "cookie(s) missing the Secure flag: ID",
+    );
+    // The count varies page to page; the text must not.
+    expect(msg("1 potential source map(s) detected")).toBe(msg("9 potential source map(s) detected"));
+    expect(msg("1,024 image(s) missing width/height")).toBe(msg("7 image(s) missing width/height"));
+    // A number in the MIDDLE of the wording is neutralised, not dropped.
+    expect(msg("Visible text is under 10% of the page HTML")).toBe(
+      "Visible text is under N% of the page HTML: ID",
+    );
+    expect(msg("Visible text is under 10% of the page HTML")).toBe(
+      msg("Visible text is under 35% of the page HTML"),
+    );
+    // No count at all: unchanged.
+    expect(msg("Invalid JSON-LD syntax")).toBe("Invalid JSON-LD syntax: ID");
+    // Nothing but a number: no wording to keep, so the check name stands in.
+    expect(msg("26")).toBe("c: ID");
+    expect(msg("2.5")).toBe("c: ID");
+    // Leading/trailing whitespace and a decimal count are handled.
+    expect(msg("   12 image(s) missing alt")).toBe("image(s) missing alt: ID");
+    expect(msg("3.5 MB of unused CSS")).toBe("MB of unused CSS: ID");
+    // Non-Latin wording counts as wording; punctuation alone does not.
+    expect(msg("12 見出しが見つかりません")).toBe("見出しが見つかりません: ID");
+    expect(msg("--- !!! ---")).toBe("c: ID");
+
+    // A pathological message cannot crowd the id out of the store's 1000-char
+    // message clamp.
+    const long = msg(`${"word ".repeat(400)}tail`);
+    expect(long.length).toBeLessThanOrEqual(240 + ": ID".length);
+    expect(long.endsWith(": ID")).toBe(true);
+  });
+
+  test("a long item id keeps its whole self inside the store's message clamp", () => {
+    // The id is the discriminator: two ids that differ only near their end must
+    // not display identically, so the prefix yields to the id, not the reverse.
+    const idA = `https://cdn.example/${"a".repeat(940)}-one`;
+    const idB = `https://cdn.example/${"a".repeat(940)}-two`;
+    const check: CheckResult = {
+      name: "sri",
+      status: "warn",
+      message: `${"long wording ".repeat(40)}without Subresource Integrity`,
+      items: [{ id: idA }, { id: idB }],
+    };
+    const rows = flattenChecks("https://x/a", "security/sri", [check]);
+    for (const r of rows) {
+      expect(r.message.length).toBeLessThanOrEqual(REPORT_LIMITS.maxMediumString);
+      expect(r.message.endsWith(r.locator)).toBe(true);
+    }
+    expect(rows[0]!.message).not.toBe(rows[1]!.message);
+  });
+
+  test("a surrogate pair is never cut in half by the prefix cap", () => {
+    // A lone surrogate is not valid text to hand a database or a JSON encoder.
+    const emoji = "\u{1F600}";
+    const msg = itemFindingMessage(
+      { name: "c", status: "warn", message: `x${emoji.repeat(200)}` },
+      { id: "ID" },
+    );
+    expect(msg.endsWith(": ID")).toBe(true);
+    const body = msg.slice(0, -": ID".length);
+    const lastUnit = body.charCodeAt(body.length - 1);
+    expect(lastUnit >= 0xd800 && lastUnit <= 0xdbff).toBe(false);
+    expect([...body].every((ch) => ch === "x" || ch === emoji)).toBe(true);
+  });
+
+  test("a check with NO items keeps the page-level message/value/expected verbatim", () => {
+    const check: CheckResult = {
+      name: "cookie-secure",
+      status: "fail",
+      message: "2 cookie(s) missing the Secure flag",
+      value: "2",
+      expected: "0",
+    };
+    const [row] = flattenChecks("https://x/a", "security/cookie-flags", [check]);
+    expect(row).toMatchObject({
+      locator: "",
+      message: "2 cookie(s) missing the Secure flag",
+      value: "2",
+      expected: "0",
+    });
+    // No aggregate stash on a whole-check row — its own columns already hold it.
+    expect(row!.payload).toBeNull();
+  });
+
+  test("an item with no id falls back to the check name, never the page message", () => {
+    const check: CheckResult = {
+      name: "sri",
+      status: "warn",
+      message: "26 cross-origin resources without Subresource Integrity",
+      items: [{ id: "" }],
+    };
+    const [row] = flattenChecks("https://x/a", "security/sri", [check]);
+    expect(row!.message).toBe("cross-origin resources without Subresource Integrity");
+    expect(itemFindingMessage(check, { id: "  " })).toBe(row!.message);
+    // A message that is nothing but a count reduces to the check name.
+    expect(itemFindingMessage({ name: "sri", status: "warn", message: "26" }, { id: "x" })).toBe(
+      "sri: x",
+    );
+  });
+
+  test("reconstruct restores the parent check's page-level message/value/expected", () => {
+    const source = sriCheck(26);
+    const rows = flattenChecks("https://x/a", "security/sri", [source]).map(toRecord);
+    const rebuilt = reconstructPageRuleChecks(rows).get("security/sri")!;
+
+    expect(rebuilt.length).toBe(1);
+    expect(rebuilt[0]).toMatchObject({
+      name: "sri",
+      status: "warn",
+      message: source.message,
+      value: "26",
+      expected: "0",
+      pageUrl: "https://x/a",
+    });
+    expect(rebuilt[0]!.items?.map((i) => i.id)).toEqual(source.items!.map((i) => i.id));
+  });
+
+  test("carriedFindingToCheck replays the page-level message, so report grouping does not split", () => {
+    const source = sriCheck(26);
+    const rows = flattenChecks("https://x/a", "security/sri", [source]).map(toRecord);
+    const replayed = rows.map((r) =>
+      carriedFindingToCheck(
+        {
+          normalizedUrl: r.normalizedUrl,
+          ruleId: r.ruleId,
+          checkName: r.checkName,
+          status: r.status,
+          message: r.message,
+          value: r.value,
+          expected: r.expected,
+          payload: r.payload,
+        },
+        r.normalizedUrl,
+      ),
+    );
+    // Report grouping keys on (name, status, digit-normalized message); every
+    // replayed item check must land in ONE group, as it did pre-#1881.
+    expect(new Set(replayed.map((c) => c.message))).toEqual(new Set([source.message]));
+    expect(new Set(replayed.map((c) => c.value))).toEqual(new Set(["26"]));
+    expect(replayed[0]!.items).toEqual([source.items![0]!]);
+  });
+
+  test("an empty-id item still restores its aggregate, even though it lands in a locator-\"\" group", () => {
+    // `m` (not the locator) is the restore marker precisely for this case: an
+    // item with id "" flattens to locator "", so a locator-gated restore would
+    // leave the reconstructed check holding the ITEM's message.
+    const check: CheckResult = {
+      name: "sri",
+      status: "warn",
+      message: "26 cross-origin resources without Subresource Integrity",
+      value: "26",
+      expected: "0",
+      items: [{ id: "" }],
+    };
+    const rows = flattenChecks("https://x/a", "security/sri", [check]).map(toRecord);
+    expect(rows[0]!.locator).toBe("");
+    expect(reconstructPageRuleChecks(rows).get("security/sri")![0]).toMatchObject({
+      message: "26 cross-origin resources without Subresource Integrity",
+      value: "26",
+      expected: "0",
+    });
+  });
+
+  test("a whole-check row whose payload carries details/pages is NOT read as an item row", () => {
+    // Payload presence alone cannot mark an item row — a whole-check finding
+    // carries details/pages too, and its own columns are already page-level.
+    const check: CheckResult = {
+      name: "slug-keywords",
+      status: "warn",
+      message: "3 keyword(s) repeated in the slug",
+      value: "3",
+      details: { some: "detail" },
+      pages: ["https://x/a"],
+    };
+    const [row] = flattenChecks("https://x/a", "url/slug-keywords", [check]);
+    expect(row!.payload).not.toBeNull();
+    expect(JSON.parse(row!.payload!).m).toBeUndefined();
+    expect(reconstructPageRuleChecks([toRecord(row!)]).get("url/slug-keywords")![0]).toMatchObject({
+      message: "3 keyword(s) repeated in the slug",
+      value: "3",
+    });
+  });
+
+  test("the aggregate stash yields rather than pushing a near-cap payload over maxFindingPayload", () => {
+    // A payload over the cap is DROPPED whole by the chunk ingest, and `details`
+    // feeds the density penalty — so growing a payload past the line would move
+    // the score. The stash is display detail, so it is what gets dropped.
+    const withBlob = (blob: string): CheckResult => ({
+      name: "sri",
+      status: "warn",
+      message: "26 cross-origin resources without Subresource Integrity",
+      value: "26",
+      expected: "0",
+      details: { blob, additional: 19 },
+      items: [{ id: "https://cdn/x.js" }],
+    });
+    const flatten = (blob: number) =>
+      flattenChecks("https://x/a", "security/sri", [withBlob("d".repeat(blob))])[0]!;
+    // Walk the blob up to the exact boundary where the stash no longer fits.
+    const start = REPORT_LIMITS.maxFindingPayload - flatten(0).payload!.length;
+    let blob = start;
+    let row = flatten(blob);
+    while (JSON.parse(row.payload!).m !== undefined && blob < start + 512) {
+      blob += 4;
+      row = flatten(blob);
+    }
+    const payload = JSON.parse(row.payload!);
+    expect(row.payload!.length).toBeLessThanOrEqual(REPORT_LIMITS.maxFindingPayload);
+    // Scoring-relevant detail survives; the aggregate is the part that yielded.
+    expect(payload.details.additional).toBe(19);
+    expect(payload.m).toBeUndefined();
+    // And the reader degrades to the row's own columns rather than blanking out.
+    expect(reconstructPageRuleChecks([toRecord(row)]).get("security/sri")![0]).toMatchObject({
+      message: "cross-origin resources without Subresource Integrity: https://cdn/x.js",
+    });
+
+    // One notch smaller and the stash is back — the drop is a cap effect, not a
+    // blanket behaviour change.
+    expect(JSON.parse(flatten(blob - 4).payload!).m).toBe(
+      "26 cross-origin resources without Subresource Integrity",
+    );
+
+    // The budget only ever removes the STASH. It must never trim items/details
+    // to fit, because this same payload goes to the CLI's local SQLite store,
+    // which has no cap — an already-over-cap payload keeps every field, byte
+    // for byte as it did pre-#1881, and shrinking it for transport is the chunk
+    // ingest's job.
+    const overCap = flatten(REPORT_LIMITS.maxFindingPayload * 2);
+    const kept = JSON.parse(overCap.payload!);
+    expect(overCap.payload!.length).toBeGreaterThan(REPORT_LIMITS.maxFindingPayload);
+    expect(kept.m).toBeUndefined();
+    expect(kept.details.additional).toBe(19);
+    expect(kept.details.blob.length).toBe(REPORT_LIMITS.maxFindingPayload * 2);
+    expect(kept.items).toEqual([{ id: "https://cdn/x.js" }]);
+  });
+
+  test("the aggregate is found on ANY sibling, so a per-item budget drop does not depend on row order", () => {
+    // The budget is decided per item, so one item with a huge payload can lose
+    // its stash while its siblings keep theirs. Reading only the first row would
+    // make the restore depend on which row the loader happened to return first.
+    const check: CheckResult = {
+      name: "sri",
+      status: "warn",
+      message: "2 cross-origin resources without Subresource Integrity",
+      value: "2",
+      items: [
+        { id: "https://cdn/huge.js", snippet: "s".repeat(REPORT_LIMITS.maxFindingPayload * 2) },
+        { id: "https://cdn/small.js" },
+      ],
+    };
+    const rows = flattenChecks("https://x/a", "security/sri", [check]).map(toRecord);
+    // The oversized item is over the cap and loses its stash; its sibling keeps
+    // one. Reading only group[0] would make the restore depend on row order.
+    expect(rows.map((r) => JSON.parse(r.payload!).m !== undefined)).toEqual([false, true]);
+
+    for (const order of [rows, [...rows].reverse()]) {
+      expect(reconstructPageRuleChecks(order).get("security/sri")![0]).toMatchObject({
+        message: "2 cross-origin resources without Subresource Integrity",
+        value: "2",
+      });
+    }
+  });
+
+  test("a pre-#1881 row (payload without the aggregate stash) still reconstructs from its own columns", () => {
+    // Rows written before this change hold the page-level message in `message`
+    // and carry no `m` — the readers must fall back to the row, not blank out.
+    const legacy: PageFindingRecord = {
+      siteKey: "SITE",
+      normalizedUrl: "https://x/a",
+      ruleId: "security/sri",
+      checkName: "sri",
+      locator: "https://cdn/x.js",
+      status: "warn",
+      severity: "warning",
+      message: "26 cross-origin resources without Subresource Integrity",
+      value: "26",
+      expected: "0",
+      payload: JSON.stringify({ items: [{ id: "https://cdn/x.js" }], i: 0 }),
+      fingerprint: "legacy",
+      firstSeenAt: 1,
+      lastSeenCrawlId: "crawl-0",
+      lastSeenAt: 1,
+      provenance: "carried",
+      state: "open",
+    };
+    const rebuilt = reconstructPageRuleChecks([legacy]).get("security/sri")![0]!;
+    expect(rebuilt).toMatchObject({
+      message: "26 cross-origin resources without Subresource Integrity",
+      value: "26",
+      expected: "0",
+    });
+    expect(
+      carriedFindingToCheck(
+        {
+          normalizedUrl: legacy.normalizedUrl,
+          ruleId: legacy.ruleId,
+          checkName: legacy.checkName,
+          status: legacy.status,
+          message: legacy.message,
+          value: legacy.value,
+          expected: legacy.expected,
+          payload: legacy.payload,
+        },
+        legacy.normalizedUrl,
+      ),
+    ).toMatchObject({
+      message: "26 cross-origin resources without Subresource Integrity",
+      value: "26",
+      expected: "0",
+    });
+  });
+});


### PR DESCRIPTION
## The defect

`findingFingerprint` hashes `[status, message, value, expected]` and is deliberately URL-free, so `finding_defs` (`site_key`, `fingerprint`) can hold one row per distinct defect. `flattenChecks` defeated that: it copied the parent check's **page-level** message/value/expected onto every item row, and a page-scope check's message is a *count of that page's items*.

One Shopify CDN script missing SRI on all 401 pages of a real audit stored 25 different messages, "26 cross-origin resources without Subresource Integrity" on one page and "24 ..." on another, and therefore 25 fingerprints for one defect.

The damage ran in both directions, which the issue did not anticipate. On the measured site, item rows carry 4,036 distinct `(rule, check, locator)` defects but only **561** distinct fingerprints, because the hash keyed on the page's item count rather than on the defect. One `finding_defs` row was standing in for many unrelated locators. So the dictionary was not merely bloated, it was wrong.

## The fix

An item row's message is now the page-invariant part of its check's message, plus the item id:

```
cross-origin resources without Subresource Integrity: https://cdn.shopify.com/extensions/.../globo.filter.min.js
potential source map(s) detected: https://cdn.example/app.js.map
cookie(s) missing the Secure flag: cart_currency
```

`pageInvariantCheckText` drops a leading count and replaces any remaining digit run with `N`. That placeholder is not invented here: the report's own grouping already renders exactly that for a merged group whose members differ only in digits (`packages/report/src/grouping.ts`), so the two surfaces read alike.

`value` and `expected` were page-level aggregates for the same reason and are dropped from item rows.

`item.label` deliberately does **not** feed the message. Several rules stamp per-page numbers into the label, `content/keyword-stuffing` emits `"everyday" (2.3%)`, so a label-bearing message re-creates the same split. The label is not lost; it rides in the payload's `items[0]`, which every reader that rebuilds a `CheckResult` replays.

Nothing downstream changes text or score. The parent check's page-level trio is stashed in the item payload as `m`/`v`/`e`, and both readers that rebuild a `CheckResult` from storage restore it verbatim:

- `carriedFindingToCheck` (`scoring.ts`), so a replayed carried check renders the page-level message. Report grouping keys on the message, so reading the item's own text there would split one carried aggregate into one group per item.
- `reconstructRuleChecks` (`reconstruct.ts`), so the complete-store round-trip stays lossless.

`m` is the sole restore marker. A pre-#1881 row has none and falls back to its own columns; a whole-check row never writes one, so payload presence alone cannot misfire; an empty-id item is caught even though it lands in a locator-`""` group. The marker is scanned across the whole group, not just `group[0]`, because the stash is budgeted per item.

**Payload budget.** The stash is added only when the serialized payload still fits `maxFindingPayload`. The chunk ingest drops an over-cap payload whole and `details.additional` feeds the scorer's density penalty, so letting the stash tip a near-cap payload over the line would move the health score, the #1179 class. The stash is display detail, so it is the part that yields.

The budget never trims `items`/`details`/`pages` to make room. This same payload feeds the CLI's local SQLite store, which persists it with no cap at all, so dropping detail here to work around a transport limit would destroy data the local path would have kept. Shrinking an already-over-cap payload for transport belongs at the transport boundary, and the paired private PR adds exactly that retry there. An over-cap payload is therefore byte-identical to what it was before this change.

Whole-check findings (locator `""`) are untouched.

## Which surfaces show this message to a person

Traced every reader of `page_findings.message` / `finding_defs.message` that does **not** first pass through `carriedFindingToCheck` or `reconstructRuleChecks`.

| surface | reads the raw stored column? | what it shows after this PR |
| --- | --- | --- |
| Dashboard report detail (`report-detail.tsx`) | no | unchanged; `topIssues` is built server-side from the R2 report payload (`routes/v1/websites.ts`), then `@squirrelscan/report` grouping |
| Issues tracker list + detail, and the issues sync | no | unchanged; `issue-sync.ts` writes title/description/recommendation from **rule metadata**, never from a finding message |
| MCP `get_issue` | no | unchanged; occurrences come from `extractRuleOccurrences` over the report payload (`run-report.ts`) |
| MCP `list_issues` | no | carries no message field at all |
| Audit summary email prompt (`packages/issues/src/prompts.ts`) | no | contains no `message` read; its input schema has no message field |
| Audit digest email | no | unchanged; `audit-digest.ts` takes its title from `flattenReport`, which reads the report payload |
| `compare_audits` | no | `audit-diff/resolve.ts` selects only `normalizedUrl, ruleId, checkName, locator, state` from `page_findings`, no message |
| Report renderers (`packages/report`) | no | never reads stored findings, only `CheckResult`s |
| `GET /v1/{reports,websites}/…/findings` (`findings-read.ts`) | **yes** | the item-scoped message above |

The one raw reader is `serveFindings`, and it is dark: `REPORTS_FINDINGS_API_ENABLED` is `"false"` in `wrangler.toml` and `wrangler.dg.toml`, `requireFindingsApi` 404s, and nothing in the monorepo calls it, not the dashboard, the API client, the cloud client or the CLI. It returns JSON, never a rendered string. So no human or agent sees this column today, and when that flag is flipped it will read as a sentence rather than a bare URL, which is why the message is not just the id.

## Measurements

**Page-invariance, whole production corpus**: 296 sites, 545,822 item rows.

| key | count |
| --- | --- |
| distinct (site, rule, check, locator, status) | 91,944 |
| plus the new message | 91,966 |
| residual split | 22, or 0.024% |

All 22 are named and filed as #231: `security/sri` and `content/meta-in-body` alternate singular and plural wording, and `schema/rating-scope` interpolates the product name into its message. That is empirical rather than a proof, and #229 is the gate that would catch a future rule reintroducing it.

**Collapse on the measured site** (drscholls, 52,526 rows):

| | rows | distinct (rule, check, locator) | identity tuple before | after | distinct fingerprints before | after |
| --- | --- | --- | --- | --- | --- | --- |
| item rows | 45,663 | 4,036 | 6,455 | 4,069 | 561 | 4,069 |
| whole-check rows | 6,863 | 43 | 519 | 519 | 519 | 519 |

Item-row inflation over the locator key falls from 59.9% to 0.8%. Whole-check rows are unchanged, as the third acceptance criterion requires. Site-wide the tuple lands 12.5% above the locator floor; the entire residual is the 43 whole-check groups this PR must leave alone, so that is the floor for #1881 and #1882/#1885 own the rest.

The fingerprint count for item rows rises from 561 to 4,069. That is the correct direction: 4,036 distinct defects previously shared 561 hashes.

**Canonical 500-page golden fixture**: item-row inflation is 0.0% before and after. The fixture's item locators are page-unique, so it never exhibited the count split and cannot demonstrate the fix, which is why the numbers above come from production.

## Gates

No golden files exist to regenerate; every "golden" in `packages/audit-engine/tests` is a self-referential parity gate over an in-process synthetic fixture. All 18 files matched by `test:golden` pass, as do `complete-store-parity`, `merge-scoring`, `fingerprint-parity` and the two CLI suites that exercise `flattenChecks`. Health score is unchanged at 49 on the canonical fixture.

Worth naming for a future issue, filed as #229: the engine golden snapshot compares only `(ruleId, checkName, status, pageUrl)`, so a change to a finding's message text passes every golden gate while re-fingerprinting every stored finding. That is why the numbers above come from measurement rather than from the gates.

## One-time effect: smaller than the issue assumed

The issue predicted that every item-row fingerprint changing would surface those findings as new or worsened in `compare_audits`. Traced, that does not happen, and no mitigation is needed.

- **`compare_audits` never reads a stored fingerprint.** `flattenReport` (`audit-diff/identity.ts`) computes its own fingerprints from the **R2 report payload's** `ruleResults[].checks[].message`, and `audit-diff/resolve.ts` selects only `normalizedUrl, ruleId, checkName, locator, state` from `page_findings`. Report checks are unchanged by this PR: fresh checks come from rule execution, and carried checks come from `carriedFindingToCheck`, which restores the page-level message from the stash. So both sides of a diff read exactly what they read before.
- **The merge does not key on the fingerprint either.** `computeMerge` matches a prior finding by `findingKey` = (url, rule, check, locator) and simply stores the new fingerprint, preserving `firstSeenAt`. Nothing is re-created, so no finding reads as newly discovered and no first-seen date resets.
- **The issues tracker is untouched.** `issue-sync.ts` writes title, description and recommendation from rule metadata, never from a finding message or fingerprint.

What does change is `finding_defs`, and in the intended direction. Projected over the current corpus it goes from **22,981 rows to about 102,499**. That is not bloat: on the measured site, 4,036 distinct defects were sharing 561 fingerprints, so the dictionary was under-counting defects by 7x. Superseded rows become orphans as each site is re-audited and are removed by the existing `sweepOrphanFindingDefs` cron, which anti-joins `finding_defs` against `page_findings` on (site_key, fingerprint). Self-healing, no backfill and no migration.

## Follow-up in the private repo

`clampFindingPayload` in the API's chunk ingest rebuilds the payload from a key allowlist (`items`, `pages`, `details`, `i`) and would silently drop `m`/`v`/`e` on the chunked-publish path. squirrelscan/repo#1890 adds the clamped pass-throughs and lands before the gitlink bump.

Blocks squirrelscan/repo#1880.
