### PR TITLE
perf(audit-engine): read two columns for the link scan, not every page's HTML

### DIFF
--- a/packages/audit-engine/scripts/site-query-cost.ts
+++ b/packages/audit-engine/scripts/site-query-cost.ts
@@ -1,0 +1,70 @@
+// What createSiteQuery costs on a real-shape crawl (#1860).
+//
+//   bun run scripts/site-query-cost.ts --db X.sqlite [--batch 50]
+//
+// Reports the heap+external the call leaves behind (the SiteQuery itself plus
+// the arena the scan grew, which never comes back) and its wall time. Run it
+// before and after a change to the scan; both numbers move together when the
+// scan stops materializing HTML it does not read.
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { Effect } from "effect";
+
+import { createSiteQuery } from "../src/site-query";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+const arg = (n: string, d: string) => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? (process.argv[i + 1] ?? d) : d;
+};
+
+const DB = arg("db", "");
+const BATCH = Number.parseInt(arg("batch", "50"), 10);
+
+const storage = new SQLiteStorage(DB);
+await run(storage.init());
+const crawls = await run(storage.listCrawls(1));
+const crawlId = (crawls as Array<{ id: string }>)[0]!.id;
+const pageCount = await run(storage.getPageCount(crawlId));
+
+function snap(): number {
+  Bun.gc(true);
+  Bun.gc(true);
+  const m = process.memoryUsage();
+  return m.heapUsed + m.external;
+}
+
+const before = snap();
+const rssBefore = process.memoryUsage.rss();
+let rssPeak = rssBefore;
+// The scan awaits between batches, so a timer DOES get to run here — unlike a
+// sampler placed around a synchronous loop, which never fires and reports 0.
+const sampler = setInterval(() => {
+  const r = process.memoryUsage.rss();
+  if (r > rssPeak) rssPeak = r;
+}, 5);
+const t0 = performance.now();
+const siteQuery = await run(createSiteQuery(storage, crawlId, { pageScanBatchSize: BATCH }));
+const ms = performance.now() - t0;
+clearInterval(sampler);
+const rssAfter = process.memoryUsage.rss();
+if (rssAfter > rssPeak) rssPeak = rssAfter;
+const after = snap();
+
+console.log(
+  JSON.stringify({
+    db: DB.split("/").pop(),
+    pages: pageCount,
+    batch: BATCH,
+    ms: Math.round(ms),
+    grownKB: Math.round((after - before) / 1024),
+    grownPerPageKB: Math.round((after - before) / pageCount / 1024),
+    rssPeakMB: Math.round((rssPeak - rssBefore) / 1024 / 1024),
+    rssHeldMB: Math.round((rssAfter - rssBefore) / 1024 / 1024),
+    // Touch the result so it cannot be collected before the sample.
+    incoming: siteQuery.incomingLinkCounts().size,
+  }),
+);
+await run(storage.close());

--- a/packages/audit-engine/scripts/site-query-cost.ts
+++ b/packages/audit-engine/scripts/site-query-cost.ts
@@ -2,10 +2,16 @@
 //
 //   bun run scripts/site-query-cost.ts --db X.sqlite [--batch 50]
 //
-// Reports the heap+external the call leaves behind (the SiteQuery itself plus
-// the arena the scan grew, which never comes back) and its wall time. Run it
-// before and after a change to the scan; both numbers move together when the
-// scan stops materializing HTML it does not read.
+// Reports two SEPARATE things, which is the whole point:
+//
+//   grownKB  the post-GC heapUsed+external delta — what the call still HOLDS.
+//   rssDelta the process RSS delta — what the allocator grew and did not give
+//            back, including memory the JS heap has already freed.
+//
+// A wide read feeding a narrow consumer moves the second and not the first, so
+// reporting either alone hides it. This is an endpoint delta, not a sampled
+// peak: the scan's batches do not reliably yield to the event loop, so a timer
+// sampler placed here can record nothing at all.
 
 import { SQLiteStorage } from "@squirrelscan/crawler";
 import { Effect } from "effect";
@@ -38,19 +44,10 @@ function snap(): number {
 
 const before = snap();
 const rssBefore = process.memoryUsage.rss();
-let rssPeak = rssBefore;
-// The scan awaits between batches, so a timer DOES get to run here — unlike a
-// sampler placed around a synchronous loop, which never fires and reports 0.
-const sampler = setInterval(() => {
-  const r = process.memoryUsage.rss();
-  if (r > rssPeak) rssPeak = r;
-}, 5);
 const t0 = performance.now();
 const siteQuery = await run(createSiteQuery(storage, crawlId, { pageScanBatchSize: BATCH }));
 const ms = performance.now() - t0;
-clearInterval(sampler);
 const rssAfter = process.memoryUsage.rss();
-if (rssAfter > rssPeak) rssPeak = rssAfter;
 const after = snap();
 
 console.log(
@@ -61,8 +58,7 @@ console.log(
     ms: Math.round(ms),
     grownKB: Math.round((after - before) / 1024),
     grownPerPageKB: Math.round((after - before) / pageCount / 1024),
-    rssPeakMB: Math.round((rssPeak - rssBefore) / 1024 / 1024),
-    rssHeldMB: Math.round((rssAfter - rssBefore) / 1024 / 1024),
+    rssDeltaMB: Math.round((rssAfter - rssBefore) / 1024 / 1024),
     // Touch the result so it cannot be collected before the sample.
     incoming: siteQuery.incomingLinkCounts().size,
   }),

--- a/packages/audit-engine/src/site-query.ts
+++ b/packages/audit-engine/src/site-query.ts
@@ -21,7 +21,7 @@ import type {
   LinkData,
   PageFeatureDuplicateField,
   PageFeatureRow,
-  PageRecord,
+  PageLinkRow,
   SiteQuery,
   StorageError,
 } from "@squirrelscan/core-contracts";
@@ -30,13 +30,11 @@ import type {
 const FEATURE_SCAN_BATCH = 500;
 
 /**
- * Default batch for the PAGES scan, which is a different animal: `getPages`
- * returns whole `PageRecord`s, html included, and this scan reads only
- * `normalizedUrl` and `parsedData`. At 500 that pulled every page of a
- * 150-page crawl resident at once — roughly 1.5 GB on ~1 MB pages, inside the
- * window a production run showed a ~1 GB step it could not attribute (#1860).
- * Callers that know their memory ceiling pass `pageScanBatchSize`; the default
- * stays modest so a caller that does not is not handed the old behaviour.
+ * Default batch for the pages scan. It reads two columns per page now
+ * (`streamPageLinkRows`), not whole `PageRecord`s, so a batch costs the stored
+ * parse rather than the page's HTML — tens of KB instead of ~1 MB each. The
+ * default stays modest anyway: `parsedData` has no size ceiling, and a caller
+ * that knows its memory ceiling passes `pageScanBatchSize`.
  */
 const PAGE_SCAN_BATCH = 50;
 
@@ -62,10 +60,10 @@ export function createSiteQuery(
      */
     universe?: readonly string[];
     /**
-     * Pages pulled per batch by the link-graph scan (#1860). `getPages` returns
-     * whole PageRecords, so this multiplies by the site's page size; the cloud
-     * passes the same batch its other streamed walks use, sized from the
-     * container's memory ceiling. Unset → {@link PAGE_SCAN_BATCH}.
+     * Pages pulled per batch by the link-graph scan (#1860). The scan reads only
+     * `normalized_url` + `parsed_data`, so this multiplies by the size of a
+     * stored parse, not of a page; the cloud passes the same batch its other
+     * streamed walks use. Unset → {@link PAGE_SCAN_BATCH}.
      */
     pageScanBatchSize?: number;
   }
@@ -178,7 +176,7 @@ function buildIncomingLinkCounts(
         contextualBucket.set(normalizeUrl(url), 0);
       }
     } else {
-      yield* streamPages(storage, crawlId, pageScanBatch, (page) => {
+      yield* streamPageLinkRows(storage, crawlId, pageScanBatch, (page) => {
         orderedUrls.push(page.normalizedUrl);
         bucket.set(normalizeUrl(page.normalizedUrl), 0);
         contextualBucket.set(normalizeUrl(page.normalizedUrl), 0);
@@ -188,7 +186,7 @@ function buildIncomingLinkCounts(
     // Pass B: count internal dofollow links whose resolved+normalized target is a
     // crawled page. A second scan keeps at most one page batch resident (vs.
     // holding every page's links). Only pages in the universe are valid sources.
-    yield* streamPages(storage, crawlId, pageScanBatch, (page) => {
+    yield* streamPageLinkRows(storage, crawlId, pageScanBatch, (page) => {
       if (universeSet && !universeSet.has(page.normalizedUrl)) return;
       for (const link of parseLinks(page.parsedData)) {
         if (link.isInternal && link.url && !link.isNofollow) {
@@ -249,17 +247,27 @@ function buildPagesByType(
   });
 }
 
-/** Invoke `onPage` for every stored page, one batch resident at a time. */
-function streamPages(
+/**
+ * Invoke `onPage` for every stored page, one batch resident at a time, reading
+ * ONLY the two columns this scan uses (#1860).
+ *
+ * The page's HTML is the whole cost here and none of it is read: `getPages`
+ * would materialize ~1 MB per page (and pull it back out of the content store
+ * when the column is empty) so the loop below can look at `parsedData.links`.
+ * That memory is dropped at the end of each batch, but the allocator keeps the
+ * pages it grew for it — measured over 150 real 959 KB pages, the two scans grew
+ * RSS 345 MB and returned none of it.
+ */
+function streamPageLinkRows(
   storage: SQLiteStorage,
   crawlId: string,
   batchSize: number,
-  onPage: (page: PageRecord) => void
+  onPage: (page: PageLinkRow) => void
 ): Effect.Effect<void, StorageError, never> {
   return Effect.gen(function* () {
     let offset = 0;
     for (;;) {
-      const batch = yield* storage.getPages(crawlId, {
+      const batch = yield* storage.getPageLinkRows(crawlId, {
         limit: batchSize,
         offset,
       });

--- a/packages/audit-engine/src/site-query.ts
+++ b/packages/audit-engine/src/site-query.ts
@@ -255,8 +255,9 @@ function buildPagesByType(
  * would materialize ~1 MB per page (and pull it back out of the content store
  * when the column is empty) so the loop below can look at `parsedData.links`.
  * That memory is dropped at the end of each batch, but the allocator keeps the
- * pages it grew for it — measured over 150 real 959 KB pages, the two scans grew
- * RSS 345 MB and returned none of it.
+ * pages it grew for it — measured over 150 real 959 KB pages at batch 50, three
+ * runs, the two scans grew RSS a median 431 MB through `getPages` and 88 MB
+ * through this, while the JS heap grew ~0.3 MB either way.
  */
 function streamPageLinkRows(
   storage: SQLiteStorage,

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -987,6 +987,18 @@ export interface PaginationOptions {
   offset?: number;
 }
 
+/**
+ * The two columns the audit's incoming-link scan reads (#1860).
+ *
+ * `getPages` is `SELECT *`, so using it for a link-graph walk materializes every
+ * page's HTML — and pulls it back out of the content store when it was
+ * offloaded — for two fields the walk never touches.
+ */
+export interface PageLinkRow {
+  normalizedUrl: string;
+  parsedData: string | null;
+}
+
 export interface StorageOptions {
   path?: string;
   projectName?: string;

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -990,9 +990,10 @@ export interface PaginationOptions {
 /**
  * The two columns the audit's incoming-link scan reads (#1860).
  *
- * `getPages` is `SELECT *`, so using it for a link-graph walk materializes every
- * page's HTML — and pulls it back out of the content store when it was
- * offloaded — for two fields the walk never touches.
+ * `getPages` is `SELECT *`, so using it for a link-graph walk materializes
+ * every page's HTML — and pulls it back out of the content store when it was
+ * offloaded — even though the walk reads only these two fields and never looks
+ * at the HTML at all.
  */
 export interface PageLinkRow {
   normalizedUrl: string;

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -1348,8 +1348,9 @@ export class SQLiteStorage implements CrawlStorage {
    * HTML per page (and re-reads it from the content store when the column is
    * empty) so the scan can look at two small fields. That HTML is never touched
    * and is dropped at the end of the batch, but the allocator keeps the pages it
-   * grew for it: measured over 150 real 959 KB pages, the two link-graph scans
-   * grew RSS 345 MB and gave none of it back, while the JS heap grew 343 KB.
+   * grew for it: measured over 150 real 959 KB pages at batch 50, three runs,
+   * the two link-graph scans grew RSS a median 431 MB through `getPages` and
+   * 88 MB through this, while the JS heap grew ~0.3 MB either way.
    *
    * Same ordering and pagination as `getPages`, so a caller swapping one for the
    * other sees the same rows in the same order.

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -1378,9 +1378,12 @@ export class SQLiteStorage implements CrawlStorage {
         const rows = stmt.all(
           ...(params as (string | number | null)[])
         ) as Record<string, unknown>[];
+        // Cast, not `?? null`: `rowToPageRecord` reads the same column the same
+        // way, and a normalization here would be a divergence from `getPages`
+        // that a parity test could not see.
         return rows.map((row) => ({
           normalizedUrl: row.normalized_url as string,
-          parsedData: (row.parsed_data as string | null) ?? null,
+          parsedData: row.parsed_data as string | null,
         }));
       },
       catch: (e) => StorageError.read(e),

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -42,6 +42,7 @@ import type {
   SitePageRecord,
   CompactFindingsOptions,
   PageFeatureRow,
+  PageLinkRow,
   PageFeatureDuplicateField,
   DuplicateGroup,
   TemplateCluster,
@@ -1334,6 +1335,53 @@ export class SQLiteStorage implements CrawlStorage {
           ...(params as (string | number | null)[])
         ) as Record<string, unknown>[];
         return rows.map((row) => this.rowToPageRecord(row));
+      },
+      catch: (e) => StorageError.read(e),
+    });
+  }
+
+  /**
+   * Just `normalized_url` + `parsed_data`, for the audit's incoming-link scan
+   * (#1860).
+   *
+   * `getPages` is `SELECT *`: on a script-heavy site it materializes ~1 MB of
+   * HTML per page (and re-reads it from the content store when the column is
+   * empty) so the scan can look at two small fields. That HTML is never touched
+   * and is dropped at the end of the batch, but the allocator keeps the pages it
+   * grew for it: measured over 150 real 959 KB pages, the two link-graph scans
+   * grew RSS 345 MB and gave none of it back, while the JS heap grew 343 KB.
+   *
+   * Same ordering and pagination as `getPages`, so a caller swapping one for the
+   * other sees the same rows in the same order.
+   */
+  getPageLinkRows(
+    crawlId: string,
+    options?: PaginationOptions
+  ): Effect.Effect<PageLinkRow[], StorageError, never> {
+    return Effect.try({
+      try: () => {
+        const db = this.getDb();
+        let query =
+          "SELECT normalized_url, parsed_data FROM pages WHERE crawl_id = ? ORDER BY normalized_url ASC";
+        const params: unknown[] = [crawlId];
+
+        if (options?.limit) {
+          query += " LIMIT ?";
+          params.push(options.limit);
+        }
+        if (options?.offset) {
+          query += " OFFSET ?";
+          params.push(options.offset);
+        }
+
+        const stmt = db.prepare(query);
+        const rows = stmt.all(
+          ...(params as (string | number | null)[])
+        ) as Record<string, unknown>[];
+        return rows.map((row) => ({
+          normalizedUrl: row.normalized_url as string,
+          parsedData: (row.parsed_data as string | null) ?? null,
+        }));
       },
       catch: (e) => StorageError.read(e),
     });

--- a/packages/crawler/tests/page-link-rows-projection.test.ts
+++ b/packages/crawler/tests/page-link-rows-projection.test.ts
@@ -126,8 +126,10 @@ describe("getPageLinkRows", () => {
     const full = await run(store.getPages(crawlId));
     const projected = await run(store.getPageLinkRows(crawlId));
 
+    // Compared RAW, with no `?? null` on either side: normalizing here would
+    // hide exactly the kind of divergence this test exists to catch.
     expect(projected).toEqual(
-      full.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData ?? null })),
+      full.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData })),
     );
     expect(projected.map((r) => r.normalizedUrl)).toEqual([...urls].sort());
     // The one page stored without a parse (inserted third, sorts second).
@@ -139,7 +141,7 @@ describe("getPageLinkRows", () => {
         const a = await run(store.getPages(crawlId, { limit, offset }));
         const b = await run(store.getPageLinkRows(crawlId, { limit, offset }));
         expect(b).toEqual(
-          a.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData ?? null })),
+          a.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData })),
         );
       }
     }

--- a/packages/crawler/tests/page-link-rows-projection.test.ts
+++ b/packages/crawler/tests/page-link-rows-projection.test.ts
@@ -135,16 +135,89 @@ describe("getPageLinkRows", () => {
     // The one page stored without a parse (inserted third, sorts second).
     expect(projected.find((r) => r.normalizedUrl.endsWith("/b"))!.parsedData).toBeNull();
 
-    // Paging: same window, same rows.
-    for (const limit of [1, 2, 5]) {
-      for (let offset = 0; offset < urls.length; offset += limit) {
-        const a = await run(store.getPages(crawlId, { limit, offset }));
-        const b = await run(store.getPageLinkRows(crawlId, { limit, offset }));
-        expect(b).toEqual(
-          a.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData })),
+    // Paging: same window, same rows — including the edges. Offset past the end
+    // returns nothing; limit 0 is falsy in BOTH builders, so both omit LIMIT,
+    // and a nonzero offset with no LIMIT is a SQLite syntax error in both. The
+    // comparison is over the OUTCOME, so "they fail the same way" counts as
+    // agreement and a divergence in either direction fails the test.
+    const outcome = async (read: Promise<unknown>) => {
+      try {
+        return { ok: await read };
+      } catch {
+        return { failed: true };
+      }
+    };
+    for (const limit of [1, 2, 5, 0]) {
+      for (const offset of [0, 1, 3, urls.length, urls.length + 10]) {
+        const a = await outcome(run(store!.getPages(crawlId, { limit, offset })));
+        const b = await outcome(run(store!.getPageLinkRows(crawlId, { limit, offset })));
+        if (a.failed || b.failed) {
+          expect({ limit, offset, a: a.failed, b: b.failed }).toEqual({
+            limit,
+            offset,
+            a: true,
+            b: true,
+          });
+          continue;
+        }
+        expect(b.ok).toEqual(
+          (a.ok as PageRecord[]).map((p) => ({
+            normalizedUrl: p.normalizedUrl,
+            parsedData: p.parsedData,
+          })),
         );
       }
     }
+  });
+
+  test("is scoped to its crawl, and orders the way getPages orders", async () => {
+    // One crawl on its own cannot catch a dropped `crawl_id` filter, and
+    // all-lowercase URLs cannot catch a change of collation.
+    store = new SQLiteStorage(":memory:");
+    await run(store.init());
+    const mine = await freshCrawl(store);
+    const other = await freshCrawl(store);
+
+    const shared = ["https://example.com/Zeta", "https://example.com/alpha"];
+    for (const url of shared) {
+      await run(store.upsertPage(mine, page(url, { parsedData: '{"links":[],"who":"mine"}' })));
+      await run(store.upsertPage(other, page(url, { parsedData: '{"links":[],"who":"other"}' })));
+    }
+    await run(
+      store.upsertPage(other, page("https://example.com/only-other", { parsedData: "{}" })),
+    );
+
+    const projected = await run(store.getPageLinkRows(mine));
+    const full = await run(store.getPages(mine));
+    expect(projected).toEqual(
+      full.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData })),
+    );
+    // The other crawl's extra page must not appear, and its rows must not win.
+    expect(projected).toHaveLength(2);
+    for (const row of projected) expect(row.parsedData).toContain('"who":"mine"');
+    // BINARY collation puts uppercase first; a switch to NOCASE would reorder.
+    expect(projected.map((r) => r.normalizedUrl)).toEqual([
+      "https://example.com/Zeta",
+      "https://example.com/alpha",
+    ]);
+  });
+
+  test("returns an empty stored parse as an empty string, not as null", async () => {
+    // `parsedData` is nullable AND can legitimately be "", and the two mean
+    // different things to the link scan: no stored parse vs a stored empty one.
+    store = new SQLiteStorage(":memory:");
+    await run(store.init());
+    const crawlId = await freshCrawl(store);
+    await run(store.upsertPage(crawlId, page("https://example.com/empty", { parsedData: "" })));
+    await run(store.upsertPage(crawlId, page("https://example.com/null", { parsedData: null })));
+
+    const projected = await run(store.getPageLinkRows(crawlId));
+    const full = await run(store.getPages(crawlId));
+    expect(projected).toEqual(
+      full.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData })),
+    );
+    expect(projected.find((r) => r.normalizedUrl.endsWith("/empty"))!.parsedData).toBe("");
+    expect(projected.find((r) => r.normalizedUrl.endsWith("/null"))!.parsedData).toBeNull();
   });
 
   test("reads the parse WITHOUT touching the content store", async () => {

--- a/packages/crawler/tests/page-link-rows-projection.test.ts
+++ b/packages/crawler/tests/page-link-rows-projection.test.ts
@@ -1,0 +1,183 @@
+// #1860 — `getPageLinkRows` is `getPages` with the columns the audit's
+// incoming-link scan does not read left out. It exists purely so that scan
+// stops materializing every page's HTML, so the one thing that matters is that
+// it never disagrees with `getPages` about which rows exist, in what order, or
+// what the two fields hold.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type {
+  CrawlMetadata,
+  PageRecord,
+  ResponseHeaders,
+  SecurityHeaders,
+} from "../src/storage/types";
+import { SQLiteStorage } from "../src/storage/sqlite";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const HEADERS: ResponseHeaders = {
+  contentType: null,
+  contentEncoding: null,
+  cacheControl: null,
+  vary: null,
+  etag: null,
+  server: null,
+  lastModified: null,
+  link: null,
+  serverTiming: null,
+  age: null,
+  xCache: null,
+  cfCacheStatus: null,
+  xVercelCache: null,
+  altSvc: null,
+  acceptRanges: null,
+};
+const SECURITY_HEADERS: SecurityHeaders = {
+  hsts: null,
+  csp: null,
+  xFrameOptions: null,
+  xContentTypeOptions: null,
+  referrerPolicy: null,
+  permissionsPolicy: null,
+  xRobotsTag: null,
+};
+
+async function freshCrawl(store: SQLiteStorage): Promise<string> {
+  const meta = {
+    baseUrl: "https://example.com",
+    startedAt: 1,
+    status: "running",
+    config: {},
+    stats: {
+      pagesTotal: 0,
+      pagesFetched: 0,
+      pagesFailed: 0,
+      pagesSkipped: 0,
+      pagesUnchanged: 0,
+      linksTotal: 0,
+      imagesTotal: 0,
+      bytesTotal: 0,
+      avgLoadTimeMs: 0,
+    },
+  } as unknown as Omit<CrawlMetadata, "id">;
+  return run(store.createCrawl(meta));
+}
+
+function page(normalizedUrl: string, over: Partial<PageRecord> = {}): PageRecord {
+  return {
+    url: normalizedUrl,
+    normalizedUrl,
+    finalUrl: normalizedUrl,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: 1,
+    loadTimeMs: 1,
+    fetchedAt: 1,
+    etag: null,
+    lastModified: null,
+    contentHash: `h-${normalizedUrl}`,
+    html: null,
+    parsedData: null,
+    headers: HEADERS,
+    securityHeaders: SECURITY_HEADERS,
+    ...over,
+  };
+}
+
+let store: SQLiteStorage | null = null;
+afterEach(async () => {
+  if (store) await run(store.close());
+  store = null;
+});
+
+describe("getPageLinkRows", () => {
+  test("matches getPages row for row, in the same order, paged the same way", async () => {
+    store = new SQLiteStorage(":memory:");
+    await run(store.init());
+    const crawlId = await freshCrawl(store);
+
+    // Inserted out of order on purpose: both reads sort by normalized_url.
+    const urls = [
+      "https://example.com/c",
+      "https://example.com/a",
+      "https://example.com/b",
+      "https://example.com/d",
+      "https://example.com/e",
+    ];
+    for (const [i, url] of urls.entries()) {
+      await run(
+        store.upsertPage(
+          crawlId,
+          page(url, {
+            html: `<html><body>${"x".repeat(2048)}</body></html>`,
+            // A page with no stored parse (an error page, a non-HTML response)
+            // must come back as null, not as an empty string.
+            parsedData: i === 2 ? null : JSON.stringify({ links: [{ url: `/l${i}` }] }),
+          }),
+        ),
+      );
+    }
+
+    const full = await run(store.getPages(crawlId));
+    const projected = await run(store.getPageLinkRows(crawlId));
+
+    expect(projected).toEqual(
+      full.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData ?? null })),
+    );
+    expect(projected.map((r) => r.normalizedUrl)).toEqual([...urls].sort());
+    // The one page stored without a parse (inserted third, sorts second).
+    expect(projected.find((r) => r.normalizedUrl.endsWith("/b"))!.parsedData).toBeNull();
+
+    // Paging: same window, same rows.
+    for (const limit of [1, 2, 5]) {
+      for (let offset = 0; offset < urls.length; offset += limit) {
+        const a = await run(store.getPages(crawlId, { limit, offset }));
+        const b = await run(store.getPageLinkRows(crawlId, { limit, offset }));
+        expect(b).toEqual(
+          a.map((p) => ({ normalizedUrl: p.normalizedUrl, parsedData: p.parsedData ?? null })),
+        );
+      }
+    }
+  });
+
+  test("reads the parse WITHOUT touching the content store", async () => {
+    // The HTML lives in the content store, and pulling it back is the expensive
+    // half of what this read exists to avoid — so the projection must not ask
+    // for it even once.
+    let reads = 0;
+    const contentStore = {
+      put: (content: string) => {
+        const hash = `cs-${content.length}`;
+        return hash;
+      },
+      getString: (_hash: string) => {
+        reads++;
+        return "<html></html>";
+      },
+    };
+    store = new SQLiteStorage(":memory:", contentStore);
+    await run(store.init());
+    const crawlId = await freshCrawl(store);
+    await run(
+      store.upsertPage(
+        crawlId,
+        page("https://example.com/a", { html: null, parsedData: '{"links":[]}' }),
+      ),
+    );
+
+    reads = 0;
+    const rows = await run(store.getPageLinkRows(crawlId));
+    expect(rows).toEqual([{ normalizedUrl: "https://example.com/a", parsedData: '{"links":[]}' }]);
+    expect(reads).toBe(0);
+
+    // The control: the full read DOES go to the content store for the same row.
+    reads = 0;
+    await run(store.getPages(crawlId));
+    expect(reads).toBe(1);
+  });
+});


### PR DESCRIPTION
Part of #1860 / the OOM incident. Independent of the detach PRs.

`createSiteQuery`'s incoming-link scan walks the pages table twice and reads `normalizedUrl` and `parsedData`. It did that through `getPages`, which is `SELECT *`: every page's HTML was materialized, and pulled back out of the content store when the column was empty, so the loop could look at `parsedData.links`.

The HTML is dropped at the end of each batch and the JS heap barely moves, which is why this never looked like a memory problem. The allocator does not give the pages back. Measured over 150 real 959 KB pages, batch 50, three runs, RSS across the call:

| | RSS growth | JS heap growth |
|---|---|---|
| before | 431 MB (230 / 431 / 492) | 0.34 MB |
| after | 88 MB (68 / 88 / 103) | 0.30 MB |

This is the ~294 MB step a production run showed at `rules_site_query`, and it is allocator residency rather than anything the audit holds. Shrinking the batch does not help: batch 500 was 581 MB and batch 50 was 431 MB, the same order.

`getPageLinkRows` is the projection: same table, same `ORDER BY`, same `LIMIT`/`OFFSET` semantics, two columns. `tests/page-link-rows-projection.test.ts` pins it against `getPages` row for row, with a second crawl holding the same URLs (so a dropped `crawl_id` filter fails), a mixed-case pair (so a collation change fails), the paging edges compared by outcome (a nonzero offset with no `LIMIT` is the same SQLite error in both), an empty stored parse against a missing one, and an assertion that it never touches the content store with the full read as the control.

Byte identity unchanged: the five site-query goldens plus the v1-vs-v2 canonical and streaming goldens pass.
