### PR TITLE
perf(crawler): cache the seven storage statements a crawl compiles per page

### DIFF
--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -161,62 +161,75 @@ remaining 95 were worth touching, and the answer was five
 
 | statements compiled, 120-page crawl at 40 links/page | before | after |
 |---|---|---|
-| `incremental: true`, the CLI default | 168 | 50 |
-| per page | 1.4 | 0.4 |
-| `incremental: false` | 513 | 48 |
-| per page | 4.3 | 0.4 |
+| `incremental: true`, the CLI default | 633 (5.3/page) | 38 (0.3/page) |
+| `incremental: false` | 513 (4.3/page) | 37 (0.3/page) |
 | scaling in page count, both | O(pages) | O(1) |
 
 The five were `upsertPage`, `upsertFrontier`, `getIncomingLinkCount`, the
-crawl-stats `UPDATE` and `getCachedPage`. That last one only appears with
-`incremental` on, which is the CLI's default and was NOT what the first census
-run measured — the count fell from 4.3 to 1.4 per page purely by turning the
-real default on, because incremental replaces four cheap compilations with one
-expensive one. Everything else in the file runs once or twice per crawl, and
-tripling links per page from 40 to 120 changed the total by nothing, which is
-what confirms #247 had already removed the only per-link statement.
+crawl-stats `UPDATE` and `getCachedPage`. That last one only runs with
+`incremental` on, which is the CLI's default and was not what the first census
+measured. Everything else in the file runs once or twice per crawl, and tripling
+links per page from 40 to 120 changed the total by nothing, which confirms #247
+had already removed the only per-link statement.
 
 Compilation cost per statement, against the real schema, minimum of five
 interleaved rounds of 5,000:
 
 | statement | `prepare` | `query` cache hit |
 |---|---|---|
-| `getCachedPage` | 15.11 us | 0.01 us |
-| `upsertFrontier` | 5.50 us | 0.01 us |
-| `updateCrawl` (stats) | 3.27 us | 0.01 us |
-| `getIncomingLinkCount` | 2.97 us | 0.01 us |
+| `getCachedPage` | 10.47 us | 0.01 us |
+| `upsertPage` | 6.80 us | 0.01 us |
+| `upsertFrontier` | 4.89 us | 0.01 us |
+| `getIncomingLinkCount` | 2.45 us | 0.01 us |
+| `updateCrawl` (stats) | 1.78 us | 0.01 us |
 
-So about 27 us per page, or **0.3 s across a 10,000-page crawl**. `upsertPage`
-is excluded: it is the widest statement in the file and quoting a number for it
-without the full binding set would be a guess.
+26.4 us per page, or **0.26 s across a 10,000-page crawl**.
 
 **This is a count, not a time.** An interleaved A/B of the crawl at 400 pages
-gave minima of 1.1 s before and 0.9 s after, but the arithmetic above accounts
-for 11 ms of that 200 ms, so the wall-clock pair is noise and is not evidence.
-A count is immune to what else the machine is doing, which is why it is the
+gave minima of 1.1 s before and 0.9 s after, but the arithmetic accounts for
+11 ms of that 200 ms, so the wall-clock pair is noise and is not evidence. A
+count is immune to what else the machine is doing, which is why it is the
 headline and why the regression test asserts on compilation rather than a clock.
-Machine: 16 GB Apple Silicon laptop, load average 8.9 with other lanes running.
+Machine: 16 GB Apple Silicon laptop, load average 4 to 9 with other lanes
+running, which disqualifies the timing rows and does not touch the counts.
 
-Crawl output is unchanged: a serialised crawl at 120, 250 and 400 pages produces
-the same digest before and after over stored pages including `html`,
-`parsed_data` and `headers`, every frontier verdict, and the crawls row. The
-first version of that digest omitted `parsed_data` and would have passed with
-all 120 values nulled, so the projection is deliberately wide rather than
-readable. The crawler does not populate `link_appearances`, so the link table
-contributes nothing to the comparison and is not evidence of anything.
+### The statement cache has a hard ceiling
 
-Two things had to be fixed before the digest meant anything, and both first
-looked like the change breaking something: the crawl is non-deterministic at
-concurrency 8, because discovery order decides each URL's depth and parent, and
-`port: 0` puts a different ephemeral port in every stored URL, so identical code
-hashed differently three times running.
+On Bun 1.3.14 it holds the first **20 texts per Database and never evicts**: the
+21st and beyond recompile on every call, forever and silently. Measured — 25
+distinct texts, then three passes over the same 25, gave 18 compilations rather
+than 0. The crawler now uses 12 texts. Converting another nine would not fail,
+it would quietly push earlier statements back onto a compile per call, so this
+is a ceiling on the whole approach rather than a tuning knob.
 
-One trap for anyone repeating this. Hooking `Database.prototype.prepare` counts
-`prepare` and NOTHING ELSE: `db.query` compiles through an internal path the
-hook never sees, so a suite that only counts `prepare` passes just as happily
-with the statement cache disabled. The census counts `prepare` calls and
-distinct `query` texts separately, and the test asserts the cache directly by
-checking `db.query(sql)` returns the same object twice.
+### Counting compilations is version-dependent
+
+On 1.3.14 `db.query` routes a cache MISS through the public `prepare`, so a hook
+on `prepare` sees every compilation from both call styles. On Bun 1.4.0 `query`
+compiles through an internal path that hook cannot see, and a census there would
+report zero and look like a pass. Two earlier versions of this measurement were
+wrong in both directions — one missed query compilations entirely, the next
+added them to the prepare count and double-counted — so check the mechanism
+before trusting a number from another Bun.
+
+### Byte-identity, and two digests that were not
+
+A serialised crawl at 120 and 250 pages produces the same digest before and
+after, over every deterministic page column, every frontier verdict and the
+crawls row, with the site crawled **twice** so the incremental path is exercised.
+
+Both narrower versions of that digest were defeated in review. The first omitted
+`parsed_data` and passed with all 120 values nulled. The second omitted the
+stored `url` and passed with every one replaced by `CORRUPTED`. A third problem
+was subtler: crawling once leaves the cache empty, so `getCachedPage` never hits
+and a version of it returning `null` unconditionally produced the same digest.
+Crawling twice catches that — verified, the mutation now changes the hash.
+
+Two further things had to be fixed before any digest meant anything, and both
+first looked like the change breaking something: the crawl is non-deterministic
+at concurrency 8, because discovery order decides each URL's depth and parent,
+and `port: 0` puts a different ephemeral port in every stored URL, so identical
+code hashed differently three times running.
 
 ## Hosted runtime, in production
 

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -156,74 +156,83 @@ compiles a new one every call. The crawler's storage layer used `prepare` in all
 116 places ([#1911](https://github.com/squirrelscan/repo/issues/1911)).
 [#247](https://github.com/squirrelscan/squirrelscan/pull/247) converted the
 per-link frontier check; a census of a real crawl then showed which of the
-remaining 95 were worth touching, and the answer was five
+remaining 95 still ran per page, and the answer was seven
 ([#262](https://github.com/squirrelscan/squirrelscan/pull/262)).
 
-| statements compiled, 120-page crawl at 40 links/page | before | after |
-|---|---|---|
-| `incremental: true`, the CLI default | 633 (5.3/page) | 38 (0.3/page) |
-| `incremental: false` | 513 (4.3/page) | 37 (0.3/page) |
-| scaling in page count, both | O(pages) | O(1) |
+Compilations from `prepare` and `query`, 120-page crawl at 40 links/page:
 
-The five were `upsertPage`, `upsertFrontier`, `getIncomingLinkCount`, the
-crawl-stats `UPDATE` and `getCachedPage`. That last one only runs with
-`incremental` on, which is the CLI's default and was not what the first census
-measured. Everything else in the file runs once or twice per crawl, and tripling
-links per page from 40 to 120 changed the total by nothing, which confirms #247
-had already removed the only per-link statement.
+| | before | after |
+|---|---|---|
+| cold crawl, `incremental: true` (the CLI default) | 633 (5.3/page) | 38 (0.3/page) |
+| cold crawl, `incremental: false` | 513 (4.3/page) | 37 (0.3/page) |
+| **warm re-crawl of the same site** | **1,482 (12.3/page)** | **48 (0.4/page)** |
+
+The warm row is the one that matters, and it is the one a first census missed
+entirely. Five statements run per page on a cold crawl — `upsertPage`,
+`upsertFrontier`, `getIncomingLinkCount`, the crawl-stats `UPDATE` and
+`getCachedPage` — and two more run per REUSED page on a warm one,
+`getLinksByPage` and `getImagesByPage`. A re-audit is the common case and was
+paying 12.3 compilations per page.
 
 Compilation cost per statement, against the real schema, minimum of five
-interleaved rounds of 5,000:
+interleaved rounds of 5,000. A `query` cache hit is 0.01 us in every row:
 
-| statement | `prepare` | `query` cache hit |
-|---|---|---|
-| `getCachedPage` | 10.47 us | 0.01 us |
-| `upsertPage` | 6.80 us | 0.01 us |
-| `upsertFrontier` | 4.89 us | 0.01 us |
-| `getIncomingLinkCount` | 2.45 us | 0.01 us |
-| `updateCrawl` (stats) | 1.78 us | 0.01 us |
+| statement | `prepare` |
+|---|---|
+| `getCachedPage` | 10.17 us |
+| `getLinksByPage` | 9.71 us |
+| `upsertPage` | 9.30 us |
+| `getImagesByPage` | 9.16 us |
+| `upsertFrontier` | 4.91 us |
+| `getIncomingLinkCount` | 2.43 us |
+| `updateCrawl` (stats) | 1.78 us |
 
-26.4 us per page, or **0.26 s across a 10,000-page crawl**.
+47.5 us per page on a warm crawl, 0.5 s across a 10,000-page re-audit.
 
 **This is a count, not a time.** An interleaved A/B of the crawl at 400 pages
 gave minima of 1.1 s before and 0.9 s after, but the arithmetic accounts for
-11 ms of that 200 ms, so the wall-clock pair is noise and is not evidence. A
-count is immune to what else the machine is doing, which is why it is the
+about 19 ms of that 200 ms, so the wall-clock pair is noise and is not evidence.
+A count is immune to what else the machine is doing, which is why it is the
 headline and why the regression test asserts on compilation rather than a clock.
 Machine: 16 GB Apple Silicon laptop, load average 4 to 9 with other lanes
 running, which disqualifies the timing rows and does not touch the counts.
 
-### The statement cache has a hard ceiling
+### The statement cache has a ceiling, and it starves rather than evicts
 
-On Bun 1.3.14 it holds the first **20 texts per Database and never evicts**: the
-21st and beyond recompile on every call, forever and silently. Measured — 25
-distinct texts, then three passes over the same 25, gave 18 compilations rather
-than 0. The crawler now uses 12 texts. Converting another nine would not fail,
-it would quietly push earlier statements back onto a compile per call, so this
-is a ceiling on the whole approach rather than a tuning knob.
+On Bun 1.3.14 it holds the first **20 texts per Database and never evicts**. A
+statement that gets in stays in; one that arrives late never gets in at all and
+recompiles on every call, forever and silently. Measured on a fresh database:
+25 distinct texts, then three passes over the same 25, gave 15 compilations
+rather than 0 — the five that never made it, three times each.
+`Database.MAX_QUERY_CACHE_SIZE` raises the limit (30 caches all 25), but the
+default is what ships. The crawler now uses 14 texts, so converting another six
+would fill it and starve whatever came next.
 
 ### Counting compilations is version-dependent
 
 On 1.3.14 `db.query` routes a cache MISS through the public `prepare`, so a hook
-on `prepare` sees every compilation from both call styles. On Bun 1.4.0 `query`
-compiles through an internal path that hook cannot see, and a census there would
-report zero and look like a pass. Two earlier versions of this measurement were
-wrong in both directions — one missed query compilations entirely, the next
-added them to the prepare count and double-counted — so check the mechanism
-before trusting a number from another Bun.
+on `prepare` sees every compilation from both call styles — though not from
+`exec`/`run`, which the schema setup uses. On Bun 1.4.0 `query` compiles through
+an internal path that hook cannot see, and a census there would report zero and
+look like a pass. Three versions of this measurement were wrong: one missed
+query compilations, the next added distinct query texts to the prepare count and
+double-counted, and the third derived "served without compiling" as
+calls-minus-texts, which assumes every repeat hits and still reported 6,034 free
+calls with the cache forced to zero entries. The census now attributes each
+compilation to the call that caused it.
 
-### Byte-identity, and two digests that were not
+### Byte-identity, and three digests that were not
 
 A serialised crawl at 120 and 250 pages produces the same digest before and
 after, over every deterministic page column, every frontier verdict and the
-crawls row, with the site crawled **twice** so the incremental path is exercised.
+crawls row, with the site crawled **twice** so the incremental path is exercised
+(the second crawl records 120 `hash_match` reuses).
 
-Both narrower versions of that digest were defeated in review. The first omitted
-`parsed_data` and passed with all 120 values nulled. The second omitted the
-stored `url` and passed with every one replaced by `CORRUPTED`. A third problem
-was subtler: crawling once leaves the cache empty, so `getCachedPage` never hits
-and a version of it returning `null` unconditionally produced the same digest.
-Crawling twice catches that — verified, the mutation now changes the hash.
+All three earlier versions of that digest were defeated in review. The first
+omitted `parsed_data` and passed with all 120 values nulled. The second omitted
+the stored `url` and passed with every one replaced by `CORRUPTED`. Both crawled
+once, which leaves the cache empty, so `getCachedPage` never hit and a version
+of it returning `null` unconditionally also passed.
 
 Two further things had to be fixed before any digest meant anything, and both
 first looked like the change breaking something: the crawl is non-deterministic

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -148,6 +148,50 @@ not merely add noise to a cache-hostile scan, it systematically inflates it**, s
 minimum-of-N on a busy box is not a defence. Re-run the pair on a quiet machine
 before publishing a delta.
 
+## Storage statement compilation in the crawler
+
+`bun:sqlite` has two ways to get a statement and they are not interchangeable:
+`db.query(sql)` caches the compiled statement by SQL text, `db.prepare(sql)`
+compiles a new one every call. The crawler's storage layer used `prepare` in all
+116 places, so every operation re-parsed its SQL
+([#1911](https://github.com/squirrelscan/repo/issues/1911)).
+[#247](https://github.com/squirrelscan/squirrelscan/pull/247) converted the
+per-link frontier check; a census of a real crawl then showed which of the
+remaining 95 were worth touching, and the answer was four
+([#259](https://github.com/squirrelscan/squirrelscan/pull/259)).
+
+| statements compiled | before | after |
+|---|---|---|
+| 120-page crawl, 40 links/page | 513 | 37 |
+| per page | 4.3 | 0.3 |
+| scaling in page count | O(pages) | O(1) |
+
+The four were `upsertPage`, `upsertFrontier`, `getIncomingLinkCount` and the
+crawl-stats `UPDATE`. Every other statement in the file runs once per crawl, and
+tripling links per page from 40 to 120 changed the total by nothing, which is
+what confirmed #247 had already removed the only per-link one.
+
+**This is a count, not a time, and that is the point.** Compilation costs
+2.4 us (minimum of five interleaved rounds of 20,000; `db.query` on a cache hit
+is 0.01 us), so removing four per page is worth about 10 us per page, or
+0.1 s across a 10,000-page crawl. An interleaved A/B of the crawl itself at 400
+pages gave minima of 1.1 s before and 0.9 s after, but the arithmetic above can
+only account for 4 ms of that 200 ms, so the rest is noise and the wall-clock
+pair is not evidence of anything. A count is immune to that, which is why it is
+the headline here and why the regression test asserts on compilations rather
+than on a clock.
+
+Machine: 16 GB Apple Silicon laptop, load average 8.9 with other lanes running.
+Stated because it disqualifies the timing rows and does not touch the counts.
+
+Crawl output is byte-identical: a serialised crawl at 120, 250 and 400 pages
+produces the same digest of stored pages, frontier verdicts and link
+appearances before and after. Two things had to be fixed before that digest
+meant anything, and both looked like failures at first — the crawl is
+non-deterministic at concurrency 8, because discovery order decides each URL's
+depth and parent, and `port: 0` puts a different ephemeral port in every URL, so
+identical code hashed differently three times running.
+
 ## Hosted runtime, in production
 
 Same 149-page rendered audit of the same site an hour apart, old image against

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -153,44 +153,70 @@ before publishing a delta.
 `bun:sqlite` has two ways to get a statement and they are not interchangeable:
 `db.query(sql)` caches the compiled statement by SQL text, `db.prepare(sql)`
 compiles a new one every call. The crawler's storage layer used `prepare` in all
-116 places, so every operation re-parsed its SQL
-([#1911](https://github.com/squirrelscan/repo/issues/1911)).
+116 places ([#1911](https://github.com/squirrelscan/repo/issues/1911)).
 [#247](https://github.com/squirrelscan/squirrelscan/pull/247) converted the
 per-link frontier check; a census of a real crawl then showed which of the
-remaining 95 were worth touching, and the answer was four
-([#259](https://github.com/squirrelscan/squirrelscan/pull/259)).
+remaining 95 were worth touching, and the answer was five
+([#262](https://github.com/squirrelscan/squirrelscan/pull/262)).
 
-| statements compiled | before | after |
+| statements compiled, 120-page crawl at 40 links/page | before | after |
 |---|---|---|
-| 120-page crawl, 40 links/page | 513 | 37 |
-| per page | 4.3 | 0.3 |
-| scaling in page count | O(pages) | O(1) |
+| `incremental: true`, the CLI default | 168 | 50 |
+| per page | 1.4 | 0.4 |
+| `incremental: false` | 513 | 48 |
+| per page | 4.3 | 0.4 |
+| scaling in page count, both | O(pages) | O(1) |
 
-The four were `upsertPage`, `upsertFrontier`, `getIncomingLinkCount` and the
-crawl-stats `UPDATE`. Every other statement in the file runs once per crawl, and
+The five were `upsertPage`, `upsertFrontier`, `getIncomingLinkCount`, the
+crawl-stats `UPDATE` and `getCachedPage`. That last one only appears with
+`incremental` on, which is the CLI's default and was NOT what the first census
+run measured — the count fell from 4.3 to 1.4 per page purely by turning the
+real default on, because incremental replaces four cheap compilations with one
+expensive one. Everything else in the file runs once or twice per crawl, and
 tripling links per page from 40 to 120 changed the total by nothing, which is
-what confirmed #247 had already removed the only per-link one.
+what confirms #247 had already removed the only per-link statement.
 
-**This is a count, not a time, and that is the point.** Compilation costs
-2.4 us (minimum of five interleaved rounds of 20,000; `db.query` on a cache hit
-is 0.01 us), so removing four per page is worth about 10 us per page, or
-0.1 s across a 10,000-page crawl. An interleaved A/B of the crawl itself at 400
-pages gave minima of 1.1 s before and 0.9 s after, but the arithmetic above can
-only account for 4 ms of that 200 ms, so the rest is noise and the wall-clock
-pair is not evidence of anything. A count is immune to that, which is why it is
-the headline here and why the regression test asserts on compilations rather
-than on a clock.
+Compilation cost per statement, against the real schema, minimum of five
+interleaved rounds of 5,000:
 
+| statement | `prepare` | `query` cache hit |
+|---|---|---|
+| `getCachedPage` | 15.11 us | 0.01 us |
+| `upsertFrontier` | 5.50 us | 0.01 us |
+| `updateCrawl` (stats) | 3.27 us | 0.01 us |
+| `getIncomingLinkCount` | 2.97 us | 0.01 us |
+
+So about 27 us per page, or **0.3 s across a 10,000-page crawl**. `upsertPage`
+is excluded: it is the widest statement in the file and quoting a number for it
+without the full binding set would be a guess.
+
+**This is a count, not a time.** An interleaved A/B of the crawl at 400 pages
+gave minima of 1.1 s before and 0.9 s after, but the arithmetic above accounts
+for 11 ms of that 200 ms, so the wall-clock pair is noise and is not evidence.
+A count is immune to what else the machine is doing, which is why it is the
+headline and why the regression test asserts on compilation rather than a clock.
 Machine: 16 GB Apple Silicon laptop, load average 8.9 with other lanes running.
-Stated because it disqualifies the timing rows and does not touch the counts.
 
-Crawl output is byte-identical: a serialised crawl at 120, 250 and 400 pages
-produces the same digest of stored pages, frontier verdicts and link
-appearances before and after. Two things had to be fixed before that digest
-meant anything, and both looked like failures at first — the crawl is
-non-deterministic at concurrency 8, because discovery order decides each URL's
-depth and parent, and `port: 0` puts a different ephemeral port in every URL, so
-identical code hashed differently three times running.
+Crawl output is unchanged: a serialised crawl at 120, 250 and 400 pages produces
+the same digest before and after over stored pages including `html`,
+`parsed_data` and `headers`, every frontier verdict, and the crawls row. The
+first version of that digest omitted `parsed_data` and would have passed with
+all 120 values nulled, so the projection is deliberately wide rather than
+readable. The crawler does not populate `link_appearances`, so the link table
+contributes nothing to the comparison and is not evidence of anything.
+
+Two things had to be fixed before the digest meant anything, and both first
+looked like the change breaking something: the crawl is non-deterministic at
+concurrency 8, because discovery order decides each URL's depth and parent, and
+`port: 0` puts a different ephemeral port in every stored URL, so identical code
+hashed differently three times running.
+
+One trap for anyone repeating this. Hooking `Database.prototype.prepare` counts
+`prepare` and NOTHING ELSE: `db.query` compiles through an internal path the
+hook never sees, so a suite that only counts `prepare` passes just as happily
+with the statement cache disabled. The census counts `prepare` calls and
+distinct `query` texts separately, and the test asserts the cache directly by
+checking `db.query(sql)` returns the same object twice.
 
 ## Hosted runtime, in production
 

--- a/packages/crawler/scripts/statement-compile-census.ts
+++ b/packages/crawler/scripts/statement-compile-census.ts
@@ -37,40 +37,62 @@ const arg = (n: string, d: string) => {
 };
 
 const PAGES = Number.parseInt(arg("pages", "200"), 10);
+// The CLI defaults `incremental` to TRUE, and that path reads a cached page per
+// URL, so a census run with it off measures a configuration real audits do not
+// use. Default it on here and let it be turned off rather than the reverse.
+const INCREMENTAL = !process.argv.includes("--no-incremental");
 const LINKS = Number.parseInt(arg("links", "50"), 10);
 const TOP = Number.parseInt(arg("top", "20"), 10);
 // `--digest` prints a hash of what the crawl actually stored instead of the
 // ranking, so the same crawl can be run on two revisions and the outputs
 // compared. A statement-caching change must not move it by a byte.
 const DIGEST = process.argv.includes("--digest");
-// `--cost` measures what one compilation of the converted statements costs, so
-// the census's count can be turned into time without borrowing a number from
-// somewhere else.
+// `--cost` measures what one compilation of each converted statement costs
+// against the real schema, so the census's count can be turned into time
+// without borrowing a number from somewhere else or from a toy table.
 const COST = process.argv.includes("--cost");
 const REPEATS = Math.max(1, Number.parseInt(arg("repeat", "1"), 10));
 
 if (COST) {
-  const db = new Database(":memory:");
-  db.run("CREATE TABLE pages (crawl_id TEXT, normalized_url TEXT, depth INT)");
-  const sql = "SELECT COUNT(*) as count FROM pages WHERE crawl_id = ? AND normalized_url = ?";
-  const N = 20_000;
+  // The REAL statements, against the real schema, because a toy SELECT against
+  // a three-column table compiles faster than a twenty-column INSERT and would
+  // understate what the conversion removes.
+  const costStore = new SQLiteStorage(":memory:");
+  await run(costStore.init());
+  const db = (costStore as unknown as { getDb(): Database }).getDb();
+  const SQL: Array<[string, string]> = [
+    ["getIncomingLinkCount", "SELECT COUNT(*) as count FROM link_appearances WHERE crawl_id = ? AND href = ?"],
+    ["getCachedPage", "SELECT * FROM pages WHERE normalized_url = ? ORDER BY fetched_at DESC, rowid DESC LIMIT 1"],
+    ["updateCrawl (stats)", "UPDATE crawls SET stats = ? WHERE id = ?"],
+    ["upsertFrontier", "INSERT OR REPLACE INTO frontier (crawl_id, normalized_url, raw_url, depth, parent_url, priority, status, source, enqueued_at, fetched_at, retry_count, reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"],
+  ];
+  const N = 5_000;
   // Interleaved, minimum of five rounds: the two arms then share whatever the
   // machine is doing rather than one of them getting a quiet stretch.
-  let bestPrepare = Infinity;
-  let bestQuery = Infinity;
-  for (let round = 0; round < 5; round++) {
-    let t = Bun.nanoseconds();
-    for (let i = 0; i < N; i++) db.prepare(sql);
-    bestPrepare = Math.min(bestPrepare, (Bun.nanoseconds() - t) / N / 1000);
-    t = Bun.nanoseconds();
-    for (let i = 0; i < N; i++) db.query(sql);
-    bestQuery = Math.min(bestQuery, (Bun.nanoseconds() - t) / N / 1000);
+  console.log(`compilation cost per statement, minimum of five interleaved rounds of ${N}:`);
+  console.log(`  ${"statement".padEnd(22)} ${"prepare".padStart(10)} ${"query hit".padStart(10)}`);
+  let totalPrepare = 0;
+  for (const [name, sql] of SQL) {
+    let bestPrepare = Infinity;
+    let bestQuery = Infinity;
+    for (let round = 0; round < 5; round++) {
+      let t = Bun.nanoseconds();
+      for (let i = 0; i < N; i++) db.prepare(sql);
+      bestPrepare = Math.min(bestPrepare, (Bun.nanoseconds() - t) / N / 1000);
+      t = Bun.nanoseconds();
+      for (let i = 0; i < N; i++) db.query(sql);
+      bestQuery = Math.min(bestQuery, (Bun.nanoseconds() - t) / N / 1000);
+    }
+    totalPrepare += bestPrepare;
+    console.log(
+      `  ${name.padEnd(22)} ${`${bestPrepare.toFixed(2)} us`.padStart(10)} ${`${bestQuery.toFixed(2)} us`.padStart(10)}`,
+    );
   }
-  console.log(
-    `compilation cost, minimum of five interleaved rounds of ${N}:\n` +
-      `  db.prepare  ${bestPrepare.toFixed(2)} us/call\n` +
-      `  db.query    ${bestQuery.toFixed(2)} us/call (cache hit)`,
-  );
+  // `upsertPage` is left out: its INSERT is the widest statement in the file and
+  // needs the full binding set to compile representatively, so quoting a number
+  // for it here would be a guess. The four above are the measurable ones.
+  console.log(`  ${"sum of the four".padEnd(22)} ${`${totalPrepare.toFixed(2)} us`.padStart(10)}`);
+  await run(costStore.close());
   process.exit(0);
 }
 
@@ -113,14 +135,36 @@ const origin = `http://127.0.0.1:${server.port}`;
 
 // ── the census ───────────────────────────────────────────────────────────────
 
-// Patched on the PROTOTYPE, before any Database is constructed, so it catches
-// every statement the storage layer compiles including the ones in `init`.
-const compiles = new Map<string, number>();
+// BOTH entry points are patched, and they are counted differently, because
+// hooking `prepare` alone counts the wrong thing.
+//
+// `db.query` does not go through the public `prepare`: Bun compiles it via an
+// internal path, so a hook on `prepare` sees none of it and a run that converted
+// everything to `query` would report zero compilations whether or not the cache
+// was working. What `query` guarantees instead is one compilation per distinct
+// SQL TEXT, with every later call a cache hit — so its compilations are the
+// count of distinct texts, and its calls beyond the first are free.
+//
+// `prepare` compiles on every call, so each call is one compilation.
+const prepareCalls = new Map<string, number>();
+const queryCalls = new Map<string, number>();
 const realPrepare = Database.prototype.prepare;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(Database.prototype as any).prepare = function patched(this: Database, sql: string, ...rest: unknown[]) {
-  compiles.set(sql, (compiles.get(sql) ?? 0) + 1);
-  return (realPrepare as (this: Database, sql: string, ...rest: unknown[]) => unknown).call(this, sql, ...rest);
+const realQuery = Database.prototype.query;
+(Database.prototype as unknown as Record<string, unknown>).prepare = function patched(
+  this: Database,
+  sql: string,
+  ...rest: unknown[]
+) {
+  prepareCalls.set(sql, (prepareCalls.get(sql) ?? 0) + 1);
+  return (realPrepare as (this: Database, sql: string, ...r: unknown[]) => unknown).call(this, sql, ...rest);
+};
+(Database.prototype as unknown as Record<string, unknown>).query = function patchedQuery(
+  this: Database,
+  sql: string,
+  ...rest: unknown[]
+) {
+  queryCalls.set(sql, (queryCalls.get(sql) ?? 0) + 1);
+  return (realQuery as (this: Database, sql: string, ...r: unknown[]) => unknown).call(this, sql, ...rest);
 };
 
 const storage = new SQLiteStorage(":memory:");
@@ -132,7 +176,7 @@ await run(storage.init());
 // worker makes discovery order a function of the site, which is what lets two
 // revisions be compared at all.
 const concurrency = DIGEST ? 1 : 8;
-const crawler = await run(createCrawler({ storage, config: { maxPages: PAGES, concurrency, perHostConcurrency: concurrency, delayMs: 0, perHostDelayMs: 0, respectRobots: false } as never }));
+const crawler = await run(createCrawler({ storage, config: { maxPages: PAGES, concurrency, perHostConcurrency: concurrency, delayMs: 0, perHostDelayMs: 0, respectRobots: false, incremental: INCREMENTAL } as never }));
 
 const startedAt = Date.now();
 const crawlId = await run(crawler.start(origin) as Effect.Effect<string, unknown, never>);
@@ -145,17 +189,26 @@ if (DIGEST) {
   // out on purpose — timings and row ids differ run to run and would mask the
   // question with noise rather than answer it.
   const db = (storage as unknown as { getDb(): import("bun:sqlite").Database }).getDb();
+  // Every column a statement-caching bug could corrupt, not a readable subset.
+  // A narrower projection let a version of this pass with `parsed_data` nulled
+  // on all 120 rows: the digest is only as good as what it looks at.
   const pages = db
     .query(
-      `SELECT normalized_url, final_url, depth, status, content_type, size_bytes, content_hash
+      `SELECT normalized_url, final_url, depth, parent_url, redirect_chain, status, content_type,
+              size_bytes, content_hash, html, parsed_data, headers, security_headers
        FROM pages WHERE crawl_id = ? ORDER BY normalized_url`,
     )
     .all(crawlId);
   const frontier = db
     .query(
-      `SELECT normalized_url, depth, status, source, retry_count, reason
+      `SELECT normalized_url, raw_url, depth, parent_url, priority, status, source, retry_count, reason
        FROM frontier WHERE crawl_id = ? ORDER BY normalized_url`,
     )
+    .all(crawlId);
+  // The crawls row too: the stats UPDATE is one of the converted statements, so
+  // leaving its output out would exempt the change from its own check.
+  const crawls = db
+    .query(`SELECT base_url, seed_url, original_url, status, config, stats FROM crawls WHERE id = ?`)
     .all(crawlId);
   const links = db
     .query(
@@ -173,7 +226,12 @@ if (DIGEST) {
     rows.map((row) =>
       Object.fromEntries(Object.entries(row as Record<string, unknown>).map(([k, v]) => [k, strip(v)])),
     );
-  const digestable = { pages: normalise(pages), frontier: normalise(frontier), links: normalise(links) };
+  const digestable = {
+    pages: normalise(pages),
+    frontier: normalise(frontier),
+    links: normalise(links),
+    crawls: normalise(crawls),
+  };
 
   const outPath = arg("out", "");
   if (outPath) await Bun.write(outPath, JSON.stringify(digestable, null, 1));
@@ -181,6 +239,7 @@ if (DIGEST) {
   hash.update(JSON.stringify(digestable));
   console.log(
     `DIGEST pages=${pages.length} frontier=${frontier.length} links=${links.length} ` +
+      `crawls=${crawls.length} ` +
       `sha256=${hash.digest("hex").slice(0, 32)}`,
   );
   await run(storage.close());
@@ -190,13 +249,25 @@ if (DIGEST) {
 
 server.stop(true);
 
-const rows = [...compiles].sort((a, b) => b[1] - a[1]);
-const total = rows.reduce((sum, [, n]) => sum + n, 0);
+// One compilation per `prepare` CALL; one per distinct `query` TEXT.
+const rows = [...prepareCalls].sort((a, b) => b[1] - a[1]);
+const prepareCompiles = rows.reduce((sum, [, n]) => sum + n, 0);
+const queryCompiles = queryCalls.size;
+const queryHits = [...queryCalls.values()].reduce((sum, n) => sum + n, 0) - queryCompiles;
+const total = prepareCompiles + queryCompiles;
 console.log(
-  `crawled ${pageCount} pages in ${(elapsed / 1000).toFixed(1)}s, ${LINKS} links/page\n` +
-    `${total} statement compilations across ${rows.length} distinct SQL texts ` +
-    `(${(total / Math.max(1, pageCount)).toFixed(1)} per page)\n`,
+  `crawled ${pageCount} pages in ${(elapsed / 1000).toFixed(1)}s, ${LINKS} links/page, ` +
+    `incremental=${INCREMENTAL}\n` +
+    `${total} statement compilations (${(total / Math.max(1, pageCount)).toFixed(1)} per page): ` +
+    `${prepareCompiles} from ${rows.length} prepare texts, ` +
+    `${queryCompiles} from ${queryCalls.size} query texts with ${queryHits} cache hits\n`,
 );
+if (queryCalls.size > 20) {
+  // Bun caches query statements in a bounded LRU. Past its size the cache
+  // thrashes and `query` starts recompiling, which would make every number
+  // above wrong in the safe-looking direction.
+  console.log(`  WARNING: ${queryCalls.size} distinct query texts may exceed Bun's statement cache\n`);
+}
 console.log(`${"count".padStart(8)} ${"per page".padStart(9)}  sql`);
 for (const [sql, n] of rows.slice(0, TOP)) {
   const flat = sql.replace(/\s+/g, " ").trim();

--- a/packages/crawler/scripts/statement-compile-census.ts
+++ b/packages/crawler/scripts/statement-compile-census.ts
@@ -73,6 +73,8 @@ if (COST) {
     // The widest statement in the file. Compilation does not need bindings —
     // it reports its 25 parameters and compiles fine — so an earlier version of
     // this that excluded it for "needing the full binding set" was wrong.
+    ["getLinksByPage", "SELECT DISTINCT l.* FROM links l INNER JOIN link_appearances la ON l.crawl_id = la.crawl_id AND l.href = la.href WHERE la.page_url = ? ORDER BY l.crawl_id DESC"],
+    ["getImagesByPage", "SELECT DISTINCT i.* FROM images i INNER JOIN image_appearances ia ON i.crawl_id = ia.crawl_id AND i.src = ia.src WHERE ia.page_url = ? ORDER BY i.crawl_id DESC"],
     ["upsertPage", "INSERT OR REPLACE INTO pages (crawl_id, url, normalized_url, final_url, depth, parent_url, redirect_chain, status, content_type, size_bytes, load_time_ms, ttfb, download_time, fetched_at, etag, last_modified, content_hash, html, parsed_data, headers, security_headers, request_headers, fetcher_id, fallback_reason, source_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"],
   ];
   const N = 5_000;
@@ -97,7 +99,7 @@ if (COST) {
       `  ${name.padEnd(22)} ${`${bestPrepare.toFixed(2)} us`.padStart(10)} ${`${bestQuery.toFixed(2)} us`.padStart(10)}`,
     );
   }
-  console.log(`  ${"sum of the five".padEnd(22)} ${`${totalPrepare.toFixed(2)} us`.padStart(10)}`);
+  console.log(`  ${"sum of the seven".padEnd(22)} ${`${totalPrepare.toFixed(2)} us`.padStart(10)}`);
   await run(costStore.close());
   process.exit(0);
 }
@@ -152,10 +154,22 @@ const origin = `http://127.0.0.1:${server.port}`;
 // internal path the hook cannot see, and a census there would need a different
 // mechanism — a hook on `prepare` alone would report zero and look like a pass.
 //
-// `query` calls are counted anyway, because their distribution is what says
-// whether the statement cache is being used and whether it is big enough.
+// `query` calls are counted anyway, and the compilations they cause are
+// attributed to them rather than to `prepare`, because their distribution is
+// what says whether the cache is being used and whether it is big enough.
+//
+// Neither hook sees `exec`/`run`, which the schema setup uses, so "every
+// compilation" here means every one from `prepare` and `query`.
 const prepareCalls = new Map<string, number>();
 const queryCalls = new Map<string, number>();
+// A `query` MISS reaches the hook below as a `prepare` call. Flagging while
+// inside `query` is what separates the two, and it is the only honest way to
+// say how many query calls actually compiled: deriving it as
+// (calls - distinct texts) assumes every repeat is a hit, which is false past
+// the cache's capacity — with the cache forced to zero entries that formula
+// still reported 6,034 free calls while everything compiled.
+let insideQuery = 0;
+let queryCompiles = 0;
 const realPrepare = Database.prototype.prepare;
 const realQuery = Database.prototype.query;
 (Database.prototype as unknown as Record<string, unknown>).prepare = function patched(
@@ -163,7 +177,8 @@ const realQuery = Database.prototype.query;
   sql: string,
   ...rest: unknown[]
 ) {
-  prepareCalls.set(sql, (prepareCalls.get(sql) ?? 0) + 1);
+  if (insideQuery > 0) queryCompiles++;
+  else prepareCalls.set(sql, (prepareCalls.get(sql) ?? 0) + 1);
   return (realPrepare as (this: Database, sql: string, ...r: unknown[]) => unknown).call(this, sql, ...rest);
 };
 (Database.prototype as unknown as Record<string, unknown>).query = function patchedQuery(
@@ -172,7 +187,12 @@ const realQuery = Database.prototype.query;
   ...rest: unknown[]
 ) {
   queryCalls.set(sql, (queryCalls.get(sql) ?? 0) + 1);
-  return (realQuery as (this: Database, sql: string, ...r: unknown[]) => unknown).call(this, sql, ...rest);
+  insideQuery++;
+  try {
+    return (realQuery as (this: Database, sql: string, ...r: unknown[]) => unknown).call(this, sql, ...rest);
+  } finally {
+    insideQuery--;
+  }
 };
 
 const storage = new SQLiteStorage(":memory:");
@@ -268,26 +288,30 @@ server.stop(true);
 // Every compilation is a `prepare` call, cache misses included. See the note
 // above the hooks.
 const rows = [...prepareCalls].sort((a, b) => b[1] - a[1]);
-const total = rows.reduce((sum, [, n]) => sum + n, 0);
+const directPrepares = rows.reduce((sum, [, n]) => sum + n, 0);
+const total = directPrepares + queryCompiles;
 const queryTotal = [...queryCalls.values()].reduce((sum, n) => sum + n, 0);
 console.log(
   `crawled ${pageCount} pages in ${(elapsed / 1000).toFixed(1)}s, ${LINKS} links/page, ` +
-    `incremental=${INCREMENTAL}, bun ${Bun.version}\n` +
-    `${total} statement compilations (${(total / Math.max(1, pageCount)).toFixed(1)} per page) ` +
-    `across ${rows.length} distinct texts\n` +
-    `${queryTotal} query calls over ${queryCalls.size} distinct texts, of which ` +
-    `${Math.max(0, queryTotal - queryCalls.size)} were served without compiling\n`,
+    `incremental=${INCREMENTAL}, twice=${TWICE}, bun ${Bun.version}\n` +
+    `${total} statement compilations (${(total / Math.max(1, pageCount)).toFixed(1)} per page): ` +
+    `${directPrepares} from prepare across ${rows.length} texts, ` +
+    `${queryCompiles} from query misses\n` +
+    `${queryTotal} query calls over ${queryCalls.size} distinct texts, ` +
+    `${queryTotal - queryCompiles} of them served without compiling\n`,
 );
 // Bun 1.3.14 caches the first 20 texts PER DATABASE and never evicts: text 21
 // and beyond recompile on every call, forever, silently. Measured: 25 texts
 // then three passes over the same 25 gave 18 compilations rather than 0. So
-// this is a real ceiling on how many statements can be converted, not a
-// tuning knob.
+// this is a ceiling on how many statements are worth converting. It IS
+// adjustable — `Database.MAX_QUERY_CACHE_SIZE = 30` caches all 25 — but the
+// default is what ships.
 const CACHE_TEXTS = 20;
 if (queryCalls.size >= CACHE_TEXTS) {
   console.log(
     `  WARNING: ${queryCalls.size} distinct query texts against a ${CACHE_TEXTS}-entry cache. ` +
-      `Texts past the ${CACHE_TEXTS}th recompile on EVERY call on this Bun.\n`,
+      `A text that never gets IN recompiles on every call; the ones already ` +
+      `cached stay cached.\n`,
   );
 }
 console.log(`${"count".padStart(8)} ${"per page".padStart(9)}  sql`);

--- a/packages/crawler/scripts/statement-compile-census.ts
+++ b/packages/crawler/scripts/statement-compile-census.ts
@@ -1,0 +1,210 @@
+// Which storage statements a real crawl actually compiles, and how often (#1911).
+//
+// `bun:sqlite` has two ways to get a statement and they are not interchangeable:
+// `db.query(sql)` caches by SQL text and hands back the SAME compiled statement,
+// `db.prepare(sql)` compiles a new one every call. The storage layer used
+// `prepare` in all 116 places, so every operation re-parsed its SQL; #247
+// converted the frontier hot path and `getCrawl` and deliberately left the rest.
+//
+// The rest is not a mass edit, because most of those 95 statements run once or
+// twice per crawl and converting them buys nothing while widening the change.
+// This says which ones are hot, from a REAL crawl rather than from reading the
+// code: it patches `Database.prototype.prepare` to count compilations by SQL,
+// runs a crawl against an in-process origin, and prints the ranking.
+//
+//   bun run scripts/statement-compile-census.ts --pages 200 --links 50
+//
+// Read the COUNT column, not the SQL. A statement compiled once per crawl is
+// not worth touching however expensive its text looks; one compiled per link is
+// the whole point of the issue.
+//
+// The origin is served in-process so the census measures storage rather than
+// network: pages are small and link-dense, which is the shape that makes the
+// frontier and link-appearance statements dominate.
+
+import { Database } from "bun:sqlite";
+import { Effect } from "effect";
+
+import { createCrawler } from "../src/core";
+import { SQLiteStorage } from "../src/storage/sqlite";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+const arg = (n: string, d: string) => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? (process.argv[i + 1] ?? d) : d;
+};
+
+const PAGES = Number.parseInt(arg("pages", "200"), 10);
+const LINKS = Number.parseInt(arg("links", "50"), 10);
+const TOP = Number.parseInt(arg("top", "20"), 10);
+// `--digest` prints a hash of what the crawl actually stored instead of the
+// ranking, so the same crawl can be run on two revisions and the outputs
+// compared. A statement-caching change must not move it by a byte.
+const DIGEST = process.argv.includes("--digest");
+// `--cost` measures what one compilation of the converted statements costs, so
+// the census's count can be turned into time without borrowing a number from
+// somewhere else.
+const COST = process.argv.includes("--cost");
+const REPEATS = Math.max(1, Number.parseInt(arg("repeat", "1"), 10));
+
+if (COST) {
+  const db = new Database(":memory:");
+  db.run("CREATE TABLE pages (crawl_id TEXT, normalized_url TEXT, depth INT)");
+  const sql = "SELECT COUNT(*) as count FROM pages WHERE crawl_id = ? AND normalized_url = ?";
+  const N = 20_000;
+  // Interleaved, minimum of five rounds: the two arms then share whatever the
+  // machine is doing rather than one of them getting a quiet stretch.
+  let bestPrepare = Infinity;
+  let bestQuery = Infinity;
+  for (let round = 0; round < 5; round++) {
+    let t = Bun.nanoseconds();
+    for (let i = 0; i < N; i++) db.prepare(sql);
+    bestPrepare = Math.min(bestPrepare, (Bun.nanoseconds() - t) / N / 1000);
+    t = Bun.nanoseconds();
+    for (let i = 0; i < N; i++) db.query(sql);
+    bestQuery = Math.min(bestQuery, (Bun.nanoseconds() - t) / N / 1000);
+  }
+  console.log(
+    `compilation cost, minimum of five interleaved rounds of ${N}:\n` +
+      `  db.prepare  ${bestPrepare.toFixed(2)} us/call\n` +
+      `  db.query    ${bestQuery.toFixed(2)} us/call (cache hit)`,
+  );
+  process.exit(0);
+}
+
+// ── the origin ───────────────────────────────────────────────────────────────
+
+const path = (i: number) => (i === 0 ? "/" : `/p/${String(i).padStart(5, "0")}`);
+
+const server = Bun.serve({
+  port: 0,
+  fetch(request) {
+    const { pathname } = new URL(request.url);
+    if (pathname === "/robots.txt") {
+      return new Response("User-agent: *\nAllow: /\n", {
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    const index = pathname === "/" ? 0 : Number.parseInt(pathname.slice(3), 10);
+    if (!Number.isFinite(index) || index < 0 || index >= PAGES) {
+      return new Response("not found", { status: 404 });
+    }
+    // Link-dense and small: the census is about statement counts, and a big
+    // page would just spend the run in the parser.
+    const links = Array.from(
+      { length: LINKS },
+      (_, k) => `<a href="${path((index * 7 + k * 13) % PAGES)}">Link ${k}</a>`,
+    ).join("");
+    const images = Array.from(
+      { length: 8 },
+      (_, k) => `<img src="/img/${index}/${k}.png" alt="Image ${k}">`,
+    ).join("");
+    return new Response(
+      `<!doctype html><html lang="en"><head><title>Page ${index}</title>` +
+        `<meta name="description" content="Census page ${index}"></head>` +
+        `<body><h1>Page ${index}</h1><nav>${links}</nav>${images}</body></html>`,
+      { headers: { "content-type": "text/html; charset=utf-8" } },
+    );
+  },
+});
+const origin = `http://127.0.0.1:${server.port}`;
+
+// ── the census ───────────────────────────────────────────────────────────────
+
+// Patched on the PROTOTYPE, before any Database is constructed, so it catches
+// every statement the storage layer compiles including the ones in `init`.
+const compiles = new Map<string, number>();
+const realPrepare = Database.prototype.prepare;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(Database.prototype as any).prepare = function patched(this: Database, sql: string, ...rest: unknown[]) {
+  compiles.set(sql, (compiles.get(sql) ?? 0) + 1);
+  return (realPrepare as (this: Database, sql: string, ...rest: unknown[]) => unknown).call(this, sql, ...rest);
+};
+
+const storage = new SQLiteStorage(":memory:");
+await run(storage.init());
+// Digest mode crawls SERIALLY. With workers in flight the order URLs are
+// discovered in decides each one's depth and parent, so the same binary
+// produces a different digest on every run and the comparison is worthless —
+// verified: three runs of identical code gave three different hashes. One
+// worker makes discovery order a function of the site, which is what lets two
+// revisions be compared at all.
+const concurrency = DIGEST ? 1 : 8;
+const crawler = await run(createCrawler({ storage, config: { maxPages: PAGES, concurrency, perHostConcurrency: concurrency, delayMs: 0, perHostDelayMs: 0, respectRobots: false } as never }));
+
+const startedAt = Date.now();
+const crawlId = await run(crawler.start(origin) as Effect.Effect<string, unknown, never>);
+const elapsed = Date.now() - startedAt;
+const pageCount = await run(storage.getPageCount(crawlId));
+
+if (DIGEST) {
+  // Everything the crawl decided, in a stable order: which URLs it stored, what
+  // it made of each one, and every frontier verdict. Volatile columns are left
+  // out on purpose — timings and row ids differ run to run and would mask the
+  // question with noise rather than answer it.
+  const db = (storage as unknown as { getDb(): import("bun:sqlite").Database }).getDb();
+  const pages = db
+    .query(
+      `SELECT normalized_url, final_url, depth, status, content_type, size_bytes, content_hash
+       FROM pages WHERE crawl_id = ? ORDER BY normalized_url`,
+    )
+    .all(crawlId);
+  const frontier = db
+    .query(
+      `SELECT normalized_url, depth, status, source, retry_count, reason
+       FROM frontier WHERE crawl_id = ? ORDER BY normalized_url`,
+    )
+    .all(crawlId);
+  const links = db
+    .query(
+      `SELECT href, page_url, position, is_nofollow FROM link_appearances
+       WHERE crawl_id = ? ORDER BY page_url, href, position`,
+    )
+    .all(crawlId);
+  // The origin is stripped before hashing. `port: 0` takes an ephemeral port,
+  // so every run has a different host in every URL and two runs of IDENTICAL
+  // code hash differently — which is what this looked like the first time, and
+  // is not a difference in what the crawl decided.
+  const strip = (value: unknown): unknown =>
+    typeof value === "string" ? value.split(origin).join("{origin}") : value;
+  const normalise = (rows: unknown[]) =>
+    rows.map((row) =>
+      Object.fromEntries(Object.entries(row as Record<string, unknown>).map(([k, v]) => [k, strip(v)])),
+    );
+  const digestable = { pages: normalise(pages), frontier: normalise(frontier), links: normalise(links) };
+
+  const outPath = arg("out", "");
+  if (outPath) await Bun.write(outPath, JSON.stringify(digestable, null, 1));
+  const hash = new Bun.CryptoHasher("sha256");
+  hash.update(JSON.stringify(digestable));
+  console.log(
+    `DIGEST pages=${pages.length} frontier=${frontier.length} links=${links.length} ` +
+      `sha256=${hash.digest("hex").slice(0, 32)}`,
+  );
+  await run(storage.close());
+  server.stop(true);
+  process.exit(0);
+}
+
+server.stop(true);
+
+const rows = [...compiles].sort((a, b) => b[1] - a[1]);
+const total = rows.reduce((sum, [, n]) => sum + n, 0);
+console.log(
+  `crawled ${pageCount} pages in ${(elapsed / 1000).toFixed(1)}s, ${LINKS} links/page\n` +
+    `${total} statement compilations across ${rows.length} distinct SQL texts ` +
+    `(${(total / Math.max(1, pageCount)).toFixed(1)} per page)\n`,
+);
+console.log(`${"count".padStart(8)} ${"per page".padStart(9)}  sql`);
+for (const [sql, n] of rows.slice(0, TOP)) {
+  const flat = sql.replace(/\s+/g, " ").trim();
+  console.log(
+    `${String(n).padStart(8)} ${(n / Math.max(1, pageCount)).toFixed(1).padStart(9)}  ` +
+      `${flat.length > 110 ? `${flat.slice(0, 107)}...` : flat}`,
+  );
+}
+const tail = rows.slice(TOP).reduce((sum, [, n]) => sum + n, 0);
+if (tail > 0) console.log(`${String(tail).padStart(8)} ${"".padStart(9)}  (${rows.length - TOP} more SQL texts)`);
+await run(storage.close());

--- a/packages/crawler/scripts/statement-compile-census.ts
+++ b/packages/crawler/scripts/statement-compile-census.ts
@@ -47,6 +47,11 @@ const TOP = Number.parseInt(arg("top", "20"), 10);
 // ranking, so the same crawl can be run on two revisions and the outputs
 // compared. A statement-caching change must not move it by a byte.
 const DIGEST = process.argv.includes("--digest");
+// `--twice` crawls the same storage a second time before digesting. The first
+// crawl starts empty, so `getCachedPage` never hits and a version of it that
+// returned `null` unconditionally produced the same digest — the incremental
+// path was not being compared at all.
+const TWICE = process.argv.includes("--twice");
 // `--cost` measures what one compilation of each converted statement costs
 // against the real schema, so the census's count can be turned into time
 // without borrowing a number from somewhere else or from a toy table.
@@ -65,6 +70,10 @@ if (COST) {
     ["getCachedPage", "SELECT * FROM pages WHERE normalized_url = ? ORDER BY fetched_at DESC, rowid DESC LIMIT 1"],
     ["updateCrawl (stats)", "UPDATE crawls SET stats = ? WHERE id = ?"],
     ["upsertFrontier", "INSERT OR REPLACE INTO frontier (crawl_id, normalized_url, raw_url, depth, parent_url, priority, status, source, enqueued_at, fetched_at, retry_count, reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"],
+    // The widest statement in the file. Compilation does not need bindings —
+    // it reports its 25 parameters and compiles fine — so an earlier version of
+    // this that excluded it for "needing the full binding set" was wrong.
+    ["upsertPage", "INSERT OR REPLACE INTO pages (crawl_id, url, normalized_url, final_url, depth, parent_url, redirect_chain, status, content_type, size_bytes, load_time_ms, ttfb, download_time, fetched_at, etag, last_modified, content_hash, html, parsed_data, headers, security_headers, request_headers, fetcher_id, fallback_reason, source_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"],
   ];
   const N = 5_000;
   // Interleaved, minimum of five rounds: the two arms then share whatever the
@@ -88,10 +97,7 @@ if (COST) {
       `  ${name.padEnd(22)} ${`${bestPrepare.toFixed(2)} us`.padStart(10)} ${`${bestQuery.toFixed(2)} us`.padStart(10)}`,
     );
   }
-  // `upsertPage` is left out: its INSERT is the widest statement in the file and
-  // needs the full binding set to compile representatively, so quoting a number
-  // for it here would be a guess. The four above are the measurable ones.
-  console.log(`  ${"sum of the four".padEnd(22)} ${`${totalPrepare.toFixed(2)} us`.padStart(10)}`);
+  console.log(`  ${"sum of the five".padEnd(22)} ${`${totalPrepare.toFixed(2)} us`.padStart(10)}`);
   await run(costStore.close());
   process.exit(0);
 }
@@ -135,17 +141,19 @@ const origin = `http://127.0.0.1:${server.port}`;
 
 // ── the census ───────────────────────────────────────────────────────────────
 
-// BOTH entry points are patched, and they are counted differently, because
-// hooking `prepare` alone counts the wrong thing.
+// Both entry points are patched, but only ONE of them counts compilations, and
+// which one depends on the Bun in use. Verify this before trusting a number
+// from another version.
 //
-// `db.query` does not go through the public `prepare`: Bun compiles it via an
-// internal path, so a hook on `prepare` sees none of it and a run that converted
-// everything to `query` would report zero compilations whether or not the cache
-// was working. What `query` guarantees instead is one compilation per distinct
-// SQL TEXT, with every later call a cache hit — so its compilations are the
-// count of distinct texts, and its calls beyond the first are free.
+// On Bun 1.3.14, which this repo pins, `db.query` routes a cache MISS through
+// the public `prepare` and a cache HIT through nothing. So the `prepare` hook
+// already sees every compilation, from both call styles, and adding the query
+// texts to it would double-count. On Bun 1.4.0 `query` compiles through an
+// internal path the hook cannot see, and a census there would need a different
+// mechanism — a hook on `prepare` alone would report zero and look like a pass.
 //
-// `prepare` compiles on every call, so each call is one compilation.
+// `query` calls are counted anyway, because their distribution is what says
+// whether the statement cache is being used and whether it is big enough.
 const prepareCalls = new Map<string, number>();
 const queryCalls = new Map<string, number>();
 const realPrepare = Database.prototype.prepare;
@@ -179,7 +187,13 @@ const concurrency = DIGEST ? 1 : 8;
 const crawler = await run(createCrawler({ storage, config: { maxPages: PAGES, concurrency, perHostConcurrency: concurrency, delayMs: 0, perHostDelayMs: 0, respectRobots: false, incremental: INCREMENTAL } as never }));
 
 const startedAt = Date.now();
-const crawlId = await run(crawler.start(origin) as Effect.Effect<string, unknown, never>);
+let crawlId = await run(crawler.start(origin) as Effect.Effect<string, unknown, never>);
+if (TWICE) {
+  const second = await run(
+    createCrawler({ storage, config: { maxPages: PAGES, concurrency, perHostConcurrency: concurrency, delayMs: 0, perHostDelayMs: 0, respectRobots: false, incremental: INCREMENTAL } as never }),
+  );
+  crawlId = await run(second.start(origin) as Effect.Effect<string, unknown, never>);
+}
 const elapsed = Date.now() - startedAt;
 const pageCount = await run(storage.getPageCount(crawlId));
 
@@ -189,13 +203,15 @@ if (DIGEST) {
   // out on purpose — timings and row ids differ run to run and would mask the
   // question with noise rather than answer it.
   const db = (storage as unknown as { getDb(): import("bun:sqlite").Database }).getDb();
-  // Every column a statement-caching bug could corrupt, not a readable subset.
-  // A narrower projection let a version of this pass with `parsed_data` nulled
-  // on all 120 rows: the digest is only as good as what it looks at.
+  // Every deterministic column, not a readable subset. Two narrower versions of
+  // this were defeated in review: one passed with `parsed_data` nulled on all
+  // 120 rows, the next passed with every stored `url` replaced by CORRUPTED.
+  // Timings and row ids are still excluded because they differ run to run.
   const pages = db
     .query(
-      `SELECT normalized_url, final_url, depth, parent_url, redirect_chain, status, content_type,
-              size_bytes, content_hash, html, parsed_data, headers, security_headers
+      `SELECT url, normalized_url, final_url, depth, parent_url, redirect_chain, status, content_type,
+              size_bytes, content_hash, html, parsed_data, headers, security_headers,
+              request_headers, etag, last_modified, fetcher_id, fallback_reason, source_hash
        FROM pages WHERE crawl_id = ? ORDER BY normalized_url`,
     )
     .all(crawlId);
@@ -249,24 +265,30 @@ if (DIGEST) {
 
 server.stop(true);
 
-// One compilation per `prepare` CALL; one per distinct `query` TEXT.
+// Every compilation is a `prepare` call, cache misses included. See the note
+// above the hooks.
 const rows = [...prepareCalls].sort((a, b) => b[1] - a[1]);
-const prepareCompiles = rows.reduce((sum, [, n]) => sum + n, 0);
-const queryCompiles = queryCalls.size;
-const queryHits = [...queryCalls.values()].reduce((sum, n) => sum + n, 0) - queryCompiles;
-const total = prepareCompiles + queryCompiles;
+const total = rows.reduce((sum, [, n]) => sum + n, 0);
+const queryTotal = [...queryCalls.values()].reduce((sum, n) => sum + n, 0);
 console.log(
   `crawled ${pageCount} pages in ${(elapsed / 1000).toFixed(1)}s, ${LINKS} links/page, ` +
-    `incremental=${INCREMENTAL}\n` +
-    `${total} statement compilations (${(total / Math.max(1, pageCount)).toFixed(1)} per page): ` +
-    `${prepareCompiles} from ${rows.length} prepare texts, ` +
-    `${queryCompiles} from ${queryCalls.size} query texts with ${queryHits} cache hits\n`,
+    `incremental=${INCREMENTAL}, bun ${Bun.version}\n` +
+    `${total} statement compilations (${(total / Math.max(1, pageCount)).toFixed(1)} per page) ` +
+    `across ${rows.length} distinct texts\n` +
+    `${queryTotal} query calls over ${queryCalls.size} distinct texts, of which ` +
+    `${Math.max(0, queryTotal - queryCalls.size)} were served without compiling\n`,
 );
-if (queryCalls.size > 20) {
-  // Bun caches query statements in a bounded LRU. Past its size the cache
-  // thrashes and `query` starts recompiling, which would make every number
-  // above wrong in the safe-looking direction.
-  console.log(`  WARNING: ${queryCalls.size} distinct query texts may exceed Bun's statement cache\n`);
+// Bun 1.3.14 caches the first 20 texts PER DATABASE and never evicts: text 21
+// and beyond recompile on every call, forever, silently. Measured: 25 texts
+// then three passes over the same 25 gave 18 compilations rather than 0. So
+// this is a real ceiling on how many statements can be converted, not a
+// tuning knob.
+const CACHE_TEXTS = 20;
+if (queryCalls.size >= CACHE_TEXTS) {
+  console.log(
+    `  WARNING: ${queryCalls.size} distinct query texts against a ${CACHE_TEXTS}-entry cache. ` +
+      `Texts past the ${CACHE_TEXTS}th recompile on EVERY call on this Bun.\n`,
+  );
 }
 console.log(`${"count".padStart(8)} ${"per page".padStart(9)}  sql`);
 for (const [sql, n] of rows.slice(0, TOP)) {

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -1138,12 +1138,17 @@ export class SQLiteStorage implements CrawlStorage {
           // texts however a caller mixes them.
           //
           // The hazard is not an unbounded cache. On Bun 1.3.14 the cache holds
-          // the first 20 texts PER DATABASE and never evicts: the 21st text and
-          // beyond recompile on every call, forever and silently. Measured — 25
-          // distinct texts, then three passes over the same 25, gave 18
-          // compilations rather than 0. So a caller that exercised many shapes
-          // here would not slow this statement down, it would push some OTHER
-          // converted statement out of the cache. The crawl loop writes only
+          // the first 20 texts PER DATABASE and NEVER EVICTS, so a statement
+          // that gets in stays in and one that arrives late never gets in at
+          // all: it recompiles on every call, forever and silently. Measured on
+          // a fresh database — 25 distinct texts, then three passes over the
+          // same 25, gave 15 compilations rather than 0, which is the five that
+          // never made it, three times each.
+          //
+          // So many shapes here would not evict anything already cached; they
+          // would fill the remaining slots and starve whatever is converted
+          // next. `Database.MAX_QUERY_CACHE_SIZE` raises the limit (30 caches
+          // all 25), but the default is what ships. The crawl loop writes only
           // `stats`, once per page (#1911).
           const stmt = db.query(
             `UPDATE crawls SET ${sets.join(", ")} WHERE id = ?`
@@ -2069,7 +2074,8 @@ export class SQLiteStorage implements CrawlStorage {
       try: () => {
         const db = this.getDb();
         // Get links that appear on this page (most recent crawl that has them)
-        const stmt = db.prepare(`
+        // Cached: once per REUSED page on a warm incremental crawl (#1911).
+        const stmt = db.query(`
           SELECT DISTINCT l.* FROM links l
           INNER JOIN link_appearances la ON l.crawl_id = la.crawl_id AND l.href = la.href
           WHERE la.page_url = ?
@@ -2225,7 +2231,8 @@ export class SQLiteStorage implements CrawlStorage {
       try: () => {
         const db = this.getDb();
         // Get images that appear on this page (most recent crawl that has them)
-        const stmt = db.prepare(`
+        // Cached: once per REUSED page on a warm incremental crawl (#1911).
+        const stmt = db.query(`
           SELECT DISTINCT i.* FROM images i
           INNER JOIN image_appearances ia ON i.crawl_id = ia.crawl_id AND i.src = ia.src
           WHERE ia.page_url = ?

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -1132,14 +1132,14 @@ export class SQLiteStorage implements CrawlStorage {
 
         if (sets.length > 0) {
           values.push(id);
-          // Cached, and safe to cache even though the SQL is built here: the
-          // statement cache is keyed by TEXT, and `sets` is drawn from a fixed
-          // list of eight optional columns, so the number of distinct texts is
-          // bounded by their combinations rather than by anything a caller
-          // controls. A dynamically-built statement whose shape came from user
-          // input would grow this cache without limit and should keep using
-          // `prepare`. The crawl loop's stats write lands here once per page
-          // (#1911).
+          // Cached, and safe to cache even though the SQL is built here. The
+          // statement cache is keyed by TEXT and `sets` is drawn from eight
+          // fixed optional columns in a fixed order, so there are at most 255
+          // distinct texts however a caller mixes them. Bun's cache is a small
+          // LRU, so the risk from a dynamically-built statement is not an
+          // unbounded cache but CHURN: a shape space larger than that LRU
+          // evicts entries and quietly puts you back on a compile per call.
+          // The crawl loop writes only `stats` here, once per page (#1911).
           const stmt = db.query(
             `UPDATE crawls SET ${sets.join(", ")} WHERE id = ?`
           );
@@ -1449,7 +1449,10 @@ export class SQLiteStorage implements CrawlStorage {
         // shadowing the just-persisted source_hash. `rowid` tracks insert order
         // for this retained, append-like pages table (it isn't WITHOUT ROWID),
         // so DESC prefers the most recently written row on a tie.
-        const stmt = db.prepare(`
+        // Cached: once per URL on the incremental path, which the CLI takes by
+        // default (#1911). Same SQL text, so the plan and the tie-break above
+        // are unchanged; only the compilation is reused.
+        const stmt = db.query(`
           SELECT * FROM pages
           WHERE normalized_url = ?
           ORDER BY fetched_at DESC, rowid DESC

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -1133,13 +1133,18 @@ export class SQLiteStorage implements CrawlStorage {
         if (sets.length > 0) {
           values.push(id);
           // Cached, and safe to cache even though the SQL is built here. The
-          // statement cache is keyed by TEXT and `sets` is drawn from eight
-          // fixed optional columns in a fixed order, so there are at most 255
-          // distinct texts however a caller mixes them. Bun's cache is a small
-          // LRU, so the risk from a dynamically-built statement is not an
-          // unbounded cache but CHURN: a shape space larger than that LRU
-          // evicts entries and quietly puts you back on a compile per call.
-          // The crawl loop writes only `stats` here, once per page (#1911).
+          // cache is keyed by TEXT and `sets` is drawn from eight fixed
+          // optional columns in a fixed order, so there are at most 255 distinct
+          // texts however a caller mixes them.
+          //
+          // The hazard is not an unbounded cache. On Bun 1.3.14 the cache holds
+          // the first 20 texts PER DATABASE and never evicts: the 21st text and
+          // beyond recompile on every call, forever and silently. Measured — 25
+          // distinct texts, then three passes over the same 25, gave 18
+          // compilations rather than 0. So a caller that exercised many shapes
+          // here would not slow this statement down, it would push some OTHER
+          // converted statement out of the cache. The crawl loop writes only
+          // `stats`, once per page (#1911).
           const stmt = db.query(
             `UPDATE crawls SET ${sets.join(", ")} WHERE id = ?`
           );

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -1132,7 +1132,15 @@ export class SQLiteStorage implements CrawlStorage {
 
         if (sets.length > 0) {
           values.push(id);
-          const stmt = db.prepare(
+          // Cached, and safe to cache even though the SQL is built here: the
+          // statement cache is keyed by TEXT, and `sets` is drawn from a fixed
+          // list of eight optional columns, so the number of distinct texts is
+          // bounded by their combinations rather than by anything a caller
+          // controls. A dynamically-built statement whose shape came from user
+          // input would grow this cache without limit and should keep using
+          // `prepare`. The crawl loop's stats write lands here once per page
+          // (#1911).
+          const stmt = db.query(
             `UPDATE crawls SET ${sets.join(", ")} WHERE id = ?`
           );
           stmt.run(...(values as (string | number | null)[]));
@@ -1247,7 +1255,10 @@ export class SQLiteStorage implements CrawlStorage {
           htmlToStore = null; // HTML is in content-store, not local DB
         }
 
-        const stmt = db.prepare(`
+        // Cached: once per crawled page (#1911). See the census in
+        // scripts/statement-compile-census.ts for why this one and not the
+        // other ninety.
+        const stmt = db.query(`
           INSERT OR REPLACE INTO pages (
             crawl_id, url, normalized_url, final_url, depth, parent_url,
             redirect_chain, status, content_type, size_bytes, load_time_ms, ttfb, download_time, fetched_at,
@@ -1535,7 +1546,8 @@ export class SQLiteStorage implements CrawlStorage {
     return Effect.try({
       try: () => {
         const db = this.getDb();
-        const stmt = db.prepare(`
+        // Cached: once per newly discovered URL (#1911).
+        const stmt = db.query(`
           INSERT OR REPLACE INTO frontier (
             crawl_id, normalized_url, raw_url, depth, parent_url,
             priority, status, source, enqueued_at, fetched_at, retry_count, reason
@@ -2000,7 +2012,9 @@ export class SQLiteStorage implements CrawlStorage {
     return Effect.try({
       try: () => {
         const db = this.getDb();
-        const stmt = db.prepare(
+        // Cached: once per newly discovered URL, on the enqueue path that has no
+        // link-count cache to read from (#1911).
+        const stmt = db.query(
           "SELECT COUNT(*) as count FROM link_appearances WHERE crawl_id = ? AND href = ?"
         );
         const row = stmt.get(crawlId, normalizedUrl) as { count: number };

--- a/packages/crawler/tests/hot-statements-cached.test.ts
+++ b/packages/crawler/tests/hot-statements-cached.test.ts
@@ -7,10 +7,17 @@
 // (scripts/statement-compile-census.ts) then showed exactly four statements
 // left running once per page and every other one running once per crawl.
 //
-// This pins those four. It counts COMPILATIONS rather than timing anything: the
-// saving is about 2.2 us per compilation, which is far too small to assert on a
-// clock and far too easy to assert on by accident. A regression to `prepare`
-// shows up here as one compile per call instead of one per suite.
+// This pins those five. It asserts on COMPILATION rather than on a clock: the
+// saving is tens of microseconds per page, far too small to assert on time and
+// far too easy to assert on by accident.
+//
+// TWO assertions are needed, and the first alone is not enough. Counting calls
+// to `Database.prototype.prepare` catches a regression BACK to `prepare` — and
+// only that. `db.query` compiles through an internal path that a hook on
+// `prepare` never sees, so a suite that only counts `prepare` passes just as
+// happily with the statement cache disabled entirely. The second assertion
+// tests the mechanism directly: `db.query` must hand back the SAME statement
+// object for the same SQL text on the Bun actually running.
 
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
@@ -126,6 +133,20 @@ async function compilationsDuring(body: () => Promise<void>): Promise<number> {
 describe("per-page storage statements are cached", () => {
   const N = 50;
 
+  test("db.query really caches on this Bun, which the counters assume", () => {
+    // The counters below prove the code no longer calls `prepare`. They cannot
+    // prove `query` caches, because its compilation is invisible to them. If
+    // this ever fails, every other test in this file is passing for free.
+    const db = new Database(":memory:");
+    db.run("CREATE TABLE t (a TEXT)");
+    const sql = "SELECT a FROM t WHERE a = ?";
+    expect(db.query(sql)).toBe(db.query(sql));
+    // Different text is a different statement, which is what makes the cache a
+    // cache rather than a single slot.
+    expect(db.query(sql)).not.toBe(db.query("SELECT a FROM t WHERE a != ?"));
+    db.close();
+  });
+
   test("upsertPage compiles once, not once per page", async () => {
     const { store, crawlId } = await freshCrawl();
     // Warm first: the first call of anything also compiles whatever the method
@@ -162,6 +183,20 @@ describe("per-page storage statements are cached", () => {
     await run(store.close());
   });
 
+  test("getCachedPage compiles once, not once per url on the incremental path", async () => {
+    // The CLI defaults `incremental` to true, so this runs once per URL on the
+    // path most audits take. A census run with incremental off does not see it,
+    // which is how it was missed the first time.
+    const { store, crawlId } = await freshCrawl();
+    await run(store.getCachedPage("http://example.test/p/0"));
+    const compiles = await compilationsDuring(async () => {
+      for (let i = 1; i <= N; i++) await run(store.getCachedPage(`http://example.test/p/${i}`));
+    });
+    expect(compiles).toBe(0);
+    expect(crawlId).toBeTruthy();
+    await run(store.close());
+  });
+
   test("the crawl stats write compiles once, not once per page", async () => {
     const { store, crawlId } = await freshCrawl();
     // Always the same SET clause, which is what the crawl loop emits. A caller
@@ -177,15 +212,20 @@ describe("per-page storage statements are cached", () => {
     await run(store.close());
   });
 
-  test("a whole crawl's storage work does not compile per page", async () => {
-    // The four above in one loop, which is the shape the crawl loop runs them
-    // in. Asserted as a total rather than per method so a NEW per-page
-    // statement added later fails here too, which is the regression this is
-    // actually guarding against.
+  test("the converted methods together compile nothing per round", async () => {
+    // The converted methods in one loop, in the shape the crawl loop runs them.
+    //
+    // This does NOT catch a new per-page statement added elsewhere in the
+    // storage layer: it only calls these methods, so a `prepare` introduced in,
+    // say, updateFrontierStatus passes here untouched (I checked). The guard
+    // for that is scripts/statement-compile-census.ts, which drives a real
+    // crawl and counts everything; this test is the fast regression pin for the
+    // five that census already found.
     const { store, crawlId } = await freshCrawl();
     const oneRound = async (i: number) => {
       await run(store.upsertFrontier(crawlId, frontier(i)));
       await run(store.getIncomingLinkCount(crawlId, `http://example.test/p/${i}`));
+      await run(store.getCachedPage(`http://example.test/p/${i}`));
       await run(store.upsertPage(crawlId, page(crawlId, i)));
       await run(store.updateCrawl(crawlId, { stats: { ...STATS, pagesFetched: i } }));
     };

--- a/packages/crawler/tests/hot-statements-cached.test.ts
+++ b/packages/crawler/tests/hot-statements-cached.test.ts
@@ -4,18 +4,21 @@
 // compiles a new one every call. The storage layer used `prepare` in all 116
 // places, so every operation re-parsed its SQL. #247 converted the per-link
 // frontier existence check; a census of a real crawl
-// (scripts/statement-compile-census.ts) then showed exactly four statements
-// left running once per page and every other one running once per crawl.
+// (scripts/statement-compile-census.ts) then showed which of the remaining 95
+// still ran per page: five on a cold crawl, and two more on a warm one that
+// reuses cached pages.
 //
-// This pins those five. It asserts on COMPILATION rather than on a clock: the
+// This pins the five on the cold path. It asserts on COMPILATION rather than on a clock: the
 // saving is tens of microseconds per page, far too small to assert on time and
 // far too easy to assert on by accident.
 //
 // TWO assertions are needed, and which one carries the weight depends on the
 // Bun in use. On 1.3.14, which this repo pins, `db.query` routes a cache MISS
 // through the public `prepare`, so the counters below really do see every
-// compilation and a disabled cache fails them (verified: forcing the cache to
-// zero entries fails six of these seven). On Bun 1.4.0 `query` compiles through
+// compilation from `prepare` and `query` — though not from `exec`/`run` — and a
+// disabled cache fails them (verified: forcing the cache to zero entries fails
+// all seven; reverting the conversions fails six, the seventh being the
+// mechanism check, which passes either way and is meant to). On Bun 1.4.0 `query` compiles through
 // an internal path the hook cannot see, and the counters alone would pass with
 // the cache off. The first test therefore checks the mechanism directly —
 // `db.query` must hand back the SAME object for the same text — so this file

--- a/packages/crawler/tests/hot-statements-cached.test.ts
+++ b/packages/crawler/tests/hot-statements-cached.test.ts
@@ -1,0 +1,199 @@
+// The storage statements a crawl runs PER PAGE must be cached (#1911).
+//
+// `db.query(sql)` caches the compiled statement by SQL text; `db.prepare(sql)`
+// compiles a new one every call. The storage layer used `prepare` in all 116
+// places, so every operation re-parsed its SQL. #247 converted the per-link
+// frontier existence check; a census of a real crawl
+// (scripts/statement-compile-census.ts) then showed exactly four statements
+// left running once per page and every other one running once per crawl.
+//
+// This pins those four. It counts COMPILATIONS rather than timing anything: the
+// saving is about 2.2 us per compilation, which is far too small to assert on a
+// clock and far too easy to assert on by accident. A regression to `prepare`
+// shows up here as one compile per call instead of one per suite.
+
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Effect } from "effect";
+
+import type { CrawlMetadata, FrontierRecord, PageRecord } from "../src/storage/types";
+import { SQLiteStorage } from "../src/storage/sqlite";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const CONFIG: CrawlMetadata["config"] = {
+  maxPages: 100,
+  concurrency: 1,
+  perHostConcurrency: 1,
+  delayMs: 0,
+  perHostDelayMs: 0,
+  timeoutMs: 1000,
+  userAgent: "test",
+  followRedirects: true,
+  respectRobots: false,
+  incremental: false,
+  include: [],
+  exclude: [],
+  allowQueryParams: [],
+  dropQueryPrefixes: [],
+  allowedDomains: [],
+} as CrawlMetadata["config"];
+
+const STATS: CrawlMetadata["stats"] = {
+  pagesTotal: 0,
+  pagesFetched: 0,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+} as CrawlMetadata["stats"];
+
+async function freshCrawl(): Promise<{ store: SQLiteStorage; crawlId: string }> {
+  const store = new SQLiteStorage(":memory:");
+  await run(store.init());
+  const crawlId = await run(
+    store.createCrawl({
+      baseUrl: "http://example.test",
+      seedUrl: "http://example.test",
+      originalUrl: "http://example.test",
+      startedAt: 1,
+      status: "running",
+      config: CONFIG,
+      stats: STATS,
+    } as Omit<CrawlMetadata, "id">),
+  );
+  return { store, crawlId };
+}
+
+function page(crawlId: string, i: number): PageRecord {
+  return {
+    url: `http://example.test/p/${i}`,
+    normalizedUrl: `http://example.test/p/${i}`,
+    finalUrl: `http://example.test/p/${i}`,
+    depth: 1,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: 10,
+    loadTimeMs: 1,
+    fetchedAt: 1,
+    etag: null,
+    lastModified: null,
+    contentHash: `h${i}`,
+    html: "<html></html>",
+    parsedData: null,
+    headers: {},
+    securityHeaders: {},
+  } as unknown as PageRecord;
+}
+
+function frontier(i: number): FrontierRecord {
+  return {
+    normalizedUrl: `http://example.test/f/${i}`,
+    rawUrl: `http://example.test/f/${i}`,
+    depth: 1,
+    priority: 1,
+    status: "pending",
+    source: "discovered",
+    enqueuedAt: 1,
+    retryCount: 0,
+  } as unknown as FrontierRecord;
+}
+
+/** Compilations that happen while `body` runs, counted on the prototype. */
+async function compilationsDuring(body: () => Promise<void>): Promise<number> {
+  let compiles = 0;
+  const real = Database.prototype.prepare;
+  (Database.prototype as unknown as Record<string, unknown>).prepare = function patched(
+    this: Database,
+    ...args: unknown[]
+  ) {
+    compiles++;
+    return (real as (this: Database, ...a: unknown[]) => unknown).call(this, ...args);
+  };
+  try {
+    await body();
+  } finally {
+    (Database.prototype as unknown as Record<string, unknown>).prepare = real;
+  }
+  return compiles;
+}
+
+describe("per-page storage statements are cached", () => {
+  const N = 50;
+
+  test("upsertPage compiles once, not once per page", async () => {
+    const { store, crawlId } = await freshCrawl();
+    // Warm first: the first call of anything also compiles whatever the method
+    // touches on its way in, and counting that would hide the thing being
+    // asserted behind a constant.
+    await run(store.upsertPage(crawlId, page(crawlId, 0)));
+    const compiles = await compilationsDuring(async () => {
+      for (let i = 1; i <= N; i++) await run(store.upsertPage(crawlId, page(crawlId, i)));
+    });
+    expect(compiles).toBe(0);
+    expect(await run(store.getPageCount(crawlId))).toBe(N + 1);
+    await run(store.close());
+  });
+
+  test("upsertFrontier compiles once, not once per discovered url", async () => {
+    const { store, crawlId } = await freshCrawl();
+    await run(store.upsertFrontier(crawlId, frontier(0)));
+    const compiles = await compilationsDuring(async () => {
+      for (let i = 1; i <= N; i++) await run(store.upsertFrontier(crawlId, frontier(i)));
+    });
+    expect(compiles).toBe(0);
+    await run(store.close());
+  });
+
+  test("getIncomingLinkCount compiles once, not once per url", async () => {
+    const { store, crawlId } = await freshCrawl();
+    await run(store.getIncomingLinkCount(crawlId, "http://example.test/p/0"));
+    const compiles = await compilationsDuring(async () => {
+      for (let i = 1; i <= N; i++) {
+        await run(store.getIncomingLinkCount(crawlId, `http://example.test/p/${i}`));
+      }
+    });
+    expect(compiles).toBe(0);
+    await run(store.close());
+  });
+
+  test("the crawl stats write compiles once, not once per page", async () => {
+    const { store, crawlId } = await freshCrawl();
+    // Always the same SET clause, which is what the crawl loop emits. A caller
+    // that varied the updated columns would legitimately compile one statement
+    // per distinct shape; that set is bounded by the eight optional columns.
+    await run(store.updateCrawl(crawlId, { stats: STATS }));
+    const compiles = await compilationsDuring(async () => {
+      for (let i = 1; i <= N; i++) {
+        await run(store.updateCrawl(crawlId, { stats: { ...STATS, pagesFetched: i } }));
+      }
+    });
+    expect(compiles).toBe(0);
+    await run(store.close());
+  });
+
+  test("a whole crawl's storage work does not compile per page", async () => {
+    // The four above in one loop, which is the shape the crawl loop runs them
+    // in. Asserted as a total rather than per method so a NEW per-page
+    // statement added later fails here too, which is the regression this is
+    // actually guarding against.
+    const { store, crawlId } = await freshCrawl();
+    const oneRound = async (i: number) => {
+      await run(store.upsertFrontier(crawlId, frontier(i)));
+      await run(store.getIncomingLinkCount(crawlId, `http://example.test/p/${i}`));
+      await run(store.upsertPage(crawlId, page(crawlId, i)));
+      await run(store.updateCrawl(crawlId, { stats: { ...STATS, pagesFetched: i } }));
+    };
+    await oneRound(0);
+    const compiles = await compilationsDuring(async () => {
+      for (let i = 1; i <= N; i++) await oneRound(i);
+    });
+    expect(compiles).toBe(0);
+    await run(store.close());
+  });
+});

--- a/packages/crawler/tests/hot-statements-cached.test.ts
+++ b/packages/crawler/tests/hot-statements-cached.test.ts
@@ -11,13 +11,15 @@
 // saving is tens of microseconds per page, far too small to assert on time and
 // far too easy to assert on by accident.
 //
-// TWO assertions are needed, and the first alone is not enough. Counting calls
-// to `Database.prototype.prepare` catches a regression BACK to `prepare` — and
-// only that. `db.query` compiles through an internal path that a hook on
-// `prepare` never sees, so a suite that only counts `prepare` passes just as
-// happily with the statement cache disabled entirely. The second assertion
-// tests the mechanism directly: `db.query` must hand back the SAME statement
-// object for the same SQL text on the Bun actually running.
+// TWO assertions are needed, and which one carries the weight depends on the
+// Bun in use. On 1.3.14, which this repo pins, `db.query` routes a cache MISS
+// through the public `prepare`, so the counters below really do see every
+// compilation and a disabled cache fails them (verified: forcing the cache to
+// zero entries fails six of these seven). On Bun 1.4.0 `query` compiles through
+// an internal path the hook cannot see, and the counters alone would pass with
+// the cache off. The first test therefore checks the mechanism directly —
+// `db.query` must hand back the SAME object for the same text — so this file
+// keeps meaning something when the Bun under it moves.
 
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";


### PR DESCRIPTION
The remainder of squirrelscan/repo#1911. #247 converted the per-link frontier check and deliberately left the other 95 `db.prepare` sites for a follow-up rather than a mass edit.

**It turns out to be seven statements, not ninety-five — and the case that matters most is a re-audit.**

## What a census of a real crawl says

Compilations from `prepare` and `query`, 120-page crawl at 40 links/page:

| | before | after |
|---|---|---|
| cold crawl, `incremental: true` (the CLI default) | 633 (5.3/page) | 38 (0.3/page) |
| cold crawl, `incremental: false` | 513 (4.3/page) | 37 (0.3/page) |
| **warm re-crawl of the same site** | **1,482 (12.3/page)** | **48 (0.4/page)** |

Five statements run per page on a cold crawl: `upsertPage`, `upsertFrontier`, `getIncomingLinkCount`, the crawl-stats `UPDATE` and `getCachedPage`. Two more run per **reused** page on a warm one: `getLinksByPage` and `getImagesByPage`. Every census I ran until the third review round crawled the site once against an empty cache, so neither of those ever appeared, and a re-audit was quietly paying 12.3 compilations per page.

Everything else in the file runs once or twice per crawl, and tripling links per page from 40 to 120 changed the total by nothing, which confirms #247 already removed the only per-link statement.

Compilation cost per statement, against the real schema, minimum of five interleaved rounds of 5,000. A `query` cache hit is 0.01 us in every row:

| statement | `prepare` |
|---|---|
| `getCachedPage` | 10.17 us |
| `getLinksByPage` | 9.71 us |
| `upsertPage` | 9.30 us |
| `getImagesByPage` | 9.16 us |
| `upsertFrontier` | 4.91 us |
| `getIncomingLinkCount` | 2.43 us |
| `updateCrawl` (stats) | 1.78 us |

47.5 us per page on a warm crawl, or 0.5 s across a 10,000-page re-audit.

**This is a count, not a time.** An interleaved A/B at 400 pages gave minima of 1.1 s before and 0.9 s after, but the arithmetic accounts for about 19 ms of that 200 ms, so the wall-clock pair is noise and I am not claiming it. A count is immune to what else the machine is doing, which is why it is the headline and why the regression test asserts on compilation rather than a clock.

## The cache starves, it does not evict

On Bun 1.3.14 it holds the first **20 texts per Database and never evicts**. A statement that gets in stays in; one that arrives late never gets in at all and recompiles on every call, forever and silently. Measured on a fresh database: 25 distinct texts, then three passes over the same 25, gave 15 compilations rather than 0 — the five that never made it, three times each.

So a large shape space does not push cached statements out, it fills the remaining slots and starves whatever is converted next. `Database.MAX_QUERY_CACHE_SIZE` raises the limit (30 caches all 25) but the default is what ships. The crawler now uses 14 texts, so this is a ceiling on how many more are worth converting, and it is documented at the one call site that builds SQL dynamically.

## Counting compilations is version-dependent, and I got it wrong three times

On 1.3.14 `db.query` routes a cache **miss** through the public `prepare`, so a hook on `prepare` sees every compilation from both call styles — though not from `exec`/`run`, which the schema setup uses. On Bun 1.4.0 `query` compiles through an internal path that hook cannot see, and a census there would report zero and look like a pass.

The three wrong versions, since each looked right: the first hooked only `prepare` and missed query compilations; the second added distinct query texts to the prepare count and double-counted them; the third derived "served without compiling" as calls minus distinct texts, which assumes every repeat hits and still reported 6,034 free calls with the cache forced to zero entries. Compilations are now attributed to the call that caused them.

## Byte-identity, and three digests that were not

A serialised crawl at 120 and 250 pages produces the same digest before and after, over every deterministic page column, every frontier verdict and the crawls row, with the site crawled **twice** so the incremental path is exercised — the second crawl records 120 `hash_match` reuses.

All three earlier digests were defeated in review:

- the first omitted `parsed_data` and passed with all 120 values nulled;
- the second omitted the stored `url` and passed with every one replaced by `CORRUPTED`;
- both crawled once, leaving the cache empty, so `getCachedPage` never hit and a version returning `null` unconditionally also passed.

Two further things had to be fixed before any digest meant anything, and both first looked like the change breaking something: the crawl is non-deterministic at concurrency 8, because discovery order decides each URL's depth and parent, and `port: 0` puts a different ephemeral port in every stored URL, so identical code hashed differently three times running.

## Tests

`tests/hot-statements-cached.test.ts`: seven tests, one per cold-path converted method, one asserting the cache mechanism itself, one combined round.

Forcing the cache to zero entries fails all seven. Reverting the conversions fails six; the seventh checks that Bun's cache works at all and passes either way, which is the point of having it, and is what keeps this file meaningful if the Bun underneath moves to one where the counters go blind.

The combined test does **not** catch a new per-page statement added elsewhere in the storage layer — it calls only these five, and a `prepare` introduced in `updateFrontierStatus` passes it untouched. Its comment says so and points at the census, which drives a real crawl, for that guarantee.

415 crawler tests pass. Rows added to `benchmarks/2026-09-perf-program.md`, including the warm row, the load average, the disqualified timing pair and the cache ceiling.
