### PR TITLE
perf(audit-engine): detach the streamed page universe from the pages it parsed

### DIFF
--- a/packages/audit-engine/scripts/universe-retention.ts
+++ b/packages/audit-engine/scripts/universe-retention.ts
@@ -1,0 +1,97 @@
+// Measure what the streamed parsed universe retains per page (#1860 (a)).
+//
+//   bun run universe-retention.ts --db X.sqlite --mode plain|detach
+//
+// Mirrors createParsedUniverseAccumulator's retention exactly: keep the parsed
+// scalars, drop textContent, release the batch's DOMs, force a collect, and
+// report heapUsed+external held with the universe still alive.
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { Effect } from "effect";
+
+import { buildSiteContext, releaseSiteContextDocuments } from "../src/adapter";
+import { detachParsedPage } from "../src/detach";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+const arg = (n: string, d: string) => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? (process.argv[i + 1] ?? d) : d;
+};
+
+const DB = arg("db", "");
+const MODE = arg("mode", "plain");
+const BATCH = Number.parseInt(arg("batch", "50"), 10);
+const MAX = Number.parseInt(arg("max", "1000000"), 10);
+
+const storage = new SQLiteStorage(DB);
+await run(storage.init());
+const crawls = await run(storage.listCrawls(1));
+const crawlId = (crawls as Array<{ id: string }>)[0]!.id;
+
+const retained: unknown[] = [];
+Bun.gc(true);
+const before = process.memoryUsage();
+
+let n = 0;
+for (let offset = 0; offset < MAX; offset += BATCH) {
+  const batch = await run(storage.getPages(crawlId, { limit: BATCH, offset }));
+  if (batch.length === 0) break;
+  if (MODE === "read") {
+    // Control: read the batch and drop it without parsing anything.
+    n += batch.length;
+    Bun.gc(true);
+    if (batch.length < BATCH) break;
+    continue;
+  }
+  const ctx = await run(buildSiteContext(batch as never));
+  for (const { page, parsed } of ctx) {
+    if (!parsed) continue;
+    const p = parsed as unknown as Record<string, unknown>;
+    const content = p.content as { textContent?: string } | undefined;
+    if (content?.textContent) content.textContent = "";
+    if (MODE === "none") {
+      // Control: retain nothing at all. Any per-page growth this reports is the
+      // measurement's own floor (storage caches, arena) and must be subtracted.
+    } else if (MODE === "scalars") {
+      retained.push({
+        url: page.normalizedUrl,
+        finalUrl: page.finalUrl,
+        statusCode: page.status,
+        headers: {},
+        redirectChain: page.redirectChain,
+      });
+    } else {
+      retained.push({
+        url: page.normalizedUrl,
+        finalUrl: page.finalUrl,
+        statusCode: page.status,
+        parsed: MODE === "detach" ? detachParsedPage(p as never) : p,
+        headers: {},
+        redirectChain: page.redirectChain,
+      });
+    }
+    n++;
+  }
+  releaseSiteContextDocuments(ctx);
+  Bun.gc(true);
+  if (batch.length < BATCH) break;
+}
+
+Bun.gc(true);
+const after = process.memoryUsage();
+const held = after.heapUsed - before.heapUsed + (after.external - before.external);
+console.log(
+  JSON.stringify({
+    db: DB.split("/").pop(),
+    mode: MODE,
+    pages: n,
+    retainedKB: Math.round(held / 1024),
+    perPageKB: Math.round(held / n / 1024),
+    heapPerPageKB: Math.round((after.heapUsed - before.heapUsed) / n / 1024),
+    externalPerPageKB: Math.round((after.external - before.external) / n / 1024),
+    alive: retained.length,
+  }),
+);
+await run(storage.close());

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -107,7 +107,7 @@ import {
   type StreamPageRulesHooks,
 } from "./streaming";
 import { collectDroppedBatch } from "./batch-gc";
-import { detachFromPage } from "./detach";
+import { detachFromPage, detachParsedPage } from "./detach";
 import { resolveCloakingProbes } from "./cloaking-probe";
 import { createSiteQuery } from "./site-query";
 import { confirmSoft404Candidates } from "./soft404-confirm";
@@ -1767,12 +1767,20 @@ function createParsedUniverseAccumulator(): {
         // read this text would produce different findings than v1 and fail.
         if (parsed.content?.textContent) parsed.content.textContent = "";
 
+        // Detach BEFORE retaining (#1860). A parse that ran against a live DOM
+        // hands back scalars that are slices of the page's HTML, and the
+        // universe outlives every batch, so one retained href holds a whole
+        // 959 KB page for the rest of the run. Cloned once and shared by both
+        // consumers below — `runSitePass`'s soft-404 confirm mutates the parse
+        // through `pageDataMap` and `parsedPages` has to see that mutation.
+        const kept = detachParsedPage(parsed);
+
         const headers = buildHeadersMap(page);
         htmlPages.push({
           url: page.normalizedUrl,
           finalUrl: page.finalUrl,
           statusCode: page.status,
-          parsed,
+          parsed: kept,
           headers,
           redirectChain: page.redirectChain,
         });
@@ -1781,7 +1789,7 @@ function createParsedUniverseAccumulator(): {
           normalizedUrl: page.normalizedUrl,
           status: page.status,
           fetcherId: page.fetcherId,
-          parsed,
+          parsed: kept,
         });
       }
     },

--- a/packages/audit-engine/src/detach.ts
+++ b/packages/audit-engine/src/detach.ts
@@ -107,9 +107,12 @@ export function resetDetachCounts(): void {
  * Only worth doing because the retained scalars are slices of the page's HTML
  * when the parse ran against a live DOM. Measured over a 150-page crawl of real
  * 959 KB pages with NO stored parsedData (the CLI path, and the fallback for
- * older crawls): the universe held 3749 KB per page, and 0 after this. With
- * parsedData present the strings come from `JSON.parse`, which already produces
- * fresh ones, and the same measurement shows 126 KB per page falling to 100.
+ * older crawls): the universe held 3900 KB per page and holds 77 KB after this.
+ * With parsedData present the strings come from `JSON.parse`, which already
+ * produces fresh ones, and the same measurement shows 126 KB per page falling
+ * to 100. Both figures are taken above a control that retains nothing, because
+ * the arena alone plateaus at a flat ~210 MB on that fixture whatever the page
+ * count.
  */
 export function detachParsedPage(parsed: ParsedPage): ParsedPage {
   const { document: _document, ...rest } = parsed;

--- a/packages/audit-engine/src/detach.ts
+++ b/packages/audit-engine/src/detach.ts
@@ -1,9 +1,12 @@
 // Detaching retained values from the page they came from (#1860).
 
+import { schemaCollectionFromJSON } from "@squirrelscan/parser";
+import type { ParsedPage } from "@squirrelscan/rules";
+
 import { logger } from "./adapter-logger";
 
 /** Where a detach happened, so a fallback can name the boundary that failed. */
-export type DetachBoundary = "page-rules" | "collected-signal";
+export type DetachBoundary = "page-rules" | "collected-signal" | "parsed-universe";
 
 export interface DetachCounts {
   /** Values copied free of their page. */
@@ -83,4 +86,49 @@ export function detachCounts(boundary: DetachBoundary): DetachCounts {
 /** Test seam: counts are process-wide, so a test that asserts on them starts here. */
 export function resetDetachCounts(): void {
   counts.clear();
+}
+
+/**
+ * Detach a parsed page for the streamed universe, which holds one per page for
+ * the whole run (#1860).
+ *
+ * `detachFromPage` cannot be used directly here for two reasons:
+ *
+ *  - `document` is a LIVE linkedom DOM at this point. Cloning it would throw,
+ *    and the throw is caught, so the whole page would silently stay attached.
+ *    The universe is DOM-free by contract (the batch's documents are released
+ *    immediately after), so it is dropped rather than copied.
+ *  - `schemas` is a `SchemaCollection`, a class with getters. `structuredClone`
+ *    keeps its data and loses its prototype, which would leave site rules
+ *    reading `undefined` off a plain object. It is rebuilt from the cloned data
+ *    with `schemaCollectionFromJSON` — the same rehydration `buildSiteContext`
+ *    already does for a page whose parse came out of storage.
+ *
+ * Only worth doing because the retained scalars are slices of the page's HTML
+ * when the parse ran against a live DOM. Measured over a 150-page crawl of real
+ * 959 KB pages with NO stored parsedData (the CLI path, and the fallback for
+ * older crawls): the universe held 3749 KB per page, and 0 after this. With
+ * parsedData present the strings come from `JSON.parse`, which already produces
+ * fresh ones, and the same measurement shows 126 KB per page falling to 100.
+ */
+export function detachParsedPage(parsed: ParsedPage): ParsedPage {
+  const { document: _document, ...rest } = parsed;
+  try {
+    const cloned = structuredClone(rest);
+    bump("parsed-universe", "detached");
+    return {
+      ...cloned,
+      schemas: schemaCollectionFromJSON(cloned.schemas),
+      document: null,
+    } as ParsedPage;
+  } catch (error) {
+    const seen = bump("parsed-universe", "fallbacks");
+    if (seen <= MAX_LOGGED_FALLBACKS) {
+      const kind = error instanceof Error ? error.name : typeof error;
+      logger.warn(
+        `detach fallback at parsed-universe (${kind}): this page stays attached to its HTML (#1860)`,
+      );
+    }
+    return parsed;
+  }
 }

--- a/packages/audit-engine/tests/detach-production-boundaries.test.ts
+++ b/packages/audit-engine/tests/detach-production-boundaries.test.ts
@@ -18,6 +18,7 @@ import { Effect } from "effect";
 import type { Config } from "@squirrelscan/config";
 import { generateSiteModel, writeCrawlToStorage } from "@squirrelscan/synthetic-site";
 import { createRunner, type SiteData } from "@squirrelscan/rules";
+import { SchemaCollection } from "@squirrelscan/parser";
 
 import {
   buildSiteContext,
@@ -26,7 +27,7 @@ import {
   runStreamingRules,
   type PreFetchedAssets,
 } from "../src/adapter";
-import { detachCounts, detachFromPage, resetDetachCounts } from "../src/detach";
+import { detachCounts, detachFromPage, detachParsedPage, resetDetachCounts } from "../src/detach";
 
 function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
   return Effect.runPromise(eff as Effect.Effect<A, never, never>);
@@ -124,6 +125,46 @@ describe("detach at the production boundaries", () => {
     // And no page silently kept its attachment.
     expect(pageRules.fallbacks).toBe(0);
     expect(signals.fallbacks).toBe(0);
+
+    await run(storage.close());
+  }, 120_000);
+
+  test("a real parsed page detaches with its schemas still usable", async () => {
+    const { storage, crawlId } = await fixture(9, 5);
+    const pages = await run(storage.getPages(crawlId));
+    const ctx = await run(buildSiteContext(pages));
+
+    resetDetachCounts();
+    let checked = 0;
+
+    for (const { parsed } of ctx) {
+      if (!parsed) continue;
+      const copy = detachParsedPage(parsed);
+      checked++;
+
+      // The DOM is dropped, not cloned: cloning a live linkedom document throws,
+      // and a throw here would silently keep the whole page attached.
+      expect(copy.document).toBeNull();
+      expect(copy).not.toBe(parsed);
+
+      // `structuredClone` keeps SchemaCollection's data and loses its prototype.
+      // Without the rehydrate, site rules would read `undefined` off a plain
+      // object and quietly stop reporting.
+      expect(copy.schemas).toBeInstanceOf(SchemaCollection);
+      expect(copy.schemas.types).toEqual(parsed.schemas.types);
+      expect(copy.schemas.all).toEqual(parsed.schemas.all);
+      expect(copy.schemas.organization).toEqual(parsed.schemas.organization);
+      expect(copy.schemas.raw).toEqual(parsed.schemas.raw);
+
+      // Everything else survives byte for byte — this is what the golden gate
+      // depends on, asserted here per field rather than per report.
+      const { document: _d, schemas: _s, ...restCopy } = copy;
+      const { document: _d2, schemas: _s2, ...restSource } = parsed;
+      expect(restCopy).toEqual(restSource);
+    }
+
+    expect(checked).toBeGreaterThan(0);
+    expect(detachCounts("parsed-universe")).toEqual({ detached: checked, fallbacks: 0 });
 
     await run(storage.close());
   }, 120_000);

--- a/packages/audit-engine/tests/detach-production-boundaries.test.ts
+++ b/packages/audit-engine/tests/detach-production-boundaries.test.ts
@@ -117,14 +117,17 @@ describe("detach at the production boundaries", () => {
 
     const pageRules = detachCounts("page-rules");
     const signals = detachCounts("collected-signal");
+    const universe = detachCounts("parsed-universe");
 
-    // Removing either call site zeroes its counter — an equality-only test would
+    // Removing any call site zeroes its counter — an equality-only test would
     // not notice, because the findings are identical either way.
     expect(pageRules.detached).toBeGreaterThan(0);
     expect(signals.detached).toBeGreaterThan(0);
+    expect(universe.detached).toBeGreaterThan(0);
     // And no page silently kept its attachment.
     expect(pageRules.fallbacks).toBe(0);
     expect(signals.fallbacks).toBe(0);
+    expect(universe.fallbacks).toBe(0);
 
     await run(storage.close());
   }, 120_000);
@@ -161,10 +164,38 @@ describe("detach at the production boundaries", () => {
       const { document: _d, schemas: _s, ...restCopy } = copy;
       const { document: _d2, schemas: _s2, ...restSource } = parsed;
       expect(restCopy).toEqual(restSource);
+
+      // DEEP, not shallow. A copy that only dropped `document` would satisfy
+      // every assertion above while every nested string still pinned the page,
+      // which is the whole point of the change.
+      expect(copy.schemas).not.toBe(parsed.schemas);
+      for (const key of ["meta", "content", "h1", "links", "images"] as const) {
+        const nested = parsed[key] as unknown;
+        if (nested && typeof nested === "object") {
+          expect(copy[key] as unknown).not.toBe(nested);
+        }
+      }
     }
 
     expect(checked).toBeGreaterThan(0);
     expect(detachCounts("parsed-universe")).toEqual({ detached: checked, fallbacks: 0 });
+
+    // The path this change is FOR: a crawl with no stored parsedData, where the
+    // parse ran against a live DOM and every scalar is a slice of the page.
+    resetDetachCounts();
+    const pagesNoParse = pages.map((p) => ({ ...p, parsedData: null }));
+    const ctxNoParse = await run(buildSiteContext(pagesNoParse));
+    let reparsed = 0;
+    for (const { parsed } of ctxNoParse) {
+      if (!parsed) continue;
+      const copy = detachParsedPage(parsed);
+      expect(copy.document).toBeNull();
+      expect(copy.schemas).toBeInstanceOf(SchemaCollection);
+      expect(copy.links).toEqual(parsed.links);
+      reparsed++;
+    }
+    expect(reparsed).toBeGreaterThan(0);
+    expect(detachCounts("parsed-universe")).toEqual({ detached: reparsed, fallbacks: 0 });
 
     await run(storage.close());
   }, 120_000);


### PR DESCRIPTION
Part of #1860 / the OOM incident.

The streamed universe keeps one parsed page per crawled page for the whole run. When the parse ran against a live DOM, every scalar it holds is a slice of that page's HTML, and JSC keeps a slice attached to the buffer it came from, so one retained href holds a whole 959 KB page as UTF-16 until the audit ends.

Measured over 150 real 959 KB pages, held above a retain-nothing control:

| stored parsedData | before | after |
|---|---|---|
| absent (CLI path, and the fallback for older crawls) | 3900 KB/page | 77 KB/page |
| present | 126 KB/page | 100 KB/page |

At 500 pages the first row is 1.9 GB of retention against 38 MB. The second row is small because `JSON.parse` already returns fresh strings: a stored parse was never the thing holding the page.

Two things the clone cannot do naively:

- `document` is a live linkedom DOM at that point. Cloning it throws, and the throw is caught, so the whole page would silently stay attached with identical findings and green goldens. It is dropped instead; the universe is DOM-free by contract and the batch's documents are released on the next line.
- `schemas` is a `SchemaCollection`, a class with getters. `structuredClone` keeps its data and loses its prototype, so it is rebuilt with `schemaCollectionFromJSON` — the same rehydration `buildSiteContext` already does for a parse that came out of storage.

Both consumers share the one copy, because `runSitePass`'s soft-404 confirm mutates the parse through `pageDataMap` and `parsedPages` has to see that mutation.

Byte identity is the gate: the v1-vs-v2 canonical, streaming, pre-rules, collector and report-stream goldens plus the five site-query goldens all pass. `tests/detach-production-boundaries.test.ts` adds a real-parse case asserting the DOM is dropped, the schemas still answer through their getters, every other field is equal, and no page took the fallback.

`scripts/universe-retention.ts` is the measurement. It has a mode that retains nothing, because the JSC arena plateaus flat at ~210 MB on this fixture whatever the page count, and dividing that constant by page count invents a per-page term that is not there.
