### PR TITLE
perf(cli): stop the report building per-page fields nothing reads

### DIFF
--- a/apps/cli/src/links/index.ts
+++ b/apps/cli/src/links/index.ts
@@ -116,7 +116,7 @@ export function analyzeInternalLinks(
 
   // Build link graph
   for (const page of pages) {
-    for (const link of page.links) {
+    for (const link of page.links ?? []) {
       if (link.isInternal) {
         totalInternalLinks++;
         const normalizedLinkUrl = normalizeUrl(link.url);
@@ -146,7 +146,7 @@ export function analyzeInternalLinks(
     const currentPage = pages.find((p) => normalizeUrl(p.url) === currentUrl);
     if (!currentPage) continue;
 
-    for (const link of currentPage.links) {
+    for (const link of currentPage.links ?? []) {
       if (!link.isInternal) continue;
 
       const normalizedLinkUrl = normalizeUrl(link.url);
@@ -179,7 +179,9 @@ export function analyzeInternalLinks(
   const pagesWithManyLinks: { url: string; count: number }[] = [];
 
   for (const page of pages) {
-    const internalLinkCount = page.links.filter((l) => l.isInternal).length;
+    const internalLinkCount = (page.links ?? []).filter(
+      (l) => l.isInternal
+    ).length;
 
     if (internalLinkCount < 3) {
       pagesWithFewLinks.push({ url: page.url, count: internalLinkCount });
@@ -212,7 +214,7 @@ export function analyzeAnchorText(
 
   for (const page of pages) {
     // We need enhanced link data - for now, analyze from raw links
-    for (const link of page.links) {
+    for (const link of page.links ?? []) {
       const text = link.text.toLowerCase().trim();
 
       // Track anchor text distribution

--- a/apps/cli/src/reports/reconstruct.ts
+++ b/apps/cli/src/reports/reconstruct.ts
@@ -1,8 +1,6 @@
 // Reconstruct AuditReport from SQLite storage
 // Rebuilds full report structure from crawl data
 
-import type { ResponseHeaders as StoredResponseHeaders } from "@squirrelscan/core-contracts";
-
 import { detachFromPage } from "@squirrelscan/audit-engine";
 import { buildCacheStats } from "@squirrelscan/core-contracts";
 import { loadAllRules, type RuleRunResult } from "@squirrelscan/rules";
@@ -61,22 +59,6 @@ export interface SmartMergeOverride {
     unrenderedFindings?: number;
   };
   carriedLastSeen: Map<string, number>;
-}
-
-// Cookie values are crawl-session artifacts, not report content — publish
-// keeps `security/cookie-flags` rule-input-only and never sends the raw
-// Set-Cookie bytes onward (the publish schema doesn't accept `setCookie` and
-// would silently drop it anyway, but by then the bytes have already ridden
-// the wire and counted against the request body cap). `PageAudit.responseHeaders`
-// is typed WITHOUT `setCookie` (see `@/types`), but `page.headers` (the
-// storage-layer `ResponseHeaders` from core-contracts) carries it at
-// runtime — assigning it straight through would leak the raw value despite
-// the narrower static type.
-function omitSetCookie(
-  headers: StoredResponseHeaders
-): Omit<StoredResponseHeaders, "setCookie"> {
-  const { setCookie: _setCookie, ...responseHeaders } = headers;
-  return responseHeaders;
 }
 
 function computeSitemapCoverage(
@@ -264,9 +246,6 @@ export function reconstructReport(
       .getSitemapUrlStatuses(crawlId)
       .pipe(Effect.catchAll(() => Effect.succeed([])));
 
-    // 5. Get all links (for broken links lookup)
-    const links = yield* storage.getLinks(crawlId);
-
     // 6. Rule results, both groupings, from ONE read (#1920). The two readers
     // this replaces differed only in their ORDER BY and each built its own
     // CheckResult per row, so a crawl's checks were materialized twice: 203,687
@@ -277,9 +256,6 @@ export function reconstructReport(
 
     // 7. Load rule registry to get metadata
     const ruleRegistry = loadAllRules();
-
-    // Create lookup maps for link data
-    const linkByHref = new Map(links.map((l) => [l.href, l]));
 
     // 8. Build PageAudit[] from page records with parsed data and rule results
     const pages: PageAudit[] = [];
@@ -327,33 +303,15 @@ export function reconstructReport(
         // Parse page HTML if available
         const parsed = page.html ? parsePageRecord(page) : null;
 
-        // Get links that appear on this page (per-page index lookup)
-        const pageLinkAppearances = yield* storage.getLinkAppearancesForPage(
-          crawlId,
-          page.normalizedUrl
-        );
-        const pageLinks = pageLinkAppearances.map((a) => {
-          const link = linkByHref.get(a.href);
-          return {
-            url: a.href,
-            text: a.anchorText,
-            isInternal: link?.isInternal ?? false,
-            status: link?.status,
-            error: link?.error,
-          };
-        });
-
-        // Get images that appear on this page (per-page index lookup)
+        // Image appearances still drive `summary.missingAltText`, which IS
+        // emitted. The per-page LINK query that used to sit here, and the
+        // whole-crawl `getLinks` that fed it, are gone with `PageAudit.links`
+        // (#1938): two queries per page and their arrays, for a field no
+        // consumer read.
         const pageImageAppearances = yield* storage.getImageAppearancesForPage(
           crawlId,
           page.normalizedUrl
         );
-        const pageImages = pageImageAppearances.map((a) => ({
-          src: a.src,
-          alt: a.alt ?? null,
-          width: null,
-          height: null,
-        }));
 
         // Get rule results for this page
         const pageChecks = ruleResultsByPage.get(page.normalizedUrl) ?? [];
@@ -386,32 +344,23 @@ export function reconstructReport(
           }
         }
 
-        // Every string below that came off the DOM is a SLICE of this page's
-        // html, and in JSC a retained slice pins the whole buffer it was cut
-        // from (#240). The resident path never had to care — it was holding the
-        // page anyway — but here the batch is dropped a few lines later and each
-        // kept title would hold its megabyte, which is the page-count-scaled
-        // term this walk exists to remove. Measured on ~1 MB pages: 77.5 MB
-        // retained across 80 pages attached, 2.1 MB detached. One copy per page
-        // of five small objects; everything else on the PageAudit comes from a
-        // storage row and is already free of the html.
+        // `meta` and `og` are the only DOM-derived fields still kept: publish
+        // reads them off the home page to seed the website record's title and
+        // description (`pickHomepageSummary`). Everything else the parse
+        // produced had no reader and is no longer carried (#1938).
+        //
+        // Detached because each of those strings is a SLICE of this page's html,
+        // and in JSC a retained slice pins the whole buffer it was cut from
+        // (#240). The batch is dropped a few lines later, so an attached title
+        // would hold its page's megabyte. Measured on ~1 MB pages: 77.5 MB
+        // retained across 80 pages attached, 2.1 MB detached.
         const kept = parsed
-          ? detachFromPage(
-              {
-                meta: parsed.meta,
-                og: parsed.og,
-                twitter: parsed.twitter,
-                schema: parsed.schema,
-                h1Text: parsed.h1.texts,
-              },
-              "report-page"
-            )
+          ? detachFromPage({ meta: parsed.meta, og: parsed.og }, "report-page")
           : null;
 
         const pageAudit: PageAudit = {
           url: page.url,
           statusCode: page.status,
-          loadTime: page.loadTimeMs,
           meta: kept?.meta ?? {
             title: null,
             description: null,
@@ -426,35 +375,10 @@ export function reconstructReport(
             image: null,
             siteName: null,
           },
-          twitter: kept?.twitter ?? {
-            card: null,
-            title: null,
-            description: null,
-            image: null,
-          },
-          schema: kept?.schema ?? {
-            types: [],
-            valid: true,
-            errors: [],
-            raw: null,
-          },
-          links: pageLinks,
-          images: pageImages,
-          h1Count: parsed?.h1.count ?? 0,
-          h1Text: kept?.h1Text ?? [],
           checks: pageChecks,
           redirectChain: page.redirectChain,
           fetcherId: page.fetcherId,
           fallbackReason: page.fallbackReason,
-          responseHeaders: omitSetCookie(page.headers),
-          security: {
-            isHttps: page.url.startsWith("https"),
-            hasMixedContent: false,
-            mixedContentUrls: [],
-            insecureFormActions: [],
-            headers: page.securityHeaders,
-            httpToHttpsRedirect: false,
-          },
         };
 
         pages.push(pageAudit);

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -344,18 +344,31 @@ export interface ImageData {
   height: string | null;
 }
 
+/**
+ * One page in a report.
+ *
+ * Several fields are optional because the CLI's report builder stopped
+ * populating them (#1938): nothing read them. No output format emits
+ * `report.pages` at all, and the publish path sends `pages: []` after taking
+ * the urls, the statuses and the home page's title. They stay in the type,
+ * optional, so anything constructing or consuming a PageAudit still compiles —
+ * and so the hosted builder, which DOES publish these, keeps the same shape.
+ *
+ * Read by production code: `url`, `statusCode`, `checks`, `meta` and `og` (the
+ * home-page summary that seeds the website record), `fallbackReason`.
+ */
 export interface PageAudit {
   url: string;
   statusCode: number;
-  loadTime: number;
+  loadTime?: number;
   meta: MetaData;
   og: OpenGraphData;
-  twitter: TwitterData;
-  schema: SchemaData;
-  links: LinkData[];
-  images: ImageData[];
-  h1Count: number;
-  h1Text: string[];
+  twitter?: TwitterData;
+  schema?: SchemaData;
+  links?: LinkData[];
+  images?: ImageData[];
+  h1Count?: number;
+  h1Text?: string[];
   checks: CheckResult[];
   // New fields for expanded audit
   urlAnalysis?: UrlAnalysis;

--- a/apps/cli/tests/audit/reconstruct-set-cookie.test.ts
+++ b/apps/cli/tests/audit/reconstruct-set-cookie.test.ts
@@ -3,9 +3,12 @@
 //
 // The report used to carry each page's `responseHeaders` with Set-Cookie
 // stripped out of it. Since #1938 it carries no response headers at all —
-// nothing read them — so the guarantee is now structural rather than a strip
-// that could be forgotten. These tests assert the stronger property: the
-// header is not on the page in any form.
+// nothing read them — so there is no strip left to forget. These tests assert
+// the property over the whole serialized report rather than one field, so a
+// cookie arriving by some other route would fail them too.
+//
+// Note the security/cookie-flags rule deliberately keeps cookie NAMES in its
+// check items; it discards the values. This is about the values.
 
 import type { PageRecord } from "@squirrelscan/core-contracts";
 
@@ -117,16 +120,17 @@ function pageWithSetCookie(setCookie: string | null): PageRecord {
 }
 
 /**
- * The whole page, as JSON, so the assertion sees the runtime shape rather than
- * the static type. A cookie hiding under a field the type does not declare
- * would still be a leak.
+ * The whole REPORT, as JSON, so the assertion sees the runtime shape rather
+ * than the static type and covers every field rather than one page's. A cookie
+ * hiding under a field the type does not declare would still be a leak, and so
+ * would one that reached a check's items or the summary.
  */
-function pageJson(report: AuditReport): string {
-  return JSON.stringify(report.pages[0] ?? {});
+function reportJson(report: AuditReport): string {
+  return JSON.stringify(report);
 }
 
 describe("reconstructReport never carries Set-Cookie (#973/#1035)", () => {
-  test("a multi-cookie header reaches no part of the page", async () => {
+  test("a multi-cookie header reaches no part of the report", async () => {
     const { store, crawlId } = await freshCrawl([
       pageWithSetCookie(
         "session=abc123; Path=/; HttpOnly\nconsent=1; Path=/; Secure"
@@ -134,7 +138,7 @@ describe("reconstructReport never carries Set-Cookie (#973/#1035)", () => {
     ]);
     const report = await run(reconstructReport(store, crawlId, undefined));
 
-    const json = pageJson(report);
+    const json = reportJson(report);
     expect(json).not.toContain("session=abc123");
     expect(json).not.toContain("consent=1");
     expect(json.toLowerCase()).not.toContain("setcookie");
@@ -142,13 +146,13 @@ describe("reconstructReport never carries Set-Cookie (#973/#1035)", () => {
     await run(store.close());
   });
 
-  test("a single cookie reaches no part of the page", async () => {
+  test("a single cookie reaches no part of the report", async () => {
     const { store, crawlId } = await freshCrawl([
       pageWithSetCookie("session=abc123; HttpOnly"),
     ]);
     const report = await run(reconstructReport(store, crawlId, undefined));
 
-    expect(pageJson(report)).not.toContain("session=abc123");
+    expect(reportJson(report)).not.toContain("session=abc123");
     await run(store.close());
   });
 

--- a/apps/cli/tests/audit/reconstruct-set-cookie.test.ts
+++ b/apps/cli/tests/audit/reconstruct-set-cookie.test.ts
@@ -1,9 +1,11 @@
-// reconstructReport strips Set-Cookie from each page's responseHeaders before
-// the report is ever handed to the publish path (#973/#1035). Cookie values
-// are crawl-session artifacts, not report content — the publish schema
-// doesn't accept `setCookie`, so this strip is defense-in-depth: the bytes
-// never ride the wire in the first place, regardless of whether a given
-// publish path also happens to drop pages[] downstream.
+// Set-Cookie must never reach a report (#973/#1035). Cookie values are
+// crawl-session artifacts, not report content.
+//
+// The report used to carry each page's `responseHeaders` with Set-Cookie
+// stripped out of it. Since #1938 it carries no response headers at all —
+// nothing read them — so the guarantee is now structural rather than a strip
+// that could be forgotten. These tests assert the stronger property: the
+// header is not on the page in any form.
 
 import type { PageRecord } from "@squirrelscan/core-contracts";
 
@@ -114,19 +116,17 @@ function pageWithSetCookie(setCookie: string | null): PageRecord {
   };
 }
 
-// `PageAudit.responseHeaders` is typed WITHOUT `setCookie` — read via a loose
-// cast so the assertion checks the raw runtime shape (proving the field is
-// truly absent, not just hidden from the static type).
-function setCookieOf(report: AuditReport): string | null | undefined {
-  return (
-    report.pages[0]?.responseHeaders as
-      | { setCookie?: string | null }
-      | undefined
-  )?.setCookie;
+/**
+ * The whole page, as JSON, so the assertion sees the runtime shape rather than
+ * the static type. A cookie hiding under a field the type does not declare
+ * would still be a leak.
+ */
+function pageJson(report: AuditReport): string {
+  return JSON.stringify(report.pages[0] ?? {});
 }
 
-describe("reconstructReport strips Set-Cookie from responseHeaders (#973/#1035)", () => {
-  test("multi-cookie set-cookie is stripped, other headers survive", async () => {
+describe("reconstructReport never carries Set-Cookie (#973/#1035)", () => {
+  test("a multi-cookie header reaches no part of the page", async () => {
     const { store, crawlId } = await freshCrawl([
       pageWithSetCookie(
         "session=abc123; Path=/; HttpOnly\nconsent=1; Path=/; Secure"
@@ -134,28 +134,31 @@ describe("reconstructReport strips Set-Cookie from responseHeaders (#973/#1035)"
     ]);
     const report = await run(reconstructReport(store, crawlId, undefined));
 
-    expect(setCookieOf(report)).toBeUndefined();
-    expect(report.pages[0]?.responseHeaders?.server).toBe("nginx");
-    expect(report.pages[0]?.responseHeaders?.contentType).toBe("text/html");
+    const json = pageJson(report);
+    expect(json).not.toContain("session=abc123");
+    expect(json).not.toContain("consent=1");
+    expect(json.toLowerCase()).not.toContain("setcookie");
+    expect(report.pages[0]?.url).toBe(SITE);
     await run(store.close());
   });
 
-  test("single cookie is stripped too", async () => {
+  test("a single cookie reaches no part of the page", async () => {
     const { store, crawlId } = await freshCrawl([
       pageWithSetCookie("session=abc123; HttpOnly"),
     ]);
     const report = await run(reconstructReport(store, crawlId, undefined));
 
-    expect(setCookieOf(report)).toBeUndefined();
+    expect(pageJson(report)).not.toContain("session=abc123");
     await run(store.close());
   });
 
-  test("no set-cookie: responseHeaders pass through unaffected", async () => {
+  test("response headers are not carried at all, cookie or no cookie", async () => {
+    // Since #1938 the guarantee is structural: nothing read `responseHeaders`,
+    // so the report stopped carrying them and there is no strip left to forget.
     const { store, crawlId } = await freshCrawl([pageWithSetCookie(null)]);
     const report = await run(reconstructReport(store, crawlId, undefined));
 
-    expect(setCookieOf(report)).toBeUndefined();
-    expect(report.pages[0]?.responseHeaders?.server).toBe("nginx");
+    expect(report.pages[0]?.responseHeaders).toBeUndefined();
     await run(store.close());
   });
 });

--- a/apps/cli/tests/controllers/publish-payload-parity.test.ts
+++ b/apps/cli/tests/controllers/publish-payload-parity.test.ts
@@ -1,0 +1,135 @@
+// #1938: the CLI's report stopped carrying per-page fields nothing read. The
+// publish payload is the one consumer that could have depended on one quietly,
+// so this pins the whole body rather than trusting a grep.
+//
+// It builds a report the way `reconstructReport` does now, runs it through the
+// real publish transform, and compares against the same report with the dropped
+// fields put back. If the payload were to depend on any of them, the two bodies
+// would differ and this fails.
+
+import { describe, expect, test } from "bun:test";
+
+import type { AuditReport, PageAudit } from "@/types";
+
+import { slimForPublish } from "../../src/controllers/report/publish";
+
+const BASE = "https://example.com";
+
+function baseReport(pages: PageAudit[]): AuditReport {
+  return {
+    crawlId: "crawl-1",
+    baseUrl: BASE,
+    timestamp: new Date(0).toISOString(),
+    pages,
+    summary: {
+      missingTitles: [],
+      missingDescriptions: [],
+      missingOgTags: [],
+      missingTwitterCards: [],
+      missingSchemas: [],
+      missingAltText: [],
+      multipleH1s: [],
+      thinContentPages: [],
+      urlIssues: [],
+      redirectChains: [],
+      securityIssues: [],
+    },
+    ruleResults: {},
+    siteChecks: [],
+    healthScore: {
+      overall: 90,
+      grade: "A",
+      groups: [],
+      passed: 1,
+      warnings: 0,
+      failed: 0,
+      total: 1,
+    },
+  } as unknown as AuditReport;
+}
+
+/** What reconstructReport builds today. */
+function leanPage(url: string, statusCode = 200): PageAudit {
+  return {
+    url,
+    statusCode,
+    meta: {
+      title: `Title ${url}`,
+      description: `Desc ${url}`,
+      canonical: null,
+      robots: null,
+    },
+    og: {
+      title: `OG ${url}`,
+      description: null,
+      url: null,
+      type: null,
+      image: null,
+      siteName: null,
+    },
+    checks: [],
+  } as unknown as PageAudit;
+}
+
+/** The same page with every field #1938 stopped populating put back. */
+function fatPage(url: string, statusCode = 200): PageAudit {
+  return {
+    ...leanPage(url, statusCode),
+    loadTime: 123,
+    twitter: { card: "summary", title: "t", description: "d", image: "i" },
+    schema: {
+      types: ["Article"],
+      valid: true,
+      errors: [],
+      raw: JSON.stringify({ "@type": "Article", body: "x".repeat(500) }),
+    },
+    links: [
+      { url: `${BASE}/other`, text: "other", isInternal: true },
+      { url: "https://out.test/a", text: "out", isInternal: false },
+    ],
+    images: [{ src: `${BASE}/a.png`, alt: "a", width: null, height: null }],
+    h1Count: 1,
+    h1Text: ["Heading"],
+    responseHeaders: { server: "nginx", contentType: "text/html" },
+    security: {
+      isHttps: true,
+      hasMixedContent: false,
+      mixedContentUrls: [],
+      insecureFormActions: [],
+      headers: {},
+      httpToHttpsRedirect: false,
+    },
+  } as unknown as PageAudit;
+}
+
+const urls = [`${BASE}/`, `${BASE}/a`, `${BASE}/b`];
+
+describe("publish payload after #1938", () => {
+  test("is byte-identical with and without the dropped page fields", () => {
+    const lean = slimForPublish(baseReport(urls.map((u) => leanPage(u))));
+    const fat = slimForPublish(baseReport(urls.map((u) => fatPage(u))));
+
+    expect(JSON.stringify(lean)).toBe(JSON.stringify(fat));
+  });
+
+  test("still carries the home page title and description", () => {
+    // pickHomepageSummary reads meta/og off the home page to seed the website
+    // record. That is why those two are the fields #1938 KEPT.
+    const slim = slimForPublish(baseReport(urls.map((u) => leanPage(u))));
+    expect(slim.homepage).toEqual({
+      title: `Title ${BASE}/`,
+      description: `Desc ${BASE}/`,
+    });
+  });
+
+  test("still reports non-2xx page statuses", () => {
+    const pages = [leanPage(`${BASE}/`), leanPage(`${BASE}/gone`, 404)];
+    const slim = slimForPublish(baseReport(pages)) as unknown as {
+      pageStatuses?: Array<{ url: string; status: number }>;
+      pages: unknown[];
+    };
+    expect(slim.pageStatuses).toEqual([{ url: `${BASE}/gone`, status: 404 }]);
+    // And pages[] is still emptied, as it always was.
+    expect(slim.pages).toEqual([]);
+  });
+});

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -256,6 +256,38 @@ factor of four), and those figures should be read as the shape rather than to
 three digits. For a change worth tens or low hundreds of megabytes, measure the
 call in isolation against a retain-nothing control instead.
 
+## The report's per-page fields that nothing read
+
+`reconstructReport` built a full `PageAudit` per page: `meta`, `og`, `twitter`,
+`schema`, `links`, `images`, `h1Count`, `h1Text`, `loadTime`, `responseHeaders`,
+`security`. No output format emits `report.pages`, and the publish path sends
+`pages: []` after taking the urls, the statuses and the home page's title, so
+most of that was built and discarded ([#260](https://github.com/squirrelscan/squirrelscan/pull/260)).
+
+Only `meta` and `og` survived the search for a reader: `pickHomepageSummary`
+reads them off the home page to seed the website record. A differential test
+pins the publish body as byte-identical with and without the dropped fields.
+
+**Measured neutral on this fixture, and the reason is the fixture.** Growth
+across `reconstructReport` on the 1,000-page corpus, warmed, two runs per side:
+
+| | heap | RSS | wall |
+|---|---|---|---|
+| before | +114 MB | +52 to +127 MB | 468-479 ms |
+| after | +113 to +117 MB | +82 to +152 MB | 446-607 ms |
+
+The two largest fields dropped are `links` and `images`, and this corpus stores
+**zero** of either: they are written by the external-link phase, and the
+benchmark runs `--offline` against a site with no outbound links. So the arrays
+being dropped were already empty, and the per-page `getLinkAppearancesForPage`
+query the change also removes had nothing to return.
+
+What the change removes structurally, and what a site with external links would
+therefore save, is one storage query per page plus a whole-crawl `getLinks`
+read, and three of the five objects in the per-page detach. That is not recorded
+here as a number because it was not measured. A fixture that can show it needs
+stored links and images, which means an audit with external-link checking on.
+
 ## Still open
 
 - Site rules are quadratic in page count (4 s at 400 pages, 99 s at 2,500,


### PR DESCRIPTION
Closes squirrelscan/repo#1938. No behaviour change; the emitted report and the publish body are unchanged.

## What was happening

`reconstructReport` built a full `PageAudit` for every crawled page: `meta`, `og`, `twitter`, `schema`, `links`, `images`, `h1Count`, `h1Text`, `loadTime`, `responseHeaders`, `security`. Most of it was built and thrown away.

No output format emits `report.pages` — not json, llm, markdown, sarif, xml, html, pdf or text. The publish path sends `pages: []` after taking the urls, the statuses and the home page's title.

## What actually reads a page field

Searched rather than assumed, across the CLI and `packages/report`:

| consumer | reads |
| --- | --- |
| `cli/commands/audit.ts` | `.length` |
| `controllers/report/publish.ts` | `.url`, `.statusCode`, and `meta`/`og` on the home page |
| `cli/commands/report.ts`, `reports/filters.ts` | `.checks`, filtered in place |
| `reports/reconstruct.ts` | `.fallbackReason`, for one count |

`links` had a reader on paper, `apps/cli/src/links/index.ts`, but that module is referenced only by its own test file and never runs in production.

So `meta` and `og` are kept, because `pickHomepageSummary` reads them off the home page to seed the website record. Everything else in the list above is no longer built.

## Also removed with them

The per-page `getLinkAppearancesForPage` query and the whole-crawl `getLinks` read that fed `links`, and three of the five objects in the per-page detach. The image-appearance query stays: it also drives `summary.missingAltText`, which *is* emitted.

## Measured neutral here, and the fixture is why

Growth across `reconstructReport` on the 1,000-page corpus, warmed, two runs per side:

| | heap | RSS | wall |
| --- | --- | --- | --- |
| before | +114 MB | +52 to +127 MB | 468-479 ms |
| after | +113 to +117 MB | +82 to +152 MB | 446-607 ms |

The two largest fields dropped are `links` and `images`, and this corpus stores **zero** of either. They are written by the external-link phase, and the benchmark runs `--offline` against a site with no outbound links, so the arrays being dropped were already empty and the per-page query had nothing to return.

What the change removes structurally — a storage query per page on any site that does have external links — is not claimed as a number, because I did not measure it. The benchmarks file says so in those words rather than recording a win that was not observed.

## Parity

- **Publish body**: a differential test builds the same report with and without every dropped field and asserts the two `slimForPublish` outputs are byte-identical, plus that the home-page title still comes through and non-2xx statuses are still reported. That is the one consumer that could have depended on a field quietly.
- **Emitted report**: byte-identical end to end at 400 pages against the pre-#1913 baseline.
- Engine goldens green; the engine's own `buildV1Report`, which publishes `pages[]` unstripped and needs these fields, is untouched.

## A side effect worth calling out

`responseHeaders` going means there is no Set-Cookie strip left to forget: the field the cookie used to ride on is no longer built. The test that covered that strip now asserts over the whole report serialized as JSON, so a cookie arriving by some other route would fail it too.

Stated precisely, because the review caught me overstating it: the first version of that test looked only at the first page's fields, which did not prove the claim the commit made. It looks at the whole report now. Note also that the `security/cookie-flags` rule deliberately keeps cookie *names* in its check items and discards the values; this is about the values.

## Type shape

The dropped fields stay in `PageAudit` as optional rather than being removed, so anything constructing or consuming one still compiles.
