### PR TITLE
perf(audit-engine): detach what the page loop retains from the page it came from

### DIFF
--- a/packages/audit-engine/scripts/build-real-fixture.ts
+++ b/packages/audit-engine/scripts/build-real-fixture.ts
@@ -34,6 +34,9 @@ const BASE = "https://www.drscholls.com";
 
 const base = await Bun.file(PAGE).text();
 
+/** The ONE path function: page records and the nav links both go through it. */
+const pathFor = (i: number): string => (i === 0 ? "/" : `/p/${String(i).padStart(4, "0")}`);
+
 /** What the crawler persists: the parsed scalars, minus the live document. */
 function serializeParsed(html: string, url: string): string {
   const parsed = parseHtmlForRules(html, url) as unknown as Record<string, unknown>;
@@ -62,14 +65,16 @@ for (let i = 0; i < N; i++) {
   // Same per-page variation the live repro server applies: a distinct title and
   // a nav of internal links, so link-graph and duplicate rules see a real site
   // rather than N copies of one page.
-  const links = Array.from(
-    { length: 40 },
-    (_, k) => `<a href="/p/${(i * 7 + k * 13) % N}">Product ${(i * 7 + k * 13) % N}</a>`,
-  ).join("\n");
+  const links = Array.from({ length: 40 }, (_, k) => {
+    const target = (i * 7 + k * 13) % N;
+    // Same path function the page RECORD uses — a link to a path no page is
+    // stored under is an external/broken link, not a link-graph edge.
+    return `<a href="${pathFor(target)}">Product ${target}</a>`;
+  }).join("\n");
   const html = base
     .replace(/<title>[^<]*<\/title>/, `<title>Page ${i} Dr Scholls</title>`)
     .replace("</body>", `<nav id="syn">${links}</nav></body>`);
-  const url = i === 0 ? `${BASE}/` : `${BASE}/p/${String(i).padStart(4, "0")}`;
+  const url = `${BASE}${pathFor(i)}`;
   await run(
     storage.upsertPage(crawlId, {
       url,

--- a/packages/audit-engine/scripts/build-real-fixture.ts
+++ b/packages/audit-engine/scripts/build-real-fixture.ts
@@ -1,0 +1,104 @@
+// Build a crawl DB from a SAVED REAL PAGE (#1860).
+//
+// The synthetic fixture was wrong about the thing that matters. A real
+// drscholls page is 959 KB of html with 1051 DOM nodes and 5 KB of visible
+// text — almost all of it inline script. The synthetic one was 983 KB with
+// 18,917 nodes. Those are opposite shapes, and the retention census run on the
+// synthetic one reported 96 KB/page retained where production measured ~8 MB.
+//
+//   bun run scripts/build-real-fixture.ts --page /path/page.html --db /tmp/real.sqlite --pages 150
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { parseHtmlForRules } from "../src/adapter";
+import { Effect } from "effect";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+const arg = (n: string, d: string) => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? (process.argv[i + 1] ?? d) : d;
+};
+
+const PAGE = arg("page", "");
+const DB = arg("db", "/tmp/real-fixture.sqlite");
+const N = Number.parseInt(arg("pages", "150"), 10);
+// The crawler stores parsedData (JSON of the extracted scalars) for every page,
+// and buildSiteContext reuses it instead of re-extracting. That path matters for
+// memory: JSON.parse produces FRESH strings, where a re-extract produces strings
+// that share the page's html buffer. A fixture with parsedData null therefore
+// measures a path production does not take. `--no-parsed-data` keeps the old
+// behaviour so the two can be compared.
+const STORE_PARSED = !process.argv.includes("--no-parsed-data");
+const BASE = "https://www.drscholls.com";
+
+const base = await Bun.file(PAGE).text();
+
+/** What the crawler persists: the parsed scalars, minus the live document. */
+function serializeParsed(html: string, url: string): string {
+  const parsed = parseHtmlForRules(html, url) as unknown as Record<string, unknown>;
+  const { document: _document, ...rest } = parsed;
+  return JSON.stringify(rest);
+}
+
+const storage = new SQLiteStorage(DB);
+await run(storage.init());
+const crawlId = await run(
+  storage.createCrawl({
+    baseUrl: BASE,
+    seedUrl: BASE,
+    originalUrl: BASE,
+    startedAt: Date.now(),
+    status: "completed",
+    config: {},
+    stats: {
+      pagesTotal: N, pagesFetched: N, pagesFailed: 0, pagesSkipped: 0,
+      pagesUnchanged: 0, linksTotal: 0, imagesTotal: 0, bytesTotal: 0, avgLoadTimeMs: 0,
+    },
+  } as never),
+);
+
+for (let i = 0; i < N; i++) {
+  // Same per-page variation the live repro server applies: a distinct title and
+  // a nav of internal links, so link-graph and duplicate rules see a real site
+  // rather than N copies of one page.
+  const links = Array.from(
+    { length: 40 },
+    (_, k) => `<a href="/p/${(i * 7 + k * 13) % N}">Product ${(i * 7 + k * 13) % N}</a>`,
+  ).join("\n");
+  const html = base
+    .replace(/<title>[^<]*<\/title>/, `<title>Page ${i} Dr Scholls</title>`)
+    .replace("</body>", `<nav id="syn">${links}</nav></body>`);
+  const url = i === 0 ? `${BASE}/` : `${BASE}/p/${String(i).padStart(4, "0")}`;
+  await run(
+    storage.upsertPage(crawlId, {
+      url,
+      normalizedUrl: url,
+      finalUrl: url,
+      depth: i === 0 ? 0 : 1,
+      status: 200,
+      contentType: "text/html",
+      sizeBytes: Buffer.byteLength(html, "utf8"),
+      loadTimeMs: 120,
+      fetchedAt: Date.now(),
+      etag: null,
+      lastModified: null,
+      contentHash: `real-${i}`,
+      html,
+      parsedData: STORE_PARSED ? serializeParsed(html, url) : null,
+      headers: {
+        contentType: "text/html", contentEncoding: "gzip", cacheControl: null, vary: null,
+        etag: null, server: "cloudflare", lastModified: null, link: null, serverTiming: null,
+        age: null, xCache: null, cfCacheStatus: "HIT", xVercelCache: null, altSvc: null,
+        acceptRanges: null,
+      },
+      securityHeaders: {
+        hsts: null, csp: null, xFrameOptions: null, xContentTypeOptions: null,
+        referrerPolicy: null, permissionsPolicy: null, xRobotsTag: null,
+      },
+    } as never),
+  );
+}
+
+console.log(`built ${DB}: ${N} pages of ${(base.length / 1024).toFixed(0)} KB real html`);
+await run(storage.close());

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -107,6 +107,7 @@ import {
   type StreamPageRulesHooks,
 } from "./streaming";
 import { collectDroppedBatch } from "./batch-gc";
+import { detachFromPage } from "./detach";
 import { resolveCloakingProbes } from "./cloaking-probe";
 import { createSiteQuery } from "./site-query";
 import { confirmSoft404Candidates } from "./soft404-confirm";
@@ -2380,7 +2381,9 @@ export function runStreamingRules(
       id: "site-dom-signals",
       collect(page, parsed) {
         collectedPages.push(
-          buildCollectedPageSignal({ url: page.normalizedUrl, finalUrl: page.finalUrl, parsed }),
+          detachFromPage(
+            buildCollectedPageSignal({ url: page.normalizedUrl, finalUrl: page.finalUrl, parsed }),
+          ),
         );
       },
     };

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -2383,6 +2383,7 @@ export function runStreamingRules(
         collectedPages.push(
           detachFromPage(
             buildCollectedPageSignal({ url: page.normalizedUrl, finalUrl: page.finalUrl, parsed }),
+            "collected-signal",
           ),
         );
       },

--- a/packages/audit-engine/src/detach.ts
+++ b/packages/audit-engine/src/detach.ts
@@ -1,0 +1,37 @@
+// Detaching retained values from the page they came from (#1860).
+
+/**
+ * Copy a per-page value so it stops referencing the page it came from (#1860).
+ *
+ * Every string a rule pulls out of a parsed page — an href, an anchor's text, a
+ * matched secret — is produced by slicing the page's HTML, and JSC keeps those
+ * slices attached to the buffer they came from. Retaining ONE of them retains
+ * the whole page as UTF-16. Measured on a real 959 KB page: the collected
+ * signal is about 1 KB of actual data and holds 3.8 MB.
+ *
+ * That is invisible in every obvious measure. `JSON.stringify(signal).length`
+ * says 1 KB, `process.memoryUsage().rss` says nothing at all because the arena
+ * absorbs it, and it only appears in `heapUsed`/`external` — which is why a
+ * production run at 149 pages held ~8 MB per page while a local census of the
+ * same structures reported 96 KB.
+ *
+ * `structuredClone` is what detaches them: it serializes, so every string comes
+ * out fresh, and unlike a JSON round-trip it preserves the `Set`s in
+ * `PageFingerprint` rather than silently turning them into `{}`. Measured on the
+ * same fixture, the collected signal goes from 3841 KB to 322 KB per page with
+ * identical values and identical types.
+ *
+ * Applied only where a value OUTLIVES its batch. Inside a batch the page is
+ * resident anyway and a copy would be pure cost.
+ */
+export function detachFromPage<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    // A value carrying something non-cloneable (a function, a DOM node) would
+    // throw. Keeping the original is the safe answer: it costs the retention
+    // this exists to avoid, but it cannot change what the audit reports.
+    return value;
+  }
+}
+

--- a/packages/audit-engine/src/detach.ts
+++ b/packages/audit-engine/src/detach.ts
@@ -1,5 +1,28 @@
 // Detaching retained values from the page they came from (#1860).
 
+import { logger } from "./adapter-logger";
+
+/** Where a detach happened, so a fallback can name the boundary that failed. */
+export type DetachBoundary = "page-rules" | "collected-signal";
+
+export interface DetachCounts {
+  /** Values copied free of their page. */
+  readonly detached: number;
+  /** Values kept ATTACHED because the copy threw — the retention is still there. */
+  readonly fallbacks: number;
+}
+
+const counts = new Map<DetachBoundary, { detached: number; fallbacks: number }>();
+/** Log the first few fallbacks per boundary; a broken page shape would hit every page. */
+const MAX_LOGGED_FALLBACKS = 3;
+
+function bump(boundary: DetachBoundary, key: "detached" | "fallbacks"): number {
+  const row = counts.get(boundary) ?? { detached: 0, fallbacks: 0 };
+  row[key] += 1;
+  counts.set(boundary, row);
+  return row[key];
+}
+
 /**
  * Copy a per-page value so it stops referencing the page it came from (#1860).
  *
@@ -24,14 +47,40 @@
  * Applied only where a value OUTLIVES its batch. Inside a batch the page is
  * resident anyway and a copy would be pure cost.
  */
-export function detachFromPage<T>(value: T): T {
+export function detachFromPage<T>(value: T, boundary: DetachBoundary): T {
   try {
-    return structuredClone(value);
-  } catch {
+    const copy = structuredClone(value);
+    bump(boundary, "detached");
+    return copy;
+  } catch (error) {
     // A value carrying something non-cloneable (a function, a DOM node) would
     // throw. Keeping the original is the safe answer: it costs the retention
     // this exists to avoid, but it cannot change what the audit reports.
+    //
+    // It is all-or-nothing per call, so ONE offending finding restores
+    // page-sized retention for every page that carries it, with identical
+    // findings and green golden tests. That is exactly the failure this counter
+    // exists to make visible; `detachCounts` is asserted zero over a real
+    // rule-runner graph in tests/detach-from-page.test.ts.
+    const seen = bump(boundary, "fallbacks");
+    if (seen <= MAX_LOGGED_FALLBACKS) {
+      // The error's TYPE only — its message can quote the offending value, and
+      // that value is page content.
+      const kind = error instanceof Error ? error.name : typeof error;
+      logger.warn(
+        `detach fallback at ${boundary} (${kind}): this page stays attached to its HTML (#1860)`,
+      );
+    }
     return value;
   }
 }
 
+/** Per-boundary detach/fallback counts for the current process. */
+export function detachCounts(boundary: DetachBoundary): DetachCounts {
+  return counts.get(boundary) ?? { detached: 0, fallbacks: 0 };
+}
+
+/** Test seam: counts are process-wide, so a test that asserts on them starts here. */
+export function resetDetachCounts(): void {
+  counts.clear();
+}

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -232,10 +232,13 @@ export function streamPageRules(
         // objects, and cloning the container in a single call preserves that
         // sharing. Cloning them separately would triple the findings.
         const byRule = [...raw.ruleResults];
-        const detached = detachFromPage({
-          checks: raw.checks,
-          ruleChecks: byRule.map(([, rr]) => rr.checks),
-        });
+        const detached = detachFromPage(
+          {
+            checks: raw.checks,
+            ruleChecks: byRule.map(([, rr]) => rr.checks),
+          },
+          "page-rules",
+        );
         const result = {
           checks: detached.checks,
           ruleResults: new Map(

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -27,6 +27,7 @@ import { mergeRuleRunResult } from "@squirrelscan/rules";
 
 import { buildSiteContext, buildHeadersMap, isRenderedFetch } from "./adapter";
 import { collectDroppedBatch } from "./batch-gc";
+import { detachFromPage } from "./detach";
 import { extractPageFeatures, isAuditablePage } from "./page-features";
 import type { PageRuleLoopHooks } from "./page-rule-executor";
 import { foldRuleResultIntoTallies, type RuleTally } from "./scoring";
@@ -206,9 +207,44 @@ export function streamPageRules(
           rendered: isRenderedFetch(page.fetcherId),
         };
 
-        const result = yield* Effect.promise(() =>
+        const raw = yield* Effect.promise(() =>
           runner.runPageRules(pageData, siteDataForPageRules)
         );
+
+        // Detach the findings from the page before retaining them (#1860). Every
+        // string a rule pulled out of this page — a message, an item label, a
+        // matched value — is a slice of the page's HTML, and JSC keeps a slice
+        // attached to the buffer it came from, so retaining any one of them
+        // retains the whole page as UTF-16 for the rest of the run.
+        //
+        // ONLY the checks graph is cloned. Two things must stay out of it:
+        //
+        //  - `meta`, which carries the rule's Zod `optionsSchema`. structuredClone
+        //    throws on it (20 of 198 page rules), and because ONE failure aborts
+        //    the whole clone, including meta made this a silent no-op that the
+        //    golden tests could never catch — the findings were unchanged, just
+        //    still attached. meta is per-RULE, not per-page, so it retains nothing.
+        //  - `parsed`, which the runner returns and nothing here reads. Cloning it
+        //    would copy the live document and strip SchemaCollection's methods.
+        //
+        // One clone for the whole graph, not one per consumer: `pageResults`,
+        // `pageRuleResults` and `ruleResultsMap` all reference the SAME check
+        // objects, and cloning the container in a single call preserves that
+        // sharing. Cloning them separately would triple the findings.
+        const byRule = [...raw.ruleResults];
+        const detached = detachFromPage({
+          checks: raw.checks,
+          ruleChecks: byRule.map(([, rr]) => rr.checks),
+        });
+        const result = {
+          checks: detached.checks,
+          ruleResults: new Map(
+            byRule.map(([ruleId, rr], i) => [
+              ruleId,
+              { ...rr, checks: detached.ruleChecks[i]! },
+            ]),
+          ),
+        };
 
         const pageUrl = page.normalizedUrl;
         pageResults.set(pageUrl, result.checks);

--- a/packages/audit-engine/tests/detach-from-page.test.ts
+++ b/packages/audit-engine/tests/detach-from-page.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { detachFromPage } from "../src/detach";
+import { detachCounts, detachFromPage, resetDetachCounts } from "../src/detach";
 
 /** Retained bytes after holding `n` copies of what `make` returns. */
 function retainedPerItem(n: number, make: (i: number) => unknown): number {
@@ -41,15 +41,19 @@ describe("detachFromPage", () => {
   test("a raw slice of a page retains the page; a detached copy does not", () => {
     const N = 80;
     const attached = retainedPerItem(N, (i) => ({ text: pageAndSlice(i).slice }));
-    const detached = retainedPerItem(N, (i) => detachFromPage({ text: pageAndSlice(i).slice }));
+    const detached = retainedPerItem(N, (i) => detachFromPage({ text: pageAndSlice(i).slice }, "page-rules"));
 
     // The measurement itself is environment-dependent: a collector that absorbs
     // the allocation reports no growth for EITHER case, and a review pass saw
-    // exactly that. Comparing two zeroes proves nothing, so the assertion only
-    // runs where the attached case actually demonstrated the retention it is
-    // meant to catch. The deterministic guarantees below hold everywhere.
+    // exactly that. Comparing two zeroes proves nothing, and asserting anything
+    // at all in that state would report a pass the run did not earn — so this
+    // says INCONCLUSIVE out loud and asserts nothing. The deterministic
+    // guarantees are the tests below plus detach-production-boundaries.test.ts.
     if (attached < 100 * KB) {
-      expect(detached).toBeLessThanOrEqual(Math.max(attached, 100 * KB));
+      console.warn(
+        `[detach] INCONCLUSIVE: control retained only ${Math.round(attached / KB)} KB/item, ` +
+          `so this run did not demonstrate the retention it is meant to catch.`,
+      );
       return;
     }
 
@@ -68,7 +72,7 @@ describe("detachFromPage", () => {
       nested: { classes: new Set(["x"]) },
       list: [new Set(["y"])],
     };
-    const copy = detachFromPage(source);
+    const copy = detachFromPage(source, "page-rules");
 
     expect(copy.assetHosts).toBeInstanceOf(Set);
     expect([...copy.assetHosts]).toEqual(["a.example", "b.example"]);
@@ -85,7 +89,7 @@ describe("detachFromPage", () => {
       nothing: null,
       when: new Date(0),
     };
-    const copy = detachFromPage(source);
+    const copy = detachFromPage(source, "page-rules");
     expect(copy).toEqual(source);
     // A copy, not the same object — otherwise nothing was detached.
     expect(copy).not.toBe(source);
@@ -97,15 +101,20 @@ describe("detachFromPage", () => {
     // check objects. One clone of the container keeps that sharing; cloning each
     // consumer separately would triple the findings instead of detaching them.
     const shared = { name: "check" };
-    const copy = detachFromPage({ flat: [shared], byRule: { r: [shared] } });
+    const copy = detachFromPage({ flat: [shared], byRule: { r: [shared] } }, "page-rules");
     expect(copy.flat[0]).toBe(copy.byRule.r[0]);
   });
 
-  test("returns the original rather than throwing on a non-cloneable value", () => {
+  test("returns the original rather than throwing on a non-cloneable value, and COUNTS it", () => {
+    resetDetachCounts();
     // Safety valve: a value carrying a function cannot be structured-cloned.
     // Keeping the original costs the retention this exists to avoid, but it
     // cannot change what the audit reports.
     const withFn = { fn: () => 1, keep: "x" };
-    expect(detachFromPage(withFn)).toBe(withFn);
+    expect(detachFromPage(withFn, "page-rules")).toBe(withFn);
+    // Silent is the failure mode that matters: a fallback keeps the page
+    // attached with identical findings, so it has to be countable.
+    expect(detachCounts("page-rules").fallbacks).toBe(1);
+    resetDetachCounts();
   });
 });

--- a/packages/audit-engine/tests/detach-from-page.test.ts
+++ b/packages/audit-engine/tests/detach-from-page.test.ts
@@ -1,0 +1,111 @@
+// #1860: what the streamed page loop retains must not stay attached to the page
+// it came from.
+//
+// Every string a rule pulls out of a parsed page is a slice of that page's HTML,
+// and JSC keeps a slice attached to the buffer it came from. Retaining one
+// 20-character href therefore retains the whole page as UTF-16 for the rest of
+// the run. Measured on a real 959 KB page: the collected signal is about 1 KB of
+// data and held 3.8 MB.
+//
+// This is invisible to every obvious measure — `JSON.stringify(x).length` sees
+// the logical size, and RSS sees nothing because the arena absorbs it — so it
+// needs a test that looks at `heapUsed` directly. A production run held ~8 MB
+// per page while a local census of the same structures reported 96 KB.
+
+import { describe, expect, test } from "bun:test";
+
+import { detachFromPage } from "../src/detach";
+
+/** Retained bytes after holding `n` copies of what `make` returns. */
+function retainedPerItem(n: number, make: (i: number) => unknown): number {
+  Bun.gc(true);
+  const before = process.memoryUsage().heapUsed;
+  const kept: unknown[] = [];
+  for (let i = 0; i < n; i++) kept.push(make(i));
+  Bun.gc(true);
+  const grown = process.memoryUsage().heapUsed - before;
+  // Touch `kept` after the sample so it cannot be collected early.
+  expect(kept.length).toBe(n);
+  return grown / n;
+}
+
+/** A page-sized string and a small slice of it, as a parse would produce. */
+function pageAndSlice(i: number): { page: string; slice: string } {
+  const page = `<html><body>${"a".repeat(500_000)}${i}</body></html>`;
+  return { page, slice: page.slice(120, 180) };
+}
+
+const KB = 1024;
+
+describe("detachFromPage", () => {
+  test("a raw slice of a page retains the page; a detached copy does not", () => {
+    const N = 80;
+    const attached = retainedPerItem(N, (i) => ({ text: pageAndSlice(i).slice }));
+    const detached = retainedPerItem(N, (i) => detachFromPage({ text: pageAndSlice(i).slice }));
+
+    // The measurement itself is environment-dependent: a collector that absorbs
+    // the allocation reports no growth for EITHER case, and a review pass saw
+    // exactly that. Comparing two zeroes proves nothing, so the assertion only
+    // runs where the attached case actually demonstrated the retention it is
+    // meant to catch. The deterministic guarantees below hold everywhere.
+    if (attached < 100 * KB) {
+      expect(detached).toBeLessThanOrEqual(Math.max(attached, 100 * KB));
+      return;
+    }
+
+    // Attached holds something on the order of the page; detached, of the slice.
+    // A ratio rather than absolute bytes, so this is not pinned to one engine's
+    // object layout.
+    expect(detached).toBeLessThan(attached / 4);
+  });
+
+  test("preserves Sets, which a JSON round-trip would silently empty", () => {
+    // PageFingerprint carries Sets. `JSON.parse(JSON.stringify(x))` also detaches
+    // strings, but turns every Set into {} — the rules downstream would then see
+    // an empty fingerprint and quietly change their findings.
+    const source = {
+      assetHosts: new Set(["a.example", "b.example"]),
+      nested: { classes: new Set(["x"]) },
+      list: [new Set(["y"])],
+    };
+    const copy = detachFromPage(source);
+
+    expect(copy.assetHosts).toBeInstanceOf(Set);
+    expect([...copy.assetHosts]).toEqual(["a.example", "b.example"]);
+    expect(copy.nested.classes).toBeInstanceOf(Set);
+    expect(copy.list[0]).toBeInstanceOf(Set);
+  });
+
+  test("round-trips the value, not just its shape", () => {
+    const source = {
+      url: "https://example.com/a?b=1#c",
+      items: [{ id: "x", label: "L", sourcePages: ["p1", "p2"] }],
+      count: 3,
+      flag: false,
+      nothing: null,
+      when: new Date(0),
+    };
+    const copy = detachFromPage(source);
+    expect(copy).toEqual(source);
+    // A copy, not the same object — otherwise nothing was detached.
+    expect(copy).not.toBe(source);
+    expect(copy.items[0]).not.toBe(source.items[0]);
+  });
+
+  test("preserves sharing WITHIN one value rather than duplicating it", () => {
+    // pageResults, pageRuleResults and ruleResultsMap all reference the same
+    // check objects. One clone of the container keeps that sharing; cloning each
+    // consumer separately would triple the findings instead of detaching them.
+    const shared = { name: "check" };
+    const copy = detachFromPage({ flat: [shared], byRule: { r: [shared] } });
+    expect(copy.flat[0]).toBe(copy.byRule.r[0]);
+  });
+
+  test("returns the original rather than throwing on a non-cloneable value", () => {
+    // Safety valve: a value carrying a function cannot be structured-cloned.
+    // Keeping the original costs the retention this exists to avoid, but it
+    // cannot change what the audit reports.
+    const withFn = { fn: () => 1, keep: "x" };
+    expect(detachFromPage(withFn)).toBe(withFn);
+  });
+});

--- a/packages/audit-engine/tests/detach-production-boundaries.test.ts
+++ b/packages/audit-engine/tests/detach-production-boundaries.test.ts
@@ -1,0 +1,130 @@
+// #1860: the detach call sites must actually detach, on the shapes production
+// produces — not just on handcrafted objects.
+//
+// `detachFromPage` falls back to returning the ORIGINAL when a value cannot be
+// structured-cloned, and that fallback is invisible: the findings are unchanged,
+// so every golden test stays green while the page-sized retention comes back.
+// A handcrafted-input test cannot see it either, because the shapes that would
+// throw come from the rule runner, not from the test.
+//
+// So this asserts against a real crawl driven through the real rule set:
+//   1. a real `runPageRules` graph clones with no fallback;
+//   2. both production boundaries actually ran (a removed call site fails here,
+//      where an equality-only test would still pass).
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { Config } from "@squirrelscan/config";
+import { generateSiteModel, writeCrawlToStorage } from "@squirrelscan/synthetic-site";
+import { createRunner, type SiteData } from "@squirrelscan/rules";
+
+import {
+  buildSiteContext,
+  buildHeadersMap,
+  isRenderedFetch,
+  runStreamingRules,
+  type PreFetchedAssets,
+} from "../src/adapter";
+import { detachCounts, detachFromPage, resetDetachCounts } from "../src/detach";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+// The whole rule set, as the golden tests run it (filterRules defaults every
+// rule to disabled, so `enable: ["*"]` is what makes this a real graph).
+const CONFIG = { rule_options: {}, rules: { enable: ["*"] } } as unknown as Config;
+
+const EMPTY_ASSETS: PreFetchedAssets = {
+  resourceSizes: { css: [], images: [] },
+  scripts: [],
+  pdfSizes: [],
+  sitemapUrlStatuses: [],
+};
+
+const EMPTY_SITE_DATA = {
+  baseUrl: "http://synthetic.test",
+  pages: [],
+  robotsTxt: null,
+  sitemaps: null,
+} as unknown as SiteData;
+
+async function fixture(seed: number, pageCount: number) {
+  const model = generateSiteModel({ seed, pageCount });
+  return writeCrawlToStorage(model, ":memory:");
+}
+
+describe("detach at the production boundaries", () => {
+  test("a real rule-runner graph clones with no fallback", async () => {
+    const { storage, crawlId } = await fixture(3, 6);
+    const pages = await run(storage.getPages(crawlId));
+    const ctx = await run(buildSiteContext(pages));
+    const runner = createRunner(CONFIG);
+
+    resetDetachCounts();
+    let cloned = 0;
+
+    for (const { page, parsed } of ctx) {
+      if (!parsed || !page.html) continue;
+      const raw = await runner.runPageRules(
+        {
+          url: page.url,
+          html: page.html,
+          statusCode: page.status,
+          loadTime: page.loadTimeMs,
+          ttfb: page.ttfb,
+          downloadTime: page.downloadTime,
+          headers: buildHeadersMap(page),
+          parsed,
+          finalUrl: page.finalUrl,
+          redirectChain: page.redirectChain,
+          rendered: isRenderedFetch(page.fetcherId),
+        } as never,
+        EMPTY_SITE_DATA,
+      );
+
+      // Exactly the graph streaming.ts detaches: the flat checks plus each
+      // rule's checks, in ONE call, so the sharing between them is preserved.
+      const byRule = [...raw.ruleResults];
+      const source = { checks: raw.checks, ruleChecks: byRule.map(([, rr]) => rr.checks) };
+      const copy = detachFromPage(source, "page-rules");
+
+      // A copy, and an equal one. `toEqual` over the real graph is the check
+      // that no rule emits a shape structuredClone alters.
+      expect(copy).not.toBe(source);
+      expect(copy).toEqual(source);
+      expect(copy.ruleChecks.length).toBe(source.ruleChecks.length);
+      cloned++;
+    }
+
+    expect(cloned).toBeGreaterThan(0);
+    // The point of the test: the real graph took the clone path every time.
+    expect(detachCounts("page-rules")).toEqual({ detached: cloned, fallbacks: 0 });
+
+    await run(storage.close());
+  }, 120_000);
+
+  test("runStreamingRules detaches at BOTH boundaries, with no fallback", async () => {
+    const { storage, crawlId } = await fixture(5, 8);
+
+    resetDetachCounts();
+    const streamed = await run(
+      runStreamingRules(storage, crawlId, CONFIG, EMPTY_ASSETS, undefined, { batchSize: 3 }),
+    );
+    expect(streamed.ruleResultsMap.size).toBeGreaterThan(0);
+
+    const pageRules = detachCounts("page-rules");
+    const signals = detachCounts("collected-signal");
+
+    // Removing either call site zeroes its counter — an equality-only test would
+    // not notice, because the findings are identical either way.
+    expect(pageRules.detached).toBeGreaterThan(0);
+    expect(signals.detached).toBeGreaterThan(0);
+    // And no page silently kept its attachment.
+    expect(pageRules.fallbacks).toBe(0);
+    expect(signals.fallbacks).toBe(0);
+
+    await run(storage.close());
+  }, 120_000);
+});


### PR DESCRIPTION
For squirrelscan/repo#1860 (epic #1866). This is the PR-F work, and it turned out not to be about capping findings at all.

## What was actually holding the memory

Measurement run #2 established that the rules phase's rise is genuinely retained — post-collect RSS equals pre-collect — at roughly 8 MB per page, released only after the site pass. The obvious explanation is the volume of findings, but a census of the retained structures reports **96 KB per page**.

The real cause: every string a rule extracts from a parsed page is a **slice** of that page's HTML, and JSC keeps a slice attached to the buffer it came from. Retaining one 20-character href retains the whole ~1 MB page as UTF-16.

This is invisible to every obvious measure, which is why it survived three rounds of looking:

- `JSON.stringify(x).length` reports the logical size, so a census says 1 KB for a value holding 3.8 MB.
- **RSS reports nothing at all** — the arena absorbs it. Every local run I did on RSS showed a flat page loop.
- It appears only in `heapUsed` / `external`, which grow linearly with page count while RSS oscillates.

## The fix

`structuredClone` at the two points where a per-page value outlives its batch: the collected site signal and the per-page findings. It detaches every string, and unlike a JSON round-trip it preserves the `Set`s in `PageFingerprint` rather than silently turning them into `{}`.

| | before | after |
|---|---|---|
| retained | 4020 KB/page | **213 KB/page** |
| peak in loop | 499 MB | 120 MB |

Measured on a 150-page fixture built from a **real saved drscholls page** — 959 KB, 1051 nodes, almost all inline script. That is the opposite shape to the synthetic fixture used earlier (983 KB, 18,917 nodes), which could not reproduce this at all. The fixture also stores `parsedData` the way the crawler does, because `buildSiteContext` reuses it and a fixture without it measures a path production does not take.

## Scope of the clone, which cost me a first attempt

Cloning the whole rule result **silently did nothing**. `meta.optionsSchema` is a Zod instance, 38 of 282 rules carry one, `structuredClone` throws on it, and one failure aborts the entire clone — so the fallback returned the original, findings unchanged and still attached to the page. No golden test can see that, because the findings are correct either way. It was caught by review, not by the suite.

So only the checks graph is cloned:

- **`meta` stays by reference** — it is per-rule, not per-page, so it retains nothing.
- **`parsed` is excluded** — nothing here reads it, and cloning it would copy the live document and strip `SchemaCollection`'s methods.
- **One clone for the whole graph**, so `pageResults`, `pageRuleResults` and `ruleResultsMap` keep referencing the same check objects instead of holding three copies. The code stamps `check.pageUrl` after the clone and relies on that identity.

## Why this is safe

Every golden and parity gate passes unchanged — the byte-identity diff against v1, the 518-page baseline, the site-query universe diff, the collector-rules golden, the scoring golden and the complete-store parity. That is the point: the values are identical, only their attachment to the page is not.

`tests/detach-from-page.test.ts` pins the contract: Sets survive, values round-trip, sharing within one value is preserved, a non-cloneable value falls back to the original rather than throwing. Its memory assertion only runs where the attached case actually demonstrates the retention, since the measurement is environment-dependent and comparing two zeroes proves nothing.

## Known remaining

When a page has no stored `parsedData`, the universe retains re-extracted strings the same way. Production stores it, so that is the CLI's path and a fallback. Detaching it needs the schemas rehydrated after the clone rather than a bare `structuredClone`, so it is deliberately not in this PR.