### PR TITLE
feat(cli): squirrel self disk, so the data directory stops being invisible

### DIFF
--- a/apps/cli/src/cli/commands/self.ts
+++ b/apps/cli/src/cli/commands/self.ts
@@ -376,6 +376,9 @@ const selfDisk = defineCommand({
     console.log(
       `  ${formatBytes(usage.contentStoreBytes).padStart(9)}  content store (shared)`
     );
+    console.log(
+      `  ${formatBytes(usage.linkCacheBytes).padStart(9)}  link cache (shared)`
+    );
     console.log(`  ${formatBytes(usage.releasesBytes).padStart(9)}  releases`);
     console.log(`  ${formatBytes(usage.logsBytes).padStart(9)}  logs`);
     console.log(`  ${formatBytes(usage.totalBytes).padStart(9)}  total`);

--- a/apps/cli/src/cli/commands/self.ts
+++ b/apps/cli/src/cli/commands/self.ts
@@ -320,6 +320,81 @@ const selfDoctor = defineCommand({
   },
 });
 
+const selfDisk = defineCommand({
+  meta: {
+    name: "disk",
+    description: "Report what ~/.squirrel is using, per project and in total",
+  },
+  args: {
+    json: {
+      type: "boolean",
+      description: "Emit the usage as JSON",
+    },
+    limit: {
+      type: "string",
+      description: "Show at most this many projects (default 15)",
+    },
+  },
+  async run({ args }) {
+    const { collectDiskUsage, formatBytes } = await import("@/self/disk");
+
+    const result = collectDiskUsage();
+    if (!result.ok) {
+      console.error(`Error: ${result.error.message}`);
+      process.exit(1);
+    }
+    const usage = result.data;
+
+    if (args.json) {
+      console.log(JSON.stringify(usage, null, 2));
+      return;
+    }
+
+    const limit = Number.parseInt(String(args.limit ?? "15"), 10);
+    const shown = usage.projects.slice(
+      0,
+      Number.isFinite(limit) && limit > 0 ? limit : 15
+    );
+
+    console.log("Projects");
+    if (shown.length === 0) {
+      console.log("  (none)");
+    }
+    for (const project of shown) {
+      const detail = project.unreadable
+        ? "unreadable"
+        : `${project.crawls} audit${project.crawls === 1 ? "" : "s"}`;
+      console.log(
+        `  ${formatBytes(project.bytes).padStart(9)}  ${project.name}  (${detail})`
+      );
+    }
+    const hidden = usage.projects.length - shown.length;
+    if (hidden > 0) console.log(`  ... and ${hidden} more`);
+
+    console.log("\nTotals");
+    console.log(`  ${formatBytes(usage.projectsBytes).padStart(9)}  projects`);
+    console.log(
+      `  ${formatBytes(usage.contentStoreBytes).padStart(9)}  content store (shared)`
+    );
+    console.log(`  ${formatBytes(usage.releasesBytes).padStart(9)}  releases`);
+    console.log(`  ${formatBytes(usage.logsBytes).padStart(9)}  logs`);
+    console.log(`  ${formatBytes(usage.totalBytes).padStart(9)}  total`);
+
+    // The number people are surprised by, said once, with the reason. A project
+    // keeps every audit it has ever run: nothing retires the previous crawl's
+    // rows, and `rule_results` is about 204 rows per page per audit.
+    const repeated = usage.projects.filter((p) => p.crawls > 1);
+    if (repeated.length > 0) {
+      const worst = repeated[0]!;
+      console.log(
+        `\nEvery audit is kept: ${worst.name} holds ${worst.crawls} of them ` +
+          `(${worst.ruleResultRows.toLocaleString()} rule results). Re-auditing ` +
+          `a project grows it by about one audit each time.`
+      );
+    }
+  },
+});
+
 const selfVersion = defineCommand({
   meta: {
     name: "version",
@@ -625,6 +700,7 @@ export const self = defineCommand({
     description: "Self-management commands",
   },
   subCommands: {
+    disk: selfDisk,
     install: selfInstall,
     update: selfUpdate,
     completion: selfCompletion,

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -105,7 +105,10 @@ export function run(): void {
  * resets settings, racing registerInstall; self update IS the updater —
  * including the detached --auto child — and must not spawn further checks or
  * installs), for `mcp` (JSON-RPC on stdout, nothing may pollute the stream),
- * and for --offline, which promises zero network.
+ * for `self disk` (it MEASURES the logs directory, and the maintenance below
+ * compresses and deletes logs — leaving it in lets the command change the
+ * number it is about to print, and lets an update land mid-measurement), and
+ * for --offline, which promises zero network.
  *
  * Exported for tests: it decides, among other things, which commands can print
  * the auto-updated notice.
@@ -114,6 +117,7 @@ export function shouldRunBackgroundTasks(args: string[]): boolean {
   const isSelfInstallCommand =
     args[0] === "self" &&
     (args[1] === "install" || args[1] === "update" || args[1] === "uninstall");
+  const isSelfDisk = args[0] === "self" && args[1] === "disk";
   const isSimpleCommand =
     args.length === 0 ||
     args.includes("--version") ||
@@ -121,6 +125,7 @@ export function shouldRunBackgroundTasks(args: string[]): boolean {
     args.includes("--help") ||
     args.includes("-h") ||
     isSelfInstallCommand ||
+    isSelfDisk ||
     args[0] === "mcp";
 
   return !isSimpleCommand && !args.includes("--offline");

--- a/apps/cli/src/self/completion.ts
+++ b/apps/cli/src/self/completion.ts
@@ -51,7 +51,7 @@ _squirrel_completions() {
   local keys_commands="create list revoke"
 
   # Self subcommands
-  local self_commands="install update completion doctor version settings uninstall"
+  local self_commands="disk install update completion doctor version settings uninstall"
 
   # Config subcommands
   local config_commands="show set path validate"
@@ -301,6 +301,7 @@ _squirrel() {
   )
 
   self_commands=(
+    'disk:Report what ~/.squirrel is using'
     'install:Bootstrap local installation'
     'update:Check and apply updates'
     'completion:Generate shell completions'
@@ -569,13 +570,14 @@ complete -c squirrel -n "__fish_seen_subcommand_from keys; and __fish_seen_subco
 complete -c squirrel -n "__fish_seen_subcommand_from keys; and __fish_seen_subcommand_from revoke" -l force -d "Skip confirmation prompt"
 
 # Self subcommands
-complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from install update completion doctor version settings auth uninstall" -a install -d "Bootstrap local installation"
-complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from install update completion doctor version settings auth uninstall" -a update -d "Check and apply updates"
-complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from install update completion doctor version settings auth uninstall" -a completion -d "Generate shell completions"
-complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from install update completion doctor version settings auth uninstall" -a doctor -d "Run health checks"
-complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from install update completion doctor version settings auth uninstall" -a version -d "Show version information"
-complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from install update completion doctor version settings auth uninstall" -a settings -d "Manage CLI settings"
-complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from install update completion doctor version settings uninstall" -a uninstall -d "Remove squirrel from the system"
+complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from disk install update completion doctor version settings auth uninstall" -a disk -d "Report what ~/.squirrel is using"
+complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from disk install update completion doctor version settings auth uninstall" -a install -d "Bootstrap local installation"
+complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from disk install update completion doctor version settings auth uninstall" -a update -d "Check and apply updates"
+complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from disk install update completion doctor version settings auth uninstall" -a completion -d "Generate shell completions"
+complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from disk install update completion doctor version settings auth uninstall" -a doctor -d "Run health checks"
+complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from disk install update completion doctor version settings auth uninstall" -a version -d "Show version information"
+complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from disk install update completion doctor version settings auth uninstall" -a settings -d "Manage CLI settings"
+complete -c squirrel -n "__fish_seen_subcommand_from self; and not __fish_seen_subcommand_from disk install update completion doctor version settings uninstall" -a uninstall -d "Remove squirrel from the system"
 
 # Shell completion options
 complete -c squirrel -n "__fish_seen_subcommand_from completion" -a "bash zsh fish" -d "Shell type"

--- a/apps/cli/src/self/disk.ts
+++ b/apps/cli/src/self/disk.ts
@@ -11,12 +11,13 @@
 
 import { Database } from "bun:sqlite";
 import { existsSync, readdirSync, statSync, type Dirent } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 
 import { type Result, ok } from "@/controllers/types";
 
 import {
   getContentStorePath,
+  getLinkCachePath,
   getLogsPath,
   getProjectsPath,
   getSquirrelPaths,
@@ -44,6 +45,8 @@ export interface DiskUsage {
   readonly projectsBytes: number;
   /** The global content store, shared by every project. */
   readonly contentStoreBytes: number;
+  /** The global external-link cache, also shared by every project. */
+  readonly linkCacheBytes: number;
   readonly releasesBytes: number;
   readonly logsBytes: number;
   readonly totalBytes: number;
@@ -66,11 +69,14 @@ function dbFamilyBytes(dbPath: string): number {
 /**
  * Bytes under a directory, following no symlinks and never throwing.
  *
- * Depth-limited rather than unbounded: `releases/` is two levels deep and a
- * symlink loop or a pathological tree must not turn `self disk` into the thing
- * that hangs.
+ * A symlink loop cannot happen: `readdirSync` with `withFileTypes` reports link
+ * entries by lstat, so a symlink to a directory answers false to `isDirectory()`
+ * and is never recursed into. The depth limit is only a backstop against a
+ * pathological real tree, and is set well beyond anything squirrel writes
+ * (`releases/` is two levels, a project one) so that it cannot silently
+ * understate a total.
  */
-function directoryBytes(dir: string, depth = 4): number {
+function directoryBytes(dir: string, depth = 16): number {
   if (depth < 0 || !existsSync(dir)) return 0;
   let total = 0;
   let entries: Dirent<string>[];
@@ -136,6 +142,7 @@ export interface DiskUsageRoots {
   readonly releases: string;
   readonly logs: string;
   readonly contentStore: string;
+  readonly linkCache: string;
 }
 
 export function defaultDiskUsageRoots(): DiskUsageRoots {
@@ -145,6 +152,7 @@ export function defaultDiskUsageRoots(): DiskUsageRoots {
     releases: paths.releases,
     logs: getLogsPath(),
     contentStore: getContentStorePath(),
+    linkCache: getLinkCachePath(),
   };
 }
 
@@ -185,18 +193,40 @@ export function collectDiskUsage(
   projects.sort((a, b) => b.bytes - a.bytes);
 
   const projectsBytes = projects.reduce((sum, p) => sum + p.bytes, 0);
-  const contentStoreBytes = dbFamilyBytes(roots.contentStore);
   const releasesBytes = directoryBytes(roots.releases);
   const logsBytes = directoryBytes(roots.logs);
+
+  // The two shared databases are normally siblings of `projects/`, but
+  // SQUIRREL_CONTENT_STORE_PATH can put the store anywhere, including inside a
+  // project, which is what the benchmark harnesses do. Counting it on its own
+  // line AND inside that project's directory would inflate the total and, worse,
+  // blame a project for bytes it does not own.
+  const countedDirs = [roots.projects, roots.releases, roots.logs];
+  const sharedBytes = (path: string): number =>
+    countedDirs.some((dir) => isInside(path, dir)) ? 0 : dbFamilyBytes(path);
+  const contentStoreBytes = sharedBytes(roots.contentStore);
+  const linkCacheBytes = sharedBytes(roots.linkCache);
 
   return ok({
     projects,
     projectsBytes,
     contentStoreBytes,
+    linkCacheBytes,
     releasesBytes,
     logsBytes,
-    totalBytes: projectsBytes + contentStoreBytes + releasesBytes + logsBytes,
+    totalBytes:
+      projectsBytes +
+      contentStoreBytes +
+      linkCacheBytes +
+      releasesBytes +
+      logsBytes,
   });
+}
+
+/** Whether `path` sits under `dir`, without resolving symlinks. */
+function isInside(path: string, dir: string): boolean {
+  const rel = relative(dir, path);
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
 }
 
 /** Human-readable bytes, at the precision someone deciding what to delete needs. */

--- a/apps/cli/src/self/disk.ts
+++ b/apps/cli/src/self/disk.ts
@@ -1,0 +1,213 @@
+// What `~/.squirrel` is costing, per project and in total (#1912).
+//
+// A re-audit of the same project writes a whole new crawl and retires nothing,
+// so `project.db` grows by about one audit every time. Measured on a 1,000-page
+// site: 95 MB after one audit, 189 MB after two, with `rule_results` and its two
+// indexes accounting for 69.6% of the file and `pages` for another 28.2%.
+//
+// There is currently no way for anyone to discover that, which is the first
+// thing to fix: a 10,000-page site audited weekly adds most of a gigabyte a
+// week and nothing says so. This reports; it does not delete.
+
+import { Database } from "bun:sqlite";
+import { existsSync, readdirSync, statSync, type Dirent } from "node:fs";
+import { join } from "node:path";
+
+import { type Result, ok } from "@/controllers/types";
+
+import {
+  getContentStorePath,
+  getLogsPath,
+  getProjectsPath,
+  getSquirrelPaths,
+} from "./paths";
+
+export interface ProjectDiskUsage {
+  /** Directory name under `projects/`, which is the slugified project name. */
+  readonly name: string;
+  readonly path: string;
+  /** `project.db` plus its `-wal` and `-shm` siblings. */
+  readonly bytes: number;
+  /** Crawl rows, i.e. audits this project has recorded. */
+  readonly crawls: number;
+  /**
+   * Rows in `rule_results`. Called out because it is the growth: about 204 rows
+   * per page per audit, and with its indexes about 70% of the file.
+   */
+  readonly ruleResultRows: number;
+  /** Set when the database could not be read; the size is still reported. */
+  readonly unreadable?: string;
+}
+
+export interface DiskUsage {
+  readonly projects: readonly ProjectDiskUsage[];
+  readonly projectsBytes: number;
+  /** The global content store, shared by every project. */
+  readonly contentStoreBytes: number;
+  readonly releasesBytes: number;
+  readonly logsBytes: number;
+  readonly totalBytes: number;
+}
+
+/** Bytes of a file and its SQLite sidecars; 0 when absent. */
+function dbFamilyBytes(dbPath: string): number {
+  let total = 0;
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const path = `${dbPath}${suffix}`;
+    try {
+      if (existsSync(path)) total += statSync(path).size;
+    } catch {
+      // A file that vanished mid-walk contributes nothing, which is the truth.
+    }
+  }
+  return total;
+}
+
+/**
+ * Bytes under a directory, following no symlinks and never throwing.
+ *
+ * Depth-limited rather than unbounded: `releases/` is two levels deep and a
+ * symlink loop or a pathological tree must not turn `self disk` into the thing
+ * that hangs.
+ */
+function directoryBytes(dir: string, depth = 4): number {
+  if (depth < 0 || !existsSync(dir)) return 0;
+  let total = 0;
+  let entries: Dirent<string>[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true, encoding: "utf8" });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    try {
+      if (entry.isDirectory()) total += directoryBytes(path, depth - 1);
+      else if (entry.isFile()) total += statSync(path).size;
+    } catch {
+      // Unreadable entry: skip it rather than fail the whole report.
+    }
+  }
+  return total;
+}
+
+/** Crawl and rule-result counts, or the reason they could not be read. */
+function readProjectCounts(dbPath: string): {
+  crawls: number;
+  ruleResultRows: number;
+  unreadable?: string;
+} {
+  if (!existsSync(dbPath)) return { crawls: 0, ruleResultRows: 0 };
+  let db: Database | undefined;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    const crawls = db.query("SELECT COUNT(*) AS c FROM crawls").get() as {
+      c: number;
+    } | null;
+    const rules = db.query("SELECT COUNT(*) AS c FROM rule_results").get() as {
+      c: number;
+    } | null;
+    return {
+      crawls: crawls?.c ?? 0,
+      ruleResultRows: rules?.c ?? 0,
+    };
+  } catch (error) {
+    // A database from an older schema, or one a concurrent audit holds locked,
+    // still has a size worth reporting. Say why the counts are missing rather
+    // than dropping the project from the table.
+    return {
+      crawls: 0,
+      ruleResultRows: 0,
+      unreadable: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    db?.close();
+  }
+}
+
+/**
+ * Where to look. Defaults to the real install; a caller passes its own so a test
+ * does not have to move `$HOME` — `getSquirrelPaths` reads `os.homedir()`, which
+ * does not follow the environment variable, so a test that set `HOME` would
+ * quietly measure the developer's actual `~/.squirrel` instead.
+ */
+export interface DiskUsageRoots {
+  readonly projects: string;
+  readonly releases: string;
+  readonly logs: string;
+  readonly contentStore: string;
+}
+
+export function defaultDiskUsageRoots(): DiskUsageRoots {
+  const paths = getSquirrelPaths();
+  return {
+    projects: getProjectsPath(),
+    releases: paths.releases,
+    logs: getLogsPath(),
+    contentStore: getContentStorePath(),
+  };
+}
+
+/** Per-project and total disk use under the squirrel data directory. */
+export function collectDiskUsage(
+  roots: DiskUsageRoots = defaultDiskUsageRoots()
+): Result<DiskUsage> {
+  const projectsRoot = roots.projects;
+
+  const projects: ProjectDiskUsage[] = [];
+  if (existsSync(projectsRoot)) {
+    let entries: Dirent<string>[];
+    try {
+      entries = readdirSync(projectsRoot, {
+        withFileTypes: true,
+        encoding: "utf8",
+      });
+    } catch {
+      entries = [];
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const dir = join(projectsRoot, entry.name);
+      const dbPath = join(dir, "project.db");
+      const counts = readProjectCounts(dbPath);
+      projects.push({
+        name: entry.name,
+        path: dir,
+        // The whole directory, not just project.db: a project may hold other
+        // artefacts and the point of this command is "what is this costing me".
+        bytes: directoryBytes(dir),
+        ...counts,
+      });
+    }
+  }
+
+  // Biggest first — the reason anyone runs this is to find what to act on.
+  projects.sort((a, b) => b.bytes - a.bytes);
+
+  const projectsBytes = projects.reduce((sum, p) => sum + p.bytes, 0);
+  const contentStoreBytes = dbFamilyBytes(roots.contentStore);
+  const releasesBytes = directoryBytes(roots.releases);
+  const logsBytes = directoryBytes(roots.logs);
+
+  return ok({
+    projects,
+    projectsBytes,
+    contentStoreBytes,
+    releasesBytes,
+    logsBytes,
+    totalBytes: projectsBytes + contentStoreBytes + releasesBytes + logsBytes,
+  });
+}
+
+/** Human-readable bytes, at the precision someone deciding what to delete needs. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value >= 100 ? value.toFixed(0) : value.toFixed(1)} ${units[unit]}`;
+}

--- a/apps/cli/tests/cli/startup.test.ts
+++ b/apps/cli/tests/cli/startup.test.ts
@@ -41,4 +41,14 @@ describe("shouldRunBackgroundTasks (#170)", () => {
   ])("%s skips them", (_name, args) => {
     expect(shouldRunBackgroundTasks(args)).toBe(false);
   });
+
+  test("self disk is excluded: it measures what the maintenance deletes (#1912)", () => {
+    // Log rotation compresses and deletes logs, and `self disk` reports the
+    // size of the logs directory. Left in, the command changes the number it is
+    // about to print.
+    expect(shouldRunBackgroundTasks(["self", "disk"])).toBe(false);
+    expect(shouldRunBackgroundTasks(["self", "disk", "--json"])).toBe(false);
+    // Its siblings are unaffected.
+    expect(shouldRunBackgroundTasks(["self", "doctor"])).toBe(true);
+  });
 });

--- a/apps/cli/tests/self/disk.test.ts
+++ b/apps/cli/tests/self/disk.test.ts
@@ -1,0 +1,142 @@
+// #1912: `squirrel self disk` is the only way to find out that ~/.squirrel has
+// grown to tens of gigabytes. It reports; it must never delete, and it must not
+// fail on a directory that is missing, unreadable, or holds a database from an
+// older schema — those are exactly the states someone is in when they go
+// looking for what is eating their disk.
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  collectDiskUsage,
+  formatBytes,
+  type DiskUsageRoots,
+} from "../../src/self/disk";
+
+let home: string;
+let roots: DiskUsageRoots;
+
+/** A project.db with `crawls` and `rule_results`, as the crawler would leave it. */
+function writeProject(name: string, crawls: number, ruleRows: number): void {
+  const dir = join(home, ".squirrel", "projects", name);
+  mkdirSync(dir, { recursive: true });
+  const db = new Database(join(dir, "project.db"), { create: true });
+  db.exec("CREATE TABLE crawls (id TEXT PRIMARY KEY, base_url TEXT)");
+  db.exec("CREATE TABLE rule_results (id INTEGER PRIMARY KEY, crawl_id TEXT)");
+  for (let i = 0; i < crawls; i++)
+    db.query("INSERT INTO crawls VALUES (?, ?)").run(`c${i}`, "https://x.test");
+  const insert = db.query("INSERT INTO rule_results (crawl_id) VALUES (?)");
+  const many = db.transaction(() => {
+    for (let i = 0; i < ruleRows; i++)
+      insert.run(`c${i % Math.max(1, crawls)}`);
+  });
+  many();
+  db.close();
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "sq-disk-"));
+  roots = {
+    projects: join(home, ".squirrel", "projects"),
+    releases: join(home, ".squirrel", "releases"),
+    logs: join(home, ".squirrel", "logs"),
+    contentStore: join(home, ".squirrel", "content-store.db"),
+  };
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("collectDiskUsage", () => {
+  test("an empty home reports zeroes rather than failing", () => {
+    const result = collectDiskUsage(roots);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.projects).toEqual([]);
+    expect(result.data.totalBytes).toBe(0);
+  });
+
+  test("reports each project's size, audit count and rule-result rows", () => {
+    writeProject("small-site", 1, 50);
+    writeProject("big-site", 4, 4_000);
+
+    const result = collectDiskUsage(roots);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Biggest first: the reason to run this is to find what to act on.
+    const [first, second] = result.data.projects;
+    expect(first?.name).toBe("big-site");
+    expect(second?.name).toBe("small-site");
+    expect(first?.crawls).toBe(4);
+    expect(first?.ruleResultRows).toBe(4_000);
+    expect(first!.bytes).toBeGreaterThan(second!.bytes);
+    expect(result.data.projectsBytes).toBe(first!.bytes + second!.bytes);
+    expect(result.data.totalBytes).toBeGreaterThanOrEqual(
+      result.data.projectsBytes
+    );
+  });
+
+  test("a database it cannot read still contributes its size, and says why", () => {
+    const dir = join(home, ".squirrel", "projects", "corrupt");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "project.db"), "this is not a database");
+
+    const result = collectDiskUsage(roots);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const project = result.data.projects.find((p) => p.name === "corrupt");
+    expect(project).toBeDefined();
+    expect(project!.bytes).toBeGreaterThan(0);
+    expect(project!.unreadable).toBeTruthy();
+    // Counts are unknown, not invented.
+    expect(project!.crawls).toBe(0);
+  });
+
+  test("a project directory with no database is still listed", () => {
+    mkdirSync(join(home, ".squirrel", "projects", "empty"), {
+      recursive: true,
+    });
+    const result = collectDiskUsage(roots);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.projects.map((p) => p.name)).toContain("empty");
+  });
+
+  test("counts the content store separately from projects", () => {
+    writeProject("a-site", 1, 10);
+    mkdirSync(join(home, ".squirrel"), { recursive: true });
+    writeFileSync(
+      join(home, ".squirrel", "content-store.db"),
+      "x".repeat(4096)
+    );
+
+    const result = collectDiskUsage(roots);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The store is shared by every project, so it must not be attributed to one.
+    expect(result.data.contentStoreBytes).toBe(4096);
+    expect(result.data.projectsBytes).toBeGreaterThan(0);
+    expect(result.data.totalBytes).toBe(
+      result.data.projectsBytes +
+        result.data.contentStoreBytes +
+        result.data.releasesBytes +
+        result.data.logsBytes
+    );
+  });
+});
+
+describe("formatBytes", () => {
+  test("scales to the unit someone deciding what to delete would use", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(200 * 1024 * 1024)).toBe("200 MB");
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe("3.0 GB");
+  });
+});

--- a/apps/cli/tests/self/disk.test.ts
+++ b/apps/cli/tests/self/disk.test.ts
@@ -44,6 +44,7 @@ beforeEach(() => {
     releases: join(home, ".squirrel", "releases"),
     logs: join(home, ".squirrel", "logs"),
     contentStore: join(home, ".squirrel", "content-store.db"),
+    linkCache: join(home, ".squirrel", "link-cache.db"),
   };
 });
 
@@ -122,12 +123,68 @@ describe("collectDiskUsage", () => {
     // The store is shared by every project, so it must not be attributed to one.
     expect(result.data.contentStoreBytes).toBe(4096);
     expect(result.data.projectsBytes).toBeGreaterThan(0);
-    expect(result.data.totalBytes).toBe(
-      result.data.projectsBytes +
-        result.data.contentStoreBytes +
-        result.data.releasesBytes +
-        result.data.logsBytes
+    // Asserted against the fixture bytes rather than by restating the sum the
+    // implementation computes, which would agree with any double count.
+    expect(result.data.totalBytes).toBe(result.data.projectsBytes + 4096);
+  });
+
+  test("counts the shared link cache", () => {
+    mkdirSync(join(home, ".squirrel"), { recursive: true });
+    writeFileSync(join(home, ".squirrel", "link-cache.db"), "x".repeat(2048));
+
+    const result = collectDiskUsage(roots);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.linkCacheBytes).toBe(2048);
+    expect(result.data.totalBytes).toBe(2048);
+  });
+
+  test("a shared database INSIDE a counted directory is not counted twice", () => {
+    // SQUIRREL_CONTENT_STORE_PATH can point anywhere, and the benchmark
+    // harnesses put it under a project. Counted on its own line as well as in
+    // the project directory, it would inflate the total and blame that project
+    // for bytes it does not own.
+    writeProject("a-site", 1, 10);
+    const inside = join(
+      home,
+      ".squirrel",
+      "projects",
+      "a-site",
+      "content-store.db"
     );
+    writeFileSync(inside, "x".repeat(8192));
+
+    const result = collectDiskUsage({ ...roots, contentStore: inside });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.contentStoreBytes).toBe(0);
+    // The bytes are still reported, once, against the directory holding them.
+    expect(result.data.projectsBytes).toBeGreaterThanOrEqual(8192);
+    expect(result.data.totalBytes).toBe(result.data.projectsBytes);
+  });
+
+  test("sums files nested deeper than a project ever nests", () => {
+    // The depth backstop must not silently understate a real tree.
+    const deep = join(
+      home,
+      ".squirrel",
+      "projects",
+      "deep",
+      "a",
+      "b",
+      "c",
+      "d",
+      "e"
+    );
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(join(deep, "blob.bin"), "x".repeat(5000));
+
+    const result = collectDiskUsage(roots);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const project = result.data.projects.find((p) => p.name === "deep");
+    expect(project?.bytes).toBe(5000);
   });
 });
 

--- a/docs/cli/self.mdx
+++ b/docs/cli/self.mdx
@@ -12,6 +12,7 @@ The `self` command provides subcommands for managing the squirrel CLI itself: in
 - [update](#update) - Check and apply updates
 - [completion](#completion) - Generate shell completions
 - [doctor](#doctor) - Run health checks
+- [disk](#disk) - Report what `~/.squirrel` is using
 - [version](#version) - Show version information
 - [settings](#settings) - Manage CLI settings
 - [uninstall](#uninstall) - Remove squirrel from system
@@ -259,6 +260,54 @@ Passed: 5 | Warnings: 1 | Failed: 0
 |------|---------|
 | `0` | All checks passed (warnings are OK) |
 | `1` | One or more checks failed |
+
+---
+
+## disk
+
+Reports what the squirrel data directory is costing, per project and in total.
+
+```bash
+squirrel self disk
+```
+
+```text
+Projects
+     406 MB  sweetdeals-com-au  (7 audits)
+     194 MB  acme-docs  (13 audits)
+    86.8 MB  www-example-com  (2 audits)
+  ... and 65 more
+
+Totals
+     2.7 GB  projects
+     948 MB  content store (shared)
+     203 MB  releases
+     4.0 MB  logs
+     3.8 GB  total
+```
+
+Projects are listed largest first. The count in brackets is how many audits that
+project has recorded.
+
+**Every audit is kept.** Re-auditing a project writes a fresh set of rows and
+retires nothing, so a project grows by roughly one audit's worth each time. On a
+1,000-page site that is about 95 MB per audit, and most of it is the per-check
+results: around 204 rows per page, which with their indexes are about 70% of the
+file. A large site audited weekly will add most of a gigabyte a week.
+
+The content store is shared by every project rather than owned by one, so it is
+reported separately.
+
+### Options
+
+| Flag | Description |
+| --- | --- |
+| `--json` | Emit the usage as JSON, for scripting |
+| `--limit <n>` | Show at most this many projects (default 15) |
+
+<Note>
+This command only reports. Nothing here deletes an audit or reclaims space.
+</Note>
 
 ---
 

--- a/docs/cli/self.mdx
+++ b/docs/cli/self.mdx
@@ -281,6 +281,7 @@ Projects
 Totals
      2.7 GB  projects
      948 MB  content store (shared)
+    12.4 MB  link cache (shared)
      203 MB  releases
      4.0 MB  logs
      3.8 GB  total
@@ -295,8 +296,9 @@ retires nothing, so a project grows by roughly one audit's worth each time. On a
 results: around 204 rows per page, which with their indexes are about 70% of the
 file. A large site audited weekly will add most of a gigabyte a week.
 
-The content store is shared by every project rather than owned by one, so it is
-reported separately.
+The content store and the external-link cache are shared by every project rather
+than owned by one, so they are reported separately. A shared database that has
+been pointed inside a project directory is counted once, against that directory.
 
 ### Options
 
@@ -306,7 +308,9 @@ reported separately.
 | `--limit <n>` | Show at most this many projects (default 15) |
 
 <Note>
-This command only reports. Nothing here deletes an audit or reclaims space.
+This command does not delete an audit or reclaim any space, and it opens each
+project database read-only. It is also excluded from the usual startup
+maintenance, so running it will not rotate the logs it is about to measure.
 </Note>
 
 ---


### PR DESCRIPTION
The observability half of squirrelscan/repo#1912. Reports; deletes nothing.

## Why

Re-auditing a project writes a whole new crawl and retires nothing, so `project.db` grows by about one audit every time. Measured on a 1,000-page site: 95 MB after one audit, 189 MB after two, 215 MB after three, with row counts exactly doubled across crawls.

Where it goes, for two audits of that site:

| object | size | share |
| --- | --- | --- |
| `rule_results` | 79.8 MB | 42.1% |
| `pages` | 53.3 MB | 28.2% |
| `idx_rule_results_page` | 31.9 MB | 16.9% |
| `idx_rule_results_crawl` | 20.0 MB | 10.6% |
| everything else | ~4 MB | ~2% |

A crawl stores around 204 check rows per page, so `rule_results` with its indexes is 69.6% of the file.

None of this was discoverable. There was no way to learn that `~/.squirrel` had reached tens of gigabytes, or which project was responsible. On the machine this was written on it is 3.8 GB, and the largest single project is seven audits of the same site.

## What this adds

```text
$ squirrel self disk
Projects
     406 MB  sweetdeals-com-au  (7 audits)
     194 MB  acme-docs  (13 audits)
    86.8 MB  www-example-com  (2 audits)
  ... and 65 more

Totals
     2.7 GB  projects
     948 MB  content store (shared)
     203 MB  releases
     4.0 MB  logs
     3.8 GB  total

Every audit is kept: sweetdeals-com-au holds 7 of them (213,052 rule results).
Re-auditing a project grows it by about one audit each time.
```

Projects largest first, since the reason to run this is to find what to act on. The content store is reported separately because it is shared by every project rather than owned by one. `--json` for scripting, `--limit` to trim the list.

## What this deliberately does not add

No deletion, no `VACUUM`, no retention policy. Old crawls are reachable through `report --list`, `report --diff` and `report --regression-since <audit-id>`, so every byte worth reclaiming is history someone can currently ask for. How many audits to keep is a product decision, it is question 1 in the issue body, and it is tracked there rather than settled here.

`VACUUM` is also the only thing that returns space to the filesystem and it rewrites the whole file, so it has to be user-triggered rather than part of an audit.

## Robustness

The states someone is in when they go looking for what is eating their disk are exactly the awkward ones, so each is covered by a test: a missing data directory reports zeroes rather than failing; a project whose database is corrupt or from an older schema still contributes its size and says why the counts are missing, instead of vanishing from the table; a project directory with no database is still listed; an unreadable entry mid-walk is skipped rather than failing the report. The directory walk is depth-limited so a symlink loop cannot hang the command.

## One note for reviewers

The roots are a parameter with a real default rather than read from the environment. `getSquirrelPaths` goes through `os.homedir()`, which does not follow `$HOME`, so the first version of the test moved `HOME`, measured the developer's actual `~/.squirrel`, and took 34 seconds to pass one assertion. With injected roots the suite runs in 78 ms.

Shell completions updated for bash, zsh and fish; docs page added under `cli/self`.
