### PR TITLE
feat(crawler): say when the crawl's base is the wrong host of a pair

### DIFF
--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -749,7 +749,36 @@ export type CrawlerEvent =
       durationMs: number;
       timestamp: number;
     }
+  | {
+      /**
+       * The crawl found something a human should see and carried on anyway.
+       * Non-fatal by construction — `error` is the other case — so a consumer
+       * that ignores this type loses information but never correctness.
+       *
+       * Added for squirrelscan/repo#1899, where a crawl audited the wrong half
+       * of an apex/www pair and said nothing: `logger.warn` reaches a terminal
+       * or a container's stdout, neither of which is where a hosted run is
+       * investigated weeks later. This rides the event stream the run already
+       * records.
+       */
+      type: "warning";
+      code: CrawlWarningCode;
+      message: string;
+      timestamp: number;
+    }
   | { type: "error"; error: string; fatal: boolean; timestamp: number };
+
+/**
+ * Stable keys for {@link CrawlerEvent} warnings, so a consumer can branch or
+ * aggregate without parsing the prose in `message`.
+ *
+ * `seed-base-mismatch`: the crawl's base origin disagrees with where the seed
+ * page itself landed, or with the canonical the seed page declares, on the same
+ * site. The base is pinned from one probe before anything is fetched; when that
+ * probe cannot see an apex→www redirect the whole audit describes the wrong
+ * host. The page fetch is the first evidence that contradicts it.
+ */
+export type CrawlWarningCode = "seed-base-mismatch";
 
 export interface AuditLifecycleEvent {
   type:

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -472,6 +472,66 @@ export function createCrawler(
     // this database can still revalidate against it.
     const cacheStore = options.cacheStore ?? new StorageCacheStore(storage);
 
+    /**
+     * A host on the crawl's own site that the base should have been pinned to,
+     * or null when `candidateUrl` agrees with the base (squirrelscan/repo#1899).
+     *
+     * The base is decided by one probe of the seed before anything is fetched.
+     * When that probe is refused — a WAF 403 carries no `Location`, so it is
+     * indistinguishable from an apex that serves the site — the base stays on
+     * the seed's host while the site lives on another. The seed page's own fetch
+     * is the first evidence that contradicts it, and it arrives too late to move
+     * the base: every root probe has already run against the wrong origin.
+     *
+     * A DIFFERENT SITE is not this. That is the #1418 case, refused deliberately
+     * by `resolveSeedRedirect` and already logged where it happens; repeating it
+     * here would turn a security decision into a bug report.
+     */
+    const sameSiteHostOtherThanBase = (candidateUrl: string): string | null => {
+      let host: string;
+      let baseHost: string;
+      try {
+        host = new URL(candidateUrl).host.toLowerCase();
+        baseHost = new URL(baseUrl).host.toLowerCase();
+      } catch {
+        return null;
+      }
+      if (!host || host === baseHost) return null;
+      if (isOffSiteFinalUrl(baseUrl, candidateUrl)) return null;
+      return host;
+    };
+
+    /**
+     * Once per crawl. Three sources of evidence feed this, in descending
+     * strength, and a seed can be re-processed; reporting each would turn one
+     * finding into a stream of them and make the count meaningless.
+     */
+    let seedBaseMismatchReported = false;
+
+    const reportSeedBaseMismatch = (
+      host: string,
+      evidence: string,
+    ): Effect.Effect<void, never, never> =>
+      Effect.gen(function* () {
+        if (seedBaseMismatchReported) return;
+        seedBaseMismatchReported = true;
+        // States what was OBSERVED and offers the cause as a possibility. A
+        // mis-pinned base is the likeliest explanation and the one worth acting
+        // on, but an apex can serve content and canonicalize elsewhere without
+        // ever redirecting, and this cannot tell those apart from here.
+        const message =
+          `the crawl is based on ${new URL(baseUrl).host} but the seed page ${evidence} ` +
+          `${host}. The base is pinned from a probe made before any page was fetched, so if ` +
+          `that probe could not see a redirect, this audit describes the wrong host of the two`;
+        logger.warn("seed base mismatch", message);
+        yield* emit({
+          type: "warning",
+          code: "seed-base-mismatch",
+          message,
+          timestamp: Date.now(),
+        });
+      });
+
     // ----------------------------------------
     // URL Normalization and Scope
     // ----------------------------------------
@@ -1341,6 +1401,25 @@ export function createCrawler(
             xRobotsTag: result.securityHeaders.xRobotsTag ?? null,
           };
 
+          // The second detector for a mis-pinned base (#1899). The seed page is
+          // the first thing the crawl fetches with its own agent, its own
+          // headers and its retry stack, so it gets through where the bare
+          // preamble probe did not — and where it LANDS is evidence the probe
+          // never had. Strongest of the three signals, and the only one that
+          // does not need the body, so it sits outside the HTML branch: a seed
+          // serving a PDF still proves which host the site is on.
+          //
+          // This does not move the base and must not: the root probes are
+          // already done against it, and re-basing mid-crawl would file one
+          // origin's content under another's name. It reports, and the apex/www
+          // scope rule keeps the crawl whole meanwhile. So it fires on a crawl
+          // that then succeeds, deliberately — that the audit describes a host
+          // the site redirects away from is worth knowing either way.
+          if (entry.source === "seed") {
+            const landedHost = sameSiteHostOtherThanBase(result.finalUrl);
+            if (landedHost) yield* reportSeedBaseMismatch(landedHost, "landed on");
+          }
+
           // Parse and discover URLs if HTML (before storing page)
           let parsedData: string | null = null;
           if (
@@ -1359,6 +1438,82 @@ export function createCrawler(
               options.parsedPageCache.size < PARSED_PAGE_CACHE_MAX_PAGES
             ) {
               options.parsedPageCache.set(entry.normalizedUrl, parsed);
+            }
+
+            // The second detector for a mis-pinned base (#1899). The seed page
+            // is the first thing the crawl fetches with its own agent, its own
+            // headers and its retry stack, so it gets through where the bare
+            // preamble probe did not — and where it LANDS, plus the canonical it
+            // declares, is evidence the probe never had.
+            //
+            // This does not move the base and must not: the root probes are
+            // already done against it, and re-basing mid-crawl would file one
+            // origin's content under another's name. It reports, and the
+            // apex/www scope rule keeps the crawl whole meanwhile. So it fires
+            // on a crawl that then succeeds, deliberately — the point is that
+            // the audit describes a host the site redirects away from, which is
+            // worth knowing whether or not the pages were reached.
+            // Second-strongest evidence: the host the seed page itself says it
+            // is. Gated on a successful response — an error page's canonical
+            // describes the error template, not the site.
+            if (entry.source === "seed" && result.status >= 200 && result.status < 300) {
+              // Resolved against the page, since a canonical may be relative.
+              let canonicalHost: string | null = null;
+              if (parsed.meta.canonical) {
+                try {
+                  canonicalHost = sameSiteHostOtherThanBase(
+                    new URL(parsed.meta.canonical, result.finalUrl).href,
+                  );
+                } catch {
+                  canonicalHost = null;
+                }
+              }
+              if (canonicalHost) {
+                yield* reportSeedBaseMismatch(canonicalHost, "declares a canonical on");
+              }
+
+              // Weakest evidence, and so the strictest test: a seed page that
+              // links to its own site but NEVER to the base host is the shape of
+              // the collapse. One stray same-site link proves nothing, so a
+              // single link back to the base is enough to stay silent.
+              //
+              // Read off `parsed.links`, not the crawlable set: that set is
+              // already filtered to the PAGE's own hostname, so on exactly the
+              // origin this is trying to describe — an apex serving the site
+              // while every link points at www — it is empty.
+              //
+              // `parsed.links` has already dropped `#`-only anchors and
+              // mailto:/tel: (`shouldSkipUrl`), so an in-page skip link cannot
+              // resolve onto the base host and veto this. Off-site links are
+              // ignored rather than counted either way: `elsewhere` only takes a
+              // SAME-SITE host, so a page linking to www plus a dozen other
+              // domains still reports, and reports the same-site host.
+              const baseHost = new URL(baseUrl).host.toLowerCase();
+              let elsewhere: string | null = null;
+              let onBase = false;
+              for (const link of parsed.links) {
+                let host: string;
+                try {
+                  host = new URL(link.url, result.finalUrl).host.toLowerCase();
+                } catch {
+                  continue;
+                }
+                if (host === baseHost) {
+                  onBase = true;
+                  break;
+                }
+                elsewhere ??= sameSiteHostOtherThanBase(new URL(link.url, result.finalUrl).href);
+              }
+              if (!onBase && elsewhere) {
+                // Not "links only to X": the page may link to several same-site
+                // hosts, and to any number of other sites. What was actually
+                // observed is that nothing points back at the base, and `elsewhere`
+                // is the first same-site host that does not.
+                yield* reportSeedBaseMismatch(
+                  elsewhere,
+                  "links to its own site without ever linking back to the base, for example at",
+                );
+              }
             }
 
             // Reuse document for URL extraction (no second parse)
@@ -2079,6 +2234,10 @@ export function createCrawler(
         prefixStats.clear();
         pendingDepth1Count = 0;
 
+        // A crawler instance can start more than one crawl, and the base moves
+        // with each; the previous crawl's report must not silence this one.
+        seedBaseMismatchReported = false;
+
         // Reset pattern stats for new crawl
         clearPatternStats(patternStats);
 
@@ -2535,6 +2694,9 @@ export function createCrawler(
         currentCrawlId = crawlId;
         isRunning = true;
         isPaused = false;
+        // A restart re-crawls from an empty frontier, so it is a fresh run for
+        // reporting purposes and must be able to say this again (#1899).
+        seedBaseMismatchReported = false;
 
         // Merge new config with existing
         const mergedConfig = { ...crawl.config, ...newConfig };

--- a/packages/crawler/src/core/types.ts
+++ b/packages/crawler/src/core/types.ts
@@ -3,7 +3,7 @@
 import type { DocumentFetcher } from "@squirrelscan/fetchers";
 import type { Stream, Effect } from "effect";
 
-import type { RedirectChain } from "@squirrelscan/core-contracts";
+import type { CrawlWarningCode, RedirectChain } from "@squirrelscan/core-contracts";
 
 import type { CrawlStorage, CrawlStats, StorageError } from "../storage/types";
 import type { TlsEvent } from "../fetcher";
@@ -204,6 +204,7 @@ export type CrawlerEvent =
   | CrawlerResumedEvent
   | CrawlerRateLimitedEvent
   | CrawlerCompletedEvent
+  | CrawlerWarningEvent
   | CrawlerErrorEvent;
 
 export interface CrawlerStartedEvent {
@@ -340,6 +341,21 @@ export interface CrawlerCompletedEvent {
   type: "completed";
   stats: CrawlStats;
   durationMs: number;
+  timestamp: number;
+}
+
+/**
+ * Something a human should see that did not stop the crawl (#1899).
+ *
+ * `code` is the machine key and lives in core-contracts, because THIS UNION IS A
+ * DUPLICATE of the one there: a consumer outside this package reads that copy,
+ * so an event added to one and not the other type-checks locally and is invisible
+ * to every consumer. Both must move together.
+ */
+export interface CrawlerWarningEvent {
+  type: "warning";
+  code: CrawlWarningCode;
+  message: string;
   timestamp: number;
 }
 

--- a/packages/crawler/tests/seed-base-collapse.test.ts
+++ b/packages/crawler/tests/seed-base-collapse.test.ts
@@ -17,7 +17,9 @@
 //      refused for reasons the crawler cannot fix.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { Effect } from "effect";
+import { Duration, Effect, Fiber, Stream } from "effect";
+
+import type { CrawlerEvent } from "@squirrelscan/core-contracts";
 
 import { createCrawler } from "../src/core/crawler";
 import type { CrawlerConfig } from "../src/core/types";
@@ -184,22 +186,50 @@ interface CrawlResult {
   fetched: string[];
   /** URLs the crawl came away with a stored 200 page for. */
   stored: string[];
+  /** Every `warning` event the crawl published. */
+  warnings: { code: string; message: string }[];
+  /**
+   * EVERY event seen. Without this a silent-warning assertion cannot tell "no
+   * warning was emitted" from "the subscription was never live", and would pass
+   * against a collector that saw nothing at all.
+   */
+  events: CrawlerEvent["type"][];
 }
 
 async function crawl(site: Record<string, Page>): Promise<CrawlResult> {
   const fetched: string[] = [];
   const fetcher = buildFetcher(site, fetched);
   const storage = new SQLiteStorage(":memory:");
+  const warnings: { code: string; message: string }[] = [];
+  const events: CrawlerEvent["type"][] = [];
   const stored = await Effect.runPromise(
     Effect.gen(function* () {
       yield* storage.init();
       const crawler = yield* createCrawler({ fetcher, storage, config: CONFIG });
+      // Subscribed BEFORE start(), or the seed page's warning is published to
+      // nobody and the assertion below passes against a crawler that never
+      // emits one.
+      const collector = yield* Stream.runForEach(
+        crawler.events.pipe(Stream.takeUntil((e) => e.type === "completed")),
+        (event: CrawlerEvent) =>
+          Effect.sync(() => {
+            events.push(event.type);
+            if (event.type === "warning") {
+              warnings.push({ code: event.code, message: event.message });
+            }
+          }),
+      ).pipe(Effect.fork);
+      yield* Effect.yieldNow();
       const crawlId = yield* crawler.start(`${APEX}/`, `${APEX}/`);
+      // Joined, not ignored: the collector ends when it sees `completed`, so a
+      // timeout here means the stream died or the crawl never completed, and
+      // both must fail the test rather than leave the arrays quietly short.
+      yield* Fiber.join(collector).pipe(Effect.timeout(Duration.seconds(10)));
       const pages = yield* storage.getPages(crawlId);
       return pages.filter((page) => page.status === 200).map((page) => page.normalizedUrl);
     }),
   );
-  return { fetched, stored };
+  return { fetched, stored, warnings, events };
 }
 
 describe("seed probe refused (#1899)", () => {
@@ -223,6 +253,126 @@ describe("seed probe refused (#1899)", () => {
     expect(stored).toContain(`${WWW}/b`);
     // The regression this pins: one page audited, a 150-page audit charged.
     expect(stored.length).toBe(3);
+  });
+
+  test("the crawl says out loud that its base is the wrong host", async () => {
+    // The second detector. The scope rule keeps the crawl whole, so without
+    // this the run looks entirely healthy while describing a host the site
+    // redirects away from — which is how this went unnoticed for weeks.
+    stubRefusedPreamble();
+    const { warnings } = await crawl({
+      [`${APEX}/`]: { body: linksTo(`${WWW}/a`), finalUrl: `${WWW}/` },
+      [`${WWW}/a`]: { body: linksTo() },
+    });
+
+    expect(warnings.map((w) => w.code)).toEqual(["seed-base-mismatch"]);
+    expect(warnings[0]?.message).toContain("example.com");
+    expect(warnings[0]?.message).toContain("www.example.com");
+  });
+
+  test("a canonical on the other host raises it even when the fetch did not redirect", async () => {
+    // An apex that serves the site rather than redirecting still tells us which
+    // host it considers canonical, and that is the same mistake.
+    stubRefusedPreamble();
+    const body =
+      `<!doctype html><html><head><link rel="canonical" href="${WWW}/"></head>` +
+      `<body><a href="${WWW}/a">link</a></body></html>`;
+    const { warnings } = await crawl({
+      [`${APEX}/`]: { body },
+      [`${WWW}/a`]: { body: linksTo() },
+    });
+
+    expect(warnings.map((w) => w.code)).toEqual(["seed-base-mismatch"]);
+    expect(warnings[0]?.message).toContain("canonical");
+  });
+
+  test("a seed page that links only to the other host raises it with no canonical", async () => {
+    // The weakest of the three signals and the one the tech lead asked for by
+    // name. No redirect, no canonical: only the navigation gives it away.
+    stubRefusedPreamble();
+    const { warnings } = await crawl({
+      [`${APEX}/`]: { body: linksTo(`${WWW}/a`, `${WWW}/b`) },
+      [`${WWW}/a`]: { body: linksTo() },
+      [`${WWW}/b`]: { body: linksTo() },
+    });
+
+    expect(warnings.map((w) => w.code)).toEqual(["seed-base-mismatch"]);
+    expect(warnings[0]?.message).toContain("without ever linking back to the base");
+  });
+
+  test("an in-page anchor or mailto link cannot veto the link evidence", async () => {
+    // `parsed.links` drops `#`-only hrefs and non-crawlable schemes before this
+    // sees them, so a skip link resolving onto the base host cannot silence it.
+    // Pinned because it would be a silent false negative on almost every real
+    // page, and nothing in this file would otherwise notice the day it changes.
+    stubRefusedPreamble();
+    const body =
+      `<!doctype html><html><body><a href="#main">skip</a>` +
+      `<a href="mailto:hi@example.com">mail</a><a href="${WWW}/a">link</a></body></html>`;
+    const { warnings } = await crawl({
+      [`${APEX}/`]: { body },
+      [`${WWW}/a`]: { body: linksTo() },
+    });
+
+    expect(warnings.map((w) => w.code)).toEqual(["seed-base-mismatch"]);
+  });
+
+  test("links to unrelated sites neither trigger nor suppress it", async () => {
+    stubRefusedPreamble();
+    const body =
+      `<!doctype html><html><body><a href="https://other.test/x">out</a>` +
+      `<a href="${WWW}/a">link</a></body></html>`;
+    const { warnings } = await crawl({
+      [`${APEX}/`]: { body },
+      [`${WWW}/a`]: { body: linksTo() },
+    });
+
+    // The reported host is the SAME-SITE one, never the unrelated domain.
+    expect(warnings.map((w) => w.code)).toEqual(["seed-base-mismatch"]);
+    expect(warnings[0]?.message).toContain("www.example.com");
+    expect(warnings[0]?.message).not.toContain("other.test");
+  });
+
+  test("one link back to the base is enough to stay silent", async () => {
+    // A single same-site link elsewhere proves nothing. Only a seed page that
+    // never links to its own base has the shape of the collapse.
+    stubRefusedPreamble();
+    const { warnings } = await crawl({
+      [`${APEX}/`]: { body: linksTo(`${APEX}/a`, `${WWW}/b`) },
+      [`${APEX}/a`]: { body: linksTo() },
+      [`${WWW}/b`]: { body: linksTo() },
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  test("a crawl whose base agrees with the seed page stays quiet", async () => {
+    stubRefusedPreamble();
+    const { warnings, events } = await crawl({
+      [`${APEX}/`]: { body: linksTo(`${APEX}/a`) },
+      [`${APEX}/a`]: { body: linksTo() },
+    });
+
+    expect(warnings).toEqual([]);
+    // Proves the silence is the crawler's and not a dead subscription.
+    expect(events).toContain("page:fetched");
+    expect(events).toContain("completed");
+  });
+
+  test("it reports once, not once per source of evidence", async () => {
+    // The seed here redirects to www AND canonicalises there AND links only
+    // there. All three detectors see it; one warning comes out.
+    stubRefusedPreamble();
+    const body =
+      `<!doctype html><html><head><link rel="canonical" href="${WWW}/"></head>` +
+      `<body><a href="${WWW}/a">link</a></body></html>`;
+    const { warnings } = await crawl({
+      [`${APEX}/`]: { body, finalUrl: `${WWW}/` },
+      [`${WWW}/a`]: { body: linksTo() },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain("landed on");
   });
 
   test("the seed probe identifies itself with the crawl's user agent", async () => {


### PR DESCRIPTION
The second detector for squirrelscan/repo#1899, requested after #248 merged.

#248 stopped a mis-pinned base from collapsing the crawl to one page. That fixed the damage but not the silence: the audit still describes a host the site redirects away from, and now it does so while looking entirely healthy. That silence is how this went unnoticed for weeks, and how a paying customer was charged in full for a one-page audit of a ten-page site.

## What it detects

The base is pinned from one probe of the seed before anything is fetched. The seed page's own fetch is the first thing that can contradict it, and three things about it are evidence, in descending strength:

1. **Where the fetch landed.** Outside the HTML branch and needing no body, so a seed serving a PDF still proves which host the site is on.
2. **The canonical the page declares.** Resolved against the page since it may be relative, and only on a 2xx: an error page's canonical describes the error template, not the site.
3. **The page's links**, when not one of them points back at the base. Read off `parsed.links` rather than the crawlable set, because that set is already filtered to the page's own hostname and so is empty on exactly the origin this describes: an apex serving the site while every link points at `www`. One link home is enough to stay silent.

A different **site** is not this. That is the #1418 case, refused deliberately by `resolveSeedRedirect` and logged where it happens; repeating it here would turn a security decision into a bug report.

It reports once per crawl and does not move the base. It cannot: the root probes have already run against it, and re-basing mid-crawl would file one origin's content under another's name. So it fires on crawls that then succeed, deliberately. The message states what was observed and offers the missed redirect as the likely cause rather than asserting it, since an apex can serve content and canonicalise elsewhere without ever redirecting.

## Why an event and not just a log line

`logger.warn` reaches a terminal or a container's stdout, neither of which is where a hosted run is investigated weeks later. This rides the event stream the run already records, on a new `warning` member of `CrawlerEvent`.

Two things a reviewer should know:

- **`CrawlerEvent` is duplicated**, in `packages/core-contracts/src/index.ts` and in the crawler's own `src/core/types.ts`. Consumers outside the crawler package read the core-contracts copy, so an event added to one and not the other type-checks locally and is invisible to every consumer. Both move here, and the shared `CrawlWarningCode` keeps the machine key from drifting.
- **No consumer handles the type yet**, so it is currently inert: the CLI switches handle only `page:*`, `progress`, `completed`, `started`, `resumed` and `url:*`, and the hosted container forwards only `progress`, `page:fetched` and `page:failed`. A small handler on the private side is what lands it in `agent_run_events`, and is tracked separately.

## Tests

`packages/crawler/tests/seed-base-collapse.test.ts` grows to 21 cases, covering each detector, the once-per-crawl guard, and the cases that must stay silent: a base that agrees with its seed page, one link back to the base, an in-page anchor or `mailto:` that must not veto the link evidence, and unrelated domains that must neither trigger it nor be named in the message.

The collector now records every event type and joins its fiber with a failing timeout instead of ignoring it, so a silent-warning assertion can no longer pass against a dead subscription. The silent case asserts it saw `page:fetched` and `completed`.

Two codex rounds on the diff; every finding addressed or answered with evidence. The fragment-veto concern turned out not to be reachable, because `shouldSkipUrl` drops `#`-only hrefs and non-crawlable schemes before `parsed.links` is built, and there is now a test pinning that.

Green locally: the new suite, plus `seed-redirect-pinning`, `carried-seed-crawl`, `full-crawl-harness`, `trailing-slash-canonical-crawl`, `incremental-freshness`, `sitemap-gate`, `rate-limit-crawl`, `slow-origin-crawl`, `injectable-cache-store`, `deterministic-ordering`. `tsgo --noEmit` clean for the crawler and the CLI, oxfmt and oxlint clean.

Refs squirrelscan/repo#1899
