### PR TITLE
docs(benchmarks): record the 2026-09 performance program and its harness

### DIFF
--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -1,0 +1,134 @@
+# 2026-09 performance program
+
+Measurements from the 7 to 8 September 2026 performance pass on the `squirrel`
+CLI, the audit engine and the hosted runtime. Everything here was measured, on
+the machines and fixtures stated, and each row links the change that produced
+it. The CLI runs on Bun 1.4 since v0.0.91.
+
+Machine for the CLI rows unless stated: 16 GB Apple Silicon laptop under heavy
+memory pressure (other work running, swap in use), so single wall-clock values
+carry noise; the shapes, ratios and controlled pairs are the trustworthy part.
+Fixture: the synthetic estate in [`harness/`](./harness/) built around a real
+982 KB script-heavy product page (10%), a stripped 159 KB variant (10%), and
+20 KB documentation, blog, listing and thin pages (80%), mean 128 KB per page.
+
+## Headline: a 2,500-page audit on one machine
+
+CLI audit, `--coverage full`, cold, fresh content store per stage, interleaved
+old/new runs, `heapUsed` sampled after a forced collection at exit. Before is the
+resident pipeline (every page held in memory through the rules pass); after is
+the streaming pipeline ([#252](https://github.com/squirrelscan/squirrelscan/pull/252)).
+
+| pages | wall before | wall after | heap before | heap after |
+|---|---|---|---|---|
+| 400 | 47 s | 47 s | 685 MB | 265 MB |
+| 1,000 | 194 s | 128 s | 1,662 MB | 565 MB |
+| 2,500 | 502 s | 177 s | 3,902 MB | 996 MB |
+| 1,000, warm re-audit | 87 s | 72 s | 1,651 MB | 561 MB |
+
+Reports are byte-identical at all three sizes (at 2,500 pages excluding
+`perf/ttfb`, which grades the test server's response time and tripped on 14
+pages while the resident run was starving it). Wall time improved rather than
+paying the parse-per-batch cost, because a multi-gigabyte heap costs more in
+collector and compressor work than the extra parse.
+
+## The cold crawl against a filled cache
+
+`ContentStore.put()` called `getStats()`, a `COUNT + SUM` over the whole global
+content store, once per stored page. On a 947 MB store that scan was 90.2% of a
+cold audit's CPU (339 s of 376 s in a CPU profile), and a store that had grown
+past its 900 MB prune threshold paid it twice per page, forever. Fixed with one
+covering index ([#246](https://github.com/squirrelscan/squirrelscan/pull/246)).
+
+| measurement | before | after |
+|---|---|---|
+| `getStats()` on a 947 MB store | 295 ms | 1.3 ms |
+| storing 60 pages into a 93 MB store | 32.4 ms/page | 0.38 ms/page |
+| 400-page cold crawl, 992 MB store | 333 s (833 ms/page) | see next row |
+| 1,000-page cold crawl, 947 MB store | | 26 s (26 ms/page) |
+| 1,000-page warm crawl, same store | | 15 s (15 ms/page) |
+
+Controlled triple that located it (400 identical pages, identical rules time):
+992 MB store 333 s, empty store 5 s, pages already stored 4 s.
+
+## Retention per page in the engine
+
+Measured on 150 real 959 KB pages with per-page-distinct assets, as string
+backing store (`process.memoryUsage().external`) above a retain-nothing control,
+batch of 50. Each of these was a string sliced from a page's HTML and kept past
+the page's lifetime, which in JavaScriptCore pins the whole page as UTF-16.
+
+| structure | before | after | change |
+|---|---|---|---|
+| page rule results attached to their page | 4,020 KB/page | 213 KB/page | [#234](https://github.com/squirrelscan/squirrelscan/pull/234) |
+| streamed universe without stored parse | 3,900 KB/page | 77 KB/page | [#237](https://github.com/squirrelscan/squirrelscan/pull/237) |
+| external-link occurrences (map keys) | 1,870 KB/page | 0 | [#240](https://github.com/squirrelscan/squirrelscan/pull/240) |
+| hosted prefetch payload excerpts | 7,800 KB/page | 130 KB/page | [#255](https://github.com/squirrelscan/squirrelscan/pull/255) |
+| site-query link scan (`SELECT *` over pages) | +431 MB RSS across the call | +88 MB | [#236](https://github.com/squirrelscan/squirrelscan/pull/236) |
+
+Remaining per-page term after these: about 80 KB of real values the site pass
+reads, flat across 50 / 100 / 150 pages.
+
+## Hosted runtime, in production
+
+Same 149-page rendered audit of the same site an hour apart, old image against
+new (#234, #236, #237), RSS in MB from the run's phase events:
+
+| phase | old image | new image |
+|---|---|---|
+| page rules growth, post-GC | +869 | +382 |
+| site-query step | +350 | -18 |
+| resident at end of rules | 1,233 | 795 |
+| peak in the rules phase | 1,581 | 1,180 |
+
+Findings unchanged (score 47 both runs).
+
+## Streaming batch budget
+
+`SQUIRREL_STREAM_BATCH_BYTES` (default 48 MB) sets how much raw HTML is parsed
+at once. Measured with the OS high-water mark on 150 real 959 KB pages
+([#245](https://github.com/squirrelscan/squirrelscan/pull/245)):
+
+| budget | pages per batch | peak RSS |
+|---|---|---|
+| 6 MB | 6 | 480 MB |
+| 12 MB | 12 | 344 MB |
+| 24 MB | 25 | 492 MB |
+| 48 MB | 51 | 509 MB |
+| 96 MB | 102 | 655 MB |
+
+No budget gets under about 357 MB (rule set, runner, SQLite caches, allocator
+floor); an 8.5x larger batch gives a 1.9x larger peak; and below about 12 pages
+per batch a smaller budget is worse, because the extra read/parse/collect cycles
+set the high-water mark.
+
+## Hosted crawl reuse
+
+A second hosted audit of an unchanged 150-page site on the old code: crawl
+433 s then 482 s (the re-run was slower), one render-cache hit out of about 140
+renders. Cross-run reuse of the previous audit's pages
+(squirrelscan/repo#1902) and a source fingerprint that survives Shopify's
+cache-entry regeneration ([#242](https://github.com/squirrelscan/squirrelscan/pull/242),
+[#244](https://github.com/squirrelscan/squirrelscan/pull/244)) are deployed;
+the measured pair will be added here when it completes.
+
+## Fixed along the way
+
+- Seed-redirect probe sent no user agent; a WAF's 403 was read as "no
+  redirect", the crawl pinned to the apex and dropped every `www.` link as
+  cross-domain, producing silent one-page audits at full price
+  ([#248](https://github.com/squirrelscan/squirrelscan/pull/248),
+  [#249](https://github.com/squirrelscan/squirrelscan/pull/249)).
+- `bun:sqlite` returns `null` for a missing row; an existence check tested
+  against `undefined` and was always true
+  ([#247](https://github.com/squirrelscan/squirrelscan/pull/247)).
+- Bun 1.4 (v0.0.91): Linux binaries 11 to 14% smaller, ~10 ms faster start,
+  byte-identical audit results.
+
+## Still open
+
+- Site rules are quadratic in page count (4 s at 400 pages, 99 s at 2,500,
+  687 s at 5,000): squirrelscan/repo#1910.
+- Report reconstruction materializes every check, ~0.35 MB per page:
+  squirrelscan/repo#1920.
+- `--max-pages` above 5,000 is silently clamped: squirrelscan/repo#1909.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,37 @@
+# Benchmarks
+
+Measured performance records for the `squirrel` CLI and the audit engine. Every
+performance change lands with a row here: what was measured, on what fixture,
+how, on which machine, and the pull request that changed it. Release notes and
+announcements draw their numbers from these files, never from memory.
+
+| record | scope | headline |
+|---|---|---|
+| [2026-09 performance program](./2026-09-perf-program.md) | CLI, engine, hosted runtime | 2,500-page audit: 3.9 GB → 996 MB heap, 502 s → 177 s; cold crawl on a filled cache 833 → 26 ms/page |
+
+## Reproducing
+
+The harness in [`harness/`](./harness/) serves a deterministic synthetic estate,
+runs `squirrel audit` against it stage by stage (400 / 1,000 / 2,500 pages),
+and records wall time, CPU, per-phase timings from `--trace`, `heapUsed` and
+`external` sampled after a forced collection, and the OS high-water mark. See
+[`harness/README.md`](./harness/README.md).
+
+Rules that keep numbers honest, learned the hard way while producing these:
+
+- Sample `process.memoryUsage()` after `Bun.gc(true)` at phase boundaries.
+  Resident set size understates a Bun heap on a machine that is paging, and an
+  interval timer is starved by the rules phase, which is one long synchronous
+  block.
+- Give each stage its own content store (`SQUIRREL_CONTENT_STORE_PATH`). The
+  store at `~/.squirrel/content-store.db` is shared by every project on the
+  machine, so a "cold" run against an existing store is neither cold nor
+  comparable.
+- Salt the fixture per stage, and quote the salt when you pass it: in zsh an
+  unquoted `${SALT:+--salt $SALT}` arrives as one argument.
+- Compare interleaved runs (old, new, old, new) rather than one block of each,
+  and report the minimum over repeats; run-to-run variance on the same budget
+  reached 100 MB.
+- Subtract a retain-nothing control when measuring retention per page, and use
+  per-page-distinct fixtures for anything keyed by URL: 150 copies of one page
+  give a URL-keyed collector five keys.

--- a/benchmarks/harness/README.md
+++ b/benchmarks/harness/README.md
@@ -1,0 +1,19 @@
+# Benchmark harness
+
+Scripts used to produce [`../2026-09-perf-program.md`](../2026-09-perf-program.md).
+They are measurement tools, not part of the product, and they assume a checkout
+of this repository with the workspace installed (`bun install` at the root).
+
+| file | role |
+|---|---|
+| `site.ts` | Serves a deterministic mixed-shape estate (product / collection / docs / blog / listing / thin, mean ~128 KB per page) with a sitemap index, robots.txt and full link reachability. Takes a base page HTML file as its first argument; the record used a real 982 KB Shopify product page, which is not committed. Any large, script-heavy page works. A per-stage `--salt` makes a run genuinely cold. |
+| `run-stage.sh` | Runs one `squirrel audit` stage (`--coverage full --max-pages N --http --offline --trace`) under `/usr/bin/time -l` with `mem-probe.ts` preloaded, a process-tree RSS sampler, and a kill guard (`BENCH_KILL_MB`, `BENCH_KILL_SEC`). `BENCH_CONTENT_STORE` gives the stage its own content store. |
+| `stages.sh` | Cold then warm stage per page count, each cold stage on a fresh store. |
+| `mem-probe.ts` | Preload: `process.memoryUsage()` after `Bun.gc(true)` at exit and at phase boundaries. |
+| `rss-sampler.ts` | Process-tree RSS sampler with the guard. |
+| `phases.ts` | Extracts per-phase timings from the CLI `--trace` output. |
+| `analyze.ts` | Turns a stage directory into the summary table rows. |
+
+Paths in `run-stage.sh` assume the harness runs from a monorepo checkout where
+this repository is the `repo-public` submodule; adjust `HERE`/the CLI path for a
+standalone clone. The scripts are zsh.

--- a/benchmarks/harness/analyze.ts
+++ b/benchmarks/harness/analyze.ts
@@ -1,0 +1,107 @@
+/**
+ * Summarize one benchmark stage. Usage: bun analyze.ts <results/<label>> [project]
+ * Reads: rss.log (external sampler), mem.jsonl (in-process probe),
+ *        audit.time (/usr/bin/time -l), report.json, audit.out.
+ */
+import { statSync, existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+
+const dir = process.argv[2];
+const mb = (b: number) => (b / 1048576).toFixed(0);
+const read = (p: string) => (existsSync(p) ? readFileSync(p, "utf8") : "");
+
+// ── external RSS sampler ────────────────────────────────────────
+const rss = read(`${dir}/rss.log`)
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .map((l) => l.trim().split(/\s+/).map(Number))
+  .filter((p) => p.length >= 2 && Number.isFinite(p[0]!) && Number.isFinite(p[1]!)) as [
+  number,
+  number,
+][];
+const peakKb = rss.length ? Math.max(...rss.map((r) => r[1])) : 0;
+const peakAt = rss.find((r) => r[1] === peakKb)?.[0] ?? 0;
+const wall = rss.length ? rss[rss.length - 1]![0] : 0;
+
+// ── in-process probe ────────────────────────────────────────────
+const mem = read(`${dir}/mem.jsonl`)
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .map((l) => {
+    try {
+      return JSON.parse(l) as Record<string, number | string>;
+    } catch {
+      return null;
+    }
+  })
+  .filter(Boolean) as Array<Record<string, number | string>>;
+const ticks = mem.filter((m) => m.tag === "tick" || m.tag === "start");
+const last = mem.find((m) => m.tag === "exit");
+const peakHeap = ticks.length ? Math.max(...ticks.map((m) => Number(m.heapUsed))) : 0;
+const peakExt = ticks.length ? Math.max(...ticks.map((m) => Number(m.external))) : 0;
+
+// ── /usr/bin/time -l ────────────────────────────────────────────
+const t = read(`${dir}/audit.time`);
+const maxrss = /(\d+)\s+maximum resident set size/.exec(t)?.[1];
+const realTime = /^\s*([\d.]+)\s+real/m.exec(t)?.[1];
+const userTime = /([\d.]+)\s+user/.exec(t)?.[1];
+const sysTime = /([\d.]+)\s+sys/.exec(t)?.[1];
+
+// ── report ──────────────────────────────────────────────────────
+const rpPath = `${dir}/report.json`;
+let pagesCrawled = 0;
+let findings = 0;
+let score: unknown = "?";
+let reportBytes = 0;
+if (existsSync(rpPath)) {
+  reportBytes = statSync(rpPath).size;
+  try {
+    const r = JSON.parse(readFileSync(rpPath, "utf8")) as Record<string, unknown>;
+    const meta = (r.meta ?? {}) as Record<string, unknown>;
+    const summary = (r.summary ?? {}) as Record<string, unknown>;
+    pagesCrawled = Number(meta.totalPages ?? summary.pagesCrawled ?? 0) || 0;
+    const sc = (r as any).score ?? {};
+    score = `${sc.overall ?? "?"} (${sc.grade ?? "?"})  passed=${summary.passed ?? "?"} warn=${summary.warnings ?? "?"} failed=${summary.failed ?? "?"}`;
+    const issues = ((r as any).issues ?? (r as any).findings ?? []) as unknown[];
+    findings = Array.isArray(issues) ? issues.length : 0;
+  } catch {
+    /* partial/truncated report */
+  }
+}
+
+// ── project db ──────────────────────────────────────────────────
+const project = read(`${dir}/project.txt`).trim() || read(`${dir}/project`).trim();
+const slug = project.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+const pdb = `${homedir()}/.squirrel/projects/${slug}/project.db`;
+const pdbSize = existsSync(pdb) ? statSync(pdb).size : 0;
+const csdb = `${homedir()}/.squirrel/content-store.db`;
+const csSize = existsSync(csdb) ? statSync(csdb).size : 0;
+
+// ── phase attribution from rss.log shape ────────────────────────
+// print a coarse profile: RSS at 10% intervals of wall time
+const marks: string[] = [];
+if (rss.length) {
+  for (let f = 0; f <= 10; f++) {
+    const target = (wall * f) / 10;
+    let best = rss[0]!;
+    for (const r of rss) if (Math.abs(r[0] - target) < Math.abs(best[0] - target)) best = r;
+    marks.push(`${best[0]}s:${mb(best[1] * 1024)}MB`);
+  }
+}
+
+console.log(`
+stage        ${dir.split("/").pop()}
+rc           ${read(`${dir}/rc`).trim()}   ${read(`${dir}/guard.log`).trim() || ""}
+wall         ${realTime ?? wall}s   (user ${userTime ?? "?"}s, sys ${sysTime ?? "?"}s)
+pages        ${pagesCrawled}   ->  ${pagesCrawled && realTime ? (pagesCrawled / Number(realTime)).toFixed(2) : "?"} pages/s
+peak RSS     ${maxrss ? mb(Number(maxrss)) : mb(peakKb * 1024)} MB  (sampler peak ${mb(peakKb * 1024)} MB at ${peakAt}s)
+peak heapUsed${peakHeap ? " " + mb(peakHeap) + " MB" : " n/a"}   peak external ${peakExt ? mb(peakExt) + " MB" : "n/a"}
+end heapUsed ${last ? mb(Number(last.heapUsed)) + " MB" : "n/a"}   end external ${last ? mb(Number(last.external)) + " MB" : "n/a"}
+findings     ${findings}   score ${score}
+report.json  ${mb(reportBytes)} MB
+project.db   ${mb(pdbSize)} MB   (${slug})
+content-store${" "}${mb(csSize)} MB (global, cumulative)
+rss profile  ${marks.join("  ")}
+`);

--- a/benchmarks/harness/analyze.ts
+++ b/benchmarks/harness/analyze.ts
@@ -3,12 +3,18 @@
  * Reads: rss.log (external sampler), mem.jsonl (in-process probe),
  *        audit.time (/usr/bin/time -l), report.json, audit.out.
  */
-import { statSync, existsSync, readFileSync } from "node:fs";
+import { statSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 
 const dir = process.argv[2];
 const mb = (b: number) => (b / 1048576).toFixed(0);
-const read = (p: string) => (existsSync(p) ? readFileSync(p, "utf8") : "");
+const read = (p: string) => {
+  try {
+    return readFileSync(p, "utf8");
+  } catch {
+    return "";
+  }
+};
 
 // ── external RSS sampler ────────────────────────────────────────
 const rss = read(`${dir}/rss.log`)
@@ -81,9 +87,19 @@ if (rpText !== null) {
 const project = read(`${dir}/project.txt`).trim() || read(`${dir}/project`).trim();
 const slug = project.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
 const pdb = `${homedir()}/.squirrel/projects/${slug}/project.db`;
-const pdbSize = existsSync(pdb) ? statSync(pdb).size : 0;
+let pdbSize = 0;
+try {
+  pdbSize = statSync(pdb).size;
+} catch {
+  pdbSize = 0;
+}
 const csdb = `${homedir()}/.squirrel/content-store.db`;
-const csSize = existsSync(csdb) ? statSync(csdb).size : 0;
+let csSize = 0;
+try {
+  csSize = statSync(csdb).size;
+} catch {
+  csSize = 0;
+}
 
 // ── phase attribution from rss.log shape ────────────────────────
 // print a coarse profile: RSS at 10% intervals of wall time

--- a/benchmarks/harness/analyze.ts
+++ b/benchmarks/harness/analyze.ts
@@ -55,10 +55,16 @@ let pagesCrawled = 0;
 let findings = 0;
 let score: unknown = "?";
 let reportBytes = 0;
-if (existsSync(rpPath)) {
-  reportBytes = statSync(rpPath).size;
+let rpText: string | null = null;
+try {
+  rpText = readFileSync(rpPath, "utf8"); // read once; no exists/stat/read race
+} catch {
+  rpText = null;
+}
+if (rpText !== null) {
+  reportBytes = Buffer.byteLength(rpText, "utf8");
   try {
-    const r = JSON.parse(readFileSync(rpPath, "utf8")) as Record<string, unknown>;
+    const r = JSON.parse(rpText) as Record<string, unknown>;
     const meta = (r.meta ?? {}) as Record<string, unknown>;
     const summary = (r.summary ?? {}) as Record<string, unknown>;
     pagesCrawled = Number(meta.totalPages ?? summary.pagesCrawled ?? 0) || 0;

--- a/benchmarks/harness/mem-probe.ts
+++ b/benchmarks/harness/mem-probe.ts
@@ -1,0 +1,53 @@
+/**
+ * Harness-side memory probe, injected with `bun --preload`. NOT product code.
+ *
+ * Samples process.memoryUsage() (rss / heapUsed / external / arrayBuffers) on a
+ * fixed cadence into $BENCH_MEM_LOG as JSONL, plus a final sample at exit.
+ * The interval is unref'd so it never keeps the CLI alive.
+ *
+ * Env:
+ *   BENCH_MEM_LOG   path to write JSONL samples (required, else probe is inert)
+ *   BENCH_MEM_MS    sample period, default 500ms
+ */
+
+const out = process.env.BENCH_MEM_LOG;
+
+if (out) {
+  const periodMs = Number(process.env.BENCH_MEM_MS ?? 500);
+  const t0 = Date.now();
+  const samples: string[] = [];
+  let peakRss = 0;
+
+  const sample = (tag: string) => {
+    const m = process.memoryUsage();
+    if (m.rss > peakRss) peakRss = m.rss;
+    samples.push(
+      JSON.stringify({
+        t: Date.now() - t0,
+        tag,
+        rss: m.rss,
+        heapUsed: m.heapUsed,
+        heapTotal: m.heapTotal,
+        external: m.external,
+        arrayBuffers: m.arrayBuffers,
+      }),
+    );
+  };
+
+  const timer = setInterval(() => sample("tick"), periodMs);
+  // never hold the process open on the probe's account
+  (timer as unknown as { unref?: () => void }).unref?.();
+
+  const flush = () => {
+    sample("exit");
+    samples.push(JSON.stringify({ t: Date.now() - t0, tag: "peakRssInProc", rss: peakRss }));
+    try {
+      require("node:fs").writeFileSync(out, samples.join("\n") + "\n");
+    } catch {
+      /* best effort: never break the run being measured */
+    }
+  };
+
+  process.on("exit", flush);
+  sample("start");
+}

--- a/benchmarks/harness/phases.ts
+++ b/benchmarks/harness/phases.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-stage phase table: crawl span (from the server request log), rules and
+ * report (from the trace log), wall + CPU (from /usr/bin/time -l).
+ * Usage: bun phases.ts <results-dir>...
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+
+const read = (p: string) => (existsSync(p) ? readFileSync(p, "utf8") : "");
+const num = (re: RegExp, s: string) => {
+  const m = re.exec(s);
+  return m ? Number(m[1]) : 0;
+};
+
+const rows: string[][] = [];
+rows.push([
+  "stage",
+  "pages",
+  "wall",
+  "cpu",
+  "crawl",
+  "ms/pg",
+  "reqs",
+  "pageReqs",
+  "rules",
+  "site",
+  "parse",
+  "peakRSS",
+  "db",
+]);
+
+for (const dir of process.argv.slice(2)) {
+  const label = dir.split("/").pop()!;
+  const t = read(`${dir}/audit.time`);
+  const wall = num(/^\s*([\d.]+)\s+real/m, t);
+  const cpu = num(/([\d.]+)\s+user/, t) + num(/([\d.]+)\s+sys/, t);
+  const maxrss = num(/(\d+)\s+maximum resident set size/, t);
+
+  const rep = `${dir}/report.json`;
+  let pages = 0;
+  if (existsSync(rep)) {
+    try {
+      pages = Number(JSON.parse(readFileSync(rep, "utf8")).meta?.totalPages ?? 0);
+    } catch {
+      /* truncated */
+    }
+  }
+
+  // crawl span from request log
+  const reqRaw = read(`${dir}/requests.log`).trim();
+  const reqs = reqRaw ? reqRaw.split("\n") : [];
+  const pageReqs = reqs.filter((l) => /\t\/p\//.test(l)).map((l) => Number(l.split("\t")[0]));
+  const crawlSpan = pageReqs.length > 1 ? (pageReqs.at(-1)! - pageReqs[0]!) / 1000 : 0;
+
+  // phases from the trace log
+  const tr = read(`${dir}/trace.log`);
+  const rules = num(/\[runPageRules:all\] duration=([\d.]+)ms/, tr) / 1000;
+  const site = num(/\[runSiteRules\] duration=([\d.]+)ms/, tr) / 1000;
+  const parseMs = (tr.match(/\[parsePageRecord\] duration=([\d.]+)ms/g) ?? [])
+    .map((s) => Number(/([\d.]+)/.exec(s)![1]))
+    .reduce((a, b) => a + b, 0);
+
+  const dbBytes = Number(read(`${dir}/projectdb.bytes`).trim() || 0);
+
+  rows.push([
+    label,
+    String(pages),
+    wall.toFixed(0) + "s",
+    cpu.toFixed(0) + "s",
+    crawlSpan.toFixed(0) + "s",
+    pages ? (crawlSpan * 1000 / pages).toFixed(0) : "-",
+    String(reqs.length),
+    String(pageReqs.length),
+    rules.toFixed(0) + "s",
+    site.toFixed(0) + "s",
+    (parseMs / 1000).toFixed(1) + "s",
+    (maxrss / 1048576).toFixed(0) + "MB",
+    dbBytes ? (dbBytes / 1048576).toFixed(0) + "MB" : "-",
+  ]);
+}
+
+const w = rows[0]!.map((_, i) => Math.max(...rows.map((r) => (r[i] ?? "").length)));
+for (const r of rows) console.log(r.map((c, i) => c.padStart(w[i]!)).join("  "));

--- a/benchmarks/harness/rss-sampler.ts
+++ b/benchmarks/harness/rss-sampler.ts
@@ -1,0 +1,119 @@
+/**
+ * External RSS sampler + guard rail. Samples the RSS of a process TREE (the
+ * /usr/bin/time wrapper plus every descendant) once a second, appends
+ * "<elapsedSec> <rssKb>" lines, and kills the tree if it breaches a ceiling.
+ *
+ * Usage: bun rss-sampler.ts <rootPid> <outLog> <killMB> <killSec> <guardLog>
+ */
+const [rootPid, outLog, killMB, killSec, guardLog] = [
+  Number(process.argv[2]),
+  process.argv[3]!,
+  Number(process.argv[4] ?? 4096),
+  Number(process.argv[5] ?? 3600),
+  process.argv[6]!,
+];
+
+const t0 = Date.now();
+const lines: string[] = [];
+
+function snapshot(): Map<number, { ppid: number; rss: number }> {
+  const out = Bun.spawnSync(["ps", "-axo", "pid=,ppid=,rss="]).stdout.toString();
+  const m = new Map<number, { ppid: number; rss: number }>();
+  for (const l of out.split("\n")) {
+    const p = l.trim().split(/\s+/);
+    if (p.length < 3) continue;
+    const pid = Number(p[0]);
+    const ppid = Number(p[1]);
+    const rss = Number(p[2]);
+    if (Number.isFinite(pid) && Number.isFinite(rss)) m.set(pid, { ppid, rss });
+  }
+  return m;
+}
+
+function treeRss(m: Map<number, { ppid: number; rss: number }>, root: number) {
+  // children index
+  const kids = new Map<number, number[]>();
+  for (const [pid, v] of m) {
+    if (!kids.has(v.ppid)) kids.set(v.ppid, []);
+    kids.get(v.ppid)!.push(pid);
+  }
+  let total = 0;
+  let n = 0;
+  const stack = [root];
+  while (stack.length) {
+    const pid = stack.pop()!;
+    const v = m.get(pid);
+    if (!v) continue;
+    total += v.rss;
+    n++;
+    for (const k of kids.get(pid) ?? []) stack.push(k);
+  }
+  return { total, n };
+}
+
+function killTree(m: Map<number, { ppid: number; rss: number }>, root: number) {
+  const kids = new Map<number, number[]>();
+  for (const [pid, v] of m) {
+    if (!kids.has(v.ppid)) kids.set(v.ppid, []);
+    kids.get(v.ppid)!.push(pid);
+  }
+  const all: number[] = [];
+  const stack = [root];
+  while (stack.length) {
+    const pid = stack.pop()!;
+    all.push(pid);
+    for (const k of kids.get(pid) ?? []) stack.push(k);
+  }
+  // deepest first so the parent cannot respawn
+  for (const pid of all.reverse()) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+const flush = () => {
+  try {
+    require("node:fs").writeFileSync(outLog, lines.join("\n") + "\n");
+  } catch {
+    /* best effort */
+  }
+};
+process.on("exit", flush);
+process.on("SIGTERM", () => {
+  flush();
+  process.exit(0);
+});
+
+let peak = 0;
+while (true) {
+  const m = snapshot();
+  if (!m.has(rootPid)) break; // run finished
+  const { total, n } = treeRss(m, rootPid);
+  const elapsed = Math.round((Date.now() - t0) / 1000);
+  if (total > peak) peak = total;
+  lines.push(`${elapsed} ${total} ${n}`);
+  if (lines.length % 20 === 0) flush();
+
+  const mb = total / 1024;
+  if (mb > killMB) {
+    require("node:fs").appendFileSync(
+      guardLog,
+      `KILLED rss=${mb.toFixed(0)}MB (ceiling ${killMB}MB) at ${elapsed}s\n`,
+    );
+    killTree(m, rootPid);
+    break;
+  }
+  if (elapsed > killSec) {
+    require("node:fs").appendFileSync(
+      guardLog,
+      `KILLED time=${elapsed}s (ceiling ${killSec}s) rss=${mb.toFixed(0)}MB\n`,
+    );
+    killTree(m, rootPid);
+    break;
+  }
+  await Bun.sleep(1000);
+}
+flush();

--- a/benchmarks/harness/run-stage.sh
+++ b/benchmarks/harness/run-stage.sh
@@ -18,7 +18,7 @@ set -u
 
 HERE=${0:A:h}
 LANE=${BENCH_REPO:-$(git -C "$HERE" rev-parse --show-toplevel)/..}
-BASE_PAGE=$HERE/../drscholls/page.html
+BASE_PAGE=${BENCH_BASE_PAGE:?set BENCH_BASE_PAGE to a large script-heavy HTML file to serve as the product template}
 LABEL=$1; PAGES=$2; MAXPAGES=$3; shift 3
 OUT=$HERE/results/$LABEL
 KILL_MB=${BENCH_KILL_MB:-4096}

--- a/benchmarks/harness/run-stage.sh
+++ b/benchmarks/harness/run-stage.sh
@@ -1,0 +1,87 @@
+#!/bin/zsh
+# One benchmark stage: serve an N-page synthetic estate, run `squirrel audit`
+# against it under an external RSS sampler + in-process heap probe, record
+# everything under results/<label>/.
+#
+# Usage: run-stage.sh <label> <pages> <maxPages> [extra squirrel args...]
+#   label     directory name for results
+#   pages     size of the synthetic site to serve
+#   maxPages  --max-pages passed to the CLI
+#
+# Env:
+#   BENCH_PROJECT   squirrel project name (controls which project.db is reused;
+#                   same name across two stages = warm/incremental run)
+#   BENCH_KILL_MB   kill the audit above this RSS (default 4096)
+#   BENCH_KILL_SEC  kill the audit after this many seconds (default 3600)
+#   BENCH_RULE_PROFILE=1 to enable per-rule timing on stderr
+set -u
+
+HERE=${0:A:h}
+LANE=${BENCH_REPO:-$(git -C "$HERE" rev-parse --show-toplevel)/..}
+BASE_PAGE=$HERE/../drscholls/page.html
+LABEL=$1; PAGES=$2; MAXPAGES=$3; shift 3
+OUT=$HERE/results/$LABEL
+KILL_MB=${BENCH_KILL_MB:-4096}
+KILL_SEC=${BENCH_KILL_SEC:-3600}
+PROJECT=${BENCH_PROJECT:-bench$PAGES}
+
+rm -rf $OUT; mkdir -p $OUT
+echo "== stage $LABEL: serving $PAGES pages, auditing max $MAXPAGES, project=$PROJECT"
+
+# ── serve ───────────────────────────────────────────────────────
+[[ ${BENCH_REQ_LOG:-0} == 1 ]] && export BENCH_REQ_LOG=$OUT/requests.log
+SALT=${BENCH_SALT:-}
+# zsh does NOT word-split an unquoted parameter expansion, so ${SALT:+--salt $SALT}
+# would arrive as ONE argv entry and indexOf("--salt") would miss it. Build an array.
+SALT_ARGS=()
+[[ -n $SALT ]] && SALT_ARGS=(--salt $SALT)
+bun $HERE/site.ts $BASE_PAGE $PAGES $SALT_ARGS > $OUT/server.port 2> $OUT/server.err &
+SRV=$!
+for i in {1..50}; do [[ -s $OUT/server.port ]] && break; sleep 0.2; done
+PORT=$(cat $OUT/server.port)
+if [[ -z $PORT ]]; then echo "SERVER FAILED"; cat $OUT/server.err; kill $SRV 2>/dev/null; exit 1; fi
+echo "   server pid=$SRV port=$PORT"
+URL="http://localhost:$PORT"
+
+# sanity: seed + one heavy page reachable
+curl -sS -o /dev/null -w "   seed %{http_code} %{size_download}B\n" $URL/ || true
+curl -sS -o /dev/null -w "   /p/0 %{http_code} %{size_download}B\n" $URL/p/0 || true
+
+# ── audit under probes ──────────────────────────────────────────
+# Point the GLOBAL content store somewhere private when asked, so a stage can be
+# measured against an empty store instead of the user's ~1 GB lifetime cache.
+[[ -n ${BENCH_CONTENT_STORE:-} ]] && export SQUIRREL_CONTENT_STORE_PATH=$BENCH_CONTENT_STORE
+export BENCH_MEM_LOG=$OUT/mem.jsonl
+export BENCH_MEM_MS=${BENCH_MEM_MS:-500}
+[[ ${BENCH_RULE_PROFILE:-0} == 1 ]] && export SQUIRREL_RULE_PROFILE=1
+
+cd $LANE
+# fresh trace log per stage so phase spans are unambiguous
+mkdir -p ~/.squirrel/logs && : > ~/.squirrel/logs/trace.log
+STARTED=$(date +%s)
+/usr/bin/time -l bun --preload $HERE/mem-probe.ts \
+  repo-public/apps/cli/src/cli.ts audit $URL \
+  --coverage full --max-pages $MAXPAGES --http --offline \
+  --project-name $PROJECT --trace \
+  -f json -o $OUT/report.json "$@" \
+  > $OUT/audit.out 2> $OUT/audit.time &
+AUDIT=$!
+
+# external RSS sampler + guard rails (samples the whole process tree)
+bun $HERE/rss-sampler.ts $AUDIT $OUT/rss.log $KILL_MB $KILL_SEC $OUT/guard.log &
+SAMPLER=$!
+
+wait $AUDIT; RC=$?
+kill $SAMPLER 2>/dev/null; wait $SAMPLER 2>/dev/null
+kill $SRV 2>/dev/null; wait $SRV 2>/dev/null
+
+cp ~/.squirrel/logs/trace.log $OUT/trace.log 2>/dev/null
+PDB=~/.squirrel/projects/$(echo $PROJECT | tr 'A-Z' 'a-z' | sed 's/[^a-z0-9]\{1,\}/-/g')/project.db
+[[ -f $PDB ]] && ls -l $PDB | awk '{print $5}' > $OUT/projectdb.bytes
+
+echo "   exit rc=$RC after $(( $(date +%s) - STARTED ))s"
+echo $RC > $OUT/rc
+echo $PORT > $OUT/port
+echo $PROJECT > $OUT/project
+[[ -f $OUT/guard.log ]] && cat $OUT/guard.log
+exit 0

--- a/benchmarks/harness/site.ts
+++ b/benchmarks/harness/site.ts
@@ -23,6 +23,7 @@
  * Prints the chosen port on stdout, then serves until killed.
  */
 
+import { parseDocument } from "@squirrelscan/parser";
 const basePath = process.argv[2];
 const N = Number(process.argv[3] ?? 1000);
 const portArgIdx = process.argv.indexOf("--port");
@@ -61,9 +62,8 @@ function tplFor(i: number): Tpl {
 // ── collection template: real page with most inline script removed ──
 // Parsed with a real HTML parser rather than a regex, so `</script >` variants and
 // nested `<script` text cannot leak through (CodeQL js/bad-tag-filter).
-import { parseHTML } from "linkedom";
 const COLLECTION_BASE = (() => {
-  const { document } = parseHTML(BASE);
+  const document = parseDocument(BASE);
   const scripts = Array.from(document.querySelectorAll("script"));
   for (const el of scripts.slice(6)) el.remove();
   return document.toString();

--- a/benchmarks/harness/site.ts
+++ b/benchmarks/harness/site.ts
@@ -59,11 +59,15 @@ function tplFor(i: number): Tpl {
 }
 
 // ── collection template: real page with most inline script removed ──
-let scriptSeen = 0;
-const COLLECTION_BASE = BASE.replace(
-  /<script\b[^>]*>[\s\S]*?<\/script>/gi,
-  (m) => (scriptSeen++ < 6 ? m : ""),
-);
+// Parsed with a real HTML parser rather than a regex, so `</script >` variants and
+// nested `<script` text cannot leak through (CodeQL js/bad-tag-filter).
+import { parseHTML } from "linkedom";
+const COLLECTION_BASE = (() => {
+  const { document } = parseHTML(BASE);
+  const scripts = Array.from(document.querySelectorAll("script"));
+  for (const el of scripts.slice(6)) el.remove();
+  return document.toString();
+})();
 
 // ── light templates, built once, node-dense (not rope-cheap filler) ──
 const WORDS =

--- a/benchmarks/harness/site.ts
+++ b/benchmarks/harness/site.ts
@@ -1,0 +1,348 @@
+/**
+ * Mixed-shape synthetic site for the 10k-page CLI benchmark (private #1028).
+ *
+ * Serves N deterministic pages across 6 templates whose sizes/node counts mimic
+ * a real enterprise storefront + docs estate:
+ *
+ *   template   share   ~size    shape
+ *   product     10%    982 KB   REAL saved drscholls page (1150 tags, 825 KB inline script)
+ *   collection  10%    120 KB   same page with most inline script stripped (link-dense)
+ *   docs        30%     20 KB   prose + code blocks, ~450 tags
+ *   blog        30%     20 KB   article markup, ~380 tags
+ *   listing     10%     35 KB   index page, 60 outbound links
+ *   thin        10%      8 KB   utility page, ~90 tags
+ *
+ * Every page is byte-unique (page id is woven into title/h1/canonical/body) so
+ * the crawler's content_hash store cannot dedupe them and hide storage cost.
+ *
+ * Link graph guarantees reachability of all N pages from "/": the seed links to
+ * every hub, each hub links to a 50-page block, and each page cross-links 40
+ * siblings. robots.txt + a sitemap index are served too (enterprise shape).
+ *
+ * Usage: bun site.ts <base-page.html> <N> [--port P]
+ * Prints the chosen port on stdout, then serves until killed.
+ */
+
+const basePath = process.argv[2];
+const N = Number(process.argv[3] ?? 1000);
+const portArgIdx = process.argv.indexOf("--port");
+const wantPort = portArgIdx > -1 ? Number(process.argv[portArgIdx + 1]) : 0;
+// A salt woven into every page so a stage can be genuinely COLD against
+// squirrel's GLOBAL ~/.squirrel/content-store.db (keyed by content hash).
+// Same salt on a later run = warm/incremental. Never clear the user's store.
+const saltIdx = process.argv.indexOf("--salt");
+const SALT = saltIdx > -1 ? String(process.argv[saltIdx + 1]) : "";
+
+const BASE = await Bun.file(basePath).text();
+const BLOCK = 50; // pages per hub
+const HUBS = Math.max(1, Math.ceil(N / BLOCK));
+
+// ── template mix ────────────────────────────────────────────────
+// Deterministic assignment by page id so a given id always renders the same
+// template across cold/warm runs.
+type Tpl = "product" | "collection" | "docs" | "blog" | "listing" | "thin";
+const MIX: Tpl[] = [
+  "product",
+  "collection",
+  "docs",
+  "docs",
+  "docs",
+  "blog",
+  "blog",
+  "blog",
+  "listing",
+  "thin",
+];
+function tplFor(i: number): Tpl {
+  // cheap deterministic scatter so templates interleave rather than clump
+  return MIX[(i * 7 + ((i / 10) | 0) * 3) % MIX.length]!;
+}
+
+// ── collection template: real page with most inline script removed ──
+let scriptSeen = 0;
+const COLLECTION_BASE = BASE.replace(
+  /<script\b[^>]*>[\s\S]*?<\/script>/gi,
+  (m) => (scriptSeen++ < 6 ? m : ""),
+);
+
+// ── light templates, built once, node-dense (not rope-cheap filler) ──
+const WORDS =
+  "insole arch support cushioning orthotic heel plantar comfort midsole gel foam pressure alignment stability pronation fascia metatarsal shock absorption footbed lining".split(
+    " ",
+  );
+function words(seed: number, n: number): string {
+  let s = seed >>> 0;
+  const out: string[] = [];
+  for (let k = 0; k < n; k++) {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    out.push(WORDS[s % WORDS.length]!);
+  }
+  return out.join(" ");
+}
+
+function crossLinks(i: number, count: number): string {
+  const out: string[] = [];
+  for (let k = 0; k < count; k++) {
+    const t = (i * 7 + k * 13 + 1) % N;
+    out.push(`<li><a href="/p/${t}">${WORDS[t % WORDS.length]} guide ${t}</a></li>`);
+  }
+  return `<ul class="xlinks">${out.join("")}</ul>`;
+}
+
+function chrome(i: number, title: string): { head: string; nav: string; foot: string } {
+  const hubLinks = Array.from(
+    { length: Math.min(HUBS, 24) },
+    (_, h) => `<li><a href="/hub/${h}">Section ${h}</a></li>`,
+  ).join("");
+  return {
+    head: `<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<meta name="description" content="${words(i + 91, 22)}">
+<link rel="canonical" href="/p/${i}">`,
+    nav: `<header><nav aria-label="Main"><ul>${hubLinks}</ul></nav></header>`,
+    foot: `<footer><nav aria-label="Footer"><ul>${Array.from({ length: 12 }, (_, k) => `<li><a href="/p/${(i + k * 977) % N}">More ${(i + k * 977) % N}</a></li>`).join("")}</ul><p>&copy; 2026 Synthetic Estate</p></nav></footer>`,
+  };
+}
+
+function docsPage(i: number): string {
+  const c = chrome(i, `Docs ${i}: ${WORDS[i % WORDS.length]} reference`);
+  const sections = Array.from({ length: 10 }, (_, s) => {
+    const items = Array.from(
+      { length: 6 },
+      (_, k) => `<li><code>opt.${WORDS[(i + s + k) % WORDS.length]}</code> &mdash; ${words(i + s * 7 + k, 12)}</li>`,
+    ).join("");
+    return `<section id="s${s}"><h2>${s + 1}. ${WORDS[(i + s) % WORDS.length]} configuration</h2>
+<p>${words(i + s * 31, 45)}</p>
+<ul>${items}</ul>
+<pre><code>const cfg = { ${WORDS[(i + s) % WORDS.length]}: ${s}, retries: 3, mode: "strict" };
+await client.apply(cfg); // ${words(i + s, 6)}</code></pre>
+<table><thead><tr><th>Field</th><th>Type</th><th>Default</th></tr></thead><tbody>
+${Array.from({ length: 5 }, (_, r) => `<tr><td>${WORDS[(i + r) % WORDS.length]}</td><td>string</td><td><code>none</code></td></tr>`).join("")}
+</tbody></table></section>`;
+  }).join("\n");
+  return `<!doctype html><html lang="en"><head>${c.head}</head><body>${c.nav}
+<main><h1>Docs ${i}: ${WORDS[i % WORDS.length]} reference</h1>
+<p class="lede">${words(i, 60)}</p>
+${sections}
+${crossLinks(i, 40)}
+</main>${c.foot}</body></html>`;
+}
+
+function blogPage(i: number): string {
+  const c = chrome(i, `${WORDS[i % WORDS.length]} and ${WORDS[(i + 3) % WORDS.length]}: field notes ${i}`);
+  const paras = Array.from(
+    { length: 22 },
+    (_, p) => `<p>${words(i * 13 + p, 55)}</p>`,
+  ).join("\n");
+  const figs = Array.from(
+    { length: 4 },
+    (_, f) =>
+      `<figure><img src="/img/${(i + f) % 200}.jpg" alt="${words(i + f, 5)}" width="800" height="450"><figcaption>${words(i + f * 3, 10)}</figcaption></figure>`,
+  ).join("\n");
+  return `<!doctype html><html lang="en"><head>${c.head}
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Field notes ${i}","datePublished":"2026-0${(i % 9) + 1}-1${i % 9}","author":{"@type":"Person","name":"Sam ${i % 40}"}}</script>
+</head><body>${c.nav}
+<main><article><h1>${WORDS[i % WORDS.length]} and ${WORDS[(i + 3) % WORDS.length]}: field notes ${i}</h1>
+<p class="byline">By Sam ${i % 40} &middot; <time datetime="2026-0${(i % 9) + 1}-1${i % 9}">2026</time></p>
+${paras}
+${figs}
+<h2>What we changed</h2><ol>${Array.from({ length: 8 }, (_, k) => `<li>${words(i + k * 5, 14)}</li>`).join("")}</ol>
+</article>
+${crossLinks(i, 40)}
+</main>${c.foot}</body></html>`;
+}
+
+function listingPage(i: number): string {
+  const c = chrome(i, `Index ${i}: ${WORDS[i % WORDS.length]} collection`);
+  const cards = Array.from({ length: 60 }, (_, k) => {
+    const t = (i * 11 + k * 7 + 5) % N;
+    return `<li class="card"><a href="/p/${t}"><img src="/img/${t % 200}.jpg" alt="${WORDS[t % WORDS.length]} ${t}" width="320" height="320"><h3>${WORDS[t % WORDS.length]} ${t}</h3><p>${words(t, 14)}</p><span class="price">$${20 + (t % 80)}.99</span></a></li>`;
+  }).join("\n");
+  return `<!doctype html><html lang="en"><head>${c.head}</head><body>${c.nav}
+<main><h1>Index ${i}: ${WORDS[i % WORDS.length]} collection</h1>
+<p>${words(i, 40)}</p>
+<ul class="grid">${cards}</ul>
+</main>${c.foot}</body></html>`;
+}
+
+function thinPage(i: number): string {
+  const c = chrome(i, `Note ${i}`);
+  return `<!doctype html><html lang="en"><head>${c.head}</head><body>${c.nav}
+<main><h1>Note ${i}</h1><p>${words(i, 70)}</p>
+<dl>${Array.from({ length: 8 }, (_, k) => `<dt>${WORDS[(i + k) % WORDS.length]}</dt><dd>${words(i + k, 8)}</dd>`).join("")}</dl>
+${crossLinks(i, 12)}
+</main>${c.foot}</body></html>`;
+}
+
+// ── heavy templates derived from the real page ──────────────────
+function heavy(base: string, i: number, label: string): string {
+  const links = Array.from({ length: 40 }, (_, k) => {
+    const t = (i * 7 + k * 13 + 1) % N;
+    return `<a href="/p/${t}">${WORDS[t % WORDS.length]} ${t}</a>`;
+  }).join("\n");
+  const hubLinks = Array.from(
+    { length: Math.min(HUBS, 24) },
+    (_, h) => `<a href="/hub/${h}">Section ${h}</a>`,
+  ).join("\n");
+  return base
+    .replace(/<title>[^<]*<\/title>/i, `<title>${label} ${i} | Synthetic Estate</title>`)
+    .replace(
+      /<\/head>/i,
+      `<link rel="canonical" href="/p/${i}"><meta name="description" content="${words(i + 5, 20)}"></head>`,
+    )
+    .replace(
+      "</body>",
+      `<nav id="syn" aria-label="Related"><h2>Related ${i}</h2>${links}${hubLinks}</nav><p id="synid">sku-${i}-${words(i, 6)}</p></body>`,
+    );
+}
+
+function hubPage(h: number): string {
+  const start = h * BLOCK;
+  const items = Array.from({ length: BLOCK }, (_, k) => start + k)
+    .filter((t) => t < N)
+    .map((t) => `<li><a href="/p/${t}">${WORDS[t % WORDS.length]} ${t}</a></li>`)
+    .join("");
+  const others = Array.from(
+    { length: Math.min(HUBS, 60) },
+    (_, o) => `<li><a href="/hub/${o}">Section ${o}</a></li>`,
+  ).join("");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Section ${h} | Synthetic Estate</title><link rel="canonical" href="/hub/${h}"><meta name="description" content="Section ${h} of the synthetic estate"></head><body>
+<header><nav aria-label="Sections"><ul>${others}</ul></nav></header>
+<main><h1>Section ${h}</h1><ul>${items}</ul></main>
+<footer><p>&copy; 2026</p></footer></body></html>`;
+}
+
+function seedPage(): string {
+  const hubs = Array.from(
+    { length: HUBS },
+    (_, h) => `<li><a href="/hub/${h}">Section ${h}</a></li>`,
+  ).join("");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Synthetic Estate | ${N} page benchmark site</title><link rel="canonical" href="/"><meta name="description" content="Synthetic enterprise estate with ${N} pages for crawl benchmarking"></head><body>
+<header><h1>Synthetic Estate</h1></header>
+<main><p>${N} pages across product, collection, docs, blog, listing and note templates.</p>
+<nav aria-label="Sections"><ul>${hubs}</ul></nav></main>
+<footer><p>&copy; 2026</p></footer></body></html>`;
+}
+
+function render(i: number): string {
+  let body: string;
+  switch (tplFor(i)) {
+    case "product":
+      body = heavy(BASE, i, "Product");
+      break;
+    case "collection":
+      body = heavy(COLLECTION_BASE, i, "Collection");
+      break;
+    case "docs":
+      body = docsPage(i);
+      break;
+    case "blog":
+      body = blogPage(i);
+      break;
+    case "listing":
+      body = listingPage(i);
+      break;
+    case "thin":
+      body = thinPage(i);
+      break;
+  }
+  if (!SALT) return body;
+  // one comment before </body>: changes the content hash, not the DOM shape
+  return body.replace("</body>", `<!-- build ${SALT} -->
+</body>`);
+}
+
+// ── sitemaps (enterprise shape: index + 1000-url children) ──────
+const SM_CHUNK = 1000;
+const SM_COUNT = Math.ceil(N / SM_CHUNK);
+
+// ── optional request log (BENCH_REQ_LOG=path) ───────────────────
+const reqLogPath = process.env.BENCH_REQ_LOG;
+const reqLog: string[] = [];
+const t0 = Date.now();
+let reqCount = 0;
+if (reqLogPath) {
+  const flush = () => {
+    try {
+      require("node:fs").writeFileSync(reqLogPath, reqLog.join("\n") + "\n");
+    } catch {
+      /* best effort */
+    }
+  };
+  process.on("exit", flush);
+  process.on("SIGTERM", () => {
+    flush();
+    process.exit(0);
+  });
+  process.on("SIGINT", () => {
+    flush();
+    process.exit(0);
+  });
+}
+
+const server = Bun.serve({
+  port: wantPort,
+  // generous: the crawler may open many sockets
+  idleTimeout: 60,
+  fetch(req) {
+    const url = new URL(req.url);
+    const p = url.pathname;
+    if (reqLogPath) {
+      reqCount++;
+      reqLog.push(`${Date.now() - t0}\t${req.method}\t${p}\t${req.headers.get("accept") ?? ""}`);
+    }
+    const html = (body: string) =>
+      new Response(body, {
+        headers: { "content-type": "text/html; charset=utf-8", "cache-control": "public, max-age=600" },
+      });
+
+    if (p === "/robots.txt") {
+      return new Response(`User-agent: *\nAllow: /\nSitemap: ${url.origin}/sitemap.xml\n`, {
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    if (p === "/sitemap.xml") {
+      const body = `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${Array.from(
+        { length: SM_COUNT },
+        (_, s) => `<sitemap><loc>${url.origin}/sitemap-${s}.xml</loc></sitemap>`,
+      ).join("")}</sitemapindex>`;
+      return new Response(body, { headers: { "content-type": "application/xml" } });
+    }
+    const sm = p.match(/^\/sitemap-(\d+)\.xml$/);
+    if (sm) {
+      const s = Number(sm[1]);
+      const start = s * SM_CHUNK;
+      const end = Math.min(N, start + SM_CHUNK);
+      const urls: string[] = [];
+      for (let i = start; i < end; i++) urls.push(`<url><loc>${url.origin}/p/${i}</loc></url>`);
+      return new Response(
+        `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls.join("")}</urlset>`,
+        { headers: { "content-type": "application/xml" } },
+      );
+    }
+    if (p === "/" || p === "/index.html") return html(seedPage());
+
+    const hub = p.match(/^\/hub\/(\d+)$/);
+    if (hub) {
+      const h = Number(hub[1]);
+      if (h < 0 || h >= HUBS) return new Response("Not found", { status: 404 });
+      return html(hubPage(h));
+    }
+    const m = p.match(/^\/p\/(\d+)$/);
+    if (m) {
+      const i = Number(m[1]);
+      if (i < 0 || i >= N) return new Response("Not found", { status: 404 });
+      return html(render(i));
+    }
+    // images referenced by templates: tiny, real content-type, cheap
+    if (/^\/img\/\d+\.jpg$/.test(p)) {
+      return new Response(new Uint8Array([0xff, 0xd8, 0xff, 0xd9]), {
+        headers: { "content-type": "image/jpeg", "cache-control": "public, max-age=3600" },
+      });
+    }
+    return new Response("Not found", { status: 404 });
+  },
+});
+
+console.log(server.port);
+await new Promise(() => {});

--- a/benchmarks/harness/stages.sh
+++ b/benchmarks/harness/stages.sh
@@ -1,0 +1,27 @@
+#!/bin/zsh
+# Page-count scaling with the content-store confound REMOVED: every cold stage
+# gets its own fresh content store, so we measure how the pipeline scales with
+# PAGES, not with the size of the user's lifetime cache.
+# Warm stage reuses the cold stage's store AND project (incremental re-crawl).
+# Usage: stages.sh <N> [N...]
+set -u
+HERE=${0:A:h}
+for N in "$@"; do
+  S=st$N$(date +%H%M%S)
+  ST=$HERE/stores/st$N.db
+  rm -f $ST $ST-shm $ST-wal
+  rm -rf ~/.squirrel/projects/bench-st$N
+
+  echo "### $(date +%T) COLD  N=$N (fresh content store)"
+  BENCH_PROJECT=bench-st$N BENCH_SALT=$S BENCH_REQ_LOG=1 BENCH_KILL_SEC=5400 \
+    BENCH_CONTENT_STORE=$ST BENCH_KILL_MB=${BENCH_KILL_MB:-4096} \
+    $HERE/run-stage.sh p${N}cold $N $N
+
+  echo "### $(date +%T) WARM  N=$N (same store, same project)"
+  BENCH_PROJECT=bench-st$N BENCH_SALT=$S BENCH_REQ_LOG=1 BENCH_KILL_SEC=5400 \
+    BENCH_CONTENT_STORE=$ST BENCH_KILL_MB=${BENCH_KILL_MB:-4096} \
+    $HERE/run-stage.sh p${N}warm $N $N
+
+  echo "### $(date +%T) store size: $(ls -l $ST 2>/dev/null | awk '{print $5}') bytes"
+done
+echo "### ALL DONE $(date +%T)"


### PR DESCRIPTION
Adds `benchmarks/`: a checked-in record of measured performance numbers, so release notes and announcements draw from sourced figures rather than memory.

- `benchmarks/README.md`: index, methodology rules (phase-boundary heap sampling, fresh content store per stage, salted fixtures, interleaved runs, retain-nothing controls).
- `benchmarks/2026-09-perf-program.md`: the 7 to 8 September 2026 program. Headline: a 2,500-page CLI audit went from 3.9 GB heap / 502 s to 996 MB / 177 s (#252), a cold crawl against a filled content store from 833 to 26 ms/page (#246), per-page engine retention from megabytes to tens of KB (#234 #237 #240 #255), hosted rules-phase peak 1,581 → 1,180 MB, plus the batch-budget dial table (#245) and the seed-probe fix (#248/#249).
- `benchmarks/harness/`: the synthetic-estate server, stage runner, memory probe and analysis scripts used to produce the CLI rows. The base page used for the record (a real 982 KB product page) is not committed; the harness takes any base page as an argument.

Every future performance PR adds a row here.