### PR TITLE
fix(cli): say so when --max-pages is clamped to the cap

### DIFF
--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -93,6 +93,7 @@ import { safeExit } from "@/self/updater";
 import { CWD_UNAVAILABLE, cwdOr } from "@/utils/cwd";
 import { configureLogger, logger, setLogInterceptor } from "@/utils/logger";
 import { getProjectNameContext, parseUserUrl } from "@/utils/url";
+import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 
 import { version as packageVersion } from "../../../package.json";
 import {
@@ -1124,7 +1125,14 @@ export const audit = defineCommand({
         process.exitCode = 1;
         return;
       }
-      const maxPages = Math.min(requestedMaxPages, MAX_PAGES_CAP);
+      // Clamp and SAY SO (#1909). Silently applying the cap made a request for
+      // 10,000 pages indistinguishable from a 5,000-page site, and the existing
+      // notice in cli/format.ts only fires when a crawl reaches the cap — so a
+      // 10,000-page request against a 4,000-page site was never mentioned.
+      const pageLimit = resolvePageLimit(requestedMaxPages);
+      const maxPages = pageLimit.effective;
+      const clampNotice = pageLimitNotice(pageLimit);
+      if (clampNotice) console.error(fmt.yellow(clampNotice));
 
       // CLI --max-depth > config crawler.max_depth > unset (unlimited).
       let maxDepth: number | undefined;
@@ -1181,6 +1189,8 @@ export const audit = defineCommand({
       const options: AuditOptions = {
         url: args.url,
         maxPages,
+        // Carried so the report can record the clamp; the controller stamps it.
+        ...(pageLimit.clamped ? { requestedMaxPages: pageLimit.requested } : {}),
         maxDepth,
         outputFormat: args.format as
           | "console"

--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -60,6 +60,7 @@ import {
   type ReportVisibility,
 } from "@/controllers/report/publish";
 import { formatBalance, isUnlimitedBalance } from "@/lib/balance";
+import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 import {
   createRunFinalizer,
   type FinalizeRunInput,
@@ -93,7 +94,6 @@ import { safeExit } from "@/self/updater";
 import { CWD_UNAVAILABLE, cwdOr } from "@/utils/cwd";
 import { configureLogger, logger, setLogInterceptor } from "@/utils/logger";
 import { getProjectNameContext, parseUserUrl } from "@/utils/url";
-import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 
 import { version as packageVersion } from "../../../package.json";
 import {
@@ -1190,7 +1190,9 @@ export const audit = defineCommand({
         url: args.url,
         maxPages,
         // Carried so the report can record the clamp; the controller stamps it.
-        ...(pageLimit.clamped ? { requestedMaxPages: pageLimit.requested } : {}),
+        ...(pageLimit.clamped
+          ? { requestedMaxPages: pageLimit.requested }
+          : {}),
         maxDepth,
         outputFormat: args.format as
           | "console"

--- a/apps/cli/src/cli/commands/crawl.ts
+++ b/apps/cli/src/cli/commands/crawl.ts
@@ -16,6 +16,7 @@ import { loadUserSettings, updateSettings } from "@/self/settings";
 import { CWD_UNAVAILABLE, cwdOr } from "@/utils/cwd";
 import { logger, setLogInterceptor } from "@/utils/logger";
 import { getProjectNameContext, parseUserUrl } from "@/utils/url";
+import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 
 import { version as packageVersion } from "../../../package.json";
 import {
@@ -113,14 +114,17 @@ export const crawl = defineCommand({
 
       // CLI --max-pages > config max_pages (if non-default) > coverage mode default
       const configMaxPagesIsDefault = config.crawler.max_pages === 100;
-      const maxPages = Math.min(
+      // Clamped and reported identically to `audit` (#1909).
+      const pageLimit = resolvePageLimit(
         args["max-pages"]
           ? Number.parseInt(args["max-pages"], 10)
           : configMaxPagesIsDefault
             ? coverageMaxPages
-            : config.crawler.max_pages,
-        MAX_PAGES_CAP
+            : config.crawler.max_pages
       );
+      const maxPages = pageLimit.effective;
+      const crawlClampNotice = pageLimitNotice(pageLimit);
+      if (crawlClampNotice) console.error(fmt.yellow(crawlClampNotice));
 
       // --concurrency / --per-host: positive-integer crawl parallelism
       // overrides, shared with `audit` (#1068/#1084).

--- a/apps/cli/src/cli/commands/crawl.ts
+++ b/apps/cli/src/cli/commands/crawl.ts
@@ -11,12 +11,12 @@ import {
   COVERAGE_FULL_MAX_PAGES,
 } from "@/constants";
 import { runCrawl, type CrawlerEvent } from "@/controllers/crawl";
+import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 import { warnIfSessionUnreadable } from "@/self/credentials";
 import { loadUserSettings, updateSettings } from "@/self/settings";
 import { CWD_UNAVAILABLE, cwdOr } from "@/utils/cwd";
 import { logger, setLogInterceptor } from "@/utils/logger";
 import { getProjectNameContext, parseUserUrl } from "@/utils/url";
-import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 
 import { version as packageVersion } from "../../../package.json";
 import {

--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -62,7 +62,6 @@ import {
   CRAWL_PHASE_MIN_TIMEOUT_MS,
   CRAWL_PHASE_PER_PAGE_BUDGET_MS,
   CRAWL_PHASE_SETUP_SLACK_MS,
-  MAX_PAGES_CAP,
 } from "@/constants";
 import {
   type Result,
@@ -90,6 +89,7 @@ import {
   parseUserUrl,
 } from "@/utils/url";
 import { resolveStickyUserAgent } from "@/utils/user-agent";
+import { resolvePageLimit } from "@/lib/page-limit";
 
 /**
  * Fields that affect crawl scope - changes require fresh crawl_id
@@ -1610,9 +1610,16 @@ export async function runAudit(
       // score with its basis. REPORT-ONLY.
       {
         const scopeMaxPages = mergedConfig.crawler.max_pages;
+        // `requestedMaxPages` from the command layer when it clamped; otherwise
+        // recompute here, since a caller reaching the controller directly never
+        // passed through that layer (#1909).
+        const requested =
+          options.requestedMaxPages ?? options.maxPages ?? config.crawler.max_pages;
+        const scopeLimit = resolvePageLimit(requested);
         report.scanScope = {
           origin: detectRunner().ci ? "ci" : "cli",
           maxPages: scopeMaxPages,
+          ...(scopeLimit.clamped ? { requestedMaxPages: scopeLimit.requested } : {}),
           pagesCrawled: report.pages.length,
           capped: report.pages.length >= scopeMaxPages,
         };
@@ -1884,10 +1891,12 @@ export function mergeOptionsToConfig(
     }),
     crawler: {
       ...config.crawler,
-      max_pages: Math.min(
-        options.maxPages ?? config.crawler.max_pages,
-        MAX_PAGES_CAP
-      ),
+      // Same clamp as the commands, through the same helper so the three cannot
+      // drift (#1909). Callers that reach the controller directly — the MCP
+      // audit tool, programmatic use — get the cap applied here; they see it in
+      // the report's `scanScope` rather than on stderr.
+      max_pages: resolvePageLimit(options.maxPages ?? config.crawler.max_pages)
+        .effective,
       ...(typeof options.maxDepth === "number"
         ? { max_depth: Math.max(1, Math.floor(options.maxDepth)) }
         : {}),

--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -75,6 +75,7 @@ import { resolveSeedRedirect } from "@/crawler/frontier";
 import { createStorage, domainToProjectName } from "@/crawler/storage";
 import { getGlobalLinkCache } from "@/crawler/storage/link-cache";
 import { preflightBalanceOf } from "@/lib/balance";
+import { resolvePageLimit } from "@/lib/page-limit";
 import { reconstructReport } from "@/reports/reconstruct";
 import { detectRunner } from "@/self/install-meta";
 import { createCloudClientFromSettings } from "@/tools/cloud";
@@ -89,7 +90,6 @@ import {
   parseUserUrl,
 } from "@/utils/url";
 import { resolveStickyUserAgent } from "@/utils/user-agent";
-import { resolvePageLimit } from "@/lib/page-limit";
 
 /**
  * Fields that affect crawl scope - changes require fresh crawl_id
@@ -1614,7 +1614,9 @@ export async function runAudit(
         // recompute here, since a caller reaching the controller directly never
         // passed through that layer (#1909).
         const requested =
-          options.requestedMaxPages ?? options.maxPages ?? config.crawler.max_pages;
+          options.requestedMaxPages ??
+          options.maxPages ??
+          config.crawler.max_pages;
         const scopeLimit = resolvePageLimit(requested);
         // FINITE only. `[crawler] max_pages = inf` is a real clamp and the
         // command says so on stderr, but `JSON.stringify(Infinity)` is `null`,
@@ -1625,7 +1627,9 @@ export async function runAudit(
         report.scanScope = {
           origin: detectRunner().ci ? "ci" : "cli",
           maxPages: scopeMaxPages,
-          ...(recordRequested ? { requestedMaxPages: scopeLimit.requested } : {}),
+          ...(recordRequested
+            ? { requestedMaxPages: scopeLimit.requested }
+            : {}),
           pagesCrawled: report.pages.length,
           capped: report.pages.length >= scopeMaxPages,
         };

--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -1901,7 +1901,7 @@ export function mergeOptionsToConfig(
     }),
     crawler: {
       ...config.crawler,
-      // Same clamp as the commands, through the same helper so the three cannot
+      // Same clamp as the commands, through the same helper so the five cannot
       // drift (#1909). Callers that reach the controller directly — the MCP
       // audit tool, programmatic use — get the cap applied here; they see it in
       // the report's `scanScope` rather than on stderr.

--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -1616,10 +1616,16 @@ export async function runAudit(
         const requested =
           options.requestedMaxPages ?? options.maxPages ?? config.crawler.max_pages;
         const scopeLimit = resolvePageLimit(requested);
+        // FINITE only. `[crawler] max_pages = inf` is a real clamp and the
+        // command says so on stderr, but `JSON.stringify(Infinity)` is `null`,
+        // and a null here would read as "no request recorded" rather than as
+        // "asked for everything" — worse than leaving it out.
+        const recordRequested =
+          scopeLimit.clamped && Number.isFinite(scopeLimit.requested);
         report.scanScope = {
           origin: detectRunner().ci ? "ci" : "cli",
           maxPages: scopeMaxPages,
-          ...(scopeLimit.clamped ? { requestedMaxPages: scopeLimit.requested } : {}),
+          ...(recordRequested ? { requestedMaxPages: scopeLimit.requested } : {}),
           pagesCrawled: report.pages.length,
           capped: report.pages.length >= scopeMaxPages,
         };

--- a/apps/cli/src/controllers/crawl.ts
+++ b/apps/cli/src/controllers/crawl.ts
@@ -24,12 +24,12 @@ import {
 } from "@/controllers/types";
 import { createCrawler } from "@/crawler/core";
 import { createStorage, domainToProjectName } from "@/crawler/storage";
+import { resolvePageLimit } from "@/lib/page-limit";
 import { initRequestTool } from "@/tools/request";
 import { configureLogger, logger } from "@/utils/logger";
 import { checkReachability } from "@/utils/reachability";
 import { getHostname, isLoopbackHost, parseUserUrl } from "@/utils/url";
 import { resolveStickyUserAgent } from "@/utils/user-agent";
-import { resolvePageLimit } from "@/lib/page-limit";
 
 export type { CrawlerEvent } from "@/crawler/core/types";
 

--- a/apps/cli/src/controllers/crawl.ts
+++ b/apps/cli/src/controllers/crawl.ts
@@ -29,6 +29,7 @@ import { configureLogger, logger } from "@/utils/logger";
 import { checkReachability } from "@/utils/reachability";
 import { getHostname, isLoopbackHost, parseUserUrl } from "@/utils/url";
 import { resolveStickyUserAgent } from "@/utils/user-agent";
+import { resolvePageLimit } from "@/lib/page-limit";
 
 export type { CrawlerEvent } from "@/crawler/core/types";
 
@@ -232,10 +233,9 @@ export async function runCrawl(
       const crawler = await Effect.runPromise(
         createCrawler({
           config: {
-            maxPages: Math.min(
-              options.maxPages ?? config.crawler.max_pages,
-              MAX_PAGES_CAP
-            ),
+            maxPages: resolvePageLimit(
+              options.maxPages ?? config.crawler.max_pages
+            ).effective,
             concurrency: crawlConcurrency.concurrency,
             perHostConcurrency: crawlConcurrency.perHostConcurrency,
             delayMs: config.crawler.delay_ms,
@@ -283,10 +283,8 @@ export async function runCrawl(
       );
 
       const crawlerConfig = {
-        maxPages: Math.min(
-          options.maxPages ?? config.crawler.max_pages,
-          MAX_PAGES_CAP
-        ),
+        maxPages: resolvePageLimit(options.maxPages ?? config.crawler.max_pages)
+          .effective,
         concurrency: crawlConcurrency.concurrency,
         perHostConcurrency: crawlConcurrency.perHostConcurrency,
         delayMs: config.crawler.delay_ms,

--- a/apps/cli/src/controllers/report.ts
+++ b/apps/cli/src/controllers/report.ts
@@ -100,6 +100,10 @@ interface SlimJsonReport {
     };
     timestamp: string;
     totalPages: number;
+    /** Page cap in force (#1909); absent in slim JSON written before it. */
+    maxPages?: number;
+    /** Requested cap, present only when it was clamped (#1909). */
+    requestedMaxPages?: number;
   };
   // Audit validity (#801): absent in slim JSON written before #801 ⇒ completed.
   status?: AuditStatus;
@@ -221,6 +225,23 @@ function convertSlimReport(report: SlimJsonReport): AuditReport {
       : {}),
     timestamp: report.meta.timestamp,
     totalPages: report.meta.totalPages,
+    // Rebuild the scan scope the slim JSON flattened into `meta` (#1909).
+    // Without this, re-rendering a saved report loses both page limits and a
+    // clamped run reads exactly like an unclamped one — which is the bug this
+    // change exists to fix, reappearing one round trip later.
+    ...(report.meta.maxPages !== undefined
+      ? {
+          scanScope: {
+            origin: "cli" as const,
+            maxPages: report.meta.maxPages,
+            ...(report.meta.requestedMaxPages !== undefined
+              ? { requestedMaxPages: report.meta.requestedMaxPages }
+              : {}),
+            pagesCrawled: report.meta.totalPages,
+            capped: report.meta.totalPages >= report.meta.maxPages,
+          },
+        }
+      : {}),
     passed: report.summary.passed,
     warnings: report.summary.warnings,
     failed: report.summary.failed,

--- a/apps/cli/src/lib/page-limit.ts
+++ b/apps/cli/src/lib/page-limit.ts
@@ -25,16 +25,25 @@ export interface PageLimit {
 /**
  * Resolve a requested page count against the cap.
  *
- * A non-finite or non-positive request is passed through untouched rather than
- * coerced: the commands reject those with their own message naming the flag,
- * and silently turning `NaN` into the cap here would hide that.
+ * `effective` is exactly `Math.min(requested, MAX_PAGES_CAP)`, which is what the
+ * three call sites did before this existed, so the ceiling behaves identically
+ * for every input including the strange ones. An earlier version of this
+ * returned non-finite and non-positive requests UNTOUCHED, on the reasoning
+ * that the commands reject them with their own message — but `[crawler]
+ * max_pages = inf` passes the config schema and never reaches that check, so
+ * `Infinity` went straight to the crawler and the hard cap stopped being hard.
+ * A safety bound does not get to have exceptions for inputs that look invalid.
+ *
+ * `clamped` is the narrower question of whether to SAY anything, so it is false
+ * for `NaN` (which no comparison makes true) and for anything at or under the
+ * cap. `Infinity` does get a notice: it really was clamped.
  */
 export function resolvePageLimit(requested: number): PageLimit {
-  if (!Number.isFinite(requested) || requested < 1) {
-    return { requested, effective: requested, clamped: false };
-  }
-  const effective = Math.min(requested, MAX_PAGES_CAP);
-  return { requested, effective, clamped: effective < requested };
+  return {
+    requested,
+    effective: Math.min(requested, MAX_PAGES_CAP),
+    clamped: requested > MAX_PAGES_CAP,
+  };
 }
 
 /**
@@ -46,9 +55,13 @@ export function resolvePageLimit(requested: number): PageLimit {
  */
 export function pageLimitNotice(limit: PageLimit): string | null {
   if (!limit.clamped) return null;
+  // `Infinity.toLocaleString()` is "∞", which reads as a rendering fault rather
+  // than as what the user typed.
+  const asked = Number.isFinite(limit.requested)
+    ? `${limit.requested.toLocaleString("en-US")} pages`
+    : "unlimited pages";
   return (
-    `⚠ Requested ${limit.requested.toLocaleString("en-US")} pages, capped at ` +
-    `${limit.effective.toLocaleString("en-US")}. This is the hard limit; split the audit ` +
-    `by section (e.g. [crawler] include) to scan more.`
+    `⚠ Requested ${asked}, capped at ${limit.effective.toLocaleString("en-US")}. ` +
+    `This is the hard limit; split the audit by section (e.g. [crawler] include) to scan more.`
   );
 }

--- a/apps/cli/src/lib/page-limit.ts
+++ b/apps/cli/src/lib/page-limit.ts
@@ -1,8 +1,8 @@
 // Resolving a requested page count against the hard cap, and saying so (#1909).
 //
-// `MAX_PAGES_CAP` was applied with a bare `Math.min` in three places — the
-// `audit` command, the `crawl` command and the audit controller — and none of
-// them said anything. `squirrel audit --max-pages 10000` crawled 5,000 and
+// `MAX_PAGES_CAP` was applied with a bare `Math.min` in five places — the
+// `audit` and `crawl` commands, the audit controller and twice in the crawl
+// controller — and none of them said anything. `squirrel audit --max-pages 10000` crawled 5,000 and
 // reported `maxPages: 5000`, which is indistinguishable from a 5,000-page site.
 // The neighbouring notice in cli/format.ts fires when a crawl REACHES the cap,
 // so a request for 10,000 against a 4,000-page site was clamped and never
@@ -26,7 +26,7 @@ export interface PageLimit {
  * Resolve a requested page count against the cap.
  *
  * `effective` is exactly `Math.min(requested, MAX_PAGES_CAP)`, which is what the
- * three call sites did before this existed, so the ceiling behaves identically
+ * five call sites did before this existed, so the ceiling behaves identically
  * for every input including the strange ones. An earlier version of this
  * returned non-finite and non-positive requests UNTOUCHED, on the reasoning
  * that the commands reject them with their own message — but `[crawler]
@@ -57,9 +57,15 @@ export function pageLimitNotice(limit: PageLimit): string | null {
   if (!limit.clamped) return null;
   // `Infinity.toLocaleString()` is "∞", which reads as a rendering fault rather
   // than as what the user typed.
-  const asked = Number.isFinite(limit.requested)
-    ? `${limit.requested.toLocaleString("en-US")} pages`
-    : "unlimited pages";
+  // A fractional request is degenerate but reachable through config, and
+  // `(5000.0001).toLocaleString()` is "5,000" — which would print "Requested
+  // 5,000 pages, capped at 5,000" and read as a bug in the notice rather than
+  // in the config. Non-integers keep their digits.
+  const asked = !Number.isFinite(limit.requested)
+    ? "unlimited pages"
+    : Number.isInteger(limit.requested)
+      ? `${limit.requested.toLocaleString("en-US")} pages`
+      : `${limit.requested} pages`;
   return (
     `⚠ Requested ${asked}, capped at ${limit.effective.toLocaleString("en-US")}. ` +
     `This is the hard limit; split the audit by section (e.g. [crawler] include) to scan more.`

--- a/apps/cli/src/lib/page-limit.ts
+++ b/apps/cli/src/lib/page-limit.ts
@@ -1,0 +1,54 @@
+// Resolving a requested page count against the hard cap, and saying so (#1909).
+//
+// `MAX_PAGES_CAP` was applied with a bare `Math.min` in three places — the
+// `audit` command, the `crawl` command and the audit controller — and none of
+// them said anything. `squirrel audit --max-pages 10000` crawled 5,000 and
+// reported `maxPages: 5000`, which is indistinguishable from a 5,000-page site.
+// The neighbouring notice in cli/format.ts fires when a crawl REACHES the cap,
+// so a request for 10,000 against a 4,000-page site was clamped and never
+// mentioned at all.
+//
+// One place to do it, so the three callers cannot drift, and so the requested
+// value survives the clamp far enough to reach the report.
+
+import { MAX_PAGES_CAP } from "@squirrelscan/core-contracts/limits";
+
+export interface PageLimit {
+  /** What the caller asked for, from `--max-pages` or `[crawler] max_pages`. */
+  readonly requested: number;
+  /** What will actually be crawled: `requested`, or the cap. */
+  readonly effective: number;
+  /** The cap bound. */
+  readonly clamped: boolean;
+}
+
+/**
+ * Resolve a requested page count against the cap.
+ *
+ * A non-finite or non-positive request is passed through untouched rather than
+ * coerced: the commands reject those with their own message naming the flag,
+ * and silently turning `NaN` into the cap here would hide that.
+ */
+export function resolvePageLimit(requested: number): PageLimit {
+  if (!Number.isFinite(requested) || requested < 1) {
+    return { requested, effective: requested, clamped: false };
+  }
+  const effective = Math.min(requested, MAX_PAGES_CAP);
+  return { requested, effective, clamped: effective < requested };
+}
+
+/**
+ * The line to print when the cap bound, or null when it did not.
+ *
+ * Deliberately does not name `--max-pages`: the same clamp applies to
+ * `[crawler] max_pages`, and a notice that names the flag would be wrong for
+ * half the ways of reaching it.
+ */
+export function pageLimitNotice(limit: PageLimit): string | null {
+  if (!limit.clamped) return null;
+  return (
+    `⚠ Requested ${limit.requested.toLocaleString("en-US")} pages, capped at ` +
+    `${limit.effective.toLocaleString("en-US")}. This is the hard limit; split the audit ` +
+    `by section (e.g. [crawler] include) to scan more.`
+  );
+}

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -542,6 +542,8 @@ export interface AuditReport {
   scanScope?: {
     origin: "cli" | "ci" | "cloud";
     maxPages?: number;
+    /** Requested page cap, when it exceeded MAX_PAGES_CAP and was clamped (#1909). */
+    requestedMaxPages?: number;
     pagesCrawled: number;
     capped: boolean;
   };
@@ -588,6 +590,15 @@ export type CoverageMode = "quick" | "surface" | "full";
 export interface AuditOptions {
   url: string;
   maxPages?: number;
+  /**
+   * What the caller asked for BEFORE `MAX_PAGES_CAP` was applied (#1909).
+   *
+   * The command layer clamps `maxPages` for its own display and cost estimate,
+   * so by the time the controller sees it the request is already gone. Passing
+   * it separately is what lets the report record that a clamp happened at all.
+   * Unset when nothing asked for more than the cap.
+   */
+  requestedMaxPages?: number;
   maxDepth?: number; // optional crawl-depth ceiling (#318); unset = unlimited
   outputFormat?:
     | "json"

--- a/apps/cli/tests/.tmp-page-limit-7ktzk2x6txc.json
+++ b/apps/cli/tests/.tmp-page-limit-7ktzk2x6txc.json
@@ -1,0 +1,11 @@
+{
+  "meta": {
+    "version": "0.0.0",
+    "baseUrl": "http://example.test",
+    "timestamp": "1970-01-01T00:00:00.000Z",
+    "totalPages": 6
+  },
+  "score": { "overall": 90, "categories": {} },
+  "summary": { "passed": 1, "warnings": 0, "failed": 0 },
+  "issues": []
+}

--- a/apps/cli/tests/.tmp-page-limit-gfj90pafj8w.json
+++ b/apps/cli/tests/.tmp-page-limit-gfj90pafj8w.json
@@ -1,0 +1,12 @@
+{
+  "meta": {
+    "version": "0.0.0",
+    "baseUrl": "http://example.test",
+    "timestamp": "1970-01-01T00:00:00.000Z",
+    "totalPages": 6,
+    "maxPages": 3
+  },
+  "score": { "overall": 90, "categories": {} },
+  "summary": { "passed": 1, "warnings": 0, "failed": 0 },
+  "issues": []
+}

--- a/apps/cli/tests/.tmp-page-limit-m1c0d1q1wt.json
+++ b/apps/cli/tests/.tmp-page-limit-m1c0d1q1wt.json
@@ -1,0 +1,13 @@
+{
+  "meta": {
+    "version": "0.0.0",
+    "baseUrl": "http://example.test",
+    "timestamp": "1970-01-01T00:00:00.000Z",
+    "totalPages": 6,
+    "maxPages": 5000,
+    "requestedMaxPages": 10000
+  },
+  "score": { "overall": 90, "categories": {} },
+  "summary": { "passed": 1, "warnings": 0, "failed": 0 },
+  "issues": []
+}

--- a/apps/cli/tests/page-limit.test.ts
+++ b/apps/cli/tests/page-limit.test.ts
@@ -1,0 +1,70 @@
+// #1909: a page request above the cap must be clamped AND said out loud.
+//
+// The bug was not the clamp, it was the silence. `squirrel audit --max-pages
+// 10000` crawled 5,000 and reported `maxPages: 5000`, which is exactly what a
+// 5,000-page site reports, so there was no way to tell the two apart. The
+// neighbouring notice in cli/format.ts fires when a crawl REACHES the cap,
+// which is a different event: a 10,000-page request against a 4,000-page site
+// was clamped and never mentioned.
+
+import { describe, expect, test } from "bun:test";
+
+import { MAX_PAGES_CAP } from "@squirrelscan/core-contracts/limits";
+
+import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
+
+describe("resolvePageLimit", () => {
+  test("clamps above the cap and records what was asked for", () => {
+    const limit = resolvePageLimit(10_000);
+    expect(limit.effective).toBe(MAX_PAGES_CAP);
+    expect(limit.requested).toBe(10_000);
+    expect(limit.clamped).toBe(true);
+  });
+
+  test("leaves a request at or below the cap alone", () => {
+    for (const requested of [1, 100, MAX_PAGES_CAP - 1, MAX_PAGES_CAP]) {
+      const limit = resolvePageLimit(requested);
+      expect(limit.effective).toBe(requested);
+      expect(limit.clamped).toBe(false);
+    }
+  });
+
+  test("the cap itself is not a clamp", () => {
+    // Off-by-one guard: `effective < requested` rather than `<=`, or every
+    // full-size audit would print a notice about not being clamped.
+    expect(resolvePageLimit(MAX_PAGES_CAP).clamped).toBe(false);
+    expect(resolvePageLimit(MAX_PAGES_CAP + 1).clamped).toBe(true);
+  });
+
+  test("passes a rejected value through rather than coercing it", () => {
+    // The commands reject NaN and non-positive values with a message naming the
+    // flag. Turning them into the cap here would hide that and crawl 5,000
+    // pages for someone who typed `--max-pages abc`.
+    for (const bad of [Number.NaN, 0, -5, Number.POSITIVE_INFINITY]) {
+      const limit = resolvePageLimit(bad);
+      expect(limit.clamped).toBe(false);
+      expect(Object.is(limit.effective, bad)).toBe(true);
+    }
+  });
+});
+
+describe("pageLimitNotice", () => {
+  test("names both numbers when the cap bound", () => {
+    const notice = pageLimitNotice(resolvePageLimit(10_000));
+    expect(notice).toBeTruthy();
+    expect(notice).toContain("10,000");
+    expect(notice).toContain(MAX_PAGES_CAP.toLocaleString("en-US"));
+  });
+
+  test("says nothing when it did not", () => {
+    expect(pageLimitNotice(resolvePageLimit(100))).toBeNull();
+    expect(pageLimitNotice(resolvePageLimit(MAX_PAGES_CAP))).toBeNull();
+  });
+
+  test("does not name the flag, because config reaches the same clamp", () => {
+    // `[crawler] max_pages = 9000` produces this notice too, and telling that
+    // user to change `--max-pages` would send them to the wrong place.
+    const notice = pageLimitNotice(resolvePageLimit(9_000)) ?? "";
+    expect(notice).not.toContain("--max-pages");
+  });
+});

--- a/apps/cli/tests/page-limit.test.ts
+++ b/apps/cli/tests/page-limit.test.ts
@@ -36,19 +36,37 @@ describe("resolvePageLimit", () => {
     expect(resolvePageLimit(MAX_PAGES_CAP + 1).clamped).toBe(true);
   });
 
-  test("passes a rejected value through rather than coercing it", () => {
-    // The commands reject NaN and non-positive values with a message naming the
-    // flag. Turning them into the cap here would hide that and crawl 5,000
-    // pages for someone who typed `--max-pages abc`.
-    for (const bad of [Number.NaN, 0, -5, Number.POSITIVE_INFINITY]) {
-      const limit = resolvePageLimit(bad);
-      expect(limit.clamped).toBe(false);
-      expect(Object.is(limit.effective, bad)).toBe(true);
+  test("NEVER returns an effective limit above the cap", () => {
+    // The regression this exists to stop. A first version passed non-finite and
+    // non-positive requests through untouched, so `[crawler] max_pages = inf`
+    // — which the config schema accepts, and which never reaches the flag
+    // validation — sent Infinity to the crawler and the hard cap stopped being
+    // hard. `effective` is `Math.min` for every input, as it was before.
+    for (const value of [Number.POSITIVE_INFINITY, 1e12, MAX_PAGES_CAP * 2]) {
+      expect(resolvePageLimit(value).effective).toBe(MAX_PAGES_CAP);
+      expect(resolvePageLimit(value).clamped).toBe(true);
     }
+  });
+
+  test("leaves the strange inputs exactly where Math.min left them", () => {
+    // Not this change's job to fix: `crawl` does no flag validation at all, so
+    // its NaN and zero behaviour is pre-existing, and quietly turning either
+    // into 5,000 here would be a new bug wearing a fix's clothes.
+    expect(Number.isNaN(resolvePageLimit(Number.NaN).effective)).toBe(true);
+    expect(resolvePageLimit(Number.NaN).clamped).toBe(false);
+    expect(resolvePageLimit(0).effective).toBe(0);
+    expect(resolvePageLimit(-5).effective).toBe(-5);
+    expect(resolvePageLimit(-5).clamped).toBe(false);
   });
 });
 
 describe("pageLimitNotice", () => {
+  test("says 'unlimited' rather than a rendering artefact for Infinity", () => {
+    const notice = pageLimitNotice(resolvePageLimit(Number.POSITIVE_INFINITY)) ?? "";
+    expect(notice).toContain("unlimited pages");
+    expect(notice).not.toContain("∞");
+  });
+
   test("names both numbers when the cap bound", () => {
     const notice = pageLimitNotice(resolvePageLimit(10_000));
     expect(notice).toBeTruthy();

--- a/apps/cli/tests/page-limit.test.ts
+++ b/apps/cli/tests/page-limit.test.ts
@@ -10,6 +10,7 @@
 import { MAX_PAGES_CAP } from "@squirrelscan/core-contracts/limits";
 import { describe, expect, test } from "bun:test";
 
+import { loadReport } from "@/controllers/report";
 import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 
 describe("resolvePageLimit", () => {
@@ -48,9 +49,10 @@ describe("resolvePageLimit", () => {
   });
 
   test("leaves the strange inputs exactly where Math.min left them", () => {
-    // Not this change's job to fix: `crawl` does no flag validation at all, so
-    // its NaN and zero behaviour is pre-existing, and quietly turning either
-    // into 5,000 here would be a new bug wearing a fix's clothes.
+    // Not this change's job to fix: `crawl` validates concurrency but not
+    // max-pages, so its NaN and zero behaviour is pre-existing, and quietly
+    // turning either into 5,000 here would be a new bug wearing a fix's
+    // clothes.
     expect(Number.isNaN(resolvePageLimit(Number.NaN).effective)).toBe(true);
     expect(resolvePageLimit(Number.NaN).clamped).toBe(false);
     expect(resolvePageLimit(0).effective).toBe(0);
@@ -65,6 +67,14 @@ describe("pageLimitNotice", () => {
       pageLimitNotice(resolvePageLimit(Number.POSITIVE_INFINITY)) ?? "";
     expect(notice).toContain("unlimited pages");
     expect(notice).not.toContain("∞");
+  });
+
+  test("keeps the digits of a fractional request", () => {
+    // `(5000.0001).toLocaleString()` is "5,000", which would print "Requested
+    // 5,000 pages, capped at 5,000" — a notice that reads as its own bug.
+    const notice =
+      pageLimitNotice(resolvePageLimit(MAX_PAGES_CAP + 0.0001)) ?? "";
+    expect(notice).toContain("5000.0001");
   });
 
   test("names both numbers when the cap bound", () => {
@@ -84,5 +94,57 @@ describe("pageLimitNotice", () => {
     // user to change `--max-pages` would send them to the wrong place.
     const notice = pageLimitNotice(resolvePageLimit(9_000)) ?? "";
     expect(notice).not.toContain("--max-pages");
+  });
+});
+
+describe("the limits survive a saved report", () => {
+  // The whole point is that a clamped run reads differently from an unclamped
+  // one. A first version of this change lost both limits the moment the slim
+  // JSON was read back, so `squirrel report` on a saved file showed exactly
+  // what it showed before the fix — the bug returning one round trip later.
+  const slim = (meta: Record<string, unknown>) => ({
+    meta: {
+      version: "0.0.0",
+      baseUrl: "http://example.test",
+      timestamp: new Date(0).toISOString(),
+      totalPages: 6,
+      ...meta,
+    },
+    score: { overall: 90, categories: {} },
+    summary: { passed: 1, warnings: 0, failed: 0 },
+    issues: [],
+  });
+
+  async function reload(meta: Record<string, unknown>) {
+    const path = `${import.meta.dir}/.tmp-page-limit-${Math.random().toString(36).slice(2)}.json`;
+    await Bun.write(path, JSON.stringify(slim(meta)));
+    try {
+      return loadReport(path);
+    } finally {
+      await Bun.file(path).delete();
+    }
+  }
+
+  test("a clamped run reloads with both limits", async () => {
+    const loaded = await reload({ maxPages: 5000, requestedMaxPages: 10_000 });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.data.scanScope?.maxPages).toBe(5000);
+    expect(loaded.data.scanScope?.requestedMaxPages).toBe(10_000);
+  });
+
+  test("an unclamped run reloads without a requested limit", async () => {
+    const loaded = await reload({ maxPages: 3 });
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.data.scanScope?.maxPages).toBe(3);
+    expect(loaded.data.scanScope?.requestedMaxPages).toBeUndefined();
+  });
+
+  test("a report written before this change reloads without a scope", async () => {
+    const loaded = await reload({});
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.data.scanScope).toBeUndefined();
   });
 });

--- a/apps/cli/tests/page-limit.test.ts
+++ b/apps/cli/tests/page-limit.test.ts
@@ -7,9 +7,8 @@
 // which is a different event: a 10,000-page request against a 4,000-page site
 // was clamped and never mentioned.
 
-import { describe, expect, test } from "bun:test";
-
 import { MAX_PAGES_CAP } from "@squirrelscan/core-contracts/limits";
+import { describe, expect, test } from "bun:test";
 
 import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 
@@ -62,7 +61,8 @@ describe("resolvePageLimit", () => {
 
 describe("pageLimitNotice", () => {
   test("says 'unlimited' rather than a rendering artefact for Infinity", () => {
-    const notice = pageLimitNotice(resolvePageLimit(Number.POSITIVE_INFINITY)) ?? "";
+    const notice =
+      pageLimitNotice(resolvePageLimit(Number.POSITIVE_INFINITY)) ?? "";
     expect(notice).toContain("unlimited pages");
     expect(notice).not.toContain("∞");
   });

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -245,7 +245,7 @@ Recorded here because #1028 needs the page count to be expressible from the CLI
 at all, and it was not. `squirrel audit --max-pages 10000` crawled 5,000 and
 reported `maxPages: 5000`, which is byte-identical to what a 5,000-page site
 reports ([#1909](https://github.com/squirrelscan/repo/issues/1909),
-[#263](https://github.com/squirrelscan/squirrelscan/pull/263)).
+[#264](https://github.com/squirrelscan/squirrelscan/pull/264)).
 
 No timings: nothing about this change affects how long anything takes, and there
 is no before/after to measure. What it changes is whether the number a

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -247,8 +247,8 @@ reported `maxPages: 5000`, which is byte-identical to what a 5,000-page site
 reports ([#1909](https://github.com/squirrelscan/repo/issues/1909),
 [#264](https://github.com/squirrelscan/squirrelscan/pull/264)).
 
-No timings: nothing about this change affects how long anything takes, and there
-is no before/after to measure. What it changes is whether the number a
+No timings: there is no intended crawl-performance change here and no
+before/after to measure. What it changes is whether the number a
 measurement was taken at is knowable afterwards, which is what every other row
 in this file depends on.
 

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -239,6 +239,26 @@ first looked like the change breaking something: the crawl is non-deterministic
 at concurrency 8, because discovery order decides each URL's depth and parent,
 and `port: 0` puts a different ephemeral port in every stored URL, so identical
 code hashed differently three times running.
+## Not a performance change: the page cap said nothing
+
+Recorded here because #1028 needs the page count to be expressible from the CLI
+at all, and it was not. `squirrel audit --max-pages 10000` crawled 5,000 and
+reported `maxPages: 5000`, which is byte-identical to what a 5,000-page site
+reports ([#1909](https://github.com/squirrelscan/repo/issues/1909),
+[#263](https://github.com/squirrelscan/squirrelscan/pull/263)).
+
+No timings: nothing about this change affects how long anything takes, and there
+is no before/after to measure. What it changes is whether the number a
+measurement was taken at is knowable afterwards, which is what every other row
+in this file depends on.
+
+`MAX_PAGES_CAP` was applied with a bare `Math.min` in three places — the `audit`
+command, the `crawl` command and the audit controller — none of which said
+anything. The existing notice fires when a crawl REACHES the cap, a different
+event: a 10,000-page request against a 4,000-page site was clamped and never
+mentioned. Now one helper resolves the request, both commands print the clamp,
+and the report carries `meta.maxPages` alongside `meta.requestedMaxPages`, the
+latter present only when a clamp happened so its absence is the normal case.
 
 ## Hosted runtime, in production
 

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -252,13 +252,21 @@ is no before/after to measure. What it changes is whether the number a
 measurement was taken at is knowable afterwards, which is what every other row
 in this file depends on.
 
-`MAX_PAGES_CAP` was applied with a bare `Math.min` in three places — the `audit`
-command, the `crawl` command and the audit controller — none of which said
-anything. The existing notice fires when a crawl REACHES the cap, a different
+`MAX_PAGES_CAP` was applied with a bare `Math.min` in five places — the `audit`
+and `crawl` commands, the audit controller, and twice in the crawl controller —
+none of which said anything. The existing notice fires when a crawl REACHES the cap, a different
 event: a 10,000-page request against a 4,000-page site was clamped and never
-mentioned. Now one helper resolves the request, both commands print the clamp,
-and the report carries `meta.maxPages` alongside `meta.requestedMaxPages`, the
-latter present only when a clamp happened so its absence is the normal case.
+mentioned. Now one helper resolves the request, both commands print the clamp, and the
+report carries `meta.maxPages` alongside `meta.requestedMaxPages`, the latter
+present only when a clamp happened so its absence is the normal case. The LLM
+render carries the same pair, which is the whole response for an MCP caller.
+
+Worth recording because it nearly went the other way: a first version of the
+helper passed non-finite requests through untouched, reasoning that the commands
+reject bad input themselves. `[crawler] max_pages = inf` passes the config
+schema and never reaches that check, so `Infinity` went straight to the crawler
+and the hard cap stopped being hard. A safety bound does not get exceptions for
+inputs that look invalid; `effective` is `Math.min` for every input, as it was.
 
 ## Hosted runtime, in production
 

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -453,6 +453,13 @@ export interface ScanScope {
   origin: "cli" | "ci" | "cloud";
   /** Page cap in effect for this run; absent when the runner had no cap. */
   maxPages?: number;
+  /**
+   * What the run ASKED for, present only when that exceeded the ceiling and was
+   * clamped down to `maxPages` (#1909). Absent on every ordinary run, so a
+   * caller detects a clamp by its presence rather than by comparing to a cap it
+   * would have to know.
+   */
+  requestedMaxPages?: number;
   /** Pages freshly crawled this run (the report.pages basis, before publish drops pages[]). */
   pagesCrawled: number;
   /** The page cap was the binding constraint — the site likely has more pages. */

--- a/packages/report/src/output/json.ts
+++ b/packages/report/src/output/json.ts
@@ -35,6 +35,19 @@ interface SlimJsonReport {
     };
     timestamp: string;
     totalPages: number;
+    /**
+     * The page cap in force for this run (#1909). Present whenever the report
+     * carries a scan scope.
+     */
+    maxPages?: number;
+    /**
+     * What the run ASKED for, present only when that exceeded the ceiling and
+     * was clamped down to `maxPages` (#1909). Its ABSENCE is the normal case,
+     * so a caller detects a clamp by whether this field is here rather than by
+     * knowing the cap. Without it, a request for 10,000 pages and a 5,000-page
+     * site produce identical reports.
+     */
+    requestedMaxPages?: number;
     /** Smart audits (#110): present only when `smart_audits` ran. */
     coverage?: {
       auditedPages: number;
@@ -183,6 +196,12 @@ function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
         : {}),
       timestamp: report.timestamp,
       totalPages: report.totalPages,
+      ...(report.scanScope?.maxPages !== undefined
+        ? { maxPages: report.scanScope.maxPages }
+        : {}),
+      ...(report.scanScope?.requestedMaxPages !== undefined
+        ? { requestedMaxPages: report.scanScope.requestedMaxPages }
+        : {}),
       ...(report.coverage ? { coverage: report.coverage } : {}),
     },
     status: report.status ?? "completed",

--- a/packages/report/src/output/llm.ts
+++ b/packages/report/src/output/llm.ts
@@ -208,8 +208,15 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
   if (report.scanScope) {
     const s = report.scanScope;
     const cap = s.maxPages !== undefined ? ` max-pages="${s.maxPages}"` : "";
+    // Present only when the request was clamped (#1909). An agent reading this
+    // otherwise cannot tell a 5,000-page site from a refusal to crawl the rest,
+    // and the LLM render is the whole response for an MCP caller.
+    const requested =
+      s.requestedMaxPages !== undefined
+        ? ` requested-max-pages="${s.requestedMaxPages}"`
+        : "";
     lines.push(
-      `<scan-scope origin="${s.origin}" crawled="${s.pagesCrawled}"${cap} capped="${s.capped}"/>`,
+      `<scan-scope origin="${s.origin}" crawled="${s.pagesCrawled}"${cap}${requested} capped="${s.capped}"/>`,
     );
   }
 


### PR DESCRIPTION
Fixes squirrelscan/repo#1909.

`squirrel audit --max-pages 10000` crawled 5,000 pages and said nothing. The report came back with `maxPages: 5000`, which is byte-identical to what a 5,000-page site reports, so there was no way to tell "the site has 5,000 pages" from "we refused to crawl the other 5,000".

## Five clamp sites, not one

The issue names `audit.ts:1127`. There were four more: the `crawl` command, the audit controller, and two in the crawl controller. The audit controller's is the one that reaches `mergedConfig.crawler.max_pages` and therefore the report, so fixing the command layer alone would have printed a notice while the report still said nothing. One helper in `lib/page-limit.ts` now, used by all five, so they cannot drift.

## The existing notice was a different event

`cli/format.ts` prints a cap notice when a crawl **reaches** the cap. A 10,000-page request against a 4,000-page site never reaches 5,000, so it was clamped and never mentioned. Verified on a six-page site: the new notice fires there, the old one does not.

The wording deliberately does not name `--max-pages`, because `[crawler] max_pages = 9000` reaches the same clamp and sending that user to the flag would be wrong:

```
⚠ Requested 10,000 pages, capped at 5,000. This is the hard limit; split the audit by section (e.g. [crawler] include) to scan more.
```

## The machine-readable half

This is the part #1028 actually needs, since a benchmark has to be able to say what page count it ran at. The JSON report carries `meta.maxPages` alongside `meta.requestedMaxPages`, `ScanScope` carries the same pair, and the LLM render carries it too — that last one matters because it is the whole response for an MCP caller, and an earlier version of this PR claimed MCP coverage it did not have.

`requestedMaxPages` is present **only** when a clamp happened, so a caller detects one by the field being there rather than by hard-coding a cap it would otherwise have to know:

| run | `meta` |
|---|---|
| `--max-pages 10000` against a 6-page site | `totalPages: 6, maxPages: 5000, requestedMaxPages: 10000` |
| `--max-pages 3` | `totalPages: 3, maxPages: 3` |

```
<scan-scope origin="cli" crawled="6" max-pages="5000" requested-max-pages="10000" capped="false"/>
```

## The mistake worth reading

A first version of the helper passed non-finite and non-positive requests through untouched, on the reasoning that the commands reject bad input with their own message naming the flag. They do — but `[crawler] max_pages = inf` passes the config schema and never reaches that check, so `Infinity` went straight to the crawler where `Math.min(Infinity, 5000)` had returned 5,000 before. **I had turned a hard cap into a soft one while adding a notice about it.**

`effective` is now `Math.min` for every input, exactly as it was, and only `clamped` — the narrower question of whether to say anything — treats the odd values specially. A safety bound does not get exceptions for inputs that look invalid. There is a test named for it.

`Infinity` prints on stderr but is **not** stamped into the report: `JSON.stringify(Infinity)` is `null`, and a null there reads as "no request recorded" rather than "asked for everything", which is worse than omitting it.

## Two things this does not do

- **`crawl` does not validate `--max-pages`.** It validates concurrency and per-host; max-pages `NaN` and zero behaviour is pre-existing, not something this preserves by choice, and it is out of scope here.
- **`Infinity` is reported on stderr but not stamped into the report.** `JSON.stringify(Infinity)` is `null`, and a null there reads as "no request recorded" rather than "asked for everything". The consequence is real and worth stating: `[crawler] max_pages = inf` is machine-indistinguishable from an explicit 5,000.
- **Publishing still strips `scanScope.requestedMaxPages`**, because the private ingest schema does not list the field, so Zod removes it. That is a private-repo change and the gitlink is frozen, so it is called out rather than claimed. Immediate output, the LLM render and saved local reports carry it.

## Verified end to end

Against a local origin, all six acceptance criteria: above the cap prints the notice and records both numbers; it fires on the clamp rather than on reaching the cap (six-page site); at or below the cap prints no CLAMP notice (the existing reached-limit notice is unaffected); `[crawler] max_pages = 9000` behaves identically to the flag; `squirrel crawl --max-pages 10000` matches `squirrel audit`; and the report records requested and effective without parsing stderr.

## A second thing review caught

The fix disappeared one round trip later. The slim JSON flattens `scanScope` into `meta` and never rebuilt it on read, so `squirrel report` on a saved file showed exactly what it showed before any of this. The converter restores the scope now, with tests for a clamped reload, an unclamped one, and a report written before this change, which must still load with no scope at all.

Thirteen tests, including the off-by-one at the cap, the Infinity regression, a fractional request (config accepts `5000.0001`, and `toLocaleString` rendered it as "Requested 5,000 pages, capped at 5,000"), and the three reload cases. 380 CLI tests and 332 report tests pass.

A note in `benchmarks/2026-09-perf-program.md` per the standing rule, with no timings, because nothing here changes how long anything takes — what it changes is whether the page count a measurement was taken at is knowable afterwards.
