### PR TITLE
perf(cli): answer the content-store prune check from a covering index

### DIFF
--- a/apps/cli/src/crawler/storage/content-store.ts
+++ b/apps/cli/src/crawler/storage/content-store.ts
@@ -53,6 +53,16 @@ CREATE TABLE IF NOT EXISTS content (
 
 CREATE INDEX IF NOT EXISTS idx_content_last_accessed ON content(last_accessed);
 CREATE INDEX IF NOT EXISTS idx_content_type ON content(content_type);
+
+-- Covering index for getStats(). Every put() that stores new content runs the
+-- prune check, which aggregates COUNT + SUM(compressed_size) +
+-- SUM(original_size) + MIN(last_accessed) over this table. Without an index
+-- holding all four values, SQLite scans the table itself and therefore pages in
+-- every gzipped BLOB just to add up their sizes -- on a filled ~1GB store that
+-- is ~300ms per stored page, which made it the single largest cost in a cold
+-- audit. Listing the columns in this order lets one covering-index scan answer
+-- the whole query without touching the table.
+CREATE INDEX IF NOT EXISTS idx_content_sizes ON content(compressed_size, original_size, last_accessed);
 `;
 
 const SQLITE_BUSY_TIMEOUT_MS = 15000;

--- a/apps/cli/tests/crawler/content-store.test.ts
+++ b/apps/cli/tests/crawler/content-store.test.ts
@@ -178,6 +178,30 @@ describe("Content Store", () => {
   });
 
   describe("getStats", () => {
+    // getStats() runs on every put() that stores new content (the prune check).
+    // Without a covering index SQLite scans the table and pages in every
+    // gzipped BLOB just to sum their sizes, which on a filled ~1GB store cost
+    // ~300ms per stored page and dominated a cold audit.
+    test("should answer the aggregate query from a covering index", () => {
+      store.put("some content to make the table non-empty", "text/html");
+
+      const db = (
+        store as unknown as { getDb: () => import("bun:sqlite").Database }
+      ).getDb();
+      const plan = db
+        .prepare(
+          `EXPLAIN QUERY PLAN
+           SELECT COUNT(*) as count, SUM(compressed_size) as total_compressed,
+                  SUM(original_size) as total_original, MIN(last_accessed) as oldest
+           FROM content`
+        )
+        .all() as Array<{ detail: string }>;
+
+      const detail = plan.map((row) => row.detail).join(" | ");
+      expect(detail).toContain("COVERING INDEX");
+      expect(detail).toContain("idx_content_sizes");
+    });
+
     test("should return empty stats for new store", () => {
       const stats = store.getStats();
 


### PR DESCRIPTION
## What

One covering SQLite index on the content store.

## Why

Every `put()` that stores new content runs `maybePrune()`, which calls `getStats()`:

```sql
SELECT COUNT(*), SUM(compressed_size), SUM(original_size), MIN(last_accessed) FROM content
```

No index held those columns, so SQLite scanned the table and paged in every gzipped BLOB just to add up their sizes. `~/.squirrel/content-store.db` is **global**: shared by every project and growing for the life of the install. So the cost of storing one page scaled with the user's lifetime cache rather than with the site being audited.

A Bun `--cpu-prof-md` profile of a cold 400-page audit put **90.2% of process CPU (338.94s of 375.79s)** in the native `get` reached from this one aggregate. The next entry was linkedom `querySelectorAll` at 1.2%.

It also never recovered on its own. `CONTENT_STORE_MAX_BYTES` is 1 GB with a 0.9 prune threshold, so a filled install sits permanently just above the threshold: each new page paid the scan **and** a prune, and `prune()` calls `getStats()` again. New installs were fast and long-time users were the slow ones, which is backwards for a cache.

## Numbers

Real 947 MB / 24,734-row store:

| | before | after |
|---|---|---|
| aggregate query | 295 ms | **1.3 ms** (227x) |
| one-time index build on first open | n/a | 295 ms |
| file size | 947 MB | 947 MB (unchanged) |

Storing 60 new pages into a 93 MB / 5,000-row store, each variant on its own fresh copy, alternated across rounds, minimum of 6 runs:

| | per page |
|---|---|
| without the index | 32.41 ms |
| with the index | **0.38 ms** (86x) |

First open is *faster* with the index (430 ms vs 631 ms on the 93 MB store), because the un-indexed run's first `put` already pays a full scan.

End to end, 400 pages of a mixed real-shape site (`audit --coverage full --http --offline`), identical rules time and identical 37 MB `project.db`:

| content store the scan walks | crawl phase | per page |
|---|---|---|
| 992 MB filled store | 333 s | 833 ms |
| empty store | 5 s | 13 ms |

That 64x gap is what this index closes: after it, per-`put` cost no longer depends on how much the store already holds.

## Notes

- The schema string is re-run with `IF NOT EXISTS` on every open, so an existing store gains the index once (295 ms on a ~1 GB store) and then behaves like a new one. No migration step.
- No behaviour change. Pruning still fires at the same threshold, still evicts least-recently-accessed first, and `getStats()` still returns the same authoritative numbers. This deliberately avoids caching or estimating the total in memory: an earlier draft did that and a review showed two concurrent writers could leave the shared store 20% over its cap with neither pruning.
- The test asserts `EXPLAIN QUERY PLAN` reports a covering-index scan. It fails against `main` (plain `SCAN content`), so it is a real guard, not a tautology.

Found while benchmarking the CLI at 400 / 1,000 / 2,500 / 5,000 pages for the large-site work. Reviewed with codex (`gpt-6-astra`), no findings.
