### PR TITLE
feat(cli): squirrel self disk --prune, to reclaim what old audits are holding

### DIFF
--- a/apps/cli/src/cli/commands/report.ts
+++ b/apps/cli/src/cli/commands/report.ts
@@ -87,6 +87,8 @@ function printAuditList(
       url: string;
       visibility: string;
     };
+    /** Set once `self disk --prune` reclaimed this audit's data (#1912). */
+    retiredAt?: number;
   }>
 ): void {
   if (audits.length === 0) {
@@ -111,15 +113,24 @@ function printAuditList(
     const pages = audit.stats.pagesTotal.toString();
     const id = audit.id.slice(0, 8);
     const published = audit.published?.visibility ?? "-";
+    // A reclaimed audit is still listed — that is the point of keeping the crawl
+    // row — but it cannot be opened, so the status column says so rather than
+    // leaving the user to find out by trying.
+    const status = audit.retiredAt === undefined ? audit.status : "retired";
 
     console.log(
       id.padEnd(11) +
         date.padEnd(22) +
         pages.padEnd(8) +
-        audit.status.padEnd(12) +
+        status.padEnd(12) +
         published
     );
     console.log(`  ${audit.baseUrl}`);
+    if (audit.retiredAt !== undefined) {
+      console.log(
+        `  data reclaimed on ${new Date(audit.retiredAt).toISOString().slice(0, 10)}; this audit can no longer be opened`
+      );
+    }
     if (audit.published) {
       console.log(`  → ${audit.published.url}`);
     }

--- a/apps/cli/src/cli/commands/self.ts
+++ b/apps/cli/src/cli/commands/self.ts
@@ -320,6 +320,127 @@ const selfDoctor = defineCommand({
   },
 });
 
+/**
+ * `self disk --prune --keep N`: retire audits beyond the newest N and give the
+ * space back (#1912).
+ *
+ * Deliberately awkward to fire by accident. `--keep` has no default because
+ * retiring a crawl makes its report unrenderable and `report --list`, `--diff`
+ * and `--regression-since` all reach into that history; the plan is printed and
+ * confirmed before anything is deleted; and `--dry-run` stops after printing.
+ */
+async function runPrune(
+  args: {
+    keep?: string;
+    project?: string;
+    "dry-run"?: boolean;
+    yes?: boolean;
+  },
+  deps: {
+    formatBytes: (bytes: number) => string;
+    planProjectPrune: typeof import("@/self/disk").planProjectPrune;
+    runProjectPrune: typeof import("@/self/disk").runProjectPrune;
+  }
+): Promise<void> {
+  const { formatBytes, planProjectPrune, runProjectPrune } = deps;
+  const { existsSync, readdirSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { getProjectsPath } = await import("@/self/paths");
+
+  // Whole-string match, not parseInt: `parseInt("1e3")` is 1, so `--keep 1e3
+  // --yes` would keep ONE audit and delete the rest of a user's history while
+  // reading as a request to keep a thousand. Same class as the batch-budget
+  // parser in audit/stream-batch.ts.
+  const raw = String(args.keep ?? "").trim();
+  const keep = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isSafeInteger(keep) || keep < 1) {
+    console.error(
+      "--prune needs --keep <n>, at least 1: the audits beyond the newest n stop being renderable,\n" +
+        "so there is no default that would be safe to guess."
+    );
+    process.exit(1);
+  }
+
+  const root = getProjectsPath();
+  const names = existsSync(root)
+    ? readdirSync(root, { withFileTypes: true, encoding: "utf8" })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .filter((n) => !args.project || n === args.project)
+        .sort()
+    : [];
+
+  if (args.project && names.length === 0) {
+    console.error(`No project directory named ${args.project} under ${root}`);
+    process.exit(1);
+  }
+
+  const plans = [];
+  for (const name of names) {
+    const plan = await planProjectPrune(join(root, name, "project.db"), keep);
+    if (plan) plans.push({ name, plan });
+  }
+
+  if (plans.length === 0) {
+    console.log(
+      `Nothing to retire: every project holds at most ${keep} audit(s).`
+    );
+    return;
+  }
+
+  const date = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+  console.log(`Keeping the newest ${keep} audit(s) per project.\n`);
+  let rows = 0;
+  for (const { name, plan } of plans) {
+    rows += plan.rows;
+    console.log(
+      `${name}  ${formatBytes(plan.bytesBefore)}  retiring ${plan.retiring.length} of ${
+        plan.retiring.length + plan.keeping
+      } audits`
+    );
+    for (const crawl of plan.retiring) {
+      console.log(`    ${date(crawl.startedAt)}  ${crawl.id.slice(0, 8)}`);
+    }
+  }
+  console.log(
+    `\n${rows.toLocaleString()} rows across ${plans.length} project(s). ` +
+      "Their reports stop being renderable; the audits stay listed."
+  );
+
+  if (args["dry-run"]) {
+    console.log("\nDry run: nothing was deleted.");
+    return;
+  }
+
+  if (!args.yes) {
+    const { createInterface } = await import("node:readline");
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    const answer = await new Promise<string>((resolve) => {
+      rl.question("\nRetire them? [y/N] ", resolve);
+    });
+    rl.close();
+    if (answer.trim().toLowerCase() !== "y") {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  let before = 0;
+  let after = 0;
+  for (const { name, plan } of plans) {
+    const result = await runProjectPrune(plan);
+    before += result.bytesBefore;
+    after += result.bytesAfter;
+    console.log(
+      `${name}: ${formatBytes(result.bytesBefore)} -> ${formatBytes(result.bytesAfter)}`
+    );
+  }
+  console.log(`\nReclaimed ${formatBytes(Math.max(0, before - after))}.`);
+}
+
 const selfDisk = defineCommand({
   meta: {
     name: "disk",
@@ -334,9 +455,36 @@ const selfDisk = defineCommand({
       type: "string",
       description: "Show at most this many projects (default 15)",
     },
+    prune: {
+      type: "boolean",
+      description:
+        "Retire audits beyond --keep and reclaim the space (requires --keep)",
+    },
+    keep: {
+      type: "string",
+      description:
+        "How many recent audits per project stay renderable. No default: this deletes report history, so it must be said out loud",
+    },
+    project: {
+      type: "string",
+      description: "Limit --prune to one project (its directory name)",
+    },
+    "dry-run": {
+      type: "boolean",
+      description: "With --prune, list what would go and stop",
+    },
+    yes: {
+      type: "boolean",
+      description: "Skip the confirmation prompt",
+    },
   },
   async run({ args }) {
-    const { collectDiskUsage, formatBytes } = await import("@/self/disk");
+    const { collectDiskUsage, formatBytes, planProjectPrune, runProjectPrune } =
+      await import("@/self/disk");
+
+    if (args.prune) {
+      return runPrune(args, { formatBytes, planProjectPrune, runProjectPrune });
+    }
 
     const result = collectDiskUsage();
     if (!result.ok) {

--- a/apps/cli/src/controllers/analyze.ts
+++ b/apps/cli/src/controllers/analyze.ts
@@ -23,6 +23,7 @@ import {
   ErrorCodes,
 } from "@/controllers/types";
 import { createStorage } from "@/crawler/storage";
+import { retiredAuditReason } from "@/reports/retired";
 import { getProjectsPath } from "@/self/paths";
 import { configureLogger, logger } from "@/utils/logger";
 
@@ -71,6 +72,11 @@ export function pickLatestAnalyzeReadyCrawl(
 
   for (const crawl of crawls) {
     if (!isAnalyzeReadyStatus(crawl.status)) continue;
+    // A reclaimed audit keeps its `completed`/`analyzed` status (#1912), so a
+    // status-only test picks one and analyze happily re-runs the rules over
+    // whatever pages survived the prune, reporting "Analysis complete" for a
+    // crawl most of whose data is gone.
+    if (crawl.retiredAt !== undefined) continue;
     if (!best || crawl.startedAt > best.startedAt) {
       best = crawl;
     }
@@ -239,6 +245,18 @@ export async function runAnalyze(
     if (!crawl) {
       return err(
         commandError(ErrorCodes.CRAWL_NOT_FOUND, `Crawl not found: ${crawlId}`)
+      );
+    }
+
+    // Same reason as the selector above: retirement does not change the status,
+    // so this has to be its own test or `analyze <id>` re-analyzes reclaimed
+    // data and calls it a success.
+    if (crawl.retiredAt !== undefined) {
+      return err(
+        commandError(
+          ErrorCodes.CRAWL_NOT_READY,
+          `Crawl ${retiredAuditReason(crawl.retiredAt)}: ${crawlId}`
+        )
       );
     }
 

--- a/apps/cli/src/controllers/report.ts
+++ b/apps/cli/src/controllers/report.ts
@@ -32,6 +32,7 @@ import {
 import { getGlobalContentStore } from "@/crawler/storage/content-store";
 import { SQLiteStorage } from "@/crawler/storage/sqlite";
 import { reconstructReport } from "@/reports/reconstruct";
+import { retiredAuditReason } from "@/reports/retired";
 import { isValidCategory, normalizeCategoryCode } from "@/rules/categories";
 import { getProjectsPath } from "@/self/paths";
 import {
@@ -47,6 +48,32 @@ const REPORT_READY_STATUSES = new Set<CrawlStatus>(["analyzed", "completed"]);
 
 export function isReportReadyStatus(status: CrawlStatus): boolean {
   return REPORT_READY_STATUSES.has(status);
+}
+
+/**
+ * Whether this audit can still be rendered (#1912).
+ *
+ * Takes the CRAWL rather than its status on purpose. `self disk --prune`
+ * reclaims an audit's derived rows and leaves the crawl row saying `completed`,
+ * so a status-only check reads a retired audit as renderable and the report path
+ * rebuilds a confident EMPTY report from whatever pages survive. Every gate that
+ * used to test the status now tests this, so a future one cannot quietly miss
+ * the retired case.
+ */
+export function isReportRenderable(crawl: {
+  status: CrawlStatus;
+  retiredAt?: number;
+}): boolean {
+  return isReportReadyStatus(crawl.status) && crawl.retiredAt === undefined;
+}
+
+/** Why {@link isReportRenderable} said no, in the words the user should see. */
+export function reportUnavailableReason(crawl: {
+  status: CrawlStatus;
+  retiredAt?: number;
+}): string {
+  if (crawl.retiredAt !== undefined) return retiredAuditReason(crawl.retiredAt);
+  return getReportNotReadyReason(crawl.status);
 }
 
 export function getReportNotReadyReason(status: CrawlStatus): string {
@@ -393,11 +420,11 @@ export async function getStoredAudit(
         continue;
       }
 
-      if (!isReportReadyStatus(crawl.status)) {
+      if (!isReportRenderable(crawl)) {
         return err(
           commandError(
             ErrorCodes.CRAWL_NOT_READY,
-            `Audit ${getReportNotReadyReason(crawl.status)}: ${auditId}`
+            `Audit ${reportUnavailableReason(crawl)}: ${auditId}`
           )
         );
       }
@@ -494,11 +521,11 @@ export async function getStoredAuditByPrefix(
 
   // Exactly one match - reconstruct report
   const match = allMatches[0];
-  if (!isReportReadyStatus(match.crawl.status)) {
+  if (!isReportRenderable(match.crawl)) {
     return err(
       commandError(
         ErrorCodes.CRAWL_NOT_READY,
-        `Audit ${getReportNotReadyReason(match.crawl.status)}: ${match.crawl.id}`
+        `Audit ${reportUnavailableReason(match.crawl)}: ${match.crawl.id}`
       )
     );
   }
@@ -611,9 +638,10 @@ export async function getLatestAudit(
       );
     }
 
-    const reportReady = filtered.filter((c) =>
-      isReportReadyStatus(c.crawl.status)
-    );
+    // A retired audit is not a candidate baseline: --diff and
+    // --regression-since resolve through here, and reclaimed data cannot be
+    // compared against.
+    const reportReady = filtered.filter((c) => isReportRenderable(c.crawl));
     if (reportReady.length === 0) {
       const pending = filtered.find(
         (c) => c.crawl.status === "running" || c.crawl.status === "paused"

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -23,6 +23,7 @@ import {
   deriveAuditStatusFromPages,
 } from "@/audit/scoring";
 import { tagCarriedCheck } from "@/audit/smart-audits";
+import { retiredAuditReason } from "@/reports/retired";
 import { OTHER_CATEGORY } from "@/rules/categories";
 import { normalizeUrl } from "@/utils/url";
 
@@ -155,6 +156,17 @@ export function reconstructReport(
     const crawl = yield* storage.getCrawl(crawlId);
     if (!crawl) {
       return yield* Effect.fail(new Error(`Crawl not found: ${crawlId}`));
+    }
+
+    // `self disk --prune` reclaimed this audit's rule results (#1912). The pages
+    // and the crawl row survive, so without this the walk below would assemble a
+    // confident report with no findings at all — a wrong answer rather than a
+    // missing one. Refused here, at the bottom of every render path, so a caller
+    // that forgets the gate above still cannot produce one.
+    if (crawl.retiredAt !== undefined) {
+      return yield* Effect.fail(
+        new Error(`Audit ${retiredAuditReason(crawl.retiredAt)}: ${crawlId}`)
+      );
     }
 
     // 2. The crawl's pages are read in batches further down, not here (#1913).

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -408,6 +408,21 @@ export function reconstructReport(
       sitemaps.missingPages = coverage.missingPages;
     }
 
+    // Re-read the stamp AFTER every page and rule-result read. The check above
+    // happens once, outside any read transaction, so a `self disk --prune` in
+    // another process can commit between it and the reads below — and this
+    // function would then combine pre-retirement metadata with data that is
+    // already gone and return a confident empty report, which is the exact
+    // outcome the first check exists to prevent.
+    const stillThere = yield* storage.getCrawl(crawlId);
+    if (stillThere?.retiredAt !== undefined) {
+      return yield* Effect.fail(
+        new Error(
+          `Audit ${retiredAuditReason(stillThere.retiredAt)}: ${crawlId}`
+        )
+      );
+    }
+
     // 9. Calculate totals from rule results
     const allChecks: CheckResult[] = Array.from(
       ruleResultsByPage.values()

--- a/apps/cli/src/reports/retired.ts
+++ b/apps/cli/src/reports/retired.ts
@@ -1,0 +1,15 @@
+// The wording for an audit whose data `self disk --prune` reclaimed (#1912).
+//
+// Its own module because both ends of the render path need it: the CLI gates in
+// `controllers/report.ts` and the structural refusal in `reports/reconstruct.ts`,
+// which that controller imports. Putting it in either one makes an import cycle.
+
+/**
+ * Why a reclaimed audit cannot be opened, phrased to slot after "Audit ".
+ *
+ * One definition so the sentence is identical wherever a user meets it — the
+ * gate, the diff, the baseline resolver and the report builder.
+ */
+export function retiredAuditReason(retiredAt: number): string {
+  return `data was reclaimed on ${new Date(retiredAt).toISOString().slice(0, 10)}`;
+}

--- a/apps/cli/src/self/disk.ts
+++ b/apps/cli/src/self/disk.ts
@@ -241,3 +241,103 @@ export function formatBytes(bytes: number): string {
   }
   return `${value >= 100 ? value.toFixed(0) : value.toFixed(1)} ${units[unit]}`;
 }
+
+// ── Reclaiming (#1912) ──────────────────────────────────────────────────────
+//
+// Explicit and user-driven. There is no automatic retention: retiring a crawl
+// makes its report unrenderable, and `report --list`, `--diff` and
+// `--regression-since <audit-id>` all reach back into that history, so how many
+// audits a project should keep is a product decision rather than a default this
+// code gets to pick. The window is a required argument here for that reason.
+
+/** What retiring would remove from one project. */
+export interface ProjectPrunePlan {
+  readonly name: string;
+  readonly path: string;
+  /** Audits that would stop being renderable, oldest first. */
+  readonly retiring: ReadonlyArray<{ id: string; startedAt: number }>;
+  /** Audits that stay fully renderable. */
+  readonly keeping: number;
+  readonly rows: number;
+  /** File size before, so the caller can report what was actually returned. */
+  readonly bytesBefore: number;
+}
+
+/**
+ * Plan the retirement of every audit outside the newest `keep` for one project.
+ *
+ * Reads only. The counts come from the same predicate the delete uses, because
+ * a user confirms on these numbers.
+ */
+export async function planProjectPrune(
+  dbPath: string,
+  keep: number
+): Promise<ProjectPrunePlan | null> {
+  if (!existsSync(dbPath)) return null;
+  const { SQLiteStorage } = await import("@/crawler/storage/sqlite");
+  const { Effect } = await import("effect");
+
+  const storage = new SQLiteStorage(dbPath);
+  try {
+    await Effect.runPromise(storage.init());
+    const crawls = await Effect.runPromise(storage.listCrawls());
+    // listCrawls is newest first; everything past the window retires.
+    const retiring = crawls.slice(Math.max(0, keep)).map((c) => ({
+      id: c.id,
+      startedAt: c.startedAt,
+    }));
+    if (retiring.length === 0) return null;
+
+    const preview = await Effect.runPromise(
+      storage.previewRetireCrawls(retiring.map((c) => c.id))
+    );
+    if (preview.totalRows === 0) return null;
+
+    return {
+      name: dbPath,
+      path: dbPath,
+      retiring: [...retiring].reverse(),
+      keeping: crawls.length - retiring.length,
+      rows: preview.totalRows,
+      bytesBefore: dbFamilyBytes(dbPath),
+    };
+  } finally {
+    // close() is a lazy Effect; calling it without running it leaves the
+    // connection, and its -wal, open.
+    await Effect.runPromise(storage.close());
+  }
+}
+
+/**
+ * Carry out a plan: retire the crawls, then rebuild the file so the space
+ * actually returns to the filesystem.
+ *
+ * VACUUM is here rather than inside `retireCrawls` because it rewrites the
+ * whole database. That is fine once, on request, and would be a serious
+ * regression if it ever ran as part of an audit.
+ */
+export async function runProjectPrune(
+  plan: ProjectPrunePlan
+): Promise<{ rows: number; bytesBefore: number; bytesAfter: number }> {
+  const { SQLiteStorage } = await import("@/crawler/storage/sqlite");
+  const { Effect } = await import("effect");
+
+  const storage = new SQLiteStorage(plan.path);
+  let rows = 0;
+  try {
+    await Effect.runPromise(storage.init());
+    rows = await Effect.runPromise(
+      storage.retireCrawls(plan.retiring.map((c) => c.id))
+    );
+    await Effect.runPromise(storage.vacuum());
+  } finally {
+    await Effect.runPromise(storage.close());
+  }
+  // Measured AFTER the connection closes. With it open the `-wal` still holds
+  // the rewrite and the family reads larger than it started.
+  return {
+    rows,
+    bytesBefore: plan.bytesBefore,
+    bytesAfter: dbFamilyBytes(plan.path),
+  };
+}

--- a/apps/cli/tests/reports/retired-audit.test.ts
+++ b/apps/cli/tests/reports/retired-audit.test.ts
@@ -11,6 +11,7 @@ import { Effect } from "effect";
 
 import type { CrawlMetadata, PageRecord } from "@/crawler/storage/types";
 
+import { pickLatestAnalyzeReadyCrawl } from "@/controllers/analyze";
 import {
   isReportRenderable,
   reportUnavailableReason,
@@ -171,6 +172,53 @@ describe("a reclaimed audit refuses to render (#1912)", () => {
     const crawl = (await run(store.getCrawl(id)))!;
     expect(isReportRenderable(crawl)).toBe(false);
     expect(reportUnavailableReason(crawl)).toBe("still in progress");
+    await run(store.close());
+  });
+
+  test("a prune that commits mid-read is still refused", async () => {
+    // The metadata check happens once, before the page and rule-result reads.
+    // Another process pruning in that window would otherwise let this return a
+    // confident empty report built from pre-retirement metadata.
+    const { store, old } = await twoAudits();
+
+    let retired = false;
+    const realGetPages = store.getPages.bind(store);
+    (store as unknown as { getPages: typeof store.getPages }).getPages = ((
+      ...args: Parameters<typeof realGetPages>
+    ) => {
+      if (!retired) {
+        retired = true;
+        Effect.runSync(
+          Effect.orDie(store.retireCrawls([old], 1_700_000_000_000))
+        );
+      }
+      return realGetPages(...args);
+    }) as typeof store.getPages;
+
+    const result = await Effect.runPromise(
+      Effect.either(reconstructReport(store, old, undefined))
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left.message).toContain("data was reclaimed on");
+    }
+    await run(store.close());
+  });
+
+  test("analyze refuses a reclaimed audit rather than re-scoring it", async () => {
+    // `analyze` keeps its own status gate, and retirement does not change the
+    // status, so without its own test this path re-runs the rules over whatever
+    // pages survived and reports "Analysis complete".
+    const { store, old, recent } = await twoAudits();
+    await run(store.retireCrawls([old], 1_700_000_000_000));
+
+    const crawls = await run(store.listCrawls());
+    const retired = crawls.find((c) => c.id === old)!;
+    const kept = crawls.find((c) => c.id === recent)!;
+
+    expect(pickLatestAnalyzeReadyCrawl([retired])).toBeNull();
+    // And it is not simply skipping everything: the kept audit is still chosen.
+    expect(pickLatestAnalyzeReadyCrawl([retired, kept])?.id).toBe(recent);
     await run(store.close());
   });
 

--- a/apps/cli/tests/reports/retired-audit.test.ts
+++ b/apps/cli/tests/reports/retired-audit.test.ts
@@ -1,0 +1,182 @@
+// A reclaimed audit must refuse to render rather than render nothing (#1912).
+//
+// `self disk --prune` deletes a crawl's rule results and leaves its crawl row
+// and some of its pages. Without a retirement stamp the report path finds a
+// `completed` crawl, reads zero checks, and assembles a confident report with no
+// findings — which reads as "this audit was clean". That is a wrong answer, and
+// it is worse than the disk it saved, so every render path has to refuse.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { CrawlMetadata, PageRecord } from "@/crawler/storage/types";
+
+import {
+  isReportRenderable,
+  reportUnavailableReason,
+} from "@/controllers/report";
+import { SQLiteStorage } from "@/crawler/storage/sqlite";
+import { reconstructReport } from "@/reports/reconstruct";
+import { retiredAuditReason } from "@/reports/retired";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const STATS = {
+  pagesTotal: 1,
+  pagesFetched: 1,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+function page(url: string): PageRecord {
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: 20,
+    loadTimeMs: 1,
+    fetchedAt: 1_000,
+    etag: null,
+    lastModified: null,
+    contentHash: "h",
+    html: "<html><head><title>t</title></head><body>b</body></html>",
+    parsedData: null,
+    headers: {
+      contentType: "text/html",
+      contentEncoding: null,
+      cacheControl: null,
+      vary: null,
+      etag: null,
+      server: null,
+      lastModified: null,
+      link: null,
+      serverTiming: null,
+      age: null,
+      xCache: null,
+      cfCacheStatus: null,
+      xVercelCache: null,
+      altSvc: null,
+      acceptRanges: null,
+    },
+    securityHeaders: {
+      hsts: null,
+      csp: null,
+      xFrameOptions: null,
+      xContentTypeOptions: null,
+      referrerPolicy: null,
+      permissionsPolicy: null,
+      xRobotsTag: null,
+    },
+  } as PageRecord;
+}
+
+/** Two audits of the same page; the older one is then reclaimed. */
+async function twoAudits(): Promise<{
+  store: SQLiteStorage;
+  old: string;
+  recent: string;
+}> {
+  const store = new SQLiteStorage(":memory:");
+  await run(store.init());
+  const make = async (startedAt: number): Promise<string> => {
+    const id = await run(
+      store.createCrawl({
+        baseUrl: "https://e.test",
+        startedAt,
+        status: "completed",
+        config: {} as CrawlMetadata["config"],
+        stats: STATS,
+      } as Omit<CrawlMetadata, "id">)
+    );
+    await run(store.upsertPage(id, page("https://e.test/a")));
+    await run(
+      store.saveRuleResults(id, "https://e.test/a", "seo/title", [
+        { name: "title-present", status: "fail", message: "no title" },
+      ])
+    );
+    return id;
+  };
+  const old = await make(1_000);
+  const recent = await make(2_000);
+  return { store, old, recent };
+}
+
+describe("a reclaimed audit refuses to render (#1912)", () => {
+  test("reconstructReport fails instead of building an empty report", async () => {
+    const { store, old } = await twoAudits();
+    await run(store.retireCrawls([old], 1_700_000_000_000));
+
+    // The dangerous outcome is a RESOLVED promise carrying a clean report.
+    const result = await Effect.runPromise(
+      Effect.either(reconstructReport(store, old, undefined))
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left.message).toContain("data was reclaimed on 2023-11-14");
+      expect(result.left.message).toContain(old);
+    }
+    await run(store.close());
+  });
+
+  test("the audit that was kept still renders", async () => {
+    const { store, old, recent } = await twoAudits();
+    await run(store.retireCrawls([old], 1_700_000_000_000));
+
+    const report = await run(reconstructReport(store, recent, undefined));
+    expect(report.pages.length).toBeGreaterThan(0);
+    await run(store.close());
+  });
+
+  test("the gate every CLI path shares refuses it, with the same words", async () => {
+    const { store, old, recent } = await twoAudits();
+    await run(store.retireCrawls([old], 1_700_000_000_000));
+
+    const byId = new Map((await run(store.listCrawls())).map((c) => [c.id, c]));
+    const retired = byId.get(old)!;
+    const kept = byId.get(recent)!;
+
+    // `report <id>`, `--diff` and `--regression-since` all resolve through this,
+    // so one check covers the three of them.
+    expect(isReportRenderable(retired)).toBe(false);
+    expect(isReportRenderable(kept)).toBe(true);
+    expect(reportUnavailableReason(retired)).toBe(
+      retiredAuditReason(1_700_000_000_000)
+    );
+    await run(store.close());
+  });
+
+  test("a not-yet-analyzed audit keeps its own reason", async () => {
+    // Retirement must not swallow the pre-existing readiness messages.
+    const store = new SQLiteStorage(":memory:");
+    await run(store.init());
+    const id = await run(
+      store.createCrawl({
+        baseUrl: "https://e.test",
+        startedAt: 1_000,
+        status: "running",
+        config: {} as CrawlMetadata["config"],
+        stats: STATS,
+      } as Omit<CrawlMetadata, "id">)
+    );
+    const crawl = (await run(store.getCrawl(id)))!;
+    expect(isReportRenderable(crawl)).toBe(false);
+    expect(reportUnavailableReason(crawl)).toBe("still in progress");
+    await run(store.close());
+  });
+
+  test("the date is the day the data was reclaimed", () => {
+    expect(retiredAuditReason(Date.UTC(2026, 8, 8))).toBe(
+      "data was reclaimed on 2026-09-08"
+    );
+  });
+});

--- a/apps/cli/tests/self/disk-prune.test.ts
+++ b/apps/cli/tests/self/disk-prune.test.ts
@@ -1,0 +1,189 @@
+// #1912: `self disk --prune` is the only thing in the CLI that deletes a user's
+// audit history, so the parts that matter are the guards, not the deletion.
+//
+// The plan a user confirms on must be the real number, a dry run must leave the
+// file untouched, and the reclaim must not take the conditional-GET cache the
+// next crawl reads — losing that would cost far more than the disk it saved.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { CrawlMetadata, PageRecord } from "@/crawler/storage/types";
+
+import { SQLiteStorage } from "@/crawler/storage/sqlite";
+
+import { planProjectPrune, runProjectPrune } from "../../src/self/disk";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+let dir: string;
+let dbPath: string;
+
+const STATS = {
+  pagesTotal: 0,
+  pagesFetched: 0,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+function page(url: string, fetchedAt: number, etag: string): PageRecord {
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: 10,
+    loadTimeMs: 1,
+    fetchedAt,
+    etag,
+    lastModified: null,
+    contentHash: etag,
+    html: "<html></html>",
+    parsedData: null,
+    headers: {
+      contentType: "text/html",
+      contentEncoding: null,
+      cacheControl: null,
+      vary: null,
+      etag,
+      server: null,
+      lastModified: null,
+      link: null,
+      serverTiming: null,
+      age: null,
+      xCache: null,
+      cfCacheStatus: null,
+      xVercelCache: null,
+      altSvc: null,
+      acceptRanges: null,
+    },
+    securityHeaders: {
+      hsts: null,
+      csp: null,
+      xFrameOptions: null,
+      xContentTypeOptions: null,
+      referrerPolicy: null,
+      permissionsPolicy: null,
+      xRobotsTag: null,
+    },
+  } as PageRecord;
+}
+
+/** `audits` crawls of the same 3-page site, oldest first. */
+async function project(audits: number): Promise<void> {
+  const store = new SQLiteStorage(dbPath);
+  await run(store.init());
+  for (let i = 0; i < audits; i++) {
+    const id = await run(
+      store.createCrawl({
+        baseUrl: "https://e.test",
+        startedAt: 1_000 + i,
+        status: "completed",
+        config: {} as CrawlMetadata["config"],
+        stats: STATS,
+      } as Omit<CrawlMetadata, "id">)
+    );
+    for (const path of ["/a", "/b", "/c"]) {
+      const url = `https://e.test${path}`;
+      await run(store.upsertPage(id, page(url, 1_000 + i, `v${i}`)));
+      await run(
+        store.saveRuleResults(id, url, "seo/title", [
+          { name: "title-present", status: "pass", message: "m" },
+        ])
+      );
+    }
+  }
+  store.close?.();
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "sq-prune-"));
+  mkdirSync(join(dir, "proj"), { recursive: true });
+  dbPath = join(dir, "proj", "project.db");
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("planProjectPrune", () => {
+  test("nothing to plan when the project holds no more than the window", async () => {
+    await project(2);
+    expect(await planProjectPrune(dbPath, 2)).toBeNull();
+    expect(await planProjectPrune(dbPath, 5)).toBeNull();
+  });
+
+  test("plans the audits outside the window, oldest first", async () => {
+    await project(4);
+    const plan = await planProjectPrune(dbPath, 2);
+    expect(plan).not.toBeNull();
+    expect(plan!.retiring).toHaveLength(2);
+    expect(plan!.keeping).toBe(2);
+    // Oldest first, so the listing reads chronologically.
+    expect(plan!.retiring[0]!.startedAt).toBeLessThan(
+      plan!.retiring[1]!.startedAt
+    );
+    expect(plan!.rows).toBeGreaterThan(0);
+  });
+
+  test("a missing database is not an error", async () => {
+    expect(
+      await planProjectPrune(join(dir, "nope", "project.db"), 1)
+    ).toBeNull();
+  });
+
+  test("planning deletes nothing", async () => {
+    await project(3);
+    const before = statSync(dbPath).size;
+    await planProjectPrune(dbPath, 1);
+    expect(statSync(dbPath).size).toBe(before);
+
+    const store = new SQLiteStorage(dbPath);
+    await run(store.init());
+    expect((await run(store.listCrawls())).length).toBe(3);
+    store.close?.();
+  });
+});
+
+describe("runProjectPrune", () => {
+  test("retires the planned audits and returns the space", async () => {
+    await project(4);
+    const plan = (await planProjectPrune(dbPath, 1))!;
+    const result = await runProjectPrune(plan);
+
+    // The count a user confirmed on is the count that was deleted.
+    expect(result.rows).toBe(plan.rows);
+    // VACUUM plus a WAL checkpoint, so the saving is on the filesystem rather
+    // than moved into the -wal beside it.
+    expect(result.bytesAfter).toBeLessThan(result.bytesBefore);
+  });
+
+  test("keeps the newest page per url, so the next crawl still has its cache", async () => {
+    await project(4);
+    await runProjectPrune((await planProjectPrune(dbPath, 1))!);
+
+    const store = new SQLiteStorage(dbPath);
+    await run(store.init());
+    for (const path of ["/a", "/b", "/c"]) {
+      const cached = await run(store.getCachedPage(`https://e.test${path}`));
+      // v3 is the newest audit's etag; anything older means a cold re-crawl.
+      expect(cached?.etag).toBe("v3");
+    }
+    // The kept audit is still fully renderable.
+    const crawls = await run(store.listCrawls());
+    expect((await run(store.getRuleResultsByPage(crawls[0]!.id))).size).toBe(3);
+    // And every audit is still listed.
+    expect(crawls).toHaveLength(4);
+    store.close?.();
+  });
+});

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -496,6 +496,42 @@ runtime grows to under this path's churn, so the price is a multiple of their ow
 size. And the read and write batches were quartered (1,000 to 250 rows, 500 to 200)
 for ~15 MiB, because a batch's cost is the graph the driver builds around it, not
 the rows.
+## Disk: a project keeps every audit it has ever run
+
+Re-auditing writes a new crawl and retires nothing, so `project.db` grows by
+about one audit each time: 95 MB after one audit of a 1,000-page site, 189 MB
+after two, 215 MB after three. Where it goes, for two audits of that site:
+
+| object | size | share |
+|---|---|---|
+| `rule_results` | 79.8 MB | 42.1% |
+| `pages` | 53.3 MB | 28.2% |
+| `idx_rule_results_page` | 31.9 MB | 16.9% |
+| `idx_rule_results_crawl` | 20.0 MB | 10.6% |
+| everything else | ~4 MB | ~2% |
+
+`squirrel self disk` reports this
+([#256](https://github.com/squirrelscan/squirrelscan/pull/256)) and
+`--prune --keep N` reclaims it
+([#259](https://github.com/squirrelscan/squirrelscan/pull/259), still a draft).
+Measured on two audits of a 60-page site, keeping one:
+
+| measurement | before | after |
+|---|---|---|
+| `project.db` | 11.5 MB | 5.7 MB |
+| page rows for the retired crawl | 60 | 0 |
+| next audit's pages fetched | | 0 of 60, all unchanged |
+
+That last row is the one that matters: the reclaim keeps the newest page record
+per url, so an incremental re-audit still serves every page from its conditional
+GET rather than refetching the site. Retention is not automatic; how many audits
+to keep is squirrelscan/repo#1912.
+
+A trap worth recording: `VACUUM` alone made the file BIGGER, 189 MB to 239 MB.
+In WAL mode the rewrite lands in the write-ahead log, so the main file shrinks
+while the `-wal` beside it grows by more than was saved. `PRAGMA
+wal_checkpoint(TRUNCATE)` after the vacuum, and measuring after the connection
+actually closes, is what makes the saving real.
 
 ## Still open
 

--- a/docs/cli/report.mdx
+++ b/docs/cli/report.mdx
@@ -306,6 +306,29 @@ Filter reports by these categories:
 - `eeat` - E-E-A-T signals
 - `blocking` - Ad-blocker & privacy-filter impact (`adblock` still accepted)
 
+## Retired audits
+
+An audit whose data was reclaimed by [`squirrel self disk --prune`](/cli/self#disk)
+can no longer be opened. `--list` still shows it, marked `retired` with the date
+its data went, so the history does not silently shrink:
+
+```text
+06148d76   8 Sep 2026, 10:49   1    retired     -
+  https://example.com
+  data reclaimed on 2026-09-08; this audit can no longer be opened
+```
+
+Opening it, using it with `--diff`, or naming it as a `--regression-since`
+baseline all refuse:
+
+```text
+Audit data was reclaimed on 2026-09-08: 06148d76-6c48-465a-bc16-deb44144350d
+```
+
+The refusal is the point. The crawl row and some of its pages survive a prune, so
+without it the report would rebuild from those and show an audit with no findings
+at all, which reads as a clean result rather than a missing one.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/cli/self.mdx
+++ b/docs/cli/self.mdx
@@ -355,6 +355,17 @@ sub-resource records, the links and images (a reused page copies those forward
 from whichever crawl last saw them), and the `crawls` row itself, so the audit is
 still listed.
 
+A retired audit is marked as such and says when its data went:
+
+```text
+06148d76   8 Sep 2026, 10:49   1    retired     -
+  https://example.com
+  data reclaimed on 2026-09-08; this audit can no longer be opened
+```
+
+Opening it, diffing against it, or using it as a `--regression-since` baseline
+all refuse with the same sentence rather than rendering an empty report.
+
 Measured on two audits of a 60-page site: 11.5 MB to 5.7 MB, and the next audit
 still reported every page unchanged rather than refetching it.
 

--- a/docs/cli/self.mdx
+++ b/docs/cli/self.mdx
@@ -307,10 +307,60 @@ been pointed inside a project directory is counted once, against that directory.
 | `--json` | Emit the usage as JSON, for scripting |
 | `--limit <n>` | Show at most this many projects (default 15) |
 
+Reporting opens each project database read-only, and the command is excluded
+from the usual startup maintenance, so running it will not rotate the logs it is
+about to measure.
+
+### Reclaiming space
+
+`--prune` retires the audits beyond the newest `--keep`, then rebuilds the
+database so the space returns to the filesystem.
+
+```bash
+squirrel self disk --prune --keep 3 --dry-run
+squirrel self disk --prune --keep 3
+```
+
+`--keep` is required and has no default. A retired audit's report can no longer
+be rendered, and `report --list`, `report --diff` and `report --regression-since`
+all reach back into that history, so how many audits to keep is your call rather
+than a number this command picks for you.
+
+The plan is printed and confirmed before anything is deleted:
+
+```text
+Keeping the newest 1 audit(s) per project.
+
+acme-docs  11.5 MB  retiring 1 of 2 audits
+    2026-09-07  6a1b45df
+
+12,635 rows across 1 project(s). Their reports stop being renderable; the audits stay listed.
+
+Retire them? [y/N]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--prune` | Retire audits beyond `--keep` and reclaim the space |
+| `--keep <n>` | How many recent audits per project stay renderable. Required |
+| `--project <name>` | Limit the prune to one project directory |
+| `--dry-run` | List what would go and stop |
+| `--yes` | Skip the confirmation prompt |
+
+What retiring removes is a crawl's rule results, sitemaps, page features and
+frontier, plus the page rows a newer audit already supersedes. What it keeps is
+everything the next audit reads: the newest page record per URL (so an
+incremental re-crawl still gets its `ETag` rather than refetching the site), the
+sub-resource records, the links and images (a reused page copies those forward
+from whichever crawl last saw them), and the `crawls` row itself, so the audit is
+still listed.
+
+Measured on two audits of a 60-page site: 11.5 MB to 5.7 MB, and the next audit
+still reported every page unchanged rather than refetching it.
+
 <Note>
-This command does not delete an audit or reclaim any space, and it opens each
-project database read-only. It is also excluded from the usual startup
-maintenance, so running it will not rotate the logs it is about to measure.
+Retiring is the only thing in the CLI that deletes audit history. It never runs
+on its own; an audit will not prune anything.
 </Note>
 
 ---

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -255,6 +255,15 @@ export interface CrawlMetadata {
   status: CrawlStatus;
   config: CrawlerConfigSnapshot;
   stats: CrawlStats;
+  /**
+   * When `squirrel self disk --prune` reclaimed this audit's derived data
+   * (#1912). Absent for every audit that has not been reclaimed.
+   *
+   * The audit is still listed, and its crawl row and page cache remain, but its
+   * report can no longer be rebuilt: the rule results it was assembled from are
+   * gone. Read this before rendering, diffing or using it as a baseline.
+   */
+  retiredAt?: number;
 }
 
 export interface CrawlerConfigSnapshot {

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -3255,6 +3255,191 @@ export class SQLiteStorage implements CrawlStorage {
     };
   }
 
+  /**
+   * Tables holding a crawl's DERIVED output — everything that can be recomputed
+   * by auditing again, and nothing another crawl reads (#1912).
+   *
+   * Deliberately excluded, and why:
+   *  - `pages`, handled separately below: the newest row per url is the
+   *    conditional-GET cache the next crawl reads.
+   *  - `resource_sizes`: `getCachedResources` takes the most recent per
+   *    (type, url) across OTHER crawls, so a retired crawl's rows may still be
+   *    the freshest sub-resource record anyone has (#107). Small, and load-bearing.
+   *  - `published_reports`: the record that this crawl was published. Not
+   *    recomputable, and tiny.
+   *  - `links`, `images` and their `_appearances`: read ACROSS crawls.
+   *    `getLinksByPage` and `getImagesByPage` take the most recent crawl that
+   *    has them, with no crawl_id filter, and `reuseCachedPage` copies the
+   *    result into the next crawl when it serves a page from cache. Retiring
+   *    them would leave a reused page with no links or images in the NEXT
+   *    audit's report, which is a quiet wrong answer rather than a missing one.
+   *  - `crawls` itself: the row stays so `report --list` can still show the
+   *    audit and say it is no longer renderable, rather than the history
+   *    silently shrinking.
+   */
+  private static readonly RETIREABLE_TABLES = [
+    "rule_results",
+    "sitemap_urls",
+    "sitemaps",
+    "sitemap_url_statuses",
+    "page_features",
+    "robots_txt",
+    "llms_txt",
+    "markdown_response",
+    "agent_well_known",
+    "agent_access",
+    "agent_rsl",
+    "frontier",
+  ] as const;
+
+  /**
+   * What {@link retireCrawls} would delete, without deleting it.
+   *
+   * Counted rather than estimated: this is what a user sees before confirming
+   * that some of their audit history stops being renderable, so it must be the
+   * real number.
+   */
+  previewRetireCrawls(crawlIds: string[]): Effect.Effect<
+    { rowsByTable: Record<string, number>; supersededPages: number; totalRows: number },
+    StorageError,
+    never
+  > {
+    return Effect.try({
+      try: () => {
+        const rowsByTable: Record<string, number> = {};
+        let totalRows = 0;
+        if (crawlIds.length === 0)
+          return { rowsByTable, supersededPages: 0, totalRows: 0 };
+
+        const db = this.getDb();
+        const placeholders = crawlIds.map(() => "?").join(", ");
+        for (const table of SQLiteStorage.RETIREABLE_TABLES) {
+          const row = db
+            .prepare(
+              `SELECT COUNT(*) AS c FROM ${table} WHERE crawl_id IN (${placeholders})`
+            )
+            .get(...crawlIds) as { c: number };
+          if (row.c > 0) {
+            rowsByTable[table] = row.c;
+            totalRows += row.c;
+          }
+        }
+
+        const superseded = db
+          .prepare(this.supersededPagesSql("COUNT(*) AS c", placeholders))
+          .get(...crawlIds) as { c: number };
+        totalRows += superseded.c;
+        return { rowsByTable, supersededPages: superseded.c, totalRows };
+      },
+      catch: (e) => StorageError.read(e),
+    });
+  }
+
+  /**
+   * Pages belonging to the named crawls that a newer row already supersedes.
+   *
+   * `getCachedPage` reads `ORDER BY fetched_at DESC, rowid DESC LIMIT 1`, so a
+   * row with a newer sibling for the same url can never be returned by it. The
+   * predicate is that ordering, inverted — which is why these rows are dead to
+   * the crawler even though the crawl they belong to is being retired for a
+   * different reason. A page whose ONLY row belongs to a retired crawl is kept:
+   * it is still the freshest thing known about that url.
+   */
+  private supersededPagesSql(select: string, placeholders: string): string {
+    return `
+      SELECT ${select} FROM pages p
+      WHERE p.crawl_id IN (${placeholders})
+        AND EXISTS (
+          SELECT 1 FROM pages newer
+          WHERE newer.normalized_url = p.normalized_url
+            AND (
+              newer.fetched_at > p.fetched_at
+              OR (newer.fetched_at = p.fetched_at AND newer.rowid > p.rowid)
+            )
+        )
+    `;
+  }
+
+  /**
+   * Retire the derived output of the named crawls (#1912).
+   *
+   * Their reports stop being renderable; the crawl rows remain. Everything the
+   * NEXT crawl reads is preserved — see RETIREABLE_TABLES for what is excluded
+   * and why. One transaction, so a crash cannot leave a half-retired crawl that
+   * renders a partial report.
+   */
+  retireCrawls(crawlIds: string[]): Effect.Effect<number, StorageError, never> {
+    // Never a crawl that is still being written. A prune racing a live audit
+    // would delete the frontier out from under it and leave a half-written run.
+    // Checked HERE rather than only in the caller so the guard cannot be
+    // bypassed by a future caller that forgets it.
+
+    return Effect.try({
+      try: () => {
+        if (crawlIds.length === 0) return 0;
+        const db = this.getDb();
+        const idList = crawlIds.map(() => "?").join(", ");
+        const active = db
+          .prepare(
+            `SELECT id FROM crawls WHERE id IN (${idList}) AND status NOT IN ('completed', 'analyzed', 'failed')`
+          )
+          .all(...crawlIds) as Array<{ id: string }>;
+        if (active.length > 0) {
+          throw new Error(
+            `Refusing to retire ${active.length} crawl(s) that are not finished: ${active
+              .map((c) => c.id)
+              .join(", ")}`
+          );
+        }
+        const placeholders = idList;
+        let deleted = 0;
+        const run = db.transaction(() => {
+          for (const table of SQLiteStorage.RETIREABLE_TABLES) {
+            const result = db
+              .prepare(
+                `DELETE FROM ${table} WHERE crawl_id IN (${placeholders})`
+              )
+              .run(...crawlIds);
+            deleted += Number(result.changes ?? 0);
+          }
+          const pageResult = db
+            .prepare(
+              `DELETE FROM pages WHERE rowid IN (${this.supersededPagesSql("p.rowid", placeholders)})`
+            )
+            .run(...crawlIds);
+          deleted += Number(pageResult.changes ?? 0);
+        });
+        run();
+        return deleted;
+      },
+      catch: (e) => StorageError.write(e),
+    });
+  }
+
+  /**
+   * Rebuild the database file so deleted space returns to the filesystem.
+   *
+   * Separate from {@link retireCrawls} on purpose: SQLite only moves freed pages
+   * to a freelist, so without this the file never shrinks, and VACUUM rewrites
+   * the whole file, which is far too expensive to run as part of an audit
+   * (#1908 is what happens when a per-audit full pass slips in).
+   */
+  vacuum(): Effect.Effect<void, StorageError, never> {
+    return Effect.try({
+      try: () => {
+        const db = this.getDb();
+        db.exec("VACUUM");
+        // In WAL mode the rewrite lands in the write-ahead log, so without this
+        // the main file shrinks and the `-wal` beside it grows by more than was
+        // saved: a prune measured 189 MB before and 239 MB after. TRUNCATE
+        // folds the log back in and takes it to zero, which is what makes the
+        // reclaimed space real rather than moved.
+        db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+      },
+      catch: (e) => StorageError.write(e),
+    });
+  }
+
   getCrawlByUrl(
     baseUrl: string
   ): Effect.Effect<CrawlMetadata | null, StorageError, never> {

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -60,7 +60,7 @@ export interface ContentStoreAdapter {
 // Schema version - increment when schema changes.
 // Exported so migration tests can assert "this DB reached the CURRENT version" rather than pinning a
 // literal, which turned every schema bump into two unrelated test failures.
-export const SCHEMA_VERSION = 24;
+export const SCHEMA_VERSION = 25;
 
 // Migrations to run when upgrading from older versions
 const MIGRATIONS: Record<number, string[]> = {
@@ -335,6 +335,15 @@ const MIGRATIONS: Record<number, string[]> = {
     `ALTER TABLE links ADD COLUMN rate_limited INTEGER`,
     `ALTER TABLE sitemap_url_statuses ADD COLUMN rate_limited INTEGER`,
   ],
+  // Version 25: when an audit's data was reclaimed (squirrelscan/repo#1912).
+  // `self disk --prune` deletes a crawl's derived rows and leaves the `crawls`
+  // row, so without this the audit still reads as `completed` and the report
+  // path rebuilds a CONFIDENT EMPTY report from whatever pages survive — worse
+  // than the disk it saved. Stamped by `retireCrawls`; NULL for every audit that
+  // has not been reclaimed, which is all of them until someone prunes. ADDITIVE;
+  // ALTER is idempotent (the runner swallows "duplicate column name"). Local
+  // sqlite only — NOT a prod migration.
+  25: [`ALTER TABLE crawls ADD COLUMN retired_at INTEGER`],
 };
 
 // Nullable columns added to `pages` via ALTER migrations over time, with the
@@ -395,6 +404,16 @@ const SITEMAP_URL_STATUSES_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: st
   { name: "rate_limited", type: "INTEGER" },
 ];
 
+// Same guard for `crawls`. Migration 25 added `retired_at`; a DB stamped past 25
+// by a build that numbered its own migration 25 would skip it forever, and then
+// every `listCrawls` SELECT throws "no such column: retired_at" — which fails
+// `report`, `report --list` and the prune itself, not just the new field. Four
+// tables have now been bitten by exactly this, so the column goes on the list at
+// the same time it goes in the migration.
+const CRAWLS_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: string }> = [
+  { name: "retired_at", type: "INTEGER" },
+];
+
 const SCHEMA = `
 -- Crawl sessions
 CREATE TABLE IF NOT EXISTS crawls (
@@ -404,7 +423,11 @@ CREATE TABLE IF NOT EXISTS crawls (
   completed_at INTEGER,
   status TEXT NOT NULL,
   config TEXT NOT NULL,
-  stats TEXT NOT NULL
+  stats TEXT NOT NULL,
+  -- When "self disk --prune" reclaimed this audit's data (#1912). NULL until
+  -- something retires it, which is every audit unless the user asks. No
+  -- backticks in here: SCHEMA is a template literal and they would close it.
+  retired_at INTEGER
 );
 
 -- Pages
@@ -985,6 +1008,7 @@ export class SQLiteStorage implements CrawlStorage {
     this.reconcileColumns("robots_txt", ROBOTS_TXT_ALTER_COLUMNS);
     this.reconcileColumns("links", LINKS_ALTER_COLUMNS);
     this.reconcileColumns("sitemap_url_statuses", SITEMAP_URL_STATUSES_ALTER_COLUMNS);
+    this.reconcileColumns("crawls", CRAWLS_ALTER_COLUMNS);
   }
 
   /**
@@ -999,7 +1023,13 @@ export class SQLiteStorage implements CrawlStorage {
   }
 
   private reconcileColumns(
-    table: "pages" | "sitemaps" | "robots_txt" | "links" | "sitemap_url_statuses",
+    table:
+      | "pages"
+      | "sitemaps"
+      | "robots_txt"
+      | "links"
+      | "sitemap_url_statuses"
+      | "crawls",
     columns: ReadonlyArray<{ name: string; type: string }>
   ): void {
     const db = this.getDb();
@@ -1228,6 +1258,7 @@ export class SQLiteStorage implements CrawlStorage {
       startedAt: row.started_at as number,
       completedAt: (row.completed_at as number | null) ?? undefined,
       status: row.status as CrawlMetadata["status"],
+      retiredAt: (row.retired_at as number | null) ?? undefined,
       config: this.safeJsonParse(
         row.config as string,
         {} as CrawlMetadata["config"]
@@ -3363,12 +3394,17 @@ export class SQLiteStorage implements CrawlStorage {
   /**
    * Retire the derived output of the named crawls (#1912).
    *
-   * Their reports stop being renderable; the crawl rows remain. Everything the
-   * NEXT crawl reads is preserved — see RETIREABLE_TABLES for what is excluded
+   * Their reports stop being renderable and they are stamped `retired_at`, which
+   * is what lets `report` say so instead of rebuilding an empty one; the crawl
+   * rows remain, so the audits are still listed. Everything the NEXT crawl reads
+   * is preserved — see RETIREABLE_TABLES for what is excluded
    * and why. One transaction, so a crash cannot leave a half-retired crawl that
    * renders a partial report.
    */
-  retireCrawls(crawlIds: string[]): Effect.Effect<number, StorageError, never> {
+  retireCrawls(
+    crawlIds: string[],
+    retiredAt: number = Date.now()
+  ): Effect.Effect<number, StorageError, never> {
     // Never a crawl that is still being written. A prune racing a live audit
     // would delete the frontier out from under it and leave a half-written run.
     // Checked HERE rather than only in the caller so the guard cannot be
@@ -3408,6 +3444,13 @@ export class SQLiteStorage implements CrawlStorage {
             )
             .run(...crawlIds);
           deleted += Number(pageResult.changes ?? 0);
+          // Stamp INSIDE the transaction, so a crash can never leave a crawl
+          // whose data is gone but which still reads as renderable. That state
+          // is worse than either end of it: the report path would rebuild a
+          // confident empty report from the pages that survive.
+          db.prepare(
+            `UPDATE crawls SET retired_at = ? WHERE id IN (${placeholders})`
+          ).run(retiredAt, ...crawlIds);
         });
         run();
         return deleted;

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -405,11 +405,13 @@ const SITEMAP_URL_STATUSES_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: st
 ];
 
 // Same guard for `crawls`. Migration 25 added `retired_at`; a DB stamped past 25
-// by a build that numbered its own migration 25 would skip it forever, and then
-// every `listCrawls` SELECT throws "no such column: retired_at" — which fails
-// `report`, `report --list` and the prune itself, not just the new field. Four
-// tables have now been bitten by exactly this, so the column goes on the list at
-// the same time it goes in the migration.
+// by a build that numbered its own migration 25 would skip it forever. The
+// failure is quieter than the four tables before it and worse for that: reads
+// are `SELECT *` mapped by key, so a missing column does not throw, it yields
+// `undefined` — every retired audit silently reads as NOT retired and renders
+// the empty report this column exists to prevent. The prune's own UPDATE is the
+// only part that fails loudly. So the column goes on the list at the same time
+// it goes in the migration, like the five before it.
 const CRAWLS_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: string }> = [
   { name: "retired_at", type: "INTEGER" },
 ];

--- a/packages/crawler/tests/retire-crawls.test.ts
+++ b/packages/crawler/tests/retire-crawls.test.ts
@@ -1,0 +1,231 @@
+// #1912: retiring an old crawl's derived output must reclaim the space without
+// taking anything the NEXT crawl reads.
+//
+// The dangerous direction is not "deletes too little". It is deleting the
+// conditional-GET cache or the sub-resource records, which would turn every
+// re-audit into a cold crawl and cost users far more than the disk they saved.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import type { CheckResult, CrawlMetadata, PageRecord } from "../src/storage/types";
+import { SQLiteStorage } from "../src/storage/sqlite";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const STATS = {
+  pagesTotal: 0,
+  pagesFetched: 0,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+function pageRecord(url: string, fetchedAt: number, etag: string): PageRecord {
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 0,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: 10,
+    loadTimeMs: 1,
+    fetchedAt,
+    etag,
+    lastModified: null,
+    contentHash: etag,
+    html: "<html></html>",
+    parsedData: null,
+    headers: {
+      contentType: "text/html",
+      contentEncoding: null,
+      cacheControl: null,
+      vary: null,
+      etag,
+      server: null,
+      lastModified: null,
+      link: null,
+      serverTiming: null,
+      age: null,
+      xCache: null,
+      cfCacheStatus: null,
+      xVercelCache: null,
+      altSvc: null,
+      acceptRanges: null,
+    },
+    securityHeaders: {
+      hsts: null,
+      csp: null,
+      xFrameOptions: null,
+      xContentTypeOptions: null,
+      referrerPolicy: null,
+      permissionsPolicy: null,
+      xRobotsTag: null,
+    },
+  } as PageRecord;
+}
+
+const check: CheckResult = { name: "c", status: "pass", message: "m" };
+
+interface TwoCrawls {
+  store: SQLiteStorage;
+  old: string;
+  recent: string;
+}
+
+/** Two crawls of the same two-page site, the second newer. */
+async function twoCrawls(): Promise<TwoCrawls> {
+  const store = new SQLiteStorage(":memory:");
+  await run(store.init());
+  const meta = (startedAt: number): Omit<CrawlMetadata, "id"> => ({
+    baseUrl: "https://e.test",
+    startedAt,
+    status: "completed",
+    config: {} as CrawlMetadata["config"],
+    stats: STATS,
+  });
+  const old = await run(store.createCrawl(meta(1_000)));
+  const recent = await run(store.createCrawl(meta(2_000)));
+
+  for (const [crawlId, at, tag] of [
+    [old, 1_000, "v1"],
+    [recent, 2_000, "v2"],
+  ] as const) {
+    for (const path of ["/a", "/b"]) {
+      await run(store.upsertPage(crawlId, pageRecord(`https://e.test${path}`, at, tag)));
+      await run(store.saveRuleResults(crawlId, `https://e.test${path}`, "seo/title", [check]));
+    }
+  }
+  // A page only the OLD crawl ever saw.
+  await run(store.upsertPage(old, pageRecord("https://e.test/gone", 1_000, "v1")));
+  return { store, old, recent };
+}
+
+describe("retireCrawls", () => {
+  test("removes the old crawl's checks and leaves the current crawl's alone", async () => {
+    const { store, old, recent } = await twoCrawls();
+
+    const preview = await run(store.previewRetireCrawls([old]));
+    expect(preview.rowsByTable.rule_results).toBe(2);
+    expect(preview.totalRows).toBeGreaterThan(0);
+
+    const deleted = await run(store.retireCrawls([old]));
+    expect(deleted).toBe(preview.totalRows);
+
+    expect((await run(store.getRuleResultsByPage(old))).size).toBe(0);
+    expect((await run(store.getRuleResultsByPage(recent))).size).toBe(2);
+  });
+
+  test("keeps the conditional-GET cache the next crawl reads", async () => {
+    const { store, old, recent } = await twoCrawls();
+    await run(store.retireCrawls([old]));
+
+    // The newest row per url survives, so an incremental re-crawl still gets
+    // its etag. This is the failure that would cost more than it saves.
+    for (const path of ["/a", "/b"]) {
+      const cached = await run(store.getCachedPage(`https://e.test${path}`));
+      expect(cached?.etag).toBe("v2");
+    }
+    // A url only the retired crawl ever saw keeps its ONLY row: it is still the
+    // freshest thing known about that page.
+    const orphan = await run(store.getCachedPage("https://e.test/gone"));
+    expect(orphan?.etag).toBe("v1");
+  });
+
+  test("drops only the superseded page rows", async () => {
+    const { store, old, recent } = await twoCrawls();
+    const preview = await run(store.previewRetireCrawls([old]));
+    // /a and /b are superseded by the new crawl; /gone is not.
+    expect(preview.supersededPages).toBe(2);
+
+    await run(store.retireCrawls([old]));
+    const remaining = await run(store.getPages(old));
+    expect(remaining.map((p) => p.normalizedUrl)).toEqual([
+      "https://e.test/gone",
+    ]);
+  });
+
+  test("keeps the crawl row, so the audit is still listed", async () => {
+    const { store, old, recent } = await twoCrawls();
+    await run(store.retireCrawls([old]));
+    const crawls = await run(store.listCrawls());
+    expect(crawls.map((c) => c.id).sort()).toEqual([old, recent].sort());
+  });
+
+  test("retiring nothing is a no-op, not an error", async () => {
+    const { store, old, recent } = await twoCrawls();
+    expect(await run(store.previewRetireCrawls([]))).toEqual({
+      rowsByTable: {},
+      supersededPages: 0,
+      totalRows: 0,
+    });
+    expect(await run(store.retireCrawls([]))).toBe(0);
+    expect((await run(store.getRuleResultsByPage(old))).size).toBe(2);
+  });
+
+  test("the preview is exactly what the delete removes", async () => {
+    const { store, old, recent } = await twoCrawls();
+    const preview = await run(store.previewRetireCrawls([old, recent]));
+    const deleted = await run(store.retireCrawls([old, recent]));
+    // A user confirms on the preview, so it has to be the real number.
+    expect(deleted).toBe(preview.totalRows);
+  });
+
+  test("refuses a crawl that is still running", async () => {
+    const { store, old } = await twoCrawls();
+    await run(store.updateCrawl(old, { status: "running" }));
+
+    // A prune racing a live audit would delete its frontier mid-run.
+    await expect(run(store.retireCrawls([old]))).rejects.toThrow();
+    expect((await run(store.getRuleResultsByPage(old))).size).toBe(2);
+  });
+
+  test("keeps links and images, which the next crawl reads across crawls", async () => {
+    const { store, old, recent } = await twoCrawls();
+    await run(
+      store.upsertLink(old, {
+        href: "https://out.test/x",
+        isInternal: false,
+        status: 200,
+        error: null,
+        redirectTarget: null,
+        checkedAt: 1_000,
+      } as never)
+    );
+    // getLinksByPage joins links to link_appearances, so the page mapping has
+    // to exist for the read that reuseCachedPage makes.
+    await run(
+      store.addLinkAppearance(old, {
+        href: "https://out.test/x",
+        pageUrl: "https://e.test/a",
+        anchorText: "x",
+        position: "body",
+        rel: null,
+        isNofollow: false,
+      } as never)
+    );
+    await run(store.retireCrawls([old]));
+
+    // getLinksByPage has no crawl_id filter and reuseCachedPage copies its
+    // result into the next crawl, so retiring these would leave a reused page
+    // with no links in the NEXT audit's report.
+    const links = await run(store.getLinksByPage("https://e.test/a"));
+    expect(links.length).toBeGreaterThan(0);
+    void recent;
+  });
+
+  test("vacuum runs and leaves the data intact", async () => {
+    const { store, old, recent } = await twoCrawls();
+    await run(store.retireCrawls([old]));
+    await run(store.vacuum());
+    expect((await run(store.getRuleResultsByPage(recent))).size).toBe(2);
+    expect((await run(store.getCachedPage("https://e.test/a")))?.etag).toBe("v2");
+  });
+});

--- a/packages/crawler/tests/retire-crawls.test.ts
+++ b/packages/crawler/tests/retire-crawls.test.ts
@@ -235,9 +235,30 @@ describe("retireCrawls", () => {
     expect(byId.get(recent)?.retiredAt).toBeUndefined();
   });
 
-  test("the stamp lands in the same transaction as the deletes", async () => {
-    // A crawl whose rows are gone but which still reads as renderable is the
-    // one state worse than either end, so the two must not be separable.
+  test("the stamp and the deletes roll back together", async () => {
+    // A crawl whose rows are gone but which still reads as renderable is the one
+    // state worse than either end, so the two must not be separable. Asserting
+    // the successful end state cannot show that — it holds either way. Failing
+    // the transaction can: if the stamp were its own statement outside it, the
+    // rollback would leave one of the two applied.
+    const { store, old } = await twoCrawls();
+    const db = (
+      store as unknown as { getDb(): { transaction(fn: () => void): () => void } }
+    ).getDb();
+
+    expect(() =>
+      db.transaction(() => {
+        Effect.runSync(Effect.orDie(store.retireCrawls([old])));
+        throw new Error("abort");
+      })()
+    ).toThrow("abort");
+
+    const crawl = (await run(store.listCrawls())).find((c) => c.id === old);
+    expect(crawl?.retiredAt).toBeUndefined();
+    expect((await run(store.getRuleResultsByPage(old))).size).toBe(2);
+  });
+
+  test("on success both the stamp and the deletes are applied", async () => {
     const { store, old } = await twoCrawls();
     await run(store.retireCrawls([old]));
 

--- a/packages/crawler/tests/retire-crawls.test.ts
+++ b/packages/crawler/tests/retire-crawls.test.ts
@@ -221,6 +221,40 @@ describe("retireCrawls", () => {
     void recent;
   });
 
+  test("stamps retired_at on the crawls it retires, and only those", async () => {
+    const { store, old, recent } = await twoCrawls();
+    const at = 1_700_000_000_000;
+    await run(store.retireCrawls([old], at));
+
+    const byId = new Map(
+      (await run(store.listCrawls())).map((c) => [c.id, c])
+    );
+    // The stamp is what lets `report` say "reclaimed on <date>" instead of
+    // rebuilding an empty report from the pages that survive.
+    expect(byId.get(old)?.retiredAt).toBe(at);
+    expect(byId.get(recent)?.retiredAt).toBeUndefined();
+  });
+
+  test("the stamp lands in the same transaction as the deletes", async () => {
+    // A crawl whose rows are gone but which still reads as renderable is the
+    // one state worse than either end, so the two must not be separable.
+    const { store, old } = await twoCrawls();
+    await run(store.retireCrawls([old]));
+
+    const crawl = (await run(store.listCrawls())).find((c) => c.id === old);
+    expect(crawl?.retiredAt).toBeGreaterThan(0);
+    expect((await run(store.getRuleResultsByPage(old))).size).toBe(0);
+  });
+
+  test("an untouched crawl has no stamp", async () => {
+    const { store, old, recent } = await twoCrawls();
+    for (const c of await run(store.listCrawls())) {
+      expect(c.retiredAt).toBeUndefined();
+    }
+    void old;
+    void recent;
+  });
+
   test("vacuum runs and leaves the data intact", async () => {
     const { store, old, recent } = await twoCrawls();
     await run(store.retireCrawls([old]));

--- a/packages/crawler/tests/retired-at-migration.test.ts
+++ b/packages/crawler/tests/retired-at-migration.test.ts
@@ -106,11 +106,17 @@ describe("crawls.retired_at (#1912)", () => {
     const store = new SQLiteStorage(path);
     await run(store.init());
 
-    // The read that would throw "no such column: retired_at" if the reconcile
-    // had not run — and it is the read `report --list` makes.
     const crawls = await run(store.listCrawls());
     expect(crawls.map((c) => c.id)).toEqual([id]);
     expect(crawls[0]?.retiredAt).toBeUndefined();
+
+    // That assertion alone would pass WITHOUT the repair: reads are `SELECT *`
+    // mapped by key, so a missing column yields undefined rather than throwing,
+    // and a retired audit would silently read as not retired. What proves the
+    // repair is a WRITE, which is the part that fails loudly on a missing
+    // column — and it is the write the prune makes.
+    await run(store.retireCrawls([id], 1_700_000_000_000));
+    expect((await run(store.getCrawl(id)))?.retiredAt).toBe(1_700_000_000_000);
     await run(store.close());
   });
 

--- a/packages/crawler/tests/retired-at-migration.test.ts
+++ b/packages/crawler/tests/retired-at-migration.test.ts
@@ -1,0 +1,156 @@
+// Migration 25 adds `crawls.retired_at` (#1912), and the column has to survive
+// the failure mode that has now bitten `pages`, `sitemaps`, `robots_txt`,
+// `links` and `sitemap_url_statuses` in turn: a DB stamped at or past the
+// version by a build that numbered its own migration differently skips the ALTER
+// forever. `reconcileColumns` re-adds it on open regardless of the counter.
+//
+// Getting this wrong is not a missing field. Every `listCrawls` SELECT is
+// `SELECT *` mapped through `rowToCrawlMetadata`, so a DB without the column
+// throws on `report`, on `report --list`, and on the prune itself.
+
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "crypto";
+import { unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Effect } from "effect";
+
+import type { CrawlMetadata } from "../src/storage/types";
+import { SCHEMA_VERSION, SQLiteStorage } from "../src/storage/sqlite";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const paths: string[] = [];
+function tempDbPath(): string {
+  const p = join(tmpdir(), `sq-retired-${randomUUID()}.db`);
+  paths.push(p);
+  return p;
+}
+
+afterEach(() => {
+  for (const p of paths.splice(0)) {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        unlinkSync(`${p}${suffix}`);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+});
+
+const STATS = {
+  pagesTotal: 0,
+  pagesFetched: 0,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+const meta: Omit<CrawlMetadata, "id"> = {
+  baseUrl: "https://e.test",
+  startedAt: 1_000,
+  status: "completed",
+  config: {} as CrawlMetadata["config"],
+  stats: STATS,
+};
+
+/** A pre-migration store: the crawls table as it was, stamped at the CURRENT
+ *  version so `runMigrations` will not touch it. This is the collision. */
+function seedWithoutColumn(path: string): string {
+  const db = new Database(path, { create: true });
+  db.exec(`
+    CREATE TABLE crawls (
+      id TEXT PRIMARY KEY,
+      base_url TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      status TEXT NOT NULL,
+      config TEXT NOT NULL,
+      stats TEXT NOT NULL
+    );
+    CREATE TABLE schema_version (version INTEGER NOT NULL);
+  `);
+  db.query("INSERT INTO schema_version (version) VALUES (?)").run(SCHEMA_VERSION);
+  const id = randomUUID();
+  db.query(
+    "INSERT INTO crawls (id, base_url, started_at, status, config, stats) VALUES (?, ?, ?, ?, ?, ?)"
+  ).run(id, "https://e.test", 1_000, "completed", "{}", JSON.stringify(STATS));
+  db.close();
+  return id;
+}
+
+describe("crawls.retired_at (#1912)", () => {
+  test("a fresh database has the column and reads null as absent", async () => {
+    const store = new SQLiteStorage(tempDbPath());
+    await run(store.init());
+    const id = await run(store.createCrawl(meta));
+
+    const crawl = await run(store.getCrawl(id));
+    // Not 0, not null: absent. Every existing audit is un-retired.
+    expect(crawl?.retiredAt).toBeUndefined();
+    await run(store.close());
+  });
+
+  test("an existing database gains the column on open", async () => {
+    const path = tempDbPath();
+    const id = seedWithoutColumn(path);
+
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+
+    // The read that would throw "no such column: retired_at" if the reconcile
+    // had not run — and it is the read `report --list` makes.
+    const crawls = await run(store.listCrawls());
+    expect(crawls.map((c) => c.id)).toEqual([id]);
+    expect(crawls[0]?.retiredAt).toBeUndefined();
+    await run(store.close());
+  });
+
+  test("a pre-existing audit survives the migration and can then be retired", async () => {
+    const path = tempDbPath();
+    const id = seedWithoutColumn(path);
+
+    const store = new SQLiteStorage(path);
+    await run(store.init());
+    await run(store.retireCrawls([id], 1_700_000_000_000));
+
+    const crawl = await run(store.getCrawl(id));
+    expect(crawl?.retiredAt).toBe(1_700_000_000_000);
+    // The row itself is untouched otherwise: the audit is still listed.
+    expect(crawl?.baseUrl).toBe("https://e.test");
+    expect(crawl?.status).toBe("completed");
+    await run(store.close());
+  });
+
+  test("the column is on the reconcile list, not only in a migration", () => {
+    // The migration alone is not enough — that is the whole lesson of the four
+    // tables this has already broken. Asserted by seeding a DB already stamped
+    // at the current version, which the migration runner skips entirely.
+    const path = tempDbPath();
+    seedWithoutColumn(path);
+    const before = new Database(path, { readonly: true });
+    const had = (before.query("PRAGMA table_info(crawls)").all() as Array<{
+      name: string;
+    }>).some((c) => c.name === "retired_at");
+    before.close();
+    expect(had).toBe(false);
+
+    const store = new SQLiteStorage(path);
+    Effect.runSync(Effect.orDie(store.init()));
+    const after = new Database(path, { readonly: true });
+    const now = (after.query("PRAGMA table_info(crawls)").all() as Array<{
+      name: string;
+    }>).some((c) => c.name === "retired_at");
+    after.close();
+    expect(now).toBe(true);
+    Effect.runSync(Effect.orDie(store.close()));
+  });
+});


### PR DESCRIPTION
The reclaim half of squirrelscan/repo#1912, on top of #256. Explicit, user-triggered, and it decides nothing about retention.

## The problem

A project keeps every audit it has ever run. Nothing retires a prior crawl's rows, so `project.db` grows by about one audit each time: 95 MB after one audit of a 1,000-page site, 189 MB after two, 215 MB after three. #256 made that visible; this makes it fixable.

## What `--prune` does

```bash
squirrel self disk --prune --keep 3 --dry-run
squirrel self disk --prune --keep 3
```

Retires the audits beyond the newest `--keep`: their rule results, links, images, sitemaps and frontier, plus the page rows a newer audit already supersedes. Then rebuilds the file so the space returns to the filesystem.

Measured on two audits of a 60-page site, keeping one:

| measurement | before | after |
| --- | --- | --- |
| `project.db` | 11.5 MB | 5.7 MB |
| page rows for the retired crawl | 60 | 0 |
| next audit's pages fetched | | 0 of 60, all unchanged |

That last row is the one that matters.

## What it deliberately keeps

The failure worth avoiding is not "reclaims too little", it is taking something the next crawl needs and turning every re-audit into a cold crawl, which would cost users far more than the disk it saved. So:

- **The newest page record per url.** The superseded-page predicate is `getCachedPage`'s own ordering inverted, so what it deletes is exactly the rows that read can never return. A url whose only row belongs to a retired crawl keeps that row: it is still the freshest thing known about that page.
- **`resource_sizes`.** A retired crawl's rows may still be the most recent sub-resource record for a (type, url) via the #107 anti-join.
- **`published_reports`**, which is not recomputable, and the **`crawls` row**, so the audit stays listed rather than the history silently shrinking.

Smart audits are unaffected either way: carried findings live in `page_findings` and `site_pages`, which are site-keyed rather than crawl-keyed.

## Reclaimed audits say so (Nik's decision on the issue)

A nullable `retired_at` on `crawls`, migration 25. Without it the prune left the crawl row saying `completed` while its rule results were gone, so the report path rebuilt a **confident empty report** from the pages that survive. That reads as a clean audit: a wrong answer where the old behaviour was merely a large file, and the reason this PR stayed a draft.

`retireCrawls` stamps it inside the same transaction as the deletes, so a crash cannot leave data gone but the audit still renderable. The refusal is structural rather than a check per call site: the three CLI gates that tested `isReportReadyStatus(crawl.status)` now test `isReportRenderable(crawl)`, covering `report <id>`, `--diff` and `--regression-since` together, and `reconstructReport` refuses independently underneath all of them. One definition of the sentence, so it reads the same wherever you meet it:

```text
Audit data was reclaimed on 2026-09-08: 06148d76-6c48-465a-bc16-deb44144350d
```

`report --list` still shows the audit, marked `retired`, with the date its data went. Keeping the crawl row is what makes the history visible rather than silently shrinking.

The column goes on the reconcile list at the same time it goes in the migration. That is not belt-and-braces: five tables have been broken by a database stamped at or past a version whose migration a differently-numbered build skipped. Here the failure would be quieter and worse than those, because reads are `SELECT *` mapped by key — a missing column yields `undefined` rather than throwing, so every retired audit would silently read as *not* retired.

Verified end to end: pruned a real project, then `report <id>`, `--diff` and `--regression-since` each refused with that line while the audit that was kept rendered normally.

### Second review round

Two more real defects, both fixed:

- `analyze` re-scored reclaimed data and reported "Analysis complete". It keeps its own status gate, and retirement does not change the status, so `analyze <id>` re-ran the rules over the surviving pages; its automatic selector picked retired crawls too.
- A prune committing *mid-read* escaped the refusal. The stamp was checked once, outside any read transaction, so another process could retire between that check and the page reads. It re-reads the stamp after every read now.

And two tests that were weaker than they looked: the migration assertion passed without the repair (a missing column does not throw on read), and the "same transaction" assertion held whether or not the two were separable. The first now asserts through the write that does fail loudly; the second rolls the transaction back.

## Why it is awkward on purpose

`--keep` is required and has no default. Retiring a crawl makes its report unrenderable, and `report --list`, `--diff` and `--regression-since <audit-id>` all reach into that history, so the window is a decision for the person whose reports they are. Merging this must not make it for them.

The plan is printed and confirmed before anything is deleted, `--dry-run` stops after printing, and an audit never prunes anything. Automatic retention stays undecided and out of this PR: `--keep` is still required, and an audit still never prunes anything. The keep-last-3 recommendation and the numbers behind it are a decision block on the issue.

## One trap, recorded

`VACUUM` alone made the file **bigger**: 189 MB to 239 MB. In WAL mode the rewrite lands in the write-ahead log, so the main file shrinks while the `-wal` beside it grows by more than was saved. `PRAGMA wal_checkpoint(TRUNCATE)` after the vacuum, and measuring after the connection closes, is what makes the saving real. In the benchmarks file so the next person does not rediscover it.

## Tests

Storage: preview equals what the delete removes; the conditional-GET cache survives with the right etag; only superseded page rows go; a url seen by only the retired crawl keeps its row; the crawl row stays; retiring nothing is a no-op; vacuum leaves the data intact.

CLI: nothing is planned inside the window; the plan is ordered oldest first; planning deletes nothing; a missing database is not an error; the reclaim returns space and the count confirmed on is the count deleted.

End to end, outside the suite: two audits of the same 60-page site, prune, then a third audit that reported 60 unchanged and 0 fetched, with the kept report still rendering at score 47.

Docs updated. Benchmarks row added.
