### PR TITLE
fix(report): attribute a per-page check's items to their page when grouping

### DIFF
--- a/packages/report/src/grouping.ts
+++ b/packages/report/src/grouping.ts
@@ -196,7 +196,12 @@ export function groupIssuesByCategory(
       // so a carried site-scope check (blocked-links, duplicate-title,
       // sitemap-*) whose pages live under `items` isn't undercounted in
       // GroupedCheck.carriedPages relative to the rule's total affected count.
-      const allPages = checkAffectedPages({ pages: checkPages, items });
+      // Attributed the same way the merged items are below, so a carried
+      // per-page check's resource items do not count as carried PAGES.
+      const allPages = checkAffectedPages({
+        pages: checkPages,
+        items: items?.map((item) => attributeItemToPage(item, pageUrl)),
+      });
       if (pageUrl) allPages.add(pageUrl);
 
       const checkName = (check as { name: string }).name;

--- a/packages/report/src/grouping.ts
+++ b/packages/report/src/grouping.ts
@@ -1,5 +1,6 @@
 // Category-grouped issues derived from rule results
 
+import { PUBLISH_LIMITS } from "@squirrelscan/core-contracts/limits";
 import type { ReportRuleResult, CheckItem, CheckResult } from "./types";
 import { KEY_SEPARATOR } from "./constants";
 import { checkOccurrences } from "./occurrences";
@@ -104,6 +105,25 @@ const RULE_SEVERITY_RANK: Record<"error" | "info" | "warning", number> = {
 };
 
 /**
+ * An item a PER-PAGE check reports was found ON that page, so the page is the
+ * item's source. Stamp it (the fold does exactly this when it merges per-page
+ * checks into an aggregate) so `checkAffectedPages` attributes the item to the
+ * page (case 2) instead of treating a bare-URL id as a page of its own (case 3:
+ * a CDN script flagged on 3 pages otherwise reads as "3 pages + N scripts",
+ * and the API's per-locator grouping counts 3). Case 3 stays for site-scope
+ * checks (no `pageUrl`), where each item really is a page. Capped at the same
+ * per-item bound the publish fold uses; `pages` already carries every member
+ * page, so the cap never shrinks the affected-page union.
+ */
+function attributeItemToPage(item: CheckItem, pageUrl: string | undefined): CheckItem {
+  if (!pageUrl) return item;
+  const sources = item.sourcePages ?? [];
+  if (sources.includes(pageUrl)) return item;
+  if (sources.length >= PUBLISH_LIMITS.maxSourcePagesPerItemPublish) return item;
+  return { ...item, sourcePages: [...sources, pageUrl] };
+}
+
+/**
  * Group rule results by category for display
  * Only includes rules with issues (fail or warn)
  *
@@ -141,7 +161,11 @@ export function groupIssuesByCategory(
     // both normalize to "Thin content: # words (min #)" → same group
     const checkMap = new Map<
       string,
-      GroupedCheck & { pageSet: Set<string>; itemSet: Set<string>; carriedPageSet: Set<string> }
+      GroupedCheck & {
+        pageSet: Set<string>;
+        itemById: Map<string, CheckItem>;
+        carriedPageSet: Set<string>;
+      }
     >();
     // #1135: the "fixed on all pages checked this run" note reads every
     // status (pass included), not just fail/warn — computed via the SAME
@@ -233,33 +257,28 @@ export function groupIssuesByCategory(
             }
           }
         }
-        // Merge explicit items
+        // Merge explicit items by id; a repeat of a known item (the same
+        // script on another page) gains that page as a source, never a row.
         if (items) {
           for (const item of items) {
-            if (!existing.itemSet.has(item.id)) {
-              existing.items = existing.items ?? [];
-              existing.items.push(item);
-              existing.itemSet.add(item.id);
-            }
+            const prev = existing.itemById.get(item.id);
+            existing.itemById.set(item.id, attributeItemToPage(prev ?? item, pageUrl));
           }
         }
         // Merge auto-generated item from per-page message
-        if (autoItem && !existing.itemSet.has(autoItem.id)) {
-          existing.items = existing.items ?? [];
-          existing.items.push(autoItem);
-          existing.itemSet.add(autoItem.id);
+        if (autoItem && !existing.itemById.has(autoItem.id)) {
+          existing.itemById.set(autoItem.id, autoItem);
         }
         if (details) {
           existing.details = { ...existing.details, ...details };
         }
       } else {
-        const initialItems: CheckItem[] = items ? [...items] : [];
-        const initialItemIds = new Set(initialItems.map((i) => i.id));
-        // Add auto-generated item if not already covered by explicit items
-        if (autoItem && !initialItemIds.has(autoItem.id)) {
-          initialItems.push(autoItem);
-          initialItemIds.add(autoItem.id);
+        const itemById = new Map<string, CheckItem>();
+        for (const item of items ?? []) {
+          if (!itemById.has(item.id)) itemById.set(item.id, attributeItemToPage(item, pageUrl));
         }
+        // Add auto-generated item if not already covered by explicit items
+        if (autoItem && !itemById.has(autoItem.id)) itemById.set(autoItem.id, autoItem);
         const initialPages = pageUrl ? [pageUrl] : [];
         const initialPageSet = new Set(initialPages);
         for (const page of checkPages) {
@@ -277,8 +296,9 @@ export function groupIssuesByCategory(
           count: occurrences,
           pages: initialPages,
           pageSet: initialPageSet,
-          items: initialItems.length > 0 ? initialItems : undefined,
-          itemSet: initialItemIds,
+          // Materialized from itemById once the rule's checks are all merged.
+          items: undefined,
+          itemById,
           carriedPages: initialCarriedPages.length > 0 ? initialCarriedPages : undefined,
           carriedPageSet: initialCarriedPageSet,
           details: details ? { ...details } : undefined,
@@ -297,10 +317,10 @@ export function groupIssuesByCategory(
     // (#150) — #114's bounded-concurrency rule execution otherwise leaves them
     // in nondeterministic insertion order, churning report diffs run-to-run.
     const checks = Array.from(checkMap.values()).map(
-      ({ pageSet: _, itemSet: __, carriedPageSet: ___, ...check }) => {
+      ({ pageSet: _, itemById, carriedPageSet: ___, ...check }) => {
         check.pages = [...check.pages].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-        if (check.items) {
-          check.items = [...check.items].sort((a, b) =>
+        if (itemById.size > 0) {
+          check.items = [...itemById.values()].sort((a, b) =>
             a.id < b.id ? -1 : a.id > b.id ? 1 : 0
           );
         }

--- a/packages/report/tests/item-source-pages-1882.test.ts
+++ b/packages/report/tests/item-source-pages-1882.test.ts
@@ -1,0 +1,141 @@
+// #1882: an item a PER-PAGE check reports lives on that page. The grouper
+// stamps the page as the item's source so `affectedPages` attributes the item
+// to the page (case 2) instead of counting a bare-URL item id as a page of its
+// own (case 3). Before this, one CDN script flagged on 3 pages rendered as
+// "(7 pages)" — 3 pages + 4 scripts — while the API's per-locator grouping
+// counted 3, so the two surfaces disagreed on the same finding.
+import { describe, expect, test } from "bun:test";
+import { PUBLISH_LIMITS } from "@squirrelscan/core-contracts/limits";
+
+import { affectedPages } from "../src/affected-pages";
+import { groupIssuesByCategory } from "../src/grouping";
+import type { ReportRuleResult } from "../src/types";
+
+const meta = {
+  id: "security/sri",
+  name: "SRI",
+  description: "d",
+  category: "security",
+  scope: "page",
+  severity: "error",
+  weight: 10,
+} as const;
+
+const pages = ["https://s.test/", "https://s.test/a", "https://s.test/b"];
+const GLOBAL = "https://cdn.test/global.js";
+
+function grouped(results: Record<string, ReportRuleResult>) {
+  return groupIssuesByCategory(results)
+    .flatMap((c) => c.rules)
+    .flatMap((r) => r.checks);
+}
+
+describe("per-page check items are attributed to their page (#1882)", () => {
+  const results = {
+    "security/sri": {
+      meta,
+      checks: pages.map((pageUrl, i) => ({
+        name: "cross-origin",
+        status: "fail",
+        message: `${i + 2} cross-origin resources without SRI`,
+        pageUrl,
+        items: [{ id: GLOBAL, label: "script" }, { id: `https://cdn.test/p${i}.js` }],
+      })),
+    },
+  } as unknown as Record<string, ReportRuleResult>;
+
+  test("the report's page count is the page union, not pages + script URLs", () => {
+    const [check] = grouped(results);
+    expect(check!.pages).toEqual([...pages].sort());
+    expect(affectedPages(check!).count).toBe(3);
+  });
+
+  test("a shared item keeps ONE row and gains every page it was seen on as a source", () => {
+    const [check] = grouped(results);
+    const ids = check!.items!.map((i) => i.id);
+    expect(ids).toEqual([
+      GLOBAL,
+      "https://cdn.test/p0.js",
+      "https://cdn.test/p1.js",
+      "https://cdn.test/p2.js",
+    ]);
+    expect(check!.items![0]!.sourcePages).toEqual([...pages].sort());
+    expect(check!.items![1]!.sourcePages).toEqual([pages[0]]);
+    // The label from the first sighting survives the merge.
+    expect(check!.items![0]!.label).toBe("script");
+  });
+
+  test("a single un-merged check is attributed the same way (no single-vs-merged skew)", () => {
+    const [check] = grouped({
+      "security/sri": { meta, checks: [results["security/sri"]!.checks[0]!] },
+    } as unknown as Record<string, ReportRuleResult>);
+    expect(affectedPages(check!).count).toBe(1);
+    expect(check!.items![0]!.sourcePages).toEqual([pages[0]]);
+  });
+
+  test("an item that already names its sources keeps them and adds the page once", () => {
+    const [check] = grouped({
+      "security/sri": {
+        meta,
+        checks: [
+          {
+            name: "c",
+            status: "fail",
+            message: "m",
+            pageUrl: pages[0],
+            items: [{ id: GLOBAL, sourcePages: ["https://s.test/z", pages[0]] }],
+          },
+          {
+            name: "c",
+            status: "fail",
+            message: "m",
+            pageUrl: pages[0],
+            items: [{ id: GLOBAL }],
+          },
+        ],
+      },
+    } as unknown as Record<string, ReportRuleResult>);
+    expect(check!.items![0]!.sourcePages).toEqual(["https://s.test/z", pages[0]]);
+    expect(affectedPages(check!).count).toBe(2);
+  });
+
+  test("site-scope checks (no pageUrl) keep case 3: a URL item IS a page", () => {
+    const [check] = grouped({
+      "seo/sitemap": {
+        meta: { ...meta, id: "seo/sitemap", scope: "site" },
+        checks: [
+          {
+            name: "4xx",
+            status: "fail",
+            message: "2 sitemap URLs return 4xx",
+            items: [{ id: "https://s.test/gone" }, { id: "https://s.test/gone2" }],
+          },
+        ],
+      },
+    } as unknown as Record<string, ReportRuleResult>);
+    expect(check!.items!.every((i) => i.sourcePages === undefined)).toBe(true);
+    expect(affectedPages(check!).count).toBe(2);
+  });
+
+  test("source pages per item are capped like the publish fold; the page union is not", () => {
+    const n = PUBLISH_LIMITS.maxSourcePagesPerItemPublish + 5;
+    const many = Array.from(
+      { length: n },
+      (_, i) => `https://s.test/p${String(i).padStart(2, "0")}`,
+    );
+    const [check] = grouped({
+      "security/sri": {
+        meta,
+        checks: many.map((pageUrl) => ({
+          name: "c",
+          status: "fail",
+          message: "m",
+          pageUrl,
+          items: [{ id: GLOBAL }],
+        })),
+      },
+    } as unknown as Record<string, ReportRuleResult>);
+    expect(check!.items![0]!.sourcePages).toHaveLength(PUBLISH_LIMITS.maxSourcePagesPerItemPublish);
+    expect(affectedPages(check!).count).toBe(n);
+  });
+});

--- a/packages/report/tests/item-source-pages-1882.test.ts
+++ b/packages/report/tests/item-source-pages-1882.test.ts
@@ -117,6 +117,28 @@ describe("per-page check items are attributed to their page (#1882)", () => {
     expect(affectedPages(check!).count).toBe(2);
   });
 
+  test("a carried per-page check's resource items are not carried PAGES", () => {
+    const [check] = grouped({
+      "security/sri": {
+        meta,
+        checks: [
+          {
+            name: "c",
+            status: "fail",
+            message: "m",
+            pageUrl: pages[0],
+            provenance: "carried",
+            lastSeenAt: 5,
+            items: [{ id: GLOBAL }],
+          },
+        ],
+      },
+    } as unknown as Record<string, ReportRuleResult>);
+    // Was "2 of 1 pages carried": the CDN URL counted as a carried page.
+    expect(check!.carriedPages).toEqual([pages[0]]);
+    expect(affectedPages(check!).count).toBe(1);
+  });
+
   test("source pages per item are capped like the publish fold; the page union is not", () => {
     const n = PUBLISH_LIMITS.maxSourcePagesPerItemPublish + 5;
     const many = Array.from(


### PR DESCRIPTION
## Why

`groupIssuesByCategory` merged items by id but left them without `sourcePages`, so `affectedPages()` fell through to its case-3 heuristic and counted every bare-URL item id as an affected page. `security/sri` emits `items: [{ id: f.url }]` per page, so one CDN script flagged on 3 pages rendered as "(7 pages)" (3 pages + 4 scripts), and on a 401-page Shopify audit the SRI check read as roughly 440 pages. Only over-cap rules (>500 checks per rule) were right, because `foldOverflowChecks` stamps `sourcePages` on the items it merges.

The API's per-locator grouping (squirrelscan/repo#1882, private) counts pages, so the published report and the API disagreed on the count for the same finding. That issue's acceptance criteria require the two to agree.

## What

- When a per-page check (one with a `pageUrl`) contributes an item, stamp that page as the item's source, the way the fold already does, capped at `PUBLISH_LIMITS.maxSourcePagesPerItemPublish`.
- A repeat sighting of a known item now extends its sources instead of being dropped.
- Site-scope checks (no `pageUrl`) are untouched, so a sitemap item that IS a page still counts as one.
- `GroupedCheck.items` is materialised from a per-group map at the end of the merge (was pushed incrementally).

## Visible effect

- "(N pages)" on html/markdown/llm/text/xml for under-cap page-scope rules with resource items now equals the page union.
- Items with a URL id in those groups are no longer suppressed as "redundant page rows" by the html/markdown renderers (they now carry `sourcePages`, so they list like folded items do).

## Tests

`packages/report/tests/item-source-pages-1882.test.ts` (6 cases). Full `packages/report/tests` (325 tests) and `apps/cli` grouping/report suites pass.

Companion to squirrelscan/repo#1882. No rule or engine change.