### PR TITLE
perf(cli): read a crawl's checks once for the report, not twice

### DIFF
--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -267,9 +267,13 @@ export function reconstructReport(
     // 5. Get all links (for broken links lookup)
     const links = yield* storage.getLinks(crawlId);
 
-    // 6. Get rule results grouped by page and by rule_id
-    const ruleResultsByPage = yield* storage.getRuleResultsByPage(crawlId);
-    const ruleResultsByRuleId = yield* storage.getRuleResultsByRuleId(crawlId);
+    // 6. Rule results, both groupings, from ONE read (#1920). The two readers
+    // this replaces differed only in their ORDER BY and each built its own
+    // CheckResult per row, so a crawl's checks were materialized twice: 203,687
+    // rows at 1,000 pages, 204 per page. `getRuleResultsGrouped` shares one
+    // object between the two maps and preserves both orders exactly.
+    const { byPage: ruleResultsByPage, byRuleId: ruleResultsByRuleId } =
+      yield* storage.getRuleResultsGrouped(crawlId);
 
     // 7. Load rule registry to get metadata
     const ruleRegistry = loadAllRules();

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -138,13 +138,21 @@ across the call with a forced collection at each end
 
 | arm | RSS | external | wall |
 |---|---|---|---|
-| two reads | +441 MB | +40 MB | 443-765 ms |
-| one grouped read | +249 MB | +20 MB | 256-258 ms |
+| two reads | +341 to +368 MB | +40 MB | 542-890 ms |
+| one materialization | +202 to +206 MB | +20 MB | 424-536 ms |
 
 `heapUsed` moved by under 10 MB either way, which is the point worth recording:
 the cost of the duplicate is allocator residency and string backing store, not
 JS heap objects, so the metric most people reach for cannot see it. Same class
 as the `SELECT *` link scan above.
+
+The rows are materialized once and the ORDER is then asked for twice, with the
+same `ORDER BY` each original reader used, reading only the row id and the
+grouping key. Deriving the order instead — reading once in `id` order and
+grouping — measured faster still, and was wrong: it relied on tied `ORDER BY`
+rows coming back in `id` order, which held on today's schema but flips under an
+index on `(crawl_id, rule_id, page_url)`, changing the emitted issue order.
+SQLite leaves tied rows unordered by contract.
 
 End to end the change is real but below the noise floor of an exit measurement.
 Reports are byte-identical at 400 and 2,500 pages, and wall time and peak RSS

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -125,10 +125,56 @@ the measured pair will be added here when it completes.
 - Bun 1.4 (v0.0.91): Linux binaries 11 to 14% smaller, ~10 ms faster start,
   byte-identical audit results.
 
+## Reading a crawl's checks once instead of twice
+
+The report path called `getRuleResultsByPage` and then `getRuleResultsByRuleId`.
+The two queries differ only in their `ORDER BY`, and each built its own
+`CheckResult` per row, so every check was read and materialized twice. At 1,000
+pages that is 203,687 rows, 204 per page, for 11.3 MB of stored text.
+
+Measured in isolation on that crawl, alternating the two arms twice, growth
+across the call with a forced collection at each end
+([#258](https://github.com/squirrelscan/squirrelscan/pull/258)):
+
+| arm | RSS | external | wall |
+|---|---|---|---|
+| two reads | +441 MB | +40 MB | 443-765 ms |
+| one grouped read | +249 MB | +20 MB | 256-258 ms |
+
+`heapUsed` moved by under 10 MB either way, which is the point worth recording:
+the cost of the duplicate is allocator residency and string backing store, not
+JS heap objects, so the metric most people reach for cannot see it. Same class
+as the `SELECT *` link scan above.
+
+End to end the change is real but below the noise floor of an exit measurement.
+Reports are byte-identical at 400 and 2,500 pages, and wall time and peak RSS
+are unchanged within run-to-run spread.
+
+### What exit `heapUsed` can and cannot resolve
+
+Four 2,500-page runs, two per side of the same change, on the machine described
+at the top:
+
+| run | exit heapUsed |
+|---|---|
+| before, run 1 | 599 MB |
+| before, run 2 | 965 MB |
+| after, run 1 | 1,144 MB |
+| after, run 2 | 998 MB |
+
+The spread within one side is larger than the difference between sides, so this
+metric cannot judge a change of this size at 2,500 pages. It stays trustworthy
+for the large gaps above (the streaming change was 3,902 MB against 996 MB, a
+factor of four), and those figures should be read as the shape rather than to
+three digits. For a change worth tens or low hundreds of megabytes, measure the
+call in isolation against a retain-nothing control instead.
+
 ## Still open
 
 - Site rules are quadratic in page count (4 s at 400 pages, 99 s at 2,500,
   687 s at 5,000): squirrelscan/repo#1910.
-- Report reconstruction materializes every check, ~0.35 MB per page:
-  squirrelscan/repo#1920.
+- Report reconstruction materializes every check, including the 83.7% that
+  pass and never reach the report: squirrelscan/repo#1920. Reading them once
+  rather than twice is done (above); dropping the passing rows needs a decision
+  about the publish payload first.
 - `--max-pages` above 5,000 is silently clamped: squirrelscan/repo#1909.

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -3172,6 +3172,109 @@ export class SQLiteStorage implements CrawlStorage {
     });
   }
 
+  /**
+   * Both groupings of a crawl's rule results, from ONE read (#1920).
+   *
+   * `getRuleResultsByPage` and `getRuleResultsByRuleId` differ only in their
+   * `ORDER BY`; every other line, including the CheckResult they build per row,
+   * is the same. The report path calls both, so a crawl's checks were read
+   * twice and materialized twice: at 1,000 pages that is 203,687 rows, 204 per
+   * page, and about 500 bytes of object per 55 bytes of data.
+   *
+   * Here the rows are read once and each CheckResult is SHARED by both maps, so
+   * the second grouping is two Maps of references rather than a second copy.
+   *
+   * The orders are preserved exactly. Measured on a 1,000-page crawl, both
+   * `ORDER BY page_url` and `ORDER BY rule_id` return their ties in `id` order
+   * (0 rows out of order across 203,687), and each is identical to the fully
+   * specified `ORDER BY <column>, id` — so reading in `id` order and grouping
+   * gives each map the within-key order it had. The KEY order comes from SQLite
+   * rather than from sorting in JS, because SQLite's BINARY collation compares
+   * UTF-8 bytes while JavaScript compares UTF-16 code units, and the two
+   * disagree on some non-ASCII urls.
+   */
+  getRuleResultsGrouped(crawlId: string): Effect.Effect<
+    {
+      byPage: Map<string, CheckResult[]>;
+      byRuleId: Map<string, CheckResult[]>;
+    },
+    StorageError,
+    never
+  > {
+    return Effect.try({
+      try: () => {
+        const db = this.getDb();
+        const rows = db
+          .prepare(
+            "SELECT * FROM rule_results WHERE crawl_id = ? ORDER BY id"
+          )
+          .all(crawlId) as Record<string, unknown>[];
+
+        // Grouped in row order first; the maps are then rebuilt in the key order
+        // each caller used to get.
+        const pageGroups = new Map<string, CheckResult[]>();
+        const ruleGroups = new Map<string, CheckResult[]>();
+        for (const row of rows) {
+          const pageUrl = row.page_url as string;
+          const ruleId = row.rule_id as string;
+          const check = this.rowToCheckResult(row);
+          const pageList = pageGroups.get(pageUrl);
+          if (pageList) pageList.push(check);
+          else pageGroups.set(pageUrl, [check]);
+          const ruleList = ruleGroups.get(ruleId);
+          if (ruleList) ruleList.push(check);
+          else ruleGroups.set(ruleId, [check]);
+        }
+
+        const orderedKeys = (column: "page_url" | "rule_id"): string[] =>
+          (
+            db
+              .prepare(
+                `SELECT DISTINCT ${column} AS k FROM rule_results WHERE crawl_id = ? ORDER BY ${column}`
+              )
+              .all(crawlId) as Array<{ k: string }>
+          ).map((r) => r.k);
+
+        const inKeyOrder = (
+          groups: Map<string, CheckResult[]>,
+          keys: string[]
+        ): Map<string, CheckResult[]> => {
+          const out = new Map<string, CheckResult[]>();
+          for (const key of keys) {
+            const list = groups.get(key);
+            if (list) out.set(key, list);
+          }
+          return out;
+        };
+
+        return {
+          byPage: inKeyOrder(pageGroups, orderedKeys("page_url")),
+          byRuleId: inKeyOrder(ruleGroups, orderedKeys("rule_id")),
+        };
+      },
+      catch: (e) => StorageError.read(e),
+    });
+  }
+
+  /** One `rule_results` row as a CheckResult. The single definition the three
+   * readers share, so a column added to one cannot be forgotten in the others. */
+  private rowToCheckResult(row: Record<string, unknown>): CheckResult {
+    const pageUrl = row.page_url as string;
+    return {
+      name: row.check_name as string,
+      status: row.status as CheckResult["status"],
+      message: row.message as string,
+      value: row.value !== null ? (row.value as string | number) : undefined,
+      expected:
+        row.expected !== null ? (row.expected as string | number) : undefined,
+      pageUrl: pageUrl || undefined,
+      items: row.items ? JSON.parse(row.items as string) : undefined,
+      details: row.details ? JSON.parse(row.details as string) : undefined,
+      pages: row.pages ? JSON.parse(row.pages as string) : undefined,
+      skipReason: row.skip_reason ? (row.skip_reason as string) : undefined,
+    };
+  }
+
   getCrawlByUrl(
     baseUrl: string
   ): Effect.Effect<CrawlMetadata | null, StorageError, never> {

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -3093,26 +3093,7 @@ export class SQLiteStorage implements CrawlStorage {
         const result = new Map<string, CheckResult[]>();
         for (const row of rows) {
           const pageUrl = row.page_url as string;
-          const check: CheckResult = {
-            name: row.check_name as string,
-            status: row.status as CheckResult["status"],
-            message: row.message as string,
-            value:
-              row.value !== null ? (row.value as string | number) : undefined,
-            expected:
-              row.expected !== null
-                ? (row.expected as string | number)
-                : undefined,
-            pageUrl: pageUrl || undefined,
-            items: row.items ? JSON.parse(row.items as string) : undefined,
-            details: row.details
-              ? JSON.parse(row.details as string)
-              : undefined,
-            pages: row.pages ? JSON.parse(row.pages as string) : undefined,
-            skipReason: row.skip_reason
-              ? (row.skip_reason as string)
-              : undefined,
-          };
+          const check = this.rowToCheckResult(row);
           const existing = result.get(pageUrl) ?? [];
           existing.push(check);
           result.set(pageUrl, existing);
@@ -3141,27 +3122,7 @@ export class SQLiteStorage implements CrawlStorage {
         const result = new Map<string, CheckResult[]>();
         for (const row of rows) {
           const ruleId = row.rule_id as string;
-          const pageUrl = row.page_url as string;
-          const check: CheckResult = {
-            name: row.check_name as string,
-            status: row.status as CheckResult["status"],
-            message: row.message as string,
-            value:
-              row.value !== null ? (row.value as string | number) : undefined,
-            expected:
-              row.expected !== null
-                ? (row.expected as string | number)
-                : undefined,
-            pageUrl: pageUrl || undefined,
-            items: row.items ? JSON.parse(row.items as string) : undefined,
-            details: row.details
-              ? JSON.parse(row.details as string)
-              : undefined,
-            pages: row.pages ? JSON.parse(row.pages as string) : undefined,
-            skipReason: row.skip_reason
-              ? (row.skip_reason as string)
-              : undefined,
-          };
+          const check = this.rowToCheckResult(row);
           const existing = result.get(ruleId) ?? [];
           existing.push(check);
           result.set(ruleId, existing);
@@ -3173,25 +3134,27 @@ export class SQLiteStorage implements CrawlStorage {
   }
 
   /**
-   * Both groupings of a crawl's rule results, from ONE read (#1920).
+   * Both groupings of a crawl's rule results, from ONE materialization (#1920).
    *
    * `getRuleResultsByPage` and `getRuleResultsByRuleId` differ only in their
-   * `ORDER BY`; every other line, including the CheckResult they build per row,
-   * is the same. The report path calls both, so a crawl's checks were read
-   * twice and materialized twice: at 1,000 pages that is 203,687 rows, 204 per
-   * page, and about 500 bytes of object per 55 bytes of data.
+   * `ORDER BY`; every other line, including the CheckResult built per row, is
+   * the same. The report path calls both, so a crawl's checks were read twice
+   * and materialized twice: at 1,000 pages that is 203,687 rows, 204 per page,
+   * and about 500 bytes of object per 55 bytes of data. Measured in isolation,
+   * the two reads grow RSS by 441 MB against 249 MB for this one.
    *
-   * Here the rows are read once and each CheckResult is SHARED by both maps, so
-   * the second grouping is two Maps of references rather than a second copy.
+   * ORDER COMES FROM SQLITE, not from a rule about ties. An earlier version of
+   * this read once `ORDER BY id` and grouped, having measured that both original
+   * queries returned their ties in `id` order. That was incidental to today's
+   * indexes: with an index on `(crawl_id, rule_id, page_url)` the per-rule query
+   * returns its ties in page_url order instead, and the emitted issue order
+   * changes with it. SQLite leaves tied `ORDER BY` rows unordered by contract.
    *
-   * The orders are preserved exactly. Measured on a 1,000-page crawl, both
-   * `ORDER BY page_url` and `ORDER BY rule_id` return their ties in `id` order
-   * (0 rows out of order across 203,687), and each is identical to the fully
-   * specified `ORDER BY <column>, id` — so reading in `id` order and grouping
-   * gives each map the within-key order it had. The KEY order comes from SQLite
-   * rather than from sorting in JS, because SQLite's BINARY collation compares
-   * UTF-8 bytes while JavaScript compares UTF-16 code units, and the two
-   * disagree on some non-ASCII urls.
+   * So the heavy work happens once and the ORDER is asked for twice, with the
+   * same `ORDER BY` each original used, reading only `id` and the grouping key.
+   * Those two extra queries carry integers and one short string per row instead
+   * of a parsed CheckResult, and the result is byte-identical to the readers
+   * this replaces under any index or query plan.
    */
   getRuleResultsGrouped(crawlId: string): Effect.Effect<
     {
@@ -3204,53 +3167,41 @@ export class SQLiteStorage implements CrawlStorage {
     return Effect.try({
       try: () => {
         const db = this.getDb();
-        const rows = db
-          .prepare(
-            "SELECT * FROM rule_results WHERE crawl_id = ? ORDER BY id"
-          )
-          .all(crawlId) as Record<string, unknown>[];
 
-        // Grouped in row order first; the maps are then rebuilt in the key order
-        // each caller used to get.
-        const pageGroups = new Map<string, CheckResult[]>();
-        const ruleGroups = new Map<string, CheckResult[]>();
-        for (const row of rows) {
-          const pageUrl = row.page_url as string;
-          const ruleId = row.rule_id as string;
-          const check = this.rowToCheckResult(row);
-          const pageList = pageGroups.get(pageUrl);
-          if (pageList) pageList.push(check);
-          else pageGroups.set(pageUrl, [check]);
-          const ruleList = ruleGroups.get(ruleId);
-          if (ruleList) ruleList.push(check);
-          else ruleGroups.set(ruleId, [check]);
+        // The one materialization. Keyed by row id so the ordering passes below
+        // can address a check without rebuilding it.
+        const byId = new Map<number, CheckResult>();
+        for (const row of db
+          .prepare("SELECT * FROM rule_results WHERE crawl_id = ?")
+          .all(crawlId) as Record<string, unknown>[]) {
+          byId.set(row.id as number, this.rowToCheckResult(row));
         }
 
-        const orderedKeys = (column: "page_url" | "rule_id"): string[] =>
-          (
-            db
-              .prepare(
-                `SELECT DISTINCT ${column} AS k FROM rule_results WHERE crawl_id = ? ORDER BY ${column}`
-              )
-              .all(crawlId) as Array<{ k: string }>
-          ).map((r) => r.k);
-
-        const inKeyOrder = (
-          groups: Map<string, CheckResult[]>,
-          keys: string[]
+        // `ORDER BY <column>` verbatim from the reader being replaced, so the
+        // sequence is whatever SQLite would have produced there.
+        const groupBy = (
+          column: "page_url" | "rule_id"
         ): Map<string, CheckResult[]> => {
+          const ordered = db
+            .prepare(
+              `SELECT id, ${column} AS k FROM rule_results WHERE crawl_id = ? ORDER BY ${column}`
+            )
+            .all(crawlId) as Array<{ id: number; k: string }>;
           const out = new Map<string, CheckResult[]>();
-          for (const key of keys) {
-            const list = groups.get(key);
-            if (list) out.set(key, list);
+          for (const { id, k } of ordered) {
+            const check = byId.get(id);
+            // Unreachable: both statements read the same rows in one connection.
+            // Skipping rather than asserting keeps a torn read from throwing in
+            // the report path, where the alternative is no report at all.
+            if (!check) continue;
+            const list = out.get(k);
+            if (list) list.push(check);
+            else out.set(k, [check]);
           }
           return out;
         };
 
-        return {
-          byPage: inKeyOrder(pageGroups, orderedKeys("page_url")),
-          byRuleId: inKeyOrder(ruleGroups, orderedKeys("rule_id")),
-        };
+        return { byPage: groupBy("page_url"), byRuleId: groupBy("rule_id") };
       },
       catch: (e) => StorageError.read(e),
     });

--- a/packages/crawler/tests/rule-results-grouped-parity.test.ts
+++ b/packages/crawler/tests/rule-results-grouped-parity.test.ts
@@ -1,0 +1,117 @@
+// #1920: `getRuleResultsGrouped` reads a crawl's rule results ONCE and hands the
+// same CheckResult objects to both groupings, replacing two full reads that
+// materialized every row twice.
+//
+// The whole value depends on it being indistinguishable from the two readers it
+// replaces — the per-rule grouping is what the report's `ruleResults` is built
+// from, and its check order is visible in the emitted `issues`. So this compares
+// the maps element by element, and it also pins the two properties the single
+// read relies on: that both `ORDER BY` clauses return their ties in `id` order,
+// and that the key order comes from SQLite rather than from a JS sort.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { CheckResult } from "../src/storage/types";
+import { SQLiteStorage } from "../src/storage/sqlite";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+async function storeWith(
+  rows: Array<{ page: string; rule: string; check: string }>
+): Promise<SQLiteStorage> {
+  const store = new SQLiteStorage(":memory:");
+  await run(store.init());
+  for (const row of rows) {
+    const check: CheckResult = {
+      name: row.check,
+      status: "pass",
+      message: `${row.rule} on ${row.page || "(site)"}`,
+      items: [{ id: `${row.page}#${row.check}` }],
+    };
+    await run(store.saveRuleResults("crawl-1", row.page, row.rule, [check]));
+  }
+  return store;
+}
+
+/** Rows written in an order that is neither page-sorted nor rule-sorted. */
+const ROWS = [
+  { page: "https://e.test/c", rule: "seo/title", check: "title-present" },
+  { page: "https://e.test/a", rule: "perf/ttfb", check: "ttfb" },
+  { page: "https://e.test/c", rule: "perf/ttfb", check: "ttfb" },
+  { page: "", rule: "crawl/sitemap-exists", check: "sitemap" },
+  { page: "https://e.test/b", rule: "seo/title", check: "title-present" },
+  { page: "https://e.test/a", rule: "seo/title", check: "title-present" },
+  { page: "https://e.test/b", rule: "a11y/lang", check: "html-lang" },
+  { page: "https://e.test/c", rule: "a11y/lang", check: "html-lang" },
+];
+
+describe("getRuleResultsGrouped", () => {
+  test("both maps match the readers it replaces, key order and check order", async () => {
+    const store = await storeWith(ROWS);
+
+    const byPage = await run(store.getRuleResultsByPage("crawl-1"));
+    const byRuleId = await run(store.getRuleResultsByRuleId("crawl-1"));
+    const grouped = await run(store.getRuleResultsGrouped("crawl-1"));
+
+    // Key order, not just key set: the report iterates these in insertion order.
+    expect([...grouped.byPage.keys()]).toEqual([...byPage.keys()]);
+    expect([...grouped.byRuleId.keys()]).toEqual([...byRuleId.keys()]);
+
+    // Value-identical, including the order of checks within each key.
+    expect(grouped.byPage).toEqual(byPage);
+    expect(grouped.byRuleId).toEqual(byRuleId);
+  });
+
+  test("the two maps SHARE their check objects rather than copying them", async () => {
+    const store = await storeWith(ROWS);
+    const grouped = await run(store.getRuleResultsGrouped("crawl-1"));
+
+    // This is the entire point: one allocation per row, referenced twice.
+    const fromPage = grouped.byPage.get("https://e.test/a")!.find(
+      (c) => c.name === "ttfb"
+    );
+    const fromRule = grouped.byRuleId
+      .get("perf/ttfb")!
+      .find((c) => c.pageUrl === "https://e.test/a");
+    expect(fromPage).toBeDefined();
+    expect(fromRule).toBe(fromPage!);
+  });
+
+  test("site-scope rows keep their empty page key", async () => {
+    const store = await storeWith(ROWS);
+    const grouped = await run(store.getRuleResultsGrouped("crawl-1"));
+    const byPage = await run(store.getRuleResultsByPage("crawl-1"));
+
+    // '' is the site-scope convention the report reads as `siteChecks`.
+    expect(grouped.byPage.has("")).toBe(true);
+    expect(grouped.byPage.get("")).toEqual(byPage.get("")!);
+    // pageUrl is undefined rather than "" on those checks.
+    expect(grouped.byPage.get("")![0]?.pageUrl).toBeUndefined();
+  });
+
+  test("an empty crawl yields two empty maps, not an error", async () => {
+    const store = new SQLiteStorage(":memory:");
+    await run(store.init());
+    const grouped = await run(store.getRuleResultsGrouped("nothing-here"));
+    expect(grouped.byPage.size).toBe(0);
+    expect(grouped.byRuleId.size).toBe(0);
+  });
+
+  test("rows of another crawl are not included", async () => {
+    const store = await storeWith(ROWS);
+    await run(
+      store.saveRuleResults("crawl-2", "https://e.test/z", "seo/title", [
+        { name: "title-present", status: "fail", message: "other crawl" },
+      ])
+    );
+
+    const grouped = await run(store.getRuleResultsGrouped("crawl-1"));
+    expect(grouped.byPage.has("https://e.test/z")).toBe(false);
+    for (const checks of grouped.byRuleId.values()) {
+      for (const check of checks) expect(check.message).not.toBe("other crawl");
+    }
+  });
+});

--- a/packages/crawler/tests/rule-results-grouped-parity.test.ts
+++ b/packages/crawler/tests/rule-results-grouped-parity.test.ts
@@ -92,6 +92,39 @@ describe("getRuleResultsGrouped", () => {
     expect(grouped.byPage.get("")![0]?.pageUrl).toBeUndefined();
   });
 
+  test("parity holds under an index that reorders the ties (#1920)", async () => {
+    // The version of this that read once ORDER BY id and grouped passed every
+    // other test here, because on today's schema both original queries happen to
+    // return their ties in id order. Add an index that makes the per-rule query
+    // walk in page_url order and the two disagree: a, m, z against z, a, m. That
+    // is the emitted issue order, so it has to come from SQLite rather than from
+    // an assumption about ties.
+    const store = await storeWith([
+      { page: "https://e.test/z", rule: "seo/title", check: "title-present" },
+      { page: "https://e.test/a", rule: "seo/title", check: "title-present" },
+      { page: "https://e.test/m", rule: "seo/title", check: "title-present" },
+    ]);
+    // Reaching into the connection deliberately: the point is a DIFFERENT query
+    // plan from the one the schema gives today.
+    (
+      store as unknown as { getDb(): { exec(sql: string): void } }
+    ).getDb().exec(
+      "CREATE INDEX IF NOT EXISTS idx_rr_probe ON rule_results (crawl_id, rule_id, page_url)"
+    );
+
+    const byRuleId = await run(store.getRuleResultsByRuleId("crawl-1"));
+    const grouped = await run(store.getRuleResultsGrouped("crawl-1"));
+
+    expect(grouped.byRuleId.get("seo/title")?.map((c) => c.pageUrl)).toEqual(
+      byRuleId.get("seo/title")!.map((c) => c.pageUrl)
+    );
+    expect(grouped.byRuleId).toEqual(byRuleId);
+
+    const byPage = await run(store.getRuleResultsByPage("crawl-1"));
+    expect([...grouped.byPage.keys()]).toEqual([...byPage.keys()]);
+    expect(grouped.byPage).toEqual(byPage);
+  });
+
   test("an empty crawl yields two empty maps, not an error", async () => {
     const store = new SQLiteStorage(":memory:");
     await run(store.init());


### PR DESCRIPTION
The contract-neutral part of squirrelscan/repo#1920. No behaviour change; the report is byte-identical.

## What was happening

`reconstructReport` called `getRuleResultsByPage` and then `getRuleResultsByRuleId`. Those two queries differ only in their `ORDER BY`, and each builds its own `CheckResult` per row, so a crawl's checks were read twice and materialized twice. At 1,000 pages that is 203,687 rows, 204 per page, for 11.3 MB of stored text.

`getRuleResultsGrouped` reads the rows once and shares one object between both maps.

## The measurement, and why it is not an end-to-end one

Isolated on a real 1,000-page crawl, alternating the two arms twice, growth across the call with a forced collection at each end:

| arm | RSS | external | wall |
| --- | --- | --- | --- |
| two reads | +341 to +368 MB | +40 MB | 542-890 ms |
| one materialization | +202 to +206 MB | +20 MB | 424-536 ms |

`heapUsed` moves by under 10 MB either way. That is the part worth knowing: the cost of the duplicate is allocator residency and string backing store, not JS heap objects, so the metric most people reach for cannot see it. Same class as the `SELECT *` link scan already in the benchmarks record.

An end-of-run `heapUsed` sample cannot judge this change at all. Four 2,500-page runs, two per side:

| run | exit heapUsed |
| --- | --- |
| before, run 1 | 599 MB |
| before, run 2 | 965 MB |
| after, run 1 | 1,144 MB |
| after, run 2 | 998 MB |

The spread within one side is wider than the difference between sides. So the honest end-to-end claim is only that nothing regressed: reports byte-identical, wall time and peak RSS unchanged within noise.

Added to `benchmarks/2026-09-perf-program.md`, including that last table, because "which measurement can resolve which size of change" is the thing this pass keeps re-learning.

## Why the orders are safe, and the mistake the review caught

The per-rule grouping becomes `report.ruleResults`, and its check order is visible in the emitted `issues`, so this had to preserve both orders exactly rather than approximately.

The first version got this wrong in an instructive way. I measured that both original queries return their ties in `id` order — 0 rows out of order across 203,687, each identical to `ORDER BY <column>, id` — and read once in `id` order and grouped. That was evidence about one schema, not about the queries. Add an index on `(crawl_id, rule_id, page_url)` and the per-rule query walks in page_url order instead: three `seo/title` checks on pages z, a, m come back a, m, z from the original reader and z, a, m from the derived one. SQLite leaves tied `ORDER BY` rows unordered by contract.

So the rows are materialized once and the ORDER is asked for twice, with the same `ORDER BY` each original reader used, reading only the row id and the grouping key. Byte-identical under any index or query plan rather than under this one. Deriving the order was faster; being right is worth the 150 ms.

The regression test creates that index and compares against the original reader. I checked it by mutation: the rejected implementation passes all five other tests in the file and fails only this one, which is exactly why it survived the first round.

The parity test also compares both maps element by element including key order, and asserts the two maps share their objects rather than copying them.

## Report parity

Byte-identical at 400 and 2,500 pages. The 1,000-page pair differs by 3 failed checks, all `perf/ttfb`, which grades the *test server's* response time and tripped while that run was being starved; the issue bodies are identical. Same artefact documented for #252.

Engine goldens (canonical-vs-streaming, streaming pre-rules, the 518-page baseline) and the CLI audit, report and controller suites are green.

## Not done here, deliberately

Scoring from the rules phase's tallies. It saves nothing while the rows are loaded for the report body anyway, and the smart-audit path scores over the union of fresh and carried findings, which the fresh-side tallies cannot express. That belongs with the decision about dropping the passing checks, which is on the issue with a recommendation.
