### PR TITLE
perf(rules): remove a per-outlier page scan, and measure the rules phases properly

### DIFF
--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -69,6 +69,48 @@ the page's lifetime, which in JavaScriptCore pins the whole page as UTF-16.
 Remaining per-page term after these: about 80 KB of real values the site pass
 reads, flat across 50 / 100 / 150 pages.
 
+## Rules-phase scaling, and one asymptotic fix with no measurable win
+
+[#1910](https://github.com/squirrelscan/repo/issues/1910) reported site rules at
+n^2.0 (4 s at 400 pages to 687 s at 5,000) and page rules at n^1.6. Re-measured
+on a quiet machine, with the content store isolated, each measurement in its own
+child process, and the two rules that reach the network excluded
+(`security/http-to-https` probes over HTTP with staggered sleeps and was 508 ms
+of a 518 ms site phase; the soft-404 confirmation pass re-fetches candidates).
+Mixed estate at #1910's template shares, 14.2 KB mean, per page in milliseconds:
+
+| pages | universe | page rules | site query | site rules | v1 load+hydrate | v1 rules | parsePageRecord |
+|---|---|---|---|---|---|---|---|
+| 400 | 0.33 | 6.95 | 0.06 | 0.17 | 0.20 | 6.44 | 0.67 |
+| 1,000 | 0.35 | 6.76 | 0.07 | 0.16 | 0.17 | 6.74 | 0.63 |
+| 2,500 | 0.32 | 7.60 | 0.08 | 0.16 | 0.19 | 7.86 | 0.59 |
+
+Slopes across 6.3x: page rules n^1.05, site rules n^0.97, parsePageRecord n^0.93,
+universe n^0.99, v1 rules n^1.11. Nothing quadratic. At 102 KB mean over 400 to
+1,600 the exponents hold. #1910's own caveat explains its numbers: its 2,500 row
+was 589 s wall against 360 s CPU and its 5,000 row 2,236 s against 1,023 s, on a
+box doing 150 MB/s of swap at load average 13.
+
+`integrity/template-discontinuity` did contain a genuinely quadratic structure:
+on the v1 path it looked each outlier's page up with `pages.find(...)`, so with
+outlier share `f` that is `f·n` scans of `n` pages. Replaced with a lazily built
+first-wins map ([#254](https://github.com/squirrelscan/squirrelscan/pull/254)).
+**The change buys nothing measurable at any size this fixture can reach**, and
+this row exists to say so:
+
+| outlier share | pages | before | after |
+|---|---|---|---|
+| 10% | 2,500 | 159 ms | 154 ms |
+| 33% | 1,000 | 74 ms | 71 ms |
+| 33% | 2,500 | 215 ms | 225 ms |
+
+Minimum of five runs each. At the largest share the rule can be given — one page
+in three, since at one in two the baseline absorbs both groups' markers and
+there are no outliers at all — 2,500 pages is about a million string compares
+inside a 215 ms rule. An earlier run of this pair reported 501 ms against 201 ms;
+that was a loaded machine, not the algorithm, and it is recorded here because a
+benchmark record that only keeps the flattering measurement is worth nothing.
+
 ## Hosted runtime, in production
 
 Same 149-page rendered audit of the same site an hour apart, old image against

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -111,6 +111,43 @@ inside a 215 ms rule. An earlier run of this pair reported 501 ms against 201 ms
 that was a loaded machine, not the algorithm, and it is recorded here because a
 benchmark record that only keeps the flattering measurement is worth nothing.
 
+Three things had to be controlled before any of the numbers above meant
+anything, and each one produced a confident wrong answer first. They are worth
+knowing before re-running this or benchmarking any other rule.
+
+**Two rules reach the network and no obvious switch stops them.**
+`security/http-to-https` probes sample URLs over HTTP with staggered sleeps; at
+400 pages it was 508 ms of a 518 ms site phase, so the whole site phase was one
+rule waiting on sockets and the first version of this concluded from it that
+site rules were "dominated by a fixed cost". The soft-404 confirmation pass
+re-fetches candidates with a per-host sleep, and disabling it needs
+`config.integrity.soft404_confirm` — a root-level key of that name is silently
+ignored, and it defaults to enabled.
+
+**The rule profiler rounds every invocation to whole milliseconds.** Harmless
+for a site rule, which runs once per audit and takes tens of ms. Fatal when
+summed over page rules: 198 rules across 2,500 pages is 495,000 rounded samples,
+sub-millisecond work sums to zero, and a rule that crosses 1 ms on heavier pages
+jumps a whole unit. That artifact produced a published claim that v1's page
+rules were n^1.47 against streaming's n^1.01; unrounded timings of the same
+invocations put both near n^1.0. Page-rule cost here comes from phase spans,
+which are unrounded, and page-rule profiler lines are counted rather than summed.
+
+**A uniform fixture skips the branches that cost anything.** Three versions of
+this corpus did. The last one scored its off-theme pages at 0.258 against
+`template-discontinuity`'s 0.2 threshold, so the rule reported "all pages share
+the site's common template" and the quadratic scan never ran at all. One cause
+generalises past this rule: **the Jaccard of two empty sets is 1**, so a
+fingerprint term that neither the baseline nor the outlier declares pays full
+weight to SIMILARITY. The corpus now also carries pages nothing links to, hubs,
+4xx and noindex pages, off-page canonicals and schema on four templates, each
+gating a branch a uniform corpus skips.
+
+And a fourth, learned the hard way on the table above: **a loaded machine does
+not merely add noise to a cache-hostile scan, it systematically inflates it**, so
+minimum-of-N on a busy box is not a defence. Re-run the pair on a quiet machine
+before publishing a delta.
+
 ## Hosted runtime, in production
 
 Same 149-page rendered audit of the same site an hour apart, old image against

--- a/packages/audit-engine/scripts/build-mixed-fixture.ts
+++ b/packages/audit-engine/scripts/build-mixed-fixture.ts
@@ -102,23 +102,54 @@ interface Page {
 const DIVERGENT_IN = 10;
 const isDivergent = (i: number) => i % DIVERGENT_IN === 3;
 
-function theme(i: number): { head: string; bodyClass: string; footer: string } {
+interface Theme {
+  head: string;
+  bodyClass: string;
+  footer: string;
+  /** Wrapper for the internal links. `<nav>` is itself a fingerprint signal. */
+  navTag: string;
+  imageHost: string;
+}
+
+/**
+ * Divergence has to beat the rule's own similarity threshold, not just look
+ * different. `similarityToBaseline` is a weighted Jaccard over stylesheet
+ * hrefs (0.35), asset hosts (0.25), body classes (0.15), CSS variables (0.10)
+ * and nav/footer presence (0.15), and the default threshold is 0.2. A first
+ * attempt at this scored 0.258 and produced ZERO outliers:
+ *
+ *   - the divergent pages still resolved `bench.test` from their canonical link
+ *     and their relative image srcs, so host Jaccard was 1/3 rather than near 0;
+ *   - both sides had NO css variables, and Jaccard of two empty sets is 1, so
+ *     that term paid full weight to similarity;
+ *   - both sides had a `<nav>`, so half the chrome term matched.
+ *
+ * So the baseline declares CSS variables, the divergent pages spread their
+ * assets over three foreign hosts, and they wrap their links in a div. That
+ * scores about 0.05 and the outliers are real.
+ */
+function theme(i: number): Theme {
   if (isDivergent(i)) {
     return {
       head:
-        `<link rel="stylesheet" href="https://assets.other-cdn.test/legacy-${i % 3}.css">` +
-        `<script src="https://assets.other-cdn.test/legacy.js"></script>`,
+        `<link rel="stylesheet" href="https://css.other-cdn.test/legacy-${i % 3}.css">` +
+        `<script src="https://js.other-cdn.test/legacy.js"></script>`,
       bodyClass: `legacy-page variant-${i % 3}`,
       footer: "",
+      navTag: "div",
+      imageHost: "https://img.other-cdn.test",
     };
   }
   return {
     head:
       `<link rel="stylesheet" href="https://cdn.bench.test/theme.css">` +
       `<link rel="stylesheet" href="https://cdn.bench.test/layout.css">` +
-      `<script src="https://cdn.bench.test/app.js"></script>`,
+      `<script src="https://cdn.bench.test/app.js"></script>` +
+      `<style>:root{--brand-color:#123456;--brand-space:8px;--brand-font:sans-serif;}</style>`,
     bodyClass: "theme-main site-page",
     footer: `<footer class="site-footer"><a href="/">Home</a><p>Bench Store</p></footer>`,
+    navTag: "nav",
+    imageHost: "",
   };
 }
 
@@ -228,18 +259,19 @@ for (let i = 0; i < N; i++) {
   const links = linkTargets(i, p.outLinks, orphanFrom)
     .map((t) => `<a href="${pathFor(t)}">Link ${t}</a>`)
     .join("");
+  const t = theme(i);
   const images = Array.from(
     { length: i % 13 === 0 ? 24 : 6 },
-    (_, k) => `<img src="/img/${i}/${k}.jpg"${k % 5 === 0 ? "" : ` alt="Image ${k} for ${i}"`}>`,
+    (_, k) => `<img src="${t.imageHost}/img/${i}/${k}.jpg"${k % 5 === 0 ? "" : ` alt="Image ${k} for ${i}"`}>`,
   ).join("");
   const external = `<a href="https://partner-${i % 50}.example.com/r">Partner</a>`;
   const robots = p.noindex ? `<meta name="robots" content="noindex,follow">` : "";
-  const t = theme(i);
   const html =
     `<!doctype html><html lang="en"><head><title>${p.title}</title>` +
     `<meta name="description" content="${p.description}">` +
     `<link rel="canonical" href="${p.canonical}">${robots}${t.head}</head>` +
-    `<body class="${t.bodyClass}">${p.body}<nav>${links}</nav>${images}${external}${t.footer}</body></html>`;
+    `<body class="${t.bodyClass}">${p.body}<${t.navTag}>${links}</${t.navTag}>` +
+    `${images}${external}${t.footer}</body></html>`;
   const url = `${BASE}${pathFor(i)}`;
   totalBytes += Buffer.byteLength(html, "utf8");
 

--- a/packages/audit-engine/scripts/build-mixed-fixture.ts
+++ b/packages/audit-engine/scripts/build-mixed-fixture.ts
@@ -17,6 +17,14 @@
 //   - SOME PAGES FAIL. 4xx pages are what broken-link and error-page rules read.
 //   - TITLES AND DESCRIPTIONS REPEAT in more than one distribution: a few large
 //     duplicate groups and a long tail of pairs.
+//   - THERE IS A SHARED THEME, AND A MINORITY THAT DIVERGES FROM IT. This one
+//     matters more than it looks. `integrity/template-discontinuity` compares
+//     each page's fingerprint — asset hosts, stylesheet hrefs, body classes,
+//     nav/footer presence — against a site baseline, and gives up immediately if
+//     no baseline exists. A corpus where every page is identically themed
+//     produces no outliers and never reaches the branch that costs anything, and
+//     on the v1 path that branch does a linear scan of the page set PER OUTLIER.
+//     A fixed share of divergent pages is what makes that term visible.
 //
 // It still is not a real estate. It has no redirect chains, no sitemap records,
 // no fetched sub-resources and no cross-origin variety, so any rule whose cost
@@ -82,6 +90,36 @@ interface Page {
   noindex: boolean;
   canonical: string;
   outLinks: number;
+}
+
+/**
+ * The site's shared theme, and the minority that diverges from it.
+ *
+ * `DIVERGENT_IN` of every that-many pages carry a different asset host, a
+ * different stylesheet and different body classes, which is what makes them
+ * outliers against the baseline the other pages establish.
+ */
+const DIVERGENT_IN = 10;
+const isDivergent = (i: number) => i % DIVERGENT_IN === 3;
+
+function theme(i: number): { head: string; bodyClass: string; footer: string } {
+  if (isDivergent(i)) {
+    return {
+      head:
+        `<link rel="stylesheet" href="https://assets.other-cdn.test/legacy-${i % 3}.css">` +
+        `<script src="https://assets.other-cdn.test/legacy.js"></script>`,
+      bodyClass: `legacy-page variant-${i % 3}`,
+      footer: "",
+    };
+  }
+  return {
+    head:
+      `<link rel="stylesheet" href="https://cdn.bench.test/theme.css">` +
+      `<link rel="stylesheet" href="https://cdn.bench.test/layout.css">` +
+      `<script src="https://cdn.bench.test/app.js"></script>`,
+    bodyClass: "theme-main site-page",
+    footer: `<footer class="site-footer"><a href="/">Home</a><p>Bench Store</p></footer>`,
+  };
 }
 
 function build(i: number): Page {
@@ -196,11 +234,12 @@ for (let i = 0; i < N; i++) {
   ).join("");
   const external = `<a href="https://partner-${i % 50}.example.com/r">Partner</a>`;
   const robots = p.noindex ? `<meta name="robots" content="noindex,follow">` : "";
+  const t = theme(i);
   const html =
     `<!doctype html><html lang="en"><head><title>${p.title}</title>` +
     `<meta name="description" content="${p.description}">` +
-    `<link rel="canonical" href="${p.canonical}">${robots}</head>` +
-    `<body>${p.body}<nav>${links}</nav>${images}${external}</body></html>`;
+    `<link rel="canonical" href="${p.canonical}">${robots}${t.head}</head>` +
+    `<body class="${t.bodyClass}">${p.body}<nav>${links}</nav>${images}${external}${t.footer}</body></html>`;
   const url = `${BASE}${pathFor(i)}`;
   totalBytes += Buffer.byteLength(html, "utf8");
 
@@ -234,6 +273,7 @@ console.log(
     `  mix: ${[...counts].map(([k, v]) => `${k} ${((100 * v) / N).toFixed(0)}%`).join(", ")}\n` +
     `  ${Math.max(0, N - orphanFrom)} pages with no inbound link, ` +
     `${Math.floor(N / 50)} hubs of 120 links, ` +
-    `${Math.floor(N / 97)} 4xx, ${Math.floor(N / 23)} noindex, ${Math.floor(N / 11)} off-page canonicals`,
+    `${Math.floor(N / 97)} 4xx, ${Math.floor(N / 23)} noindex, ${Math.floor(N / 11)} off-page canonicals, ` +
+    `${Math.floor(N / DIVERGENT_IN)} off-theme`,
 );
 await run(storage.close());

--- a/packages/audit-engine/scripts/build-mixed-fixture.ts
+++ b/packages/audit-engine/scripts/build-mixed-fixture.ts
@@ -1,8 +1,8 @@
 // A mixed-shape crawl DB for the rules-scaling work (#1910).
 //
 // A NEGATIVE result is only as good as its corpus, and this fixture exists to
-// support one — "the rules phases are not superlinear in page count" — so what
-// it does NOT contain is as important as what it does. Each of these is here
+// support claims of the shape "this phase did not grow superlinearly HERE", so
+// what it does NOT contain is as important as what it does. Each of these is here
 // because a uniform corpus lets a rule take an early exit and then report a flat
 // line that says nothing:
 //
@@ -40,7 +40,10 @@
 // `--divergent-in N` puts one page in every N off the shared theme. The default
 // of 10 is a plausible share for a real site; a lower number is how you make a
 // term that is linear in the OUTLIER SHARE and quadratic in page count visible
-// above the noise, which at a 10% share it is not.
+// above the noise, which at a 10% share it is not. Do not go below 3: at one
+// page in two the baseline is built from a majority threshold that includes
+// BOTH groups' markers, which lifts the divergent pages' similarity from 0.05
+// to 0.2375, above the 0.2 threshold, and the rule reports no outliers at all.
 
 import { SQLiteStorage } from "@squirrelscan/crawler";
 import { Effect } from "effect";
@@ -258,9 +261,17 @@ const crawlId = await run(
 // a fully connected corpus never reaches that branch.
 const orphanFrom = Math.max(1, Math.floor(N * 0.95));
 let totalBytes = 0;
+// Counted while generating rather than derived with `Math.floor(N / k)`, which
+// ignores the residue offset and was reporting 4 and 17 where 5 and 18 were
+// written.
+const tally = { errors: 0, noindex: 0, offCanonical: 0, offTheme: 0 };
 
 for (let i = 0; i < N; i++) {
   const p = build(i);
+  if (p.status >= 400) tally.errors++;
+  if (p.noindex) tally.noindex++;
+  if (p.canonical !== `${BASE}${pathFor(i)}`) tally.offCanonical++;
+  if (isDivergent(i)) tally.offTheme++;
   const links = linkTargets(i, p.outLinks, orphanFrom)
     .map((t) => `<a href="${pathFor(t)}">Link ${t}</a>`)
     .join("");
@@ -310,7 +321,7 @@ console.log(
     `  mix: ${[...counts].map(([k, v]) => `${k} ${((100 * v) / N).toFixed(0)}%`).join(", ")}\n` +
     `  ${Math.max(0, N - orphanFrom)} pages with no inbound link, ` +
     `${Math.floor(N / 50)} hubs of 120 links, ` +
-    `${Math.floor(N / 97)} 4xx, ${Math.floor(N / 23)} noindex, ${Math.floor(N / 11)} off-page canonicals, ` +
-    `${Math.floor(N / DIVERGENT_IN)} off-theme`,
+    `${tally.errors} 4xx, ${tally.noindex} noindex, ${tally.offCanonical} off-page canonicals, ` +
+    `${tally.offTheme} off-theme`,
 );
 await run(storage.close());

--- a/packages/audit-engine/scripts/build-mixed-fixture.ts
+++ b/packages/audit-engine/scripts/build-mixed-fixture.ts
@@ -1,67 +1,239 @@
 // A mixed-shape crawl DB for the rules-scaling work (#1910).
 //
-// Shares follow the corpus #1910 was measured on: 10% script-heavy product,
-// 10% collection, 30% docs, 30% blog, 10% listing, 10% thin. Shape matters more
-// than raw size for this question — the DOM scanners walk inline script, the
-// link rules walk the graph, and the duplicate rules walk titles and
-// descriptions — so every page carries 40 internal links spread across the whole
-// estate, six images, an external link, and a description that repeats across
-// half the corpus so the duplicate rules have real work.
+// A NEGATIVE result is only as good as its corpus, and this fixture exists to
+// support one — "the rules phases are not superlinear in page count" — so what
+// it does NOT contain is as important as what it does. Each of these is here
+// because a uniform corpus lets a rule take an early exit and then report a flat
+// line that says nothing:
+//
+//   - LINK DENSITY VARIES and some pages are unreachable. A corpus where every
+//     page has exactly N inbound links never enters orphan detection's hidden-page
+//     analysis, and hubs are where a link-graph rule's cost concentrates.
+//   - SCHEMA IS ON MORE THAN ONE TEMPLATE. `schema/coverage-outlier` groups by
+//     page type and excludes `unknown`, so a corpus where 90% of pages are
+//     unknown never builds a group large enough to compare.
+//   - INDEXABILITY AND CANONICALS VARY. All-self-canonical, all-indexable pages
+//     skip the canonical-drift, noindex-conflict and sitemap-conflict paths.
+//   - SOME PAGES FAIL. 4xx pages are what broken-link and error-page rules read.
+//   - TITLES AND DESCRIPTIONS REPEAT in more than one distribution: a few large
+//     duplicate groups and a long tail of pairs.
+//
+// It still is not a real estate. It has no redirect chains, no sitemap records,
+// no fetched sub-resources and no cross-origin variety, so any rule whose cost
+// lives in those is untested here and this fixture cannot speak for it.
 //
 //   bun run scripts/build-mixed-fixture.ts --db /tmp/mix400.sqlite --pages 400
 //
-// `--weight N` scales every template. Weight 1 is ~13 KB mean and weight 5 is
-// ~100 KB, which brackets the 128 KB mean of #1910's estate; the scaling
-// EXPONENT came out the same at both, which is the point of having the dial.
-//
-// html is stored in the crawl DB, never in the global content store, so #1908's
-// scan-per-insert cannot participate in anything measured on these fixtures.
+// `--weight N` scales the text and script payload of every template. The script
+// prints the resulting mean page size rather than asserting one, because the
+// mean is a consequence of the template mix and the weight, and quoting a
+// remembered number is how a fixture comment goes stale.
+
 import { SQLiteStorage } from "@squirrelscan/crawler";
-import { parseHtmlForRules } from "../src/adapter";
 import { Effect } from "effect";
 
-const run = <A,>(e: Effect.Effect<A, unknown, never>) => Effect.runPromise(e as Effect.Effect<A, never, never>);
-const arg = (n: string, d: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? (process.argv[i + 1] ?? d) : d; };
+import { parseHtmlForRules } from "../src/adapter";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+const arg = (n: string, d: string) => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? (process.argv[i + 1] ?? d) : d;
+};
+
 const DB = arg("db", "");
 const N = Number.parseInt(arg("pages", "400"), 10);
-const W = Number.parseFloat(arg("weight", "1"));
+const WEIGHT = Number.parseFloat(arg("weight", "1"));
 const BASE = "https://bench.test";
 
-const pad = (s: string, n: number) => s.padEnd(n, " lorem ipsum dolor sit amet consectetur ");
+const pad = (s: string, n: number) => s.padEnd(Math.max(s.length, n), " lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod ");
 const pathFor = (i: number) => (i === 0 ? "/" : `/p/${String(i).padStart(5, "0")}`);
+const scale = (n: number) => Math.round(n * WEIGHT);
 
-/** Mixed estate: shares from #1910's corpus, scaled so 2,500 pages is buildable. */
-function template(i: number): { kind: string; body: string; title: string } {
-  const m = i % 10;
-  if (m === 0) {
-    // Script-heavy, like the real product pages in #1910's corpus: most of the
-    // weight is inline script, which is what the DOM scanners actually walk.
-    const scripts = Array.from({ length: Math.max(1, Math.round(20 * W)) }, (_, k) =>
-      `<script>var block${k}=${JSON.stringify(`payload ${i}-${k} `.padEnd(2000, "abcdefghij"))};</script>`).join("");
-    return { kind: "product", title: `Product ${i} | Bench Store`, body: pad(`<h1>Product ${i}</h1><script type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Product ${i}","offers":{"@type":"Offer","price":"${10 + (i % 90)}.00","priceCurrency":"USD"}}</script>${scripts}`, Math.round(40_000*W)) };
+/**
+ * Template shares, asserted by construction rather than by a comment: the
+ * cumulative table IS the distribution, so it cannot drift from the prose.
+ */
+const TEMPLATES = [
+  { kind: "product", share: 10 },
+  { kind: "collection", share: 10 },
+  { kind: "docs", share: 30 },
+  { kind: "blog", share: 30 },
+  { kind: "listing", share: 10 },
+  { kind: "thin", share: 10 },
+] as const;
+
+function kindFor(i: number): (typeof TEMPLATES)[number]["kind"] {
+  const bucket = i % 100;
+  let acc = 0;
+  for (const t of TEMPLATES) {
+    acc += t.share;
+    if (bucket < acc) return t.kind;
   }
-  if (m === 1) return { kind: "collection", title: `Collection ${i} | Bench Store`, body: pad(`<h1>Collection ${i}</h1>`, Math.round(16_000*W)) };
-  if (m < 4) return { kind: "docs", title: `Docs page ${i}`, body: pad(`<h1>Docs ${i}</h1><h2>Section</h2>`, Math.round(12_000*W)) };
-  if (m < 7) return { kind: "blog", title: `Blog post ${i}`, body: pad(`<h1>Post ${i}</h1><article>text</article>`, Math.round(10_000*W)) };
-  if (m < 9) return { kind: "listing", title: `Listing ${i}`, body: pad(`<h1>Listing ${i}</h1>`, Math.round(6_000*W)) };
-  // Deliberate duplicates: title/description rules are among the suspects.
-  return { kind: "thin", title: "Thin page", body: `<h1>Thin</h1><p>short</p>` };
+  return "thin";
+}
+
+interface Page {
+  title: string;
+  description: string;
+  body: string;
+  status: number;
+  noindex: boolean;
+  canonical: string;
+  outLinks: number;
+}
+
+function build(i: number): Page {
+  const kind = kindFor(i);
+  const self = `${BASE}${pathFor(i)}`;
+  // Structural variety, each one gating a rule path a uniform corpus skips.
+  const status = i % 97 === 5 ? 404 : 200;
+  const noindex = i % 23 === 3;
+  // A tenth of pages point their canonical at another page, which is what the
+  // canonical-drift and sitemap-conflict rules actually look for.
+  const canonical = i % 11 === 4 ? `${BASE}${pathFor((i + 1) % N)}` : self;
+  // Hubs, ordinary pages and a tail of pages nothing links to. Link COUNT and
+  // link TARGETS both vary, so the graph has a real degree distribution.
+  const outLinks = i % 50 === 0 ? 120 : i % 7 === 0 ? 4 : 40;
+
+  const schema = (type: string, extra: string) =>
+    `<script type="application/ld+json">{"@context":"https://schema.org","@type":"${type}","name":"${kind} ${i}"${extra}}</script>`;
+
+  switch (kind) {
+    case "product": {
+      // Script-heavy, like the product pages in #1910's estate: most of the
+      // weight is inline script, which is what the DOM scanners walk.
+      const scripts = Array.from(
+        { length: Math.max(1, scale(20)) },
+        (_, k) => `<script>var b${k}=${JSON.stringify(`payload ${i}-${k} `.padEnd(2000, "abcdefghij"))};</script>`,
+      ).join("");
+      return {
+        title: `Product ${i} | Bench Store`,
+        description: `Buy product ${i % Math.max(1, Math.floor(N / 2))} at Bench Store`,
+        body: pad(`<h1>Product ${i}</h1>${schema("Product", `,"offers":{"@type":"Offer","price":"${10 + (i % 90)}.00","priceCurrency":"USD"}`)}${scripts}`, scale(20_000)),
+        status, noindex, canonical, outLinks,
+      };
+    }
+    case "collection":
+      return {
+        title: `Collection ${i} | Bench Store`,
+        description: `Shop the ${i % 40} collection`,
+        body: pad(`<h1>Collection ${i}</h1>${schema("CollectionPage", "")}`, scale(16_000)),
+        status, noindex, canonical, outLinks,
+      };
+    case "docs":
+      return {
+        title: `Docs page ${i}`,
+        description: `Reference documentation for topic ${i % Math.max(1, Math.floor(N / 2))}`,
+        body: pad(`<h1>Docs ${i}</h1><h2>Section</h2><h3>Detail</h3>${schema("TechArticle", "")}`, scale(12_000)),
+        status, noindex, canonical, outLinks,
+      };
+    case "blog":
+      return {
+        title: `Blog post ${i}`,
+        description: `Post ${i % Math.max(1, Math.floor(N / 2))} on the Bench blog`,
+        body: pad(`<h1>Post ${i}</h1><article>text</article>${schema("BlogPosting", `,"datePublished":"2026-0${1 + (i % 9)}-01"`)}`, scale(10_000)),
+        status, noindex, canonical, outLinks,
+      };
+    case "listing":
+      return {
+        title: `Listing ${i}`,
+        description: `Listing page ${i % 25}`,
+        body: pad(`<h1>Listing ${i}</h1>`, scale(6_000)),
+        status, noindex, canonical, outLinks,
+      };
+    default:
+      // One large duplicate group: 10% of the corpus shares a title AND a
+      // description, which is the shape the duplicate rules are sized for.
+      return {
+        title: "Thin page",
+        description: "A thin page with very little content",
+        body: `<h1>Thin</h1><p>short</p>`,
+        status, noindex, canonical, outLinks: 2,
+      };
+  }
+}
+
+/** Link targets for page i: spread across the estate, skipping the orphan tail. */
+function linkTargets(i: number, count: number, orphanFrom: number): number[] {
+  const out: number[] = [];
+  for (let k = 0; k < count; k++) out.push((i * 7 + k * 13) % orphanFrom);
+  return out;
 }
 
 const storage = new SQLiteStorage(DB);
 await run(storage.init());
-const crawlId = await run(storage.createCrawl({ baseUrl: BASE, seedUrl: BASE, originalUrl: BASE, startedAt: Date.now(), status: "completed", config: {}, stats: { pagesTotal: N, pagesFetched: N, pagesFailed: 0, pagesSkipped: 0, pagesUnchanged: 0, linksTotal: 0, imagesTotal: 0, bytesTotal: 0, avgLoadTimeMs: 0 } } as never));
+const crawlId = await run(
+  storage.createCrawl({
+    baseUrl: BASE,
+    seedUrl: BASE,
+    originalUrl: BASE,
+    startedAt: Date.now(),
+    status: "completed",
+    config: {},
+    stats: {
+      pagesTotal: N, pagesFetched: N, pagesFailed: 0, pagesSkipped: 0,
+      pagesUnchanged: 0, linksTotal: 0, imagesTotal: 0, bytesTotal: 0, avgLoadTimeMs: 0,
+    },
+  } as never),
+);
+
+// The last 5% are reachable from the sitemap-shaped seed only, i.e. nothing in
+// the link graph points at them. Orphan detection needs pages nobody links to;
+// a fully connected corpus never reaches that branch.
+const orphanFrom = Math.max(1, Math.floor(N * 0.95));
+let totalBytes = 0;
 
 for (let i = 0; i < N; i++) {
-  const t = template(i);
-  const links = Array.from({ length: 40 }, (_, k) => `<a href="${pathFor((i * 7 + k * 13) % N)}">Link ${(i * 7 + k * 13) % N}</a>`).join("");
-  const imgs = Array.from({ length: 6 }, (_, k) => `<img src="/img/${i}/${k}.jpg" alt="Image ${k} for ${i}">`).join("");
-  const ext = `<a href="https://partner-${i % 50}.example.com/r">Partner</a>`;
-  const html = `<!doctype html><html lang="en"><head><title>${t.title}</title><meta name="description" content="Description for ${t.kind} ${i % (N / 2 || 1)}"><link rel="canonical" href="${BASE}${pathFor(i)}"></head><body>${t.body}<nav>${links}</nav>${imgs}${ext}</body></html>`;
+  const p = build(i);
+  const links = linkTargets(i, p.outLinks, orphanFrom)
+    .map((t) => `<a href="${pathFor(t)}">Link ${t}</a>`)
+    .join("");
+  const images = Array.from(
+    { length: i % 13 === 0 ? 24 : 6 },
+    (_, k) => `<img src="/img/${i}/${k}.jpg"${k % 5 === 0 ? "" : ` alt="Image ${k} for ${i}"`}>`,
+  ).join("");
+  const external = `<a href="https://partner-${i % 50}.example.com/r">Partner</a>`;
+  const robots = p.noindex ? `<meta name="robots" content="noindex,follow">` : "";
+  const html =
+    `<!doctype html><html lang="en"><head><title>${p.title}</title>` +
+    `<meta name="description" content="${p.description}">` +
+    `<link rel="canonical" href="${p.canonical}">${robots}</head>` +
+    `<body>${p.body}<nav>${links}</nav>${images}${external}</body></html>`;
   const url = `${BASE}${pathFor(i)}`;
+  totalBytes += Buffer.byteLength(html, "utf8");
+
   const parsed = parseHtmlForRules(html, url) as unknown as Record<string, unknown>;
-  const { document: _d, ...rest } = parsed;
-  await run(storage.upsertPage(crawlId, { url, normalizedUrl: url, finalUrl: url, depth: i === 0 ? 0 : 1, status: 200, contentType: "text/html", sizeBytes: Buffer.byteLength(html, "utf8"), loadTimeMs: 100, fetchedAt: Date.now(), etag: null, lastModified: null, contentHash: `mix-${i}`, html, parsedData: JSON.stringify(rest), headers: { contentType: "text/html", contentEncoding: null, cacheControl: null, vary: null, etag: null, server: "bench", lastModified: null, link: null, serverTiming: null, age: null, xCache: null, cfCacheStatus: null, xVercelCache: null, altSvc: null, acceptRanges: null }, securityHeaders: { hsts: null, csp: null, xFrameOptions: null, xContentTypeOptions: null, referrerPolicy: null, permissionsPolicy: null, xRobotsTag: null } } as never));
+  const { document: _document, ...rest } = parsed;
+  await run(
+    storage.upsertPage(crawlId, {
+      url, normalizedUrl: url, finalUrl: url, depth: i === 0 ? 0 : 1,
+      status: p.status, contentType: "text/html",
+      sizeBytes: Buffer.byteLength(html, "utf8"), loadTimeMs: 100, fetchedAt: Date.now(),
+      etag: null, lastModified: null, contentHash: `mix-${i}`, html,
+      parsedData: JSON.stringify(rest),
+      headers: {
+        contentType: "text/html", contentEncoding: null, cacheControl: null, vary: null,
+        etag: null, server: "bench", lastModified: null, link: null, serverTiming: null,
+        age: null, xCache: null, cfCacheStatus: null, xVercelCache: null, altSvc: null,
+        acceptRanges: null,
+      },
+      securityHeaders: {
+        hsts: null, csp: null, xFrameOptions: null, xContentTypeOptions: null,
+        referrerPolicy: null, permissionsPolicy: null, xRobotsTag: null,
+      },
+    } as never),
+  );
 }
-console.log(`built ${DB}: ${N} mixed pages`);
+
+const counts = new Map<string, number>();
+for (let i = 0; i < N; i++) counts.set(kindFor(i), (counts.get(kindFor(i)) ?? 0) + 1);
+console.log(
+  `built ${DB}: ${N} pages, weight ${WEIGHT}, mean ${(totalBytes / N / 1024).toFixed(1)} KB\n` +
+    `  mix: ${[...counts].map(([k, v]) => `${k} ${((100 * v) / N).toFixed(0)}%`).join(", ")}\n` +
+    `  ${Math.max(0, N - orphanFrom)} pages with no inbound link, ` +
+    `${Math.floor(N / 50)} hubs of 120 links, ` +
+    `${Math.floor(N / 97)} 4xx, ${Math.floor(N / 23)} noindex, ${Math.floor(N / 11)} off-page canonicals`,
+);
 await run(storage.close());

--- a/packages/audit-engine/scripts/build-mixed-fixture.ts
+++ b/packages/audit-engine/scripts/build-mixed-fixture.ts
@@ -36,6 +36,11 @@
 // prints the resulting mean page size rather than asserting one, because the
 // mean is a consequence of the template mix and the weight, and quoting a
 // remembered number is how a fixture comment goes stale.
+//
+// `--divergent-in N` puts one page in every N off the shared theme. The default
+// of 10 is a plausible share for a real site; a lower number is how you make a
+// term that is linear in the OUTLIER SHARE and quadratic in page count visible
+// above the noise, which at a 10% share it is not.
 
 import { SQLiteStorage } from "@squirrelscan/crawler";
 import { Effect } from "effect";
@@ -99,8 +104,8 @@ interface Page {
  * different stylesheet and different body classes, which is what makes them
  * outliers against the baseline the other pages establish.
  */
-const DIVERGENT_IN = 10;
-const isDivergent = (i: number) => i % DIVERGENT_IN === 3;
+const DIVERGENT_IN = Math.max(2, Number.parseInt(arg("divergent-in", "10"), 10));
+const isDivergent = (i: number) => i % DIVERGENT_IN === 1;
 
 interface Theme {
   head: string;

--- a/packages/audit-engine/scripts/build-mixed-fixture.ts
+++ b/packages/audit-engine/scripts/build-mixed-fixture.ts
@@ -1,0 +1,67 @@
+// A mixed-shape crawl DB for the rules-scaling work (#1910).
+//
+// Shares follow the corpus #1910 was measured on: 10% script-heavy product,
+// 10% collection, 30% docs, 30% blog, 10% listing, 10% thin. Shape matters more
+// than raw size for this question — the DOM scanners walk inline script, the
+// link rules walk the graph, and the duplicate rules walk titles and
+// descriptions — so every page carries 40 internal links spread across the whole
+// estate, six images, an external link, and a description that repeats across
+// half the corpus so the duplicate rules have real work.
+//
+//   bun run scripts/build-mixed-fixture.ts --db /tmp/mix400.sqlite --pages 400
+//
+// `--weight N` scales every template. Weight 1 is ~13 KB mean and weight 5 is
+// ~100 KB, which brackets the 128 KB mean of #1910's estate; the scaling
+// EXPONENT came out the same at both, which is the point of having the dial.
+//
+// html is stored in the crawl DB, never in the global content store, so #1908's
+// scan-per-insert cannot participate in anything measured on these fixtures.
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { parseHtmlForRules } from "../src/adapter";
+import { Effect } from "effect";
+
+const run = <A,>(e: Effect.Effect<A, unknown, never>) => Effect.runPromise(e as Effect.Effect<A, never, never>);
+const arg = (n: string, d: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? (process.argv[i + 1] ?? d) : d; };
+const DB = arg("db", "");
+const N = Number.parseInt(arg("pages", "400"), 10);
+const W = Number.parseFloat(arg("weight", "1"));
+const BASE = "https://bench.test";
+
+const pad = (s: string, n: number) => s.padEnd(n, " lorem ipsum dolor sit amet consectetur ");
+const pathFor = (i: number) => (i === 0 ? "/" : `/p/${String(i).padStart(5, "0")}`);
+
+/** Mixed estate: shares from #1910's corpus, scaled so 2,500 pages is buildable. */
+function template(i: number): { kind: string; body: string; title: string } {
+  const m = i % 10;
+  if (m === 0) {
+    // Script-heavy, like the real product pages in #1910's corpus: most of the
+    // weight is inline script, which is what the DOM scanners actually walk.
+    const scripts = Array.from({ length: Math.max(1, Math.round(20 * W)) }, (_, k) =>
+      `<script>var block${k}=${JSON.stringify(`payload ${i}-${k} `.padEnd(2000, "abcdefghij"))};</script>`).join("");
+    return { kind: "product", title: `Product ${i} | Bench Store`, body: pad(`<h1>Product ${i}</h1><script type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Product ${i}","offers":{"@type":"Offer","price":"${10 + (i % 90)}.00","priceCurrency":"USD"}}</script>${scripts}`, Math.round(40_000*W)) };
+  }
+  if (m === 1) return { kind: "collection", title: `Collection ${i} | Bench Store`, body: pad(`<h1>Collection ${i}</h1>`, Math.round(16_000*W)) };
+  if (m < 4) return { kind: "docs", title: `Docs page ${i}`, body: pad(`<h1>Docs ${i}</h1><h2>Section</h2>`, Math.round(12_000*W)) };
+  if (m < 7) return { kind: "blog", title: `Blog post ${i}`, body: pad(`<h1>Post ${i}</h1><article>text</article>`, Math.round(10_000*W)) };
+  if (m < 9) return { kind: "listing", title: `Listing ${i}`, body: pad(`<h1>Listing ${i}</h1>`, Math.round(6_000*W)) };
+  // Deliberate duplicates: title/description rules are among the suspects.
+  return { kind: "thin", title: "Thin page", body: `<h1>Thin</h1><p>short</p>` };
+}
+
+const storage = new SQLiteStorage(DB);
+await run(storage.init());
+const crawlId = await run(storage.createCrawl({ baseUrl: BASE, seedUrl: BASE, originalUrl: BASE, startedAt: Date.now(), status: "completed", config: {}, stats: { pagesTotal: N, pagesFetched: N, pagesFailed: 0, pagesSkipped: 0, pagesUnchanged: 0, linksTotal: 0, imagesTotal: 0, bytesTotal: 0, avgLoadTimeMs: 0 } } as never));
+
+for (let i = 0; i < N; i++) {
+  const t = template(i);
+  const links = Array.from({ length: 40 }, (_, k) => `<a href="${pathFor((i * 7 + k * 13) % N)}">Link ${(i * 7 + k * 13) % N}</a>`).join("");
+  const imgs = Array.from({ length: 6 }, (_, k) => `<img src="/img/${i}/${k}.jpg" alt="Image ${k} for ${i}">`).join("");
+  const ext = `<a href="https://partner-${i % 50}.example.com/r">Partner</a>`;
+  const html = `<!doctype html><html lang="en"><head><title>${t.title}</title><meta name="description" content="Description for ${t.kind} ${i % (N / 2 || 1)}"><link rel="canonical" href="${BASE}${pathFor(i)}"></head><body>${t.body}<nav>${links}</nav>${imgs}${ext}</body></html>`;
+  const url = `${BASE}${pathFor(i)}`;
+  const parsed = parseHtmlForRules(html, url) as unknown as Record<string, unknown>;
+  const { document: _d, ...rest } = parsed;
+  await run(storage.upsertPage(crawlId, { url, normalizedUrl: url, finalUrl: url, depth: i === 0 ? 0 : 1, status: 200, contentType: "text/html", sizeBytes: Buffer.byteLength(html, "utf8"), loadTimeMs: 100, fetchedAt: Date.now(), etag: null, lastModified: null, contentHash: `mix-${i}`, html, parsedData: JSON.stringify(rest), headers: { contentType: "text/html", contentEncoding: null, cacheControl: null, vary: null, etag: null, server: "bench", lastModified: null, link: null, serverTiming: null, age: null, xCache: null, cfCacheStatus: null, xVercelCache: null, altSvc: null, acceptRanges: null }, securityHeaders: { hsts: null, csp: null, xFrameOptions: null, xContentTypeOptions: null, referrerPolicy: null, permissionsPolicy: null, xRobotsTag: null } } as never));
+}
+console.log(`built ${DB}: ${N} mixed pages`);
+await run(storage.close());

--- a/packages/audit-engine/scripts/rules-scaling-bench.ts
+++ b/packages/audit-engine/scripts/rules-scaling-bench.ts
@@ -1,34 +1,43 @@
 // How the rules phases scale with page count (#1910).
 //
 // #1910 reports site rules going from 4s at 400 pages to 687s at 5,000 — about
-// n^2 — with page rules at n^1.6 and even `parsePageRecord` per page rising from
-// 5.5 to 40 ms, which is the strangest of the three, because parsing one page
-// should not depend on how many other pages exist. This is the benchmark that
-// re-measures those numbers under conditions where they can be believed.
+// n^2 — with page rules at n^1.6 and per-page `parsePageRecord` cost rising from
+// 5.5 to 40 ms, and asks for a re-measurement it can believe. Five things have
+// to be controlled for the answer to mean anything, and four of them cost a
+// wrong answer rather than a vague one:
 //
-// THREE THINGS THE ORIGINAL MEASUREMENT COULD NOT CONTROL, and this does:
-//
-//   - CONTENTION. #1910's own caveat says its 2,500 row was 589s wall against
-//     360s CPU and its 5,000 row 2,236s against 1,023s, on a 16 GB box doing
-//     150 MB/s of swap with a load average of 13. Wall time under those
-//     conditions is mostly waiting. Run this on a quiet machine and read the
-//     per-page columns, which is where a superlinear term shows up as a rising
-//     number rather than as a big one.
-//   - THE CONTENT STORE. #1908's full-table scan per stored page makes a single
-//     crawl quadratic in its own page count and would dominate anything measured
-//     through it. The fixtures here store html in the crawl DB itself and never
-//     touch the global store, so it cannot participate.
-//   - THE PATH. The CLI runs v1 (`runRulesOnStorage`, every page resident) and
-//     the cloud runs the streamed pass; #1910 measured the CLI. Both are timed
-//     here, because "site rules are quadratic" would mean something different
-//     about each.
+//   1. THE NETWORK. `security/http-to-https` probes sample URLs over HTTP with
+//      staggered sleeps, and none of the cloud/intel/external-link switches
+//      turns it off. On this fixture it was 508-790 ms of a 518-790 ms site
+//      phase: the whole phase was one rule waiting on sockets, and every other
+//      site rule's scaling was invisible underneath it. It is DISABLED by
+//      default here (`--disable`), and the disabled set is printed, because a
+//      site-rule number measured with it on is a number about the network.
+//   2. THE CONTENT STORE. #1908's full-table scan per stored page makes a crawl
+//      quadratic in its own page count. The fixtures keep html in the crawl DB
+//      and never touch the global store.
+//   3. CONTENTION. #1910's own caveat records its 2,500 row as 589s wall against
+//      360s CPU and its 5,000 row as 2,236s against 1,023s, on a 16 GB box doing
+//      150 MB/s of swap at load average 13. Read the per-page columns on a quiet
+//      machine; a superlinear term shows up there as a rising number.
+//   4. ORDER AND WARMTH. Every measurement runs in its OWN child process, so no
+//      arm inherits another's warm JIT, parser structures or SQLite cache, and
+//      the sizes cannot warm each other.
+//   5. WHICH PARSE. `parsePageRecord` is the full extraction. `buildSiteContext`
+//      on a fixture with stored `parsedData` only re-parses the DOM and
+//      deserializes the rest, which is a different and cheaper thing. Both are
+//      timed, separately, and only the first answers #1910's parse observation.
 //
 //   bun run scripts/build-mixed-fixture.ts --db /tmp/mix400.sqlite --pages 400
 //   bun run scripts/rules-scaling-bench.ts --dbs /tmp/mix400.sqlite,/tmp/mix2500.sqlite
 //
-// Add `--profile` for per-rule timings, which is what names an individual rule
-// that walks the page set once per page. Note that site rules run with bounded
-// concurrency, so their per-rule times sum to MORE than the phase's wall time.
+// The CLI runs v1 (`runRulesOnStorage`, every page resident) and the cloud runs
+// the streamed pass; #1910 measured the CLI, so both are timed, and v1 is split
+// into its page-scope and site-scope halves with the rule profiler rather than
+// reported as one number — a near-linear total cannot rule out a superlinear
+// site component hiding inside it.
+//
+// --child is the inner half; the parent re-invokes this file with it.
 
 import { getDefaultConfig, type Config } from "@squirrelscan/config";
 import { SQLiteStorage } from "@squirrelscan/crawler";
@@ -36,6 +45,7 @@ import { Effect } from "effect";
 
 import {
   buildSiteContext,
+  parsePageRecord,
   runRulesOnStorage,
   runStreamingRules,
   type PreFetchedAssets,
@@ -50,11 +60,18 @@ const arg = (n: string, d: string) => {
   return i >= 0 ? (process.argv[i + 1] ?? d) : d;
 };
 
-const DBS = arg("dbs", "")
+const MODE = arg("mode", "streamed");
+const DB = arg("db", "");
+const BATCH = Number.parseInt(arg("batch", "200"), 10);
+/**
+ * Rules excluded from every arm. Not a convenience: a rule that waits on the
+ * network contributes a fixed, sleep-shaped cost that swamps the computational
+ * term this benchmark exists to measure.
+ */
+const DISABLE = arg("disable", "security/http-to-https")
   .split(",")
   .map((d) => d.trim())
   .filter(Boolean);
-const BATCH = Number.parseInt(arg("batch", "200"), 10);
 
 const EMPTY_ASSETS: PreFetchedAssets = {
   resourceSizes: { css: [], images: [] },
@@ -64,9 +81,9 @@ const EMPTY_ASSETS: PreFetchedAssets = {
 };
 
 /**
- * Every rule on, nothing that reaches the network. `rules.enable: ["*"]` is not
- * optional: `filterRules` defaults every rule to DISABLED, so a bench without it
- * measures an empty rule set and reports a flat, meaningless line.
+ * Every rule on except the excluded ones. `rules.enable: ["*"]` is not optional:
+ * `filterRules` defaults every rule to DISABLED, so a bench without it measures
+ * an empty rule set and reports a flat, meaningless line.
  */
 function benchConfig(): Config {
   const base = getDefaultConfig();
@@ -75,106 +92,156 @@ function benchConfig(): Config {
     cloud: { ...base.cloud, enabled: false },
     intel: { ...base.intel, enabled: false },
     external_links: { ...base.external_links, enabled: false },
-    rules: { enable: ["*"] },
+    rules: { enable: ["*"], disable: DISABLE },
   } as unknown as Config;
 }
 
-interface Row {
-  pages: number;
-  universeMs: number;
-  pageRulesMs: number;
-  siteRulesMs: number;
-  siteQueryMs: number;
-  v1ParseMs: number;
-  v1RulesMs: number;
-}
+// ── child ────────────────────────────────────────────────────────────────────
 
-async function measure(db: string): Promise<Row> {
-  const storage = new SQLiteStorage(db);
+if (process.argv.includes("--child")) {
+  const storage = new SQLiteStorage(DB);
   await run(storage.init());
   const crawls = await run(storage.listCrawls(1));
   const crawlId = (crawls as Array<{ id: string }>)[0]!.id;
   const pages = await run(storage.getPageCount(crawlId));
+  const out: Record<string, number> = { pages };
 
-  const started = new Map<StreamingRulePhase, number>();
-  const phase = new Map<StreamingRulePhase, number>();
-  await run(
-    runStreamingRules(storage, crawlId, benchConfig(), EMPTY_ASSETS, undefined, {
-      batchSize: BATCH,
-      onPhase: (name, boundary) => {
-        if (boundary === "start") started.set(name, Date.now());
-        else phase.set(name, Date.now() - started.get(name)!);
-      },
-    }),
-  );
-
-  // v1, the path the CLI takes and the one #1910 measured. Its parse is timed
-  // separately because #1910 reports per-page PARSE cost rising too, and in v1
-  // the parse is a distinct step rather than part of the batched walk.
-  const t0 = Date.now();
-  const all = await run(storage.getPages(crawlId));
-  const ctx = await run(buildSiteContext(all));
-  const v1ParseMs = Date.now() - t0;
-  const t1 = Date.now();
-  await run(runRulesOnStorage(storage, crawlId, ctx, benchConfig(), EMPTY_ASSETS));
-  const v1RulesMs = Date.now() - t1;
+  if (MODE === "streamed") {
+    const started = new Map<StreamingRulePhase, number>();
+    await run(
+      runStreamingRules(storage, crawlId, benchConfig(), EMPTY_ASSETS, undefined, {
+        batchSize: BATCH,
+        onPhase: (name, boundary) => {
+          if (boundary === "start") started.set(name, Date.now());
+          else out[name] = Date.now() - started.get(name)!;
+        },
+      }),
+    );
+  } else if (MODE === "v1") {
+    const t0 = Date.now();
+    const all = await run(storage.getPages(crawlId));
+    const ctx = await run(buildSiteContext(all));
+    // NOT parsePageRecord: with stored parsedData this re-parses the DOM and
+    // deserializes the rest. Named `hydrate` so it cannot be read as the parse
+    // #1910 is talking about.
+    out.hydrate = Date.now() - t0;
+    const t1 = Date.now();
+    await run(runRulesOnStorage(storage, crawlId, ctx, benchConfig(), EMPTY_ASSETS));
+    out.v1Rules = Date.now() - t1;
+  } else if (MODE === "parse") {
+    // The real thing: full extraction per page, which is what #1910 reports
+    // rising from 5.5 to 40 ms per page.
+    const all = await run(storage.getPages(crawlId));
+    const t0 = Date.now();
+    let parsed = 0;
+    for (const page of all) if (parsePageRecord(page)) parsed++;
+    out.parse = Date.now() - t0;
+    out.parsedPages = parsed;
+  }
 
   await run(storage.close());
-  return {
-    pages,
-    universeMs: phase.get("universe") ?? 0,
-    pageRulesMs: phase.get("page-rules") ?? 0,
-    siteRulesMs: phase.get("site-rules") ?? 0,
-    siteQueryMs: phase.get("site-query") ?? 0,
-    v1ParseMs,
-    v1RulesMs,
-  };
+  console.log(`CHILD ${JSON.stringify(out)}`);
+  process.exit(0);
 }
 
-const rows: Row[] = [];
+// ── parent ───────────────────────────────────────────────────────────────────
+
+const DBS = arg("dbs", "")
+  .split(",")
+  .map((d) => d.trim())
+  .filter(Boolean);
+const REPEATS = Math.max(1, Number.parseInt(arg("repeat", "3"), 10));
+const PROFILE = process.argv.includes("--profile");
+
+function child(mode: string, db: string): Record<string, number> | null {
+  const proc = Bun.spawnSync({
+    cmd: [
+      process.execPath, "run", import.meta.path, "--child",
+      "--mode", mode, "--db", db, "--batch", String(BATCH), "--disable", DISABLE.join(","),
+    ],
+    // The profiler is read from the environment at module load, so it has to be
+    // set here rather than passed as a flag the child would have to re-plumb.
+    env: PROFILE ? { ...process.env, SQUIRREL_RULE_PROFILE: "1" } : process.env,
+    stdout: "pipe",
+    stderr: PROFILE ? "inherit" : "pipe",
+  });
+  if (proc.exitCode !== 0) {
+    console.error(`  ${mode} on ${db}: exit ${proc.exitCode}\n${proc.stderr?.toString().slice(-500) ?? ""}`);
+    return null;
+  }
+  const line = proc.stdout.toString().split("\n").find((l) => l.startsWith("CHILD "));
+  return line ? (JSON.parse(line.slice(6)) as Record<string, number>) : null;
+}
+
+const MODES = ["streamed", "v1", "parse"] as const;
+/** db -> mode -> metric -> the best (lowest) of the repeats. */
+const results = new Map<string, Map<string, Record<string, number>>>();
+
 for (const db of DBS) {
-  const row = await measure(db);
-  rows.push(row);
-  console.log(`measured ${db.split("/").pop()} (${row.pages} pages)`);
+  const perMode = new Map<string, Record<string, number>>();
+  for (const mode of MODES) {
+    let best: Record<string, number> | null = null;
+    for (let attempt = 0; attempt < REPEATS; attempt++) {
+      const got = child(mode, db);
+      if (!got) continue;
+      // Lowest of the repeats per metric. Noise on a timing bench adds work; it
+      // does not remove it, so the minimum is the closest thing to the cost.
+      if (!best) best = got;
+      else for (const [k, v] of Object.entries(got)) best[k] = Math.min(best[k] ?? v, v);
+    }
+    if (best) perMode.set(mode, best);
+  }
+  results.set(db, perMode);
+  console.log(`measured ${db.split("/").pop()}`);
 }
 
-// PER-PAGE is the column that answers the question. A phase that doubles when
-// the crawl doubles is linear and its per-page number is flat; a superlinear
-// phase shows up here as a rising one, whatever the absolute times are.
-const per = (ms: number, pages: number) => (ms / pages).toFixed(2);
+const COLUMNS: Array<[string, string, string]> = [
+  ["streamed", "universe", "universe"],
+  ["streamed", "page-rules", "pageRules"],
+  ["streamed", "site-query", "siteQuery"],
+  ["streamed", "site-rules", "siteRules"],
+  ["v1", "hydrate", "v1 hydrate"],
+  ["v1", "v1Rules", "v1 rules"],
+  ["parse", "parse", "parsePageRecord"],
+];
+
+const rows = DBS.map((db) => {
+  const perMode = results.get(db)!;
+  const pages = perMode.get("streamed")?.pages ?? perMode.get("v1")?.pages ?? perMode.get("parse")?.pages ?? 0;
+  const values = COLUMNS.map(([mode, key]) => perMode.get(mode)?.[key] ?? 0);
+  return { db, pages, values };
+}).filter((r) => r.pages > 0);
+
+console.log(`\nrules disabled: ${DISABLE.join(", ") || "(none)"}   repeats: ${REPEATS} (minimum shown)`);
 console.log(
-  `\n${"pages".padStart(6)} ` +
-    `${"universe".padStart(9)} ${"/pg".padStart(6)} ` +
-    `${"pageRules".padStart(10)} ${"/pg".padStart(6)} ` +
-    `${"siteRules".padStart(10)} ${"/pg".padStart(6)} ` +
-    `${"v1 parse".padStart(9)} ${"/pg".padStart(6)} ` +
-    `${"v1 rules".padStart(9)} ${"/pg".padStart(6)}`,
+  `${"pages".padStart(6)} ` + COLUMNS.map(([, , label]) => `${label.padStart(16)} ${"/pg".padStart(6)}`).join(" "),
 );
-for (const r of rows) {
+for (const row of rows) {
   console.log(
-    `${String(r.pages).padStart(6)} ` +
-      `${`${r.universeMs}ms`.padStart(9)} ${per(r.universeMs, r.pages).padStart(6)} ` +
-      `${`${r.pageRulesMs}ms`.padStart(10)} ${per(r.pageRulesMs, r.pages).padStart(6)} ` +
-      `${`${r.siteRulesMs}ms`.padStart(10)} ${per(r.siteRulesMs, r.pages).padStart(6)} ` +
-      `${`${r.v1ParseMs}ms`.padStart(9)} ${per(r.v1ParseMs, r.pages).padStart(6)} ` +
-      `${`${r.v1RulesMs}ms`.padStart(9)} ${per(r.v1RulesMs, r.pages).padStart(6)}`,
+    `${String(row.pages).padStart(6)} ` +
+      row.values
+        .map((ms) => `${`${ms}ms`.padStart(16)} ${(ms / row.pages).toFixed(2).padStart(6)}`)
+        .join(" "),
   );
 }
 
+// Slopes across the endpoints, and only when the endpoints differ. Two points
+// cannot separate `A + Bn` from `A + Bn + Cn²` over a narrow range — a fixed
+// cost A makes per-page fall either way — so this is labelled an OBSERVED slope
+// and the per-page columns above are the thing to read.
 if (rows.length >= 2) {
   const first = rows[0]!;
   const last = rows[rows.length - 1]!;
-  const ratio = last.pages / first.pages;
-  // The exponent, so a reader does not have to divide in their head. Linear is
-  // 1.0; #1910 reports 2.0 for site rules.
-  const exponent = (a: number, b: number) =>
-    a > 0 && b > 0 ? (Math.log(b / a) / Math.log(ratio)).toFixed(2) : "n/a";
-  console.log(
-    `\nacross ${first.pages} -> ${last.pages} pages (${ratio.toFixed(1)}x), cost ~ n^k:\n` +
-      `  universe   n^${exponent(first.universeMs, last.universeMs)}\n` +
-      `  pageRules  n^${exponent(first.pageRulesMs, last.pageRulesMs)}\n` +
-      `  siteRules  n^${exponent(first.siteRulesMs, last.siteRulesMs)}\n` +
-      `  v1 parse   n^${exponent(first.v1ParseMs, last.v1ParseMs)}\n` +
-      `  v1 rules   n^${exponent(first.v1RulesMs, last.v1RulesMs)}`,
-  );
+  if (last.pages === first.pages) {
+    console.log(`\nno slope: endpoint page counts are equal (${first.pages}).`);
+  } else {
+    const ratio = last.pages / first.pages;
+    console.log(`\nobserved slope across ${first.pages} -> ${last.pages} pages (${ratio.toFixed(1)}x), cost ~ n^k:`);
+    COLUMNS.forEach(([, , label], i) => {
+      const a = first.values[i]!;
+      const b = last.values[i]!;
+      const k = a > 0 && b > 0 ? (Math.log(b / a) / Math.log(ratio)).toFixed(2) : "n/a";
+      console.log(`  ${label.padEnd(16)} n^${k}`);
+    });
+  }
 }

--- a/packages/audit-engine/scripts/rules-scaling-bench.ts
+++ b/packages/audit-engine/scripts/rules-scaling-bench.ts
@@ -113,7 +113,15 @@ function benchConfig(): Config {
     cloud: { ...base.cloud, enabled: false },
     intel: { ...base.intel, enabled: false },
     external_links: { ...base.external_links, enabled: false },
-    soft404_confirm: { ...(base as { soft404_confirm?: object }).soft404_confirm, enabled: false },
+    // NESTED under `integrity`, which is where both engine paths read it. A
+    // root-level `soft404_confirm` is silently ignored and the pass stays on.
+    integrity: {
+      ...(base as { integrity?: { soft404_confirm?: object } }).integrity,
+      soft404_confirm: {
+        ...(base as { integrity?: { soft404_confirm?: object } }).integrity?.soft404_confirm,
+        enabled: false,
+      },
+    },
     rules: { enable: ["*"], disable: DISABLE },
   } as unknown as Config;
 }

--- a/packages/audit-engine/scripts/rules-scaling-bench.ts
+++ b/packages/audit-engine/scripts/rules-scaling-bench.ts
@@ -152,9 +152,10 @@ if (process.argv.includes("--child")) {
     const all = await run(storage.getPages(crawlId));
     const ctx = await run(buildSiteContext(all));
     // NOT parsePageRecord: with stored parsedData this re-parses the DOM and
-    // deserializes the rest. Named `hydrate` so it cannot be read as the parse
-    // #1910 is talking about.
-    out.hydrate = Date.now() - t0;
+    // deserializes the rest. It also includes the `getPages` read, which the
+    // parse arm excludes — hence `load+hydrate`, so neither the name nor the
+    // number can be read as the parse #1910 is talking about.
+    out["load+hydrate"] = Date.now() - t0;
     const t1 = Date.now();
     await run(runRulesOnStorage(storage, crawlId, ctx, benchConfig(), EMPTY_ASSETS));
     out.v1Rules = Date.now() - t1;
@@ -266,7 +267,7 @@ const COLUMNS: Array<[string, string, string]> = [
   ["streamed", "page-rules", "pageRules"],
   ["streamed", "site-query", "siteQuery"],
   ["streamed", "site-rules", "siteRules"],
-  ["v1", "hydrate", "v1 hydrate"],
+  ["v1", "load+hydrate", "v1 load+hydrate"],
   ["v1", "v1Rules", "v1 rules"],
   ["parse", "parse", "parsePageRecord"],
 ];

--- a/packages/audit-engine/scripts/rules-scaling-bench.ts
+++ b/packages/audit-engine/scripts/rules-scaling-bench.ts
@@ -42,10 +42,21 @@
 // the rule profiler, because a near-linear total cannot rule out a superlinear
 // site component hiding inside it.
 //
-// Those per-rule sums are OVERLAPPING WALL DURATIONS: rules run with bounded
-// concurrency, so they add to more than the phase they came from. Read them
-// against each other and against the same column at another page count, never
-// against a phase time.
+// ONLY SITE RULES ARE REPORTED PER RULE, and that is a hard limit of the
+// profiler rather than a choice. It rounds every invocation to whole
+// milliseconds. A site rule runs ONCE per audit and takes tens or hundreds of
+// ms, so rounding costs it under half a millisecond. A page rule runs once per
+// page — 198 rules across 2,500 pages is 495,000 rounded samples — and summing
+// them buries every sub-millisecond invocation at zero while any rule that
+// crosses the 1 ms boundary as pages get heavier jumps a whole unit. Summed page
+// -scope profiler numbers made the two arms look like n^1.47 against n^1.01 when
+// unrounded timings of the same invocations put both near n^1.0. Page-rule cost
+// is read from the PHASE timings above, which are plain unrounded spans.
+//
+// Site rules also run with bounded concurrency, so their per-rule times add to
+// more than the site phase they came from; page rules run serially. Read a
+// per-rule number against the same rule at another page count, never against a
+// phase.
 //
 // --child is the inner half; the parent re-invokes this file with it.
 
@@ -188,13 +199,15 @@ function child(mode: string, db: string): Record<string, number> | null {
 }
 
 /** arm -> db -> ruleId -> summed ms, and the page/site split, per attempt. */
-const profiles = new Map<string, Map<string, { page: number; site: number; rules: Map<string, number> }>>();
+const profiles = new Map<string, Map<string, { pageInvocations: number; site: number; rules: Map<string, number> }>>();
 
 function recordProfile(mode: string, db: string, stderr: string): void {
   const byDb = profiles.get(mode) ?? new Map();
-  // Lowest attempt wins, same as the phase numbers: keep whichever attempt
-  // produced the smaller site total rather than averaging across noise.
-  const acc = { page: 0, site: 0, rules: new Map<string, number>() };
+  // Lowest SITE TOTAL wins, and that is the whole selection: the per-rule rows
+  // shown come from that same attempt rather than being a per-rule minimum
+  // across attempts, so they are internally consistent with each other and with
+  // the total above them.
+  const acc = { pageInvocations: 0, site: 0, rules: new Map<string, number>() };
   for (const line of stderr.split("\n")) {
     if (!line.startsWith("[rule-profile]")) continue;
     try {
@@ -202,10 +215,13 @@ function recordProfile(mode: string, db: string, stderr: string): void {
       const ms = d.durationMs ?? 0;
       // A site-scope rule runs once per audit and carries no pageUrl; a page
       // rule emits one line per page.
+      // Page-scope lines are COUNTED, not summed: see the header. Their summed
+      // durations are a rounding artifact, and reporting the count instead makes
+      // it visible that both arms ran the same number of rule invocations.
       if (d.pageUrl === undefined) {
         acc.site += ms;
         acc.rules.set(d.ruleId, (acc.rules.get(d.ruleId) ?? 0) + ms);
-      } else acc.page += ms;
+      } else acc.pageInvocations += 1;
     } catch {
       // A truncated line at the end of a pipe is not worth failing a run over.
     }
@@ -250,7 +266,9 @@ const COLUMNS: Array<[string, string, string]> = [
 const rows = DBS.map((db) => {
   const perMode = results.get(db)!;
   const pages = perMode.get("streamed")?.pages ?? perMode.get("v1")?.pages ?? perMode.get("parse")?.pages ?? 0;
-  const values = COLUMNS.map(([mode, key]) => perMode.get(mode)?.[key] ?? 0);
+  // `undefined`, not 0: an arm whose every attempt failed would otherwise print
+  // "0ms / 0.00" and read as the fastest row in the table.
+  const values = COLUMNS.map(([mode, key]) => perMode.get(mode)?.[key]);
   return { db, pages, values };
 }).filter((r) => r.pages > 0);
 
@@ -262,7 +280,11 @@ for (const row of rows) {
   console.log(
     `${String(row.pages).padStart(6)} ` +
       row.values
-        .map((ms) => `${`${ms}ms`.padStart(16)} ${(ms / row.pages).toFixed(2).padStart(6)}`)
+        .map((ms) =>
+          ms === undefined
+            ? `${"failed".padStart(16)} ${"-".padStart(6)}`
+            : `${`${ms}ms`.padStart(16)} ${(ms / row.pages).toFixed(2).padStart(6)}`,
+        )
         .join(" "),
   );
 }
@@ -282,9 +304,10 @@ if (PROFILE) {
     const k = (x: number, y: number) =>
       x > 0 && y > 0 && ratio > 1 ? `n^${(Math.log(y / x) / Math.log(ratio)).toFixed(2)}` : "n/a";
     console.log(
-      `\n=== ${mode} arm, per-rule (summed overlapping wall time, NOT a phase) ===\n` +
-        `  page-scope total  ${a.page.toFixed(0)}ms -> ${b.page.toFixed(0)}ms   ${k(a.page, b.page)}\n` +
-        `  site-scope total  ${a.site.toFixed(0)}ms -> ${b.site.toFixed(0)}ms   ${k(a.site, b.site)}`,
+      `\n=== ${mode} arm, SITE rules (one attempt, the one with the lowest total) ===\n` +
+        `  page-rule invocations  ${a.pageInvocations} -> ${b.pageInvocations} ` +
+        `(counted, not timed — the profiler's whole-ms rounding makes their sum meaningless)\n` +
+        `  site-scope total       ${a.site.toFixed(0)}ms -> ${b.site.toFixed(0)}ms   ${k(a.site, b.site)}`,
     );
     const top = [...b.rules].sort((x, y) => y[1] - x[1]).slice(0, TOP_RULES);
     console.log(`  ${"site rule".padEnd(36)} ${"first".padStart(8)} ${"last".padStart(8)} ${"slope".padStart(8)}`);
@@ -308,9 +331,11 @@ if (rows.length >= 2) {
     const ratio = last.pages / first.pages;
     console.log(`\nobserved slope across ${first.pages} -> ${last.pages} pages (${ratio.toFixed(1)}x), cost ~ n^k:`);
     COLUMNS.forEach(([, , label], i) => {
-      const a = first.values[i]!;
-      const b = last.values[i]!;
-      const k = a > 0 && b > 0 ? (Math.log(b / a) / Math.log(ratio)).toFixed(2) : "n/a";
+      const a = first.values[i];
+      const b = last.values[i];
+      const k = a !== undefined && b !== undefined && a > 0 && b > 0
+        ? (Math.log(b / a) / Math.log(ratio)).toFixed(2)
+        : "n/a";
       console.log(`  ${label.padEnd(16)} n^${k}`);
     });
   }

--- a/packages/audit-engine/scripts/rules-scaling-bench.ts
+++ b/packages/audit-engine/scripts/rules-scaling-bench.ts
@@ -6,13 +6,18 @@
 // to be controlled for the answer to mean anything, and four of them cost a
 // wrong answer rather than a vague one:
 //
-//   1. THE NETWORK. `security/http-to-https` probes sample URLs over HTTP with
-//      staggered sleeps, and none of the cloud/intel/external-link switches
-//      turns it off. On this fixture it was 508-790 ms of a 518-790 ms site
+//   1. THE NETWORK. Two things reach it. `security/http-to-https` probes sample
+//      URLs over HTTP with staggered sleeps, and none of the cloud, intel or
+//      external-link switches turns it off. On this fixture it was 508-790 ms of a 518-790 ms site
 //      phase: the whole phase was one rule waiting on sockets, and every other
 //      site rule's scaling was invisible underneath it. It is DISABLED by
 //      default here (`--disable`), and the disabled set is printed, because a
-//      site-rule number measured with it on is a number about the network.
+//      site-rule number measured with it on is a number about the network. And
+//      the soft-404 confirmation pass re-fetches every flagged candidate with a
+//      sleep between same-host requests; it is off here too. Neither fires on
+//      these fixtures, but another database could make either of them the
+//      measurement. Note this also means the result is about the REMAINING
+//      rules, not about production rules-phase latency.
 //   2. THE CONTENT STORE. #1908's full-table scan per stored page makes a crawl
 //      quadratic in its own page count. The fixtures keep html in the crawl DB
 //      and never touch the global store.
@@ -32,10 +37,15 @@
 //   bun run scripts/rules-scaling-bench.ts --dbs /tmp/mix400.sqlite,/tmp/mix2500.sqlite
 //
 // The CLI runs v1 (`runRulesOnStorage`, every page resident) and the cloud runs
-// the streamed pass; #1910 measured the CLI, so both are timed, and v1 is split
-// into its page-scope and site-scope halves with the rule profiler rather than
-// reported as one number — a near-linear total cannot rule out a superlinear
+// the streamed pass; #1910 measured the CLI, so both are timed. With `--profile`
+// the parent also splits each arm into its page-scope and site-scope halves from
+// the rule profiler, because a near-linear total cannot rule out a superlinear
 // site component hiding inside it.
+//
+// Those per-rule sums are OVERLAPPING WALL DURATIONS: rules run with bounded
+// concurrency, so they add to more than the phase they came from. Read them
+// against each other and against the same column at another page count, never
+// against a phase time.
 //
 // --child is the inner half; the parent re-invokes this file with it.
 
@@ -92,6 +102,7 @@ function benchConfig(): Config {
     cloud: { ...base.cloud, enabled: false },
     intel: { ...base.intel, enabled: false },
     external_links: { ...base.external_links, enabled: false },
+    soft404_confirm: { ...(base as { soft404_confirm?: object }).soft404_confirm, enabled: false },
     rules: { enable: ["*"], disable: DISABLE },
   } as unknown as Config;
 }
@@ -152,6 +163,7 @@ const DBS = arg("dbs", "")
   .filter(Boolean);
 const REPEATS = Math.max(1, Number.parseInt(arg("repeat", "3"), 10));
 const PROFILE = process.argv.includes("--profile");
+const TOP_RULES = Math.max(1, Number.parseInt(arg("top", "10"), 10));
 
 function child(mode: string, db: string): Record<string, number> | null {
   const proc = Bun.spawnSync({
@@ -163,14 +175,44 @@ function child(mode: string, db: string): Record<string, number> | null {
     // set here rather than passed as a flag the child would have to re-plumb.
     env: PROFILE ? { ...process.env, SQUIRREL_RULE_PROFILE: "1" } : process.env,
     stdout: "pipe",
-    stderr: PROFILE ? "inherit" : "pipe",
+    stderr: "pipe",
   });
+  const stderr = proc.stderr?.toString() ?? "";
   if (proc.exitCode !== 0) {
-    console.error(`  ${mode} on ${db}: exit ${proc.exitCode}\n${proc.stderr?.toString().slice(-500) ?? ""}`);
+    console.error(`  ${mode} on ${db}: exit ${proc.exitCode}\n${stderr.slice(-500)}`);
     return null;
   }
+  if (PROFILE) recordProfile(mode, db, stderr);
   const line = proc.stdout.toString().split("\n").find((l) => l.startsWith("CHILD "));
   return line ? (JSON.parse(line.slice(6)) as Record<string, number>) : null;
+}
+
+/** arm -> db -> ruleId -> summed ms, and the page/site split, per attempt. */
+const profiles = new Map<string, Map<string, { page: number; site: number; rules: Map<string, number> }>>();
+
+function recordProfile(mode: string, db: string, stderr: string): void {
+  const byDb = profiles.get(mode) ?? new Map();
+  // Lowest attempt wins, same as the phase numbers: keep whichever attempt
+  // produced the smaller site total rather than averaging across noise.
+  const acc = { page: 0, site: 0, rules: new Map<string, number>() };
+  for (const line of stderr.split("\n")) {
+    if (!line.startsWith("[rule-profile]")) continue;
+    try {
+      const d = JSON.parse(line.slice(14)) as { ruleId: string; pageUrl?: string; durationMs?: number };
+      const ms = d.durationMs ?? 0;
+      // A site-scope rule runs once per audit and carries no pageUrl; a page
+      // rule emits one line per page.
+      if (d.pageUrl === undefined) {
+        acc.site += ms;
+        acc.rules.set(d.ruleId, (acc.rules.get(d.ruleId) ?? 0) + ms);
+      } else acc.page += ms;
+    } catch {
+      // A truncated line at the end of a pipe is not worth failing a run over.
+    }
+  }
+  const prev = byDb.get(db);
+  if (!prev || acc.site < prev.site) byDb.set(db, acc);
+  profiles.set(mode, byDb);
 }
 
 const MODES = ["streamed", "v1", "parse"] as const;
@@ -223,6 +265,34 @@ for (const row of rows) {
         .map((ms) => `${`${ms}ms`.padStart(16)} ${(ms / row.pages).toFixed(2).padStart(6)}`)
         .join(" "),
   );
+}
+
+if (PROFILE) {
+  const sizeOf = (db: string) => rows.find((r) => r.db === db)?.pages ?? 0;
+  const ordered = [...DBS].sort((a, b) => sizeOf(a) - sizeOf(b));
+  const first = ordered[0];
+  const last = ordered[ordered.length - 1];
+  for (const mode of ["streamed", "v1"] as const) {
+    const byDb = profiles.get(mode);
+    if (!byDb || !first || !last) continue;
+    const a = byDb.get(first);
+    const b = byDb.get(last);
+    if (!a || !b) continue;
+    const ratio = sizeOf(last) / sizeOf(first);
+    const k = (x: number, y: number) =>
+      x > 0 && y > 0 && ratio > 1 ? `n^${(Math.log(y / x) / Math.log(ratio)).toFixed(2)}` : "n/a";
+    console.log(
+      `\n=== ${mode} arm, per-rule (summed overlapping wall time, NOT a phase) ===\n` +
+        `  page-scope total  ${a.page.toFixed(0)}ms -> ${b.page.toFixed(0)}ms   ${k(a.page, b.page)}\n` +
+        `  site-scope total  ${a.site.toFixed(0)}ms -> ${b.site.toFixed(0)}ms   ${k(a.site, b.site)}`,
+    );
+    const top = [...b.rules].sort((x, y) => y[1] - x[1]).slice(0, TOP_RULES);
+    console.log(`  ${"site rule".padEnd(36)} ${"first".padStart(8)} ${"last".padStart(8)} ${"slope".padStart(8)}`);
+    for (const [rule, ms] of top) {
+      const before = a.rules.get(rule) ?? 0;
+      console.log(`  ${rule.padEnd(36)} ${`${before.toFixed(0)}ms`.padStart(8)} ${`${ms.toFixed(0)}ms`.padStart(8)} ${k(before, ms).padStart(8)}`);
+    }
+  }
 }
 
 // Slopes across the endpoints, and only when the endpoints differ. Two points

--- a/packages/audit-engine/scripts/rules-scaling-bench.ts
+++ b/packages/audit-engine/scripts/rules-scaling-bench.ts
@@ -1,0 +1,180 @@
+// How the rules phases scale with page count (#1910).
+//
+// #1910 reports site rules going from 4s at 400 pages to 687s at 5,000 — about
+// n^2 — with page rules at n^1.6 and even `parsePageRecord` per page rising from
+// 5.5 to 40 ms, which is the strangest of the three, because parsing one page
+// should not depend on how many other pages exist. This is the benchmark that
+// re-measures those numbers under conditions where they can be believed.
+//
+// THREE THINGS THE ORIGINAL MEASUREMENT COULD NOT CONTROL, and this does:
+//
+//   - CONTENTION. #1910's own caveat says its 2,500 row was 589s wall against
+//     360s CPU and its 5,000 row 2,236s against 1,023s, on a 16 GB box doing
+//     150 MB/s of swap with a load average of 13. Wall time under those
+//     conditions is mostly waiting. Run this on a quiet machine and read the
+//     per-page columns, which is where a superlinear term shows up as a rising
+//     number rather than as a big one.
+//   - THE CONTENT STORE. #1908's full-table scan per stored page makes a single
+//     crawl quadratic in its own page count and would dominate anything measured
+//     through it. The fixtures here store html in the crawl DB itself and never
+//     touch the global store, so it cannot participate.
+//   - THE PATH. The CLI runs v1 (`runRulesOnStorage`, every page resident) and
+//     the cloud runs the streamed pass; #1910 measured the CLI. Both are timed
+//     here, because "site rules are quadratic" would mean something different
+//     about each.
+//
+//   bun run scripts/build-mixed-fixture.ts --db /tmp/mix400.sqlite --pages 400
+//   bun run scripts/rules-scaling-bench.ts --dbs /tmp/mix400.sqlite,/tmp/mix2500.sqlite
+//
+// Add `--profile` for per-rule timings, which is what names an individual rule
+// that walks the page set once per page. Note that site rules run with bounded
+// concurrency, so their per-rule times sum to MORE than the phase's wall time.
+
+import { getDefaultConfig, type Config } from "@squirrelscan/config";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { Effect } from "effect";
+
+import {
+  buildSiteContext,
+  runRulesOnStorage,
+  runStreamingRules,
+  type PreFetchedAssets,
+  type StreamingRulePhase,
+} from "../src/adapter";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+const arg = (n: string, d: string) => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? (process.argv[i + 1] ?? d) : d;
+};
+
+const DBS = arg("dbs", "")
+  .split(",")
+  .map((d) => d.trim())
+  .filter(Boolean);
+const BATCH = Number.parseInt(arg("batch", "200"), 10);
+
+const EMPTY_ASSETS: PreFetchedAssets = {
+  resourceSizes: { css: [], images: [] },
+  scripts: [],
+  pdfSizes: [],
+  sitemapUrlStatuses: [],
+};
+
+/**
+ * Every rule on, nothing that reaches the network. `rules.enable: ["*"]` is not
+ * optional: `filterRules` defaults every rule to DISABLED, so a bench without it
+ * measures an empty rule set and reports a flat, meaningless line.
+ */
+function benchConfig(): Config {
+  const base = getDefaultConfig();
+  return {
+    ...base,
+    cloud: { ...base.cloud, enabled: false },
+    intel: { ...base.intel, enabled: false },
+    external_links: { ...base.external_links, enabled: false },
+    rules: { enable: ["*"] },
+  } as unknown as Config;
+}
+
+interface Row {
+  pages: number;
+  universeMs: number;
+  pageRulesMs: number;
+  siteRulesMs: number;
+  siteQueryMs: number;
+  v1ParseMs: number;
+  v1RulesMs: number;
+}
+
+async function measure(db: string): Promise<Row> {
+  const storage = new SQLiteStorage(db);
+  await run(storage.init());
+  const crawls = await run(storage.listCrawls(1));
+  const crawlId = (crawls as Array<{ id: string }>)[0]!.id;
+  const pages = await run(storage.getPageCount(crawlId));
+
+  const started = new Map<StreamingRulePhase, number>();
+  const phase = new Map<StreamingRulePhase, number>();
+  await run(
+    runStreamingRules(storage, crawlId, benchConfig(), EMPTY_ASSETS, undefined, {
+      batchSize: BATCH,
+      onPhase: (name, boundary) => {
+        if (boundary === "start") started.set(name, Date.now());
+        else phase.set(name, Date.now() - started.get(name)!);
+      },
+    }),
+  );
+
+  // v1, the path the CLI takes and the one #1910 measured. Its parse is timed
+  // separately because #1910 reports per-page PARSE cost rising too, and in v1
+  // the parse is a distinct step rather than part of the batched walk.
+  const t0 = Date.now();
+  const all = await run(storage.getPages(crawlId));
+  const ctx = await run(buildSiteContext(all));
+  const v1ParseMs = Date.now() - t0;
+  const t1 = Date.now();
+  await run(runRulesOnStorage(storage, crawlId, ctx, benchConfig(), EMPTY_ASSETS));
+  const v1RulesMs = Date.now() - t1;
+
+  await run(storage.close());
+  return {
+    pages,
+    universeMs: phase.get("universe") ?? 0,
+    pageRulesMs: phase.get("page-rules") ?? 0,
+    siteRulesMs: phase.get("site-rules") ?? 0,
+    siteQueryMs: phase.get("site-query") ?? 0,
+    v1ParseMs,
+    v1RulesMs,
+  };
+}
+
+const rows: Row[] = [];
+for (const db of DBS) {
+  const row = await measure(db);
+  rows.push(row);
+  console.log(`measured ${db.split("/").pop()} (${row.pages} pages)`);
+}
+
+// PER-PAGE is the column that answers the question. A phase that doubles when
+// the crawl doubles is linear and its per-page number is flat; a superlinear
+// phase shows up here as a rising one, whatever the absolute times are.
+const per = (ms: number, pages: number) => (ms / pages).toFixed(2);
+console.log(
+  `\n${"pages".padStart(6)} ` +
+    `${"universe".padStart(9)} ${"/pg".padStart(6)} ` +
+    `${"pageRules".padStart(10)} ${"/pg".padStart(6)} ` +
+    `${"siteRules".padStart(10)} ${"/pg".padStart(6)} ` +
+    `${"v1 parse".padStart(9)} ${"/pg".padStart(6)} ` +
+    `${"v1 rules".padStart(9)} ${"/pg".padStart(6)}`,
+);
+for (const r of rows) {
+  console.log(
+    `${String(r.pages).padStart(6)} ` +
+      `${`${r.universeMs}ms`.padStart(9)} ${per(r.universeMs, r.pages).padStart(6)} ` +
+      `${`${r.pageRulesMs}ms`.padStart(10)} ${per(r.pageRulesMs, r.pages).padStart(6)} ` +
+      `${`${r.siteRulesMs}ms`.padStart(10)} ${per(r.siteRulesMs, r.pages).padStart(6)} ` +
+      `${`${r.v1ParseMs}ms`.padStart(9)} ${per(r.v1ParseMs, r.pages).padStart(6)} ` +
+      `${`${r.v1RulesMs}ms`.padStart(9)} ${per(r.v1RulesMs, r.pages).padStart(6)}`,
+  );
+}
+
+if (rows.length >= 2) {
+  const first = rows[0]!;
+  const last = rows[rows.length - 1]!;
+  const ratio = last.pages / first.pages;
+  // The exponent, so a reader does not have to divide in their head. Linear is
+  // 1.0; #1910 reports 2.0 for site rules.
+  const exponent = (a: number, b: number) =>
+    a > 0 && b > 0 ? (Math.log(b / a) / Math.log(ratio)).toFixed(2) : "n/a";
+  console.log(
+    `\nacross ${first.pages} -> ${last.pages} pages (${ratio.toFixed(1)}x), cost ~ n^k:\n` +
+      `  universe   n^${exponent(first.universeMs, last.universeMs)}\n` +
+      `  pageRules  n^${exponent(first.pageRulesMs, last.pageRulesMs)}\n` +
+      `  siteRules  n^${exponent(first.siteRulesMs, last.siteRulesMs)}\n` +
+      `  v1 parse   n^${exponent(first.v1ParseMs, last.v1ParseMs)}\n` +
+      `  v1 rules   n^${exponent(first.v1RulesMs, last.v1RulesMs)}`,
+  );
+}

--- a/packages/audit-engine/scripts/rules-scaling-bench.ts
+++ b/packages/audit-engine/scripts/rules-scaling-bench.ts
@@ -36,8 +36,13 @@
 //   bun run scripts/build-mixed-fixture.ts --db /tmp/mix400.sqlite --pages 400
 //   bun run scripts/rules-scaling-bench.ts --dbs /tmp/mix400.sqlite,/tmp/mix2500.sqlite
 //
-// The CLI runs v1 (`runRulesOnStorage`, every page resident) and the cloud runs
-// the streamed pass; #1910 measured the CLI, so both are timed. With `--profile`
+// Both rule paths are timed. When #1910 was filed the CLI's `audit` ran v1
+// (`runRulesOnStorage`, every page held resident through the rules pass) and the
+// cloud ran the streamed pass, and #1910 measured the CLI. #252 has since moved
+// `audit` onto the streamed pipeline, so v1 now serves `squirrel analyze` and
+// any caller still on `runRulesOnStorage` — which is why it is still measured
+// here, and why the arm that turns out to be the superlinear one is the one
+// being retired rather than the one most audits run. With `--profile`
 // the parent also splits each arm into its page-scope and site-scope halves from
 // the rule profiler, because a near-linear total cannot rule out a superlinear
 // site component hiding inside it.

--- a/packages/rules/src/integrity/template-discontinuity.ts
+++ b/packages/rules/src/integrity/template-discontinuity.ts
@@ -128,6 +128,15 @@ export const templateDiscontinuityRule: Rule = {
     // on a site that actually has outliers, which is why a corpus of uniformly
     // themed pages never showed it (#1910).
     //
+    // The saving is ASYMPTOTIC, not something you can see today. At the largest
+    // share the rule can be given (one page in three; at one in two the baseline
+    // absorbs both groups and there are no outliers at all) 2,500 pages is
+    // 833 outliers over 2,500 entries, about a million string compares, which is
+    // a small part of a rule that takes ~215 ms. Measured before and after at
+    // that size and share on a quiet machine: 215 ms and 225 ms, i.e. nothing.
+    // The term is real and grows as f*n^2; it is simply not what dominates at a
+    // size this fixture can reach.
+    //
     // LAZY, so a site with no outliers pays nothing and an outlier run pays one
     // O(n) build instead of one O(n) scan per outlier, and FIRST-WINS, because
     // `find` returned the first match and `SiteData.pages` is caller-supplied

--- a/packages/rules/src/integrity/template-discontinuity.ts
+++ b/packages/rules/src/integrity/template-discontinuity.ts
@@ -120,6 +120,18 @@ export const templateDiscontinuityRule: Rule = {
       ? new Map(collected.pages.map((r) => [r.url, r.signals.length]))
       : null;
 
+    // v1 looks the outlier's page up by url to build a context for the signal
+    // detectors. That lookup used to be `pages.find(...)`, a scan of the whole
+    // page set PER OUTLIER: with an outlier share f that is f*n lookups over n
+    // pages, so the branch was quadratic in page count and linear in the share.
+    // It only ever ran on the v1 path — streaming reads the map above — and only
+    // on a site that actually has outliers, which is why a corpus of uniformly
+    // themed pages never showed it (#1910).
+    //
+    // Built once, and only when it will be used, so a streamed run and a site
+    // with no outliers both pay nothing.
+    const pageByUrl = signalCountByUrl ? null : new Map(pages.map((p) => [p.url, p]));
+
     for (const { url, fp } of entries) {
       const similarity = similarityToBaseline(fp, baseline);
       if (similarity >= threshold) continue;
@@ -132,7 +144,7 @@ export const templateDiscontinuityRule: Rule = {
         // signals? Build a minimal page ctx for the signal detectors. `html: ""` is
         // intentional — the detectors read parsed.document/parsed.content, not
         // page.html (see orphan-page.ts for the same note).
-        const page = pages.find((p) => p.url === url)!;
+        const page = pageByUrl!.get(url)!;
         const pageCtx: RuleContext = {
           page: {
             url: page.url,

--- a/packages/rules/src/integrity/template-discontinuity.ts
+++ b/packages/rules/src/integrity/template-discontinuity.ts
@@ -128,7 +128,8 @@ export const templateDiscontinuityRule: Rule = {
     // on a site that actually has outliers, which is why a corpus of uniformly
     // themed pages never showed it (#1910).
     //
-    // LAZY, so a site with no outliers pays nothing, and FIRST-WINS, because
+    // LAZY, so a site with no outliers pays nothing and an outlier run pays one
+    // O(n) build instead of one O(n) scan per outlier, and FIRST-WINS, because
     // `find` returned the first match and `SiteData.pages` is caller-supplied
     // and not deduplicated. Building it with `new Map(pages.map(...))` would
     // keep the LAST entry for a repeated url, which flips this rule's verdict

--- a/packages/rules/src/integrity/template-discontinuity.ts
+++ b/packages/rules/src/integrity/template-discontinuity.ts
@@ -128,9 +128,19 @@ export const templateDiscontinuityRule: Rule = {
     // on a site that actually has outliers, which is why a corpus of uniformly
     // themed pages never showed it (#1910).
     //
-    // Built once, and only when it will be used, so a streamed run and a site
-    // with no outliers both pay nothing.
-    const pageByUrl = signalCountByUrl ? null : new Map(pages.map((p) => [p.url, p]));
+    // LAZY, so a site with no outliers pays nothing, and FIRST-WINS, because
+    // `find` returned the first match and `SiteData.pages` is caller-supplied
+    // and not deduplicated. Building it with `new Map(pages.map(...))` would
+    // keep the LAST entry for a repeated url, which flips this rule's verdict
+    // from info to fail when a benign page and a compromised one share one.
+    let pageByUrl: Map<string, (typeof pages)[number]> | null = null;
+    const pageFor = (url: string) => {
+      if (!pageByUrl) {
+        pageByUrl = new Map();
+        for (const p of pages) if (!pageByUrl.has(p.url)) pageByUrl.set(p.url, p);
+      }
+      return pageByUrl.get(url)!;
+    };
 
     for (const { url, fp } of entries) {
       const similarity = similarityToBaseline(fp, baseline);
@@ -144,7 +154,7 @@ export const templateDiscontinuityRule: Rule = {
         // signals? Build a minimal page ctx for the signal detectors. `html: ""` is
         // intentional — the detectors read parsed.document/parsed.content, not
         // page.html (see orphan-page.ts for the same note).
-        const page = pageByUrl!.get(url)!;
+        const page = pageFor(url);
         const pageCtx: RuleContext = {
           page: {
             url: page.url,


### PR DESCRIPTION
For squirrelscan/repo#1910 (part of #1028). One rule fix, two scripts.

**Nothing measured is quadratic in page count, but one thing was quadratic in the code**, and the fixture had to be rebuilt twice before it could see it.

## The fix, and why it buys nothing today

`integrity/template-discontinuity` builds a signal context per outlier on the v1 path and looked the page up with `pages.find(...)`. With an outlier share `f` that is `f·n` scans of `n` pages: **quadratic in page count, linear in the share**. It never runs on the streamed path, which reads a map of page-time signals, and never on a site with no outliers. It is a lazily built, first-wins map now.

| outlier share | pages | before | after |
|---|---|---|---|
| 10% | 2,500 | 159 ms | 154 ms |
| 33% | 1,000 | 74 ms | 71 ms |
| 33% | 2,500 | 215 ms | 225 ms |

Minimum of five runs each, on a quiet machine. **There is no measurable win, and an earlier version of this PR claimed one.** It reported 501 ms against 201 ms on the last row; that was a loaded machine exaggerating a cache-hostile scan. At the largest share the rule can be given — one page in three, because at one in two the baseline absorbs both groups' markers and the rule reports no outliers at all — 2,500 pages is about a million string compares inside a 215 ms rule.

The `f·n²` term is real and the map removes it. The change stands on that and on costing one O(n) build on outlier runs against one O(n) scan per outlier, not on a number. Both figures are in `benchmarks/2026-09-perf-program.md`, the withdrawn one included.

Two behaviour details the first version of the fix got wrong, both caught in review: `new Map(pages.map(...))` keeps the LAST entry for a repeated url where `find` returned the FIRST, which flips this rule from info to fail when a benign page and a compromised one share one, and `SiteData.pages` is caller-supplied and not deduplicated. And building the map before the similarity check made every consistently themed v1 site pay an O(n) allocation for nothing.

## The phases

14.2 KB mean at #1910's template shares, quiet machine, per page in ms:

| pages | universe | page rules | site query | site rules | v1 load+hydrate | v1 rules | parsePageRecord |
|---|---|---|---|---|---|---|---|
| 400 | 0.33 | 6.95 | 0.06 | 0.17 | 0.20 | 6.44 | 0.67 |
| 1,000 | 0.35 | 6.76 | 0.07 | 0.16 | 0.17 | 6.74 | 0.63 |
| 2,500 | 0.32 | 7.60 | 0.08 | 0.16 | 0.19 | 7.86 | 0.59 |

Slopes across 6.3x: page rules n^1.05, site rules n^0.97, parsePageRecord n^0.93, universe n^0.99, **v1 rules n^1.11**. Per site rule, the streamed arm totals n^0.86 and the v1 arm n^1.22; the most superlinear on v1 are the link rules, `links/orphan-pages` n^1.46 and `links/weak-internal-links` n^1.41, which read `siteQuery` on the streamed path and walk parsed link arrays on v1.

Against the issue's criteria: page-rule per-page cost is flat within 12% on the streamed path and v1's rules phase within 22%, both inside the 25% band. `parsePageRecord` per page falls rather than rising. `parsePageRecord` per page does not rise.

## Two measurement defects worth knowing about

Both produced confident wrong answers in earlier drafts of this PR.

**The profiler rounds every invocation to whole milliseconds.** A site rule runs once per audit and takes tens of ms, so rounding costs it nothing. A page rule runs once per page, 495,000 samples at 2,500 pages, and summing them buries sub-millisecond work at zero while a rule that crosses 1 ms on heavier pages jumps a whole unit. That artifact produced an earlier claim here that v1's page rules were n^1.47 against streaming's n^1.01. Unrounded timings of the same invocations put both near n^1.0. The benchmark counts page-rule invocations now and reads page-rule cost from the phase spans.

**Three things reached the network or the clock, and no config switch I wrote stopped them until the fourth review round.** `security/http-to-https` probes sample URLs over HTTP with staggered sleeps: at 400 pages it was **508 ms of a 518 ms site phase**, so the entire site phase was one rule waiting on sockets and an earlier draft concluded from it that site rules were "dominated by a fixed cost". The soft-404 confirmation pass re-fetches candidates with a sleep between same-host requests, and my first attempt to disable it wrote a root-level key while both engine paths read `config.integrity.soft404_confirm` — so it was on for every measurement until it was nested correctly. Both are excluded now, which also means these numbers are about the remaining rules and not about production rules-phase latency.

## Why the fixture took three attempts

A negative result is only as good as its corpus, and each version let a rule take an early exit and report a flat line that meant nothing.

The last one is the instructive one. The divergent pages scored **0.258** against the rule's 0.2 threshold, so it reported "all pages share the site's common template". Three separate reasons: they still resolved `bench.test` from their canonical link and relative image srcs, so host Jaccard was 1/3 rather than near 0; **neither side declared CSS variables, and the Jaccard of two empty sets is 1**, so that term paid full weight to similarity; and both sides had a `<nav>`, so half the chrome term matched. The baseline declares CSS variables now, the divergent pages spread assets over three foreign hosts and wrap their links in a div, and they score 0.05. Verified: 40 outliers at 400 pages, exactly the 10% intended.

The corpus also has pages nothing links to, hubs of 120 links, 4xx pages, noindex pages, off-page canonicals and schema on four templates, each gating a branch a uniform corpus skips.

## What this does not claim

- It stops at 2,500 pages. The 5,000-page row is where #1910's numbers are most extreme and most contended, and its own caveat records that box at 150 MB/s of swap and load average 13.
- The per-rule figures move by up to 2x between runs. Read the totals and the direction, not an individual rule's third significant figure.
- Two page weights, 14.2 KB and 102 KB, both below the issue's 128 KB mean.
- Slopes are two-endpoint fits; two points cannot separate `A + Bn` from `A + Bn + Cn²` over a narrow range, which is why the per-page columns are printed and are the thing to read.
- The v1-versus-streamed gap is a controlled comparison, not a demonstrated mechanism. I have not shown that resident DOMs cost the time, only that the arm holding them is the arm that rises.
- The fixture still has no redirect chains, no sitemap records, no fetched sub-resources and no cross-origin variety.

Goldens unchanged: collector-rules, canonical, streaming, pre-rules, report-stream v2, and the rules package's integrity suite.
