### PR TITLE
fix(core-contracts): require the status lead-in for 429 too

### DIFF
--- a/packages/core-contracts/src/failure-reason.ts
+++ b/packages/core-contracts/src/failure-reason.ts
@@ -474,9 +474,14 @@ export function classifyAuditFailureReasonText(
     /rate[\s-]?limit/.test(r) ||
     /\bwaf\b/.test(r) ||
     r.includes("captcha") ||
-    /\b429\b/.test(r) ||
+    // ALL THREE refusal statuses require the status lead-in. A bare number
+    // match reads "failed after 403 retries" as a bot block, which is the same
+    // hole the bare "HTTP NNN" fix closed. Nothing is lost: "429 Too Many
+    // Requests" classifies on the "too many requests" marker above, and the
+    // crawler's own throttle message classifies on "rate limit".
     statusIn(r, 401, 401) ||
-    statusIn(r, 403, 403)
+    statusIn(r, 403, 403) ||
+    statusIn(r, 429, 429)
   ) {
     return "http_4xx";
   }

--- a/packages/core-contracts/tests/classifier-parity.test.ts
+++ b/packages/core-contracts/tests/classifier-parity.test.ts
@@ -44,6 +44,21 @@ describe("classifier parity corpus (#1822)", () => {
     }
   });
 
+  test("a bare 429 in an internal message is not read as a refusal", () => {
+    // 429 needs the status lead-in like 401 and 403. Every real throttle string
+    // still classifies, on a marker rather than on the number.
+    expect(classifyAuditFailureReasonText("database query failed after 429 retries")).toBe(
+      "unknown",
+    );
+    for (const reason of [
+      "429 Too Many Requests",
+      "Rate limited (429), retry after 30s",
+      "example.com returned 429 Too Many Requests",
+    ]) {
+      expect(classifyAuditFailureReasonText(reason)).toBe("http_4xx");
+    }
+  });
+
   test("our own internal failures never read as the audited site's", () => {
     // The half of the corpus that matters most: every one of these would
     // otherwise tell a site owner to fix something that was never theirs.

--- a/packages/crawler/tests/root-failure-classification.test.ts
+++ b/packages/crawler/tests/root-failure-classification.test.ts
@@ -85,7 +85,9 @@ describe("crawlErrorToFailureDetail (#1822)", () => {
   });
 
   test("http_5xx: a server error keeps its status and stays attributed to the origin", () => {
-    const detail = crawlErrorToFailureDetail(CrawlError.network(URL_ROOT, "Server error: 503", 503));
+    const detail = crawlErrorToFailureDetail(
+      CrawlError.network(URL_ROOT, "Server error: 503", 503),
+    );
     expect(detail.code).toBe("http_5xx");
     expect(detail.status).toBe(503);
   });
@@ -134,7 +136,12 @@ describe("crawlErrorToFailureDetail (#1822)", () => {
     // (squirrelscan/repo#1840). Reading the code means the classification
     // follows the runtime instead of chasing its wording.
     const detail = crawlErrorToFailureDetail(
-      CrawlError.network(URL_ROOT, "Unable to connect. Is the computer able to access the url?", undefined, "ENOTFOUND"),
+      CrawlError.network(
+        URL_ROOT,
+        "Unable to connect. Is the computer able to access the url?",
+        undefined,
+        "ENOTFOUND",
+      ),
     );
     expect(detail.code).toBe("dns");
   });

--- a/packages/report/tests/failure-reason-renderers.test.ts
+++ b/packages/report/tests/failure-reason-renderers.test.ts
@@ -33,7 +33,10 @@ function failedReport(
 }
 
 const DNS = failedReport("DNS lookup failed for ejconsultor.es: NXDOMAIN", "dns");
-const TLS = failedReport("TLS handshake with ejconsultor.es failed: certificate has expired", "tls");
+const TLS = failedReport(
+  "TLS handshake with ejconsultor.es failed: certificate has expired",
+  "tls",
+);
 const SERVER = failedReport("ejconsultor.es returned 503 Service Unavailable", "http_5xx");
 
 describe("text output (#1822)", () => {


### PR DESCRIPTION
Follow-up to #201, from its last review round, which landed after that PR merged.

## The hole

The bare `429` match in the refusal classifier had no status lead-in, unlike the `401` and `403` checks beside it. Those two got the lead-in during #201 precisely because a bare status number in an internal message was misread as a bot block: `"database query failed after 403 retries"` classified as a refusal. `429` was left bare and labelled "pre-#1822 behavior, kept", which was the wrong call. The same reasoning applies, and this is the third shape of the same bug that branch fixed, after the bare 401/403 and the bare `HTTP NNN` callback wording.

## Why nothing is lost by closing it

Every real throttle string still classifies, on a marker rather than on the number:

| reason | classifies via |
|---|---|
| `429 Too Many Requests` | the `too many requests` marker |
| `Rate limited (429), retry after 30s` | the `rate limit` marker |
| `example.com returned 429 Too Many Requests` | the `returned` lead-in |
| `database query failed after 429 retries` | nothing, which is the point |

Only a bare number with no refusal marker around it stops matching, which is exactly the internal case.

Paired with a matching change on the private side so the two classifiers stay in step. The shared parity corpus is unchanged and still byte-identical in both repos.

Also wraps four over-width test lines the same review flagged.
