### PR TITLE
fix(audit-engine): emit the assemble phase the streamed rules pass declared

### DIFF
--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -2432,17 +2432,28 @@ export function runStreamingRules(
     // Step 6: assemble. Page rules were already merged + folded by streamPageRules;
     // merge + fold the site rules on top so ruleResultsMap and tallies stay in
     // lockstep — calculateHealthScoreFromTallies(tallies) === calculateHealthScore(ruleResultsMap).
-    const ruleResultsMap = streamed.ruleResultsMap;
-    const tallies = streamed.tallies;
-    for (const [ruleId, rr] of sitePass.siteRuleRunResults) {
-      mergeRuleRunResult(ruleResultsMap, ruleId, rr);
-      foldRuleResultIntoTallies(tallies, ruleId, rr);
-    }
+    //
+    // Reported as a phase like the rest: this is where the report's parsed-page
+    // cache is built, which is one of the structures that still scales with page
+    // count, so it is exactly the step whose cost we want visible when deciding
+    // whether to bound it. It was the one declared phase the pass never emitted.
+    const { ruleResultsMap, tallies, parsedPagesCache } = yield* phase("assemble", () =>
+      Effect.sync(() => {
+        const map = streamed.ruleResultsMap;
+        const folded = streamed.tallies;
+        for (const [ruleId, rr] of sitePass.siteRuleRunResults) {
+          mergeRuleRunResult(map, ruleId, rr);
+          foldRuleResultIntoTallies(folded, ruleId, rr);
+        }
 
-    // Parsed-page cache for the report tail — same universe (auditable pages) v1
-    // returns, with DOMs already dropped (report reads only extracted fields).
-    const parsedPagesCache = new Map<string, ParsedPage>();
-    for (const [url, { parsed }] of pageDataMap) parsedPagesCache.set(url, parsed);
+        // Parsed-page cache for the report tail — same universe (auditable pages)
+        // v1 returns, with DOMs already dropped (report reads only extracted
+        // fields).
+        const cache = new Map<string, ParsedPage>();
+        for (const [url, { parsed }] of pageDataMap) cache.set(url, parsed);
+        return { ruleResultsMap: map, tallies: folded, parsedPagesCache: cache };
+      }),
+    );
 
     return {
       pageResults: streamed.pageResults,

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -29,6 +29,9 @@ export type {
   SiteContextPage,
   RuleExecutionResult,
   StreamingRuleExecutionResult,
+  // #1860: the sub-phase names, so a consumer can map them exhaustively rather
+  // than reconstructing the strings and casting.
+  StreamingRulePhase,
   PreFetchedAssets,
   ResourceCheckOverrides,
   ExternalLinkCheckProgress,


### PR DESCRIPTION
For squirrelscan/repo#1860, follow-up to #226. Two lines of behaviour, no change to what an audit computes.

`StreamingRulePhase` declared six phases and `runStreamingRules` emitted five. The missing one was `assemble`, so the only sub-phase a consumer could not observe was the last one.

That matters more than a tidy-up: assemble is where the report's parsed-page cache is built, and the retained rule-results structures are the last terms in the pipeline that still scale with page count. It is precisely the step whose cost has to be visible when deciding whether to bound them.

Wrapped like the other five, in `Effect.sync` so the boundary can be reported. Same merge, same fold, same cache build. All golden and streaming gates pass unchanged.

Downstream: the private side maps `StreamingRulePhase` to a `PostCrawlStage` and had `rules_assemble` sitting dead in its union. With this merged that mapping becomes exhaustive, so a future phase added here fails the private typecheck instead of being silently dropped.