### PR TITLE
feat(crawler): make the cache seam injectable so a cloud run can revalidate

### DIFF
--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -68,7 +68,7 @@ import {
   isNotModifiedResponse,
   type FreshReason,
 } from "../incremental";
-import { StorageCacheStore } from "../cache-store";
+import { StorageCacheStore, type CacheStore } from "../cache-store";
 import {
   createPatternStats,
   getPatternStats,
@@ -304,6 +304,22 @@ export interface CreateCrawlerOptions {
   parsedPageCache?: ParsedPageCache;
   // Opt-in: injectable fetch seam; defaults to the real fetchPageWithRetry (#315)
   fetcher?: CrawlFetcher;
+  /**
+   * Opt-in: injectable cache seam; defaults to {@link StorageCacheStore} over
+   * `storage` (#1899).
+   *
+   * The default reads the previous crawl straight out of the same SQLite the
+   * current crawl writes, which is why a CLI re-run is near free and a cloud
+   * run is not: a cloud container starts with an empty database, so there is
+   * nothing to revalidate against. A caller that HAS a previous crawl
+   * elsewhere supplies a store that can reach it.
+   *
+   * Anything reached over a network belongs behind this seam rather than in the
+   * crawl loop: the loop asks for one URL at a time, so an implementation that
+   * fetches a body per lookup keeps residency at one page, and a lookup that
+   * fails or returns `{ entry: null }` simply costs a normal fetch.
+   */
+  cacheStore?: CacheStore;
 }
 
 export function createCrawler(
@@ -451,8 +467,10 @@ export function createCrawler(
         }
       });
 
-    // Shared cache seam (#147): same lookup logic runs local + cloud.
-    const cacheStore = new StorageCacheStore(storage);
+    // Shared cache seam (#147): same lookup logic runs local + cloud. Injectable
+    // since #1899 so a caller whose previous crawl lives somewhere other than
+    // this database can still revalidate against it.
+    const cacheStore = options.cacheStore ?? new StorageCacheStore(storage);
 
     // ----------------------------------------
     // URL Normalization and Scope

--- a/packages/crawler/tests/injectable-cache-store.test.ts
+++ b/packages/crawler/tests/injectable-cache-store.test.ts
@@ -1,0 +1,196 @@
+// #1899 — the cache seam is injectable, so a crawl whose previous crawl lives
+// somewhere other than this database can still revalidate against it.
+//
+// The default `StorageCacheStore` reads the previous crawl out of the same
+// SQLite the current crawl writes. That is why a CLI re-run is near free and a
+// cloud run is not: the container starts empty, so `incremental` has nothing to
+// revalidate against and every page is fetched and rendered again.
+//
+// What matters for the cloud is that the injected store is asked for ONE url at
+// a time and that a store which cannot answer costs nothing but a normal fetch.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { createCrawler } from "../src/core/crawler";
+import { SQLiteStorage } from "../src/storage/sqlite";
+import type { CacheLookup, CacheStore } from "../src/cache-store";
+import type { CrawlFetcher } from "../src/core/types";
+import type { PageRecord } from "../src/storage/types";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const HTML = `<!doctype html><html><head><title>Cached</title></head><body><h1>Cached</h1></body></html>`;
+
+/** A page as a previous crawl stored it, complete with body. */
+function priorPage(url: string): PageRecord {
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: HTML.length,
+    loadTimeMs: 5,
+    fetchedAt: Date.now() - 60_000,
+    etag: 'W/"prior"',
+    lastModified: null,
+    contentHash: "prior-hash",
+    html: HTML,
+    parsedData: null,
+    headers: {
+      contentType: "text/html",
+      contentEncoding: null,
+      cacheControl: null,
+      vary: null,
+      etag: 'W/"prior"',
+      server: null,
+      lastModified: null,
+      link: null,
+      serverTiming: null,
+      age: null,
+      xCache: null,
+      cfCacheStatus: null,
+      xVercelCache: null,
+      altSvc: null,
+      acceptRanges: null,
+    },
+    securityHeaders: {
+      hsts: null,
+      csp: null,
+      xFrameOptions: null,
+      xContentTypeOptions: null,
+      referrerPolicy: null,
+      permissionsPolicy: null,
+      xRobotsTag: null,
+    },
+  } as PageRecord;
+}
+
+/** Records what the crawl asked for, and answers with the given status. */
+function trackingFetcher(seen: string[], status: (url: string) => number): CrawlFetcher {
+  return ((url: string) => {
+    seen.push(url);
+    const code = status(url);
+    const body = code === 304 ? "" : HTML;
+    return Effect.succeed({
+      url,
+      finalUrl: url,
+      status: code,
+      loadTime: 1,
+      headers: priorPage(url).headers,
+      securityHeaders: priorPage(url).securityHeaders,
+      contentType: "text/html",
+      body,
+      sizeBytes: body.length,
+      redirectChain: [],
+    });
+  }) as unknown as CrawlFetcher;
+}
+
+describe("injectable cache store (#1899)", () => {
+  test("an injected store is consulted, one url at a time", async () => {
+    const storage = new SQLiteStorage(":memory:");
+    await run(storage.init());
+    const asked: string[] = [];
+    const store: CacheStore = {
+      lookup: (normalizedUrl) => {
+        asked.push(normalizedUrl);
+        return Effect.succeed({ entry: null } satisfies CacheLookup);
+      },
+      store: () => Effect.void,
+    };
+    const seen: string[] = [];
+    const crawler = await run(
+      createCrawler({
+        storage,
+        cacheStore: store,
+        fetcher: trackingFetcher(seen, () => 200),
+        config: {
+          maxPages: 1,
+          incremental: true,
+          concurrency: 1,
+          respectRobots: false,
+          followRedirects: false,
+        },
+      }),
+    );
+    await run(crawler.start("https://cache-seam.test/"));
+
+    // The seam was used, and it was asked per url rather than for a bulk map.
+    expect(asked.length).toBeGreaterThan(0);
+    expect(asked.every((u) => typeof u === "string")).toBe(true);
+    // A store that answers "no entry" costs nothing but the normal fetch.
+    expect(seen.length).toBeGreaterThan(0);
+    await run(storage.close());
+  }, 60_000);
+
+  test("a store that answers from elsewhere turns a 304 into a reused page", async () => {
+    const storage = new SQLiteStorage(":memory:");
+    await run(storage.init());
+    const url = "https://cache-seam.test/";
+    // The previous crawl is NOT in this database — only this store can reach it.
+    const store: CacheStore = {
+      lookup: (normalizedUrl) =>
+        Effect.succeed(
+          normalizedUrl === url
+            ? ({
+                entry: priorPage(url),
+                freshness: { fresh: false, revalidate: false } as never,
+              } satisfies CacheLookup)
+            : ({ entry: null } satisfies CacheLookup),
+        ),
+      store: () => Effect.void,
+    };
+    const crawler = await run(
+      createCrawler({
+        storage,
+        cacheStore: store,
+        fetcher: trackingFetcher([], () => 304),
+        config: {
+          maxPages: 1,
+          incremental: true,
+          concurrency: 1,
+          respectRobots: false,
+          followRedirects: false,
+        },
+      }),
+    );
+    const crawlId = await run(crawler.start(url));
+
+    // The page landed in this crawl with the body the store supplied, and it
+    // counted as unchanged rather than as a fresh fetch.
+    const pages = await run(storage.getPages(crawlId));
+    expect(pages).toHaveLength(1);
+    expect(pages[0]!.html).toBe(HTML);
+    const crawlRow = await run(storage.getCrawl(crawlId));
+    expect(crawlRow?.stats.pagesUnchanged).toBe(1);
+    expect(crawlRow?.stats.cacheHitsByReason?.["304"]).toBe(1);
+    await run(storage.close());
+  }, 60_000);
+
+  test("with no store injected the default still reads this database", async () => {
+    const storage = new SQLiteStorage(":memory:");
+    await run(storage.init());
+    const crawler = await run(
+      createCrawler({
+        storage,
+        fetcher: trackingFetcher([], () => 200),
+        config: {
+          maxPages: 1,
+          incremental: true,
+          concurrency: 1,
+          respectRobots: false,
+          followRedirects: false,
+        },
+      }),
+    );
+    const crawlId = await run(crawler.start("https://cache-seam.test/"));
+    const pages = await run(storage.getPages(crawlId));
+    expect(pages).toHaveLength(1);
+    await run(storage.close());
+  }, 60_000);
+});


### PR DESCRIPTION
First of the #1899 pull requests. Groundwork only: this changes no behaviour on its own.

`incremental` has been false on the hosted path since the cloud runner's first commit (d7019fea, Feb 2026), and flipping it alone would do nothing. The crawler builds its cache store over the same SQLite the current crawl writes, so it revalidates against the previous crawl only when that crawl is in the same database. That is why a CLI re-run is near free and a cloud re-run is not: the container starts empty, there is nothing to revalidate against, and every page is fetched and rendered again.

A 304 is also not just a skipped fetch. `reuseCachedPage` copies the previous page row into the current crawl, html and parsedData included, plus its links and images. Handing a container only etags and last-modified would produce a 304 with nothing behind it, and an empty audit rather than a fast one.

So `createCrawler` takes an optional `cacheStore`, defaulting to today's `StorageCacheStore` over `storage`. A caller whose previous crawl lives somewhere else supplies a store that can reach it.

Two properties make this safe for the hosted path, and both are asserted:

- The crawl loop asks for **one url at a time**. An implementation that fetches a body per lookup keeps residency at one page instead of materializing the crawl, which matters after #1860.
- A store that cannot answer returns `{ entry: null }` and costs nothing but a normal fetch.

The test that carries the weight drives a real crawl whose previous page exists only behind an injected store. The fetch answers 304 and the page lands in the new crawl with its body, counted as unchanged with `cacheHitsByReason` 304. The other two pin the per-url call shape and that the default still reads the local database.

Existing cache tests (incremental freshness, cache store, cache-fresh delay skip, cache stats) pass unchanged.

The hosted store that uses this seam, the endpoints behind it, and the measurement on drscholls follow in the private repo.
