### PR TITLE
perf(audit-engine): stream the carried side of the publish merge #1876

### DIFF
--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -425,6 +425,50 @@ read, and three of the five objects in the per-page detach. That is not recorded
 here as a number because it was not measured. A fixture that can show it needs
 stored links and images, which means an audit with external-link checking on.
 
+## The publish finalize's carried side
+
+The chunked publish's `/finalize` runs in a 128 MB API isolate. #1873 bounded the
+FRESH half: this audit's findings stream out of Postgres a page at a time and fold
+into per-rule tallies. The CARRIED half stayed an array — every open finding the
+site had outside this run, loaded, indexed by key, walked twice, replayed as a
+`CheckResult` and folded into the report — which costs nothing on a full re-audit
+(almost everything is re-observed) and everything on a PARTIAL re-audit of a site
+with a large open backlog (almost nothing is).
+
+Whole-handler RSS growth through `handlePublishFinalize` against a real local
+Postgres, the fixture seeded by a SUBPROCESS so the measuring process never
+allocated it, 2,000 fresh findings and 500 crawled pages throughout, 40 page-scope
+rules. Harness: `apps/api/tests/routes/finalize-memory-scale.test.ts` in the
+private repo, `FINALIZE_MEMORY_CARRIED` arm.
+
+| carried findings | before | after |
+|---|---|---|
+| 0 | 42.2 MiB | 39 MiB |
+| 5,000 | 90.5 MiB | 62 MiB |
+| 20,000 | 189.6 MiB | 65 MiB |
+| 60,000 | 328.6 MiB | 98 MiB |
+
+Before is linear at about 4.8 KiB per carried finding. After is not: both halves of
+a page now arrive together from ONE keyset cursor over the site's open findings,
+the merge decides each prior as it goes past, and the page is dropped. Medians of
+three to four runs per cell; the spread within a cell is 10 to 15 MiB.
+
+**Peak RSS still climbs from 20,000 to 60,000, and residency does not.** Settled
+`heapUsed` after a forced collection at the end of the handler is 20.3 MiB at
+20,000 carried findings and 21.0 MiB at 60,000 — flat, which is the claim. Peak RSS
+is a high-water mark over the whole handler, so it also records how far the runtime
+lets the heap run ahead of the driver's churn while 60,000 rows are read and
+rewritten, and that is proportional to the work whatever the design holds. Read the
+two numbers together before concluding a streaming path has a leak.
+
+Two of the three cuts were not the ones the shape predicted. The report's carried
+sample is capped at 25 checks per rule because 100 cost ~25 MiB of peak and 500
+cost ~80 — the retained checks are small, but a larger live set raises the heap the
+runtime grows to under this path's churn, so the price is a multiple of their own
+size. And the read and write batches were quartered (1,000 to 250 rows, 500 to 200)
+for ~15 MiB, because a batch's cost is the graph the driver builds around it, not
+the rows.
+
 ## Still open
 
 - Site rules are quadratic in page count (4 s at 400 pages, 99 s at 2,500,
@@ -434,3 +478,6 @@ stored links and images, which means an audit with external-link checking on.
   rather than twice is done (above); dropping the passing rows needs a decision
   about the publish payload first.
 - `--max-pages` above 5,000 is silently clamped: squirrelscan/repo#1909.
+- The finalize rewrites every carried finding to stamp `provenance`, even when it
+  already reads "carried" from an earlier run. A no-op write is most of the write
+  traffic on a site that carries the same backlog audit after audit.

--- a/packages/audit-engine/src/complete-store-fold.ts
+++ b/packages/audit-engine/src/complete-store-fold.ts
@@ -1,4 +1,4 @@
-// Bounded complete-store scoring fold (#1873).
+// Bounded complete-store scoring fold (#1873, carried side #1876).
 //
 // #1023 R-D3 made the chunked publish score off the COMPLETE per-page findings,
 // but by MATERIALIZING them: load every page_findings row → reconstruct every
@@ -19,16 +19,23 @@
 // count) is LOCAL TO ONE CALL. Folding incrementally therefore matches folding the
 // concatenated array if and only if no (checkName, pageUrl) bucket is ever split
 // across two calls. Two consequences, both load-bearing:
-//   1. `findingPages` MUST yield a page's findings whole (one page per item), never
+//   1. a page's findings MUST arrive whole (one `foldPage` call per page), never
 //      half a page — a split page would clamp and count one bucket twice;
 //   2. carried findings on a page that ALSO has fresh findings are folded together
-//      WITH that page, not in the trailing carried pass. In complete mode a carried
+//      WITH that page, not in a trailing carried pass. In complete mode a carried
 //      finding normally sits on an un-crawled page (the merge resolves anything on
 //      a crawled page), so the overlap only arises for a page missing from the
-//      crawled set — but "normally" is not "never", and the cost of handling it is
-//      one map lookup.
+//      crawled set — but "normally" is not "never".
+//
+// (#1876) The carried side is no longer an array this module indexes. Both halves
+// of a page now arrive together from ONE cursor over the site's open findings,
+// split by crawl id — which is what makes consequence 2 structural rather than a
+// lookup that happens to be there. What this module keeps per rule is two counters,
+// never the pages or the findings behind them.
 
 import type { CheckResult, PageFindingRecord } from "@squirrelscan/core-contracts";
+import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
+import { DEFAULT_FOLD_LIMITS, foldOverflowChecks } from "@squirrelscan/rules/fold";
 import type { RuleRunResult } from "@squirrelscan/rules/types";
 
 import { reconstructPageRuleChecks } from "./reconstruct";
@@ -37,6 +44,7 @@ import {
   carriedFindingToCheck,
   emptyTally,
   type CarriedFinding,
+  type CarriedUnionSource,
   type RuleTally,
 } from "./scoring";
 import type { SkippedPassCounts } from "./stream-findings";
@@ -84,27 +92,92 @@ export interface CompleteStoreTallyInput {
   ruleMetaIndex: Map<string, RuleRunResult["meta"]>;
 }
 
+/** Everything {@link createCompleteStoreTallyFold} needs; the findings themselves
+ *  arrive through {@link CompleteStoreTallyFold.foldPage}. */
+export type CompleteStoreFoldInput = Omit<
+  CompleteStoreTallyInput,
+  "findingPages" | "carriedFindings"
+> & {
+  /**
+   * (#1876) Also keep a BOUNDED per-rule sample of the carried checks this fold
+   * replays, so the report body can be built without a second pass over the
+   * carried set — see {@link CompleteStoreTallyFold.carriedUnion}. Off by default:
+   * the whole-array driver still builds the union from the carried array itself.
+   */
+  retainCarriedChecks?: boolean;
+};
+
+/**
+ * The fold as an accumulator (#1876), so the caller owns the page loop.
+ *
+ * #1873 could own it: the carried findings were a materialized array the fold
+ * indexed by page up front, and only the FRESH side streamed. Bounding the carried
+ * side means it streams too, out of the same cursor as the fresh side — and the
+ * merge has to decide each prior's fate as it goes past. That decision belongs to
+ * `computeMerge`, not here, so the loop moves out and this becomes the thing the
+ * loop feeds.
+ */
+export interface CompleteStoreTallyFold {
+  /**
+   * Fold ONE page: the findings this audit ingested for it, plus the findings the
+   * merge is carrying forward on it. BOTH halves in a single `addChecksToTally`
+   * call per rule, which is the whole point — see the module header's invariant.
+   *
+   * Call at most ONCE per normalized URL. A second call for the same page would
+   * split its (checkName, pageUrl) buckets across two folds (double-clamping the
+   * per-key unit cap) and double-count it in the dirty-page denominators.
+   */
+  foldPage(
+    normalizedUrl: string,
+    fresh: readonly PageFindingRecord[],
+    carried: readonly CarriedFinding[]
+  ): void;
+  /**
+   * Trailing pass over every rule the shell carries: site-scope checks verbatim,
+   * page-scope clean-page counts. Call ONCE, after every page has been folded — it
+   * reads the dirty-page counts the page pass accumulates.
+   */
+  foldShellRules(): void;
+  /** Carried-only rules (page-scope, absent from the shell), then the tallies. */
+  finish(): Map<string, RuleTally>;
+  /**
+   * The carried half of the union, bounded (#1876). Only meaningful with
+   * `retainCarriedChecks`; call after the last {@link foldPage}.
+   *
+   * A rule whose carried checks fit under `REPORT_LIMITS.maxChecksPerRule` reaches
+   * the report EXACTLY as it did before this bound existed. Past it, the rule keeps
+   * that many checks and the dropped ones survive as numbers: the last retained
+   * check of each (name, status) class is stamped with the class's true
+   * `occurrences` and its true distinct-page count as `pagesTruncated`, which is
+   * what the publish fold sums and maxes to build the aggregate. So the counts the
+   * report and issue-sync read stay exact while the objects behind them do not have
+   * to be resident. What IS lost above the cap is display detail only: the dropped
+   * checks' `items`, their page URLs, and their `details.additional`.
+   */
+  carriedUnion(): CarriedUnionSource;
+}
+
 /**
  * Fold this audit's complete findings + the merge's carried findings into per-rule
  * tallies — the bounded twin of
  * `buildScoringResultsFromMerged({ freshResults: reconstructCompleteResults(…), … })`.
  *
- * MUST run BEFORE the merge's persistence writes: `computeMerge` stamps RESOLVED
- * rows with this run's crawlId, so a fold that ran after them would read a
- * just-resolved finding back as fresh evidence of failure.
+ * MUST see a page BEFORE the merge's persistence writes touch it: `computeMerge`
+ * stamps rows it RESOLVES with this run's crawlId, so a fold that read a page after
+ * them would take a just-resolved finding as fresh evidence of failure. A cursor
+ * that reads each page once and only writes rows behind it satisfies this.
  */
-export async function foldCompleteStoreTallies(
-  input: CompleteStoreTallyInput
-): Promise<Map<string, RuleTally>> {
+export function createCompleteStoreTallyFold(
+  input: CompleteStoreFoldInput
+): CompleteStoreTallyFold {
   const {
     ruleResults,
-    findingPages,
     crawledUrls,
     skippedPassCounts,
-    carriedFindings,
     carriedPageUrls,
     ruleMetaIndex,
     removedUrls,
+    retainCarriedChecks,
   } = input;
 
   const tallies = new Map<string, RuleTally>();
@@ -120,48 +193,52 @@ export async function foldCompleteStoreTallies(
   };
   const advisory = (meta: RuleRunResult["meta"]): boolean => meta.severity === "info";
 
-  // Carried findings indexed two ways, both bounded by the carried set (the
-  // findings a previous audit left open on pages this run did not re-crawl):
-  //  - byPage: to fold a page's carried checks in the SAME call as its fresh ones;
-  //  - pagesByRule: the clean-carried-pass denominator, which must survive the
-  //    page pass (it counts every carried page a rule has NO finding on).
-  const carriedByPage = new Map<string, Map<string, CarriedFinding[]>>();
-  const carriedPagesByRule = new Map<string, Set<string>>();
-  for (const f of carriedFindings) {
-    const meta = metaOf(f.ruleId);
-    // Unknown rule — cannot be scored (no meta); site-scope rules never carry
-    // per-page findings. Both mirror buildScoringResultsFromMerged's guards.
-    if (meta?.scope !== "page") continue;
-    let byRule = carriedByPage.get(f.normalizedUrl);
-    if (!byRule) {
-      byRule = new Map();
-      carriedByPage.set(f.normalizedUrl, byRule);
-    }
-    const list = byRule.get(f.ruleId);
-    if (list) list.push(f);
-    else byRule.set(f.ruleId, [f]);
-    let pages = carriedPagesByRule.get(f.ruleId);
-    if (!pages) {
-      pages = new Set();
-      carriedPagesByRule.set(f.ruleId, pages);
-    }
-    pages.add(f.normalizedUrl);
-  }
-
   // Pages this run has a finding on, per rule — the fresh-clean denominator's
   // subtrahend. Counted (not collected) so it stays O(rules), and counted only for
   // CRAWLED pages, matching reconstructCompleteResults' `crawledUrls \ failingPages`.
   const dirtyPagesByRule = new Map<string, number>();
 
-  /** Fold ONE page: its reconstructed fresh checks plus any carried findings that
-   * sit on the same page, in a single addChecksToTally call per rule so no
-   * (checkName, pageUrl) bucket is ever split. */
-  const foldPage = (normalizedUrl: string, page: readonly PageFindingRecord[]): void => {
-    const freshByRule = reconstructPageRuleChecks(page);
-    const carriedForPage = carriedByPage.get(normalizedUrl);
-    // Consumed: this page's carried findings are folded here, so the trailing
-    // carried pass must not fold them a second time.
-    if (carriedForPage) carriedByPage.delete(normalizedUrl);
+  // The carried half of the same bookkeeping, and the same reason for counting
+  // rather than collecting (#1876): a partial re-audit of a large site carries tens
+  // of thousands of findings, so neither the findings nor their pages can be held.
+  //  - carriedRuleIds: page-scope rules with ANY carried finding, so a rule absent
+  //    from the shell still gets its carried-clean passes. O(rules).
+  //  - carriedDirtyPagesByRule: how many CARRIED PAGES (⊆ carriedPageUrls) have a
+  //    finding for the rule. `carriedPageUrls.size` minus this is exactly the
+  //    set-difference count the materialized path computes, because every page is
+  //    folded exactly once. O(rules).
+  const carriedRuleIds = new Set<string>();
+  const carriedDirtyPagesByRule = new Map<string, number>();
+
+  // (#1876) The report's carried sample, taken from the SAME replayed checks the
+  // tally consumes — building it here rather than in a second pass is what stops a
+  // carried finding's stored payload being JSON-parsed twice.
+  const carriedReport = retainCarriedChecks ? new Map<string, CarriedRuleReport>() : undefined;
+
+  const foldPage: CompleteStoreTallyFold["foldPage"] = (normalizedUrl, fresh, carried) => {
+    const freshByRule = fresh.length > 0 ? reconstructPageRuleChecks(fresh) : undefined;
+    // Carried findings for this page, grouped per rule. Bounded by ONE page.
+    let carriedByRule: Map<string, CarriedFinding[]> | undefined;
+    for (const f of carried) {
+      // Unknown rule — cannot be scored (no meta); site-scope rules never carry
+      // per-page findings. Both mirror buildScoringResultsFromMerged's guards.
+      if (metaOf(f.ruleId)?.scope !== "page") continue;
+      if (!carriedByRule) carriedByRule = new Map();
+      const list = carriedByRule.get(f.ruleId);
+      if (list) list.push(f);
+      else carriedByRule.set(f.ruleId, [f]);
+    }
+    if (carriedByRule) {
+      const isCarriedPage = carriedPageUrls.has(normalizedUrl);
+      for (const ruleId of carriedByRule.keys()) {
+        carriedRuleIds.add(ruleId);
+        if (isCarriedPage) {
+          carriedDirtyPagesByRule.set(ruleId, (carriedDirtyPagesByRule.get(ruleId) ?? 0) + 1);
+        }
+      }
+    }
+    if (!freshByRule && !carriedByRule) return;
+
     const isCrawled = crawledUrls.has(normalizedUrl);
     // 404/410 this run: the page is gone, so its fresh checks leave the union
     // (mirroring freshForUnion). Carried findings are folded regardless — the
@@ -169,8 +246,8 @@ export async function foldCompleteStoreTallies(
     // the shape then matches the materialized path rather than relying on that.
     const isRemoved = removedUrls?.has(normalizedUrl) ?? false;
 
-    const ruleIds = new Set<string>(freshByRule.keys());
-    if (carriedForPage) for (const ruleId of carriedForPage.keys()) ruleIds.add(ruleId);
+    const ruleIds = new Set<string>(freshByRule?.keys() ?? []);
+    if (carriedByRule) for (const ruleId of carriedByRule.keys()) ruleIds.add(ruleId);
 
     for (const ruleId of ruleIds) {
       const meta = metaOf(ruleId);
@@ -178,19 +255,382 @@ export async function foldCompleteStoreTallies(
       // a site-scope rule never has per-page findings. Mirrors the unknown-rule
       // guards in reconstructCompleteResults / buildScoringResultsFromMerged.
       if (meta?.scope !== "page") continue;
-      const fresh = isRemoved ? undefined : freshByRule.get(ruleId);
-      const carried = carriedForPage?.get(ruleId);
-      const checks: CheckResult[] = carried
-        ? [...(fresh ?? []), ...carried.map((f) => carriedFindingToCheck(f, normalizedUrl))]
-        : (fresh ?? []);
+      const freshChecks = isRemoved ? undefined : freshByRule?.get(ruleId);
+      const carriedForRule = carriedByRule?.get(ruleId);
+      const carriedChecks = carriedForRule?.map((f) => carriedFindingToCheck(f, normalizedUrl));
+      if (carriedReport && carriedChecks) retainCarried(carriedReport, ruleId, carriedChecks);
+      const checks: CheckResult[] = carriedChecks
+        ? [...(freshChecks ?? []), ...carriedChecks]
+        : (freshChecks ?? []);
       if (checks.length === 0) continue;
       addChecksToTally(entryFor(ruleId, meta).tally, checks, advisory(meta), 0);
-      if (fresh && fresh.length > 0 && isCrawled) {
+      if (freshChecks && freshChecks.length > 0 && isCrawled) {
         dirtyPagesByRule.set(ruleId, (dirtyPagesByRule.get(ruleId) ?? 0) + 1);
       }
     }
   };
 
+  /** Carried pages with NO finding for this rule — the carried half of the
+   *  pass-ratio denominator (#918). Folded to a count, never to synthetic "pass"
+   *  CheckResults, so a partial re-audit of a large site cannot materialize
+   *  (page-scope rules × carried pages) objects. */
+  const cleanCarriedPasses = (ruleId: string): number =>
+    carriedPageUrls.size - (carriedDirtyPagesByRule.get(ruleId) ?? 0);
+
+  const foldShellRules: CompleteStoreTallyFold["foldShellRules"] = () => {
+    for (const [ruleId, r] of Object.entries(ruleResults)) {
+      if (r.meta.scope !== "page") {
+        // Site-scope rule: findings never carry these (flattenChecks skips
+        // no-pageUrl checks), so it is scored from the shell's checks verbatim —
+        // the same ones reconstructCompleteResults passes through.
+        addChecksToTally(entryFor(ruleId, r.meta).tally, r.checks, advisory(r.meta), 0);
+        continue;
+      }
+      const entry = entryFor(ruleId, r.meta);
+      // Fresh clean pages: crawled pages with NO finding for this rule. See the
+      // SKIP-AS-PASS approximation documented on reconstructCompleteResults — a page
+      // the rule skipped has no finding and is counted here as a pass, exactly as
+      // the #918 carried-clean model already does.
+      const clean = crawledUrls.size - (dirtyPagesByRule.get(ruleId) ?? 0);
+      // (#1305) Passing SIBLING checks on dirty pages, with the round-5 SECURITY
+      // CLAMP: skippedPassCounts is untrusted finalize-body input, and an inflated
+      // count added straight into the pass numerator would drive a genuinely-failing
+      // rule's passRate toward 1.0 — the exact #1179 integrity class this feature
+      // fixes. A check cannot pass on more pages than were crawled, so bounding the
+      // per-rule sum to the crawl universe only ever reduces an over-count.
+      let skippedPasses = 0;
+      const perCheck = skippedPassCounts?.[ruleId];
+      if (perCheck) for (const n of Object.values(perCheck)) skippedPasses += n;
+      skippedPasses = Math.min(skippedPasses, crawledUrls.size);
+      addChecksToTally(
+        entry.tally,
+        [],
+        advisory(r.meta),
+        clean + skippedPasses + cleanCarriedPasses(ruleId)
+      );
+    }
+  };
+
+  const finish: CompleteStoreTallyFold["finish"] = () => {
+    // Carried-only rules (page-scope, absent from the shell) get no fresh-clean
+    // count — reconstructCompleteResults never runs for them — but they DO get the
+    // carried-clean passes buildScoringResultsFromMerged gives them.
+    for (const ruleId of carriedRuleIds) {
+      if (ruleResults[ruleId]) continue; // already handled by foldShellRules
+      const meta = metaOf(ruleId);
+      if (meta?.scope !== "page") continue;
+      addChecksToTally(entryFor(ruleId, meta).tally, [], advisory(meta), cleanCarriedPasses(ruleId));
+    }
+    return tallies;
+  };
+
+  // Collapsing stamps the dropped counts ONTO a retained check, so it must happen
+  // exactly once however many times the caller asks for the union.
+  let collapsed: Map<string, readonly CheckResult[]> | undefined;
+  const carriedUnion: CompleteStoreTallyFold["carriedUnion"] = () => {
+    const checksByRule = (collapsed ??= collapseCarriedReport(
+      carriedReport ?? new Map<string, CarriedRuleReport>(),
+    ));
+    return {
+      ruleIds: () => carriedRuleIds,
+      checksFor: (ruleId) => checksByRule.get(ruleId) ?? EMPTY_CHECKS,
+      dirtyCarriedPageCount: (ruleId) => carriedDirtyPagesByRule.get(ruleId) ?? 0,
+    };
+  };
+
+  return { foldPage, foldShellRules, finish, carriedUnion };
+}
+
+const EMPTY_CHECKS: readonly CheckResult[] = [];
+
+/**
+ * Carried checks retained per rule for the report body (#1876).
+ *
+ * A rule under it reaches the report byte-for-byte as it did before this bound
+ * existed. Past it the rule's carried side is ONE aggregate per issue class,
+ * carrying the true occurrence and affected-page counts — which is the shape the
+ * complete-store report already uses for page-scope rules, since the staged shell
+ * ships aggregates rather than per-page checks.
+ *
+ * MEASURED, and low for a reason that is not the obvious one. The retained checks
+ * are small; what costs is that a larger live set raises the heap the runtime
+ * grows to under this path's churn, so the price is a multiple of their own size.
+ * Whole-handler peak at 60,000 carried findings over 40 rules, everything else
+ * equal: 500 per rule cost ~180 MiB, 100 cost ~123, 25 costs ~78, and retaining
+ * nothing at all costs ~77. Past about 25 the sample buys report detail with
+ * isolate the 128 MB budget does not have.
+ */
+const CARRIED_REPORT_SAMPLE_PER_RULE = 25;
+
+/**
+ * Per-(name, status) issue class: what was seen versus what was kept.
+ *
+ * Everything a dropped check would have contributed to its aggregate is counted
+ * here, because the aggregate is built from the RETAINED sample and would
+ * otherwise report only that sample's share. Four things travel that way, and
+ * each was a real loss before it did.
+ */
+interface CarriedClassCounts {
+  /**
+   * Occurrences of this class, kept or dropped — WEIGHTED, not an object count. A
+   * constituent that is itself an aggregate stands for its own `occurrences`, the
+   * same distinction `foldGroup` draws when it sums them.
+   */
+  total: number;
+  /** Occurrences of the constituents that are in `checks`, weighted the same way. */
+  retained: number;
+  /**
+   * Constituents seen, and of those how many are in `checks` — plain OBJECT
+   * counts, tracked separately from the weights above because a weight can be
+   * zero. `foldGroup` floors `details.occurrences`, so a check declaring `0.5`
+   * contributes nothing to either total, and a class that lost only such checks
+   * would look complete while its pages and provenance had gone missing.
+   */
+  members: number;
+  retainedMembers: number;
+  /** Distinct PAGES with at least one — exact, because a page folds exactly once. */
+  pages: number;
+  /**
+   * Largest `details.pagesTruncated` any constituent carried. A carried finding
+   * can hold one: `unfoldAggregateCheck` strips `aggregated`/`occurrences` when it
+   * expands a published aggregate but leaves this, so the per-page rows the merge
+   * stores inherit it. Losing a dropped check's floor would make the aggregate
+   * claim fewer affected pages than a constituent already reported.
+   */
+  pagesFloor: number;
+  /** Last retained check of the class: where the dropped counts get stamped. */
+  last?: CheckResult;
+  /** Newest `lastSeenAt` across every constituent, dropped ones included. */
+  lastSeenAt?: number;
+  /** True while EVERY constituent is provenance "carried". */
+  allCarried: boolean;
+  /** True while EVERY constituent is provenance "unrendered". */
+  allUnrendered: boolean;
+}
+
+/** What a check contributes to an occurrence total: its own count, or itself. */
+function occurrencesOf(check: CheckResult): number {
+  const own = check.details?.occurrences;
+  return typeof own === "number" && Number.isFinite(own) && own > 0 ? Math.floor(own) : 1;
+}
+
+interface CarriedRuleReport {
+  checks: CheckResult[];
+  classes: Map<string, CarriedClassCounts>;
+}
+
+/** One page's carried checks for one rule, retained up to the per-rule cap. */
+function retainCarried(
+  report: Map<string, CarriedRuleReport>,
+  ruleId: string,
+  checks: readonly CheckResult[]
+): void {
+  let entry = report.get(ruleId);
+  if (!entry) {
+    entry = { checks: [], classes: new Map() };
+    report.set(ruleId, entry);
+  }
+  // Classes already counted for THIS page, so `pages` counts pages, not checks.
+  const pageClasses = new Set<string>();
+  for (const check of checks) {
+    // The key the publish fold groups on, so a stamp lands on the class it will
+    // actually be summed into. NUL cannot appear in a check name.
+    const key = `${check.name}\u0000${check.status}`;
+    let counts = entry.classes.get(key);
+    if (!counts) {
+      counts = {
+        total: 0,
+        retained: 0,
+        members: 0,
+        retainedMembers: 0,
+        pages: 0,
+        pagesFloor: 0,
+        allCarried: true,
+        allUnrendered: true,
+      };
+      entry.classes.set(key, counts);
+    }
+    counts.total += occurrencesOf(check);
+    counts.members += 1;
+    if (!pageClasses.has(key)) {
+      counts.pages += 1;
+      pageClasses.add(key);
+    }
+    const ownFloor = check.details?.pagesTruncated;
+    if (typeof ownFloor === "number" && Number.isFinite(ownFloor) && ownFloor > counts.pagesFloor) {
+      counts.pagesFloor = Math.floor(ownFloor);
+    }
+    if (check.provenance !== "carried") counts.allCarried = false;
+    if (check.provenance !== "unrendered") counts.allUnrendered = false;
+    if (check.lastSeenAt !== undefined) {
+      counts.lastSeenAt = Math.max(counts.lastSeenAt ?? 0, check.lastSeenAt);
+    }
+    // The rule's budget never costs a class its EXISTENCE. A class first seen
+    // after the budget is spent still keeps its first check, because that check is
+    // where its dropped occurrences and affected pages are stamped — without one
+    // the whole class would vanish from the report while its findings stayed open
+    // in the store. The bound becomes max(budget, distinct issue classes), and the
+    // classes of one rule are its distinct check names.
+    if (counts.retainedMembers > 0 && entry.checks.length >= CARRIED_REPORT_SAMPLE_PER_RULE) {
+      continue;
+    }
+    entry.checks.push(check);
+    counts.retained += occurrencesOf(check);
+    counts.retainedMembers += 1;
+    counts.last = check;
+  }
+}
+
+/**
+ * Turn the retained sample into the checks the report body gets.
+ *
+ * A rule that lost nothing passes through UNTOUCHED, so its report is byte-for-byte
+ * what the materialized path builds — `applyUnionToReport` folds it downstream
+ * exactly as before.
+ *
+ * A rule that DID lose carried findings is folded here instead. Two reasons, and
+ * the second is why this is not merely an optimization:
+ *  1. the dropped findings survive as numbers, and numbers only reach the report
+ *     through an aggregate — `foldGroup` sums each constituent's
+ *     `details.occurrences` (defaulting to 1) and takes the MAX of their
+ *     `details.pagesTruncated`, so stamping one retained member of a class with the
+ *     class totals makes the aggregate report the true occurrence count and the
+ *     true affected-page count, which issue-sync and `affectedPages()` read;
+ *  2. a rule over the cap folded to a handful of aggregates BEFORE this bound
+ *     existed (its carried checks were far past `maxChecksPerRule`, so the publish
+ *     fold always collapsed them). Handing the report a retained sample that sits
+ *     exactly AT the cap would sail under that fold and publish thousands of
+ *     per-page checks where there used to be three — a bigger report, not a
+ *     smaller one. Measured: 40 rules × 500 retained checks = a 5.4 MB payload,
+ *     over the pre-warm budget.
+ */
+function collapseCarriedReport(
+  report: Map<string, CarriedRuleReport>,
+): Map<string, readonly CheckResult[]> {
+  const out = new Map<string, readonly CheckResult[]>();
+  for (const [ruleId, entry] of report) {
+    let anyDropped = false;
+    for (const counts of entry.classes.values()) {
+      const last = counts.last;
+      // Keyed on MEMBERS, not on weight: a dropped check whose declared
+      // occurrence count floors to zero still took its pages and its provenance
+      // with it.
+      if (counts.members <= counts.retainedMembers || !last) continue;
+      anyDropped = true;
+      const stamped = occurrencesOf(last) + (counts.total - counts.retained);
+      // Replaced, never mutated in place: `details` can be the object parsed out of
+      // the finding's stored payload, which other readers of that payload share.
+      //
+      // A stamp of ZERO is never written. `foldGroup` reads a non-positive
+      // `occurrences` as "no count declared" and substitutes 1, so writing the 0
+      // this class genuinely weighs would ADD an occurrence the materialized fold
+      // does not have. Leaving the field as the retained check declared it lets
+      // the fold reach the same total by the same route it always did.
+      last.details = {
+        ...(last.details ?? {}),
+        ...(stamped > 0 ? { occurrences: stamped } : {}),
+        pagesTruncated: Math.max(counts.pages, counts.pagesFloor),
+      };
+    }
+    if (!anyDropped) {
+      out.set(ruleId, entry.checks);
+      continue;
+    }
+    // `maxChecks` = the class count, which is the largest value that still folds
+    // every class (the fold is a no-op at or under it) and keeps all of them (it
+    // slices only past it).
+    const folded = foldOverflowChecks(entry.checks, {
+      ...DEFAULT_FOLD_LIMITS,
+      maxChecks: entry.classes.size,
+    });
+    for (const aggregate of folded) reconcileCarriedAggregate(aggregate, entry.classes);
+    out.set(ruleId, folded);
+  }
+  return out;
+}
+
+/**
+ * Repair the two things `foldGroup` can only read off the constituents in front of
+ * it, and which the RETAINED sample therefore answers for the whole class.
+ *
+ * `provenance` is all-or-nothing there: it stamps "carried" when every constituent
+ * is carried, "unrendered" when every one is. A sample can be uniform when the
+ * class is not — the first 25 findings all on pages an earlier audit rendered, the
+ * rest on pages nothing ever has — and the aggregate would then claim an audit saw
+ * findings that no audit has. `lastSeenAt` has the mirror-image problem: it is the
+ * MAX over the group, so a dropped constituent with a newer date makes the badge
+ * read stale.
+ *
+ * Both are corrected from counters kept over every constituent. A mixed class ends
+ * up with neither marker, which is what a mixed group of real checks would have
+ * produced.
+ */
+function reconcileCarriedAggregate(
+  aggregate: CheckResult,
+  classes: Map<string, CarriedClassCounts>
+): void {
+  const counts = classes.get(`${aggregate.name}\u0000${aggregate.status}`);
+  // Untouched unless this class actually lost members; a fully-present class was
+  // folded from every constituent and is already right.
+  if (!counts || counts.members <= counts.retainedMembers) return;
+
+  // A class whose sample is a SINGLE check was not folded at all — `foldGroup`
+  // short-circuits a one-member group and returns the check itself — so it still
+  // reads as one page's finding while its stamped counts speak for many, and a
+  // reader would attribute every occurrence to that page. Give it the shape the
+  // fold would have produced from the same constituents.
+  if (aggregate.details?.aggregated !== true) {
+    if (aggregate.pageUrl) {
+      aggregate.pages = [aggregate.pageUrl];
+      delete aggregate.pageUrl;
+    }
+    aggregate.details = { ...(aggregate.details ?? {}), aggregated: true };
+    const occurrences = occurrencesOf(aggregate);
+    if (occurrences > 1) {
+      aggregate.message = `${aggregate.message} (+${occurrences - 1} more pages)`.slice(
+        0,
+        REPORT_LIMITS.maxMediumString
+      );
+    }
+  }
+
+  if (counts.allUnrendered) {
+    aggregate.provenance = "unrendered";
+    delete aggregate.lastSeenAt;
+    return;
+  }
+  if (counts.allCarried) {
+    aggregate.provenance = "carried";
+    if (counts.lastSeenAt !== undefined) aggregate.lastSeenAt = counts.lastSeenAt;
+    return;
+  }
+  delete aggregate.provenance;
+  delete aggregate.lastSeenAt;
+}
+
+/**
+ * Whole-array driver: the #1873 shape, where the carried findings are already
+ * materialized and only the FRESH side streams. Kept as the entry point for the
+ * CLI-shaped callers and the parity fixtures; the API's streaming finalize drives
+ * {@link createCompleteStoreTallyFold} directly off one cursor instead.
+ */
+export async function foldCompleteStoreTallies(
+  input: CompleteStoreTallyInput
+): Promise<Map<string, RuleTally>> {
+  const { findingPages, carriedFindings, ...rest } = input;
+  const fold = createCompleteStoreTallyFold(rest);
+
+  // Carried findings indexed by page, so a page's carried checks fold in the SAME
+  // call as its fresh ones. Bounded by the carried set — which is exactly what the
+  // streaming driver exists to avoid, and why this one is not the API's path.
+  const carriedByPage = new Map<string, CarriedFinding[]>();
+  for (const f of carriedFindings) {
+    const list = carriedByPage.get(f.normalizedUrl);
+    if (list) list.push(f);
+    else carriedByPage.set(f.normalizedUrl, [f]);
+  }
+
+  const EMPTY: readonly CarriedFinding[] = [];
   for await (const batch of findingPages) {
     if (batch.length === 0) continue;
     // Re-group by page rather than trusting a batch to hold exactly one. What the
@@ -198,72 +638,26 @@ export async function foldCompleteStoreTallies(
     // carrying several WHOLE pages is harmless, and grouping here means such a
     // producer cannot silently attribute one page's findings to another page's
     // crawled/removed state.
-    for (const [normalizedUrl, page] of groupByPage(batch)) foldPage(normalizedUrl, page);
-  }
-
-  // Trailing pass 1 — every rule the shell carries.
-  for (const [ruleId, r] of Object.entries(ruleResults)) {
-    if (r.meta.scope !== "page") {
-      // Site-scope rule: findings never carry these (flattenChecks skips
-      // no-pageUrl checks), so it is scored from the shell's checks verbatim —
-      // the same ones reconstructCompleteResults passes through.
-      addChecksToTally(entryFor(ruleId, r.meta).tally, r.checks, advisory(r.meta), 0);
-      continue;
-    }
-    const entry = entryFor(ruleId, r.meta);
-    // Fresh clean pages: crawled pages with NO finding for this rule. See the
-    // SKIP-AS-PASS approximation documented on reconstructCompleteResults — a page
-    // the rule skipped has no finding and is counted here as a pass, exactly as
-    // the #918 carried-clean model already does.
-    const clean = crawledUrls.size - (dirtyPagesByRule.get(ruleId) ?? 0);
-    // (#1305) Passing SIBLING checks on dirty pages, with the round-5 SECURITY
-    // CLAMP: skippedPassCounts is untrusted finalize-body input, and an inflated
-    // count added straight into the pass numerator would drive a genuinely-failing
-    // rule's passRate toward 1.0 — the exact #1179 integrity class this feature
-    // fixes. A check cannot pass on more pages than were crawled, so bounding the
-    // per-rule sum to the crawl universe only ever reduces an over-count.
-    let skippedPasses = 0;
-    const perCheck = skippedPassCounts?.[ruleId];
-    if (perCheck) for (const n of Object.values(perCheck)) skippedPasses += n;
-    skippedPasses = Math.min(skippedPasses, crawledUrls.size);
-    addChecksToTally(
-      entry.tally,
-      [],
-      advisory(r.meta),
-      clean + skippedPasses + cleanCarriedPasses(ruleId, carriedPageUrls, carriedPagesByRule)
-    );
-  }
-
-  // Trailing pass 2 — carried findings whose page was never streamed (the normal
-  // case: an un-crawled page), plus carried-only rules absent from the shell.
-  for (const [normalizedUrl, byRule] of carriedByPage) {
-    for (const [ruleId, findings] of byRule) {
-      const meta = metaOf(ruleId)!; // indexed above only when page-scope meta exists
-      addChecksToTally(
-        entryFor(ruleId, meta).tally,
-        findings.map((f) => carriedFindingToCheck(f, normalizedUrl)),
-        advisory(meta),
-        0
-      );
+    for (const [normalizedUrl, page] of groupByPage(batch)) {
+      const carried = carriedByPage.get(normalizedUrl);
+      // Consumed: this page's carried findings are folded here, so the trailing
+      // carried pass must not fold them a second time.
+      if (carried) carriedByPage.delete(normalizedUrl);
+      fold.foldPage(normalizedUrl, page, carried ?? EMPTY);
     }
   }
-  // Carried-only rules (page-scope, absent from the shell) get no fresh-clean
-  // count — reconstructCompleteResults never runs for them — but they DO get the
-  // carried-clean passes buildScoringResultsFromMerged gives them.
-  for (const ruleId of carriedPagesByRule.keys()) {
-    if (ruleResults[ruleId]) continue; // already handled in trailing pass 1
-    const meta = metaOf(ruleId);
-    if (meta?.scope !== "page") continue;
-    addChecksToTally(
-      entryFor(ruleId, meta).tally,
-      [],
-      advisory(meta),
-      cleanCarriedPasses(ruleId, carriedPageUrls, carriedPagesByRule)
-    );
+
+  // Carried findings whose page was never streamed (the normal case: an un-crawled
+  // page), plus carried-only rules absent from the shell.
+  for (const [normalizedUrl, carried] of carriedByPage) {
+    fold.foldPage(normalizedUrl, EMPTY_ROWS, carried);
   }
 
-  return tallies;
+  fold.foldShellRules();
+  return fold.finish();
 }
+
+const EMPTY_ROWS: readonly PageFindingRecord[] = [];
 
 /** Split a batch of findings into per-page groups, preserving arrival order. */
 function groupByPage(
@@ -276,22 +670,4 @@ function groupByPage(
     else byPage.set(f.normalizedUrl, [f]);
   }
   return byPage;
-}
-
-/**
- * Carried pages with NO finding for this rule — the carried half of the pass-ratio
- * denominator (#918). Folded to a count, never to synthetic "pass" CheckResults,
- * so a partial re-audit of a large site cannot materialize
- * (page-scope rules × carried pages) objects.
- */
-function cleanCarriedPasses(
-  ruleId: string,
-  carriedPageUrls: Set<string>,
-  carriedPagesByRule: Map<string, Set<string>>
-): number {
-  const dirty = carriedPagesByRule.get(ruleId);
-  if (!dirty || dirty.size === 0) return carriedPageUrls.size;
-  let clean = 0;
-  for (const url of carriedPageUrls) if (!dirty.has(url)) clean++;
-  return clean;
 }

--- a/packages/audit-engine/src/merge-core.ts
+++ b/packages/audit-engine/src/merge-core.ts
@@ -385,6 +385,51 @@ export function flattenChecks(
   return out;
 }
 
+/** Inputs to a {@link createMergeSession}: everything except the prior findings,
+ *  which the session consumes incrementally. */
+export type MergeSessionInput = Omit<ComputeMergeInput, "priorFindings">;
+
+/**
+ * Where a merge session sends the records it derives from PRIOR findings (#1876).
+ *
+ * Prior-derived output is pushed rather than returned so a caller can stream tens
+ * of thousands of priors past the session without any of them, or of the records
+ * they produce, being resident at once. {@link computeMerge}'s sink appends to
+ * arrays, which is what keeps the array API byte-identical.
+ */
+export interface MergePriorSink {
+  /** A row to upsert: a carried, resolved or staled prior. */
+  persist(record: PageFindingRecord): void;
+  /** A prior that is OPEN in the merged union (i.e. carried). Fresh actives are
+   *  NOT sent here — they come back from {@link MergeSession.finish}. */
+  active(finding: MergedFinding): void;
+}
+
+/** A merge in progress: prior findings stream in, fresh records come out at the end. */
+export interface MergeSession {
+  /**
+   * Site pages after the merge, and the URLs active afterwards. Step 3 of the
+   * merge reads only `priorPages` + this run's crawl, never a prior FINDING, so
+   * both are known before the first prior arrives — which is what lets the caller
+   * derive `carriedPageUrls` up front and fold carried findings as they stream.
+   */
+  readonly sitePages: SitePageRecord[];
+  readonly activePageUrls: Set<string>;
+  /**
+   * Decide one batch of prior OPEN findings, pushing the results to the sink.
+   * The decision is per row and never depends on how the priors are batched, so
+   * any batching (one array, one page, one row) yields the same records in the
+   * same order.
+   */
+  addPriorFindings(priors: readonly PageFindingRecord[]): void;
+  /**
+   * Emit this run's FRESH records. Call once, AFTER every prior has been added:
+   * a fresh finding inherits `firstSeenAt` from the prior it supersedes, and
+   * those stamps are harvested as the priors go past.
+   */
+  finish(): { persisted: PageFindingRecord[]; active: MergedFinding[] };
+}
+
 /**
  * Merge this run's fresh findings against the prior site state (pure).
  *
@@ -395,8 +440,99 @@ export function flattenChecks(
  * - stale: a previously-active page that returned 404/410 this run → page
  *   removed, its findings staled. (Pages merely scoped-out — not popped this
  *   run — are NOT removed; they carry.)
+ *
+ * (#1876) The whole-array form: it drives a {@link createMergeSession} with a
+ * sink that collects, so there is exactly ONE decision implementation shared with
+ * the API's streaming driver. Fresh records lead `persisted`/`findings` here
+ * because that is the order the pre-#1876 two-pass loop produced and the report's
+ * carried replays are built from it.
  */
 export function computeMerge(input: ComputeMergeInput): MergedState {
+  const priorPersisted: PageFindingRecord[] = [];
+  const priorActive: MergedFinding[] = [];
+  const session = createMergeSession(input, {
+    persist: (record) => {
+      priorPersisted.push(record);
+    },
+    active: (finding) => {
+      priorActive.push(finding);
+    },
+  });
+  // The array API takes an ARRAY, so nothing stops a caller passing the same
+  // finding key twice, and the pre-#1876 loop handled a repeat by ignoring it
+  // (one `handledKeys` set answered both "superseded by a fresh finding" and
+  // "already decided"). The session does not carry that set — it is the one
+  // structure whose size is the prior count, and a store read cannot produce a
+  // repeat because the key IS the primary key — so the dedupe lives here, where
+  // the whole array is resident anyway.
+  session.addPriorFindings(dedupeByKey(input.priorFindings, freshKeysOf(input.freshFindings)));
+  const fresh = session.finish();
+  return {
+    findings: [...fresh.active, ...priorActive],
+    persisted: [...fresh.persisted, ...priorPersisted],
+    sitePages: session.sitePages,
+    activePageUrls: session.activePageUrls,
+  };
+}
+
+function freshKeysOf(fresh: readonly FlatFinding[]): Set<string> {
+  const keys = new Set<string>();
+  for (const f of fresh) keys.add(findingKey(f.normalizedUrl, f.ruleId, f.checkName, f.locator));
+  return keys;
+}
+
+/**
+ * Repeated prior keys, resolved the way the pre-#1876 loop resolved them — which
+ * is NOT one rule (see {@link computeMerge}).
+ *
+ * A prior the merge decides on: FIRST wins. `handledKeys` was set by the decision,
+ * so every later repeat hit the `continue` at the top of the loop.
+ *
+ * A prior a FRESH finding supersedes: LAST wins. Those never reached the loop's
+ * decision at all — they were read out of `priorByKey`, an index built by
+ * assigning each prior in turn, so the last assignment is the one the fresh
+ * record inherited its `firstSeenAt` from. They are passed through here for the
+ * same reason: the session returns early on them, keeping only the stamp, and the
+ * last one to go past sets it.
+ */
+function dedupeByKey(
+  priors: readonly PageFindingRecord[],
+  freshKeys: Set<string>
+): readonly PageFindingRecord[] {
+  const seen = new Set<string>();
+  const out: PageFindingRecord[] = [];
+  for (const p of priors) {
+    const key = findingKey(p.normalizedUrl, p.ruleId, p.checkName, p.locator);
+    if (!freshKeys.has(key)) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+    }
+    out.push(p);
+  }
+  return out.length === priors.length ? priors : out;
+}
+
+/**
+ * The merge as a resumable state machine (#1876), so prior findings can arrive
+ * from a cursor in bounded batches instead of as one materialized array.
+ *
+ * PRECONDITION: prior findings are unique by {@link findingKey}. That is the
+ * page_findings primary key, so every store read satisfies it; the array-shaped
+ * {@link computeMerge} enforces it for callers that build the list by hand.
+ *
+ * WHAT CHANGED vs the pre-#1876 two-pass loop, and why it is equivalent: that
+ * version indexed EVERY prior into `priorByKey` so the fresh pass could ask "did a
+ * previous audit see this one" (for `firstSeenAt`), then walked the priors again.
+ * The index is the unbounded part, and it only ever answered questions about keys
+ * in the FRESH set — which is bounded by the run. So the lookup is flipped: the
+ * fresh set is indexed, priors stream past it, and a prior that matches one leaves
+ * its `firstSeenAt` behind on the way through. The fresh records are then emitted
+ * by {@link MergeSession.finish}, which is why it must be called last.
+ */
+export function createMergeSession(
+  input: MergeSessionInput,
+  sink: MergePriorSink
+): MergeSession {
   const {
     siteKey,
     crawlId,
@@ -405,21 +541,11 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
     removedUrls,
     severityByRule,
     statusByUrl,
-    priorFindings,
     priorPages,
     now,
     sampledCheckPages,
     resolution,
   } = input;
-
-  // Index prior findings by full key for O(1) lookup.
-  const priorByKey = new Map<string, PageFindingRecord>();
-  for (const p of priorFindings) {
-    priorByKey.set(
-      findingKey(p.normalizedUrl, p.ruleId, p.checkName, p.locator),
-      p
-    );
-  }
 
   // Index fresh findings by key (latest wins on dup keys within a run).
   const freshByKey = new Map<string, FlatFinding>();
@@ -430,9 +556,10 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
     );
   }
 
-  const persisted: PageFindingRecord[] = [];
-  const activeFindings: MergedFinding[] = [];
-  const handledKeys = new Set<string>();
+  // (#1876) First-seen stamps harvested from the priors this run's fresh findings
+  // SUPERSEDE — the one thing the fresh pass needed the prior index for. Bounded
+  // by the fresh set, so it is the half of the old index that can stay resident.
+  const firstSeenByFreshKey = new Map<string, number>();
 
   // (#1652) The site's render history: `site_pages` rows are written only for
   // pages a run actually crawled (step 3 below), in any lifecycle state — a
@@ -459,174 +586,12 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
   const neverRendered = (normalizedUrl: string, renderedThisRun: boolean): boolean =>
     !renderedThisRun && !everRenderedUrls.has(normalizedUrl);
 
-  // 1) FRESH — upsert findings for crawled URLs.
-  for (const [key, f] of freshByKey) {
-    const prior = priorByKey.get(key);
-    const fp = fingerprint(f.status, f.message, f.value, f.expected);
-    const severity = severityByRule.get(f.ruleId) ?? "warning";
-    const record: PageFindingRecord = {
-      siteKey,
-      normalizedUrl: f.normalizedUrl,
-      ruleId: f.ruleId,
-      checkName: f.checkName,
-      locator: f.locator,
-      status: f.status,
-      severity,
-      message: f.message,
-      value: f.value,
-      expected: f.expected,
-      payload: f.payload,
-      fingerprint: fp,
-      firstSeenAt: prior?.firstSeenAt ?? now,
-      lastSeenCrawlId: crawlId,
-      lastSeenAt: now,
-      provenance: "fresh",
-      state: "open",
-    };
-    persisted.push(record);
-    // A fresh finding was evaluated on a page rendered this run, by definition.
-    activeFindings.push(toMerged(record, false));
-    handledKeys.add(key);
-  }
-
-  // 2) Prior OPEN findings (we only loaded "open"): resolve, stale, or carry.
-  for (const prior of priorFindings) {
-    const key = findingKey(
-      prior.normalizedUrl,
-      prior.ruleId,
-      prior.checkName,
-      prior.locator
-    );
-    if (handledKeys.has(key)) continue; // superseded by a fresh finding
-
-    const wasCrawled = crawledUrls.has(prior.normalizedUrl);
-    const wasRemoved = removedUrls.has(prior.normalizedUrl);
-    // (#1185) Crawled per the unsampled signal ONLY — the page produced no
-    // checks in the sampled payload (clean everywhere, or clipped from every
-    // sample) so it's absent from the payload-derived `crawledUrls`.
-    const signalCrawled =
-      !wasCrawled && (resolution?.crawledUrls.has(prior.normalizedUrl) ?? false);
-    // (#1652) Same value for every carry branch below — computed once here so a
-    // new branch can't silently forget it and default a never-rendered page back
-    // to "carried".
-    const unrendered = neverRendered(
-      prior.normalizedUrl,
-      wasCrawled || signalCrawled
-    );
-
-    if (wasRemoved) {
-      // Page gone — stale this finding. NOTE: site_pages state + the bulk
-      // finding-stale UPDATE are written transactionally by `markPageRemoved`
-      // (the orchestrator); we only record the staled row here so the
-      // returned union correctly EXCLUDES it from scoring/report this run.
-      persisted.push({
-        ...prior,
-        state: "stale",
-        lastSeenCrawlId: crawlId,
-        lastSeenAt: now,
-      });
-      handledKeys.add(key);
-      continue;
-    }
-
-    if (wasCrawled || signalCrawled) {
-      // (#1185) Resolution-signal override: a key present in `failingByCheck`
-      // means the check RAN this run with page-attributable results, so its
-      // UNSAMPLED failing set is authoritative — hash present → still failing
-      // (clipped from the sample, carry); hash absent → crawled clean this run
-      // → resolve, regardless of the #1167 sample guard below. A key marked
-      // truncated (or absent — rule disabled, unknown shape, old CLI) gives no
-      // authority and falls through to the pre-#1185 behavior.
-      const checkKey = `${prior.ruleId}${KEY_SEP}${prior.checkName}`;
-      const priorHash = resolution ? resolutionUrlHash(prior.normalizedUrl) : "";
-      // The check produced NO evaluated result for this page this run (the rule
-      // `skipped` it — perf/ttfb without timing data — or emitted nothing for
-      // it). Its absence from the fresh findings is not evidence the finding is
-      // gone, so it can never resolve: carry regardless of what the sampled
-      // payload suggests.
-      if (resolution?.notEvaluatedByCheck.get(checkKey)?.has(priorHash)) {
-        const carried: PageFindingRecord = { ...prior, provenance: "carried" };
-        persisted.push(carried);
-        activeFindings.push(toMerged(carried, unrendered));
-        handledKeys.add(key);
-        continue;
-      }
-      const failingSet = resolution?.failingByCheck.get(checkKey);
-      if (failingSet) {
-        if (failingSet.has(priorHash)) {
-          // Unlike the sample-guard carry below, this page WAS observed failing
-          // this run — the signal is unsampled, so its presence is positive
-          // evidence, not an absence we couldn't rule out. Refresh the
-          // last-seen stamps so the dashboard's "carried forward" badge doesn't
-          // read as stale on exactly the >100-page sites this fixes. Provenance
-          // stays "carried": presence was reconfirmed, but the check payload
-          // (message/details/severity) wasn't re-derived.
-          const carried: PageFindingRecord = {
-            ...prior,
-            provenance: "carried",
-            lastSeenCrawlId: crawlId,
-            lastSeenAt: now,
-          };
-          persisted.push(carried);
-          activeFindings.push(toMerged(carried, unrendered));
-          handledKeys.add(key);
-          continue;
-        }
-        if (!resolution!.truncatedChecks.has(checkKey)) {
-          persisted.push({
-            ...prior,
-            state: "resolved",
-            lastSeenCrawlId: crawlId,
-            lastSeenAt: now,
-          });
-          handledKeys.add(key);
-          continue;
-        }
-      }
-
-      if (signalCrawled) {
-        // No authoritative signal for this check and the page is absent from
-        // the sampled payload — exactly today's un-crawled behavior: carry.
-        const carried: PageFindingRecord = { ...prior, provenance: "carried" };
-        persisted.push(carried);
-        activeFindings.push(toMerged(carried, unrendered));
-        handledKeys.add(key);
-        continue;
-      }
-
-      // (#1167) Truncated-sample guard: if this rule+check shipped a SAMPLE of its
-      // affected pages and THIS page was clipped out of it, its absence from the
-      // fresh findings is NOT evidence the finding is gone — carry it forward.
-      // Only a page that WAS in the sample (or a non-truncated check) gives an
-      // authoritative "re-crawled, no longer present → resolved".
-      const sample = sampledCheckPages?.get(checkKey);
-      if (sample && !sample.has(prior.normalizedUrl)) {
-        const carried: PageFindingRecord = { ...prior, provenance: "carried" };
-        persisted.push(carried);
-        activeFindings.push(toMerged(carried, unrendered));
-        handledKeys.add(key);
-        continue;
-      }
-
-      // Re-crawled and the finding is no longer present → resolved (evidence).
-      persisted.push({
-        ...prior,
-        state: "resolved",
-        lastSeenCrawlId: crawlId,
-        lastSeenAt: now,
-      });
-      handledKeys.add(key);
-      continue;
-    }
-
-    // Un-crawled, still-active page: carry forward unchanged (no TTL).
-    const carried: PageFindingRecord = { ...prior, provenance: "carried" };
-    persisted.push(carried);
-    activeFindings.push(toMerged(carried, unrendered));
-    handledKeys.add(key);
-  }
-
   // 3) Site pages — active set (crawled non-removed) ∪ prior actives minus removed.
+  //
+  // (#1876) Hoisted ahead of the finding passes: it reads `priorPages`, not prior
+  // FINDINGS, so it can be settled before a single prior streams in. The caller
+  // needs `activePageUrls` to derive `carriedPageUrls`, and the carried scoring
+  // fold needs THAT before it can fold the first carried page.
   const sitePageMap = new Map<string, SitePageRecord>();
   for (const p of priorPages) {
     sitePageMap.set(p.normalizedUrl, p);
@@ -661,7 +626,183 @@ export function computeMerge(input: ComputeMergeInput): MergedState {
     sitePages.filter((p) => p.state === "active").map((p) => p.normalizedUrl)
   );
 
-  return { findings: activeFindings, persisted, sitePages, activePageUrls };
+  /** This run's FRESH records — emitted by `finish()`, once every prior has had
+   *  its chance to leave a `firstSeenAt` behind. */
+  const emitFresh = (): { persisted: PageFindingRecord[]; active: MergedFinding[] } => {
+    const persisted: PageFindingRecord[] = [];
+    const active: MergedFinding[] = [];
+    for (const [key, f] of freshByKey) {
+      const fp = fingerprint(f.status, f.message, f.value, f.expected);
+      const severity = severityByRule.get(f.ruleId) ?? "warning";
+      const record: PageFindingRecord = {
+        siteKey,
+        normalizedUrl: f.normalizedUrl,
+        ruleId: f.ruleId,
+        checkName: f.checkName,
+        locator: f.locator,
+        status: f.status,
+        severity,
+        message: f.message,
+        value: f.value,
+        expected: f.expected,
+        payload: f.payload,
+        fingerprint: fp,
+        firstSeenAt: firstSeenByFreshKey.get(key) ?? now,
+        lastSeenCrawlId: crawlId,
+        lastSeenAt: now,
+        provenance: "fresh",
+        state: "open",
+      };
+      persisted.push(record);
+      // A fresh finding was evaluated on a page rendered this run, by definition.
+      active.push(toMerged(record, false));
+    }
+    return { persisted, active };
+  };
+
+  /** Prior OPEN findings (we only ever load "open"): resolve, stale, or carry. */
+  const addPrior = (prior: PageFindingRecord): void => {
+    const key = findingKey(
+      prior.normalizedUrl,
+      prior.ruleId,
+      prior.checkName,
+      prior.locator
+    );
+    // Superseded by a fresh finding this run. The fresh record inherits this
+    // prior's first-seen (a finding that resolved and returned must not reset it),
+    // which is the ONLY thing the pre-#1876 whole-prior index was for.
+    if (freshByKey.has(key)) {
+      firstSeenByFreshKey.set(key, prior.firstSeenAt);
+      return;
+    }
+
+    const wasCrawled = crawledUrls.has(prior.normalizedUrl);
+    const wasRemoved = removedUrls.has(prior.normalizedUrl);
+    // (#1185) Crawled per the unsampled signal ONLY — the page produced no
+    // checks in the sampled payload (clean everywhere, or clipped from every
+    // sample) so it's absent from the payload-derived `crawledUrls`.
+    const signalCrawled =
+      !wasCrawled && (resolution?.crawledUrls.has(prior.normalizedUrl) ?? false);
+    // (#1652) Same value for every carry branch below — computed once here so a
+    // new branch can't silently forget it and default a never-rendered page back
+    // to "carried".
+    const unrendered = neverRendered(
+      prior.normalizedUrl,
+      wasCrawled || signalCrawled
+    );
+
+    if (wasRemoved) {
+      // Page gone — stale this finding. NOTE: site_pages state + the bulk
+      // finding-stale UPDATE are written transactionally by `markPageRemoved`
+      // (the orchestrator); we only record the staled row here so the
+      // returned union correctly EXCLUDES it from scoring/report this run.
+      sink.persist({
+        ...prior,
+        state: "stale",
+        lastSeenCrawlId: crawlId,
+        lastSeenAt: now,
+      });
+      return;
+    }
+
+    if (wasCrawled || signalCrawled) {
+      // (#1185) Resolution-signal override: a key present in `failingByCheck`
+      // means the check RAN this run with page-attributable results, so its
+      // UNSAMPLED failing set is authoritative — hash present → still failing
+      // (clipped from the sample, carry); hash absent → crawled clean this run
+      // → resolve, regardless of the #1167 sample guard below. A key marked
+      // truncated (or absent — rule disabled, unknown shape, old CLI) gives no
+      // authority and falls through to the pre-#1185 behavior.
+      const checkKey = `${prior.ruleId}${KEY_SEP}${prior.checkName}`;
+      const priorHash = resolution ? resolutionUrlHash(prior.normalizedUrl) : "";
+      // The check produced NO evaluated result for this page this run (the rule
+      // `skipped` it — perf/ttfb without timing data — or emitted nothing for
+      // it). Its absence from the fresh findings is not evidence the finding is
+      // gone, so it can never resolve: carry regardless of what the sampled
+      // payload suggests.
+      if (resolution?.notEvaluatedByCheck.get(checkKey)?.has(priorHash)) {
+        const carried: PageFindingRecord = { ...prior, provenance: "carried" };
+        sink.persist(carried);
+        sink.active(toMerged(carried, unrendered));
+        return;
+      }
+      const failingSet = resolution?.failingByCheck.get(checkKey);
+      if (failingSet) {
+        if (failingSet.has(priorHash)) {
+          // Unlike the sample-guard carry below, this page WAS observed failing
+          // this run — the signal is unsampled, so its presence is positive
+          // evidence, not an absence we couldn't rule out. Refresh the
+          // last-seen stamps so the dashboard's "carried forward" badge doesn't
+          // read as stale on exactly the >100-page sites this fixes. Provenance
+          // stays "carried": presence was reconfirmed, but the check payload
+          // (message/details/severity) wasn't re-derived.
+          const carried: PageFindingRecord = {
+            ...prior,
+            provenance: "carried",
+            lastSeenCrawlId: crawlId,
+            lastSeenAt: now,
+          };
+          sink.persist(carried);
+          sink.active(toMerged(carried, unrendered));
+          return;
+        }
+        if (!resolution!.truncatedChecks.has(checkKey)) {
+          sink.persist({
+            ...prior,
+            state: "resolved",
+            lastSeenCrawlId: crawlId,
+            lastSeenAt: now,
+          });
+          return;
+        }
+      }
+
+      if (signalCrawled) {
+        // No authoritative signal for this check and the page is absent from
+        // the sampled payload — exactly today's un-crawled behavior: carry.
+        const carried: PageFindingRecord = { ...prior, provenance: "carried" };
+        sink.persist(carried);
+        sink.active(toMerged(carried, unrendered));
+        return;
+      }
+
+      // (#1167) Truncated-sample guard: if this rule+check shipped a SAMPLE of its
+      // affected pages and THIS page was clipped out of it, its absence from the
+      // fresh findings is NOT evidence the finding is gone — carry it forward.
+      // Only a page that WAS in the sample (or a non-truncated check) gives an
+      // authoritative "re-crawled, no longer present → resolved".
+      const sample = sampledCheckPages?.get(checkKey);
+      if (sample && !sample.has(prior.normalizedUrl)) {
+        const carried: PageFindingRecord = { ...prior, provenance: "carried" };
+        sink.persist(carried);
+        sink.active(toMerged(carried, unrendered));
+        return;
+      }
+
+      // Re-crawled and the finding is no longer present → resolved (evidence).
+      sink.persist({
+        ...prior,
+        state: "resolved",
+        lastSeenCrawlId: crawlId,
+        lastSeenAt: now,
+      });
+      return;
+    }
+
+    // Un-crawled, still-active page: carry forward unchanged (no TTL).
+    const carried: PageFindingRecord = { ...prior, provenance: "carried" };
+    sink.persist(carried);
+    sink.active(toMerged(carried, unrendered));
+  };
+
+  return {
+    sitePages,
+    activePageUrls,
+    addPriorFindings: (priors) => {
+      for (const prior of priors) addPrior(prior);
+    },
+    finish: emitFresh,
+  };
 }
 
 function toMerged(

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -25,12 +25,15 @@ import { normalizeUrl } from "@squirrelscan/utils/url";
 
 import {
   computeMerge,
+  createMergeSession,
   flattenChecks,
   type FlatFinding,
+  type MergedFinding,
   type MergedState,
   type MergeResolutionInput,
 } from "./merge-core";
 import {
+  createCompleteStoreTallyFold,
   foldCompleteStoreTallies,
   type FindingPageSource,
 } from "./complete-store-fold";
@@ -38,11 +41,49 @@ import type { SkippedPassCounts } from "./stream-findings";
 import {
   buildScoringResultsFromMerged,
   type CarriedFinding,
+  type CarriedUnionSource,
   type RuleTally,
 } from "./scoring";
 
+
 /** 404/410 = page gone → stale its findings (not carry). */
 const REMOVED_STATUSES = new Set([404, 410]);
+
+/**
+ * Rows buffered before a merge flush (#1876).
+ *
+ * MEASURED, and smaller than it looks like it should be. The flush's cost is not
+ * the rows it holds but the transient graph the driver builds around them — an
+ * insert of 500 findings is 8,500 bound parameters plus a dictionary insert — and
+ * that spike lands on top of whatever the page loop is holding. Halving the batch
+ * took ~15 MiB off the finalize's peak at 60,000 carried findings, for round trips
+ * that cost single-digit milliseconds each.
+ */
+const MERGE_PERSIST_BATCH = 200;
+
+/**
+ * One page's OPEN findings, split by which audit last saw them (#1876).
+ *
+ * Both halves come from ONE cursor over `page_findings`, which is what makes the
+ * fold's page-boundary contract structural: a page's fresh evidence and the
+ * findings earlier audits left on it are handed over together, so they cannot land
+ * in two different `addChecksToTally` calls. Two independent cursors could not
+ * promise that without comparing URLs across them in JS, and JS string order is not
+ * the database's collation.
+ */
+export interface OpenFindingPage {
+  normalizedUrl: string;
+  /** Ingested by THIS audit (`lastSeenCrawlId === crawlId`). */
+  fresh: readonly PageFindingRecord[];
+  /** Left open by an EARLIER audit — the merge decides carry/resolve/stale. */
+  prior: readonly PageFindingRecord[];
+}
+
+/** Pages in `normalizedUrl` order, each yielded exactly once and never split. */
+export type OpenFindingPageSource = AsyncIterable<OpenFindingPage>;
+
+/** Prior findings a page at a time; a page must never be split across two items. */
+export type PriorFindingPageSource = AsyncIterable<readonly PageFindingRecord[]>;
 
 /**
  * Narrow Promise port of the smart-audits store surface. A backing store
@@ -52,6 +93,19 @@ const REMOVED_STATUSES = new Set([404, 410]);
 export interface SmartAuditStore {
   /** Findings for a site, optionally restricted to lifecycle `states`. */
   getFindings(siteKey: string, states?: FindingState[]): Promise<PageFindingRecord[]>;
+  /**
+   * (#1876) OPTIONAL page-at-a-time cursor over the same rows {@link getFindings}
+   * returns. When a store offers it, the merge decides carry/resolve/stale in
+   * bounded batches instead of over one array — which is the difference between a
+   * partial re-audit of a site with 60,000 open findings costing hundreds of MB and
+   * costing tens. A page's findings must never be split across two yields.
+   *
+   * Optional so an in-memory store (tests, fixtures) needs only `getFindings`.
+   */
+  streamFindingPages?(
+    siteKey: string,
+    states?: FindingState[],
+  ): PriorFindingPageSource;
   getSitePages(siteKey: string): Promise<SitePageRecord[]>;
   upsertFindings(findings: PageFindingRecord[]): Promise<void>;
   upsertSitePages(pages: SitePageRecord[]): Promise<void>;
@@ -149,16 +203,29 @@ export interface CloudSmartAuditsInput {
      * delivered ONE PAGE AT A TIME and folded into per-rule tallies rather than
      * materialized — a 43k-finding audit does not fit in the 128 MB API isolate.
      * See {@link FindingPageSource} for the page-boundary contract.
+     *
+     * Pair with {@link priorOpenFindings}, or supply {@link openPages} instead.
      */
-    findingPages: FindingPageSource;
+    findingPages?: FindingPageSource;
     /**
      * (#1873) Prior OPEN findings for the site EXCLUDING the rows this audit's
-     * chunk ingest wrote. Required in complete mode: those rows are the fresh
-     * evidence (already persisted, and folded from `findingPages`), so loading
-     * them as "prior" would both double the isolate's memory and make the merge
-     * reason about this run's own findings as if a previous run had left them.
+     * chunk ingest wrote. Those rows are the fresh evidence (already persisted, and
+     * folded from `findingPages`), so loading them as "prior" would both double the
+     * isolate's memory and make the merge reason about this run's own findings as if
+     * a previous run had left them.
+     *
+     * MATERIALIZED, so it is bounded by the site's whole open backlog rather than by
+     * this run — the #1876 OOM. Prefer {@link openPages}.
      */
-    priorOpenFindings: PageFindingRecord[];
+    priorOpenFindings?: PageFindingRecord[];
+    /**
+     * (#1876) Both halves of the site's open findings from ONE cursor, a page at a
+     * time — the bounded replacement for `findingPages` + `priorOpenFindings`, and
+     * what the API's finalize supplies. When set, those two are ignored: the merge
+     * decides each prior as it goes past, the fold folds the page's fresh and
+     * carried findings together, and the rows are dropped.
+     */
+    openPages?: OpenFindingPageSource;
     /** Full crawled-URL list (`resolutionSignal.crawledUrls`); normalized here. */
     crawledUrls: string[];
     /**
@@ -388,76 +455,162 @@ export async function runCloudSmartAudits(
     };
   }
 
-  const merged = await mergeFindingsPromise({
-    store,
-    siteKey,
-    crawlId,
-    crawledUrls,
-    freshFindings,
-    removedUrls,
-    severityByRule,
-    statusByUrl,
-    now,
-    sampledCheckPages,
-    resolution,
-    priorFindings: completeStore?.priorOpenFindings,
-  });
+  // ── merge ────────────────────────────────────────────────────────────────
+  //
+  // (#1876) Prior findings stream past the merge rather than being loaded into an
+  // array. The session settles the site's page set up front (it reads `priorPages`,
+  // never a prior FINDING), which is what lets `carriedPageUrls` — and with it the
+  // carried scoring fold — exist before the first prior arrives.
+  const priorPages = await store.getSitePages(siteKey);
+  let onPersist: (record: PageFindingRecord) => void = () => {};
+  let onActive: (finding: MergedFinding) => void = () => {};
+  const session = createMergeSession(
+    {
+      siteKey,
+      crawlId,
+      crawledUrls,
+      freshFindings,
+      removedUrls,
+      severityByRule,
+      statusByUrl,
+      priorPages,
+      now,
+      sampledCheckPages,
+      resolution,
+    },
+    {
+      persist: (record) => onPersist(record),
+      active: (finding) => onActive(finding),
+    },
+  );
 
   // Carried pages = every active page NOT (re-)crawled this run (incl. clean
   // ones, so the union scorer can emit synthetic passes for them).
   const carriedPageUrls = new Set<string>();
-  for (const url of merged.activePageUrls) {
+  for (const url of session.activePageUrls) {
     if (!crawledUrls.has(url)) carriedPageUrls.add(url);
   }
 
-  // Carried findings = active (open) findings on those carried pages, SPLIT by
-  // whether any audit has ever rendered the page (#1652): a never-rendered page's
-  // finding was not inherited from a previous run, so it must not be counted as
-  // carried nor given a last-seen date implying an earlier observation.
-  const carriedFindings: CarriedFinding[] = [];
-  const carriedLastSeen = new Map<string, number>();
-  let unrenderedCount = 0;
-  for (const f of merged.findings) {
-    if (f.provenance !== "carried") continue;
-    carriedFindings.push({
-      normalizedUrl: f.normalizedUrl,
-      ruleId: f.ruleId,
-      checkName: f.checkName,
-      status: f.status,
-      message: f.message,
-      value: f.value,
-      expected: f.expected,
-      payload: f.payload,
-      neverRendered: f.neverRendered,
-    });
-    if (f.neverRendered) {
-      unrenderedCount++;
-      continue;
-    }
-    carriedLastSeen.set(carriedKey(f.normalizedUrl, f.ruleId, f.checkName), f.lastSeenAt);
-  }
+  const streamedComplete = completeStore?.openPages;
+  // Writing as the merge streams is safe ONLY when the reader is a cursor that has
+  // already passed the rows being written (it reads each page once, and the merge
+  // only ever writes rows behind it). The materialized complete path reads its
+  // fresh side from a SECOND source after the merge, so there it must still be
+  // "fold first, then persist" — `computeMerge` stamps resolved rows with this
+  // run's crawl id, and a fold that ran after them would read one back as fresh
+  // evidence that the page still fails.
+  const persistWhileStreaming = !completeStore || !!streamedComplete;
 
-  // (#1873) COMPLETE mode: fold this audit's findings into per-rule tallies, page
-  // at a time, straight off the store.
-  //
-  // ORDER IS LOAD-BEARING — this MUST run before the persistence block below.
-  // `computeMerge` stamps RESOLVED rows with THIS run's crawlId, and the fold's
-  // source selects by that crawlId, so folding after the writes would read a
-  // finding the merge just resolved back as fresh evidence that the page fails.
+  let persistedFindings = 0;
+  const pendingWrites: PageFindingRecord[] = [];
+  const deferredWrites: PageFindingRecord[] = [];
+  const flushWrites = async (): Promise<void> => {
+    if (pendingWrites.length > 0) await store.upsertFindings(pendingWrites.splice(0));
+  };
+  onPersist = (record) => {
+    persistedFindings += 1;
+    // Findings on a page that 404/410'd are staled transactionally by
+    // `markPagesRemoved` below, so the row written here would be overwritten.
+    if (removedUrls.has(record.normalizedUrl)) return;
+    (persistWhileStreaming ? pendingWrites : deferredWrites).push(record);
+  };
+
+  // Carried findings, SPLIT by whether any audit has ever rendered the page
+  // (#1652): a never-rendered page's finding was not inherited from a previous run,
+  // so it must not be counted as carried nor given a last-seen date implying an
+  // earlier observation.
+  let carriedCount = 0;
+  let unrenderedCount = 0;
+  const carriedLastSeen = new Map<string, number>();
+  // Materialized only off the streaming path: there the union IS the score, and it
+  // is bounded by the run rather than by the site's backlog.
+  const carriedFindings: CarriedFinding[] = [];
+  const pageCarried: CarriedFinding[] = [];
+
   let scoringTallies: Map<string, RuleTally> | undefined;
-  if (completeStore) {
-    scoringTallies = await foldCompleteStoreTallies({
+  let carriedSource: CarriedUnionSource | undefined;
+
+  if (streamedComplete) {
+    const fold = createCompleteStoreTallyFold({
       ruleResults: input.ruleResults,
-      findingPages: completeStore.findingPages,
       crawledUrls,
       skippedPassCounts: completeStore.skippedPassCounts,
-      carriedFindings,
       carriedPageUrls,
       ruleMetaIndex,
       // Same exclusion the union scoring applies below via `freshForUnion`: a
       // page that 404/410'd this run is not one of the known non-removed pages.
       removedUrls,
+      // The report body's carried side comes out of the same replay, bounded.
+      retainCarriedChecks: true,
     });
+    onActive = (finding) => {
+      if (finding.provenance !== "carried") return;
+      carriedCount += 1;
+      if (finding.neverRendered) unrenderedCount += 1;
+      // No copy: `MergedFinding` already carries every field `CarriedFinding`
+      // reads, `lastSeenAt` included — which is what stamps the replayed check
+      // (#1876). One fewer object per carried finding, on the path where that
+      // multiplies by the whole backlog.
+      pageCarried.push(finding);
+    };
+    for await (const page of streamedComplete) {
+      pageCarried.length = 0;
+      session.addPriorFindings(page.prior);
+      fold.foldPage(page.normalizedUrl, page.fresh, pageCarried);
+      if (pendingWrites.length >= MERGE_PERSIST_BATCH) await flushWrites();
+    }
+    // Complete mode passes no fresh findings (the ingest already persisted them),
+    // so this is normally empty — driven anyway so the contract holds either way.
+    for (const record of session.finish().persisted) onPersist(record);
+    await flushWrites();
+    fold.foldShellRules();
+    scoringTallies = fold.finish();
+    carriedSource = fold.carriedUnion();
+  } else {
+    onActive = (finding) => {
+      if (finding.provenance !== "carried") return;
+      carriedCount += 1;
+      const carried = toCarriedFinding(finding);
+      carriedFindings.push(carried);
+      if (finding.neverRendered) {
+        unrenderedCount += 1;
+        return;
+      }
+      carriedLastSeen.set(
+        carriedKey(finding.normalizedUrl, finding.ruleId, finding.checkName),
+        finding.lastSeenAt,
+      );
+    };
+    for await (const batch of priorFindingPages(store, siteKey, completeStore?.priorOpenFindings)) {
+      session.addPriorFindings(batch);
+      if (persistWhileStreaming && pendingWrites.length >= MERGE_PERSIST_BATCH) {
+        await flushWrites();
+      }
+    }
+    for (const record of session.finish().persisted) onPersist(record);
+    if (persistWhileStreaming) await flushWrites();
+
+    // (#1873) COMPLETE mode, materialized inputs: fold this audit's findings into
+    // per-rule tallies, page at a time, off the caller's fresh source.
+    //
+    // ORDER IS LOAD-BEARING — this MUST run before the deferred writes below.
+    if (completeStore) {
+      scoringTallies = await foldCompleteStoreTallies({
+        ruleResults: input.ruleResults,
+        findingPages: completeStore.findingPages ?? emptyPageSource(),
+        crawledUrls,
+        skippedPassCounts: completeStore.skippedPassCounts,
+        carriedFindings,
+        carriedPageUrls,
+        ruleMetaIndex,
+        removedUrls,
+      });
+      // Pushed one at a time: a spread of a whole site's backlog is an argument
+      // list, and an argument list has a limit an array does not.
+      for (const record of deferredWrites) pendingWrites.push(record);
+      deferredWrites.length = 0;
+      await flushWrites();
+    }
   }
 
   // Persist: removed pages (transactional stale) first, then the rest. One tx
@@ -467,8 +620,9 @@ export async function runCloudSmartAudits(
     lastStatus: statusByUrl.get(url) ?? 404,
   }));
   await store.markPagesRemoved(siteKey, removedPages, crawlId);
-  await store.upsertFindings(merged.persisted.filter((f) => !removedUrls.has(f.normalizedUrl)));
-  await store.upsertSitePages(merged.sitePages.filter((p) => !removedUrls.has(p.normalizedUrl)));
+  await store.upsertSitePages(
+    session.sitePages.filter((p) => !removedUrls.has(p.normalizedUrl)),
+  );
   // Best-effort hygiene — only ever prunes terminal rows, never open/carried, so
   // it can't affect the merged report. NEVER fail the audit on a prune error.
   try {
@@ -506,6 +660,7 @@ export async function runCloudSmartAudits(
     carriedFindings,
     carriedPageUrls,
     ruleMetaIndex,
+    ...(carriedSource ? { carriedSource } : {}),
   });
 
   return {
@@ -513,13 +668,63 @@ export async function runCloudSmartAudits(
     ...(scoringTallies ? { scoringTallies } : {}),
     coverage: {
       auditedPages: crawledUrls.size,
-      knownPages: merged.activePageUrls.size,
-      carriedFindings: carriedFindings.length - unrenderedCount,
+      knownPages: session.activePageUrls.size,
+      carriedFindings: carriedCount - unrenderedCount,
       ...(unrenderedCount > 0 ? { unrenderedFindings: unrenderedCount } : {}),
     },
     carriedLastSeen,
-    persistedFindings: merged.persisted.length,
+    persistedFindings,
     removedPages: removedUrls.size,
     completeStore: !!completeStore,
+  };
+}
+
+/** No fresh side at all — a complete-store caller that passed only priors. */
+async function* emptyPageSource(): FindingPageSource {
+  // Intentionally yields nothing.
+}
+
+/**
+ * Prior OPEN findings, page at a time: the caller's own set when it supplied one
+ * (the complete-store finalize excludes this audit's ingest), else the store's
+ * cursor, else one array from `getFindings` for stores without a cursor.
+ */
+async function* priorFindingPages(
+  store: SmartAuditStore,
+  siteKey: string,
+  preloaded: PageFindingRecord[] | undefined,
+): PriorFindingPageSource {
+  if (preloaded) {
+    if (preloaded.length > 0) yield preloaded;
+    return;
+  }
+  if (store.streamFindingPages) {
+    yield* store.streamFindingPages(siteKey, ["open"]);
+    return;
+  }
+  const all = await store.getFindings(siteKey, ["open"]);
+  if (all.length > 0) yield all;
+}
+
+/**
+ * The merge's view of a carried finding, reduced to what the scorers replay.
+ *
+ * The SAMPLED path only, and the reduction is the point: dropping `lastSeenAt`
+ * is what keeps the replayed check untagged there, so the caller's
+ * `carriedLastSeen` pass still does the tagging its callers assert. The streaming
+ * path passes the `MergedFinding` straight through instead — it has no such map to
+ * tag from, and building one would be the allocation #1876 exists to remove.
+ */
+function toCarriedFinding(f: MergedFinding): CarriedFinding {
+  return {
+    normalizedUrl: f.normalizedUrl,
+    ruleId: f.ruleId,
+    checkName: f.checkName,
+    status: f.status,
+    message: f.message,
+    value: f.value,
+    expected: f.expected,
+    payload: f.payload,
+    neverRendered: f.neverRendered,
   };
 }

--- a/packages/audit-engine/src/scoring.ts
+++ b/packages/audit-engine/src/scoring.ts
@@ -85,6 +85,38 @@ export interface CarriedFinding {
    * relabelling it "carried" — both preserve an already-set provenance.
    */
   neverRendered?: boolean;
+  /**
+   * (#1876) When set, {@link carriedFindingToCheck} stamps the replayed check
+   * `provenance: "carried"` + this `lastSeenAt` itself, instead of leaving the
+   * caller to do it from a `${url}|${rule}|${check}` → lastSeenAt map.
+   *
+   * WHY IT MOVED: that map is one entry per carried finding, so a partial
+   * re-audit of a site with tens of thousands of open findings has to build tens
+   * of thousands of entries to tag a report that keeps a bounded sample of them.
+   * Stamping at construction is the same information carried by the object that
+   * needs it. Left undefined by the sampled path, where the caller's tagging pass
+   * still runs and the map is bounded by the run.
+   */
+  lastSeenAt?: number;
+}
+
+/**
+ * (#1876) The carried half of the union, pre-indexed and BOUNDED, for callers that
+ * cannot hold the carried findings themselves.
+ *
+ * The complete-store finalize scores from tallies and uses the union map only as
+ * the report body, so it folds carried findings into a per-rule sample as they
+ * stream and hands the result over through this. `carriedFindings` stays the input
+ * for the sampled path, where the union IS the score and is bounded by the run.
+ */
+export interface CarriedUnionSource {
+  /** Rules with at least one carried finding (page-scope ones matter). */
+  ruleIds(): Iterable<string>;
+  /** The carried checks to replay into the union for a rule — already bounded. */
+  checksFor(ruleId: string): readonly CheckResult[];
+  /** How many pages in `carriedPageUrls` have a carried finding for this rule.
+   *  `carriedPageUrls.size` minus this is the clean-carried pass count. */
+  dirtyCarriedPageCount(ruleId: string): number;
 }
 
 /** Minimal rule meta the union scorer needs. */
@@ -101,6 +133,9 @@ export interface MergedScoringInput {
   carriedPageUrls: Set<string>;
   /** ruleId -> meta for rules absent from `freshResults` (carried-only rules). */
   ruleMetaIndex: Map<string, RuleRunResult["meta"]>;
+  /** (#1876) Bounded pre-indexed carried side. When present it REPLACES
+   *  `carriedFindings` entirely — pass `[]` for that. */
+  carriedSource?: CarriedUnionSource;
 }
 
 /**
@@ -153,14 +188,21 @@ export function carriedFindingToCheck(
     ...(payload.items ? { items: payload.items } : {}),
     ...(payload.details ? { details: payload.details } : {}),
     ...(payload.pages ? { pages: payload.pages } : {}),
-    ...(f.neverRendered ? { provenance: "unrendered" as const } : {}),
+    // Key ORDER matters: the sampled path's caller ASSIGNS provenance then
+    // lastSeenAt after this returns, so stamping them last here serializes
+    // identically to a check the caller tagged (#1876).
+    ...(f.neverRendered
+      ? { provenance: "unrendered" as const }
+      : f.lastSeenAt !== undefined
+        ? { provenance: "carried" as const, lastSeenAt: f.lastSeenAt }
+        : {}),
   };
 }
 
 export function buildScoringResultsFromMerged(
   input: MergedScoringInput
 ): Map<string, RuleRunResult> {
-  const { freshResults, carriedFindings, carriedPageUrls, ruleMetaIndex } =
+  const { freshResults, carriedFindings, carriedPageUrls, ruleMetaIndex, carriedSource } =
     input;
 
   // Clone fresh results (don't mutate the caller's map / arrays). Preserve any
@@ -179,17 +221,20 @@ export function buildScoringResultsFromMerged(
     });
   }
 
-  // Index carried findings by (ruleId -> normalizedUrl -> findings).
+  // Index carried findings by (ruleId -> normalizedUrl -> findings). Skipped when
+  // the caller supplied a pre-indexed bounded source (#1876).
   const carriedByRule = new Map<string, Map<string, CarriedFinding[]>>();
-  for (const f of carriedFindings) {
-    let byUrl = carriedByRule.get(f.ruleId);
-    if (!byUrl) {
-      byUrl = new Map();
-      carriedByRule.set(f.ruleId, byUrl);
+  if (!carriedSource) {
+    for (const f of carriedFindings) {
+      let byUrl = carriedByRule.get(f.ruleId);
+      if (!byUrl) {
+        byUrl = new Map();
+        carriedByRule.set(f.ruleId, byUrl);
+      }
+      const list = byUrl.get(f.normalizedUrl) ?? [];
+      list.push(f);
+      byUrl.set(f.normalizedUrl, list);
     }
-    const list = byUrl.get(f.normalizedUrl) ?? [];
-    list.push(f);
-    byUrl.set(f.normalizedUrl, list);
   }
 
   // Every page-scope rule that exists this run OR carried a finding applies to
@@ -198,7 +243,7 @@ export function buildScoringResultsFromMerged(
   for (const [ruleId, result] of union) {
     if (result.meta.scope === "page") pageScopeRuleIds.add(ruleId);
   }
-  for (const ruleId of carriedByRule.keys()) {
+  for (const ruleId of carriedSource?.ruleIds() ?? carriedByRule.keys()) {
     const meta = union.get(ruleId)?.meta ?? ruleMetaIndex.get(ruleId);
     if (meta?.scope === "page") pageScopeRuleIds.add(ruleId);
   }
@@ -222,7 +267,11 @@ export function buildScoringResultsFromMerged(
     // the replay were gated on carriedPageUrls (which excludes crawled pages) that
     // finding would persist open in storage yet vanish from the union score,
     // report, and issue-sync — re-inflating exactly the score #1167 protects.
-    if (carriedForRule) {
+    if (carriedSource) {
+      // Already built and already bounded — the caller replayed each carried
+      // finding as it streamed and kept a per-rule sample.
+      for (const check of carriedSource.checksFor(ruleId)) result.checks.push(check);
+    } else if (carriedForRule) {
       for (const [url, findings] of carriedForRule) {
         for (const f of findings) {
           result.checks.push(carriedFindingToCheck(f, url));
@@ -237,10 +286,17 @@ export function buildScoringResultsFromMerged(
     // passed+total. Only carriedPageUrls (un-crawled active pages) are eligible —
     // a crawled page's pass/fail is already counted by its fresh (or replayed
     // carried) check, so it must not also count here.
+    // (#1876) Counted, not enumerated, when the caller pre-indexed: it tracked how
+    // many carried pages have a finding for the rule as they streamed, and
+    // |carriedPageUrls| minus that is the same set difference.
     let cleanCarriedPasses = 0;
-    for (const url of carriedPageUrls) {
-      const findings = carriedForRule?.get(url);
-      if (!findings || findings.length === 0) cleanCarriedPasses++;
+    if (carriedSource) {
+      cleanCarriedPasses = carriedPageUrls.size - carriedSource.dirtyCarriedPageCount(ruleId);
+    } else {
+      for (const url of carriedPageUrls) {
+        const findings = carriedForRule?.get(url);
+        if (!findings || findings.length === 0) cleanCarriedPasses++;
+      }
     }
     // ADD to any fresh-clean count the reconstruction stamped (#1023), rather
     // than overwrite — a complete-store re-audit has BOTH fresh crawled-clean

--- a/packages/audit-engine/src/smart-audits.ts
+++ b/packages/audit-engine/src/smart-audits.ts
@@ -9,6 +9,7 @@
 
 export {
   computeMerge,
+  createMergeSession,
   fingerprint,
   findingKey,
   flattenChecks,
@@ -17,6 +18,9 @@ export type {
   ComputeMergeInput,
   FlatFinding,
   MergedFinding,
+  MergePriorSink,
+  MergeSession,
+  MergeSessionInput,
   MergedState,
 } from "./merge-core";
 
@@ -30,6 +34,11 @@ export type {
   CloudSmartAuditsInput,
   CloudSmartAuditsResult,
   MergeFindingsPromiseInput,
+  // (#1876) The finalize's bounded prior read: both halves of a page's open
+  // findings from one cursor.
+  OpenFindingPage,
+  OpenFindingPageSource,
+  PriorFindingPageSource,
   SmartAuditStore,
 } from "./merge-promise";
 
@@ -48,6 +57,7 @@ export {
 } from "./scoring";
 export type {
   CarriedFinding,
+  CarriedUnionSource,
   IssueTally,
   MergedScoringInput,
   RuleTally,
@@ -57,8 +67,13 @@ export type {
 export { reconstructCompleteResults, reconstructPageRuleChecks } from "./reconstruct";
 export type { ReconstructCompleteInput } from "./reconstruct";
 
-export { foldCompleteStoreTallies } from "./complete-store-fold";
-export type { CompleteStoreTallyInput, FindingPageSource } from "./complete-store-fold";
+export { createCompleteStoreTallyFold, foldCompleteStoreTallies } from "./complete-store-fold";
+export type {
+  CompleteStoreFoldInput,
+  CompleteStoreTallyFold,
+  CompleteStoreTallyInput,
+  FindingPageSource,
+} from "./complete-store-fold";
 
 export { buildStreamFindings, buildSkippedPassCounts } from "./stream-findings";
 export type { StreamFindingLine, SkippedPassCounts } from "./stream-findings";

--- a/packages/audit-engine/tests/bounded-carried-merge.test.ts
+++ b/packages/audit-engine/tests/bounded-carried-merge.test.ts
@@ -1,0 +1,709 @@
+// The CARRIED side of the publish merge, bounded (#1876) — THE EQUIVALENCE GATE.
+//
+// #1873 bounded the fresh side: this audit's findings stream out of the store a
+// page at a time and fold into per-rule tallies. The carried side stayed an array:
+// every open finding the site had outside this run was loaded, indexed by key,
+// walked twice, replayed as a CheckResult and folded into the report — about
+// 4.8 KiB per carried finding, 329 MiB at 60,000 of them against a 128 MB isolate.
+//
+// Now both halves of a page arrive together from one cursor and the merge decides
+// each prior as it goes past. This file pins that the two produce the SAME audit:
+// same tallies, same score, same coverage, same rows left in the store. The
+// fixtures deliberately include the three shapes the streaming driver could get
+// wrong and the array driver could not — a page holding fresh AND carried findings,
+// a page removed this run, and a rule carrying more findings than the report keeps.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  CheckResult,
+  FindingState,
+  PageFindingRecord,
+  SitePageRecord,
+} from "@squirrelscan/core-contracts";
+import { DEFAULT_FOLD_LIMITS, foldOverflowChecks } from "@squirrelscan/rules/fold";
+
+import { computeMerge, findingKey } from "../src/merge-core";
+import {
+  runCloudSmartAudits,
+  type CloudSmartAuditsResult,
+  type OpenFindingPage,
+  type SmartAuditStore,
+} from "../src/merge-promise";
+import { calculateHealthScoreFromTallies } from "../src/scoring";
+import { findingFingerprint } from "../src/fingerprint";
+
+const SITE = "web_1876";
+const AUDIT = "audit_2";
+const PRIOR_AUDIT = "audit_1";
+const RULE = "content/meta-description";
+const CHECK = "has-meta-description";
+
+const meta = {
+  id: RULE,
+  name: "Meta Description",
+  description: "Pages should have a meta description",
+  category: "content",
+  scope: "page" as const,
+  severity: "warning" as const,
+  weight: 10,
+};
+
+class MemStore implements SmartAuditStore {
+  findings = new Map<string, PageFindingRecord>();
+  pages = new Map<string, SitePageRecord>();
+  /** Set on the streaming store so a fallback to the unbounded read is a failure. */
+  refuseWholeRead = false;
+  upsertCalls = 0;
+
+  private key(f: {
+    normalizedUrl: string;
+    ruleId: string;
+    checkName: string;
+    locator: string;
+  }) {
+    return findingKey(f.normalizedUrl, f.ruleId, f.checkName, f.locator);
+  }
+  async getFindings(_siteKey: string, states?: FindingState[]): Promise<PageFindingRecord[]> {
+    if (this.refuseWholeRead) {
+      throw new Error("getFindings: the streaming path must never load the whole open set");
+    }
+    const all = [...this.findings.values()];
+    return states ? all.filter((f) => states.includes(f.state)) : all;
+  }
+  async getSitePages(): Promise<SitePageRecord[]> {
+    return [...this.pages.values()];
+  }
+  async upsertFindings(findings: PageFindingRecord[]): Promise<void> {
+    this.upsertCalls += 1;
+    for (const f of findings) {
+      const k = this.key(f);
+      const prior = this.findings.get(k);
+      this.findings.set(k, {
+        ...f,
+        firstSeenAt: prior ? Math.min(prior.firstSeenAt, f.firstSeenAt) : f.firstSeenAt,
+      });
+    }
+  }
+  async upsertSitePages(pages: SitePageRecord[]): Promise<void> {
+    for (const p of pages) this.pages.set(p.normalizedUrl, { ...p });
+  }
+  async markPageRemoved(
+    siteKey: string,
+    normalizedUrl: string,
+    crawlId: string,
+    lastStatus: number,
+  ): Promise<void> {
+    this.pages.set(normalizedUrl, {
+      siteKey,
+      normalizedUrl,
+      lastStatus,
+      state: "removed",
+      lastSeenCrawlId: crawlId,
+      lastSeenAt: 1_700_000_000_000,
+    });
+    for (const [k, f] of this.findings) {
+      if (f.normalizedUrl === normalizedUrl && f.state === "open") {
+        this.findings.set(k, { ...f, state: "stale", lastSeenCrawlId: crawlId });
+      }
+    }
+  }
+  async markPagesRemoved(
+    siteKey: string,
+    pages: Array<{ normalizedUrl: string; lastStatus: number }>,
+    crawlId: string,
+  ): Promise<void> {
+    for (const p of pages) {
+      await this.markPageRemoved(siteKey, p.normalizedUrl, crawlId, p.lastStatus);
+    }
+  }
+  async compactFindings(): Promise<number> {
+    return 0;
+  }
+}
+
+function row(
+  normalizedUrl: string,
+  locator: string,
+  auditId: string,
+  overrides: Partial<PageFindingRecord> = {},
+): PageFindingRecord {
+  const message = `Missing meta description${locator ? `: ${locator}` : ""}`;
+  return {
+    siteKey: SITE,
+    normalizedUrl,
+    ruleId: RULE,
+    checkName: CHECK,
+    locator,
+    status: "fail",
+    severity: meta.severity,
+    message,
+    value: null,
+    expected: null,
+    payload: locator ? JSON.stringify({ items: [{ id: locator, label: locator }], i: 0 }) : null,
+    fingerprint: findingFingerprint("fail", message, null, null),
+    firstSeenAt: 1_600_000_000_000,
+    lastSeenCrawlId: auditId,
+    lastSeenAt: 1_600_000_000_000,
+    provenance: "fresh",
+    state: "open",
+    ...overrides,
+  };
+}
+
+function activePage(normalizedUrl: string): SitePageRecord {
+  return {
+    siteKey: SITE,
+    normalizedUrl,
+    lastStatus: 200,
+    state: "active",
+    lastSeenCrawlId: PRIOR_AUDIT,
+    lastSeenAt: 1_600_000_000_000,
+  };
+}
+
+/** The shell the container stages: rule meta, no per-page checks. */
+const shell = { [RULE]: { meta, checks: [] as CheckResult[] } };
+
+/**
+ * The API's cursor, in memory: every OPEN finding for the site in page order, one
+ * page per item, split by which audit last saw it.
+ */
+async function* openPagesOf(store: MemStore, auditId: string): AsyncGenerator<OpenFindingPage> {
+  const byPage = new Map<string, PageFindingRecord[]>();
+  const sorted = [...store.findings.values()]
+    .filter((f) => f.state === "open")
+    .sort((a, b) => {
+      const ka = findingKey(a.normalizedUrl, a.ruleId, a.checkName, a.locator);
+      const kb = findingKey(b.normalizedUrl, b.ruleId, b.checkName, b.locator);
+      return ka < kb ? -1 : ka > kb ? 1 : 0;
+    });
+  for (const f of sorted) {
+    const rows = byPage.get(f.normalizedUrl);
+    if (rows) rows.push(f);
+    else byPage.set(f.normalizedUrl, [f]);
+  }
+  for (const [normalizedUrl, rows] of byPage) {
+    yield {
+      normalizedUrl,
+      fresh: rows.filter((f) => f.lastSeenCrawlId === auditId),
+      prior: rows.filter((f) => f.lastSeenCrawlId !== auditId),
+    };
+  }
+}
+
+/** The pre-#1876 inputs: this audit's findings streamed, the priors materialized. */
+async function* freshPagesOf(store: MemStore, auditId: string) {
+  for await (const page of openPagesOf(store, auditId)) {
+    if (page.fresh.length > 0) yield page.fresh as PageFindingRecord[];
+  }
+}
+
+interface Fixture {
+  /** Rows already in the store when the finalize starts (ingest + backlog). */
+  rows: PageFindingRecord[];
+  /** site_pages rows a previous audit left. */
+  pages: string[];
+  /** `resolutionSignal.crawledUrls` for this run. */
+  crawled: string[];
+  /** Per-page HTTP status for this run. */
+  statuses?: Array<{ url: string; status: number }>;
+}
+
+function seed(fixture: Fixture): MemStore {
+  const store = new MemStore();
+  for (const r of fixture.rows) {
+    store.findings.set(findingKey(r.normalizedUrl, r.ruleId, r.checkName, r.locator), r);
+  }
+  for (const p of fixture.pages) store.pages.set(p, activePage(p));
+  return store;
+}
+
+async function runStreamed(fixture: Fixture): Promise<[CloudSmartAuditsResult, MemStore]> {
+  const store = seed(fixture);
+  const result = await runCloudSmartAudits({
+    store,
+    siteKey: SITE,
+    crawlId: AUDIT,
+    ruleResults: shell,
+    pageStatuses: fixture.statuses ?? fixture.crawled.map((url) => ({ url, status: 200 })),
+    now: 1_700_000_000_000,
+    completeStore: {
+      openPages: openPagesOf(store, AUDIT),
+      crawledUrls: fixture.crawled,
+    },
+  });
+  return [result, store];
+}
+
+async function runMaterialized(fixture: Fixture): Promise<[CloudSmartAuditsResult, MemStore]> {
+  const store = seed(fixture);
+  const result = await runCloudSmartAudits({
+    store,
+    siteKey: SITE,
+    crawlId: AUDIT,
+    ruleResults: shell,
+    pageStatuses: fixture.statuses ?? fixture.crawled.map((url) => ({ url, status: 200 })),
+    now: 1_700_000_000_000,
+    completeStore: {
+      findingPages: freshPagesOf(store, AUDIT),
+      priorOpenFindings: [...store.findings.values()].filter(
+        (f) => f.state === "open" && f.lastSeenCrawlId !== AUDIT,
+      ),
+      crawledUrls: fixture.crawled,
+    },
+  });
+  return [result, store];
+}
+
+/** Store contents reduced to what the merge is responsible for. */
+function storeState(store: MemStore): Array<[string, string, string]> {
+  return [...store.findings.values()]
+    .map(
+      (f) =>
+        [
+          findingKey(f.normalizedUrl, f.ruleId, f.checkName, f.locator),
+          f.state,
+          f.provenance,
+        ] as [string, string, string],
+    )
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+}
+
+/** Everything a caller reads off the result, order-normalized. */
+function surface(result: CloudSmartAuditsResult) {
+  const checks = result.unionRuleResults.get(RULE)?.checks ?? [];
+  return {
+    score: calculateHealthScoreFromTallies(result.scoringTallies!, result.unionRuleResults),
+    tally: result.scoringTallies!.get(RULE)!.tally,
+    coverage: result.coverage,
+    persistedFindings: result.persistedFindings,
+    removedPages: result.removedPages,
+    syntheticPassCount: result.unionRuleResults.get(RULE)?.syntheticPassCount,
+    checks: checks
+      .map((c) => `${c.status}|${c.pageUrl ?? ""}|${c.message}`)
+      .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+  };
+}
+
+describe("streamed carried merge == materialized carried merge (#1876)", () => {
+  /**
+   * One fixture holding every shape at once: this run's ingest, a backlog the run
+   * never touches, a prior the run re-crawled clean, a page that 404'd with an open
+   * prior on it, and a page carrying BOTH this run's findings and an older one.
+   */
+  function everyShape(): Fixture {
+    const crawled = Array.from({ length: 6 }, (_, i) => `https://x.test/p/${i}`);
+    const carriedPages = Array.from({ length: 5 }, (_, i) => `https://x.test/old/${i}`);
+    const removed = "https://x.test/gone";
+    // A page with ingested findings that is NOT in the crawled set — the merge
+    // carries its priors, so its fresh and carried findings must fold together.
+    const overlap = "https://x.test/uncrawled-but-ingested";
+
+    const rows: PageFindingRecord[] = [
+      // This run's ingest: 2 of the 6 crawled pages fail.
+      row(crawled[0]!, "", AUDIT),
+      row(crawled[1]!, "", AUDIT),
+      // A prior the run re-crawled and did NOT re-observe → resolves.
+      row(crawled[2]!, "", PRIOR_AUDIT),
+      // The backlog: 3 of the 5 un-crawled pages carry, 2 stay clean.
+      row(carriedPages[0]!, "", PRIOR_AUDIT),
+      row(carriedPages[1]!, "item-a", PRIOR_AUDIT),
+      row(carriedPages[1]!, "item-b", PRIOR_AUDIT),
+      row(carriedPages[2]!, "", PRIOR_AUDIT),
+      // Removed this run → its open prior stales.
+      row(removed, "", PRIOR_AUDIT),
+      // The overlap page: one locator ingested this run, one left by the last.
+      row(overlap, "item-new", AUDIT),
+      row(overlap, "item-old", PRIOR_AUDIT),
+    ];
+    return {
+      rows,
+      pages: [...crawled, ...carriedPages, removed, overlap],
+      crawled,
+      statuses: [
+        ...crawled.map((url) => ({ url, status: 200 })),
+        { url: removed, status: 404 },
+      ],
+    };
+  }
+
+  test("the whole result surface is identical, and so is what is left in the store", async () => {
+    const fixture = everyShape();
+    const [streamed, streamedStore] = await runStreamed(fixture);
+    const [materialized, materializedStore] = await runMaterialized(fixture);
+
+    expect(surface(streamed)).toEqual(surface(materialized));
+    expect(storeState(streamedStore)).toEqual(storeState(materializedStore));
+  });
+
+  test("the streaming path never falls back to loading the whole open set", async () => {
+    const fixture = everyShape();
+    const store = seed(fixture);
+    store.refuseWholeRead = true;
+    const result = await runCloudSmartAudits({
+      store,
+      siteKey: SITE,
+      crawlId: AUDIT,
+      ruleResults: shell,
+      pageStatuses: fixture.statuses!,
+      now: 1_700_000_000_000,
+      completeStore: { openPages: openPagesOf(store, AUDIT), crawledUrls: fixture.crawled },
+    });
+    // 5 carried: 4 on the three un-crawled backlog pages (one holds two items),
+    // plus the one on the ingested-but-uncrawled page.
+    expect(result.coverage.carriedFindings).toBe(5);
+  });
+
+  test("a page holding BOTH this run's findings and an older one folds as one page", async () => {
+    // The invariant the page-boundary contract exists for: `addChecksToTally`
+    // clamps fail units per (checkName, pageUrl) WITHIN one call, so folding the
+    // overlap page's two locators in two calls would count the bucket twice.
+    const overlap = "https://x.test/uncrawled-but-ingested";
+    const fixture: Fixture = {
+      rows: [row(overlap, "item-new", AUDIT), row(overlap, "item-old", PRIOR_AUDIT)],
+      pages: [overlap],
+      crawled: [],
+      statuses: [],
+    };
+    const [streamed] = await runStreamed(fixture);
+    const [materialized] = await runMaterialized(fixture);
+    expect(streamed.scoringTallies!.get(RULE)!.tally).toEqual(
+      materialized.scoringTallies!.get(RULE)!.tally,
+    );
+    // ONE (check, page) bucket, two item findings in it: 2 fail units, not 2 buckets.
+    expect(streamed.scoringTallies!.get(RULE)!.tally.failUnits).toBe(2);
+    expect(streamed.scoringTallies!.get(RULE)!.tally.failed).toBe(2);
+  });
+
+  test("a carried finding's replayed check carries its provenance and last-seen date", async () => {
+    const fixture = everyShape();
+    const [streamed] = await runStreamed(fixture);
+    const [materialized] = await runMaterialized(fixture);
+    const carried = streamed.unionRuleResults
+      .get(RULE)!
+      .checks.find((c) => c.pageUrl === "https://x.test/old/0")!;
+    // Stamped at construction rather than from a per-finding map, so the streaming
+    // path needs no `carriedLastSeen` — but it must say exactly what that map said.
+    expect(carried.provenance).toBe("carried");
+    expect(carried.lastSeenAt).toBe(
+      materialized.carriedLastSeen.get(`https://x.test/old/0|${RULE}|${CHECK}`),
+    );
+    expect(streamed.carriedLastSeen.size).toBe(0);
+  });
+});
+
+describe("the report's carried side is bounded per rule (#1876)", () => {
+  // Comfortably past the per-rule sample, so the class is folded and stamped.
+  const OVER_CAP = 520;
+  /** Mirrors CARRIED_REPORT_SAMPLE_PER_RULE, which the module keeps private. */
+  const CARRIED_SAMPLE_PER_RULE = 25;
+
+  test("past the cap the checks stop growing but the occurrence count stays true", async () => {
+    const carriedPages = Array.from(
+      { length: OVER_CAP },
+      (_, i) => `https://x.test/backlog/${String(i).padStart(4, "0")}`,
+    );
+    const fixture: Fixture = {
+      rows: carriedPages.map((u) => row(u, "", PRIOR_AUDIT)),
+      pages: carriedPages,
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+
+    // One aggregate for the rule's single issue class, NOT 500 per-page checks:
+    // a rule this far over the cap folded to a handful of aggregates before the
+    // bound existed, and publishing the retained sample verbatim would make the
+    // report bigger than it used to be, not smaller.
+    const checks = streamed.unionRuleResults.get(RULE)!.checks;
+    expect(checks).toHaveLength(1);
+    expect(checks[0]!.details?.aggregated).toBe(true);
+
+    // The 20 dropped ones survive as numbers: the fold sums `occurrences` and
+    // maxes `pagesTruncated` across the group, so the aggregate the report stores
+    // still reports every occurrence and every affected page.
+    expect(checks[0]!.details?.occurrences).toBe(OVER_CAP);
+    expect(checks[0]!.details?.pagesTruncated).toBe(OVER_CAP);
+    expect(checks[0]!.message).toContain(`(+${OVER_CAP - 1} more pages)`);
+    expect(checks[0]!.provenance).toBe("carried");
+
+    // And it survives the publish fold the caller runs over the whole rule.
+    const refolded = foldOverflowChecks([...checks], DEFAULT_FOLD_LIMITS);
+    expect(refolded[0]!.details?.occurrences).toBe(OVER_CAP);
+
+    // And the SCORE saw all of them — the bound is on the report body only.
+    expect(streamed.scoringTallies!.get(RULE)!.tally.failed).toBe(OVER_CAP);
+    expect(streamed.coverage.carriedFindings).toBe(OVER_CAP);
+  });
+
+  test("a class first seen after the budget is spent still reaches the report", async () => {
+    // The budget is per RULE, so one loud issue class can spend all of it before a
+    // second class is ever seen. Dropping the second class would lose it from the
+    // report entirely while its findings stayed open in the store — the counts have
+    // to ride on a check, so every class keeps one.
+    const loud = Array.from({ length: 200 }, (_, i) => `https://x.test/loud/${i}`);
+    const quiet = ["https://x.test/quiet/0", "https://x.test/quiet/1"];
+    const fixture: Fixture = {
+      rows: [
+        ...loud.map((u) => row(u, "", PRIOR_AUDIT)),
+        // A different checkName under the same rule = a different issue class,
+        // and its pages sort after every loud one, so it is seen last.
+        ...quiet.map((u) => ({
+          ...row(u, "", PRIOR_AUDIT),
+          checkName: "has-og-description",
+          message: "Missing og:description",
+        })),
+      ],
+      pages: [...loud, ...quiet],
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+
+    const checks = streamed.unionRuleResults.get(RULE)!.checks;
+    const quietChecks = checks.filter((c) => c.name === "has-og-description");
+    expect(quietChecks).toHaveLength(1);
+    expect(quietChecks[0]!.details?.occurrences).toBe(2);
+    expect(quietChecks[0]!.details?.pagesTruncated).toBe(2);
+    // Its sample is ONE check, which the fold leaves alone, so it would otherwise
+    // still read as that single page's finding while standing for two.
+    expect(quietChecks[0]!.details?.aggregated).toBe(true);
+    expect(quietChecks[0]!.pageUrl).toBeUndefined();
+    expect(quietChecks[0]!.message).toContain("(+1 more pages)");
+    // And the loud class still reports all 200.
+    const loudChecks = checks.filter((c) => c.name === CHECK);
+    expect(loudChecks).toHaveLength(1);
+    expect(loudChecks[0]!.details?.occurrences).toBe(200);
+    // Every carried finding still scored.
+    expect(streamed.scoringTallies!.get(RULE)!.tally.failed).toBe(202);
+  });
+
+  test("a dropped check's own occurrence and page counts are not lost", async () => {
+    // A carried finding can already stand for many: `unfoldAggregateCheck` strips
+    // `aggregated` and `occurrences` when it expands a published aggregate but
+    // leaves `pagesTruncated`, so the per-page rows the merge stores inherit it,
+    // and a rule's own `details` can carry either. Counting each replay as one
+    // occurrence and one page would understate the aggregate by whatever the
+    // dropped checks were standing for.
+    // PADDED: the cursor yields pages in normalized-URL order, so an unpadded
+    // "agg/29" would sort before "agg/3" and land INSIDE the retained sample —
+    // and the test would pass without exercising a drop at all.
+    const backlog = Array.from(
+      { length: 30 },
+      (_, i) => `https://x.test/agg/${String(i).padStart(2, "0")}`,
+    );
+    const fixture: Fixture = {
+      rows: backlog.map((u, i) => ({
+        ...row(u, "", PRIOR_AUDIT),
+        // Every replay stands for 2 findings; the LAST one — dropped, because the
+        // sample is full by then — also reports 400 affected pages.
+        payload: JSON.stringify({
+          details: i === backlog.length - 1 ? { occurrences: 2, pagesTruncated: 400 } : { occurrences: 2 },
+        }),
+      })),
+      pages: backlog,
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+    const checks = streamed.unionRuleResults.get(RULE)!.checks;
+    expect(checks).toHaveLength(1);
+    expect(checks[0]!.details?.occurrences).toBe(60);
+    expect(checks[0]!.details?.pagesTruncated).toBe(400);
+  });
+
+  test("a class the sample saw as all-carried but is not loses the claim", async () => {
+    // `foldGroup` stamps "carried" only when EVERY constituent is, so a uniform
+    // sample of a mixed class would have the aggregate assert an earlier audit saw
+    // findings no audit has ever rendered. The newest date has the mirror problem:
+    // it is a max over the group, so a dropped constituent carrying a later one
+    // would leave the badge reading stale.
+    const rendered = Array.from(
+      { length: 30 },
+      (_, i) => `https://x.test/seen/${String(i).padStart(2, "0")}`,
+    );
+    // Sorts AFTER every rendered page, so the sample is full before it is seen and
+    // the mixed class is only visible through the counters.
+    const unseen = "https://x.test/zz-never";
+    const fixture: Fixture = {
+      rows: [
+        ...rendered.map((u) => ({ ...row(u, "", PRIOR_AUDIT), lastSeenAt: 1_600_000_000_000 })),
+        { ...row(unseen, "", PRIOR_AUDIT), lastSeenAt: 1_650_000_000_000 },
+      ],
+      // `unseen` gets NO site_pages row, so no audit has ever rendered it (#1652).
+      pages: rendered,
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+    const checks = streamed.unionRuleResults.get(RULE)!.checks;
+    expect(checks).toHaveLength(1);
+    // Mixed carried + unrendered: neither marker, which is what folding all 31
+    // real checks would have produced.
+    expect(checks[0]!.provenance).toBeUndefined();
+    expect(checks[0]!.lastSeenAt).toBeUndefined();
+    expect(checks[0]!.details?.occurrences).toBe(31);
+  });
+
+  test("an all-carried class keeps the NEWEST last-seen, dropped checks included", async () => {
+    const backlog = Array.from(
+      { length: 30 },
+      (_, i) => `https://x.test/dated/${String(i).padStart(2, "0")}`,
+    );
+    const fixture: Fixture = {
+      rows: backlog.map((u, i) => ({
+        ...row(u, "", PRIOR_AUDIT),
+        // The newest date is on a check the sample drops.
+        lastSeenAt: i === backlog.length - 1 ? 1_690_000_000_000 : 1_600_000_000_000,
+      })),
+      pages: backlog,
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+    const checks = streamed.unionRuleResults.get(RULE)!.checks;
+    expect(checks).toHaveLength(1);
+    expect(checks[0]!.provenance).toBe("carried");
+    expect(checks[0]!.lastSeenAt).toBe(1_690_000_000_000);
+  });
+
+  test("a dropped check whose occurrence weight floors to zero still counts as lost", async () => {
+    // `foldGroup` floors `details.occurrences`, so a check declaring 0.5 adds
+    // nothing to either weight. Keying "did this class lose anything" on weight
+    // would call such a class complete and skip both the stamp and the provenance
+    // reconciliation, losing its pages and its never-rendered status with it.
+    // EXACTLY the sample budget, so the zero-weight check below is the ONLY thing
+    // dropped — otherwise the other drops' weight would trip a weight-keyed test
+    // and this would prove nothing.
+    const backlog = Array.from(
+      { length: CARRIED_SAMPLE_PER_RULE },
+      (_, i) => `https://x.test/frac/${String(i).padStart(2, "0")}`,
+    );
+    const odd = "https://x.test/zz-odd";
+    const fixture: Fixture = {
+      rows: [
+        ...backlog.map((u) => row(u, "", PRIOR_AUDIT)),
+        {
+          ...row(odd, "", PRIOR_AUDIT),
+          payload: JSON.stringify({ details: { occurrences: 0.5, pagesTruncated: 400 } }),
+        },
+      ],
+      // `odd` has no site_pages row, so nothing has ever rendered it.
+      pages: backlog,
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+    const checks = streamed.unionRuleResults.get(RULE)!.checks;
+    expect(checks).toHaveLength(1);
+    expect(checks[0]!.details?.pagesTruncated).toBe(400);
+    // Mixed carried + unrendered, so neither marker survives.
+    expect(checks[0]!.provenance).toBeUndefined();
+  });
+
+  test("a class weighing zero is not rounded UP by the stamp", async () => {
+    // `foldGroup` reads a non-positive `occurrences` as "no count declared" and
+    // substitutes 1, so stamping the 0 a fractional-weight class genuinely weighs
+    // would invent an occurrence the materialized fold does not have.
+    const plain = Array.from(
+      { length: CARRIED_SAMPLE_PER_RULE - 1 },
+      (_, i) => `https://x.test/plain/${String(i).padStart(2, "0")}`,
+    );
+    const fractional = ["https://x.test/zz-frac-0", "https://x.test/zz-frac-1"];
+    const fixture: Fixture = {
+      rows: [
+        ...plain.map((u) => row(u, "", PRIOR_AUDIT)),
+        ...fractional.map((u) => ({
+          ...row(u, "", PRIOR_AUDIT),
+          payload: JSON.stringify({ details: { occurrences: 0.5 } }),
+        })),
+      ],
+      pages: [...plain, ...fractional],
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+    const checks = streamed.unionRuleResults.get(RULE)!.checks;
+    expect(checks).toHaveLength(1);
+    // 24 checks weighing 1, two weighing 0 — the same total the materialized fold
+    // reaches over all 26.
+    expect(checks[0]!.details?.occurrences).toBe(CARRIED_SAMPLE_PER_RULE - 1);
+  });
+
+  test("under the cap the report is exactly what the materialized path builds", async () => {
+    const carriedPages = Array.from({ length: 20 }, (_, i) => `https://x.test/backlog/${i}`);
+    const fixture: Fixture = {
+      rows: carriedPages.map((u) => row(u, "", PRIOR_AUDIT)),
+      pages: carriedPages,
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+    const [materialized] = await runMaterialized(fixture);
+    expect(surface(streamed)).toEqual(surface(materialized));
+    expect(streamed.unionRuleResults.get(RULE)!.checks).toHaveLength(20);
+  });
+});
+
+describe("computeMerge keeps its array-API contract (#1876)", () => {
+  test("a repeated prior key is decided once, as it was before the merge streamed", async () => {
+    // The session has no `handledKeys` set — that set's size is the prior count,
+    // which is the whole point — so it takes key-unique priors, which is what the
+    // page_findings primary key guarantees. The array API has no such guarantee:
+    // its caller builds the list, and the pre-#1876 loop ignored a repeat.
+    const prior = row("https://x.test/dup", "", PRIOR_AUDIT);
+    const merged = computeMerge({
+      siteKey: SITE,
+      crawlId: AUDIT,
+      crawledUrls: new Set<string>(),
+      freshFindings: [],
+      removedUrls: new Set<string>(),
+      severityByRule: new Map([[RULE, meta.severity]]),
+      statusByUrl: new Map<string, number>(),
+      priorFindings: [prior, { ...prior }],
+      priorPages: [activePage("https://x.test/dup")],
+      now: 1_700_000_000_000,
+    });
+    expect(merged.findings).toHaveLength(1);
+    expect(merged.persisted).toHaveLength(1);
+    expect(merged.findings[0]!.provenance).toBe("carried");
+  });
+
+  test("a repeated prior a fresh finding supersedes still hands over the LAST first-seen", async () => {
+    // The other half of the same contract, and it points the other way. A
+    // superseded prior never reached the old loop's decision — it was read out of
+    // an index built by assigning each prior in turn, so the LAST assignment won.
+    const url = "https://x.test/dup";
+    const base = row(url, "", PRIOR_AUDIT);
+    const merged = computeMerge({
+      siteKey: SITE,
+      crawlId: AUDIT,
+      crawledUrls: new Set([url]),
+      freshFindings: [
+        {
+          normalizedUrl: url,
+          ruleId: RULE,
+          checkName: CHECK,
+          locator: "",
+          status: "fail",
+          message: "Missing meta description",
+          value: null,
+          expected: null,
+          payload: null,
+        },
+      ],
+      removedUrls: new Set<string>(),
+      severityByRule: new Map([[RULE, meta.severity]]),
+      statusByUrl: new Map([[url, 200]]),
+      priorFindings: [
+        { ...base, firstSeenAt: 1_500_000_000_000 },
+        { ...base, firstSeenAt: 1_400_000_000_000 },
+      ],
+      priorPages: [activePage(url)],
+      now: 1_700_000_000_000,
+    });
+    expect(merged.persisted).toHaveLength(1);
+    expect(merged.persisted[0]!.firstSeenAt).toBe(1_400_000_000_000);
+  });
+});

--- a/packages/rules/src/fold.ts
+++ b/packages/rules/src/fold.ts
@@ -829,7 +829,16 @@ function foldGroup(group: CheckResult[], limits: FoldLimits): CheckResult {
 
   // Composed message must stay under the API's medium-string cap or the whole
   // publish 400s (strings are rejected, not truncated).
-  const message = `${first.message} (+${group.length - 1} more pages)`.slice(
+  //
+  // Counted off `occurrences`, not off how many OBJECTS this group holds — the
+  // same distinction the occurrences sum above draws, for the same reason. They
+  // are equal for a group of plain per-page checks (each contributes 1), so every
+  // ordinary fold is byte-identical; they differ only when a constituent already
+  // stands for many findings, which is exactly when the object count is the wrong
+  // number to show. (#1876) That case is now routine: a rule carrying more than
+  // `maxChecksPerRule` findings reaches the report as a bounded sample whose
+  // occurrence total is stamped rather than materialized.
+  const message = `${first.message} (+${occurrences - 1} more pages)`.slice(
     0,
     REPORT_LIMITS.maxMediumString,
   );


### PR DESCRIPTION
Follow-up to #224, which bounded the FRESH half of the complete-store finalize: this audit's findings arrive a page at a time and fold into per-rule tallies. The carried half stayed an array — every open finding the site had outside this run, loaded, indexed by key, walked twice, replayed as a `CheckResult` and folded into the report.

That is free on a full re-audit, where the chunk ingest has already re-stamped almost everything and what remains is a small delta. It is the whole backlog on a PARTIAL re-audit, where almost nothing is re-observed: about 4.8 KiB per carried finding, 329 MiB at 60,000 of them against a 128 MB isolate. Tracked privately as squirrelscan/repo#1876.

## What changed

**One decision, two drivers.** `createMergeSession` is `computeMerge` as a state machine. The supersede lookup is flipped: the FRESH set is indexed (bounded by the run) and priors stream past it, leaving their `firstSeenAt` behind on the way through, which is the only thing the whole-prior index ever answered. `computeMerge` still takes an array and drives the session with a collecting sink, so it is byte-identical — including the two different repeat-key rules the old loop had (first wins for a prior it decides, last wins for one a fresh finding supersedes).

**Both halves of a page, together.** The scoring fold becomes an accumulator the caller drives. The API feeds it from ONE cursor over the site's open findings, split by crawl id, so a page's fresh evidence and the findings earlier audits left on it reach `addChecksToTally` in the same call. That is what the fold's per-`(checkName, pageUrl)` unit cap requires, and it is now structural rather than a lookup that happens to be there — two independent cursors could only line their pages up by comparing URLs in JS, and JS string order is not the database's collation.

**A bounded carried report.** Past a per-rule sample the rule's carried side is one aggregate per issue class. Everything the dropped checks would have contributed travels as counters: occurrence WEIGHT (a constituent can already stand for many), the exact affected-page count and any constituent's own page floor, the newest last-seen date, and whether the class really is all-carried or all-unrendered. Every class keeps one check whatever the budget, because that check is where those counts land.

`foldGroup` now counts `(+N more pages)` off `occurrences` rather than object count. Identical for a group of plain per-page checks; correct for one where a constituent already stands for many.

## Measured

Whole-handler RSS growth through the API's publish finalize against a real Postgres, fixture seeded in a separate process, 2,000 fresh findings and 500 crawled pages throughout, 40 page-scope rules:

| carried findings | before | after |
|---|---|---|
| 0 | 42.2 MiB | 39 MiB |
| 5,000 | 90.5 MiB | 62 MiB |
| 20,000 | 189.6 MiB | 65 MiB |
| 60,000 | 328.6 MiB | 98 MiB (max 104 over thirteen runs) |

**Peak RSS still climbs from 20,000 to 60,000, and residency does not.** Settled `heapUsed` after a forced collection at the end of the handler is 20.3 MiB at 20,000 carried findings and 21.0 at 60,000. Peak RSS is a high-water mark over the whole handler, so it also records how far the runtime lets the heap run ahead of the driver's churn while 60,000 rows are read and rewritten, which is proportional to the work whatever the design holds. Recorded with the rest of the September program in `benchmarks/2026-09-perf-program.md`.

Two of the three cuts were not the ones the shape predicted, and both are written down where the constants are: the report's carried sample is 25 checks per rule because 100 cost ~25 MiB of peak and 500 cost ~80, and the read and write batches were quartered for ~15 MiB.

## Gates

`packages/audit-engine/tests/complete-store-parity.test.ts` is unchanged and green — it is the byte-identity gate on the score. `packages/audit-engine/tests/bounded-carried-merge.test.ts` is new and runs the same fixture through both drivers, asserting the whole result surface and the rows left in the store are identical, over a fixture holding a page with fresh AND carried findings, a page removed this run, a page an earlier run resolved, and a rule carrying more findings than the report keeps.

Three adversarial review passes raised nine defects, every one of them in the bounded report sample or the array API's repeat-key handling rather than in the streaming itself. All nine are fixed, each with a regression test that was mutation-checked against the implementation it rejects.