### PR TITLE
perf(cli): run the audit's post-crawl phases on the streaming pipeline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -246,7 +246,7 @@
         "filename": "docs/cli/debug.mdx",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 146
       }
     ],
     "packages/audit-engine/tests/fingerprint-parity.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-03T22:14:20Z"
+  "generated_at": "2026-09-07T19:26:19Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ How it works:
 - Use `###` (or deeper) for sub-sections within an entry — a `## ` heading marks a new version.
 - A `## [Unreleased]
 
+## [Unreleased]
+
+### Changed
+
+- **A local audit no longer holds the whole site in memory.** The CLI's
+  post-crawl phases ran the resident pipeline: one parsed page plus its DOM per
+  crawled page, held from the end of the crawl through the entire rules pass,
+  and a second full read of every page to assemble the report. Retained heap
+  grew about 1.5 MB per crawled page, so a 2,500-page audit ended holding 3.9 GB
+  while the operating system's "resident" figure read a reassuring 1.4 GB.
+  Every phase after the crawl now walks the pages table in batches sized to the
+  site and drops each batch before reading the next, which is what the hosted
+  runtime has done since v0.0.91. Reports are unchanged, page for page.
+
+  Batch size follows the site's own average page against a byte budget.
+  `SQUIRREL_STREAM_BATCH_BYTES` sets that budget (48 MB of raw HTML by default)
+  and `SQUIRREL_STREAM_BATCH_PAGES` pins an exact page count instead. Turning
+  the budget below roughly a dozen pages' worth is counterproductive: the same
+  crawl becomes several times as many read-parse-collect cycles and peaks
+  higher, not lower.
+
 ## v0.0.91
 
 A release about big sites. A 500-page audit of a store whose pages weigh a

--- a/apps/cli/src/audit/adapter.ts
+++ b/apps/cli/src/audit/adapter.ts
@@ -3,9 +3,14 @@
 
 import {
   generateReportFromStorage as generateReportFromStorageCore,
+  resolveStreamBatch,
   runRulesOnStorage as runRulesOnStorageCore,
+  runStreamingPreRules as runStreamingPreRulesCore,
+  runStreamingRules as runStreamingRulesCore,
   setAdapterLogger,
+  STREAM_BATCH_BYTES,
   type AdapterLogger,
+  type StreamingRulePhase,
 } from "@squirrelscan/audit-engine";
 import {
   detectPageType,
@@ -191,6 +196,11 @@ export {
   releaseSiteContextDocuments,
   ensureSiteContextDocuments,
 } from "@squirrelscan/audit-engine";
+
+// Batch sizing for the streamed passes (#1913) — same helper and same default
+// byte budget the hosted runtime resolves its batch from.
+export { resolveStreamBatch, STREAM_BATCH_BYTES };
+export type { StreamPreRulesResult } from "@squirrelscan/audit-engine";
 
 // ============================================
 // PARSED PAGE CONVERSION
@@ -799,6 +809,39 @@ export function fetchResourceAssets(
     return result;
   });
 }
+
+/**
+ * Streamed twin of {@link runRulesOnStorage} — the live CLI rules path (#1913).
+ *
+ * Delegates to the same engine function the hosted runtime uses: DOM residency
+ * is one page batch instead of one per crawled page, and the report it feeds is
+ * byte-identical (the engine's canonical-vs-streaming golden and its 518-page
+ * baseline gate that). Wired here rather than called directly so the CLI keeps
+ * one seam onto the engine and its logger stays injected.
+ */
+export function runStreamingRules(
+  storage: import("@/crawler/storage/sqlite").SQLiteStorage,
+  crawlId: string,
+  config: Config,
+  assets: PreFetchedAssets,
+  scope?: RunnerScope,
+  opts?: {
+    batchSize?: number;
+    onPhase?: (phase: StreamingRulePhase, boundary: "start" | "end") => void;
+  }
+): Effect.Effect<RuleExecutionResult, never, never> {
+  return runStreamingRulesCore(storage, crawlId, config, assets, scope, opts);
+}
+
+export type { StreamingRulePhase };
+
+/**
+ * Streamed pre-rules phase (#1913) — the batched walk that replaces
+ * `buildSiteContext` + {@link checkExternalLinksOnStorage} +
+ * {@link fetchResourceAssets} over a whole-crawl page array. Same delegating
+ * seam as {@link runStreamingRules}.
+ */
+export const runStreamingPreRules = runStreamingPreRulesCore;
 
 // runRulesOnStorage lives once in @squirrelscan/audit-engine (#145); this CLI
 // wrapper delegates to the shared core (CLI logger injected at module load).

--- a/apps/cli/src/audit/cloud-payloads-blocklist.ts
+++ b/apps/cli/src/audit/cloud-payloads-blocklist.ts
@@ -2,6 +2,8 @@
 // artifacts. Pure CLI-shape adaptation — the credit-gated call itself is
 // dispatched by the cloud prefetch phase (@squirrelscan/audit-engine).
 
+import { detachFromPage } from "@squirrelscan/audit-engine";
+
 import type { SiteContextPage } from "@/audit/adapter";
 
 import { getHostname } from "@/utils/url";
@@ -21,20 +23,40 @@ function isHttpUrl(url: string): boolean {
 /** Collect external resource/link urls: anchors, images, script srcs. */
 function collectUrls(siteContext: SiteContextPage[]): string[] {
   const urls = new Set<string>();
+  absorbUrls(urls, siteContext);
+  return [...urls];
+}
 
+/**
+ * {@link collectUrls}' body accumulating into a caller-owned set, so the
+ * streamed pre-rules walk can feed it one page batch at a time (#1913). The
+ * MAX_URLS cap is a set-size test, so stopping at a batch boundary and resuming
+ * on the next visits exactly the sequence one whole-array pass would.
+ *
+ * Every url added is a slice of the page's html, and a retained slice pins that
+ * page's whole backing store (#240) — invisible in `heapUsed`, visible in
+ * `external`. In the resident path the page was live anyway; on the streamed
+ * path the batch is dropped right after this returns, so each kept url is
+ * detached from it.
+ */
+export function absorbUrls(
+  urls: Set<string>,
+  siteContext: SiteContextPage[]
+): void {
   for (const { page, parsed } of siteContext) {
     if (!parsed || page.status < 200 || page.status >= 300) continue;
     const pageHost = getHostname(page.url);
 
     for (const link of parsed.links) {
-      if (urls.size >= MAX_URLS) return [...urls];
-      if (!link.isInternal && isHttpUrl(link.url)) urls.add(link.url);
+      if (urls.size >= MAX_URLS) return;
+      if (!link.isInternal && isHttpUrl(link.url))
+        urls.add(detachFromPage(link.url, "cloud-payload"));
     }
 
     for (const image of parsed.images) {
-      if (urls.size >= MAX_URLS) return [...urls];
+      if (urls.size >= MAX_URLS) return;
       if (isHttpUrl(image.src) && getHostname(image.src) !== pageHost)
-        urls.add(image.src);
+        urls.add(detachFromPage(image.src, "cloud-payload"));
     }
 
     // ParsedPage carries no script list — pull external script srcs (the most
@@ -42,25 +64,49 @@ function collectUrls(siteContext: SiteContextPage[]): string[] {
     const doc = parsed.document;
     if (!doc) continue;
     for (const script of doc.querySelectorAll("script[src]")) {
-      if (urls.size >= MAX_URLS) return [...urls];
+      if (urls.size >= MAX_URLS) return;
       const src = script.getAttribute("src");
-      if (src && isHttpUrl(src) && getHostname(src) !== pageHost) urls.add(src);
+      if (src && isHttpUrl(src) && getHostname(src) !== pageHost)
+        urls.add(detachFromPage(src, "cloud-payload"));
     }
   }
-
-  return [...urls];
 }
 
 /** Collect simple `.class` / `#id` selectors present on the first pages. */
 function collectSelectors(siteContext: SiteContextPage[]): string[] {
-  const selectors = new Set<string>();
-  let pagesScanned = 0;
+  const state = createSelectorState();
+  absorbSelectors(state, siteContext);
+  return [...state.selectors];
+}
 
+export interface SelectorState {
+  selectors: Set<string>;
+  pagesScanned: number;
+}
+
+export function createSelectorState(): SelectorState {
+  return { selectors: new Set<string>(), pagesScanned: 0 };
+}
+
+/**
+ * {@link collectSelectors}' body over caller-owned state, so the
+ * MAX_SELECTOR_PAGES scan budget spans batches instead of resetting on each
+ * one (#1913). Selector tokens are `id`/`class` attribute slices, detached for
+ * the same reason as the urls above.
+ */
+export function absorbSelectors(
+  state: SelectorState,
+  siteContext: SiteContextPage[]
+): void {
+  const { selectors } = state;
   for (const { page, parsed } of siteContext) {
-    if (selectors.size >= MAX_SELECTORS || pagesScanned >= MAX_SELECTOR_PAGES)
-      break;
+    if (
+      selectors.size >= MAX_SELECTORS ||
+      state.pagesScanned >= MAX_SELECTOR_PAGES
+    )
+      return;
     if (!parsed?.document || page.status < 200 || page.status >= 300) continue;
-    pagesScanned++;
+    state.pagesScanned++;
 
     let elements: Iterable<Element>;
     try {
@@ -72,17 +118,17 @@ function collectSelectors(siteContext: SiteContextPage[]): string[] {
     for (const el of elements) {
       if (selectors.size >= MAX_SELECTORS) break;
       const id = el.getAttribute("id");
-      if (id && SIMPLE_TOKEN_RE.test(id)) selectors.add(`#${id}`);
+      if (id && SIMPLE_TOKEN_RE.test(id))
+        selectors.add(detachFromPage(`#${id}`, "cloud-payload"));
       const classAttr = el.getAttribute("class");
       if (!classAttr) continue;
       for (const cls of classAttr.split(/\s+/)) {
         if (selectors.size >= MAX_SELECTORS) break;
-        if (cls && SIMPLE_TOKEN_RE.test(cls)) selectors.add(`.${cls}`);
+        if (cls && SIMPLE_TOKEN_RE.test(cls))
+          selectors.add(detachFromPage(`.${cls}`, "cloud-payload"));
       }
     }
   }
-
-  return [...selectors];
 }
 
 /**

--- a/apps/cli/src/audit/cloud-payloads-gaps.ts
+++ b/apps/cli/src/audit/cloud-payloads-gaps.ts
@@ -2,8 +2,10 @@
 // request payloads from crawl artifacts + config. Pure adaptation: the prefetch
 // phase (@squirrelscan/audit-engine) dispatches these; no HTTP here.
 
-import type { CloudSitePayloads } from "@squirrelscan/audit-engine";
-
+import {
+  detachFromPage,
+  type CloudSitePayloads,
+} from "@squirrelscan/audit-engine";
 import { SERVICE_LIMITS } from "@squirrelscan/core-contracts";
 
 import type { SiteContextPage } from "@/audit/adapter";
@@ -65,8 +67,33 @@ function cleanSeed(text: string): string | null {
 
 /** Seed keywords / covered topics from page titles + h1s (dedup, ≤50). */
 function collectSeeds(siteContext: SiteContextPage[]): string[] {
-  const seeds: string[] = [];
-  const seen = new Set<string>();
+  const state = createSeedState();
+  absorbSeeds(state, siteContext);
+  return state.seeds;
+}
+
+export interface SeedState {
+  seeds: string[];
+  seen: Set<string>;
+}
+
+export function createSeedState(): SeedState {
+  return { seeds: [], seen: new Set<string>() };
+}
+
+/**
+ * {@link collectSeeds}' body over caller-owned state, so the ≤50 seed cap and
+ * the dedupe set span page batches instead of resetting on each one (#1913).
+ * A seed is a title/h1 substring, so it pins the page it was read off (#240)
+ * unless detached — and on the streamed path that page is dropped immediately
+ * after this returns.
+ */
+export function absorbSeeds(
+  state: SeedState,
+  siteContext: SiteContextPage[]
+): void {
+  const { seeds, seen } = state;
+  if (seeds.length >= SERVICE_LIMITS.gapsMaxSeeds) return;
   for (const { page, parsed } of siteContext) {
     if (!parsed || page.status < 200 || page.status >= 300) continue;
     const candidates = [parsed.meta.title ?? "", ...parsed.h1.texts];
@@ -76,11 +103,10 @@ function collectSeeds(siteContext: SiteContextPage[]): string[] {
       const key = seed.toLowerCase();
       if (seen.has(key)) continue;
       seen.add(key);
-      seeds.push(seed);
-      if (seeds.length >= SERVICE_LIMITS.gapsMaxSeeds) return seeds;
+      seeds.push(detachFromPage(seed, "cloud-payload"));
+      if (seeds.length >= SERVICE_LIMITS.gapsMaxSeeds) return;
     }
   }
-  return seeds;
 }
 
 /**
@@ -93,8 +119,19 @@ export function buildGapsPayloads(
   baseUrl: string,
   config: Config
 ): GapsPayloads {
+  return buildGapsPayloadsFromSeeds(collectSeeds(siteContext), baseUrl, config);
+}
+
+/**
+ * {@link buildGapsPayloads} over seeds gathered elsewhere — the streamed
+ * pre-rules walk accumulates them batch by batch (#1913).
+ */
+export function buildGapsPayloadsFromSeeds(
+  seeds: string[],
+  baseUrl: string,
+  config: Config
+): GapsPayloads {
   const domain = apexDomain(baseUrl);
-  const seeds = collectSeeds(siteContext);
   if (!domain || seeds.length === 0) return {};
 
   const keywordOpts = gapsOptions(config, "gaps/keywords");

--- a/apps/cli/src/audit/cloud.ts
+++ b/apps/cli/src/audit/cloud.ts
@@ -20,8 +20,11 @@ import type {
 import type { Document } from "linkedom";
 
 import {
+  detachFromPage,
   detectReportTechnologiesMulti,
+  ensureSiteContextDocuments,
   prefetchCloudData,
+  releaseSiteContextDocuments,
   renderedPageUrlsFrom,
   type CloudPrefetchResult,
 } from "@squirrelscan/audit-engine";
@@ -43,8 +46,18 @@ import type { ExternalBulkChecker, SiteContextPage } from "@/audit/adapter";
 import type { Config } from "@/config";
 import type { PreflightBalance } from "@/lib/balance";
 
-import { buildBlocklistPayload } from "@/audit/cloud-payloads-blocklist";
-import { buildGapsPayloads } from "@/audit/cloud-payloads-gaps";
+import {
+  absorbSelectors,
+  absorbUrls,
+  buildBlocklistPayload,
+  createSelectorState,
+} from "@/audit/cloud-payloads-blocklist";
+import {
+  absorbSeeds,
+  buildGapsPayloads,
+  buildGapsPayloadsFromSeeds,
+  createSeedState,
+} from "@/audit/cloud-payloads-gaps";
 import { logger } from "@/utils/logger";
 import { getOrigin, getPathname } from "@/utils/url";
 
@@ -176,18 +189,29 @@ export function buildCloudPagePayloads(
         0,
         MAX_DESCRIPTION_CHARS
       );
-    payloads.push({
-      url: page.url,
-      title: parsed.meta.title?.slice(0, MAX_TITLE_CHARS) ?? undefined,
-      textExcerpt: truncateUtf8Bytes(
-        parsed.content.textContent,
-        MAX_EXCERPT_BYTES
-      ),
-      meta: Object.keys(meta).length > 0 ? meta : undefined,
-      headings: parsed.headings.headings
-        .slice(0, 20)
-        .map((h) => h.text.slice(0, MAX_HEADING_CHARS)),
-    });
+    payloads.push(
+      // Every field here is a SLICE of the page's html, and a retained slice
+      // pins that page's whole backing store (#240) — one 6 KB excerpt holding
+      // a megabyte, per page, which would put the page-count-scaled term
+      // straight back into the streamed walk (#1913). Detached at the point of
+      // retention; the resident path pays the same copy for pages it was
+      // holding anyway.
+      detachFromPage(
+        {
+          url: page.url,
+          title: parsed.meta.title?.slice(0, MAX_TITLE_CHARS) ?? undefined,
+          textExcerpt: truncateUtf8Bytes(
+            parsed.content.textContent,
+            MAX_EXCERPT_BYTES
+          ),
+          meta: Object.keys(meta).length > 0 ? meta : undefined,
+          headings: parsed.headings.headings
+            .slice(0, 20)
+            .map((h) => h.text.slice(0, MAX_HEADING_CHARS)),
+        },
+        "cloud-payload"
+      )
+    );
   }
   return payloads;
 }
@@ -428,6 +452,209 @@ export async function runCloudPrefetch(
   });
 }
 
+// ── Streamed payload collection (#1913) ─────────────────────────────────────
+//
+// The audit controller no longer holds a whole-crawl site context: pages are
+// walked in byte-budgeted batches and each batch's DOMs are dropped as soon as
+// the walk moves on. Everything below is the batch-at-a-time form of the
+// builders above, so the prefetch request body is identical either way while
+// what stays resident is a fixed sample plus explicitly capped payload lists.
+
+/** Prefetch inputs gathered across a streamed walk, ready for dispatch. */
+export interface CloudPrefetchPayloadSet {
+  pages: CloudPagePayload[];
+  metadataPages: SiteMetadataPagePayload[];
+  blocklist: { urls: string[]; selectors: string[] } | null;
+  gapsSeeds: string[];
+  renderedPageUrls: Set<string>;
+}
+
+/**
+ * Accumulate every cloud-prefetch payload one page batch at a time.
+ *
+ * The page payloads and the blocklist/gaps/rendered collectors are capped lists
+ * that carry across batches, so they see exactly the sequence a whole-array pass
+ * would. The Stage-0 metadata sample is different: `buildMetadataPayload` reads
+ * the DOM, and by the time the walk ends every batch is long gone. So the
+ * collector RETAINS the bounded set of entries that pass can possibly choose —
+ * the first `metadataMaxPages` usable pages, plus the two home-page candidates
+ * its fallback chain looks for — and re-parses just those at build time.
+ */
+export function createCloudPrefetchCollector(baseUrl: string): {
+  absorb: (siteContext: SiteContextPage[]) => void;
+  build: () => CloudPrefetchPayloadSet;
+} {
+  const pages: CloudPagePayload[] = [];
+  const renderedPageUrls = new Set<string>();
+  const blocklistUrls = new Set<string>();
+  const selectorState = createSelectorState();
+  const seedState = createSeedState();
+
+  // Bounded metadata sample — never page-count-scaled. Entries keep their
+  // PageRecord (so `page.html` can be re-parsed at build time) but their DOMs go
+  // with the batch like everything else.
+  const metadataPrefix: SiteContextPage[] = [];
+  let primaryHome: SiteContextPage | undefined;
+  let rootHome: SiteContextPage | undefined;
+
+  const baseOrigin = getOrigin(baseUrl);
+  const isRoot = (u: string): boolean => {
+    const path = getPathname(u);
+    return getOrigin(u) === baseOrigin && (path === "" || path === "/");
+  };
+
+  return {
+    absorb(siteContext: SiteContextPage[]): void {
+      for (const payload of buildCloudPagePayloads(siteContext))
+        pages.push(payload);
+      for (const url of renderedPageUrlsFrom(siteContext))
+        renderedPageUrls.add(url);
+      absorbUrls(blocklistUrls, siteContext);
+      absorbSelectors(selectorState, siteContext);
+      absorbSeeds(seedState, siteContext);
+
+      for (const entry of siteContext) {
+        // The same "usable" test buildMetadataPayload applies.
+        if (entry.parsed?.document == null) continue;
+        const { url, finalUrl, status } = entry.page;
+        if (status < 200 || status >= 300) continue;
+        if (metadataPrefix.length < SERVICE_LIMITS.metadataMaxPages)
+          metadataPrefix.push(entry);
+        if (!primaryHome && (finalUrl === baseUrl || url === baseUrl)) {
+          primaryHome = entry;
+        }
+        if (!rootHome && (isRoot(finalUrl || url) || isRoot(url))) {
+          rootHome = entry;
+        }
+      }
+    },
+
+    build(): CloudPrefetchPayloadSet {
+      // Dedupe by identity, preserving encounter order: a home already inside
+      // the retained prefix must not appear twice, or buildMetadataPayload's
+      // `usable.filter(p => p !== home)` would leave a duplicate in `rest`.
+      const sample: SiteContextPage[] = [...metadataPrefix];
+      for (const home of [primaryHome, rootHome]) {
+        if (home && !sample.includes(home)) sample.push(home);
+      }
+      // The batches these entries came from were released long ago; re-parse.
+      // Deterministic: `buildSiteContext` never yields a non-null `parsed`
+      // without html, so every retained entry rebuilds identically.
+      ensureSiteContextDocuments(sample);
+      const metadataPages = buildMetadataPayload(sample, baseUrl);
+      releaseSiteContextDocuments(sample);
+
+      const urls = [...blocklistUrls];
+      const selectors = [...selectorState.selectors];
+      return {
+        pages,
+        metadataPages,
+        blocklist:
+          urls.length === 0 && selectors.length === 0
+            ? null
+            : { urls, selectors },
+        gapsSeeds: seedState.seeds,
+        renderedPageUrls,
+      };
+    },
+  };
+}
+
+/**
+ * A bounded sample of crawled pages that yields the SAME ordered page list the
+ * tech-detect builders would pick from the whole crawl (#1913).
+ *
+ * Both `runCloudTechDetect` and `detectLocalTechnologies` filter to HTML 2xx
+ * pages, put the base-URL page first when there is one, and keep at most
+ * `techDetectMaxPages`. Retaining that prefix plus the home candidate is enough
+ * to reproduce the selection exactly: when the home page is inside the prefix
+ * the sample IS the prefix, and when it is not, appending it puts it exactly
+ * where the builders' `findIndex` will pick it up while the prefix supplies the
+ * same `rest`. Neither builder reads `parsed`, so the entries carry a null one.
+ */
+export function createTechDetectSampleCollector(baseUrl: string): {
+  absorb: (siteContext: SiteContextPage[]) => void;
+  build: () => SiteContextPage[];
+} {
+  const prefix: SiteContextPage["page"][] = [];
+  let home: SiteContextPage["page"] | undefined;
+
+  return {
+    absorb(siteContext: SiteContextPage[]): void {
+      for (const { page } of siteContext) {
+        if (!page.html || page.status < 200 || page.status >= 300) continue;
+        if (prefix.length < SERVICE_LIMITS.techDetectMaxPages)
+          prefix.push(page);
+        if (!home && (page.finalUrl === baseUrl || page.url === baseUrl))
+          home = page;
+      }
+    },
+    build(): SiteContextPage[] {
+      const sample = [...prefix];
+      if (home && !sample.includes(home)) sample.push(home);
+      return sample.map((page) => ({ page, parsed: null }));
+    },
+  };
+}
+
+/**
+ * {@link countExternalLinks} accumulating into a caller-owned set so the
+ * streamed walk can feed it batch by batch. Reads the crawl-time extraction
+ * (`parsed.links`), never the DOM.
+ */
+export function absorbExternalLinkUrls(
+  seen: Set<string>,
+  siteContext: SiteContextPage[]
+): void {
+  for (const { parsed } of siteContext) {
+    if (!parsed) continue;
+    for (const link of parsed.links) {
+      // Crawl-time extraction keeps unparseable hrefs as error entries (with
+      // isInternal=false); the DOM re-walk this replaced skipped those, so
+      // filter them to keep the estimate equivalent.
+      if (!link.isInternal && link.url && !link.error)
+        seen.add(detachFromPage(link.url, "cloud-payload"));
+    }
+  }
+}
+
+/**
+ * {@link runCloudPrefetch} over payloads collected during a streamed pre-rules
+ * walk (#1913) instead of from a whole-crawl site context. Same request body.
+ */
+export async function runCloudPrefetchFromPayloads(
+  opts: Omit<RunCloudPrefetchOptions, "siteContext" | "onPayloadsBuilt">,
+  payloads: CloudPrefetchPayloadSet
+): Promise<CloudPrefetchResult> {
+  const sitePayloads = {
+    ...(payloads.blocklist ? { "blocklist-check": payloads.blocklist } : {}),
+    ...buildGapsPayloadsFromSeeds(
+      payloads.gapsSeeds,
+      opts.baseUrl,
+      opts.config
+    ),
+    // Archive Indexing (#789) — the payload is just the site URL; the server
+    // resolves the domain and runs the Wayback + Common Crawl lookups.
+    "archive-indexing": { url: opts.baseUrl },
+  };
+
+  return prefetchCloudData({
+    client: opts.client,
+    config: opts.cloudConfig,
+    rules: selectCloudRules(opts.config),
+    pages: payloads.pages,
+    siteUrl: opts.baseUrl,
+    sitePayloads,
+    metadataPages: payloads.metadataPages,
+    gate: opts.gate,
+    auditId: opts.auditId,
+    confirm: opts.confirm,
+    onProgress: opts.onProgress,
+    crawlRendered: opts.crawlRendered ?? false,
+    renderedPageUrls: payloads.renderedPageUrls,
+  });
+}
+
 /**
  * Build the cloud dead-links bulk checker for the external-links phase, or
  * null when cloud is off / logged out / the `links/dead-links` rule is not
@@ -473,15 +700,7 @@ function buildDeadLinksBulkChecker(
  */
 function countExternalLinks(siteContext: SiteContextPage[]): number {
   const seen = new Set<string>();
-  for (const { parsed } of siteContext) {
-    if (!parsed) continue;
-    for (const link of parsed.links) {
-      // Crawl-time extraction keeps unparseable hrefs as error entries (with
-      // isInternal=false); the DOM re-walk this replaced skipped those, so
-      // filter them to keep the estimate equivalent.
-      if (!link.isInternal && link.url && !link.error) seen.add(link.url);
-    }
-  }
+  absorbExternalLinkUrls(seen, siteContext);
   return seen.size;
 }
 
@@ -503,7 +722,15 @@ export async function resolveDeadLinksBulkChecker(opts: {
   client: CloudServicesClient | null;
   config: Config;
   auditId: string;
-  siteContext: SiteContextPage[];
+  /** Whole-crawl site context, when the caller holds one. */
+  siteContext?: SiteContextPage[];
+  /**
+   * The estimate's basis, when the caller counted the crawl's distinct external
+   * links itself — the streamed walk accumulates it batch by batch (#1913)
+   * rather than holding every parsed page to count them at the end. Same number
+   * {@link countExternalLinks} produces; supplying it wins over `siteContext`.
+   */
+  externalLinkCount?: number;
   /** Preflight balance for the confirm prompt; absent → no balance shown. */
   getBalance?: () => Promise<PreflightBalance>;
   confirm?: (
@@ -517,14 +744,15 @@ export async function resolveDeadLinksBulkChecker(opts: {
    */
   onSpend?: (units: number, credits: number) => void;
 }): Promise<ExternalBulkChecker | null> {
-  const { client, config, auditId, siteContext, confirm } = opts;
+  const { client, config, auditId, confirm } = opts;
   if (!client || !config.cloud.enabled) return null;
   const enabled = selectCloudRules(config).some(
     (r) => r.id === "links/dead-links"
   );
   if (!enabled) return null;
 
-  const linkCount = countExternalLinks(siteContext);
+  const linkCount =
+    opts.externalLinkCount ?? countExternalLinks(opts.siteContext ?? []);
   if (linkCount === 0) return null;
 
   const estimate = computeCost("dead_links", linkCount);

--- a/apps/cli/src/audit/stream-batch.ts
+++ b/apps/cli/src/audit/stream-batch.ts
@@ -1,0 +1,77 @@
+// Batch sizing for the CLI's streamed post-crawl phases (#1913).
+//
+// The batch is normally derived from the site's own average page size against a
+// byte budget — that is what makes one setting behave the same on a docs site of
+// 30 KB pages and a storefront of 1 MB ones. These two env vars override it, and
+// they are the SAME names the hosted runtime reads so a number tuned against a
+// local repro means the same thing in a container.
+
+import {
+  STREAM_BATCH_BYTES_DEFAULT,
+  STREAM_BATCH_BYTES_MAX,
+  STREAM_BATCH_BYTES_MIN,
+  STREAM_BATCH_PAGES_MAX,
+  STREAM_BATCH_PAGES_MIN,
+} from "@/constants";
+import { logger } from "@/utils/logger";
+
+/**
+ * Strictly-numeric env parse. `Number.parseInt` stops at the first non-digit, so
+ * the obvious `SQUIRREL_STREAM_BATCH_BYTES=48mb` parses as 48 BYTES and clamps
+ * to the 1 MB floor — a fifty-fold smaller batch than the author asked for, with
+ * nothing said. Anything that is not a plain integer is refused and named.
+ */
+function parseIntegerFromEnv(
+  name: string,
+  rawValue: string | undefined
+): number | undefined {
+  if (rawValue === undefined || rawValue.trim() === "") return undefined;
+  const trimmed = rawValue.trim();
+  if (!/^-?\d+$/.test(trimmed)) {
+    logger.warn(
+      `${name}="${rawValue}" is not a plain integer; ignoring it and using the default`
+    );
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Byte budget for one streamed batch of raw html.
+ * `SQUIRREL_STREAM_BATCH_BYTES`, clamped; default 48 MB.
+ */
+export function resolveStreamBatchBytes(
+  env: Record<string, string | undefined> = process.env
+): number {
+  const value = parseIntegerFromEnv(
+    "SQUIRREL_STREAM_BATCH_BYTES",
+    env.SQUIRREL_STREAM_BATCH_BYTES
+  );
+  if (value === undefined) return STREAM_BATCH_BYTES_DEFAULT;
+  return Math.min(
+    STREAM_BATCH_BYTES_MAX,
+    Math.max(STREAM_BATCH_BYTES_MIN, value)
+  );
+}
+
+/**
+ * Explicit page count for one streamed batch, pinning the byte budget out of the
+ * decision. `SQUIRREL_STREAM_BATCH_PAGES`, clamped.
+ *
+ * Undefined rather than a default: unset means "size it from this site's pages",
+ * which is a different thing from "use this number when nobody said otherwise".
+ */
+export function resolveStreamBatchPagesOverride(
+  env: Record<string, string | undefined> = process.env
+): number | undefined {
+  const value = parseIntegerFromEnv(
+    "SQUIRREL_STREAM_BATCH_PAGES",
+    env.SQUIRREL_STREAM_BATCH_PAGES
+  );
+  if (value === undefined) return undefined;
+  return Math.min(
+    STREAM_BATCH_PAGES_MAX,
+    Math.max(STREAM_BATCH_PAGES_MIN, value)
+  );
+}

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -160,3 +160,25 @@ export const CRAWL_PHASE_MIN_TIMEOUT_MS = 120_000;
 export const CRAWL_PHASE_MAX_TIMEOUT_MS = 1_800_000; // 30 min
 
 // CSR-shell thresholds (#294) moved to @squirrelscan/fetchers csr-detect.ts.
+
+// ── Streamed rules pipeline (#1913) ─────────────────────────────────────────
+//
+// The audit's post-crawl phases walk the pages table in byte-budgeted batches
+// instead of materializing every page, so peak residency is set by the batch,
+// not by the crawl. Same two dials the hosted runtime reads, with the same
+// names and the same default, so a batch tuned in one place means the same
+// thing in the other.
+//
+// Sizing, measured on real ~1 MB pages: peak ≈ a ~300 MB floor (rule set,
+// runner, SQLite caches, allocator arena) plus ~3.5 MB per page of batch. The
+// budget is NOT worth turning down below about 12 pages' worth — under that the
+// same crawl becomes several times as many read/parse/collect cycles and the
+// churn sets a HIGHER high-water than a larger batch does.
+/** Raw html held per streamed batch. `SQUIRREL_STREAM_BATCH_BYTES` overrides. */
+export const STREAM_BATCH_BYTES_DEFAULT = 48 * 1024 * 1024;
+/** Clamp band for the byte budget, so a typo can't ask for a gigabyte or a byte. */
+export const STREAM_BATCH_BYTES_MIN = 1024 * 1024;
+export const STREAM_BATCH_BYTES_MAX = 512 * 1024 * 1024;
+/** Clamp band for an explicit page count (`SQUIRREL_STREAM_BATCH_PAGES`). */
+export const STREAM_BATCH_PAGES_MIN = 5;
+export const STREAM_BATCH_PAGES_MAX = 500;

--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -74,6 +74,7 @@ import {
 import { createHybridDocumentFetcher } from "@/crawl/hybrid-fetcher";
 import { resolveSeedRedirect } from "@/crawler/frontier";
 import { createStorage, domainToProjectName } from "@/crawler/storage";
+import { getGlobalLinkCache } from "@/crawler/storage/link-cache";
 import { preflightBalanceOf } from "@/lib/balance";
 import { reconstructReport } from "@/reports/reconstruct";
 import { detectRunner } from "@/self/install-meta";
@@ -1302,6 +1303,14 @@ export async function runAudit(
             ? {
                 externalLinks: {
                   config: mergedConfig.external_links,
+                  // The CLI's own persistent dead-link cache. The resident
+                  // path took it as a given inside checkExternalLinksOnStorage;
+                  // the engine's collected-links entry point takes it as an
+                  // argument and treats an absent one as "no caching", so
+                  // omitting it here would make every re-audit re-check every
+                  // external link AND resubmit already-known urls to the PAID
+                  // bulk checker.
+                  linkCache: getGlobalLinkCache(),
                   onProgress: (progress) => {
                     logger.debug(
                       "external links",

--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -27,17 +27,18 @@ import {
 import type { PreflightBalance } from "@/lib/balance";
 
 import {
-  fetchResourceAssets,
-  runRulesOnStorage,
-  checkExternalLinksOnStorage,
-  buildSiteContext,
-  releaseSiteContextDocuments,
+  resolveStreamBatch,
+  runStreamingPreRules,
+  runStreamingRules,
 } from "@/audit/adapter";
 import {
+  absorbExternalLinkUrls,
+  createCloudPrefetchCollector,
+  createTechDetectSampleCollector,
   resolveDeadLinksBulkChecker,
   runCloudDomainStats,
   runCloudEditorSummary,
-  runCloudPrefetch,
+  runCloudPrefetchFromPayloads,
   runCloudTechDetect,
   detectLocalTechnologies,
   type CloudPrefetchResult,
@@ -46,6 +47,10 @@ import {
 import { gateStage1 } from "@/audit/cloud-gating";
 import { resolveRulesConfig } from "@/audit/rule-filter";
 import { runSmartAudits } from "@/audit/smart-audits";
+import {
+  resolveStreamBatchBytes,
+  resolveStreamBatchPagesOverride,
+} from "@/audit/stream-batch";
 import {
   loadConfig,
   DEFAULT_CRAWLER_CONCURRENCY,
@@ -358,8 +363,11 @@ export function foldRenderSpendLines(
  */
 export const AUDIT_PHASES = [
   "crawl",
-  "external_links",
-  "assets",
+  // One streamed walk over the crawl's pages does the external-link collection
+  // + check and the resource-asset fetch that used to be timed separately as
+  // `external_links` and `assets` (#1913). They cannot be split without
+  // reintroducing the whole-crawl page array, so they are reported as one.
+  "pre_rules",
   "cloud_prefetch",
   "tech_detect",
   "rules",
@@ -369,6 +377,34 @@ export const AUDIT_PHASES = [
   "domain_stats",
   "publish",
 ] as const;
+
+/**
+ * Opt-in per-sub-phase memory line for the streamed rules pass (#1913).
+ *
+ * The rules phase is one long synchronous block, so an interval sampler is
+ * starved by it — a 10-minute run yielded three samples, only the last of which
+ * meant anything — and on macOS the compressor absorbs the growth, so RSS reads
+ * flat while the heap is climbing by gigabytes. These boundaries are the only
+ * place a local repro can see where a phase's heap went, which is why the hosted
+ * runtime samples the same ones.
+ *
+ * Off unless `SQUIRREL_STREAM_PHASE_MEM=1`: the forced collect each boundary
+ * needs to make the number mean anything is not free, and the line is
+ * diagnostic output, not part of any report.
+ */
+export function streamPhaseMemoryLogger():
+  | ((phase: string, boundary: "start" | "end") => void)
+  | undefined {
+  if (process.env.SQUIRREL_STREAM_PHASE_MEM !== "1") return undefined;
+  const mb = (bytes: number) => `${Math.round(bytes / (1024 * 1024))}MB`;
+  return (phase, boundary) => {
+    Bun.gc(true);
+    const m = process.memoryUsage();
+    console.error(
+      `[stream] ${phase} ${boundary} heapUsed=${mb(m.heapUsed)} external=${mb(m.external)} rss=${mb(m.rss)}`
+    );
+  };
+}
 
 /**
  * `CommandError.details` shape on a failed `runAudit()` (#871) — the partial
@@ -1111,19 +1147,34 @@ export async function runAudit(
       );
 
       // ============================================
-      // BUILD SITE CONTEXT (parse once, use everywhere)
+      // POST-CRAWL: STREAMED PIPELINE (#1913)
       // ============================================
-      logger.debug("building site context", crawlId);
-      const pages = await Effect.runPromise(
-        storage
-          .getPages(crawlId)
-          .pipe(Effect.catchAll(() => Effect.succeed([])))
+      // Everything from here to the report walks the pages table in
+      // byte-budgeted batches and drops each batch's DOMs before reading the
+      // next. The resident pipeline this replaced built one site context over
+      // every crawled page and held a parsed page plus its DOM through the whole
+      // rules phase: ~1.5 MB of retained heap per crawled page, 3.9 GB at 2,500
+      // pages. Nothing here holds a page-count-scaled structure of pages.
+      //
+      // A page COUNT is all the empty-crawl guard needs; reading every
+      // PageRecord to check for zero would reintroduce the term this exists to
+      // remove.
+      //
+      // The streamed passes need the concrete SQLite storage (LIMIT/OFFSET
+      // paging + page_features). `createStorage` only ever builds one; the
+      // narrowing here is the same one the report path already makes below.
+      const sqliteStorage =
+        storage as import("@/crawler/storage/sqlite").SQLiteStorage;
+      const pageCount = await Effect.runPromise(
+        sqliteStorage
+          .getPageCount(crawlId)
+          .pipe(Effect.catchAll(() => Effect.succeed(0)))
       );
 
       // If the crawl phase was force-stopped by the wall-clock backstop and
       // produced nothing, fail with a clear reason instead of analyzing an
       // empty site (which would surface as confusing all-pass/zero results).
-      if (crawlPhaseStopped && pages.length === 0) {
+      if (crawlPhaseStopped && pageCount === 0) {
         throw new Error(
           `Crawl phase timed out after ${Math.round((crawlPhaseTimeoutMs ?? 0) / 1000)}s with no pages collected`
         );
@@ -1131,7 +1182,7 @@ export async function runAudit(
       if (crawlPhaseStopped) {
         logger.warn(
           "partial crawl",
-          `analyzing ${pages.length} page(s) collected before the crawl-phase timeout`
+          `analyzing ${pageCount} page(s) collected before the crawl-phase timeout`
         );
       }
       // #1829: name the throttling host(s) and the knobs that fix it. Without
@@ -1144,13 +1195,34 @@ export async function runAudit(
         );
       }
 
-      const siteContext = await Effect.runPromise(
-        buildSiteContext(pages, parsedPageCache)
-      ).finally(() => {
-        // siteContext owns the reused DOMs now; drop crawl-time refs on any path
-        parsedPageCache.clear();
-      });
+      // Nothing downstream reads the crawl-time DOMs now that each streamed
+      // batch parses its own: drop them here rather than carrying up to
+      // PARSED_PAGE_CACHE_MAX_PAGES documents through the rest of the run.
+      parsedPageCache.clear();
       phaseTimer.mark("crawl");
+
+      // One batch size for every streamed walk, derived from this site's own
+      // average page size against a byte budget rather than fixed at a page
+      // count — a docs site of 30 KB pages and a storefront of 1 MB ones need
+      // very different page counts to hold the same bytes. Sampling costs a
+      // dozen page reads and is what makes the bound hold across site shapes.
+      const streamBatch = await Effect.runPromise(
+        resolveStreamBatch(sqliteStorage, crawlId, pageCount, {
+          pages: resolveStreamBatchPagesOverride(),
+          byteBudget: resolveStreamBatchBytes(),
+        })
+      );
+      const streamBatchSize = streamBatch.pages;
+      logger.debug(
+        "stream batch",
+        streamBatch.explicit
+          ? `${streamBatchSize} pages (explicit)`
+          : `${streamBatchSize} pages (avg page ${
+              streamBatch.avgPageBytes >= 1024
+                ? `${Math.round(streamBatch.avgPageBytes / 1024)} KB`
+                : `${streamBatch.avgPageBytes} B`
+            }, budget ${Math.round(streamBatch.byteBudget / (1024 * 1024))} MB)`
+      );
 
       // Queue-wait vs render-time breakdown for the crawl just finished
       // (#826) — tells cloud render latency apart as browser-pool queueing
@@ -1165,119 +1237,168 @@ export async function runAudit(
       }
 
       // ============================================
-      // STEP 1.5: CHECK EXTERNAL LINKS
+      // STEP 1.5 + 2: PRE-RULES WALK (external links, resource assets, payloads)
       // ============================================
-      if (mergedConfig.external_links.enabled) {
-        phaseTimer.enter("external_links");
-        logger.debug("step 1.5: checking external links", crawlId);
-        onProgress({ phase: "external-links" });
+      // One batched walk of the pages table replaces the whole-crawl
+      // buildSiteContext + checkExternalLinksOnStorage + fetchResourceAssets
+      // sequence (#1913). Each collector below absorbs a batch while its DOMs
+      // are live and keeps only capped, page-detached output; the batch is then
+      // dropped. The network halves (link checking, asset fetching) run once
+      // over the collected occurrences, in the same order as before.
+      phaseTimer.enter("pre_rules");
+      logger.debug("step 1.5+2: pre-rules walk", crawlId);
+      const externalLinksEnabled = mergedConfig.external_links.enabled;
+      onProgress({ phase: externalLinksEnabled ? "external-links" : "rules" });
 
-        // Cloud bulk dead-link checks (shared global cache) when authed and
-        // the links/dead-links rule is enabled; null → plain local checking.
-        // Gated behind the SAME spend confirmation as STEP 2.4 prefetch so the
-        // dead_links charge (which happens here, before that confirm) can't be
-        // a surprise: when the estimate exceeds [cloud].confirm_threshold and a
-        // TTY confirm callback exists, the user is prompted first; a decline
-        // falls back to local per-link checks.
-        const deadLinksClient =
-          options.cloudAvailable === false || isQuickMode
-            ? null
-            : createCloudClientFromSettings();
-        const bulkChecker = await resolveDeadLinksBulkChecker({
-          client: deadLinksClient,
-          config: mergedConfig,
-          auditId: crawlId,
-          siteContext,
-          getBalance: deadLinksClient
-            ? async () =>
-                preflightBalanceOf((await deadLinksClient.getBalance()).balance)
-            : undefined,
-          confirm: options.confirmCloudSpend,
-          onSpend: (units, credits) => {
-            deadLinksUnits += units;
-            deadLinksCredits += credits;
+      // Cloud bulk dead-link checks (shared global cache) when authed and
+      // the links/dead-links rule is enabled; null → plain local checking.
+      // Gated behind the SAME spend confirmation as STEP 2.4 prefetch so the
+      // dead_links charge (which happens here, before that confirm) can't be
+      // a surprise: when the estimate exceeds [cloud].confirm_threshold and a
+      // TTY confirm callback exists, the user is prompted first; a decline
+      // falls back to local per-link checks.
+      const deadLinksClient =
+        options.cloudAvailable === false || isQuickMode
+          ? null
+          : createCloudClientFromSettings();
+
+      // Cloud-prefetch payloads (STEP 2.4) and the tech-detect sample (STEP 2.6
+      // / the local fallback) are the two consumers that used to read the whole
+      // site context AFTER this walk. Both collect during it instead: the
+      // prefetch collector keeps capped payload lists plus the bounded Stage-0
+      // metadata sample, the tech collector keeps at most techDetectMaxPages
+      // page records.
+      const cloudPrefetchEnabled =
+        mergedConfig.cloud.enabled &&
+        options.cloudAvailable !== false &&
+        !isQuickMode;
+      const prefetchCollector = cloudPrefetchEnabled
+        ? createCloudPrefetchCollector(url)
+        : null;
+      const techSampleCollector = createTechDetectSampleCollector(url);
+      // normalizedUrl + status per page, for the smart-audits merge and nothing
+      // else — two scalars a page instead of the PageRecord it used to slice
+      // them off.
+      const pageStatuses: Array<{ normalizedUrl: string; status: number }> = [];
+      // Distinct external link urls, sized exactly as countExternalLinks does,
+      // so the dead-links spend estimate is the number v1 showed. Only
+      // accumulated when a paid checker could ask for it — this is the one
+      // collector here whose size follows the crawl rather than a cap, and on
+      // the common signed-out or `--offline` run nothing ever reads it.
+      const needExternalLinkCount =
+        cloudPrefetchEnabled && externalLinksEnabled;
+      const externalLinkUrls = new Set<string>();
+
+      const preRules = await Effect.runPromise(
+        runStreamingPreRules(sqliteStorage, crawlId, mergedConfig, {
+          batchSize: streamBatchSize,
+          resourceOverrides: {
+            resourceCheckMaxItems: options.resourceCheckMaxItems,
+            resourceCheckTimeoutMs: options.resourceCheckTimeoutMs,
+            // Sub-resource cache reuse (#107): mirrors the crawler's incremental flag.
+            incremental: incrementalEnabled,
           },
-        });
-
-        await Effect.runPromise(
-          checkExternalLinksOnStorage(
-            storage,
-            crawlId,
-            siteContext,
-            mergedConfig.external_links,
-            (progress) => {
-              logger.debug(
-                "external links",
-                `${progress.checked}/${progress.total}`,
-                `(${progress.fromCache} cached)`
-              );
-              onProgress({
-                phase: "external-links",
-                current: progress.checked,
-                total: progress.total,
+          ...(externalLinksEnabled
+            ? {
+                externalLinks: {
+                  config: mergedConfig.external_links,
+                  onProgress: (progress) => {
+                    logger.debug(
+                      "external links",
+                      `${progress.checked}/${progress.total}`,
+                      `(${progress.fromCache} cached)`
+                    );
+                    onProgress({
+                      phase: "external-links",
+                      current: progress.checked,
+                      total: progress.total,
+                    });
+                  },
+                  // Resolved after the walk has counted the links and before any
+                  // of them is checked, so the spend confirm still lands ahead
+                  // of the phase rather than inside its progress output.
+                  resolveBulkChecker: async () =>
+                    (await resolveDeadLinksBulkChecker({
+                      client: deadLinksClient,
+                      config: mergedConfig,
+                      auditId: crawlId,
+                      externalLinkCount: externalLinkUrls.size,
+                      getBalance: deadLinksClient
+                        ? async () =>
+                            preflightBalanceOf(
+                              (await deadLinksClient.getBalance()).balance
+                            )
+                        : undefined,
+                      confirm: options.confirmCloudSpend,
+                      onSpend: (units, credits) => {
+                        deadLinksUnits += units;
+                        deadLinksCredits += credits;
+                      },
+                    })) ?? undefined,
+                },
+              }
+            : {}),
+          onBatchContext: (batchContext) => {
+            prefetchCollector?.absorb(batchContext);
+            techSampleCollector.absorb(batchContext);
+            if (needExternalLinkCount)
+              absorbExternalLinkUrls(externalLinkUrls, batchContext);
+            for (const { page } of batchContext) {
+              pageStatuses.push({
+                normalizedUrl: page.normalizedUrl,
+                status: page.status,
               });
-            },
-            bulkChecker ?? undefined
-          )
-        );
-        phaseTimer.mark("external_links");
-      }
-
-      // ============================================
-      // STEP 2: FETCH RESOURCE ASSETS
-      // ============================================
-      phaseTimer.enter("assets");
-      logger.debug("step 2: fetching resource assets", crawlId);
-      onProgress({ phase: "rules" });
-
-      const assets = await Effect.runPromise(
-        fetchResourceAssets(storage, crawlId, siteContext, mergedConfig, {
-          resourceCheckMaxItems: options.resourceCheckMaxItems,
-          resourceCheckTimeoutMs: options.resourceCheckTimeoutMs,
-          // Sub-resource cache reuse (#107): mirrors the crawler's incremental flag.
-          incremental: incrementalEnabled,
+            }
+          },
         })
       );
-      phaseTimer.mark("assets");
+      const assets = preRules.assets;
+      const techSample = techSampleCollector.build();
+      // v1 opened the external-links phase and then the rules phase separately,
+      // the second just before the asset fetch. The asset fetch is inside the
+      // walk now, so the opener went above and the rules banner comes here —
+      // both markers a run used to emit, still exactly once.
+      if (externalLinksEnabled) onProgress({ phase: "rules" });
+      phaseTimer.mark("pre_rules");
 
       // ============================================
       // STEP 2.4: CLOUD PREFETCH (the only networked enrichment step)
       // ============================================
       let cloudResult: CloudPrefetchResult | null = null;
-      if (
-        mergedConfig.cloud.enabled &&
-        options.cloudAvailable !== false &&
-        !isQuickMode
-      ) {
+      // `prefetchCollector` is non-null on exactly the condition this block used
+      // to spell out (see `cloudPrefetchEnabled`); testing it here is the same
+      // gate and narrows the collector for the dispatch below.
+      if (prefetchCollector) {
         phaseTimer.enter("cloud_prefetch");
         logger.debug("step 2.4: cloud prefetch", crawlId);
         onProgress({ phase: "cloud" });
         try {
-          cloudResult = await runCloudPrefetch({
-            client: createCloudClientFromSettings(),
-            cloudConfig: mergedConfig.cloud,
-            config: mergedConfig,
-            siteContext,
-            baseUrl: url,
-            auditId: crawlId,
-            // Stage-1 gating policy (CLI-owned): Stage-0 metadata gates which
-            // downstream cloud features run before the per-audit cap.
-            gate: gateStage1,
-            // Consented users skip THIS confirm (capped + disclosed up front);
-            // dead-links/tech/editor keep their gate below.
-            confirm: options.cloudConsented
-              ? undefined
-              : options.confirmCloudSpend,
-            onProgress: (detail) => onProgress({ phase: "cloud", detail }),
-            // Skip the raw-vs-rendered `render` service only when the crawl rendered EVERY page — i.e. the
-            // resolved fetcher is the full-render one ("cloud-render"), NOT the "auto" hybrid ("hybrid-http-
-            // first", most pages raw) or plain HTTP (undefined). #673.
-            crawlRendered: documentFetcher?.id === "cloud-render",
-            // Payloads built → nothing reads the DOMs again until the rules
-            // phase (which re-parses on demand). Drop them so the cloud round
-            // trips don't idle a GB-scale working set (#858).
-            onPayloadsBuilt: () => releaseSiteContextDocuments(siteContext),
-          });
+          cloudResult = await runCloudPrefetchFromPayloads(
+            {
+              client: createCloudClientFromSettings(),
+              cloudConfig: mergedConfig.cloud,
+              config: mergedConfig,
+              baseUrl: url,
+              auditId: crawlId,
+              // Stage-1 gating policy (CLI-owned): Stage-0 metadata gates which
+              // downstream cloud features run before the per-audit cap.
+              gate: gateStage1,
+              // Consented users skip THIS confirm (capped + disclosed up front);
+              // dead-links/tech/editor keep their gate below.
+              confirm: options.cloudConsented
+                ? undefined
+                : options.confirmCloudSpend,
+              onProgress: (detail) => onProgress({ phase: "cloud", detail }),
+              // Skip the raw-vs-rendered `render` service only when the crawl rendered EVERY page — i.e. the
+              // resolved fetcher is the full-render one ("cloud-render"), NOT the "auto" hybrid ("hybrid-http-
+              // first", most pages raw) or plain HTTP (undefined). #673.
+              crawlRendered: documentFetcher?.id === "cloud-render",
+            },
+            // Collected batch by batch during the pre-rules walk (#1913), so
+            // there is no whole-crawl DOM working set left to release for the
+            // duration of the cloud round trips — each batch's went with it.
+            prefetchCollector.build()
+          );
           logger.debug(
             "cloud prefetch done",
             `spent=${cloudResult.totalSpent}`,
@@ -1312,7 +1433,9 @@ export async function runAudit(
           config: mergedConfig,
           auditId: crawlId,
           baseUrl: url,
-          siteContext,
+          // The bounded sample collected during the pre-rules walk. It yields
+          // the same ordered page list the whole-crawl context did (#1913).
+          siteContext: techSample,
           scripts: assets.scripts,
           getBalance: techClient
             ? async () =>
@@ -1336,16 +1459,16 @@ export async function runAudit(
       // Thread cloud results + the resolved Stage-0 profile into the rules phase
       // per audit run — no process-global singleton. The metadata drives
       // `appliesWhen` rule gating; undefined = run as today.
-      const rulesEffect = runRulesOnStorage(
-        storage,
+      const rulesEffect = runStreamingRules(
+        sqliteStorage,
         crawlId,
-        siteContext,
         mergedConfig,
         assets,
         {
           cloudResults: cloudResult?.store,
           siteMetadata: cloudResult?.siteMetadata ?? undefined,
-        }
+        },
+        { batchSize: streamBatchSize, onPhase: streamPhaseMemoryLogger() }
       );
       const rulesPhaseTimeoutMs = options.rulesPhaseTimeoutMs;
       let ruleResults: Effect.Effect.Success<typeof rulesEffect>;
@@ -1444,10 +1567,9 @@ export async function runAudit(
               crawlId,
               siteKey: baseUrl,
               ruleResults,
-              pages: pages.map((p) => ({
-                normalizedUrl: p.normalizedUrl,
-                status: p.status,
-              })),
+              // Collected during the pre-rules walk in the same
+              // normalized_url order `getPages` returns (#1913).
+              pages: pageStatuses,
             })
           );
         } catch (error) {
@@ -1467,11 +1589,11 @@ export async function runAudit(
       logger.debug("step 3: generating report", crawlId);
 
       const report = await Effect.runPromise(
-        reconstructReport(
-          storage as import("@/crawler/storage/sqlite").SQLiteStorage,
-          crawlId,
-          smartMerge
-        )
+        reconstructReport(sqliteStorage, crawlId, smartMerge, {
+          // Same batch the streamed rules phases used, so one setting describes
+          // the whole post-crawl pipeline's residency.
+          batchSize: streamBatchSize,
+        })
       );
 
       // Scan scope disclosure (#1180): stamp where this audit ran and how much
@@ -1495,7 +1617,7 @@ export async function runAudit(
       } else {
         const localTech = detectLocalTechnologies({
           baseUrl: url,
-          siteContext,
+          siteContext: techSample,
           scripts: assets.scripts,
         });
         if (localTech) report.technologies = localTech;

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -3,6 +3,7 @@
 
 import type { ResponseHeaders as StoredResponseHeaders } from "@squirrelscan/core-contracts";
 
+import { detachFromPage } from "@squirrelscan/audit-engine";
 import { buildCacheStats } from "@squirrelscan/core-contracts";
 import { loadAllRules, type RuleRunResult } from "@squirrelscan/rules";
 import { isRateLimitStatus } from "@squirrelscan/utils/rate-limit";
@@ -381,17 +382,39 @@ export function reconstructReport(
           }
         }
 
+        // Every string below that came off the DOM is a SLICE of this page's
+        // html, and in JSC a retained slice pins the whole buffer it was cut
+        // from (#240). The resident path never had to care — it was holding the
+        // page anyway — but here the batch is dropped a few lines later and each
+        // kept title would hold its megabyte, which is the page-count-scaled
+        // term this walk exists to remove. Measured on ~1 MB pages: 77.5 MB
+        // retained across 80 pages attached, 2.1 MB detached. One copy per page
+        // of five small objects; everything else on the PageAudit comes from a
+        // storage row and is already free of the html.
+        const kept = parsed
+          ? detachFromPage(
+              {
+                meta: parsed.meta,
+                og: parsed.og,
+                twitter: parsed.twitter,
+                schema: parsed.schema,
+                h1Text: parsed.h1.texts,
+              },
+              "report-page"
+            )
+          : null;
+
         const pageAudit: PageAudit = {
           url: page.url,
           statusCode: page.status,
           loadTime: page.loadTimeMs,
-          meta: parsed?.meta ?? {
+          meta: kept?.meta ?? {
             title: null,
             description: null,
             canonical: null,
             robots: null,
           },
-          og: parsed?.og ?? {
+          og: kept?.og ?? {
             title: null,
             description: null,
             url: null,
@@ -399,13 +422,13 @@ export function reconstructReport(
             image: null,
             siteName: null,
           },
-          twitter: parsed?.twitter ?? {
+          twitter: kept?.twitter ?? {
             card: null,
             title: null,
             description: null,
             image: null,
           },
-          schema: parsed?.schema ?? {
+          schema: kept?.schema ?? {
             types: [],
             valid: true,
             errors: [],
@@ -414,7 +437,7 @@ export function reconstructReport(
           links: pageLinks,
           images: pageImages,
           h1Count: parsed?.h1.count ?? 0,
-          h1Text: parsed?.h1.texts ?? [],
+          h1Text: kept?.h1Text ?? [],
           checks: pageChecks,
           redirectChain: page.redirectChain,
           fetcherId: page.fetcherId,

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -143,23 +143,44 @@ function computeSitemapCoverage(
   return { orphanPages, missingPages };
 }
 
+/** Default page batch for the report's summary + pageAudits walk (#1913). */
+export const RECONSTRUCT_PAGE_BATCH = 100;
+
+export interface ReconstructOptions {
+  /**
+   * Pages read per `getPages` batch. The audit controller passes the same batch
+   * the streamed rules phases used, so one setting describes the whole
+   * post-crawl pipeline's residency.
+   */
+  batchSize?: number;
+}
+
 /**
  * Reconstruct full AuditReport from stored crawl data
  */
 export function reconstructReport(
   storage: SQLiteStorage,
   crawlId: string,
-  smartMerge?: SmartMergeOverride
+  smartMerge?: SmartMergeOverride,
+  options?: ReconstructOptions
 ): Effect.Effect<AuditReport, Error, never> {
   return Effect.gen(function* () {
+    // Clamped: SQLite reads `LIMIT 0` as no limit, so a zero batch would return
+    // the whole table every iteration while `offset += 0` never advanced.
+    const batchSize = Math.max(1, options?.batchSize ?? RECONSTRUCT_PAGE_BATCH);
     // 1. Get crawl metadata
     const crawl = yield* storage.getCrawl(crawlId);
     if (!crawl) {
       return yield* Effect.fail(new Error(`Crawl not found: ${crawlId}`));
     }
 
-    // 2. Get all pages for this crawl
-    const pageRecords = yield* storage.getPages(crawlId);
+    // 2. The crawl's pages are read in batches further down, not here (#1913).
+    // A PageRecord carries the page's full html, so one `getPages(crawlId)`
+    // held the whole crawl resident for the length of the report assembly —
+    // a second page-count-scaled term landing on top of the rules phase's
+    // peak. `getPages` orders by normalized_url ASC with or without
+    // LIMIT/OFFSET, so the batched walk visits exactly the sequence the
+    // resident array did: same summary entries, same page order, same report.
 
     // 3. Get robots.txt data
     const robotsRecord = yield* storage.getRobotsTxt(crawlId);
@@ -231,18 +252,9 @@ export function reconstructReport(
           }
         : undefined;
 
-    if (sitemaps) {
-      const coverage = computeSitemapCoverage(
-        pageRecords.map((p) => ({
-          url: p.normalizedUrl,
-          finalUrl: p.finalUrl,
-          statusCode: p.status,
-        })),
-        sitemaps.discovered.flatMap((s: SitemapData) => s.urls)
-      );
-      sitemaps.orphanPages = coverage.orphanPages;
-      sitemaps.missingPages = coverage.missingPages;
-    }
+    // Sitemap coverage needs one scalar triple per page, which the batched page
+    // walk below collects; computed once it has them (pure, so moving it past
+    // the walk changes nothing but when it runs).
 
     const resourceSizeRecords = yield* storage
       .getResourceSizes(crawlId)
@@ -280,118 +292,157 @@ export function reconstructReport(
       securityIssues: [],
     };
 
-    for (const page of pageRecords) {
-      // Parse page HTML if available
-      const parsed = page.html ? parsePageRecord(page) : null;
+    // Scalars the sections after this walk need, so nothing has to keep a
+    // PageRecord alive past the batch it arrived in: three fields for sitemap
+    // coverage, the status for the audit-validity verdict + rate-limit count.
+    const coverageInputs: Array<{
+      url: string;
+      finalUrl?: string;
+      statusCode: number;
+    }> = [];
+    const pageStatuses: Array<{ status: number }> = [];
 
-      // Get links that appear on this page (per-page index lookup)
-      const pageLinkAppearances = yield* storage.getLinkAppearancesForPage(
-        crawlId,
-        page.normalizedUrl
-      );
-      const pageLinks = pageLinkAppearances.map((a) => {
-        const link = linkByHref.get(a.href);
-        return {
-          url: a.href,
-          text: a.anchorText,
-          isInternal: link?.isInternal ?? false,
-          status: link?.status,
-          error: link?.error,
-        };
+    for (let offset = 0; ; offset += batchSize) {
+      // Fails rather than degrading: the whole-crawl read this replaced
+      // propagated its StorageError too, and ending a BATCHED walk early would
+      // publish a confident report over a truncated page set instead.
+      const batch = yield* storage.getPages(crawlId, {
+        limit: batchSize,
+        offset,
       });
+      if (batch.length === 0) break;
 
-      // Get images that appear on this page (per-page index lookup)
-      const pageImageAppearances = yield* storage.getImageAppearancesForPage(
-        crawlId,
-        page.normalizedUrl
-      );
-      const pageImages = pageImageAppearances.map((a) => ({
-        src: a.src,
-        alt: a.alt ?? null,
-        width: null,
-        height: null,
-      }));
+      for (const page of batch) {
+        coverageInputs.push({
+          url: page.normalizedUrl,
+          finalUrl: page.finalUrl,
+          statusCode: page.status,
+        });
+        pageStatuses.push({ status: page.status });
+        // Parse page HTML if available
+        const parsed = page.html ? parsePageRecord(page) : null;
 
-      // Get rule results for this page
-      const pageChecks = ruleResultsByPage.get(page.normalizedUrl) ?? [];
+        // Get links that appear on this page (per-page index lookup)
+        const pageLinkAppearances = yield* storage.getLinkAppearancesForPage(
+          crawlId,
+          page.normalizedUrl
+        );
+        const pageLinks = pageLinkAppearances.map((a) => {
+          const link = linkByHref.get(a.href);
+          return {
+            url: a.href,
+            text: a.anchorText,
+            isInternal: link?.isInternal ?? false,
+            status: link?.status,
+            error: link?.error,
+          };
+        });
 
-      // Build summary data
-      if (parsed) {
-        if (!parsed.meta.title) summary.missingTitles.push(page.normalizedUrl);
-        if (!parsed.meta.description)
-          summary.missingDescriptions.push(page.normalizedUrl);
-        if (!parsed.og.title && !parsed.og.image)
-          summary.missingOgTags.push(page.normalizedUrl);
-        if (!parsed.twitter.card)
-          summary.missingTwitterCards.push(page.normalizedUrl);
-        if (!parsed.schema.types.length)
-          summary.missingSchemas.push(page.normalizedUrl);
-        if (parsed.h1.count > 1) summary.multipleH1s.push(page.normalizedUrl);
-        if (parsed.content.isThinContent)
-          summary.thinContentPages.push(page.normalizedUrl);
-      }
+        // Get images that appear on this page (per-page index lookup)
+        const pageImageAppearances = yield* storage.getImageAppearancesForPage(
+          crawlId,
+          page.normalizedUrl
+        );
+        const pageImages = pageImageAppearances.map((a) => ({
+          src: a.src,
+          alt: a.alt ?? null,
+          width: null,
+          height: null,
+        }));
 
-      // Check missing alt text. alt="" is the correct markup for a decorative
-      // image (HTML spec, WCAG H67), so only an absent attribute counts (#143).
-      for (const imgAppearance of pageImageAppearances) {
-        if (imgAppearance.alt === undefined || imgAppearance.alt === null) {
-          summary.missingAltText.push({
-            page: page.normalizedUrl,
-            image: imgAppearance.src,
-          });
+        // Get rule results for this page
+        const pageChecks = ruleResultsByPage.get(page.normalizedUrl) ?? [];
+
+        // Build summary data
+        if (parsed) {
+          if (!parsed.meta.title)
+            summary.missingTitles.push(page.normalizedUrl);
+          if (!parsed.meta.description)
+            summary.missingDescriptions.push(page.normalizedUrl);
+          if (!parsed.og.title && !parsed.og.image)
+            summary.missingOgTags.push(page.normalizedUrl);
+          if (!parsed.twitter.card)
+            summary.missingTwitterCards.push(page.normalizedUrl);
+          if (!parsed.schema.types.length)
+            summary.missingSchemas.push(page.normalizedUrl);
+          if (parsed.h1.count > 1) summary.multipleH1s.push(page.normalizedUrl);
+          if (parsed.content.isThinContent)
+            summary.thinContentPages.push(page.normalizedUrl);
         }
+
+        // Check missing alt text. alt="" is the correct markup for a decorative
+        // image (HTML spec, WCAG H67), so only an absent attribute counts (#143).
+        for (const imgAppearance of pageImageAppearances) {
+          if (imgAppearance.alt === undefined || imgAppearance.alt === null) {
+            summary.missingAltText.push({
+              page: page.normalizedUrl,
+              image: imgAppearance.src,
+            });
+          }
+        }
+
+        const pageAudit: PageAudit = {
+          url: page.url,
+          statusCode: page.status,
+          loadTime: page.loadTimeMs,
+          meta: parsed?.meta ?? {
+            title: null,
+            description: null,
+            canonical: null,
+            robots: null,
+          },
+          og: parsed?.og ?? {
+            title: null,
+            description: null,
+            url: null,
+            type: null,
+            image: null,
+            siteName: null,
+          },
+          twitter: parsed?.twitter ?? {
+            card: null,
+            title: null,
+            description: null,
+            image: null,
+          },
+          schema: parsed?.schema ?? {
+            types: [],
+            valid: true,
+            errors: [],
+            raw: null,
+          },
+          links: pageLinks,
+          images: pageImages,
+          h1Count: parsed?.h1.count ?? 0,
+          h1Text: parsed?.h1.texts ?? [],
+          checks: pageChecks,
+          redirectChain: page.redirectChain,
+          fetcherId: page.fetcherId,
+          fallbackReason: page.fallbackReason,
+          responseHeaders: omitSetCookie(page.headers),
+          security: {
+            isHttps: page.url.startsWith("https"),
+            hasMixedContent: false,
+            mixedContentUrls: [],
+            insecureFormActions: [],
+            headers: page.securityHeaders,
+            httpToHttpsRedirect: false,
+          },
+        };
+
+        pages.push(pageAudit);
       }
 
-      const pageAudit: PageAudit = {
-        url: page.url,
-        statusCode: page.status,
-        loadTime: page.loadTimeMs,
-        meta: parsed?.meta ?? {
-          title: null,
-          description: null,
-          canonical: null,
-          robots: null,
-        },
-        og: parsed?.og ?? {
-          title: null,
-          description: null,
-          url: null,
-          type: null,
-          image: null,
-          siteName: null,
-        },
-        twitter: parsed?.twitter ?? {
-          card: null,
-          title: null,
-          description: null,
-          image: null,
-        },
-        schema: parsed?.schema ?? {
-          types: [],
-          valid: true,
-          errors: [],
-          raw: null,
-        },
-        links: pageLinks,
-        images: pageImages,
-        h1Count: parsed?.h1.count ?? 0,
-        h1Text: parsed?.h1.texts ?? [],
-        checks: pageChecks,
-        redirectChain: page.redirectChain,
-        fetcherId: page.fetcherId,
-        fallbackReason: page.fallbackReason,
-        responseHeaders: omitSetCookie(page.headers),
-        security: {
-          isHttps: page.url.startsWith("https"),
-          hasMixedContent: false,
-          mixedContentUrls: [],
-          insecureFormActions: [],
-          headers: page.securityHeaders,
-          httpToHttpsRedirect: false,
-        },
-      };
+      if (batch.length < batchSize) break;
+    }
 
-      pages.push(pageAudit);
+    if (sitemaps) {
+      const coverage = computeSitemapCoverage(
+        coverageInputs,
+        sitemaps.discovered.flatMap((s: SitemapData) => s.urls)
+      );
+      sitemaps.orphanPages = coverage.orphanPages;
+      sitemaps.missingPages = coverage.missingPages;
     }
 
     // 9. Calculate totals from rule results
@@ -540,9 +591,9 @@ export function reconstructReport(
     // count; a stored 429/430 page adds to it.
     const rateLimitedCount =
       (crawl.stats?.pagesRateLimited ?? 0) +
-      pageRecords.filter((p) => isRateLimitStatus(p.status)).length;
+      pageStatuses.filter((p) => isRateLimitStatus(p.status)).length;
     const runStatus = deriveAuditStatusFromPages(
-      pageRecords,
+      pageStatuses,
       crawl.stats?.pagesBlocked ?? 0,
       {
         // #1829: a rate-limited fetch stores no page, so the count comes from

--- a/apps/cli/tests/audit/stream-batch-dial.test.ts
+++ b/apps/cli/tests/audit/stream-batch-dial.test.ts
@@ -1,0 +1,80 @@
+// #1913: the CLI reads the same two batch dials the hosted runtime does, with
+// the same names and the same 48 MB default, so a batch tuned against a local
+// repro means the same thing in a container. A bad value must clamp, never pass
+// through: an unbounded batch is the resident pipeline again, and a batch of one
+// makes the per-batch storage reads dominate.
+
+import { STREAM_BATCH_BYTES } from "@squirrelscan/audit-engine";
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveStreamBatchBytes,
+  resolveStreamBatchPagesOverride,
+} from "../../src/audit/stream-batch";
+import {
+  STREAM_BATCH_BYTES_DEFAULT,
+  STREAM_BATCH_BYTES_MAX,
+  STREAM_BATCH_BYTES_MIN,
+  STREAM_BATCH_PAGES_MAX,
+  STREAM_BATCH_PAGES_MIN,
+} from "../../src/constants";
+
+describe("SQUIRREL_STREAM_BATCH_BYTES", () => {
+  test("defaults to 48 MB when unset", () => {
+    expect(resolveStreamBatchBytes({})).toBe(STREAM_BATCH_BYTES_DEFAULT);
+    expect(STREAM_BATCH_BYTES_DEFAULT).toBe(48 * 1024 * 1024);
+  });
+
+  test("the CLI default is the engine's own default", () => {
+    // Restated in @/constants rather than imported: `@/constants` is pulled in
+    // by nearly every CLI entry point and importing the audit-engine barrel
+    // there would drag the rule set into `squirrel self version`. This is what
+    // stops the two copies drifting.
+    expect(STREAM_BATCH_BYTES_DEFAULT).toBe(STREAM_BATCH_BYTES);
+  });
+
+  test("an explicit budget is honoured", () => {
+    expect(
+      resolveStreamBatchBytes({ SQUIRREL_STREAM_BATCH_BYTES: "96000000" })
+    ).toBe(96_000_000);
+  });
+
+  test("clamps a value outside the band", () => {
+    expect(resolveStreamBatchBytes({ SQUIRREL_STREAM_BATCH_BYTES: "1" })).toBe(
+      STREAM_BATCH_BYTES_MIN
+    );
+    expect(
+      resolveStreamBatchBytes({ SQUIRREL_STREAM_BATCH_BYTES: "999999999999" })
+    ).toBe(STREAM_BATCH_BYTES_MAX);
+  });
+
+  test("a non-numeric value falls back to the default rather than NaN", () => {
+    expect(
+      resolveStreamBatchBytes({ SQUIRREL_STREAM_BATCH_BYTES: "48mb" })
+    ).toBe(STREAM_BATCH_BYTES_DEFAULT);
+    expect(resolveStreamBatchBytes({ SQUIRREL_STREAM_BATCH_BYTES: "" })).toBe(
+      STREAM_BATCH_BYTES_DEFAULT
+    );
+  });
+});
+
+describe("SQUIRREL_STREAM_BATCH_PAGES", () => {
+  test("undefined when unset — the batch is sized from the site's own pages", () => {
+    expect(resolveStreamBatchPagesOverride({})).toBeUndefined();
+  });
+
+  test("an explicit page count pins the batch", () => {
+    expect(
+      resolveStreamBatchPagesOverride({ SQUIRREL_STREAM_BATCH_PAGES: "64" })
+    ).toBe(64);
+  });
+
+  test("clamps a value outside the band", () => {
+    expect(
+      resolveStreamBatchPagesOverride({ SQUIRREL_STREAM_BATCH_PAGES: "0" })
+    ).toBe(STREAM_BATCH_PAGES_MIN);
+    expect(
+      resolveStreamBatchPagesOverride({ SQUIRREL_STREAM_BATCH_PAGES: "100000" })
+    ).toBe(STREAM_BATCH_PAGES_MAX);
+  });
+});

--- a/apps/cli/tests/audit/streamed-payload-parity.test.ts
+++ b/apps/cli/tests/audit/streamed-payload-parity.test.ts
@@ -1,0 +1,287 @@
+// #1913: the audit controller no longer holds a whole-crawl site context, so
+// every consumer that used to read one now collects during the streamed
+// pre-rules walk instead. This pins the two that produce user-visible output —
+// the cloud-prefetch request payloads and the tech-detect page sample — to the
+// whole-array builders they replaced, batch boundaries and all.
+//
+// The batching is the part worth testing: each collector's caps are carried
+// state, so a cap that reset per batch, or a home page found in a later batch
+// than the sample it belongs in front of, changes what the cloud is asked.
+
+import type { CloudServicesClient } from "@squirrelscan/cloud-client";
+import type { TechDetectPagePayload } from "@squirrelscan/core-contracts";
+import type { PageRecord } from "@squirrelscan/core-contracts/storage";
+
+import { SERVICE_LIMITS } from "@squirrelscan/core-contracts/limits";
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import {
+  buildSiteContext,
+  releaseSiteContextDocuments,
+} from "../../src/audit/adapter";
+import {
+  absorbExternalLinkUrls,
+  buildCloudPagePayloads,
+  buildMetadataPayload,
+  createCloudPrefetchCollector,
+  createTechDetectSampleCollector,
+  detectLocalTechnologies,
+  runCloudTechDetect,
+} from "../../src/audit/cloud";
+import { buildBlocklistPayload } from "../../src/audit/cloud-payloads-blocklist";
+import { buildGapsPayloads } from "../../src/audit/cloud-payloads-gaps";
+import { getDefaultConfig } from "../../src/config";
+
+const BASE = "https://example.com/";
+
+function pageRecord(
+  url: string,
+  html: string,
+  overrides: Partial<PageRecord> = {}
+): PageRecord {
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: html.length,
+    loadTimeMs: 10,
+    fetchedAt: Date.now(),
+    etag: null,
+    lastModified: null,
+    contentHash: `hash-${url}`,
+    html,
+    parsedData: null,
+    headers: {
+      contentType: "text/html",
+      contentEncoding: null,
+      cacheControl: null,
+      vary: null,
+      etag: null,
+      server: null,
+      lastModified: null,
+      link: null,
+      serverTiming: null,
+      age: null,
+      xCache: null,
+      cfCacheStatus: null,
+      xVercelCache: null,
+      altSvc: null,
+      acceptRanges: null,
+    },
+    securityHeaders: {
+      hsts: null,
+      csp: null,
+      xFrameOptions: null,
+      xContentTypeOptions: null,
+      referrerPolicy: null,
+      permissionsPolicy: null,
+      xRobotsTag: null,
+    },
+    ...overrides,
+  };
+}
+
+/** A page with per-page-distinct links, images, scripts, ids and classes. */
+function html(i: number): string {
+  return `<!doctype html><html lang="en"><head>
+<title>Page ${i} | Example</title>
+<meta name="description" content="Description for page ${i}">
+<meta property="og:title" content="OG ${i}">
+<link rel="alternate" hreflang="en-${i}" href="https://example.com/en-${i}">
+<script type="application/ld+json">{"@type":"Organization","name":"Acme ${i}"}</script>
+<script src="https://cdn${i}.example.net/tracker.js"></script>
+</head><body>
+<h1>Heading ${i}</h1>
+<div id="wrap${i}" class="layout col${i}">
+<a href="https://outbound${i}.example.org/a">out ${i}</a>
+<a href="mailto:hi${i}@example.com">mail ${i}</a>
+<a href="/internal/${i}">internal ${i}</a>
+<img src="https://img${i}.example.net/p.png" alt="img ${i}">
+<p>${`body copy for page ${i}. `.repeat(20)}</p>
+</div></body></html>`;
+}
+
+/**
+ * 30 pages: the base URL is deliberately LAST, past both the metadata sample
+ * prefix (6) and the tech-detect prefix (12), so the "home page lives in a
+ * batch the prefix never reached" path is the one under test. Two pages are
+ * non-2xx and one is a non-HTML asset, so the usable-page filters have
+ * something to drop.
+ */
+function corpus(): PageRecord[] {
+  const pages: PageRecord[] = [];
+  for (let i = 0; i < 29; i++) {
+    const url = `https://example.com/p/${String(i).padStart(2, "0")}`;
+    if (i === 5) {
+      pages.push(pageRecord(url, html(i), { status: 404 }));
+    } else if (i === 9) {
+      pages.push(
+        pageRecord(url, "body { color: red }", {
+          contentType: "text/css",
+          headers: {
+            ...pageRecord(url, "").headers,
+            contentType: "text/css",
+          },
+        })
+      );
+    } else {
+      pages.push(pageRecord(url, html(i)));
+    }
+  }
+  // normalized_url ASC puts "/" after "/p/..." only if we say so; the walk
+  // visits whatever order storage returns, and the collectors must not care.
+  pages.push(pageRecord(BASE, html(99)));
+  return pages;
+}
+
+const context = (pages: PageRecord[]) =>
+  Effect.runSync(buildSiteContext(pages));
+
+/** Feed a collector the corpus one batch at a time, releasing like the walk does. */
+function streamed<
+  T extends { absorb: (ctx: ReturnType<typeof context>) => void },
+>(collector: T, pages: PageRecord[], batchSize: number): T {
+  for (let offset = 0; offset < pages.length; offset += batchSize) {
+    const batch = context(pages.slice(offset, offset + batchSize));
+    collector.absorb(batch);
+    releaseSiteContextDocuments(batch);
+  }
+  return collector;
+}
+
+describe("streamed cloud-prefetch payload collection (#1913)", () => {
+  for (const batchSize of [1, 4, 7, 1000]) {
+    test(`batch=${batchSize} produces the whole-array payloads`, () => {
+      const pages = corpus();
+      const whole = context(pages);
+      const config = getDefaultConfig();
+
+      const expectedPages = buildCloudPagePayloads(whole);
+      const expectedBlocklist = buildBlocklistPayload(whole);
+      const expectedGaps = buildGapsPayloads(whole, BASE, config);
+      const expectedMetadata = buildMetadataPayload(whole, BASE);
+
+      const built = streamed(
+        createCloudPrefetchCollector(BASE),
+        pages,
+        batchSize
+      ).build();
+
+      expect(built.pages).toEqual(expectedPages);
+      expect(built.blocklist).toEqual(expectedBlocklist);
+      expect(built.metadataPages).toEqual(expectedMetadata);
+      // The gaps payloads are seeds plus config, so compare the dispatched shape.
+      expect(
+        Object.keys(expectedGaps).length > 0
+          ? expectedGaps["keyword-gaps"]?.seedKeywords
+          : []
+      ).toEqual(built.gapsSeeds);
+    });
+  }
+
+  test("the retained metadata sample is bounded, not page-scaled", () => {
+    const built = streamed(
+      createCloudPrefetchCollector(BASE),
+      corpus(),
+      4
+    ).build();
+    expect(built.metadataPages.length).toBeLessThanOrEqual(
+      SERVICE_LIMITS.metadataMaxPages
+    );
+    // The home page leads it even though it was crawled last.
+    expect(built.metadataPages[0]?.url).toBe(BASE);
+  });
+
+  test("the dead-links estimate counts the same urls batched or not", () => {
+    const pages = corpus();
+    const batched = new Set<string>();
+    for (let offset = 0; offset < pages.length; offset += 3) {
+      absorbExternalLinkUrls(batched, context(pages.slice(offset, offset + 3)));
+    }
+    const wholePass = new Set<string>();
+    absorbExternalLinkUrls(wholePass, context(pages));
+
+    expect([...batched].sort()).toEqual([...wholePass].sort());
+    // Each html page carries one distinct outbound host.
+    expect(batched.size).toBeGreaterThan(0);
+  });
+});
+
+describe("streamed tech-detect sample (#1913)", () => {
+  test("local detection over the sample equals detection over the crawl", () => {
+    const pages = corpus();
+    const scripts = [
+      { url: "https://cdn0.example.net/tracker.js", content: "var x = 1;" },
+    ];
+    const expected = detectLocalTechnologies({
+      baseUrl: BASE,
+      siteContext: context(pages),
+      scripts,
+    });
+    const sample = streamed(
+      createTechDetectSampleCollector(BASE),
+      pages,
+      5
+    ).build();
+    expect(
+      detectLocalTechnologies({ baseUrl: BASE, siteContext: sample, scripts })
+    ).toEqual(expected);
+  });
+
+  test("the cloud tech-detect body is the same pages in the same order", async () => {
+    const pages = corpus();
+    const config = getDefaultConfig();
+    config.cloud.enabled = true;
+    config.cloud.technologies = true;
+
+    const captured: TechDetectPagePayload[][] = [];
+    const client = {
+      detectTechnologies: async (req: { pages: TechDetectPagePayload[] }) => {
+        captured.push(req.pages);
+        return {
+          technologies: [],
+          added: [],
+          removed: [],
+          firstScan: true,
+        };
+      },
+    } as unknown as CloudServicesClient;
+
+    const run = (siteContext: ReturnType<typeof context>) =>
+      runCloudTechDetect({
+        client,
+        config,
+        auditId: "audit-1",
+        baseUrl: BASE,
+        siteContext,
+        scripts: [],
+      });
+
+    await run(context(pages));
+    await run(
+      streamed(createTechDetectSampleCollector(BASE), pages, 5).build()
+    );
+
+    expect(captured).toHaveLength(2);
+    expect(captured[1]).toEqual(captured[0]!);
+    expect(captured[0]?.[0]?.url).toBe(BASE);
+    expect(captured[0]!.length).toBeLessThanOrEqual(
+      SERVICE_LIMITS.techDetectMaxPages
+    );
+  });
+
+  test("the sample is bounded by techDetectMaxPages plus the home page", () => {
+    const sample = streamed(
+      createTechDetectSampleCollector(BASE),
+      corpus(),
+      5
+    ).build();
+    expect(sample.length).toBeLessThanOrEqual(
+      SERVICE_LIMITS.techDetectMaxPages + 1
+    );
+  });
+});

--- a/docs/cli/debug.mdx
+++ b/docs/cli/debug.mdx
@@ -100,6 +100,43 @@ Traces include:
 - Rule execution duration
 - Crawl phase boundaries
 
+## Memory on large audits
+
+Everything after the crawl reads the site in batches and drops each batch before
+reading the next, so a 2,500-page audit holds roughly what a 400-page one does
+rather than several gigabytes. The batch is sized from the site's own average
+page against a byte budget, because a docs site of 30 KB pages and a storefront
+of 1 MB ones need very different page counts to hold the same bytes.
+
+Two environment variables override that, and they are the same names and the
+same default the hosted runtime uses:
+
+| Variable | Meaning |
+| --- | --- |
+| `SQUIRREL_STREAM_BATCH_BYTES` | Raw HTML held per batch. Default 48 MB. |
+| `SQUIRREL_STREAM_BATCH_PAGES` | An exact page count, taking the byte budget out of the decision. |
+
+Both take a plain integer. A value with a unit suffix is refused with a warning
+rather than partly read, so `SQUIRREL_STREAM_BATCH_BYTES=48mb` does not quietly
+become 48 bytes.
+
+Turning the budget down is usually the wrong move. Peak memory is a fixed floor
+for the rule set and caches plus a few megabytes per page of batch, so the floor
+is not reachable from this dial, and below roughly a dozen pages per batch the
+same crawl becomes several times as many read-and-parse cycles whose churn peaks
+*higher* than a larger batch does.
+
+To see where memory goes, set `SQUIRREL_STREAM_PHASE_MEM=1`. Each sub-phase of
+the rules pass then prints its heap after a forced collection:
+
+```text
+[stream] universe end heapUsed=285MB external=51MB rss=915MB
+[stream] page-rules end heapUsed=287MB external=56MB rss=798MB
+```
+
+Read `heapUsed`, not `rss`. Under memory pressure macOS compresses pages and the
+resident figure stops tracking what the process actually holds.
+
 ## Sensitive data redaction
 
 Logs automatically redact sensitive data:

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -727,9 +727,18 @@ export function fetchAssetsFromOccurrences(
       truncated: crawl?.stats?.sitemapDiscoveryTruncated ?? false,
     };
 
+    // Every orphan the coverage pass found, in its order. These are the
+    // sitemap-status check's CANDIDATES; what bounds them is `sitemapStatusLimit`
+    // below (the configured resource limit), not the report's array cap.
+    // Capping here instead silently stopped checking past REPORT_LIMITS.maxPages,
+    // so a 404 at orphan 2,001 of a 3,000-page crawl was never looked at and
+    // `crawl/sitemap-4xx` reported a pass (#1913). The cloud is unaffected: it
+    // passes resourceCheckMaxItems = 100.
+    let orphanCandidates: string[] = [];
     if (sitemapDiscovery.discovered.length > 0) {
       const coverage = computeSitemapCoverageData(occurrences.coveragePages, sitemapDiscovery);
-      // Cap to keep resource-check URLs within reasonable bounds
+      orphanCandidates = coverage.orphanPages;
+      // The arrays that TRAVEL stay capped at the schema's array limit.
       sitemapDiscovery.orphanPages = coverage.orphanPages.slice(0, REPORT_LIMITS.maxPages);
       sitemapDiscovery.missingPages = coverage.missingPages.slice(0, REPORT_LIMITS.maxPages);
     }
@@ -800,7 +809,7 @@ export function fetchAssetsFromOccurrences(
     };
 
     const sitemapStatusLimit = Math.min(
-      sitemapDiscovery.orphanPages.length,
+      orphanCandidates.length,
       maxResources ?? config.crawler?.max_pages ?? 500,
     );
 
@@ -830,7 +839,7 @@ export function fetchAssetsFromOccurrences(
           resourceCheckOptions,
         ),
         sitemap: checkResourceSizes(
-          sitemapDiscovery.orphanPages.slice(0, sitemapStatusLimit),
+          orphanCandidates.slice(0, sitemapStatusLimit),
           resourceCheckOptions,
         ),
       },

--- a/packages/audit-engine/src/detach.ts
+++ b/packages/audit-engine/src/detach.ts
@@ -12,7 +12,9 @@ export type DetachBoundary =
   | "parsed-universe"
   | "external-links"
   /** Cloud-prefetch payloads collected during a streamed pre-rules walk (#1913). */
-  | "cloud-payload";
+  | "cloud-payload"
+  /** Per-page fields the CLI's report keeps after its page batch is dropped (#1913). */
+  | "report-page";
 
 export interface DetachCounts {
   /** Values copied free of their page. */

--- a/packages/audit-engine/src/detach.ts
+++ b/packages/audit-engine/src/detach.ts
@@ -10,7 +10,9 @@ export type DetachBoundary =
   | "page-rules"
   | "collected-signal"
   | "parsed-universe"
-  | "external-links";
+  | "external-links"
+  /** Cloud-prefetch payloads collected during a streamed pre-rules walk (#1913). */
+  | "cloud-payload";
 
 export interface DetachCounts {
   /** Values copied free of their page. */

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -201,6 +201,7 @@ export type { PageSignalCollector, StreamPageRulesHooks, StreamPageRulesResult }
 // Streamed pre-rules phase (#1860) — one batched walk that feeds the asset,
 // external-link, tech-detect, intel and cloud-prefetch collectors together.
 export { runStreamingPreRules, PRE_RULES_PAGE_BATCH } from "./streaming-pre-rules";
+export { detachFromPage, type DetachBoundary } from "./detach";
 export type { StreamPreRulesOptions, StreamPreRulesResult } from "./streaming-pre-rules";
 
 // Byte-budget batch sizing (#1860) — pages per batch derived from the site's own

--- a/packages/audit-engine/src/streaming-pre-rules.ts
+++ b/packages/audit-engine/src/streaming-pre-rules.ts
@@ -41,6 +41,7 @@ import {
   type ExternalLinkOccurrences,
   type PreFetchedAssets,
   type ResourceCheckOverrides,
+  type SiteContextPage,
 } from "./adapter";
 import { collectDroppedBatch } from "./batch-gc";
 import { createCloudPrefetchCollector, type CloudPrefetchPayloadSet } from "./cloud-prefetch-run";
@@ -64,6 +65,19 @@ export interface StreamPreRulesOptions {
     onProgress?: (progress: ExternalLinkCheckProgress) => void;
     linkCache?: LinkCache | null;
     bulkChecker?: (urls: string[]) => Promise<Map<string, ExternalCheckResult>>;
+    /**
+     * Resolve the bulk checker after the collection walk and BEFORE any link is
+     * checked (#1913). The CLI gates its paid dead-links checker on a spend
+     * confirmation sized from the crawl's external-link count — a number the
+     * resident path had up front from a whole-crawl site context and this pass
+     * only has once the walk ends. Deferring to the first bulk call instead
+     * would put the prompt in the middle of the link-check progress output.
+     * Ignored when `bulkChecker` is supplied; its rejection is fatal, exactly
+     * as an unhandled throw from building the checker would have been.
+     */
+    resolveBulkChecker?: () => Promise<
+      ((urls: string[]) => Promise<Map<string, ExternalCheckResult>>) | undefined
+    >;
   };
   /**
    * Site URL to collect cloud-prefetch payloads for. Omit when the run has no
@@ -78,6 +92,21 @@ export interface StreamPreRulesOptions {
   /** Fired after each page batch with the running count — the container's
    * liveness heartbeat, so a long pre-rules pass is never silent. */
   onBatch?: (info: { pagesDone: number }) => void;
+  /**
+   * Per-batch collector seam (#1913). Called with the batch's site context after
+   * this pass's own collectors have absorbed it and while its DOMs are still
+   * LIVE, so a caller with its own page-time signal to gather (the CLI's cloud
+   * prefetch payloads, its bounded tech-detect sample, its smart-audit page
+   * list) can do it inside this walk instead of holding a whole-crawl site
+   * context of its own — which is the residency term this pass exists to remove.
+   *
+   * The callee MUST NOT retain anything reachable from the batch's documents or
+   * html beyond a bounded sample: the batch is released immediately after this
+   * returns, and a retained reference re-links the page-count-scaled term. A
+   * string sliced out of a page's html pins that page's whole backing store
+   * (#240), so detach what you keep.
+   */
+  onBatchContext?: (siteContext: SiteContextPage[]) => void;
 }
 
 export interface StreamPreRulesResult {
@@ -166,6 +195,8 @@ export function runStreamingPreRules(
       assetCollector.absorb(ctx);
       if (externalLinksEnabled) absorbExternalLinkOccurrences(externalLinkOccurrences, ctx);
       prefetchCollector?.absorb(ctx);
+      // Caller-owned collectors run last, still inside the live-DOM window.
+      options?.onBatchContext?.(ctx);
       releaseSiteContextDocuments(ctx);
       // Dropped is not collected — see batch-gc.ts. Without this the walk's peak
       // is set by how far behind the collector happens to be, not by batchSize.
@@ -178,6 +209,12 @@ export function runStreamingPreRules(
     // Network halves, in v1's order: external links are checked and PERSISTED
     // first because `buildStreamingSiteData` later reads the link + appearance
     // rows they write.
+    const bulkChecker = options?.externalLinks
+      ? (options.externalLinks.bulkChecker ??
+        (options.externalLinks.resolveBulkChecker
+          ? yield* Effect.promise(options.externalLinks.resolveBulkChecker)
+          : undefined))
+      : undefined;
     const externalLinkResults = options?.externalLinks
       ? yield* checkCollectedExternalLinks(
           storage,
@@ -186,7 +223,7 @@ export function runStreamingPreRules(
           options.externalLinks.config,
           options.externalLinks.onProgress,
           options.externalLinks.linkCache ?? null,
-          options.externalLinks.bulkChecker,
+          bulkChecker,
         )
       : [];
 


### PR DESCRIPTION
Wires the `squirrel` CLI's post-crawl audit phases onto the streaming pipeline the hosted runtime has used since #1860, so a local audit's memory is bounded by the batch instead of by the page count. Private issue #1913.

## The problem

The CLI still ran the resident pipeline. `storage.getPages(crawlId)` materialized every crawled page, `buildSiteContext` parsed each one into a live DOM, and that single array was held through the external-link check, the resource-asset fetch, the cloud prefetch, tech detect and the whole rules phase. Then `reconstructReport` read every page a second time.

Retained heap grew about 1.5 MB per crawled page. Max resident set size read flat across the same runs, because on a machine under memory pressure the macOS compressor absorbs the growth: at 2,500 pages the process held 3.9 GB of heap while "resident" said 1.4 GB.

## What changed

Every phase after the crawl now walks the pages table in byte-budgeted batches and drops each batch's DOMs before reading the next. No engine code was copied; the CLI calls the same functions the container does, and two seams were added to `runStreamingPreRules` for the things only the CLI needs:

- `onBatchContext`, so a caller can run its own collectors inside the walk while the batch's DOMs are live.
- `resolveBulkChecker`, so the paid dead-links spend confirmation still lands before the link phase instead of in the middle of its progress output. The resident path had the link count up front from a whole-crawl context; this pass only has it once the walk ends.

The CLI-side consumers that used to read a whole-crawl site context now collect during that walk: the cloud-prefetch payloads, a bounded tech-detect page sample, the dead-links link count and the smart-audits page list. `reconstructReport`'s page pass is batched the same way.

Strings kept out of a parsed page are detached from it. A 6 KB text excerpt is a slice of the page's HTML, and in JSC a retained slice pins the buffer it was cut from, so one excerpt per page would have put the page-count-scaled term straight back. The resident path never had to care, because it was holding the page anyway.

## Numbers

Interleaved cold runs on a 6-template synthetic estate (mean 128 KB/page, 10% a real 982 KB product page), fresh content store per stage, same page bytes both sides. `heapUsed` is `process.memoryUsage()` after `Bun.gc(true)` at exit, not RSS.

| pages | wall (resident → streamed) | end heapUsed (resident → streamed) | max RSS |
|---|---|---|---|
| 400 | 47s → 47s | 685 MB → 265 MB | 865 → 786 MB |
| 1,000 | 194s → 128s | 1,662 MB → 565 MB | 1,300 → 1,108 MB |
| 2,500 | 502s → 177s | 3,902 MB → 996 MB | 1,463 → 1,688 MB |
| 1,000 warm | 87s → 72s | 1,651 MB → 561 MB | 1,944 → 1,734 MB |

Wall time improves rather than regressing. The issue expected a 16% streaming penalty, measured on the container. Locally the resident path pays for its own 1.6 to 3.9 GB in collector and compressor work, and that costs more than the extra parse per page the streamed walk adds. At 400 pages, where the resident heap still fits comfortably, the two are identical.

The remaining slope is about 0.3 to 0.5 MB per page, down from 1.5. It is the engine's DOM-free scalar page universe, which is v1's page set and load-bearing for byte identity, not something this change can remove.

## Report parity

Reports are identical at 400, 1,000 and 2,500 pages, after stripping only the fields that are per-run by construction: crawl id, timestamps, durations, load times and the ephemeral test server's port.

One caveat worth stating. At 2,500 pages the raw diff showed 14 findings' difference, all of them `perf/ttfb`, which grades the *server's* response time. The resident run was under 3.9 GB of pressure and starved the local server past the 600 ms threshold on 14 pages. Excluding that one wall-clock rule, the two reports are byte-for-byte equal. Nothing else differs.

The engine's canonical-vs-streaming golden and its 518-page baseline stay green, as do the CLI's own suites.

## Against the acceptance criteria

Read these before reading "flat" literally anywhere above.

**Rules run through the streaming pipeline rather than materialising every page.** Met. Nothing after the crawl holds a page-count-scaled structure of pages, and the two remaining whole-crawl reads (the site context and the report's own `getPages`) are gone.

**End-of-run heapUsed flat within the batch bound across 1,000 and 2,500 pages.** Partially met, and worth being precise about. DOM residency is batch-bounded, which is the part that produced the 1.5 MB per page. What remains is not flat: 265 MB at 400 pages, 565 MB at 1,000, 996 MB at 2,500, a slope of roughly 0.3 to 0.5 MB per page against the resident path's 1.5, and decelerating rather than linear.

That residual is the engine's DOM-free scalar page universe, `streamParsedUniverse`'s `pageDataMap`. It is v1's page set and the streaming golden depends on it, so it cannot be dropped here without changing the report. The per-sub-phase trace shows it is the only term still growing: at 1,000 pages the universe pass reaches 285 MB and every phase after it, page-rules, site-query, site-rules and assemble, sits at 287 MB.

```text
[stream] universe end    heapUsed=285MB external=51MB rss=915MB
[stream] page-rules end  heapUsed=287MB external=56MB rss=798MB
[stream] site-rules end  heapUsed=287MB external=54MB rss=853MB
[stream] assemble end    heapUsed=287MB external=36MB rss=853MB
```

**Report byte-identical on the golden fixture and the 518-page baseline.** Met, both green.

**Report identical end to end.** Met at 400 and 1,000 pages with no exclusions. At 2,500 the raw diff showed 14 findings differing and every one of them was `perf/ttfb`, which grades the *server's* response time rather than anything about the page. The resident run was carrying 3.9 GB and starved the local test server past the 600 ms threshold on 14 pages; the streamed run did not. Excluding that one wall-clock rule the two reports are byte-for-byte equal. Nothing else differs, at any size.

**Cold and warm wall-clock no worse.** Met, and better: no size regressed, and 1,000 and 2,500 pages improved by 34% and 65%.

**The batch dial is the one the cloud uses and its default is stated.** Met, `SQUIRREL_STREAM_BATCH_BYTES`, 48 MB, see below.

**Memory verified with heapUsed rather than max RSS alone.** Met. Every figure here is `process.memoryUsage()` after `Bun.gc(true)`. Max RSS is quoted alongside only to show it is the misleading one: at 2,500 pages the resident path held 3,902 MB of heap while RSS read 1,463 MB.

## The dial

`SQUIRREL_STREAM_BATCH_BYTES` sets the byte budget, 48 MB of raw HTML by default, the same name and default the container reads. `SQUIRREL_STREAM_BATCH_PAGES` pins an exact page count instead. Both clamp.

Do not turn the budget below roughly a dozen pages' worth. Measured on real ~1 MB pages, peak is a ~300 MB floor plus about 3.5 MB per page of batch, and under about 12 pages the same crawl becomes several times as many read-parse-collect cycles whose churn sets a *higher* high-water than a larger batch does.

A value that is not a plain integer is now refused and named rather than partially parsed: `SQUIRREL_STREAM_BATCH_BYTES=48mb` through `parseInt` is 48 *bytes*, which clamps to a 1 MB batch and looks like the fix not working.

## Review findings, all fixed

An adversarial review of the first commit found three real defects, fixed in the second:

1. **The external-link phase lost the global dead-link cache.** The resident entry point reached for `getGlobalLinkCache()` inside itself; the collected-links entry point takes it as an argument and reads an absent one as "no caching". Every re-audit would have re-checked every external link and resubmitted already-known URLs to the paid bulk checker.
2. **The report's per-page fields still pinned whole pages.** `meta`, `og`, `twitter`, `schema` and the h1 texts are HTML slices. 77.5 MB retained across 80 ~1 MB pages attached, 2.1 MB detached.
3. **Sitemap status checks silently stopped at 2,000 URLs.** The engine's asset pass capped the orphan list at `REPORT_LIMITS.maxPages` before the configured resource limit applied, so on a 3,000-page crawl with more than 2,000 uncrawled sitemap URLs a 404 at position 2,001 was never fetched and `crawl/sitemap-4xx` reported a pass. Candidates are now bounded by the resource limit alone; the arrays that travel on the report stay capped. The cloud is unaffected, it passes `resourceCheckMaxItems = 100`.

Reports stayed identical at 400 and 1,000 pages after these fixes, with end heapUsed unchanged.

## Tests

New: streamed payload parity (the collectors versus the whole-array builders at batch sizes 1, 4, 7 and 1000, including the case where the home page lands in a later batch than the sample it must lead) and the batch dial.

Run green: the full CLI suite (1,960 tests), and in the engine the canonical-vs-streaming golden, the streaming pre-rules golden, the 518-page baseline, the detach suites and batch sizing.

## Not in scope

`squirrel analyze`, which runs the resident path over an already-stored crawl, is unchanged. The engine's container-side cloud-prefetch replica has the same un-detached page-payload retention this fixes on the CLI side; that is a separate change.

