### PR TITLE
fix(crawler): hasPage() was always true; add a real frontier existence check

### DIFF
--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -1041,6 +1041,15 @@ export interface CrawlStorage {
 
   // Frontier
   upsertFrontier(crawlId: string, entry: FrontierRecord): Effect.Effect<void, StorageError, never>;
+  /**
+   * Existence-only frontier lookup for the enqueue path, which asks once per
+   * discovered link and only needs to know whether the URL is already known.
+   * Use `getFrontierEntry` when the record itself is needed.
+   */
+  hasFrontierEntry(
+    crawlId: string,
+    normalizedUrl: string,
+  ): Effect.Effect<boolean, StorageError, never>;
   getFrontierEntry(
     crawlId: string,
     normalizedUrl: string,

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -523,9 +523,10 @@ export function createCrawler(
         // Depth ceiling (#318): never enqueue past maxDepth. Unset = unlimited (no-op).
         if (config.maxDepth != null && depth > config.maxDepth) return;
 
-        // Check if already in frontier
-        const existing = yield* storage.getFrontierEntry(crawlId, normalized);
-        if (existing) return;
+        // Check if already in frontier. Existence only: this runs once per
+        // discovered link, so it must not read or materialise the whole row.
+        const alreadyQueued = yield* storage.hasFrontierEntry(crawlId, normalized);
+        if (alreadyQueued) return;
 
         // Oversize URLs (#1229): the publish schema caps pages[].url et al at
         // REPORT_LIMITS.maxUrlLength STRICT (no clamp — they're join keys the

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -1078,7 +1078,7 @@ export class SQLiteStorage implements CrawlStorage {
     return Effect.try({
       try: () => {
         const db = this.getDb();
-        const stmt = db.prepare("SELECT * FROM crawls WHERE id = ?");
+        const stmt = db.query("SELECT * FROM crawls WHERE id = ?");
         const row = stmt.get(id) as Record<string, unknown> | undefined;
         if (!row) return null;
         return this.rowToCrawlMetadata(row);
@@ -1412,10 +1412,12 @@ export class SQLiteStorage implements CrawlStorage {
     return Effect.try({
       try: () => {
         const db = this.getDb();
-        const stmt = db.prepare(
-          "SELECT 1 FROM pages WHERE crawl_id = ? AND normalized_url = ?"
+        const stmt = db.query(
+          "SELECT 1 FROM pages WHERE crawl_id = ? AND normalized_url = ? LIMIT 1"
         );
-        return stmt.get(crawlId, normalizedUrl) !== undefined;
+        // bun:sqlite returns NULL (not undefined) for no row, so a
+        // `!== undefined` test here is always true. See hasFrontierEntry.
+        return stmt.get(crawlId, normalizedUrl) != null;
       },
       catch: (e) => StorageError.read(e),
     });
@@ -1558,6 +1560,33 @@ export class SQLiteStorage implements CrawlStorage {
     });
   }
 
+  /**
+   * Existence-only frontier lookup for the enqueue path.
+   *
+   * `enqueueUrl` runs this once per discovered link -- the highest-frequency
+   * read in a crawl, roughly 50x per page on a link-dense site -- and only
+   * needs to know whether the URL is already known. `getFrontierEntry` stays
+   * for the watchdog path, which reads `status` off the record.
+   */
+  hasFrontierEntry(
+    crawlId: string,
+    normalizedUrl: string
+  ): Effect.Effect<boolean, StorageError, never> {
+    return Effect.try({
+      try: () => {
+        const db = this.getDb();
+        const stmt = db.query(
+          "SELECT 1 FROM frontier WHERE crawl_id = ? AND normalized_url = ? LIMIT 1"
+        );
+        // `!= null`, NOT `!== undefined`: bun:sqlite's Statement.get() returns
+        // NULL when no row matches, so an undefined test never fails and the
+        // helper answers "yes" for every URL.
+        return stmt.get(crawlId, normalizedUrl) != null;
+      },
+      catch: (e) => StorageError.read(e),
+    });
+  }
+
   getFrontierEntry(
     crawlId: string,
     normalizedUrl: string
@@ -1565,7 +1594,7 @@ export class SQLiteStorage implements CrawlStorage {
     return Effect.try({
       try: () => {
         const db = this.getDb();
-        const stmt = db.prepare(
+        const stmt = db.query(
           "SELECT * FROM frontier WHERE crawl_id = ? AND normalized_url = ?"
         );
         const row = stmt.get(crawlId, normalizedUrl) as
@@ -1599,7 +1628,7 @@ export class SQLiteStorage implements CrawlStorage {
         if (!row) return null;
 
         // Update status to fetching
-        const updateStmt = db.prepare(`
+        const updateStmt = db.query(`
           UPDATE frontier SET status = 'fetching'
           WHERE crawl_id = ? AND normalized_url = ?
         `);
@@ -1628,7 +1657,7 @@ export class SQLiteStorage implements CrawlStorage {
         const db = this.getDb();
 
         // Get next N pending URLs with highest priority
-        const selectStmt = db.prepare(`
+        const selectStmt = db.query(`
           SELECT * FROM frontier
           WHERE crawl_id = ? AND status = 'pending'
           ORDER BY priority ASC, enqueued_at ASC
@@ -1644,7 +1673,7 @@ export class SQLiteStorage implements CrawlStorage {
         const rows = capBatchPerHost(candidates, perHostLimit);
 
         // Update all selected to fetching in one transaction
-        const updateStmt = db.prepare(`
+        const updateStmt = db.query(`
           UPDATE frontier SET status = 'fetching'
           WHERE crawl_id = ? AND normalized_url = ?
         `);
@@ -1668,7 +1697,7 @@ export class SQLiteStorage implements CrawlStorage {
     return Effect.try({
       try: () => {
         const db = this.getDb();
-        const stmt = db.prepare(
+        const stmt = db.query(
           "SELECT COUNT(*) as count FROM frontier WHERE crawl_id = ? AND status = 'pending'"
         );
         const row = stmt.get(crawlId) as { count: number };
@@ -1684,7 +1713,7 @@ export class SQLiteStorage implements CrawlStorage {
     return Effect.try({
       try: () => {
         const db = this.getDb();
-        const stmt = db.prepare(
+        const stmt = db.query(
           "SELECT COUNT(*) as count FROM frontier WHERE crawl_id = ? AND status = 'fetching'"
         );
         const row = stmt.get(crawlId) as { count: number };
@@ -1707,14 +1736,14 @@ export class SQLiteStorage implements CrawlStorage {
           status === "done" || status === "failed" ? Date.now() : null;
 
         if (reason !== undefined) {
-          const stmt = db.prepare(`
+          const stmt = db.query(`
             UPDATE frontier
             SET status = ?, reason = ?, fetched_at = COALESCE(?, fetched_at)
             WHERE crawl_id = ? AND normalized_url = ?
           `);
           stmt.run(status, reason, fetchedAt, crawlId, normalizedUrl);
         } else {
-          const stmt = db.prepare(`
+          const stmt = db.query(`
             UPDATE frontier
             SET status = ?, fetched_at = COALESCE(?, fetched_at)
             WHERE crawl_id = ? AND normalized_url = ?

--- a/packages/crawler/src/types/bun-sqlite.d.ts
+++ b/packages/crawler/src/types/bun-sqlite.d.ts
@@ -15,6 +15,15 @@ declare module "bun:sqlite" {
     constructor(path?: string, options?: unknown);
     run(sql: string, ...params: unknown[]): SQLiteRunResult;
     exec(sql: string): void;
+    /**
+     * Compile a statement and CACHE it on the Database, keyed by the SQL text:
+     * the same SQL returns the same object rather than being re-parsed. Prefer
+     * this over `prepare` on any statement a crawl runs more than a handful of
+     * times. This overload was missing from this ambient declaration, which is
+     * why the storage layer reached for `prepare` everywhere.
+     */
+    query(sql: string): SQLiteStatement;
+    /** Compile a NEW statement every call. Use `query` in hot paths. */
     prepare(sql: string): SQLiteStatement;
     transaction<T extends (...args: any[]) => any>(fn: T): T;
     close(): void;

--- a/packages/crawler/tests/frontier-exists-cached.test.ts
+++ b/packages/crawler/tests/frontier-exists-cached.test.ts
@@ -1,0 +1,152 @@
+// hasFrontierEntry — the enqueue path asks "is this URL already known?" once
+// per discovered link, roughly 50x per page on a link-dense site. It must
+// answer that without selecting or materialising the whole frontier row, and
+// it must agree with getFrontierEntry (which the watchdog path still needs for
+// `status`).
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { CrawlMetadata, FrontierRecord } from "../src/storage/types";
+import { SQLiteStorage } from "../src/storage/sqlite";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+async function freshStore(): Promise<SQLiteStorage> {
+  const store = new SQLiteStorage(":memory:");
+  await run(store.init());
+  return store;
+}
+
+async function freshCrawl(store: SQLiteStorage, baseUrl: string): Promise<string> {
+  const meta: Omit<CrawlMetadata, "id"> = {
+    baseUrl,
+    startedAt: 1,
+    status: "running",
+    config: {
+      maxPages: 100,
+      concurrency: 10,
+      perHostConcurrency: 2,
+      delayMs: 0,
+      perHostDelayMs: 0,
+      timeoutMs: 1000,
+      userAgent: "test",
+      followRedirects: true,
+      respectRobots: false,
+      incremental: false,
+      include: [],
+      exclude: [],
+      allowQueryParams: [],
+      dropQueryPrefixes: [],
+      allowedDomains: [],
+    },
+    stats: {
+      pagesTotal: 0,
+      pagesFetched: 0,
+      pagesFailed: 0,
+      pagesSkipped: 0,
+      pagesUnchanged: 0,
+      linksTotal: 0,
+      imagesTotal: 0,
+      bytesTotal: 0,
+      avgLoadTimeMs: 0,
+    },
+  };
+  return run(store.createCrawl(meta));
+}
+
+async function seed(
+  store: SQLiteStorage,
+  crawlId: string,
+  url: string,
+  status: FrontierRecord["status"] = "pending"
+): Promise<void> {
+  const entry: FrontierRecord = {
+    normalizedUrl: url,
+    rawUrl: `${url}?utm_source=x`,
+    depth: 2,
+    priority: 0,
+    status,
+    source: "discovered",
+    enqueuedAt: 1,
+    retryCount: 0,
+  };
+  await run(store.upsertFrontier(crawlId, entry));
+}
+
+describe("hasFrontierEntry", () => {
+  test("reports presence and absence", async () => {
+    const store = await freshStore();
+    const crawlId = await freshCrawl(store, "https://example.com");
+    await seed(store, crawlId, "https://example.com/known");
+
+    expect(await run(store.hasFrontierEntry(crawlId, "https://example.com/known"))).toBe(true);
+    expect(await run(store.hasFrontierEntry(crawlId, "https://example.com/unknown"))).toBe(false);
+    store.close();
+  });
+
+  test("agrees with getFrontierEntry across every status", async () => {
+    const store = await freshStore();
+    const crawlId = await freshCrawl(store, "https://example.com");
+    const statuses: FrontierRecord["status"][] = [
+      "pending",
+      "fetching",
+      "done",
+      "failed",
+      "skipped",
+    ];
+
+    for (const status of statuses) {
+      const url = `https://example.com/${status}`;
+      await seed(store, crawlId, url, status);
+      const record = await run(store.getFrontierEntry(crawlId, url));
+      const exists = await run(store.hasFrontierEntry(crawlId, url));
+      // An entry is "already known" regardless of how its fetch turned out;
+      // treating a failed/skipped URL as unknown would re-enqueue it forever.
+      expect(exists).toBe(record !== null);
+      expect(exists).toBe(true);
+    }
+    store.close();
+  });
+
+  test("is scoped to its crawl", async () => {
+    const store = await freshStore();
+    const crawlA = await freshCrawl(store, "https://a.example.com");
+    const crawlB = await freshCrawl(store, "https://b.example.com");
+    const url = "https://a.example.com/only-in-a";
+    await seed(store, crawlA, url);
+
+    expect(await run(store.hasFrontierEntry(crawlA, url))).toBe(true);
+    expect(await run(store.hasFrontierEntry(crawlB, url))).toBe(false);
+    store.close();
+  });
+
+  test("reuses one cached statement instead of compiling per call", async () => {
+    const store = await freshStore();
+    const crawlId = await freshCrawl(store, "https://example.com");
+    await seed(store, crawlId, "https://example.com/known");
+
+    // The whole point of this path is that it is called once per discovered
+    // link. Count compilations: db.query caches by SQL text, db.prepare does
+    // not, so a regression to prepare shows up here as one compile per call.
+    const db = (store as unknown as { getDb: () => import("bun:sqlite").Database }).getDb();
+    let compiles = 0;
+    const realPrepare = db.prepare.bind(db);
+    const realQuery = db.query.bind(db);
+    db.prepare = (sql: string) => {
+      compiles++;
+      return realPrepare(sql);
+    };
+    db.query = (sql: string) => realQuery(sql);
+
+    for (let i = 0; i < 200; i++) {
+      await run(store.hasFrontierEntry(crawlId, "https://example.com/known"));
+    }
+
+    // db.query compiles once and caches; db.prepare would compile 200 times.
+    expect(compiles).toBeLessThanOrEqual(1);
+    store.close();
+  });
+});


### PR DESCRIPTION
## The actual bug

`bun:sqlite`'s `Statement.get()` returns **NULL**, not `undefined`, when no row matches. `hasPage()` tested:

```ts
return stmt.get(crawlId, normalizedUrl) !== undefined;
```

which is true for every input. It reported "this page exists" for pages that had never been crawled. Nothing calls it today, so this was a landmine rather than a live incident, but it is the kind that costs someone an afternoon when they finally wire it up.

## The frontier existence check

`enqueueUrl` (`packages/crawler/src/core/crawler.ts:509`) ran `getFrontierEntry` once per discovered link, the highest-frequency read in a crawl at roughly 52 per page on a link-dense site, and used only its truthiness. So it was doing `SELECT *` and materialising a whole `FrontierRecord` to answer a boolean.

`hasFrontierEntry` answers it directly and carries the same `!= null` fix, so the new helper cannot repeat `hasPage`'s mistake. `getFrontierEntry` stays for the watchdog path, which genuinely reads `status`.

## Why the storage layer never used `db.query`

`db.query` caches the compiled statement by SQL text; `db.prepare` compiles a new one every call. All 116 statements in `packages/crawler/src/storage/sqlite.ts` used `prepare`, and the reason is not preference: this repo ships its own `declare module "bun:sqlite"` (`packages/crawler/src/types/bun-sqlite.d.ts`) that shadows `bun-types` and **never declared `query`**, so the faster call was unreachable from TypeScript. Both real `bun-types` 1.3.14 and 1.4.0 declare it.

That declaration now has `query`, which is what unblocks converting the rest. This PR converts only the hot frontier statements plus `getCrawl`; the remaining ~105 are deliberately left for a follow-up rather than a mass edit.

## Being honest about the speed

| layer | before | after | |
|---|---|---|---|
| raw SQL, 5,000-row frontier | 7.70 us/call | 0.61 us/call | 12.6x |
| through the Effect-wrapped storage method | 2.42 us/call | 1.50 us/call | **1.61x** |

The second row is the one that matters, and the wrapper dominates it. At ~52 links per page that is 0.05 ms per page, about **half a second across a 10,000-page crawl**. Do this as mechanical correctness, not as a performance win.

The measurement is arguably the more useful output: micro-optimising SQL inside these `Effect.try` wrappers is not where crawl time goes. (A first pass of this benchmark reported 8.11 vs 7.02 us because a duplicate Effect copy was logging a version-mismatch warning on every call; running it from inside the package gives the numbers above.)

## Tests

`packages/crawler/tests/frontier-exists-cached.test.ts` covers presence and absence, agreement with `getFrontierEntry` across every frontier status (a failed or skipped URL is still "known", or it gets re-enqueued forever), crawl scoping, and a guard that counts statement compilations. That last one reports 200 compilations if the path regresses to `prepare`; I verified it by reverting the call and watching it fail.

Crawler tests and typecheck show no change against the base in this worktree. Reviewed with codex (`gpt-6-astra`): no actionable findings, and it independently reproduced both the `hasPage` fix and the cache guard.

Part of squirrelscan/repo#1911.
