### PR TITLE
fix(audit-engine): stop the container's cloud-prefetch payloads holding their pages

### DIFF
--- a/apps/cli/src/audit/cloud-payloads-blocklist.ts
+++ b/apps/cli/src/audit/cloud-payloads-blocklist.ts
@@ -49,13 +49,20 @@ export function absorbUrls(
 
     for (const link of parsed.links) {
       if (urls.size >= MAX_URLS) return;
-      if (!link.isInternal && isHttpUrl(link.url))
+      // `has` first: the cap counts UNIQUE urls, but the clone was being paid
+      // per occurrence, and a site that links the same forty hosts from every
+      // page has far more occurrences than uniques.
+      if (!link.isInternal && isHttpUrl(link.url) && !urls.has(link.url))
         urls.add(detachFromPage(link.url, "cloud-payload"));
     }
 
     for (const image of parsed.images) {
       if (urls.size >= MAX_URLS) return;
-      if (isHttpUrl(image.src) && getHostname(image.src) !== pageHost)
+      if (
+        isHttpUrl(image.src) &&
+        getHostname(image.src) !== pageHost &&
+        !urls.has(image.src)
+      )
         urls.add(detachFromPage(image.src, "cloud-payload"));
     }
 
@@ -66,7 +73,12 @@ export function absorbUrls(
     for (const script of doc.querySelectorAll("script[src]")) {
       if (urls.size >= MAX_URLS) return;
       const src = script.getAttribute("src");
-      if (src && isHttpUrl(src) && getHostname(src) !== pageHost)
+      if (
+        src &&
+        isHttpUrl(src) &&
+        getHostname(src) !== pageHost &&
+        !urls.has(src)
+      )
         urls.add(detachFromPage(src, "cloud-payload"));
     }
   }
@@ -82,6 +94,12 @@ function collectSelectors(siteContext: SiteContextPage[]): string[] {
 export interface SelectorState {
   selectors: Set<string>;
   pagesScanned: number;
+}
+
+/** Add a selector once, detaching only the copy that is actually kept. */
+function addSelector(selectors: Set<string>, selector: string): void {
+  if (!selectors.has(selector))
+    selectors.add(detachFromPage(selector, "cloud-payload"));
 }
 
 export function createSelectorState(): SelectorState {
@@ -118,14 +136,12 @@ export function absorbSelectors(
     for (const el of elements) {
       if (selectors.size >= MAX_SELECTORS) break;
       const id = el.getAttribute("id");
-      if (id && SIMPLE_TOKEN_RE.test(id))
-        selectors.add(detachFromPage(`#${id}`, "cloud-payload"));
+      if (id && SIMPLE_TOKEN_RE.test(id)) addSelector(selectors, `#${id}`);
       const classAttr = el.getAttribute("class");
       if (!classAttr) continue;
       for (const cls of classAttr.split(/\s+/)) {
         if (selectors.size >= MAX_SELECTORS) break;
-        if (cls && SIMPLE_TOKEN_RE.test(cls))
-          selectors.add(detachFromPage(`.${cls}`, "cloud-payload"));
+        if (cls && SIMPLE_TOKEN_RE.test(cls)) addSelector(selectors, `.${cls}`);
       }
     }
   }

--- a/packages/audit-engine/src/cloud-prefetch-run.ts
+++ b/packages/audit-engine/src/cloud-prefetch-run.ts
@@ -34,6 +34,7 @@ import {
   releaseSiteContextDocuments,
   type SiteContextPage,
 } from "./adapter";
+import { detachFromPage } from "./detach";
 
 // The parsed page's linkedom Document, without adding a direct linkedom dep here.
 type Document = NonNullable<NonNullable<SiteContextPage["parsed"]>["document"]>;
@@ -80,15 +81,28 @@ export function buildCloudPagePayloads(siteContext: SiteContextPage[]): CloudPag
     const meta: Record<string, string> = {};
     if (parsed.meta.description)
       meta.description = parsed.meta.description.slice(0, MAX_DESCRIPTION_CHARS);
-    payloads.push({
-      url: page.url,
-      title: parsed.meta.title?.slice(0, MAX_TITLE_CHARS) ?? undefined,
-      textExcerpt: truncateUtf8Bytes(parsed.content.textContent, MAX_EXCERPT_BYTES),
-      meta: Object.keys(meta).length > 0 ? meta : undefined,
-      headings: parsed.headings.headings
-        .slice(0, 20)
-        .map((h) => h.text.slice(0, MAX_HEADING_CHARS)),
-    });
+    payloads.push(
+      // Every field here is a SLICE of the page's html, and in JSC a retained
+      // slice pins the buffer it was cut from (#240). One payload per page, so
+      // this is the page-count-scaled term the streamed pre-rules walk exists to
+      // remove: the 6 KB excerpt alone held a megabyte per page on the sites
+      // that OOM-killed #1862. `truncateUtf8Bytes` returns the slice UNCHANGED
+      // whenever it already fits the byte budget, which is every all-ASCII page,
+      // so it detaches nothing on its own. Invisible in `heapUsed` and in RSS;
+      // it shows only in `process.memoryUsage().external`.
+      detachFromPage(
+        {
+          url: page.url,
+          title: parsed.meta.title?.slice(0, MAX_TITLE_CHARS) ?? undefined,
+          textExcerpt: truncateUtf8Bytes(parsed.content.textContent, MAX_EXCERPT_BYTES),
+          meta: Object.keys(meta).length > 0 ? meta : undefined,
+          headings: parsed.headings.headings
+            .slice(0, 20)
+            .map((h) => h.text.slice(0, MAX_HEADING_CHARS)),
+        },
+        "cloud-payload",
+      ),
+    );
   }
   return payloads;
 }
@@ -228,18 +242,21 @@ function absorbBlocklistUrls(urls: Set<string>, siteContext: SiteContextPage[]):
     const pageHost = getHostname(page.url);
     for (const link of parsed.links) {
       if (urls.size >= BL_MAX_URLS) return;
-      if (!link.isInternal && isHttpUrl(link.url)) urls.add(link.url);
+      if (!link.isInternal && isHttpUrl(link.url))
+        urls.add(detachFromPage(link.url, "cloud-payload"));
     }
     for (const image of parsed.images) {
       if (urls.size >= BL_MAX_URLS) return;
-      if (isHttpUrl(image.src) && getHostname(image.src) !== pageHost) urls.add(image.src);
+      if (isHttpUrl(image.src) && getHostname(image.src) !== pageHost)
+        urls.add(detachFromPage(image.src, "cloud-payload"));
     }
     const doc = parsed.document;
     if (!doc) continue;
     for (const script of doc.querySelectorAll("script[src]")) {
       if (urls.size >= BL_MAX_URLS) return;
       const src = (script as Element).getAttribute("src");
-      if (src && isHttpUrl(src) && getHostname(src) !== pageHost) urls.add(src);
+      if (src && isHttpUrl(src) && getHostname(src) !== pageHost)
+        urls.add(detachFromPage(src, "cloud-payload"));
     }
   }
 }
@@ -270,12 +287,14 @@ function absorbBlocklistSelectors(
     for (const el of elements) {
       if (selectors.size >= BL_MAX_SELECTORS) break;
       const id = el.getAttribute("id");
-      if (id && SIMPLE_TOKEN_RE.test(id)) selectors.add(`#${id}`);
+      if (id && SIMPLE_TOKEN_RE.test(id))
+        selectors.add(detachFromPage(`#${id}`, "cloud-payload"));
       const classAttr = el.getAttribute("class");
       if (!classAttr) continue;
       for (const cls of classAttr.split(/\s+/)) {
         if (selectors.size >= BL_MAX_SELECTORS) break;
-        if (cls && SIMPLE_TOKEN_RE.test(cls)) selectors.add(`.${cls}`);
+        if (cls && SIMPLE_TOKEN_RE.test(cls))
+          selectors.add(detachFromPage(`.${cls}`, "cloud-payload"));
       }
     }
   }
@@ -383,7 +402,7 @@ function absorbSeeds(
       const key = seed.toLowerCase();
       if (seen.has(key)) continue;
       seen.add(key);
-      seeds.push(seed);
+      seeds.push(detachFromPage(seed, "cloud-payload"));
       if (seeds.length >= SERVICE_LIMITS.gapsMaxSeeds) return;
     }
   }

--- a/packages/audit-engine/src/cloud-prefetch-run.ts
+++ b/packages/audit-engine/src/cloud-prefetch-run.ts
@@ -242,12 +242,15 @@ function absorbBlocklistUrls(urls: Set<string>, siteContext: SiteContextPage[]):
     const pageHost = getHostname(page.url);
     for (const link of parsed.links) {
       if (urls.size >= BL_MAX_URLS) return;
-      if (!link.isInternal && isHttpUrl(link.url))
+      // `has` first: the cap counts UNIQUE urls, but the clone was being paid
+      // per occurrence, and a site that links the same forty hosts from every
+      // page has far more occurrences than uniques.
+      if (!link.isInternal && isHttpUrl(link.url) && !urls.has(link.url))
         urls.add(detachFromPage(link.url, "cloud-payload"));
     }
     for (const image of parsed.images) {
       if (urls.size >= BL_MAX_URLS) return;
-      if (isHttpUrl(image.src) && getHostname(image.src) !== pageHost)
+      if (isHttpUrl(image.src) && getHostname(image.src) !== pageHost && !urls.has(image.src))
         urls.add(detachFromPage(image.src, "cloud-payload"));
     }
     const doc = parsed.document;
@@ -255,10 +258,15 @@ function absorbBlocklistUrls(urls: Set<string>, siteContext: SiteContextPage[]):
     for (const script of doc.querySelectorAll("script[src]")) {
       if (urls.size >= BL_MAX_URLS) return;
       const src = (script as Element).getAttribute("src");
-      if (src && isHttpUrl(src) && getHostname(src) !== pageHost)
+      if (src && isHttpUrl(src) && getHostname(src) !== pageHost && !urls.has(src))
         urls.add(detachFromPage(src, "cloud-payload"));
     }
   }
+}
+
+/** Add a selector once, detaching only the copy that is actually kept. */
+function addSelector(selectors: Set<string>, selector: string): void {
+  if (!selectors.has(selector)) selectors.add(detachFromPage(selector, "cloud-payload"));
 }
 
 function collectBlocklistSelectors(siteContext: SiteContextPage[]): string[] {
@@ -287,14 +295,12 @@ function absorbBlocklistSelectors(
     for (const el of elements) {
       if (selectors.size >= BL_MAX_SELECTORS) break;
       const id = el.getAttribute("id");
-      if (id && SIMPLE_TOKEN_RE.test(id))
-        selectors.add(detachFromPage(`#${id}`, "cloud-payload"));
+      if (id && SIMPLE_TOKEN_RE.test(id)) addSelector(selectors, `#${id}`);
       const classAttr = el.getAttribute("class");
       if (!classAttr) continue;
       for (const cls of classAttr.split(/\s+/)) {
         if (selectors.size >= BL_MAX_SELECTORS) break;
-        if (cls && SIMPLE_TOKEN_RE.test(cls))
-          selectors.add(detachFromPage(`.${cls}`, "cloud-payload"));
+        if (cls && SIMPLE_TOKEN_RE.test(cls)) addSelector(selectors, `.${cls}`);
       }
     }
   }
@@ -402,7 +408,12 @@ function absorbSeeds(
       const key = seed.toLowerCase();
       if (seen.has(key)) continue;
       seen.add(key);
-      seeds.push(detachFromPage(seed, "cloud-payload"));
+      // No detach: this `cleanSeed` assembles its result character by character
+      // and returns `parts.join("")`, a fresh string that references no page.
+      // The CLI's twin builds the same value with split/replace/trim, whose
+      // results CAN be slices, so its seeds do need one — a real difference
+      // between the two, not a missed case.
+      seeds.push(seed);
       if (seeds.length >= SERVICE_LIMITS.gapsMaxSeeds) return;
     }
   }

--- a/packages/audit-engine/tests/cloud-payload-detach.test.ts
+++ b/packages/audit-engine/tests/cloud-payload-detach.test.ts
@@ -1,0 +1,156 @@
+// #253: the container's cloud-prefetch payloads must not hold the pages they
+// were read off.
+//
+// `buildCloudPagePayloads` keeps a 6 KB text excerpt PER PAGE, plus a title, a
+// description and up to twenty headings. Every one of those is a slice of the
+// page's html, and in JSC a slice pins the buffer it was cut from, so the
+// payload list holds the whole crawl as UTF-16 for as long as the prefetch
+// runs. That is the page-count-scaled term the streamed pre-rules walk exists
+// to remove, and the walk drops each batch right after the collector absorbs
+// it, so nothing else is keeping those pages alive.
+//
+// `truncateUtf8Bytes` is not a detach. It returns `text.slice(0, maxBytes)`
+// unchanged whenever the sliced text already fits the byte budget, which is
+// every all-ASCII page, so the excerpt comes back still attached.
+//
+// The measurement reads `external` and subtracts a retain-nothing control, and
+// fails loudly when it did not reproduce the retention — see helpers/retention.ts.
+
+import type { PageRecord } from "@squirrelscan/core-contracts";
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { buildSiteContext } from "../src/adapter";
+import { buildCloudPagePayloads, truncateUtf8Bytes } from "../src/cloud-prefetch-run";
+import { compareRetention, expectDetached, MB } from "./helpers/retention";
+
+const MAX_EXCERPT_BYTES = 6_000;
+const MAX_TITLE_CHARS = 300;
+const MAX_DESCRIPTION_CHARS = 500;
+const MAX_HEADING_CHARS = 200;
+
+/**
+ * A page whose visible text is unique per index, so the excerpt is a real slice
+ * of a real buffer. Built from distinct chunks rather than `.repeat()`: JSC
+ * ropes share backing storage, so a repeated corpus is nearly free to hold and
+ * the attached arm would look detached.
+ */
+function heavyPage(i: number, bytes: number): PageRecord {
+  const chunk = 20_000;
+  const body = Array.from({ length: Math.max(1, Math.ceil(bytes / chunk)) }, (_, k) =>
+    `${i}-${k} `.padEnd(chunk, "abcdefghij "),
+  ).join(" ");
+  const html =
+    `<!doctype html><html><head><title>Title ${i} of the page</title>` +
+    `<meta name="description" content="Description ${i} for this page"></head>` +
+    `<body><h1>Heading ${i}</h1><p>${body}</p></body></html>`;
+  const url = `https://example.com/p/${i}`;
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: html.length,
+    loadTimeMs: 1,
+    fetchedAt: Date.now(),
+    etag: null,
+    lastModified: null,
+    contentHash: `h${i}`,
+    html,
+    parsedData: null,
+    headers: {
+      contentType: "text/html",
+      contentEncoding: null,
+      cacheControl: null,
+      vary: null,
+      etag: null,
+      server: null,
+      lastModified: null,
+      link: null,
+      serverTiming: null,
+      age: null,
+      xCache: null,
+      cfCacheStatus: null,
+      xVercelCache: null,
+      altSvc: null,
+      acceptRanges: null,
+    },
+    securityHeaders: {
+      hsts: null,
+      csp: null,
+      xFrameOptions: null,
+      xContentTypeOptions: null,
+      referrerPolicy: null,
+      permissionsPolicy: null,
+      xRobotsTag: null,
+    },
+  } as PageRecord;
+}
+
+const contextFor = (page: PageRecord) => Effect.runSync(buildSiteContext([page]));
+
+/** The payload builder's body WITHOUT the detach — what the bug looked like. */
+function attachedPayload(i: number, bytes: number) {
+  const ctx = contextFor(heavyPage(i, bytes));
+  const entry = ctx[0]!;
+  const parsed = entry.parsed!;
+  const meta: Record<string, string> = {};
+  if (parsed.meta.description)
+    meta.description = parsed.meta.description.slice(0, MAX_DESCRIPTION_CHARS);
+  return {
+    url: entry.page.url,
+    title: parsed.meta.title?.slice(0, MAX_TITLE_CHARS) ?? undefined,
+    textExcerpt: truncateUtf8Bytes(parsed.content.textContent, MAX_EXCERPT_BYTES),
+    meta: Object.keys(meta).length > 0 ? meta : undefined,
+    headings: parsed.headings.headings.slice(0, 20).map((h) => h.text.slice(0, MAX_HEADING_CHARS)),
+  };
+}
+
+describe("cloud-prefetch page payloads (#253)", () => {
+  test("a payload does not retain the page it was built from", () => {
+    const N = 24;
+    const SOURCE_BYTES = 4_000_000;
+
+    const result = compareRetention({
+      iterations: N,
+      // Same parse, same extraction, same slices taken — keeps only a length,
+      // so the parser's own cost is present in all three arms and subtracts out.
+      control: (i) => attachedPayload(i, SOURCE_BYTES).textExcerpt.length,
+      attached: (i) => attachedPayload(i, SOURCE_BYTES),
+      detached: (i) => buildCloudPagePayloads(contextFor(heavyPage(i, SOURCE_BYTES)))[0],
+    });
+
+    expectDetached(result, {
+      marginBytes: 40 * MB,
+      ratio: 4,
+      label: `${N} cloud page payloads from ${(SOURCE_BYTES / MB).toFixed(0)} MB pages`,
+    });
+  }, 300_000);
+
+  test("the payload's values are unchanged by the detach", () => {
+    const page = heavyPage(7, 40_000);
+    const [detached] = buildCloudPagePayloads(contextFor(page));
+    const attached = attachedPayload(7, 40_000);
+
+    // Same fields, same values — this fix is a memory property, not a payload
+    // change, and the request body the container sends must be byte-for-byte
+    // what it sent before.
+    expect(detached).toEqual(attached);
+    expect(detached?.title).toBe("Title 7 of the page");
+    expect(detached?.meta?.description).toBe("Description 7 for this page");
+    expect(detached?.headings).toEqual(["Heading 7"]);
+    expect(detached?.textExcerpt.length).toBeGreaterThan(0);
+  });
+
+  test("truncateUtf8Bytes returns an ASCII slice unchanged, so it detaches nothing", () => {
+    // The reason the excerpt was attached in the first place: the byte-budget
+    // path only round-trips through TextEncoder when the slice OVERFLOWS the
+    // budget. Documented as a test so a future reader does not mistake it for
+    // a detach.
+    const source = "a".repeat(10_000);
+    expect(truncateUtf8Bytes(source, MAX_EXCERPT_BYTES)).toBe(source.slice(0, MAX_EXCERPT_BYTES));
+  });
+});


### PR DESCRIPTION
Closes #253. The container-side twin of the retention fixed on the CLI side in #252.

## What was wrong

`buildCloudPagePayloads` keeps a 6 KB text excerpt per page, plus a title, a description and up to twenty headings. Every one of those is a slice of that page's HTML, and in JSC a retained slice pins the buffer it was cut from. So the payload list held the whole crawl as UTF-16 for the length of the prefetch.

That is exactly the page-count-scaled term the streamed pre-rules walk exists to remove. The walk drops each batch as soon as the collectors have absorbed it, so nothing else is keeping those pages alive, and the payloads were quietly holding all of them.

`truncateUtf8Bytes` is not a detach, which is the part that makes this easy to miss. It returns `text.slice(0, maxBytes)` unchanged whenever the slice already fits the byte budget, and for an all-ASCII page it always does. Only an overflowing multi-byte slice takes the `TextEncoder` round trip that would have detached it. There is now a test saying so, so the next reader does not take it for a detach.

It shows only in `process.memoryUsage().external`. Not in `heapUsed`, where it is a rounding error, and not in RSS, where the allocator absorbs it.

## The measurement

Using the retention harness from #250, on per-page-distinct 4 MB pages, `external` with a retain-nothing control subtracted:

| arm | retained across 24 pages |
| --- | --- |
| attached | +186 MB |
| detached | +3 MB |

About 7.8 MB held per page before, 0.13 MB after. The harness fails loudly rather than passing when the attached arm does not clear the control by its margin, so a run that did not reproduce the retention cannot report success.

## Also detached

The blocklist URLs and selectors and the gaps seeds. Those three are capped at 1,500, 500 and 50, so their worst case was bounded by the cap rather than by page count. A capped list of 1,500 attached URLs still pins up to 1,500 pages, though, so they get the same treatment.

Not detached: `renderedPageUrls`, whose entries are `page.url` read from a storage row rather than sliced out of HTML, and the Stage-0 metadata payloads, which are built from a bounded sample the collector is already retaining whole.

## Parity

This is a memory property, not a payload change. Same fields, same values, same order, asserted directly and covered by the existing CLI-versus-container prefetch parity test. The streaming pre-rules golden and the canonical-versus-streaming golden are green.

## Review follow-up

A codex pass returned no correctness defects and three efficiency notes, all taken in the second commit:

- The blocklist url and selector sets cap *unique* values, but the clone was being paid per occurrence. A site that links the same forty hosts and reuses the same layout classes on every page has far more occurrences than uniques, so the set is now tested before the copy is made. The resulting set is identical either way, since a duplicate never grew it.
- The container's `cleanSeed` assembles its result character by character and returns `parts.join("")`, a fresh string referencing no page, so detaching a seed there was pure cost. Dropped. The CLI's twin still needs one, because it builds the same value with split/replace/trim whose results can be slices. That is a real difference between the two files, not a missed case, and it is commented as such.
- The CLI's twin gets the same dedupe-before-clone, so the pair stays in lockstep where it should be. That is the only change here outside `packages/audit-engine`.
