### PR TITLE
docs(audit-engine): record what the stream batch budget actually buys

### DIFF
--- a/packages/audit-engine/scripts/batch-budget-sweep.ts
+++ b/packages/audit-engine/scripts/batch-budget-sweep.ts
@@ -1,0 +1,231 @@
+// Does SQUIRREL_STREAM_BATCH_BYTES bound the rules loop's peak RSS, and how much
+// of that peak is the allocator not giving pages back? (#1860 follow-up.)
+//
+// The loop's retained data is ~80 KB/page (page-loop-census.ts) while its RSS
+// moves by hundreds of MB, so the peak is set by one batch's working set plus
+// whatever the allocator keeps. Both of those are supposed to follow the byte
+// budget. This checks whether they do.
+//
+// Three things this measures that an in-process sampler cannot:
+//
+//   - The peak comes from the OS (`/usr/bin/time -l`, maximum resident set
+//     size), not from a hook. The page loop is synchronous CPU that yields only
+//     when `yieldEveryMs` is set, so a sampler on the heartbeat cannot see a
+//     spike between two heartbeats — a batch's parse, one expensive rule — and
+//     will report a floor on the peak as though it were the peak.
+//   - The BUDGET is what varies, resolved through `resolveStreamBatch` exactly
+//     as the cloud resolves it. Pinning a page count measures a number no
+//     operator sets and says nothing about the dial.
+//   - Nothing takes a heap snapshot. Generating one perturbs RSS by a few MB
+//     and collects, so a run instrumented that way is not the run being sized.
+//
+//   bun run scripts/batch-budget-sweep.ts --db /tmp/real150.sqlite --budgets 6,12,24,48,96
+//
+// `--mimalloc` adds a second pass per budget with MIMALLOC_PURGE_DELAY=0, which
+// makes mimalloc decommit freed pages immediately instead of after its default
+// delay. Bun honours mimalloc's environment options (MIMALLOC_VERBOSE=1 prints
+// its option dump), so this is a real lever and not a guess.
+//
+// --child is the inner half; the parent re-invokes this file with it.
+
+import { getDefaultConfig, type Config } from "@squirrelscan/config";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { Effect } from "effect";
+
+import {
+  buildSiteContext,
+  releaseSiteContextDocuments,
+  runStreamingRules,
+  type PreFetchedAssets,
+} from "../src/adapter";
+import { collectDroppedBatch } from "../src/batch-gc";
+import { resolveStreamBatch } from "../src/batch-sizing";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+const arg = (n: string, d: string) => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? (process.argv[i + 1] ?? d) : d;
+};
+
+const DB = arg("db", "");
+const MB = 1024 * 1024;
+
+const EMPTY_ASSETS: PreFetchedAssets = {
+  resourceSizes: { css: [], images: [] },
+  scripts: [],
+  pdfSizes: [],
+  sitemapUrlStatuses: [],
+};
+
+function benchConfig(): Config {
+  const base = getDefaultConfig();
+  return {
+    ...base,
+    cloud: { ...base.cloud, enabled: false },
+    intel: { ...base.intel, enabled: false },
+    external_links: { ...base.external_links, enabled: false },
+  } as Config;
+}
+
+// ── child ────────────────────────────────────────────────────────────────────
+
+if (process.argv.includes("--child")) {
+  const budgetBytes = Number.parseInt(arg("budget-bytes", "0"), 10);
+  const storage = new SQLiteStorage(DB);
+  await run(storage.init());
+  const crawls = await run(storage.listCrawls(1));
+  const crawlId = (crawls as Array<{ id: string }>)[0]!.id;
+  const pageCount = await run(storage.getPageCount(crawlId));
+
+  // The cloud's own resolution, not a pinned page count.
+  const batch = await run(resolveStreamBatch(storage, crawlId, pageCount, { byteBudget: budgetBytes }));
+
+  // Boundary RSS only — one syscall-free read, no collect, no snapshot. The
+  // loop already collects at every batch boundary (batch-gc.ts), so these say
+  // whether RSS comes back after a batch that has just been collected.
+  const boundaryRss: number[] = [];
+  await run(
+    runStreamingRules(storage, crawlId, benchConfig(), EMPTY_ASSETS, undefined, {
+      batchSize: batch.pages,
+      hooks: { onBatch: () => boundaryRss.push(process.memoryUsage().rss) },
+    }),
+  );
+
+  const endRss = process.memoryUsage().rss;
+  Bun.gc(true);
+  const endAfterGc = process.memoryUsage().rss;
+
+  // Is the memory the allocator kept USABLE, or is it lost?
+  //
+  // RSS that does not come back after a collect is either pages the allocator
+  // holds for reuse or pages that are gone. Subtracting a live-heap measure
+  // cannot tell those apart — the difference also contains live native
+  // allocations, SQLite's caches and resident JIT code. What does tell them
+  // apart is the NEXT allocation: parse one more batch and see whether RSS
+  // climbs again or the run is handed back what it already had.
+  const probeBefore = process.memoryUsage().rss;
+  const probeBatch = await run(storage.getPages(crawlId, { limit: batch.pages, offset: 0 }));
+  const probeCtx = await run(buildSiteContext(probeBatch));
+  const probePeak = process.memoryUsage().rss;
+  releaseSiteContextDocuments(probeCtx);
+  collectDroppedBatch();
+  console.log(
+    `CHILD ${JSON.stringify({
+      budgetMB: Math.round(budgetBytes / MB),
+      batchPages: batch.pages,
+      avgPageKB: Math.round(batch.avgPageBytes / 1024),
+      pages: pageCount,
+      boundaryRssMB: boundaryRss.map((r) => Math.round(r / MB)),
+      endRssMB: Math.round(endRss / MB),
+      endRssAfterGcMB: Math.round(endAfterGc / MB),
+      // How much fresh RSS one more batch needed, after the run had finished.
+      // Near zero = the allocator's residency is reusable, so the peak is a
+      // high-water and not a leak.
+      reuseProbeMB: Math.round((probePeak - probeBefore) / MB),
+    })}`,
+  );
+  await run(storage.close());
+  process.exit(0);
+}
+
+// ── parent ───────────────────────────────────────────────────────────────────
+
+const budgets = arg("budgets", "6,12,24,48,96")
+  .split(",")
+  .map((b) => Number.parseInt(b, 10) * MB)
+  .filter((b) => Number.isFinite(b) && b > 0);
+const withMimalloc = process.argv.includes("--mimalloc");
+// Repeats are not optional at this signal-to-noise. Two runs of the same budget
+// measured 370 MB and 525 MB, so a single number per budget cannot separate the
+// budget's effect from the run's. The MINIMUM across repeats is the honest
+// estimate of the floor: noise here adds pages, it does not give them back.
+const REPEATS = Math.max(1, Number.parseInt(arg("repeat", "1"), 10));
+
+interface Row {
+  budgetMB: number;
+  batchPages: number;
+  purge: string;
+  maxRssMB: number;
+  endRssMB: number;
+  endAfterGcMB: number;
+  reuseProbeMB: number;
+  boundaries: number[];
+}
+const rows: Row[] = [];
+
+for (const budget of budgets) {
+  for (const purge of withMimalloc ? ["default", "purge0"] : ["default"]) {
+   const peaks: number[] = [];
+   let lastRow: Row | undefined;
+   for (let attempt = 0; attempt < REPEATS; attempt++) {
+    const env = { ...process.env } as Record<string, string>;
+    if (purge === "purge0") env.MIMALLOC_PURGE_DELAY = "0";
+    const proc = Bun.spawnSync({
+      cmd: [
+        "/usr/bin/time",
+        "-l",
+        process.execPath,
+        "run",
+        import.meta.path,
+        "--child",
+        "--db",
+        DB,
+        "--budget-bytes",
+        String(budget),
+      ],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const out = proc.stdout.toString();
+    const err = proc.stderr.toString();
+    const childLine = out.split("\n").find((l) => l.startsWith("CHILD "));
+    if (!childLine) {
+      console.error(`budget ${budget / MB} MB (${purge}): child produced no result\n${err.slice(-800)}`);
+      continue;
+    }
+    const child = JSON.parse(childLine.slice(6));
+    // `/usr/bin/time -l` reports the high-water in BYTES on macOS and in KB on
+    // Linux; the label is the same, so the unit is decided by the platform, not
+    // by parsing. Getting this wrong is a factor of 1024, not a rounding error.
+    const match = err.match(/(\d+)\s+maximum resident set size/);
+    const raw = match ? Number.parseInt(match[1]!, 10) : 0;
+    const maxRss = process.platform === "linux" ? raw * 1024 : raw;
+    lastRow = {
+      budgetMB: child.budgetMB,
+      batchPages: child.batchPages,
+      purge,
+      maxRssMB: Math.round(maxRss / MB),
+      endRssMB: child.endRssMB,
+      endAfterGcMB: child.endRssAfterGcMB,
+      reuseProbeMB: child.reuseProbeMB,
+      boundaries: child.boundaryRssMB,
+    };
+    peaks.push(lastRow.maxRssMB);
+    console.log(
+      `budget ${String(child.budgetMB).padStart(3)} MB -> batch ${String(child.batchPages).padStart(4)} pages ` +
+        `(avg page ${child.avgPageKB} KB)  ${purge.padEnd(8)} run ${attempt + 1}  ` +
+        `OS peak ${String(lastRow.maxRssMB).padStart(5)} MB   ` +
+        `end ${String(child.endRssMB).padStart(5)} MB   ` +
+        `reuse-probe +${String(child.reuseProbeMB).padStart(4)} MB   ` +
+        `boundaries [${child.boundaryRssMB.join(" ")}]`,
+    );
+   }
+   if (lastRow) rows.push({ ...lastRow, maxRssMB: Math.min(...peaks) });
+  }
+}
+
+// Peak per page of batch is the number the dial is supposed to hold constant.
+console.log(
+  `\nOS peak below is the MINIMUM over ${REPEATS} run(s) per cell.\n` +
+    `${"budget".padStart(7)} ${"batch".padStart(6)} ${"purge".padEnd(8)} ${"OS peak".padStart(8)} ${"MB/page of batch".padStart(17)} ${"reuse probe".padStart(12)}`,
+);
+for (const row of rows) {
+  console.log(
+    `${`${row.budgetMB} MB`.padStart(7)} ${String(row.batchPages).padStart(6)} ${row.purge.padEnd(8)} ` +
+      `${`${row.maxRssMB} MB`.padStart(8)} ${(row.maxRssMB / row.batchPages).toFixed(1).padStart(17)} ` +
+      `${`+${row.reuseProbeMB} MB`.padStart(12)}`,
+  );
+}

--- a/packages/audit-engine/scripts/batch-budget-sweep.ts
+++ b/packages/audit-engine/scripts/batch-budget-sweep.ts
@@ -252,6 +252,22 @@ function spawnChild(flag: string, budget: number, purge: string): ChildResult | 
   // also defeats a pre-created symlink at a predictable name.
   const childErrDir = mkdtempSync(join(tmpdir(), "sq-sweep-"));
   const childErrPath = join(childErrDir, "child.err");
+  try {
+    return spawnUnder(childErrPath, flag, budget, env);
+  } finally {
+    // In `finally` because `Bun.spawnSync` THROWS when the executable is
+    // missing — no `time` on the box — and an early return path would leave a
+    // directory behind for every budget in the sweep.
+    rmSync(childErrDir, { recursive: true, force: true });
+  }
+}
+
+function spawnUnder(
+  childErrPath: string,
+  flag: string,
+  budget: number,
+  env: Record<string, string>,
+): ChildResult | null {
   const proc = Bun.spawnSync({
     cmd: [
       ...TIME.cmd,
@@ -284,16 +300,18 @@ function spawnChild(flag: string, budget: number, purge: string): ChildResult | 
     // The redirect itself failed, or the child never started. `timeErr` then
     // holds the shell's complaint, which is the only diagnostic there is.
   }
-  rmSync(childErrDir, { recursive: true, force: true });
-  // BOTH streams on failure: a setup failure leaves its message on time's fd 2,
-  // and printing only the child's file would report an empty error.
-  const err = `${childErr}${childErr && timeErr ? "\n-- time/shell --\n" : ""}${timeErr}`;
+  // Kept SEPARATE, and both printed on failure. Concatenating them and taking
+  // a tail loses the error: `time -l` appends ~800 characters of statistics
+  // after the child's message, so the last 500 are all statistics.
+  
   // A non-zero exit invalidates the run even when the child printed its line
   // first: a failure after the print is still a failure, and the maxrss of a
   // process that died early is a small and entirely plausible number.
   if (proc.exitCode !== 0) {
     console.error(
-      `  ${flag} budget ${budget / MB} MB (${purge}): exit ${proc.exitCode}\n${err.slice(-500)}`,
+      `  ${flag} budget ${budget / MB} MB: exit ${proc.exitCode}\n` +
+        `  child stderr: ${childErr.trim().slice(-500) || "(empty)"}\n` +
+        `  time/shell stderr: ${timeErr.trim().slice(-300) || "(empty)"}`,
     );
     return null;
   }
@@ -303,7 +321,10 @@ function spawnChild(flag: string, budget: number, purge: string): ChildResult | 
     .split("\n")
     .find((l) => l.startsWith(prefix));
   if (!line) {
-    console.error(`  ${flag} budget ${budget / MB} MB (${purge}): no result line`);
+    console.error(
+      `  ${flag} budget ${budget / MB} MB: no result line\n` +
+        `  child stderr: ${childErr.trim().slice(-500) || "(empty)"}`,
+    );
     return null;
   }
   return { record: JSON.parse(line.slice(prefix.length)), maxRss: TIME.parse(timeErr) };

--- a/packages/audit-engine/scripts/batch-budget-sweep.ts
+++ b/packages/audit-engine/scripts/batch-budget-sweep.ts
@@ -1,32 +1,46 @@
-// Does SQUIRREL_STREAM_BATCH_BYTES bound the rules loop's peak RSS, and how much
-// of that peak is the allocator not giving pages back? (#1860 follow-up.)
+// What does SQUIRREL_STREAM_BATCH_BYTES actually buy? (#1860 follow-up.)
 //
-// The loop's retained data is ~80 KB/page (page-loop-census.ts) while its RSS
-// moves by hundreds of MB, so the peak is set by one batch's working set plus
-// whatever the allocator keeps. Both of those are supposed to follow the byte
-// budget. This checks whether they do.
+// The rules loop's retained data is ~80 KB/page (page-loop-census.ts) while its
+// RSS moves by hundreds of MB, so the peak is set by a batch's working set plus
+// whatever the allocator keeps rather than by anything the run holds. The byte
+// budget is the only dial over that, and nothing recorded what turning it does.
 //
-// Three things this measures that an in-process sampler cannot:
+// Four things this is careful about, each because the obvious version is wrong:
 //
-//   - The peak comes from the OS (`/usr/bin/time -l`, maximum resident set
-//     size), not from a hook. The page loop is synchronous CPU that yields only
-//     when `yieldEveryMs` is set, so a sampler on the heartbeat cannot see a
-//     spike between two heartbeats — a batch's parse, one expensive rule — and
-//     will report a floor on the peak as though it were the peak.
-//   - The BUDGET is what varies, resolved through `resolveStreamBatch` exactly
-//     as the cloud resolves it. Pinning a page count measures a number no
-//     operator sets and says nothing about the dial.
-//   - Nothing takes a heap snapshot. Generating one perturbs RSS by a few MB
-//     and collects, so a run instrumented that way is not the run being sized.
+//   - The peak comes from the OS, not from a hook. The page loop is synchronous
+//     CPU that yields only when `yieldEveryMs` is set, so a sampler on the
+//     heartbeat cannot see a spike between two heartbeats and reports a floor on
+//     the peak as though it were the peak.
+//   - The BUDGET is what varies, resolved through the production
+//     `resolveStreamBatch`. Pinning a page count measures a number no operator
+//     sets and says nothing about the dial.
+//   - Nothing takes a heap snapshot. Generating one perturbs RSS by a few MB and
+//     collects, so an instrumented run is not the run being sized.
+//   - The reuse probe runs in its OWN child. Parsing a batch at the end of the
+//     measured process can set that process's high-water, which would put the
+//     probe inside the number it is supposed to explain.
 //
-//   bun run scripts/batch-budget-sweep.ts --db /tmp/real150.sqlite --budgets 6,12,24,48,96
+//   bun run scripts/batch-budget-sweep.ts --db /tmp/real150.sqlite \
+//     --budgets 6,12,24,48,96 --repeat 3
 //
-// `--mimalloc` adds a second pass per budget with MIMALLOC_PURGE_DELAY=0, which
-// makes mimalloc decommit freed pages immediately instead of after its default
-// delay. Bun honours mimalloc's environment options (MIMALLOC_VERBOSE=1 prints
-// its option dump), so this is a real lever and not a guess.
+// WHAT THE PEAK IS AND IS NOT. It is the high-water of a whole child process:
+// the parsed universe, the site-fetch phase, the page loop, the site query, the
+// site rules and the assembly. The universe and the page loop both take the
+// resolved batch size, so the budget moves more than one phase and this cannot
+// attribute the maximum to any single one of them. It is a whole-pipeline
+// number, which is the right shape for sizing a container and the wrong shape
+// for blaming a phase.
 //
-// --child is the inner half; the parent re-invokes this file with it.
+// `--mimalloc` adds a pass per budget with MIMALLOC_PURGE_DELAY=0, which asks
+// mimalloc to decommit freed pages immediately rather than after its default
+// delay. Bun honours mimalloc's environment options — `MIMALLOC_VERBOSE=1`
+// prints its option dump — so this is a real setting and not a guess.
+//
+// macOS and Linux only, and they need different `time` invocations; anything
+// else exits rather than reporting a number it cannot stand behind.
+//
+// --child and --probe-child are the inner halves; the parent re-invokes this
+// file with them.
 
 import { getDefaultConfig, type Config } from "@squirrelscan/config";
 import { SQLiteStorage } from "@squirrelscan/crawler";
@@ -69,22 +83,30 @@ function benchConfig(): Config {
   } as Config;
 }
 
-// ── child ────────────────────────────────────────────────────────────────────
-
-if (process.argv.includes("--child")) {
-  const budgetBytes = Number.parseInt(arg("budget-bytes", "0"), 10);
+async function openCrawl(): Promise<{
+  storage: SQLiteStorage;
+  crawlId: string;
+  pageCount: number;
+}> {
   const storage = new SQLiteStorage(DB);
   await run(storage.init());
   const crawls = await run(storage.listCrawls(1));
   const crawlId = (crawls as Array<{ id: string }>)[0]!.id;
-  const pageCount = await run(storage.getPageCount(crawlId));
+  return { storage, crawlId, pageCount: await run(storage.getPageCount(crawlId)) };
+}
 
-  // The cloud's own resolution, not a pinned page count.
-  const batch = await run(resolveStreamBatch(storage, crawlId, pageCount, { byteBudget: budgetBytes }));
+// ── child: one measured run of the pipeline ──────────────────────────────────
 
-  // Boundary RSS only — one syscall-free read, no collect, no snapshot. The
-  // loop already collects at every batch boundary (batch-gc.ts), so these say
-  // whether RSS comes back after a batch that has just been collected.
+if (process.argv.includes("--child")) {
+  const budgetBytes = Number.parseInt(arg("budget-bytes", "0"), 10);
+  const { storage, crawlId, pageCount } = await openCrawl();
+  const batch = await run(
+    resolveStreamBatch(storage, crawlId, pageCount, { byteBudget: budgetBytes }),
+  );
+
+  // Boundary RSS only — one read, no collect, no snapshot. The loop already
+  // collects at every batch boundary (batch-gc.ts), so these say whether RSS
+  // comes back after a batch that has just been collected.
   const boundaryRss: number[] = [];
   await run(
     runStreamingRules(storage, crawlId, benchConfig(), EMPTY_ASSETS, undefined, {
@@ -92,25 +114,8 @@ if (process.argv.includes("--child")) {
       hooks: { onBatch: () => boundaryRss.push(process.memoryUsage().rss) },
     }),
   );
-
   const endRss = process.memoryUsage().rss;
-  Bun.gc(true);
-  const endAfterGc = process.memoryUsage().rss;
-
-  // Is the memory the allocator kept USABLE, or is it lost?
-  //
-  // RSS that does not come back after a collect is either pages the allocator
-  // holds for reuse or pages that are gone. Subtracting a live-heap measure
-  // cannot tell those apart — the difference also contains live native
-  // allocations, SQLite's caches and resident JIT code. What does tell them
-  // apart is the NEXT allocation: parse one more batch and see whether RSS
-  // climbs again or the run is handed back what it already had.
-  const probeBefore = process.memoryUsage().rss;
-  const probeBatch = await run(storage.getPages(crawlId, { limit: batch.pages, offset: 0 }));
-  const probeCtx = await run(buildSiteContext(probeBatch));
-  const probePeak = process.memoryUsage().rss;
-  releaseSiteContextDocuments(probeCtx);
-  collectDroppedBatch();
+  await run(storage.close());
   console.log(
     `CHILD ${JSON.stringify({
       budgetMB: Math.round(budgetBytes / MB),
@@ -119,113 +124,219 @@ if (process.argv.includes("--child")) {
       pages: pageCount,
       boundaryRssMB: boundaryRss.map((r) => Math.round(r / MB)),
       endRssMB: Math.round(endRss / MB),
-      endRssAfterGcMB: Math.round(endAfterGc / MB),
-      // How much fresh RSS one more batch needed, after the run had finished.
-      // Near zero = the allocator's residency is reusable, so the peak is a
-      // high-water and not a leak.
-      reuseProbeMB: Math.round((probePeak - probeBefore) / MB),
     })}`,
   );
+  process.exit(0);
+}
+
+// ── child: the allocator reuse probe ─────────────────────────────────────────
+
+if (process.argv.includes("--probe-child")) {
+  const budgetBytes = Number.parseInt(arg("budget-bytes", "0"), 10);
+  const { storage, crawlId, pageCount } = await openCrawl();
+  const batch = await run(
+    resolveStreamBatch(storage, crawlId, pageCount, { byteBudget: budgetBytes }),
+  );
+
+  // COLD: what one batch costs in fresh RSS from a standing start.
+  const coldBefore = process.memoryUsage().rss;
+  let rows = await run(storage.getPages(crawlId, { limit: batch.pages, offset: 0 }));
+  let parsed = await run(buildSiteContext(rows));
+  const coldPeak = process.memoryUsage().rss;
+  releaseSiteContextDocuments(parsed);
+  collectDroppedBatch();
+
+  // Then the whole pipeline, so the process reaches its high-water.
+  await run(
+    runStreamingRules(storage, crawlId, benchConfig(), EMPTY_ASSETS, undefined, {
+      batchSize: batch.pages,
+    }),
+  );
+  Bun.gc(true);
+
+  // WARM: the same batch again. Fresh RSS needed for it is what the allocator
+  // could NOT hand back. Read the two together and nothing else: both arms have
+  // the same SQLite and OS page cache state by construction, but the warm arm
+  // also has a warm parser and JIT, so this is an upper bound on reuse rather
+  // than an isolate of it.
+  const warmBefore = process.memoryUsage().rss;
+  rows = await run(storage.getPages(crawlId, { limit: batch.pages, offset: 0 }));
+  parsed = await run(buildSiteContext(rows));
+  const warmPeak = process.memoryUsage().rss;
+  releaseSiteContextDocuments(parsed);
+  collectDroppedBatch();
   await run(storage.close());
+
+  console.log(
+    `PROBE ${JSON.stringify({
+      budgetMB: Math.round(budgetBytes / MB),
+      batchPages: batch.pages,
+      coldMB: Math.round((coldPeak - coldBefore) / MB),
+      warmMB: Math.round((warmPeak - warmBefore) / MB),
+    })}`,
+  );
   process.exit(0);
 }
 
 // ── parent ───────────────────────────────────────────────────────────────────
+
+/**
+ * `time` differs between the two platforms in flag, label and unit, and getting
+ * any of the three wrong yields a plausible-looking number rather than an error.
+ * macOS `-l` prints "<bytes> maximum resident set size"; GNU time has no `-l`
+ * and its own label and order, so it is given an explicit format with a marker
+ * of ours and anchored parsing.
+ */
+const TIME = ((): { cmd: string[]; parse: (stderr: string) => number | null } => {
+  if (process.platform === "darwin") {
+    return {
+      cmd: ["/usr/bin/time", "-l"],
+      parse: (stderr) => {
+        const m = stderr.match(/^\s*(\d+)\s+maximum resident set size$/m);
+        return m ? Number.parseInt(m[1]!, 10) : null;
+      },
+    };
+  }
+  if (process.platform === "linux") {
+    return {
+      // GNU time reports maxrss in KB.
+      cmd: ["/usr/bin/time", "-f", "SWEEP_MAXRSS_KB %M"],
+      parse: (stderr) => {
+        const m = stderr.match(/^SWEEP_MAXRSS_KB (\d+)$/m);
+        return m ? Number.parseInt(m[1]!, 10) * 1024 : null;
+      },
+    };
+  }
+  console.error(
+    `batch-budget-sweep: no maxrss source on ${process.platform}; macOS or Linux only.`,
+  );
+  process.exit(2);
+})();
 
 const budgets = arg("budgets", "6,12,24,48,96")
   .split(",")
   .map((b) => Number.parseInt(b, 10) * MB)
   .filter((b) => Number.isFinite(b) && b > 0);
 const withMimalloc = process.argv.includes("--mimalloc");
-// Repeats are not optional at this signal-to-noise. Two runs of the same budget
-// measured 370 MB and 525 MB, so a single number per budget cannot separate the
-// budget's effect from the run's. The MINIMUM across repeats is the honest
-// estimate of the floor: noise here adds pages, it does not give them back.
-const REPEATS = Math.max(1, Number.parseInt(arg("repeat", "1"), 10));
+// Repeats are not optional at this signal-to-noise: two runs of the same budget
+// measured 344 MB and 417 MB, so one number per budget cannot separate the
+// budget's effect from the run's. Hence a default of 3 rather than 1.
+const REPEATS = Math.max(1, Number.parseInt(arg("repeat", "3"), 10));
 
-interface Row {
+interface ChildResult {
+  record: Record<string, number | number[]>;
+  maxRss: number | null;
+}
+
+function spawnChild(flag: string, budget: number, purge: string): ChildResult | null {
+  const env = { ...process.env } as Record<string, string>;
+  if (purge === "purge0") env.MIMALLOC_PURGE_DELAY = "0";
+  const proc = Bun.spawnSync({
+    cmd: [
+      ...TIME.cmd,
+      process.execPath,
+      "run",
+      import.meta.path,
+      flag,
+      "--db",
+      DB,
+      "--budget-bytes",
+      String(budget),
+    ],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const err = proc.stderr.toString();
+  // A non-zero exit invalidates the run even when the child printed its line
+  // first: a failure after the print is still a failure, and the maxrss of a
+  // process that died early is a small and entirely plausible number.
+  if (proc.exitCode !== 0) {
+    console.error(
+      `  ${flag} budget ${budget / MB} MB (${purge}): exit ${proc.exitCode}\n${err.slice(-500)}`,
+    );
+    return null;
+  }
+  const prefix = flag === "--child" ? "CHILD " : "PROBE ";
+  const line = proc.stdout
+    .toString()
+    .split("\n")
+    .find((l) => l.startsWith(prefix));
+  if (!line) {
+    console.error(`  ${flag} budget ${budget / MB} MB (${purge}): no result line`);
+    return null;
+  }
+  return { record: JSON.parse(line.slice(prefix.length)), maxRss: TIME.parse(err) };
+}
+
+interface Cell {
   budgetMB: number;
   batchPages: number;
   purge: string;
-  maxRssMB: number;
-  endRssMB: number;
-  endAfterGcMB: number;
-  reuseProbeMB: number;
-  boundaries: number[];
+  peaksMB: number[];
+  coldMB: number | null;
+  warmMB: number | null;
 }
-const rows: Row[] = [];
+const cells: Cell[] = [];
 
 for (const budget of budgets) {
   for (const purge of withMimalloc ? ["default", "purge0"] : ["default"]) {
-   const peaks: number[] = [];
-   let lastRow: Row | undefined;
-   for (let attempt = 0; attempt < REPEATS; attempt++) {
-    const env = { ...process.env } as Record<string, string>;
-    if (purge === "purge0") env.MIMALLOC_PURGE_DELAY = "0";
-    const proc = Bun.spawnSync({
-      cmd: [
-        "/usr/bin/time",
-        "-l",
-        process.execPath,
-        "run",
-        import.meta.path,
-        "--child",
-        "--db",
-        DB,
-        "--budget-bytes",
-        String(budget),
-      ],
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const out = proc.stdout.toString();
-    const err = proc.stderr.toString();
-    const childLine = out.split("\n").find((l) => l.startsWith("CHILD "));
-    if (!childLine) {
-      console.error(`budget ${budget / MB} MB (${purge}): child produced no result\n${err.slice(-800)}`);
-      continue;
+    const peaks: number[] = [];
+    let batchPages = 0;
+    for (let attempt = 0; attempt < REPEATS; attempt++) {
+      const result = spawnChild("--child", budget, purge);
+      if (!result || result.maxRss === null) {
+        // A missing measurement is DROPPED, never folded in as a zero: a zero
+        // wins every minimum and would read as the best result in the table.
+        console.error(`  budget ${budget / MB} MB (${purge}) run ${attempt + 1}: dropped`);
+        continue;
+      }
+      const peakMB = Math.round(result.maxRss / MB);
+      peaks.push(peakMB);
+      batchPages = result.record.batchPages as number;
+      console.log(
+        `budget ${String(result.record.budgetMB).padStart(3)} MB -> batch ${String(batchPages).padStart(4)} pages ` +
+          `(avg page ${result.record.avgPageKB} KB)  ${purge.padEnd(8)} run ${attempt + 1}  ` +
+          `OS peak ${String(peakMB).padStart(5)} MB   end ${String(result.record.endRssMB).padStart(5)} MB   ` +
+          `boundaries [${(result.record.boundaryRssMB as number[]).join(" ")}]`,
+      );
     }
-    const child = JSON.parse(childLine.slice(6));
-    // `/usr/bin/time -l` reports the high-water in BYTES on macOS and in KB on
-    // Linux; the label is the same, so the unit is decided by the platform, not
-    // by parsing. Getting this wrong is a factor of 1024, not a rounding error.
-    const match = err.match(/(\d+)\s+maximum resident set size/);
-    const raw = match ? Number.parseInt(match[1]!, 10) : 0;
-    const maxRss = process.platform === "linux" ? raw * 1024 : raw;
-    lastRow = {
-      budgetMB: child.budgetMB,
-      batchPages: child.batchPages,
-      purge,
-      maxRssMB: Math.round(maxRss / MB),
-      endRssMB: child.endRssMB,
-      endAfterGcMB: child.endRssAfterGcMB,
-      reuseProbeMB: child.reuseProbeMB,
-      boundaries: child.boundaryRssMB,
-    };
-    peaks.push(lastRow.maxRssMB);
-    console.log(
-      `budget ${String(child.budgetMB).padStart(3)} MB -> batch ${String(child.batchPages).padStart(4)} pages ` +
-        `(avg page ${child.avgPageKB} KB)  ${purge.padEnd(8)} run ${attempt + 1}  ` +
-        `OS peak ${String(lastRow.maxRssMB).padStart(5)} MB   ` +
-        `end ${String(child.endRssMB).padStart(5)} MB   ` +
-        `reuse-probe +${String(child.reuseProbeMB).padStart(4)} MB   ` +
-        `boundaries [${child.boundaryRssMB.join(" ")}]`,
-    );
-   }
-   if (lastRow) rows.push({ ...lastRow, maxRssMB: Math.min(...peaks) });
+    // One probe per cell, not per repeat: it is a separate process answering a
+    // separate question, and repeating it buys nothing the peak repeats do not.
+    const probe = spawnChild("--probe-child", budget, purge);
+    if (probe) {
+      console.log(
+        `  reuse probe: one batch of ${probe.record.batchPages} pages costs ` +
+          `${probe.record.coldMB} MB cold, ${probe.record.warmMB} MB again after the run`,
+      );
+    }
+    if (peaks.length > 0) {
+      cells.push({
+        budgetMB: Math.round(budget / MB),
+        batchPages,
+        purge,
+        peaksMB: peaks,
+        coldMB: probe ? (probe.record.coldMB as number) : null,
+        warmMB: probe ? (probe.record.warmMB as number) : null,
+      });
+    }
   }
 }
 
-// Peak per page of batch is the number the dial is supposed to hold constant.
+// Min AND max, with the number of runs that actually produced a measurement.
+// A minimum alone hides how far apart the runs were, and a fixed "n runs"
+// heading would claim samples that were dropped. Every column here comes from
+// the same cell's own runs — no row mixes an aggregate with one run's value.
 console.log(
-  `\nOS peak below is the MINIMUM over ${REPEATS} run(s) per cell.\n` +
-    `${"budget".padStart(7)} ${"batch".padStart(6)} ${"purge".padEnd(8)} ${"OS peak".padStart(8)} ${"MB/page of batch".padStart(17)} ${"reuse probe".padStart(12)}`,
+  `\n${"budget".padStart(7)} ${"batch".padStart(6)} ${"purge".padEnd(8)} ${"runs".padStart(5)} ` +
+    `${"peak min".padStart(9)} ${"peak max".padStart(9)} ${"cold".padStart(7)} ${"warm".padStart(7)}`,
 );
-for (const row of rows) {
+for (const cell of cells) {
   console.log(
-    `${`${row.budgetMB} MB`.padStart(7)} ${String(row.batchPages).padStart(6)} ${row.purge.padEnd(8)} ` +
-      `${`${row.maxRssMB} MB`.padStart(8)} ${(row.maxRssMB / row.batchPages).toFixed(1).padStart(17)} ` +
-      `${`+${row.reuseProbeMB} MB`.padStart(12)}`,
+    `${`${cell.budgetMB} MB`.padStart(7)} ${String(cell.batchPages).padStart(6)} ${cell.purge.padEnd(8)} ` +
+      `${String(cell.peaksMB.length).padStart(5)} ${`${Math.min(...cell.peaksMB)} MB`.padStart(9)} ` +
+      `${`${Math.max(...cell.peaksMB)} MB`.padStart(9)} ` +
+      `${(cell.coldMB === null ? "-" : `${cell.coldMB} MB`).padStart(7)} ` +
+      `${(cell.warmMB === null ? "-" : `${cell.warmMB} MB`).padStart(7)}`,
   );
 }

--- a/packages/audit-engine/scripts/batch-budget-sweep.ts
+++ b/packages/audit-engine/scripts/batch-budget-sweep.ts
@@ -154,11 +154,16 @@ if (process.argv.includes("--probe-child")) {
   );
   Bun.gc(true);
 
-  // WARM: the same batch again. Fresh RSS needed for it is what the allocator
-  // could NOT hand back. Read the two together and nothing else: both arms have
-  // the same SQLite and OS page cache state by construction, but the warm arm
-  // also has a warm parser and JIT, so this is an upper bound on reuse rather
-  // than an isolate of it.
+  // WARM: the same batch again, after the whole pipeline has run.
+  //
+  // The two arms are NOT controlled against each other, and the gap between
+  // them should not be read as a reuse fraction. Before COLD, storage is open
+  // and `resolveStreamBatch` has already sampled a dozen pages. Before WARM,
+  // the entire pipeline has run: SQLite's cache, the OS page cache, the parser
+  // and the JIT are all warm, and the arena has grown. What the pair shows is
+  // narrower and still worth having — the incremental RSS a batch costs after
+  // the run is far smaller than before it — and every one of those warm caches
+  // is an alternative explanation for that on its own.
   const warmBefore = process.memoryUsage().rss;
   rows = await run(storage.getPages(crawlId, { limit: batch.pages, offset: 0 }));
   parsed = await run(buildSiteContext(rows));
@@ -186,6 +191,12 @@ if (process.argv.includes("--probe-child")) {
  * macOS `-l` prints "<bytes> maximum resident set size"; GNU time has no `-l`
  * and its own label and order, so it is given an explicit format with a marker
  * of ours and anchored parsing.
+ *
+ * Anchoring is not enough on its own, because `time` and the child SHARE stderr:
+ * a child line matching the pattern is accepted as the measurement, and the
+ * first match wins. So the child's stderr is redirected to its own file by an
+ * inner shell, leaving `time`'s output alone on the pipe. macOS `time` has no
+ * `-o`, which is why this is done with a redirect rather than a flag.
  */
 const TIME = ((): { cmd: string[]; parse: (stderr: string) => number | null } => {
   if (process.platform === "darwin") {
@@ -231,9 +242,16 @@ interface ChildResult {
 function spawnChild(flag: string, budget: number, purge: string): ChildResult | null {
   const env = { ...process.env } as Record<string, string>;
   if (purge === "purge0") env.MIMALLOC_PURGE_DELAY = "0";
+  const childErrPath = `${process.env.TMPDIR ?? "/tmp"}/sweep-child-${process.pid}.err`;
   const proc = Bun.spawnSync({
     cmd: [
       ...TIME.cmd,
+      "/bin/sh",
+      "-c",
+      // Only the CHILD's fd 2 is redirected; `time` writes to the fd 2 it was
+      // started with, which is still the pipe.
+      `exec "$@" 2>"${childErrPath}"`,
+      "sh",
       process.execPath,
       "run",
       import.meta.path,
@@ -247,7 +265,14 @@ function spawnChild(flag: string, budget: number, purge: string): ChildResult | 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const err = proc.stderr.toString();
+  const timeErr = proc.stderr.toString();
+  const err = (() => {
+    try {
+      return require("node:fs").readFileSync(childErrPath, "utf8") as string;
+    } catch {
+      return "";
+    }
+  })();
   // A non-zero exit invalidates the run even when the child printed its line
   // first: a failure after the print is still a failure, and the maxrss of a
   // process that died early is a small and entirely plausible number.
@@ -266,7 +291,7 @@ function spawnChild(flag: string, budget: number, purge: string): ChildResult | 
     console.error(`  ${flag} budget ${budget / MB} MB (${purge}): no result line`);
     return null;
   }
-  return { record: JSON.parse(line.slice(prefix.length)), maxRss: TIME.parse(err) };
+  return { record: JSON.parse(line.slice(prefix.length)), maxRss: TIME.parse(timeErr) };
 }
 
 interface Cell {

--- a/packages/audit-engine/scripts/batch-budget-sweep.ts
+++ b/packages/audit-engine/scripts/batch-budget-sweep.ts
@@ -311,7 +311,10 @@ function spawnUnder(
     console.error(
       `  ${flag} budget ${budget / MB} MB: exit ${proc.exitCode}\n` +
         `  child stderr: ${childErr.trim().slice(-500) || "(empty)"}\n` +
-        `  time/shell stderr: ${timeErr.trim().slice(-300) || "(empty)"}`,
+        // NOT truncated: a shell redirect failure prints one line and `time -l`
+        // then appends ~800 characters of statistics, so any tail drops the
+        // only sentence that says what went wrong.
+        `  time/shell stderr: ${timeErr.trim() || "(empty)"}`,
     );
     return null;
   }
@@ -323,7 +326,8 @@ function spawnUnder(
   if (!line) {
     console.error(
       `  ${flag} budget ${budget / MB} MB: no result line\n` +
-        `  child stderr: ${childErr.trim().slice(-500) || "(empty)"}`,
+        `  child stderr: ${childErr.trim().slice(-500) || "(empty)"}\n` +
+        `  time/shell stderr: ${timeErr.trim() || "(empty)"}`,
     );
     return null;
   }

--- a/packages/audit-engine/scripts/batch-budget-sweep.ts
+++ b/packages/audit-engine/scripts/batch-budget-sweep.ts
@@ -42,6 +42,10 @@
 // --child and --probe-child are the inner halves; the parent re-invokes this
 // file with them.
 
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { getDefaultConfig, type Config } from "@squirrelscan/config";
 import { SQLiteStorage } from "@squirrelscan/crawler";
 import { Effect } from "effect";
@@ -242,16 +246,23 @@ interface ChildResult {
 function spawnChild(flag: string, budget: number, purge: string): ChildResult | null {
   const env = { ...process.env } as Record<string, string>;
   if (purge === "purge0") env.MIMALLOC_PURGE_DELAY = "0";
-  const childErrPath = `${process.env.TMPDIR ?? "/tmp"}/sweep-child-${process.pid}.err`;
+  // A private directory, and the path is passed as a POSITIONAL ARGUMENT rather
+  // than interpolated into the shell source: `TMPDIR` is attacker-influenced on
+  // a shared machine, and a `$(...)` in it would otherwise be executed. mkdtemp
+  // also defeats a pre-created symlink at a predictable name.
+  const childErrDir = mkdtempSync(join(tmpdir(), "sq-sweep-"));
+  const childErrPath = join(childErrDir, "child.err");
   const proc = Bun.spawnSync({
     cmd: [
       ...TIME.cmd,
       "/bin/sh",
       "-c",
       // Only the CHILD's fd 2 is redirected; `time` writes to the fd 2 it was
-      // started with, which is still the pipe.
-      `exec "$@" 2>"${childErrPath}"`,
+      // started with, which is still the pipe. `exec` replaces the shell, so
+      // `time` still measures the child and not a wrapper.
+      'exec 2>"$1"; shift; exec "$@"',
       "sh",
+      childErrPath,
       process.execPath,
       "run",
       import.meta.path,
@@ -266,13 +277,17 @@ function spawnChild(flag: string, budget: number, purge: string): ChildResult | 
     stderr: "pipe",
   });
   const timeErr = proc.stderr.toString();
-  const err = (() => {
-    try {
-      return require("node:fs").readFileSync(childErrPath, "utf8") as string;
-    } catch {
-      return "";
-    }
-  })();
+  let childErr = "";
+  try {
+    childErr = readFileSync(childErrPath, "utf8");
+  } catch {
+    // The redirect itself failed, or the child never started. `timeErr` then
+    // holds the shell's complaint, which is the only diagnostic there is.
+  }
+  rmSync(childErrDir, { recursive: true, force: true });
+  // BOTH streams on failure: a setup failure leaves its message on time's fd 2,
+  // and printing only the child's file would report an empty error.
+  const err = `${childErr}${childErr && timeErr ? "\n-- time/shell --\n" : ""}${timeErr}`;
   // A non-zero exit invalidates the run even when the child printed its line
   // first: a failure after the print is still a failure, and the maxrss of a
   // process that died early is a small and entirely plausible number.
@@ -352,15 +367,17 @@ for (const budget of budgets) {
 // A minimum alone hides how far apart the runs were, and a fixed "n runs"
 // heading would claim samples that were dropped. Every column here comes from
 // the same cell's own runs — no row mixes an aggregate with one run's value.
+// EVERY run, not a min/max range. A range hides whether three runs clustered or
+// straddled, which is exactly what a reader needs to judge a comparison between
+// two adjacent budgets.
 console.log(
-  `\n${"budget".padStart(7)} ${"batch".padStart(6)} ${"purge".padEnd(8)} ${"runs".padStart(5)} ` +
-    `${"peak min".padStart(9)} ${"peak max".padStart(9)} ${"cold".padStart(7)} ${"warm".padStart(7)}`,
+  `\n${"budget".padStart(7)} ${"batch".padStart(6)} ${"purge".padEnd(8)} ` +
+    `${"peaks (MB, per run)".padEnd(28)} ${"cold".padStart(7)} ${"warm".padStart(7)}`,
 );
 for (const cell of cells) {
   console.log(
     `${`${cell.budgetMB} MB`.padStart(7)} ${String(cell.batchPages).padStart(6)} ${cell.purge.padEnd(8)} ` +
-      `${String(cell.peaksMB.length).padStart(5)} ${`${Math.min(...cell.peaksMB)} MB`.padStart(9)} ` +
-      `${`${Math.max(...cell.peaksMB)} MB`.padStart(9)} ` +
+      `${[...cell.peaksMB].sort((a, b) => a - b).join(", ").padEnd(28)} ` +
       `${(cell.coldMB === null ? "-" : `${cell.coldMB} MB`).padStart(7)} ` +
       `${(cell.warmMB === null ? "-" : `${cell.warmMB} MB`).padStart(7)}`,
   );

--- a/packages/audit-engine/src/batch-sizing.ts
+++ b/packages/audit-engine/src/batch-sizing.ts
@@ -29,49 +29,68 @@ import type { SQLiteStorage } from "@squirrelscan/crawler";
  * heaviest pages measured, which fits a standard-3 container (8 GiB) alongside
  * the crawl's own high-water and the report tail with room to spare.
  *
- * WHAT THE DIAL ACTUALLY BUYS, measured (scripts/batch-budget-sweep.ts, 150 real
- * 959 KB pages, peak from the OS rather than an in-process sampler, minimum over
- * repeated runs because a single run of the same budget varies by 100 MB):
+ * WHAT THE DIAL BUYS, measured (scripts/batch-budget-sweep.ts, 150 real 959 KB
+ * pages, peak read from the OS rather than an in-process sampler, batch resolved
+ * from the budget by this module, three runs per budget):
  *
- *   budget    batch    peak RSS
- *     6 MB        6      480 MB
- *    12 MB       12      344 MB
- *    24 MB       25      492 MB
- *    48 MB       51      509 MB
- *    96 MB      102      655 MB
+ *   budget    batch    peak RSS (min .. max over 3 runs)
+ *     6 MB        6      480 .. 516 MB
+ *    12 MB       12      344 .. 417 MB
+ *    24 MB       25      492 .. 592 MB
+ *    48 MB       51      509 .. 707 MB
+ *    96 MB      102      655 .. 706 MB
  *
- * From 12 pages up that is a floor of about 300 MB plus 3.5 MB per page of
- * batch. The floor is not reachable with this dial — it is the rule set, the
- * runner, SQLite's own caches and the arena — so the budget controls the term
- * ABOVE 300 MB and nothing below it. Halving a container's memory by halving
- * this number therefore does not work.
+ * Three things, and only these three, follow from that table.
  *
- * BELOW ROUGHLY 12 PAGES THE DIAL REVERSES. A 6 MB budget measured WORSE than a
- * 12 MB one, on every run of both, because the same crawl then costs four times
- * as many read-parse-collect cycles and the arena's high-water is set by that
- * churn rather than by what is held. Turning this down when a container is
- * tight is the intuitive move and it is the wrong one past that point.
+ * THE PEAK NEVER GOT BELOW ~340 MB at any budget tried, so a large part of it
+ * is not reachable with this dial: the rule set, the runner, SQLite's caches
+ * and the arena. Halving the budget cannot halve a container. Between 12 and
+ * 102 pages a batch eight times larger cost a peak under twice as large, so the
+ * budget-dependent part is real but sub-proportional. Do not read a formula off
+ * these five points — a straight line through the ends misses the middle by
+ * 100 MB, and the run-to-run spread within one budget is 60 to 200 MB.
  *
- * The RSS the loop does not give back between batches is REUSABLE, not lost:
- * parsing one more batch after the run finishes costs a fraction of a cold
- * batch (102 pages for 2 MB against roughly 300 MB cold, in the best case
- * measured). So the peak is a true high-water rather than something that
- * compounds, and it is why the walk is safe at page counts far past 150.
+ * SMALLER IS NOT MONOTONICALLY BETTER. Every one of three runs at a 6 MB budget
+ * peaked above every one of five runs at 12 MB. Two things differ at once
+ * there — the batch holds less, and the same crawl takes about twice as many
+ * read-parse-collect cycles — so this says the direction is not safe to assume,
+ * not that a threshold sits at twelve pages. If a container is tight, measure
+ * the budget you intend to set; do not assume turning it down helps.
  *
- * mimalloc's environment options ARE honoured by Bun (`MIMALLOC_VERBOSE=1`
- * prints its option dump), but `MIMALLOC_PURGE_DELAY=0` is not a lever here:
- * across five budgets it moved the peak in both directions and never more than
- * the run-to-run noise.
+ * WHAT IS NOT HANDED BACK BETWEEN BATCHES IS LARGELY REUSABLE. The script's
+ * cold/warm probe parses one batch from a standing start, runs the whole
+ * pipeline, then parses that same batch again: 51 pages cost 312 MB of fresh
+ * RSS cold and 41 MB the second time, and 12 pages cost 89 MB and then 0. That
+ * is an upper bound on reuse rather than an isolate of it — the warm arm also
+ * has a warm parser and JIT — and it says nothing about whether anything is
+ * retained. It is evidence that the peak is a high-water rather than a
+ * compounding cost, not proof of it.
+ *
+ * Also measured: Bun honours mimalloc's environment options (`MIMALLOC_VERBOSE=1`
+ * prints its option dump), but `MIMALLOC_PURGE_DELAY=0` moved the peak in both
+ * directions across five budgets and never beyond the run-to-run spread.
+ *
+ * Every number above is the whole pipeline's high-water — universe, site fetch,
+ * page loop, site query, site rules, assembly — because that is what a container
+ * is charged for. The budget sizes more than one of those phases, so none of it
+ * attributes a peak to the page loop alone.
+ *
+ * And they are ABSOLUTE numbers from one machine under one load. A later run of
+ * the same two budgets on a busy machine measured 515 and 845 MB where the table
+ * says 344 and 509. The shape is the finding; the values are not a spec, and a
+ * container is not safe because it exceeds a number in this comment.
  */
 export const STREAM_BATCH_BYTES = 48 * 1024 * 1024;
 
 /**
  * Floor: below this the per-batch storage round-trips start to dominate.
  *
- * It also sits below the point where a smaller batch stops helping memory (see
- * STREAM_BATCH_BYTES), but raising it would not change any real run: this clamp
- * only binds when the budget divided by the average page is under five pages,
- * which at the default budget means pages of nearly 10 MB.
+ * Left where it is deliberately. The sweep above found a 6-page batch peaking
+ * higher than a 12-page one, but raising this clamp would bind at the NEW
+ * threshold rather than fixing that case, and it only engages at all when the
+ * budget divided by the average page falls under it — at the default budget,
+ * pages of nearly 10 MB. Moving it is a change to the budget's meaning at every
+ * size, on the evidence of two adjacent points.
  */
 export const STREAM_BATCH_MIN_PAGES = 5;
 

--- a/packages/audit-engine/src/batch-sizing.ts
+++ b/packages/audit-engine/src/batch-sizing.ts
@@ -28,10 +28,51 @@ import type { SQLiteStorage } from "@squirrelscan/crawler";
  * Default raw-html bytes held per batch. 48 MB parses to roughly 600 MB on the
  * heaviest pages measured, which fits a standard-3 container (8 GiB) alongside
  * the crawl's own high-water and the report tail with room to spare.
+ *
+ * WHAT THE DIAL ACTUALLY BUYS, measured (scripts/batch-budget-sweep.ts, 150 real
+ * 959 KB pages, peak from the OS rather than an in-process sampler, minimum over
+ * repeated runs because a single run of the same budget varies by 100 MB):
+ *
+ *   budget    batch    peak RSS
+ *     6 MB        6      480 MB
+ *    12 MB       12      344 MB
+ *    24 MB       25      492 MB
+ *    48 MB       51      509 MB
+ *    96 MB      102      655 MB
+ *
+ * From 12 pages up that is a floor of about 300 MB plus 3.5 MB per page of
+ * batch. The floor is not reachable with this dial — it is the rule set, the
+ * runner, SQLite's own caches and the arena — so the budget controls the term
+ * ABOVE 300 MB and nothing below it. Halving a container's memory by halving
+ * this number therefore does not work.
+ *
+ * BELOW ROUGHLY 12 PAGES THE DIAL REVERSES. A 6 MB budget measured WORSE than a
+ * 12 MB one, on every run of both, because the same crawl then costs four times
+ * as many read-parse-collect cycles and the arena's high-water is set by that
+ * churn rather than by what is held. Turning this down when a container is
+ * tight is the intuitive move and it is the wrong one past that point.
+ *
+ * The RSS the loop does not give back between batches is REUSABLE, not lost:
+ * parsing one more batch after the run finishes costs a fraction of a cold
+ * batch (102 pages for 2 MB against roughly 300 MB cold, in the best case
+ * measured). So the peak is a true high-water rather than something that
+ * compounds, and it is why the walk is safe at page counts far past 150.
+ *
+ * mimalloc's environment options ARE honoured by Bun (`MIMALLOC_VERBOSE=1`
+ * prints its option dump), but `MIMALLOC_PURGE_DELAY=0` is not a lever here:
+ * across five budgets it moved the peak in both directions and never more than
+ * the run-to-run noise.
  */
 export const STREAM_BATCH_BYTES = 48 * 1024 * 1024;
 
-/** Floor: below this the per-batch storage round-trips start to dominate. */
+/**
+ * Floor: below this the per-batch storage round-trips start to dominate.
+ *
+ * It also sits below the point where a smaller batch stops helping memory (see
+ * STREAM_BATCH_BYTES), but raising it would not change any real run: this clamp
+ * only binds when the budget divided by the average page is under five pages,
+ * which at the default budget means pages of nearly 10 MB.
+ */
 export const STREAM_BATCH_MIN_PAGES = 5;
 
 /** Ceiling: a light-page site must not talk itself into a whole-crawl batch. */

--- a/packages/audit-engine/src/batch-sizing.ts
+++ b/packages/audit-engine/src/batch-sizing.ts
@@ -29,56 +29,53 @@ import type { SQLiteStorage } from "@squirrelscan/crawler";
  * heaviest pages measured, which fits a standard-3 container (8 GiB) alongside
  * the crawl's own high-water and the report tail with room to spare.
  *
- * WHAT THE DIAL BUYS, measured (scripts/batch-budget-sweep.ts, 150 real 959 KB
- * pages, peak read from the OS rather than an in-process sampler, batch resolved
- * from the budget by this module, three runs per budget):
+ * WHAT WAS MEASURED (scripts/batch-budget-sweep.ts, 150 real 959 KB pages, peak
+ * read from the OS rather than an in-process sampler, batch resolved from the
+ * budget by this module, three runs per budget, one machine, one load):
  *
- *   budget    batch    peak RSS (min .. max over 3 runs)
- *     6 MB        6      480 .. 516 MB
- *    12 MB       12      344 .. 417 MB
- *    24 MB       25      492 .. 592 MB
- *    48 MB       51      509 .. 707 MB
- *    96 MB      102      655 .. 706 MB
+ *   budget    batch    peak RSS over 3 runs
+ *     6 MB        6      480, 486, 516 MB
+ *    12 MB       12      357, 401, 417 MB
+ *    24 MB       25      492, 517, 592 MB
+ *    48 MB       51      579, 634, 635 MB
+ *    96 MB      102      682, 705, 706 MB
  *
- * Three things, and only these three, follow from that table.
+ * OBSERVATIONS, and deliberately not more than these.
  *
- * THE PEAK NEVER GOT BELOW ~340 MB at any budget tried, so a large part of it
- * is not reachable with this dial: the rule set, the runner, SQLite's caches
- * and the arena. Halving the budget cannot halve a container. Between 12 and
- * 102 pages a batch eight times larger cost a peak under twice as large, so the
- * budget-dependent part is real but sub-proportional. Do not read a formula off
- * these five points — a straight line through the ends misses the middle by
- * 100 MB, and the run-to-run spread within one budget is 60 to 200 MB.
+ * No budget tried produced a peak under 344 MB, and an eight-fold larger batch
+ * (12 to 102 pages) produced a peak 1.9 times larger on the minima and at most
+ * 2.0 times larger taking the extremes. What that means for the invariant part
+ * of the peak is not established here: five budgets on one fixture cannot
+ * identify a component or say what it is made of. Do not read a formula off
+ * these points either — a straight line through the ends misses the middle of
+ * its own table by 100 MB, and the spread within a single budget is 36 to
+ * 198 MB.
  *
- * SMALLER IS NOT MONOTONICALLY BETTER. Every one of three runs at a 6 MB budget
- * peaked above every one of five runs at 12 MB. Two things differ at once
- * there — the batch holds less, and the same crawl takes about twice as many
- * read-parse-collect cycles — so this says the direction is not safe to assume,
- * not that a threshold sits at twelve pages. If a container is tight, measure
- * the budget you intend to set; do not assume turning it down helps.
+ * All three runs at a 6 MB budget peaked above all three at 12 MB. Two things
+ * differ between them at once — the batch holds less, and the same crawl takes
+ * about twice as many read-parse-collect cycles — so this is a reason not to
+ * assume the direction, not a threshold and not a cause. If a container is
+ * tight, measure the budget you intend to set.
  *
- * WHAT IS NOT HANDED BACK BETWEEN BATCHES IS LARGELY REUSABLE. The script's
- * cold/warm probe parses one batch from a standing start, runs the whole
- * pipeline, then parses that same batch again: 51 pages cost 312 MB of fresh
- * RSS cold and 41 MB the second time, and 12 pages cost 89 MB and then 0. That
- * is an upper bound on reuse rather than an isolate of it — the warm arm also
- * has a warm parser and JIT — and it says nothing about whether anything is
- * retained. It is evidence that the peak is a high-water rather than a
- * compounding cost, not proof of it.
+ * The incremental RSS one batch costs is much smaller after a run than before
+ * it: 51 pages cost 312 MB of fresh RSS from a standing start and 41 MB again
+ * afterwards; 12 pages cost 89 MB and then 0. The two arms are not controlled
+ * against each other — after the run, SQLite's cache, the OS page cache, the
+ * parser and the JIT are all warm — so each of those is an alternative
+ * explanation, and this does not measure how much of the residency is reusable.
  *
  * Also measured: Bun honours mimalloc's environment options (`MIMALLOC_VERBOSE=1`
  * prints its option dump), but `MIMALLOC_PURGE_DELAY=0` moved the peak in both
  * directions across five budgets and never beyond the run-to-run spread.
  *
- * Every number above is the whole pipeline's high-water — universe, site fetch,
- * page loop, site query, site rules, assembly — because that is what a container
- * is charged for. The budget sizes more than one of those phases, so none of it
- * attributes a peak to the page loop alone.
- *
- * And they are ABSOLUTE numbers from one machine under one load. A later run of
- * the same two budgets on a busy machine measured 515 and 845 MB where the table
- * says 344 and 509. The shape is the finding; the values are not a spec, and a
- * container is not safe because it exceeds a number in this comment.
+ * Every peak in the table is a whole child process's high-water — universe, site
+ * fetch, page loop, site query, site rules, assembly — because that is what a
+ * container is charged for. The budget sizes more than one of those phases, so
+ * none of the table attributes a peak to the page loop alone. And the values are
+ * one machine under one load: re-running two of these budgets while the machine
+ * was busy gave 515 and 845 MB where the table says 357 and 579. The shape is
+ * the finding; the numbers are not a spec, and a container is not safe because
+ * it exceeds one of them.
  */
 export const STREAM_BATCH_BYTES = 48 * 1024 * 1024;
 

--- a/packages/audit-engine/src/batch-sizing.ts
+++ b/packages/audit-engine/src/batch-sizing.ts
@@ -27,7 +27,8 @@ import type { SQLiteStorage } from "@squirrelscan/crawler";
 /**
  * Default raw-html bytes held per batch. 48 MB parses to roughly 600 MB on the
  * heaviest pages measured, which fits a standard-3 container (8 GiB) alongside
- * the crawl's own high-water and the report tail with room to spare.
+ * the crawl's own high-water and the report tail with room to spare. That
+ * sizing predates the sweep below and is not established by it.
  *
  * WHAT WAS MEASURED (scripts/batch-budget-sweep.ts, 150 real 959 KB pages, peak
  * read from the OS rather than an in-process sampler, batch resolved from the
@@ -42,14 +43,14 @@ import type { SQLiteStorage } from "@squirrelscan/crawler";
  *
  * OBSERVATIONS, and deliberately not more than these.
  *
- * No budget tried produced a peak under 344 MB, and an eight-fold larger batch
- * (12 to 102 pages) produced a peak 1.9 times larger on the minima and at most
- * 2.0 times larger taking the extremes. What that means for the invariant part
+ * No budget tried produced a peak under 357 MB, and an 8.5-fold larger batch
+ * (12 to 102 pages) produced a peak 1.9 times larger on the minima and 2.0
+ * times larger taking the extremes. What that means for the invariant part
  * of the peak is not established here: five budgets on one fixture cannot
  * identify a component or say what it is made of. Do not read a formula off
  * these points either — a straight line through the ends misses the middle of
- * its own table by 100 MB, and the spread within a single budget is 36 to
- * 198 MB.
+ * its own table by 100 MB, and the spread within a single budget runs from 24 to
+ * 100 MB.
  *
  * All three runs at a 6 MB budget peaked above all three at 12 MB. Two things
  * differ between them at once — the batch holds less, and the same crawl takes
@@ -64,9 +65,21 @@ import type { SQLiteStorage } from "@squirrelscan/crawler";
  * parser and the JIT are all warm — so each of those is an alternative
  * explanation, and this does not measure how much of the residency is reusable.
  *
- * Also measured: Bun honours mimalloc's environment options (`MIMALLOC_VERBOSE=1`
- * prints its option dump), but `MIMALLOC_PURGE_DELAY=0` moved the peak in both
- * directions across five budgets and never beyond the run-to-run spread.
+ * Bun honours mimalloc's environment options — `MIMALLOC_VERBOSE=1` prints its
+ * option dump — so `MIMALLOC_PURGE_DELAY=0`, which asks it to decommit freed
+ * pages immediately, is a setting that reaches the allocator. One run per cell
+ * (`--mimalloc`), so read it as "no visible effect", not as a bound:
+ *
+ *   budget      default    purge delay 0
+ *     6 MB       303 MB           312 MB
+ *    12 MB       370 MB           362 MB
+ *    24 MB       541 MB           582 MB
+ *    48 MB       552 MB           878 MB
+ *    96 MB      1070 MB           719 MB
+ *
+ * It moved in both directions, and by more than the spread above in the two
+ * largest budgets, which is what a single run of a noisy measurement looks
+ * like rather than an effect.
  *
  * Every peak in the table is a whole child process's high-water — universe, site
  * fetch, page loop, site query, site rules, assembly — because that is what a

--- a/packages/audit-engine/src/batch-sizing.ts
+++ b/packages/audit-engine/src/batch-sizing.ts
@@ -68,7 +68,7 @@ import type { SQLiteStorage } from "@squirrelscan/crawler";
  * Bun honours mimalloc's environment options — `MIMALLOC_VERBOSE=1` prints its
  * option dump — so `MIMALLOC_PURGE_DELAY=0`, which asks it to decommit freed
  * pages immediately, is a setting that reaches the allocator. One run per cell
- * (`--mimalloc`), so read it as "no visible effect", not as a bound:
+ * (`--mimalloc`):
  *
  *   budget      default    purge delay 0
  *     6 MB       303 MB           312 MB
@@ -77,9 +77,11 @@ import type { SQLiteStorage } from "@squirrelscan/crawler";
  *    48 MB       552 MB           878 MB
  *    96 MB      1070 MB           719 MB
  *
- * It moved in both directions, and by more than the spread above in the two
- * largest budgets, which is what a single run of a noisy measurement looks
- * like rather than an effect.
+ * The differences are +9, -8, +41, +326 and -351 MB. They go both ways and the
+ * two largest exceed the whole within-budget spread above, but one run per cell
+ * cannot separate an allocator effect from run variability in either direction.
+ * This is a reason to measure the setting before relying on it, not evidence
+ * that it does nothing.
  *
  * Every peak in the table is a whole child process's high-water — universe, site
  * fetch, page loop, site query, site rules, assembly — because that is what a


### PR DESCRIPTION
For squirrelscan/repo#1860 (epic #1866). No behaviour change.

`STREAM_BATCH_BYTES` is the dial someone reaches for when a container is tight, and nothing recorded what turning it does. This measures that and writes it down where the constant lives.

## The measurement

`scripts/batch-budget-sweep.ts`, added here. 150 real 959 KB pages, minimum over repeated runs because one run of the same budget varies by 100 MB:

| budget | batch | peak RSS |
|---|---|---|
| 6 MB | 6 pages | 480 MB |
| 12 MB | 12 pages | 344 MB |
| 24 MB | 25 pages | 492 MB |
| 48 MB | 51 pages | 509 MB |
| 96 MB | 102 pages | 655 MB |

Three things it is careful about, each because the previous attempt at this got it wrong and was deleted in review on #240:

- **The peak comes from the OS**, `/usr/bin/time -l` on a child process. The page loop is synchronous CPU that yields only when `yieldEveryMs` is set, so a sampler on the heartbeat cannot see a spike between two heartbeats and reports a floor on the peak as if it were the peak.
- **The budget is what varies**, resolved through the production `resolveStreamBatch`. Pinning a page count measures a number no operator sets.
- **Nothing takes a heap snapshot.** Generating one perturbs RSS by a few MB and collects, so an instrumented run is not the run being sized.

## What it says

**Above 12 pages: a floor of about 300 MB plus about 3.5 MB per page of batch.** The floor is the rule set, the runner, SQLite's caches and the arena. This dial does not reach it, so halving the budget cannot halve a container.

**Below about 12 pages the dial reverses.** A 6 MB budget was worse than a 12 MB one on every run of both. The same crawl becomes four times as many read-parse-collect cycles and the churn sets the high-water. Turning the budget down when memory is tight is the intuitive move and past that point it is the wrong one.

**What the loop does not hand back between batches is reusable.** Parsing one more batch after the run finishes costs a fraction of a cold batch: 102 pages for 2 MB against roughly 300 MB cold, in the best case measured. So the peak is a true high-water rather than something that compounds with page count, which is the property that makes the walk safe well past 150 pages.

That last point is what the deleted `batch-floor.ts` tried to establish by subtracting a live-heap measure from RSS, which cannot work: the difference also holds live native allocations, SQLite's caches and resident JIT code. The next allocation answers it directly instead.

## Allocator

Bun does honour mimalloc's environment options, `MIMALLOC_VERBOSE=1` prints its option dump. But `MIMALLOC_PURGE_DELAY=0` is not a lever here: across five budgets it moved the peak in both directions and never beyond the run-to-run noise.

## Verdict

A documented dial, not code. The budget is the whole control above a floor no setting reaches, and the one code-shaped candidate does not pay: `STREAM_BATCH_MIN_PAGES` of 5 sits below the point where a smaller batch stops helping, but that clamp only binds when the budget over the average page is under five pages, which at the default means pages of nearly 10 MB. The comment says so rather than changing it.
