### PR TITLE
test(audit-engine): give the detach memory tests a control they can survive CI with

### DIFF
--- a/packages/audit-engine/tests/detach-from-page.test.ts
+++ b/packages/audit-engine/tests/detach-from-page.test.ts
@@ -9,68 +9,62 @@
 //
 // This is invisible to every obvious measure — `JSON.stringify(x).length` sees
 // the logical size, and RSS sees nothing because the arena absorbs it — so it
-// needs a test that looks at `heapUsed` directly. A production run held ~8 MB
+// needs a test that looks at the allocator directly. A production run held ~8 MB
 // per page while a local census of the same structures reported 96 KB.
+//
+// The measurement itself lives in helpers/retention.ts, which explains why it
+// reads `external` rather than `heapUsed`, why it subtracts a retain-nothing
+// control, and why an unusable run fails rather than passing quietly.
 
 import { describe, expect, test } from "bun:test";
 
 import { detachCounts, detachFromPage, resetDetachCounts } from "../src/detach";
+import { compareRetention, expectDetached, MB } from "./helpers/retention";
 
 /**
- * Retained bytes after holding `n` copies of what `make` returns.
+ * A page-sized string and a small slice of it, as a parse would produce.
  *
- * heapUsed + external, not heapUsed alone: a string's backing store is not on
- * the JS heap, and a slice pins the BUFFER, not a heap object. Measured on
- * heapUsed by itself the attached control reported 0 KB/item, which sent this
- * test down its INCONCLUSIVE branch on every run — green, and asserting
- * nothing.
+ * Built from per-source UNIQUE chunks rather than one repeated character: JSC
+ * ropes share backing storage, so a corpus made with `.repeat()` is nearly free
+ * to hold and the attached arm would look detached.
  */
-function retainedPerItem(n: number, make: (i: number) => unknown): number {
-  Bun.gc(true);
-  const before = process.memoryUsage();
-  const kept: unknown[] = [];
-  for (let i = 0; i < n; i++) kept.push(make(i));
-  Bun.gc(true);
-  const after = process.memoryUsage();
-  const grown = after.heapUsed - before.heapUsed + (after.external - before.external);
-  // Touch `kept` after the sample so it cannot be collected early.
-  expect(kept.length).toBe(n);
-  return grown / n;
-}
-
-/** A page-sized string and a small slice of it, as a parse would produce. */
-function pageAndSlice(i: number): { page: string; slice: string } {
-  const page = `<html><body>${"a".repeat(500_000)}${i}</body></html>`;
+function pageAndSlice(i: number, bytes: number): { page: string; slice: string } {
+  const chunk = 20_000;
+  const body = Array.from(
+    { length: Math.max(1, Math.ceil(bytes / chunk)) },
+    (_, k) => `${i}-${k} `.padEnd(chunk, "abcdefghij"),
+  ).join("");
+  const page = `<html><body>${body}</body></html>`;
   return { page, slice: page.slice(120, 180) };
 }
 
-const KB = 1024;
-
 describe("detachFromPage", () => {
   test("a raw slice of a page retains the page; a detached copy does not", () => {
-    const N = 80;
-    const attached = retainedPerItem(N, (i) => ({ text: pageAndSlice(i).slice }));
-    const detached = retainedPerItem(N, (i) => detachFromPage({ text: pageAndSlice(i).slice }, "page-rules"));
+    // Three arms with a retain-nothing control subtracted, on multi-megabyte
+    // sources — see helpers/retention.ts. The previous version compared the two
+    // real arms against each other on 500 KB pages and, when they landed on top
+    // of one another, printed INCONCLUSIVE and passed. It did that on every run.
+    const N = 48;
+    const SOURCE_BYTES = 6_000_000;
 
-    // The measurement itself is environment-dependent: a collector that absorbs
-    // the allocation reports no growth for EITHER case, and a review pass saw
-    // exactly that. Comparing two zeroes proves nothing, and asserting anything
-    // at all in that state would report a pass the run did not earn — so this
-    // says INCONCLUSIVE out loud and asserts nothing. The deterministic
-    // guarantees are the tests below plus detach-production-boundaries.test.ts.
-    if (attached < 100 * KB) {
-      console.warn(
-        `[detach] INCONCLUSIVE: control retained only ${Math.round(attached / KB)} KB/item, ` +
-          `so this run did not demonstrate the retention it is meant to catch.`,
-      );
-      return;
-    }
+    const result = compareRetention({
+      iterations: N,
+      // The control builds the same source and takes the same slice, then keeps
+      // only its length: the allocation is identical, the retention is not.
+      control: (i) => pageAndSlice(i, SOURCE_BYTES).slice.length,
+      attached: (i) => ({ text: pageAndSlice(i, SOURCE_BYTES).slice }),
+      detached: (i) => detachFromPage({ text: pageAndSlice(i, SOURCE_BYTES).slice }, "page-rules"),
+    });
 
-    // Attached holds something on the order of the page; detached, of the slice.
-    // A ratio rather than absolute bytes, so this is not pinned to one engine's
-    // object layout.
-    expect(detached).toBeLessThan(attached / 4);
-  });
+    // Attached holds something on the order of the source; detached, of the
+    // slice. A ratio rather than absolute bytes, so this is not pinned to one
+    // engine's object layout.
+    expectDetached(result, {
+      marginBytes: 150 * MB,
+      ratio: 4,
+      label: `raw slices of ${N} sources of ${(SOURCE_BYTES / MB).toFixed(0)} MB`,
+    });
+  }, 300_000);
 
   test("preserves Sets, which a JSON round-trip would silently empty", () => {
     // PageFingerprint carries Sets. `JSON.parse(JSON.stringify(x))` also detaches

--- a/packages/audit-engine/tests/detach-production-boundaries.test.ts
+++ b/packages/audit-engine/tests/detach-production-boundaries.test.ts
@@ -32,6 +32,7 @@ import {
   type SiteContextPage,
 } from "../src/adapter";
 import { extractLinks } from "@squirrelscan/parser";
+import { compareRetention, expectDetached, MB } from "./helpers/retention";
 import { detachCounts, detachFromPage, detachParsedPage, resetDetachCounts } from "../src/detach";
 
 function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
@@ -237,56 +238,65 @@ describe("detach at the production boundaries", () => {
   }, 120_000);
 
   test("absorbing from a page-sized document does not retain the document", () => {
-    // The assertions above cannot see the thing this change is for: the values
-    // are identical whether or not they are attached. So this measures on
-    // page-sized inputs, with the same INCONCLUSIVE guard
-    // detach-from-page.test.ts uses — a run where the control retains nothing
-    // demonstrates nothing, and asserting on it would report a pass it did not
-    // earn.
+    // Three arms over the SAME pages, differing only in what they keep, with
+    // the retain-nothing arm subtracted from the other two. See
+    // helpers/retention.ts for why external rather than heapUsed, why the
+    // control is not optional, and why an unusable run fails instead of
+    // passing quietly.
     //
-    // heapUsed + external, not heapUsed alone: a string's backing store is not
-    // on the JS heap, and a slice pins the BUFFER. Measuring heapUsed by itself
-    // reports 0 KB/page for the attached control and makes this test
-    // permanently inconclusive.
-    // Page-SIZED, and few enough that the transient DOMs stay modest: a real
-    // drscholls page is ~959 KB, and the retention this catches is proportional
-    // to the source buffer, so a small fixture makes the control indistinguishable
-    // from noise (a 300 KB one measured 30 KB/page and stayed inconclusive).
-    const N = 30;
+    // MULTI-MEGABYTE pages, few of them. The retention is proportional to the
+    // source buffer, and a shared CI runner moves by tens of MB on its own, so
+    // the fixture is sized to put the attached arm hundreds of MB clear rather
+    // than tens — an earlier ~900 KB version landed the two arms within 2% of
+    // each other on CI and went red. The markup is deliberately node-POOR:
+    // what has to be large is the buffer a slice can pin, and a page of the
+    // same weight in small elements costs several times as much to hold as a
+    // live DOM for no extra signal.
+    // 48 pages of 6 MB. Sized from the measurement rather than guessed: 24
+    // pages of 3.8 MB put the attached arm 82 MB above the control and the
+    // detached arm on top of it, so this scales the source until the attached
+    // figure is comfortably past the margin while the whole test still runs in
+    // seconds and the process stays a few hundred MB.
+    const PAGES = 48;
+    const PAGE_BYTES = 6_000_000;
 
-    function retainedPerPage(
-      absorb: (target: ExternalLinkOccurrences, ctx: SiteContextPage[]) => void,
-    ): number {
-      Bun.gc(true);
-      const before = process.memoryUsage();
-      const target: ExternalLinkOccurrences = new Map();
-      for (let i = 0; i < N; i++) absorb(target, externalLinkPage(i, 900_000));
-      Bun.gc(true);
-      const after = process.memoryUsage();
-      const grown = after.heapUsed - before.heapUsed + (after.external - before.external);
-      expect(target.size).toBe(N); // touch it after the sample
-      return grown / N;
-    }
+    const result = compareRetention({
+      iterations: PAGES,
+      control: (i) => {
+        // Parses and extracts exactly as the other arms do, and keeps only a
+        // count. Everything the parse costs is in all three arms.
+        let seen = 0;
+        for (const { page, parsed } of externalLinkPage(i, PAGE_BYTES)) {
+          if (!parsed?.document) continue;
+          for (const link of extractLinks(parsed.document, page.finalUrl)) {
+            if (!link.isInternal && link.href) seen++;
+          }
+        }
+        return seen;
+      },
+      attached: (i) => {
+        const target: ExternalLinkOccurrences = new Map();
+        absorbAttached(target, externalLinkPage(i, PAGE_BYTES));
+        return target;
+      },
+      detached: (i) => {
+        const target: ExternalLinkOccurrences = new Map();
+        absorbExternalLinkOccurrences(target, externalLinkPage(i, PAGE_BYTES));
+        return target;
+      },
+    });
 
-    // Warm both paths before measuring either. The first arm to run pays for
-    // the parser's one-time structures, which on this fixture is hundreds of KB
-    // per page — enough to make whichever arm goes first look like the leaker.
-    retainedPerPage(absorbExternalLinkOccurrences);
-    retainedPerPage(absorbAttached);
-
-    const detached = retainedPerPage(absorbExternalLinkOccurrences);
-    const attached = retainedPerPage(absorbAttached);
-
-    const KB = 1024;
-    if (attached < 100 * KB) {
-      console.warn(
-        `[detach] INCONCLUSIVE: control retained only ${Math.round(attached / KB)} KB/page, ` +
-          `so this run did not demonstrate the retention it is meant to catch.`,
-      );
-      return;
-    }
-    expect(detached).toBeLessThan(attached / 4);
-  }, 120_000);
+    // 150 MB of margin against a runner that moves by ~50, and a 4x ratio: the
+    // detached arm holds the link data, which is kilobytes, so anything near
+    // the attached figure means a page is still pinned.
+    expectDetached(result, {
+      marginBytes: 150 * MB,
+      ratio: 4,
+      label:
+        `external-link occurrences over ${PAGES} pages of ` +
+        `${(PAGE_BYTES / MB).toFixed(0)} MB`,
+    });
+  }, 300_000);
 });
 
 /**
@@ -300,9 +310,14 @@ function externalLinkPage(i: number, fillerChars: number): SiteContextPage[] {
   // Long text per node rather than many tiny nodes: the size that matters here
   // is the html BUFFER, and a node-dense page of the same byte count costs
   // several times as much to hold as a live DOM for no extra signal.
-  const chunk = 200;
+  //
+  // Each chunk starts with its own page and chunk number, so no two pages share
+  // a backing store. A corpus built by repeating one string is nearly free to
+  // hold — JSC ropes share storage — and would make the attached arm look
+  // detached.
+  const chunk = 20_000;
   const filler = Array.from(
-    { length: Math.ceil(fillerChars / (chunk + 24)) },
+    { length: Math.max(1, Math.ceil(fillerChars / (chunk + 7))) },
     (_, k) => `<p>${`${i}-${k} `.padEnd(chunk, "abcdefghij")}</p>`,
   ).join("");
   const html =

--- a/packages/audit-engine/tests/helpers/retention.ts
+++ b/packages/audit-engine/tests/helpers/retention.ts
@@ -1,0 +1,139 @@
+// Measuring "does this still hold the page it came from" without flaking (#1860).
+//
+// The detach tests assert a memory property, and the values are identical
+// whether or not the retention is there, so nothing else can see it. A first
+// version of this compared an attached arm against a detached arm on ~900 KB
+// pages and went red on a shared CI runner at 541,604 against 531,770 bytes —
+// the two arms landed on top of each other, which is what runner noise looks
+// like, not a regression.
+//
+// Four things make the measurement survive that.
+//
+// EXTERNAL, NOT heapUsed. A JS string's characters live in a backing store off
+// the JS heap, and a slice pins the BUFFER rather than a heap object. `heapUsed`
+// therefore moves by almost nothing for the case being caught: measured on a
+// 150-page fixture, the attached arm's `external` was 287 MB against a control's
+// 100 MB while the two heaps were 143 and 131 MB. Reading heapUsed makes the
+// signal a rounding error on the noise.
+//
+// A RETAIN-NOTHING CONTROL, SUBTRACTED. Every arm parses the same pages and runs
+// the same extraction; only what it keeps differs. The control's cost — the
+// parser's structures, the transient DOMs, the arena's growth — is present in
+// all three and is worth hundreds of MB on a fixture this size. Subtracting it
+// is what turns three large numbers into one small difference and one large one.
+//
+// A FIXTURE BIG ENOUGH TO BEAT THE RUNNER. The retention is proportional to the
+// source buffer, so the fixture is sized to put the attached arm hundreds of MB
+// above the control rather than tens. A shared runner moves by ±50 MB for
+// reasons that have nothing to do with the code.
+//
+// AND A LOUD FAILURE WHEN THE MEASUREMENT DID NOT WORK. If the attached arm is
+// not clear of the control by the margin, this reports that and fails, rather
+// than returning early and passing. An inconclusive run that reports success is
+// worse than a red one: the earlier version of these tests did exactly that, on
+// every run, for a week.
+
+import { expect } from "bun:test";
+
+export const MB = 1024 * 1024;
+
+/** One arm's retained bytes, and enough context to explain a bad run. */
+export interface RetentionMeasurement {
+  /** `external` growth across the arm, after a synchronous collect at each end. */
+  readonly externalBytes: number;
+  /** Kept alive until the sample is taken; exported so a caller can assert on it. */
+  readonly kept: number;
+}
+
+/**
+ * Run one arm: `build` is called `iterations` times and whatever it returns is
+ * retained until after the sample.
+ *
+ * The collect at both ends is synchronous (`Bun.gc(true)`): JSC grows the heap
+ * in preference to collecting, so an opportunistic collect leaves the arm's
+ * garbage in the number and makes every arm look like a leak.
+ */
+export function measureArm(iterations: number, build: (i: number) => unknown): RetentionMeasurement {
+  Bun.gc(true);
+  const before = process.memoryUsage().external;
+  const kept: unknown[] = [];
+  for (let i = 0; i < iterations; i++) kept.push(build(i));
+  Bun.gc(true);
+  const after = process.memoryUsage().external;
+  // Touched AFTER the sample so nothing here can be collected early.
+  expect(kept.length).toBe(iterations);
+  return { externalBytes: after - before, kept: kept.length };
+}
+
+export interface RetentionComparison {
+  /** Attached minus control — the retention the test exists to catch. */
+  readonly attachedBytes: number;
+  /** Detached minus control — what is left after the fix. */
+  readonly detachedBytes: number;
+  readonly controlBytes: number;
+}
+
+/**
+ * The three arms, warmed, in a fixed order, with the control subtracted.
+ *
+ * Order matters and is why the warm-up is not optional: whichever arm runs
+ * first pays for the parser's one-time structures, which on a page-sized
+ * fixture is enough to make it look like the leaker. Both real arms are run
+ * once and discarded before anything is recorded.
+ */
+export function compareRetention(opts: {
+  iterations: number;
+  control: (i: number) => unknown;
+  attached: (i: number) => unknown;
+  detached: (i: number) => unknown;
+}): RetentionComparison {
+  measureArm(Math.max(1, Math.floor(opts.iterations / 4)), opts.attached);
+  measureArm(Math.max(1, Math.floor(opts.iterations / 4)), opts.detached);
+
+  const control = measureArm(opts.iterations, opts.control);
+  const attached = measureArm(opts.iterations, opts.attached);
+  const detached = measureArm(opts.iterations, opts.detached);
+
+  return {
+    controlBytes: control.externalBytes,
+    attachedBytes: attached.externalBytes - control.externalBytes,
+    detachedBytes: detached.externalBytes - control.externalBytes,
+  };
+}
+
+/**
+ * Assert the detached arm holds a small fraction of what the attached arm does.
+ *
+ * `marginBytes` is how far clear of the control the attached arm must be for
+ * the run to count. Below that the comparison is measuring the runner, so this
+ * FAILS and says so — the alternative is a green run that asserted nothing,
+ * which is how the retention this catches survived three rounds of looking.
+ */
+export function expectDetached(
+  result: RetentionComparison,
+  opts: { marginBytes: number; ratio: number; label: string },
+): void {
+  const mb = (bytes: number) => `${(bytes / MB).toFixed(0)} MB`;
+  // Signed, because a control-subtracted arm can legitimately come out slightly
+  // negative and "+-1 MB" reads like a formatting bug rather than a number.
+  const signed = (bytes: number) => `${bytes < 0 ? "-" : "+"}${mb(Math.abs(bytes))}`;
+  const summary =
+    `${opts.label}: control ${mb(result.controlBytes)}, ` +
+    `attached ${signed(result.attachedBytes)}, detached ${signed(result.detachedBytes)}`;
+
+  // Printed on every run, pass or fail. When this does flake, the three numbers
+  // are the whole diagnosis, and a green CI log that recorded nothing leaves
+  // the next person re-deriving them.
+  console.log(`[retention] ${summary} (margin ${mb(opts.marginBytes)}, ratio ${opts.ratio}x)`);
+
+  if (result.attachedBytes < opts.marginBytes) {
+    throw new Error(
+      `${summary} — the attached arm is not clear of the control by the ${mb(opts.marginBytes)} ` +
+        `margin, so this run did not reproduce the retention and cannot judge the fix. ` +
+        `That is a measurement failure, not a regression: check whether the fixture still ` +
+        `produces slices of a flat source string, and whether the runner has memory to spare.`,
+    );
+  }
+
+  expect(result.detachedBytes).toBeLessThan(result.attachedBytes / opts.ratio);
+}


### PR DESCRIPTION
Tests only. Fixes the flake that took #240 red on run 34139295533.

## What failed and why

`absorbing from a page-sized document does not retain the document` failed with 541,604 bytes against an expected 531,770 — the attached and detached arms landing within 2% of each other on a shared runner. That is noise, not the fix regressing: it passed locally and on the pre-rebase run.

**The measurement had no control.** It compared the two real arms directly, so the parse, the transient DOMs and the arena's growth were inside both numbers, and the difference it asserted on was a couple of percent of each. On a quiet machine that works; on a shared runner the two numbers touch.

Its sibling in `detach-from-page.test.ts` had the same shape with a worse failure mode: when the arms collapsed it printed INCONCLUSIVE and **passed**. It had been doing that on every run since it was written, so the second memory gate in this area has been asserting nothing.

## The harness

`tests/helpers/retention.ts`, used by both:

- **`external`, not `heapUsed`.** A string's characters live in a backing store off the JS heap, and a slice pins the buffer rather than a heap object. Measured on a 150-page fixture, the attached arm's `external` was 287 MB against a control's 100 MB while the two heaps were 143 and 131. Reading `heapUsed` makes the signal a rounding error on the noise.
- **A retain-nothing arm, subtracted.** Every arm builds the same sources and runs the same extraction; only what it keeps differs.
- **Multi-megabyte sources, deliberately node-poor.** What has to be large is the buffer a slice can pin; a page of the same weight in small elements costs several times as much to hold as a live DOM for no extra signal. Sized from measurement rather than guessed: 24 pages of 3.8 MB put the attached arm 82 MB clear of the control, 48 of 6 MB put it at 234.
- **An unusable run fails loudly.** If the attached arm is not clear of the control by the margin, the test reports the three numbers and fails, saying it is a measurement failure rather than a regression. The alternative is the INCONCLUSIVE branch that has been passing for a week.

Both fixtures build from per-source unique chunks. A corpus made with `.repeat()` is nearly free to hold, because JSC ropes share backing storage, and the attached arm would look detached.

## Numbers

Three consecutive local runs, both tests, against a 150 MB margin and a 4x ratio:

| test | control | attached | detached |
|---|---|---|---|
| external-link occurrences, 48 x 6 MB | 0-1 MB | +234 MB | within 1 MB of 0 |
| raw slices, 48 x 6 MB | 0 MB | +275 MB | +0 MB |

The three numbers are printed on every run, pass or fail, so the next flake comes with its own diagnosis instead of leaving someone to re-derive it.

With the `detachFromPage` call site deleted, the detached arm jumps to +243 MB and the assertion fails, so the test still catches the thing it was written for.
