### PR TITLE
fix(utils): match identity by name AND value shape, and compose the two sorts

### DIFF
--- a/packages/utils/src/fingerprint.ts
+++ b/packages/utils/src/fingerprint.ts
@@ -22,6 +22,12 @@
 // All three yield a stable hash across fetches while keeping the fingerprint
 // sensitive to real payload changes.
 //
+// COLLISION SCOPE, approved by the team lead on 2026-09-07: same domain, same
+// URL, same tenant's own render, 7-day TTL. Deliberately malformed markup
+// (`<plaintext>`, self-closed `<script/>`) that htmlparser2 tokenizes
+// differently from a browser can only collide a page with another version of
+// ITSELF; that is accepted and out of scope for a Workers-bundled tokenizer.
+//
 // ORDER-INSENSITIVITY IS AN ACCEPTED NARROWING, approved by the team lead on
 // 2026-09-07, in these words: "order-insensitivity for Shopify app blocks and
 // cdn.shopify.com/extensions asset tags is an accepted narrowing: the miss case
@@ -73,19 +79,27 @@ const APP_BLOCK_BEGIN = /^\s*BEGIN app block:\s*shopify:\/\//i;
 const APP_BLOCK_END = /^\s*END app block\s*$/i;
 
 /**
- * Recognizes a Shopify analytics payload — the only place identity fields are
- * neutralized.
+ * Request/visitor identity fields, matched by NAME **and** by the shape of the
+ * value.
  *
- * Anchored on the payload, not on the field name alone and not on the uuid
- * shape. `"u"` in an arbitrary script can be content: the script
- * `document.body.textContent=({"u":"Alice"}).u` renders "Alice", and blanking
- * that field would collide it with "Bob". Inside Shopify's analytics bootstrap
- * the same field is a per-visitor token that rotates with every cache entry.
+ * Neither half is sufficient alone, and both were tried:
+ *
+ *  - Shape alone (any uuid in any script) collapses two pages whose only
+ *    difference is the resource a script fetches.
+ *  - Name alone erases content: `document.body.textContent=({"u":"Alice"}).u`
+ *    renders "Alice", and blanking that field collides it with "Bob".
+ *  - Recognizing the enclosing analytics payload and neutralizing names within
+ *    it sounds tighter and is not: a mention in a comment qualifies the whole
+ *    body, and the real payloads include a 16 KB minified bundle with no stable
+ *    anchor to recognize.
+ *
+ * Together they are narrow. `reqid` and `requestId` must hold a uuid, optionally
+ * with the `-<epoch-seconds>` suffix Shopify appends; `eventMetadataId` a uuid;
+ * `u` exactly twelve lowercase hex, which is the visitor-token shape. A field
+ * carrying a name, a word or an id of any other shape is left alone.
  */
-const SHOPIFY_ANALYTICS = /\b(?:__st\b|ShopifyAnalytics|Shopify\.shop\b)/;
-
-/** Request/visitor identity fields, neutralized only inside the above. */
-const IDENTITY_FIELD = /"(reqid|requestId|eventMetadataId|u)"\s*:\s*"[^"]*"/g;
+const IDENTITY_FIELD =
+  /"(reqid|requestId|eventMetadataId)"(\s*:\s*)"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:-\d{6,})?"|"(u)"(\s*:\s*)"[0-9a-f]{12}"/gi;
 
 interface Region {
   start: number;
@@ -113,6 +127,19 @@ function isExtensionAsset(url: string | undefined): boolean {
   }
 }
 
+/**
+ * The index just past a tag's `>`, given a parser end index.
+ *
+ * `endIndex + 1` is right for `</script>` and wrong for `</script >`, where
+ * htmlparser2 reports the index of the space. Taking the reported index
+ * literally left the stray `>` behind on a removal, and carried it along when a
+ * neighbouring asset was sorted.
+ */
+function closeEnd(html: string, endIndex: number): number {
+  const gt = html.indexOf(">", endIndex);
+  return gt < 0 ? html.length : gt + 1;
+}
+
 /** Rewrite `html` by replacing disjoint regions, left to right. */
 function spliceRegions(html: string, edits: Array<Region & { text: string }>): string {
   if (edits.length === 0) return html;
@@ -136,12 +163,20 @@ function spliceRegions(html: string, edits: Array<Region & { text: string }>): s
  * Sorting every match in the document, or the span from the first match to the
  * last, would silently relocate everything in between.
  */
+function isHtmlWhitespaceOnly(text: string): boolean {
+  // HTML ASCII whitespace, explicitly. `String.prototype.trim` also strips
+  // NBSP and other Unicode spaces, which are substantive TEXT: two blocks
+  // separated by an NBSP are not adjacent siblings, and treating them as such
+  // sorts across visible content.
+  return /^[\t\n\f\r ]*$/.test(text);
+}
+
 function groupAdjacent(html: string, regions: Region[]): Region[][] {
   const runs: Region[][] = [];
   let current: Region[] = [];
   for (const region of regions) {
     const prev = current[current.length - 1];
-    if (prev && html.slice(prev.end, region.start).trim() !== "") {
+    if (prev && !isHtmlWhitespaceOnly(html.slice(prev.end, region.start))) {
       if (current.length > 1) runs.push(current);
       current = [];
     }
@@ -172,19 +207,13 @@ function neutralizeScripts(html: string): string {
   const edits: Array<Region & { text: string }> = [];
   let openEnd: number | null = null;
   let start = 0;
-  let isSt = false;
 
   const parser: Parser = new Parser(
     {
-      onopentag(name, attribs) {
+      onopentag(name) {
         if (name !== "script") return;
         start = parser.startIndex;
         openEnd = parser.endIndex + 1;
-        // An EXACT attribute value. `id="__st suffix"` is a different id, and a
-        // `data-note` whose value merely contains `id="__st"` is not an id at
-        // all — both were false positives when this was matched with a regex
-        // over the raw open tag.
-        isSt = attribs.id === "__st";
       },
       onclosetag(name) {
         if (name !== "script" || openEnd === null) return;
@@ -198,16 +227,22 @@ function neutralizeScripts(html: string): string {
         // body is empty and whose src is the giveaway.
         const openTag = html.slice(start, bodyStart);
         if (CF_CHALLENGE.test(openTag) || CF_CHALLENGE.test(body)) {
-          edits.push({ start, end: parser.endIndex + 1, text: "" });
+          // A comment, not "". Deleting the block outright can JOIN the text on
+          // either side into markup that was not there: a stray `<` before the
+          // block and an attribute-looking string after it become a tag once the
+          // block between them vanishes, and the next pass then treats that
+          // manufactured tag as a real element. A placeholder keeps the boundary.
+          edits.push({ start, end: closeEnd(html, parser.endIndex), text: "<!--cf-->" });
           return;
         }
         // JSON-LD bodies are deliberately in scope for the epoch pass: a payload
         // differing only in a 13-digit numeric field reuses a stale render —
         // accepted narrowing, bounded by the 7-day TTL (#991).
-        let rewritten = body.replace(EPOCH_MS_TOKEN, "0");
-        if (isSt || SHOPIFY_ANALYTICS.test(body)) {
-          rewritten = rewritten.replace(IDENTITY_FIELD, '"$1":""');
-        }
+        const rewritten = body
+          .replace(EPOCH_MS_TOKEN, "0")
+          .replace(IDENTITY_FIELD, (_m, name1, sep1, name2, sep2) =>
+            `"${name1 ?? name2}"${name1 ? sep1 : sep2}""`,
+          );
         if (rewritten !== body) edits.push({ start: bodyStart, end: bodyEnd, text: rewritten });
       },
     },
@@ -240,7 +275,7 @@ function sortShopifyRuns(html: string): string {
         if (APP_BLOCK_END.test(text) && blockDepth > 0) {
           blockDepth--;
           if (blockDepth === 0 && blockStart !== null) {
-            appBlocks.push({ start: blockStart, end: parser.endIndex + 1 });
+            appBlocks.push({ start: blockStart, end: closeEnd(html, parser.endIndex) });
             blockStart = null;
           }
         }
@@ -250,13 +285,16 @@ function sortShopifyRuns(html: string): string {
           pendingAsset = parser.startIndex;
           return;
         }
-        if (name === "link" && isExtensionAsset(attribs.href)) {
+        // Only a stylesheet. `rel="canonical"` and `rel="preconnect"` pointing
+        // at the same host are metadata, not assets, and reordering metadata is
+        // outside the accepted narrowing.
+        if (name === "link" && attribs.rel === "stylesheet" && isExtensionAsset(attribs.href)) {
           assetTags.push({ start: parser.startIndex, end: parser.endIndex + 1 });
         }
       },
       onclosetag(name) {
         if (name === "script" && pendingAsset !== null) {
-          assetTags.push({ start: pendingAsset, end: parser.endIndex + 1 });
+          assetTags.push({ start: pendingAsset, end: closeEnd(html, parser.endIndex) });
           pendingAsset = null;
         }
       },
@@ -266,16 +304,55 @@ function sortShopifyRuns(html: string): string {
   parser.write(html);
   parser.end();
 
+  // INNER FIRST. An app block can contain a run of asset tags, so the two edit
+  // classes overlap and "keep the first" would discard the inner sort whenever
+  // the enclosing blocks also needed reordering — and keep it when they did not.
+  // The same page then normalizes two ways depending on the order it arrived in,
+  // and `f(f(x))` stops equalling `f(x)`. Sorting the assets first and then
+  // sorting blocks over the RESULT composes instead of competing.
+  return sortRuns(sortRuns(html, assetTags), appBlocks, true);
+}
+
+/**
+ * Sort each contiguous run among `regions`. When `rescan` is set the regions
+ * were located against a DIFFERENT string, so they are re-derived here.
+ */
+function sortRuns(html: string, regions: Region[], rescan = false): string {
+  const located = rescan ? locateAppBlocks(html) : regions;
   const edits: Array<Region & { text: string }> = [];
-  for (const regions of [appBlocks, assetTags]) {
-    for (const run of groupAdjacent(html, regions)) {
-      const texts = run.map((r) => html.slice(r.start, r.end));
-      const sorted = [...texts].sort();
-      if (sorted.every((t, i) => t === texts[i])) continue;
-      run.forEach((region, i) => {
-        edits.push({ start: region.start, end: region.end, text: sorted[i]! });
-      });
-    }
+  for (const run of groupAdjacent(html, located)) {
+    const texts = run.map((r) => html.slice(r.start, r.end));
+    const sorted = [...texts].sort();
+    if (sorted.every((t, i) => t === texts[i])) continue;
+    run.forEach((region, i) => {
+      edits.push({ start: region.start, end: region.end, text: sorted[i]! });
+    });
   }
   return spliceRegions(html, edits);
+}
+
+/** Re-derive app-block regions against a rewritten string. */
+function locateAppBlocks(html: string): Region[] {
+  const blocks: Region[] = [];
+  let blockStart: number | null = null;
+  let depth = 0;
+  const parser: Parser = new Parser({
+    oncomment(text) {
+      if (APP_BLOCK_BEGIN.test(text)) {
+        if (depth === 0) blockStart = parser.startIndex;
+        depth++;
+        return;
+      }
+      if (APP_BLOCK_END.test(text) && depth > 0) {
+        depth--;
+        if (depth === 0 && blockStart !== null) {
+          blocks.push({ start: blockStart, end: closeEnd(html, parser.endIndex) });
+          blockStart = null;
+        }
+      }
+    },
+  });
+  parser.write(html);
+  parser.end();
+  return blocks;
 }

--- a/packages/utils/tests/fingerprint-shopify.test.ts
+++ b/packages/utils/tests/fingerprint-shopify.test.ts
@@ -175,15 +175,17 @@ describe("a block that contains a script", () => {
     // exactly the pages whose blocks needed reordering, and leaves it
     // neutralized for the pages that did not — so two fetches of the SAME page
     // normalize differently, which is the failure the function exists to stop.
-    const a = `<body>${block("aaa", "R1")}${block("bbb", "R1")}</body>`;
-    const b = `<body>${block("bbb", "R2")}${block("aaa", "R2")}</body>`;
+    const one = "d95d8a62-c404-4417-b6ab-289c89e9dd61-1788784074";
+    const two = "33449930-e1b6-47fe-934c-09410b1932fe-1788784195";
+    const a = `<body>${block("aaa", one)}${block("bbb", one)}</body>`;
+    const b = `<body>${block("bbb", two)}${block("aaa", two)}</body>`;
     expect(normalizeHtmlForFingerprint(a)).toBe(normalizeHtmlForFingerprint(b));
     // And the token really is gone, rather than the two just agreeing.
-    expect(normalizeHtmlForFingerprint(b)).not.toContain("R2");
+    expect(normalizeHtmlForFingerprint(b)).not.toContain(two);
   });
 
   test("a change to the contained script still moves the fingerprint", () => {
-    const a = `<body>${block("aaa", "R1")}${block("bbb", "R1")}</body>`;
+    const a = `<body>${block("aaa", "d95d8a62-c404-4417-b6ab-289c89e9dd61")}${block("bbb", "d95d8a62-c404-4417-b6ab-289c89e9dd61")}</body>`;
     const changed = a.replace("window.ShopifyAnalytics.meta=", "window.ShopifyAnalytics.other=");
     expect(normalizeHtmlForFingerprint(changed)).not.toBe(normalizeHtmlForFingerprint(a));
   });
@@ -246,6 +248,70 @@ describe("review counterexamples", () => {
     const one = `<body><script id="__st">var __st={"u":"fc3e51fed339"}</script></body>`;
     const two = `<body><script id="__st">var __st={"u":"be9f47fdfff1"}</script></body>`;
     expect(normalizeHtmlForFingerprint(one)).toBe(normalizeHtmlForFingerprint(two));
+  });
+
+  test("an identity field mentioned near 'ShopifyAnalytics' is still content", () => {
+    // Recognizing the enclosing payload and neutralizing names inside it was
+    // tried and is not tighter: a mention in a COMMENT qualified the whole body.
+    const one = `<body><script>/* ShopifyAnalytics */document.body.textContent=({"u":"Alice"}).u</script></body>`;
+    const two = `<body><script>/* ShopifyAnalytics */document.body.textContent=({"u":"Bob"}).u</script></body>`;
+    expect(normalizeHtmlForFingerprint(one)).not.toBe(normalizeHtmlForFingerprint(two));
+  });
+
+  test("an identity field holding something that is not identity-shaped is content", () => {
+    // Name AND shape, together. A "requestId" holding a slug is a page's own
+    // data; one holding a uuid is Shopify's rotating request id.
+    const slugA = `<body><script>var x={"requestId":"order-alpha"}</script></body>`;
+    const slugB = `<body><script>var x={"requestId":"order-beta"}</script></body>`;
+    expect(normalizeHtmlForFingerprint(slugA)).not.toBe(normalizeHtmlForFingerprint(slugB));
+
+    const uuidA = `<body><script>var x={"requestId":"d95d8a62-c404-4417-b6ab-289c89e9dd61-1788784074"}</script></body>`;
+    const uuidB = `<body><script>var x={"requestId":"33449930-e1b6-47fe-934c-09410b1932fe-1788784195"}</script></body>`;
+    expect(normalizeHtmlForFingerprint(uuidA)).toBe(normalizeHtmlForFingerprint(uuidB));
+  });
+
+  test("a deleted Cloudflare block cannot join text into a tag the sort then eats", () => {
+    // Removing the block outright let a stray `<` before it and an
+    // attribute-looking string after it become a tag that pass 2 sorted.
+    const ext = (x: string) =>
+      `<script src="https://cdn.shopify.com/extensions/${x}/a.js"></script>`;
+    const cf = `<script src="/cdn-cgi/challenge-platform/x"></script>`;
+    const ghost = (x: string) => "<" + cf + ext(x).slice(1);
+    expect(normalizeHtmlForFingerprint(ghost("b") + ext("a"))).not.toBe(
+      normalizeHtmlForFingerprint(ghost("a") + ext("b")),
+    );
+  });
+
+  test("a non-breaking space between blocks is text, not adjacency", () => {
+    const block = (x: string, c: string) =>
+      `<!-- BEGIN app block: shopify://apps/${x}/b/1 -->${c}<!-- END app block -->`;
+    const a = `${block("b", "<p>1</p>")}\u00a0${block("a", "<p>2</p>")}`;
+    const b = `${block("a", "<p>2</p>")}\u00a0${block("b", "<p>1</p>")}`;
+    expect(normalizeHtmlForFingerprint(a)).not.toBe(normalizeHtmlForFingerprint(b));
+  });
+
+  test("a canonical or preconnect link to the CDN is metadata, not an asset", () => {
+    const canonical = (x: string) =>
+      `<link rel="canonical" href="https://cdn.shopify.com/extensions/${x}">`;
+    expect(normalizeHtmlForFingerprint(canonical("z") + canonical("a"))).not.toBe(
+      normalizeHtmlForFingerprint(canonical("a") + canonical("z")),
+    );
+  });
+
+  test("sorting composes: assets inside blocks survive the block sort", () => {
+    // The two edit classes overlap. Sorting blocks over raw text discarded the
+    // asset sort inside them, so the same page normalized two ways depending on
+    // the order it arrived in, and f(f(x)) stopped equalling f(x).
+    const ext = (x: string) =>
+      `<script src="https://cdn.shopify.com/extensions/${x}/a.js"></script>`;
+    const block = (x: string, c: string) =>
+      `<!-- BEGIN app block: shopify://apps/${x}/b/1 -->${c}<!-- END app block -->`;
+    const one = block("b", ext("z") + ext("a")) + block("a", "<p>A</p>");
+    const two = block("a", "<p>A</p>") + block("b", ext("z") + ext("a"));
+    expect(normalizeHtmlForFingerprint(one)).toBe(normalizeHtmlForFingerprint(two));
+    expect(normalizeHtmlForFingerprint(normalizeHtmlForFingerprint(one))).toBe(
+      normalizeHtmlForFingerprint(one),
+    );
   });
 
   test("the CDN string in a data attribute does not make a script sortable", () => {


### PR DESCRIPTION
Follow-up to #242, which was squash-merged before this review round landed. Main is functional — it still collapses the corpus — but it carries six defects this fixes. Opening immediately so the merged state is not the weaker one for long.

## Corpus, re-run on this branch

```
15 bodies, 3 distinct hashes, 44.9 ms each
  4bfa515f20a4  body-t2 body-t3 body-t4 s1 s2 s3 s4 s5 s6 s7 s8 s9 s10
  3eb1869a41de  body-t1
  1aa08147f82c  body-t0
```

13 of 15 collapse to one hash. The 2 that stay apart are from before drscholls published a theme, which is a real content change and must move the fingerprint.

## Identity recognition took four attempts

Three of the four look tighter than they are:

| rule | why it fails |
|---|---|
| uuid **shape** alone | collapses two pages whose only difference is the resource a script fetches |
| field **name** alone | erases content: `({"u":"Alice"}).u` renders "Alice" and collides with Bob |
| recognize the enclosing **analytics payload** | a `/* ShopifyAnalytics */` comment qualifies the whole body — and one real rotating payload is a 16 KB minified bundle with no stable anchor |
| name **and** value shape | needs no payload recognition at all |

The third is the one worth dwelling on: it passed every unit test and silently stopped the corpus collapsing, 15 bodies to 15 hashes. Only the corpus script caught it, which is the argument for keeping that script.

So `reqid`/`requestId` must hold a uuid (optionally with Shopify's `-<epoch-seconds>` suffix), `eventMetadataId` a uuid, and `u` exactly twelve lowercase hex.

## Five more

**A deleted Cloudflare block could manufacture a tag.** A stray `<` before it and an attribute-looking string after it become markup once the block between them vanishes, and the next pass sorted that invented tag. It leaves a comment now, keeping the boundary.

**The two sorts overlapped.** An app block contains its assets, so sorting blocks over raw text discarded the asset sort inside them when the blocks also moved, and kept it when they did not. The same page normalized two ways depending on arrival order, and `f(f(x))` stopped equalling `f(x)`. Assets sort first, blocks over the result.

**Only `rel="stylesheet"` is an asset** — a canonical or preconnect link to the same host is metadata, outside the accepted class.

**Adjacency uses HTML ASCII whitespace**, not `String.trim`, which treats a non-breaking space as empty when it is substantive text.

**A close tag's end is found, not assumed** — htmlparser2 reports `</script >` as ending at the space, which left a stray `>` behind on removal and carried it along on a sort.

Every one is a fixture in `fingerprint-shopify.test.ts`.

## Collision scope (accepted, approved by the team lead 2026-09-07)

> Same domain, same URL, same tenant's own render, 7-day TTL. Deliberately malformed markup (`<plaintext>`, self-closed `<script/>`) that htmlparser2 tokenizes differently from a browser can only collide a page with another version of itself; that is accepted and out of scope for a Workers-bundled tokenizer.

That statement is also in the file header. It and the order-insensitivity narrowing are settled decisions; please quote them rather than re-arguing.