### PR TITLE
feat(audit-engine): populate the template cluster key on page_features

### DIFF
--- a/apps/cli/scripts/template-cluster-census.ts
+++ b/apps/cli/scripts/template-cluster-census.ts
@@ -1,0 +1,190 @@
+// Template cluster census (#1949) — what `page_features.template_fp` groups a
+// real crawl into, read straight off a finished `project.db`. No network, and no
+// write to the crawl it reads.
+//
+//   bun run scripts/template-cluster-census.ts --db ~/.squirrel/projects/rl-e2e/project.db
+//   bun run scripts/template-cluster-census.ts --db <path> --crawl <id>
+//
+// It does NOT trust its own in-memory grouping. Crawls finished before #1949 hold
+// `template_fp NULL` on every row, so the only honest way to check the shipped
+// path end to end is to replay it: run the REAL writer (`extractPageFeatures`)
+// into a scratch `:memory:` store, then read the clusters back through the REAL
+// reader (`getPageFeatureTemplateClusters`, i.e. `SiteQuery.templateClusters()`)
+// and require the SQL `GROUP BY` to agree with the grouping computed here. A
+// census that only hashed in memory would print identical totals against an
+// entirely null column.
+//
+// Why this lives here and not in packages/audit-engine/scripts: a finished
+// project.db stores `pages.html` as NULL and keeps the bytes in the GLOBAL content
+// store, which is a CLI module. A `SQLiteStorage` built without
+// `getGlobalContentStore()` reads every page as html-less, parses nothing, and
+// reports zero clusters while looking like it worked.
+//
+// The numbers this is here to hold the key to (measured for #1026):
+//
+//   corpus                      pages  clusters  multi-page  redundant
+//   gymshark.com                  247        13           8      94.7%
+//   openelectricity.org.au        100        12           3      88.0%
+//
+// Do NOT re-derive those from the synthetic bench corpora. They are generated from
+// 1-6 templates, so every clustering definition collapses to ~99% redundancy on
+// them and the answer comes out flattering and wrong.
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import {
+  buildSiteContext,
+  extractPageFeatures,
+  isAuditablePage,
+  templateFingerprintKey,
+} from "@squirrelscan/audit-engine";
+import { fingerprintPage } from "@squirrelscan/rules";
+import { isRateLimitStatus } from "@squirrelscan/utils/rate-limit";
+import { Effect } from "effect";
+
+import { getGlobalContentStore } from "@/crawler/storage/content-store";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const arg = (name: string, fallback: string): string => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? (process.argv[i + 1] ?? fallback) : fallback;
+};
+
+const DB = arg("db", "");
+if (!DB) {
+  console.error("usage: bun run scripts/template-cluster-census.ts --db <project.db> [--crawl <id>]");
+  process.exit(1);
+}
+
+// Validated before anything opens: `getPages` passes the limit straight to
+// SQLite, where `LIMIT 0` means NO limit, and `offset += 0` never advances — so a
+// non-positive or NaN batch reads the whole crawl forever instead of erroring.
+const BATCH = Number.parseInt(arg("batch", "50"), 10);
+if (!Number.isSafeInteger(BATCH) || BATCH < 1) {
+  console.error(`--batch must be a positive integer, got ${JSON.stringify(arg("batch", "50"))}`);
+  process.exit(1);
+}
+
+const storage = new SQLiteStorage(DB, getGlobalContentStore());
+await run(storage.init());
+
+const crawlArg = arg("crawl", "");
+const crawls = (await run(storage.listCrawls(50))) as Array<{ id: string; baseUrl?: string }>;
+const crawlId = crawlArg || crawls[0]?.id;
+if (!crawlId) {
+  console.error("no crawls in this db");
+  process.exit(1);
+}
+
+// The scratch store the replayed page_features rows go into. The crawl being
+// censused is never written to.
+const replay = new SQLiteStorage(":memory:");
+await run(replay.init());
+
+const byKey = new Map<string, string[]>();
+let scored = 0;
+let rateLimited = 0;
+let noKey = 0;
+let fingerprintMs = 0;
+let keyMs = 0;
+
+for (let offset = 0; ; offset += BATCH) {
+  const batch = await run(storage.getPages(crawlId, { limit: BATCH, offset }));
+  if (batch.length === 0) break;
+  const ctx = await run(buildSiteContext(batch));
+
+  for (const { page, parsed } of ctx) {
+    if (!parsed) continue;
+    // Production's scored universe, not `isAuditablePage` alone: the streamed
+    // loop takes v1's page universe, which drops rate-limited pages as well as
+    // WAF challenges (#1829). Grading a 429 body would put a page nobody has
+    // seen into a cluster.
+    if (isRateLimitStatus(page.status)) {
+      rateLimited++;
+      parsed.document = null;
+      continue;
+    }
+    if (!isAuditablePage(page)) {
+      parsed.document = null;
+      continue;
+    }
+
+    // Split, because the two halves answer different questions: the DOM walk was
+    // already being paid by `buildCollectedPageSignal` and is shared now, so only
+    // the key reduction is new work in the streamed loop.
+    const t0 = Bun.nanoseconds();
+    const fp = fingerprintPage(parsed, page.normalizedUrl);
+    const t1 = Bun.nanoseconds();
+    const key = templateFingerprintKey(fp);
+    const t2 = Bun.nanoseconds();
+    fingerprintMs += (t1 - t0) / 1e6;
+    keyMs += (t2 - t1) / 1e6;
+
+    // The shipped writer, with the shipped argument, so what lands in the scratch
+    // column is what a real crawl would store — not a key this script computed.
+    await run(replay.upsertPageFeatures(crawlId, extractPageFeatures(page, parsed, { fingerprint: fp })));
+
+    scored++;
+    if (key == null) {
+      noKey++;
+    } else {
+      const urls = byKey.get(key);
+      if (urls) urls.push(page.normalizedUrl);
+      else byKey.set(key, [page.normalizedUrl]);
+    }
+    parsed.document = null;
+  }
+}
+
+const clusters = [...byKey.entries()].sort((a, b) => b[1].length - a[1].length);
+const multi = clusters.filter(([, urls]) => urls.length > 1);
+const singletons = clusters.length - multi.length;
+const redundant = clusters.reduce((n, [, urls]) => n + urls.length - 1, 0);
+
+// The check that makes the rest of this output mean anything: the same clusters,
+// read back out of the column through the reader the product uses. It reports
+// multi-page groups only (`HAVING count > 1`), so that is what it is compared to.
+const stored = await run(
+  replay.getPageFeatureTemplateClusters(crawlId, {
+    maxGroups: 100_000,
+    maxUrlsPerGroup: 100_000,
+  }),
+);
+const asText = (rows: Array<{ fp: string; urls: string[] }>): string =>
+  JSON.stringify(
+    rows.map((r) => [r.fp, [...r.urls].sort()]).sort((a, b) => (a[0] as string).localeCompare(b[0] as string)),
+  );
+const expected = multi.map(([fp, urls]) => ({ fp, urls }));
+if (asText(stored) !== asText(expected)) {
+  console.error("STORED CLUSTERS DISAGREE with the recomputed grouping");
+  console.error(`  stored   ${stored.length} groups`);
+  console.error(`  expected ${expected.length} groups`);
+  process.exit(2);
+}
+
+console.log(`db          ${DB}`);
+console.log(`crawl       ${crawlId}`);
+console.log(`pages       ${scored} scored (${rateLimited} rate-limited, ${noKey} with no key)`);
+console.log(`clusters    ${clusters.length} (${multi.length} multi-page, ${singletons} singleton)`);
+console.log(
+  `redundant   ${redundant} pages (${((redundant / Math.max(1, scored - noKey)) * 100).toFixed(1)}%)`,
+);
+console.log(
+  `GROUP BY    ${stored.length} multi-page groups over ${stored.reduce((n, g) => n + g.count, 0)} pages — agrees`,
+);
+console.log(
+  `fingerprint ${fingerprintMs.toFixed(0)} ms total, ${(fingerprintMs / Math.max(1, scored)).toFixed(3)} ms/page (shared DOM walk, already paid)`,
+);
+console.log(
+  `key         ${keyMs.toFixed(0)} ms total, ${(keyMs / Math.max(1, scored)).toFixed(3)} ms/page (the new work)`,
+);
+console.log("");
+for (const [key, urls] of clusters) {
+  console.log(`  ${key}  ${String(urls.length).padStart(4)}  ${urls[0]}`);
+}
+
+// `close()` returns an Effect; calling it bare leaves the handle open.
+await run(replay.close());
+await run(storage.close());

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -2396,10 +2396,19 @@ export function runStreamingRules(
     const collectedPages: CollectedPageSignal[] = [];
     const signalCollector: PageSignalCollector = {
       id: "site-dom-signals",
-      collect(page, parsed) {
+      collect(page, parsed, shared) {
         collectedPages.push(
           detachFromPage(
-            buildCollectedPageSignal({ url: page.normalizedUrl, finalUrl: page.finalUrl, parsed }),
+            // `shared.fingerprint` is the one the loop already built for
+            // page_features' cluster key (#1949) — reusing it keeps this pass at
+            // one DOM walk per page. detachFromPage clones it, so the signal this
+            // array retains does not hold the loop's copy or its page.
+            buildCollectedPageSignal({
+              url: page.normalizedUrl,
+              finalUrl: page.finalUrl,
+              parsed,
+              fingerprint: shared.fingerprint,
+            }),
             "collected-signal",
           ),
         );

--- a/packages/audit-engine/src/fingerprint.ts
+++ b/packages/audit-engine/src/fingerprint.ts
@@ -15,8 +15,14 @@ const FNV_PRIME = 1099511628211n;
 const FNV_OFFSET = 14695981039346656037n;
 const MASK64 = (1n << 64n) - 1n;
 
-/** One 64-bit FNV-1a lane over `bytes`, seeded so lanes decorrelate. 16 hex. */
-function fnv1a64(bytes: Uint8Array, seed: bigint): string {
+/**
+ * One 64-bit FNV-1a lane over `bytes`, seeded so lanes decorrelate. 16 hex.
+ *
+ * Exported so the template cluster key (#1949) hashes with the SAME reviewed,
+ * parity-pinned primitive rather than a second hand-rolled one. Changing it
+ * changes both, which the pinned golden in `fingerprint-parity.test.ts` catches.
+ */
+export function fnv1a64(bytes: Uint8Array, seed: bigint): string {
   let h = (FNV_OFFSET ^ seed) & MASK64;
   for (let i = 0; i < bytes.length; i++) {
     h = (h ^ BigInt(bytes[i])) & MASK64;

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -194,9 +194,18 @@ export { createSiteQuery } from "./site-query";
 export { extractPageFeatures, isAuditablePage } from "./page-features";
 export { isHtmlContentType } from "./adapter";
 
+// Template cluster key (#1949) — the equality reduction of `fingerprintPage`
+// stored on page_features.template_fp and grouped by SiteQuery.templateClusters().
+export { templateFingerprintKey } from "./template-key";
+
 // Streaming rules engine (#1021, PR-E) — batched page-rule pass with DOM-drop.
 export { streamPageRules, STREAM_PAGE_BATCH } from "./streaming";
-export type { PageSignalCollector, StreamPageRulesHooks, StreamPageRulesResult } from "./streaming";
+export type {
+  PageSignalCollector,
+  SharedPageSignals,
+  StreamPageRulesHooks,
+  StreamPageRulesResult,
+} from "./streaming";
 
 // Streamed pre-rules phase (#1860) — one batched walk that feeds the asset,
 // external-link, tech-detect, intel and cloud-prefetch collectors together.

--- a/packages/audit-engine/src/page-features.ts
+++ b/packages/audit-engine/src/page-features.ts
@@ -19,12 +19,13 @@
 import { detectWafChallengePage } from "@squirrelscan/waf-detect";
 import { extractNapSignal, getRichResultTypes, isPageIndexable } from "@squirrelscan/utils";
 
-import { extractSiteChromeSignal } from "@squirrelscan/rules";
+import { extractSiteChromeSignal, fingerprintPage } from "@squirrelscan/rules";
 
 import type { PageRecord, PageFeatureRow } from "@squirrelscan/core-contracts";
-import type { ParsedPage } from "@squirrelscan/rules";
+import type { PageFingerprint, ParsedPage } from "@squirrelscan/rules";
 
 import { buildHeadersMap, isHtmlContentType } from "./adapter";
+import { templateFingerprintKey } from "./template-key";
 
 /**
  * Whether a crawled page enters the audit the way v1 `runRulesOnStorage` decides:
@@ -80,13 +81,25 @@ function metaRobotsNoindex(robots: string | null): boolean {
  * the stored scalar is byte-identical to the legacy rule computing it inline.
  *
  * `transfer_bytes` is populated from `PageRecord.sizeBytes` (the page document
- * body size). `template_fp` and `secret_hits` are left null — see the PR notes:
- * their would-be consumers (template-discontinuity's fuzzy similarity,
- * leaked-secrets' masked-list output) can't be reproduced from an equality
- * fingerprint / a bare count, and the leaked-secret scanner is not yet a shared
- * export. Populating them is deferred until a rule can dual-path on them.
+ * body size).
+ *
+ * `template_fp` is the chrome-fingerprint equality key (#1949) — see
+ * {@link templateFingerprintKey} for why it is a hash and not the fingerprint,
+ * and why `template-discontinuity`'s fuzzy comparison is unaffected. Pass
+ * `opts.fingerprint` when the caller has ALREADY built the page's
+ * `PageFingerprint` (the streamed loop has, for `buildCollectedPageSignal`);
+ * omitting it computes one here, which costs a second DOM walk. It is deliberately
+ * NOT `null`-by-default on the plain 2-arg call: a caller that forgot to thread it
+ * would silently reproduce the dead column this replaces.
+ *
+ * `secret_hits` is still null: leaked-secrets' output is a masked list that a bare
+ * count can't reproduce, and its scanner is not yet a shared export.
  */
-export function extractPageFeatures(page: PageRecord, parsed: ParsedPage): PageFeatureRow {
+export function extractPageFeatures(
+  page: PageRecord,
+  parsed: ParsedPage,
+  opts?: { fingerprint?: PageFingerprint | null }
+): PageFeatureRow {
   const headers = buildHeadersMap(page);
   // meta+header indexability only; the robots.txt reason is site-level and is
   // appended by the rules from ctx.site.robotsTxt at run time.
@@ -122,7 +135,11 @@ export function extractPageFeatures(page: PageRecord, parsed: ParsedPage): PageF
     visibleDate:
       parsed.visibleDatePublished != null || parsed.visibleDateModified != null,
     transferBytes: page.sizeBytes ?? null,
-    templateFp: null,
+    templateFp: templateFingerprintKey(
+      opts?.fingerprint !== undefined
+        ? opts.fingerprint
+        : fingerprintPage(parsed, page.normalizedUrl)
+    ),
     secretHits: null,
     metaNoindex: metaRobotsNoindex(parsed.meta.robots),
     indexableReasons: indexability.reasons,

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -21,9 +21,9 @@ import { Effect } from "effect";
 
 import type { PageRecord } from "@squirrelscan/core-contracts";
 import type { SQLiteStorage } from "@squirrelscan/crawler";
-import type { RuleRunResult, SiteData, PageData, ParsedPage } from "@squirrelscan/rules";
+import type { PageFingerprint, RuleRunResult, SiteData, PageData, ParsedPage } from "@squirrelscan/rules";
 import type { RuleRunner } from "@squirrelscan/rules";
-import { mergeRuleRunResult } from "@squirrelscan/rules";
+import { fingerprintPage, mergeRuleRunResult } from "@squirrelscan/rules";
 
 import { buildSiteContext, buildHeadersMap, isRenderedFetch } from "./adapter";
 import { collectDroppedBatch } from "./batch-gc";
@@ -36,16 +36,33 @@ import { foldRuleResultIntoTallies, type RuleTally } from "./scoring";
 export const STREAM_PAGE_BATCH = 200;
 
 /**
+ * Per-page values the loop computed for `page_features` and hands to collectors so
+ * they are built ONCE per page rather than once per consumer (#1949).
+ */
+export interface SharedPageSignals {
+  /**
+   * `fingerprintPage(parsed, normalizedUrl)` — five `querySelectorAll` passes over
+   * the live DOM. Both `page_features.template_fp` (as an equality key) and the
+   * collected signal `template-discontinuity` aggregates (as a fuzzy comparand)
+   * need it, and computing it twice would put a second per-page DOM walk back into
+   * the pipeline #1913 exists to keep flat. `null` when the page has no document.
+   */
+  readonly fingerprint: PageFingerprint | null;
+}
+
+/**
  * A per-page collector invoked with the LIVE parsed page during the stream, right
  * next to extractPageFeatures. E-E ships zero registered collectors; E-E2 registers
  * one per DOM-scanning site rule (leaked-secrets, total-byte-weight,
  * template-discontinuity, orphan-page, adblock, subprocessor-disclosure) so their
  * per-page signal is captured with the DOM live and the site pass no longer needs
- * to re-materialize DOMs. The collector MUST NOT retain the DOM past its call.
+ * to re-materialize DOMs. The collector MUST NOT retain the DOM past its call, and
+ * must not retain `shared` either — its fingerprint holds page-HTML slices, so a
+ * collector that keeps it keeps the page (#1860); `detachFromPage` first.
  */
 export interface PageSignalCollector {
   readonly id: string;
-  collect(page: PageRecord, parsed: ParsedPage): void;
+  collect(page: PageRecord, parsed: ParsedPage, shared: SharedPageSignals): void;
 }
 
 export interface StreamPageRulesHooks {
@@ -269,11 +286,20 @@ export function streamPageRules(
         // page_features + E-E2 collectors, DOM still live. The early
         // `!isAuditablePage(page)` continue above already guarantees this page is
         // auditable, so no second gate is needed here.
+        //
+        // ONE fingerprint per page, two consumers: `page_features.template_fp`
+        // reduces it to an equality cluster key (#1949) and the collected signal
+        // keeps it whole for `template-discontinuity`'s fuzzy comparison. Built
+        // here rather than inside either consumer so the loop still walks each DOM
+        // exactly once.
+        const shared: SharedPageSignals = {
+          fingerprint: fingerprintPage(parsed, pageUrl),
+        };
         yield* storage
-          .upsertPageFeatures(crawlId, extractPageFeatures(page, parsed))
+          .upsertPageFeatures(crawlId, extractPageFeatures(page, parsed, shared))
           .pipe(Effect.catchAll(() => Effect.void));
         extractedCount++;
-        for (const c of collectors) c.collect(page, parsed);
+        for (const c of collectors) c.collect(page, parsed, shared);
 
         // Drop this page's DOM before moving on — the residency bound.
         parsed.document = null;

--- a/packages/audit-engine/src/template-key.ts
+++ b/packages/audit-engine/src/template-key.ts
@@ -1,0 +1,76 @@
+// Template cluster key (#1949) — the equality reduction of a page's chrome
+// fingerprint, stored on `page_features.template_fp` and grouped by
+// `SiteQuery.templateClusters()`.
+//
+// WHY AN EQUALITY KEY AND NOT THE FINGERPRINT ITSELF. `integrity/template-
+// discontinuity` compares `PageFingerprint`s by weighted Jaccard *similarity* to
+// a site baseline, which no single hash can reproduce; that is why the column was
+// left null when `page_features` shipped. #1026's fan-out needs the other thing —
+// "are these two pages the same template?" as a `GROUP BY` — and the two coexist:
+// this reduction is write-only from the rule's point of view, and the rule keeps
+// reading the live fingerprint.
+//
+// WHAT IT CLUSTERS. `fingerprintPage` captures a page's chrome: external asset
+// hosts, `<body>` class tokens, CSS custom-property names, stylesheet hrefs, and
+// whether nav/footer are present. On real sites that is the template signal —
+// measured on gymshark.com (247 pages) it yields 13 clusters, on
+// openelectricity.org.au (100 pages) 12. An exact DOM skeleton, the intuitive
+// alternative, yields 231 and 42 for the same crawls, because real pages of one
+// template differ in body content (variant counts, review counts, related items).
+// Do NOT re-derive that number from the synthetic bench corpora: they are
+// generated from 1-6 templates, so every clustering definition collapses to ~99%
+// redundancy on them and any sizing done there is wrong in the flattering
+// direction.
+
+import { fnv1a64 } from "./fingerprint";
+
+import type { PageFingerprint } from "@squirrelscan/rules";
+
+/**
+ * Canonical, injective encoding of a fingerprint's chrome markers.
+ *
+ * ORDER-INSENSITIVITY IS LOAD-BEARING. Every marker arrives in a `Set`, whose
+ * iteration order is INSERTION order — i.e. document order — so two pages built
+ * from one template but listing their stylesheets in a different order would hash
+ * differently and split the cluster. Each set is sorted before encoding.
+ *
+ * JSON, not a join: a delimiter-joined encoding lets a marker containing the
+ * delimiter forge a different field boundary. `JSON.stringify` over the array of
+ * arrays is injective for this shape, exactly as `findingFingerprint` does it.
+ */
+function canonicalize(fp: PageFingerprint): string {
+  return JSON.stringify([
+    [...fp.assetHosts].sort(),
+    [...fp.bodyClasses].sort(),
+    [...fp.cssVars].sort(),
+    [...fp.stylesheetHrefs].sort(),
+    fp.hasNav,
+    fp.hasFooter,
+  ]);
+}
+
+/**
+ * Reduce a page fingerprint to the stored template cluster key: 16 lowercase hex
+ * chars, or `null` for a page with no document (which stays out of every cluster —
+ * `getPageFeatureTemplateClusters` filters `template_fp IS NOT NULL AND != ''`).
+ *
+ * Deterministic and pure: equal chrome ⇒ equal key, across runs and across
+ * processes. It is a CHANGE/EQUALITY key, not a security primitive, so it uses
+ * the same portable FNV-1a lane `findingFingerprint` does (sync, dependency-free,
+ * identical on Bun and on Workers) rather than a digest.
+ *
+ * 64 bits is the width that matters here: the birthday bound is over the number of
+ * DISTINCT templates in one crawl (13 on gymshark), not the page count, and a
+ * collision would silently merge two templates — which #1951 would then fan a
+ * rule verdict across. At 10k distinct templates a 32-bit key collides ~1.2% of
+ * the time and this one ~3e-12.
+ *
+ * Changing `canonicalize` or the hash changes every key. That is harmless and
+ * needs no backfill: `page_features` rows are written per `(crawl_id,
+ * normalized_url)` by the crawl that produces them, nothing compares keys across
+ * crawls, and no reader treats a pre-existing null as meaningful.
+ */
+export function templateFingerprintKey(fp: PageFingerprint | null): string | null {
+  if (!fp) return null;
+  return fnv1a64(new TextEncoder().encode(canonicalize(fp)), 0n);
+}

--- a/packages/audit-engine/tests/page-features-noindex-golden.test.ts
+++ b/packages/audit-engine/tests/page-features-noindex-golden.test.ts
@@ -243,7 +243,11 @@ describe("extractPageFeatures — field extraction", () => {
     expect(row.richResultTypes).toEqual(["Article"]); // canonical casing, unknown dropped
     expect(row.title).toBe("T"); // raw
     expect(row.transferBytes).toBe(1234); // page.sizeBytes
-    expect(row.templateFp).toBeNull(); // deferred
+    // This fixture's `parsed` is a cast literal with no `document`, so there is
+    // no chrome to fingerprint and the cluster key is null (#1949 populates it
+    // from `fingerprintPage`, which needs a document; see
+    // template-cluster-key-golden.test.ts for the populated cases).
+    expect(row.templateFp).toBeNull();
     expect(row.secretHits).toBeNull(); // deferred
   });
 

--- a/packages/audit-engine/tests/template-cluster-key-golden.test.ts
+++ b/packages/audit-engine/tests/template-cluster-key-golden.test.ts
@@ -1,0 +1,389 @@
+// Template cluster key on page_features (#1949).
+//
+// `page_features.template_fp` shipped as an indexed column that `extractPageFeatures`
+// set to `null` on every row, with no reader anywhere. This is the gate for
+// populating it: the key has to be a deterministic, order-insensitive function of
+// the chrome fingerprint `fingerprintPage` already builds, it has to reach the
+// column, `GROUP BY template_fp` has to cluster on it, and the streamed loop has to
+// get it from the fingerprint it ALREADY computes rather than walking each DOM a
+// second time.
+//
+// Named `*golden*` deliberately: that glob is what the "Audit engine golden tests"
+// CI job runs. `fingerprint-parity.test.ts` holds the other pinned hash in this
+// package and is NOT matched by it, so it has never run in CI (public #229) — a
+// mistake worth not repeating for a key that #1951 will fan rule verdicts across.
+//
+// The cluster counts this key has to reproduce are measured on REAL crawls, not
+// here: gymshark.com 247 pages → 13 clusters (8 multi-page, 94.7% redundant),
+// openelectricity.org.au 100 pages → 12 clusters (3 multi-page, 88.0%). Reproduce
+// with `apps/cli/scripts/template-cluster-census.ts`. They cannot be asserted from
+// a fixture in this repo, and specifically not from the synthetic bench corpora:
+// those are generated from 1-6 templates, so every clustering definition collapses
+// to ~99% redundancy on them and agrees for the wrong reason. Proving the key
+// clusters REAL multi-page templates the way running per page would is #1950's
+// parity gate, not this file's job.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { generateSiteModel, writeCrawlToStorage } from "@squirrelscan/synthetic-site";
+import {
+  buildCollectedPageSignal,
+  createRunner,
+  fingerprintPage,
+  fingerprintWalkCount,
+  resetFingerprintWalkCount,
+} from "@squirrelscan/rules";
+import type { PageFingerprint, ParsedPage, SiteData } from "@squirrelscan/rules";
+import type { Config } from "@squirrelscan/config";
+import type { PageRecord } from "@squirrelscan/core-contracts";
+
+import { createSiteQuery, extractPageFeatures, templateFingerprintKey } from "../src/index";
+import { parseHtmlForRules } from "../src/adapter";
+import { streamPageRules, type SharedPageSignals } from "../src/streaming";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const CRAWL = "crawl-1";
+
+function fp(over: Partial<PageFingerprint> = {}): PageFingerprint {
+  return {
+    assetHosts: new Set(["cdn.example.com"]),
+    bodyClasses: new Set(["theme-a", "page"]),
+    cssVars: new Set(["--brand"]),
+    stylesheetHrefs: new Set(["/theme.css"]),
+    hasNav: true,
+    hasFooter: true,
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The key itself
+// ---------------------------------------------------------------------------
+
+describe("templateFingerprintKey", () => {
+  test("is 16 hex chars and deterministic across calls", () => {
+    const key = templateFingerprintKey(fp());
+    expect(key).toMatch(/^[0-9a-f]{16}$/);
+    expect(templateFingerprintKey(fp())).toBe(key);
+  });
+
+  test("is independent of set iteration order", () => {
+    // The failure this exists for: `Set` iterates in INSERTION order, which is
+    // document order, so two pages off one template that list their stylesheets
+    // or classes in a different order would land in different clusters. Every
+    // set is built here in the reverse order of the baseline.
+    const forward = fp({
+      assetHosts: new Set(["a.example.com", "b.example.com"]),
+      bodyClasses: new Set(["one", "two", "three"]),
+      cssVars: new Set(["--a", "--b"]),
+      stylesheetHrefs: new Set(["/1.css", "/2.css"]),
+    });
+    const reversed = fp({
+      assetHosts: new Set(["b.example.com", "a.example.com"]),
+      bodyClasses: new Set(["three", "two", "one"]),
+      cssVars: new Set(["--b", "--a"]),
+      stylesheetHrefs: new Set(["/2.css", "/1.css"]),
+    });
+    expect([...forward.bodyClasses]).not.toEqual([...reversed.bodyClasses]); // orders really differ
+    expect(templateFingerprintKey(reversed)).toBe(templateFingerprintKey(forward));
+  });
+
+  test("every marker is part of the key", () => {
+    const base = templateFingerprintKey(fp());
+    const changed = [
+      fp({ assetHosts: new Set(["other.example.com"]) }),
+      fp({ bodyClasses: new Set(["theme-b", "page"]) }),
+      fp({ cssVars: new Set(["--other"]) }),
+      fp({ stylesheetHrefs: new Set(["/other.css"]) }),
+      fp({ hasNav: false }),
+      fp({ hasFooter: false }),
+    ].map(templateFingerprintKey);
+    for (const key of changed) expect(key).not.toBe(base);
+    expect(new Set(changed).size).toBe(changed.length); // and they differ from each other
+  });
+
+  test("markers cannot migrate between fields without changing the key", () => {
+    // A delimiter-joined encoding would let a marker forge a different field
+    // boundary; the JSON-of-arrays encoding is injective for this shape.
+    const asHost = templateFingerprintKey(
+      fp({ assetHosts: new Set(["x"]), bodyClasses: new Set() }),
+    );
+    const asClass = templateFingerprintKey(
+      fp({ assetHosts: new Set(), bodyClasses: new Set(["x"]) }),
+    );
+    expect(asClass).not.toBe(asHost);
+
+    const split = templateFingerprintKey(fp({ bodyClasses: new Set(["a", "b"]) }));
+    const joined = templateFingerprintKey(fp({ bodyClasses: new Set(['a","b']) }));
+    expect(joined).not.toBe(split);
+  });
+
+  test("a page with no document has no key, so it joins no cluster", () => {
+    // `getPageFeatureTemplateClusters` filters `IS NOT NULL AND != ''`, so null
+    // is the value that keeps an unfingerprintable page out of every cluster.
+    expect(templateFingerprintKey(null)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reaching the column
+// ---------------------------------------------------------------------------
+
+const CHROME_A = `<link rel="stylesheet" href="/theme-a.css"><script src="https://cdn.a.test/app.js"></script><style>:root{--brand-a:#111}</style>`;
+const CHROME_B = `<link rel="stylesheet" href="/theme-b.css"><script src="https://cdn.b.test/app.js"></script><style>:root{--brand-b:#222}</style>`;
+
+function html(chrome: string, bodyClass: string, body: string): string {
+  return `<html><head><title>T</title>${chrome}</head><body class="${bodyClass}"><nav>n</nav>${body}<footer>f</footer></body></html>`;
+}
+
+function mkPage(url: string, pageHtml: string): { page: PageRecord; parsed: ParsedPage } {
+  const page = {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 1,
+    status: 200,
+    contentType: "text/html",
+    sizeBytes: pageHtml.length,
+    loadTimeMs: 5,
+    fetchedAt: 1,
+    etag: null,
+    lastModified: null,
+    contentHash: `h:${url}`,
+    html: pageHtml,
+    parsedData: null,
+    headers: { contentType: "text/html" },
+    securityHeaders: {},
+  } as unknown as PageRecord;
+  return { page, parsed: parseHtmlForRules(pageHtml, url) };
+}
+
+describe("extractPageFeatures — template_fp", () => {
+  test("two pages of one template share a key; different chrome does not", () => {
+    // Bodies differ the way real template siblings differ (a product page with a
+    // different number of variants), which is exactly the case an exact DOM
+    // skeleton splits and chrome clustering does not.
+    const a1 = mkPage("https://example.com/p1", html(CHROME_A, "tpl-a", "<p>one</p>"));
+    const a2 = mkPage(
+      "https://example.com/p2",
+      html(CHROME_A, "tpl-a", "<p>one</p><p>two</p><ul><li>x</li><li>y</li></ul>"),
+    );
+    const b1 = mkPage("https://example.com/q1", html(CHROME_B, "tpl-b", "<p>one</p>"));
+
+    const keyA1 = extractPageFeatures(a1.page, a1.parsed).templateFp;
+    const keyA2 = extractPageFeatures(a2.page, a2.parsed).templateFp;
+    const keyB1 = extractPageFeatures(b1.page, b1.parsed).templateFp;
+
+    expect(keyA1).toMatch(/^[0-9a-f]{16}$/);
+    expect(keyA2).toBe(keyA1);
+    expect(keyB1).not.toBe(keyA1);
+  });
+
+  test("re-extracting an unchanged page gives the same key", () => {
+    const first = mkPage("https://example.com/p1", html(CHROME_A, "tpl-a", "<p>one</p>"));
+    const second = mkPage("https://example.com/p1", html(CHROME_A, "tpl-a", "<p>one</p>"));
+    expect(extractPageFeatures(second.page, second.parsed).templateFp).toBe(
+      extractPageFeatures(first.page, first.parsed).templateFp,
+    );
+  });
+
+  test("a supplied fingerprint is used verbatim, and an explicit null clears the key", () => {
+    // The streamed loop supplies one; this is what proves it is USED rather than
+    // silently recomputed, and it is why the option is `PageFingerprint`-shaped
+    // instead of a pre-hashed string.
+    const a = mkPage("https://example.com/p1", html(CHROME_A, "tpl-a", "<p>one</p>"));
+    const b = mkPage("https://example.com/q1", html(CHROME_B, "tpl-b", "<p>one</p>"));
+    const bFingerprint = fingerprintPage(b.parsed, b.page.normalizedUrl);
+
+    expect(extractPageFeatures(a.page, a.parsed, { fingerprint: bFingerprint }).templateFp).toBe(
+      extractPageFeatures(b.page, b.parsed).templateFp,
+    );
+    expect(extractPageFeatures(a.page, a.parsed, { fingerprint: null }).templateFp).toBeNull();
+    // Omitting the option is NOT the same as passing null: it computes.
+    expect(extractPageFeatures(a.page, a.parsed, {}).templateFp).not.toBeNull();
+  });
+
+  test("a page with no document gets a null key rather than a shared one", () => {
+    const bare = {
+      meta: { title: "T", description: null, canonical: null, robots: null },
+      schemas: { types: [], valid: true, errors: [], raw: null },
+      content: { wordCount: 0 },
+    } as unknown as ParsedPage;
+    const { page } = mkPage("https://example.com/x", html(CHROME_A, "tpl-a", "<p>x</p>"));
+    expect(extractPageFeatures(page, bare).templateFp).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GROUP BY
+// ---------------------------------------------------------------------------
+
+describe("templateClusters over the stored key", () => {
+  test("groups the pages of a template and leaves singletons out", async () => {
+    const store = new SQLiteStorage(":memory:");
+    await run(store.init());
+
+    const pages = [
+      mkPage("https://example.com/a1", html(CHROME_A, "tpl-a", "<p>1</p>")),
+      mkPage("https://example.com/a2", html(CHROME_A, "tpl-a", "<p>1</p><p>2</p>")),
+      mkPage("https://example.com/a3", html(CHROME_A, "tpl-a", "<h2>x</h2>")),
+      mkPage("https://example.com/b1", html(CHROME_B, "tpl-b", "<p>1</p>")),
+      mkPage("https://example.com/b2", html(CHROME_B, "tpl-b", "<p>2</p>")),
+      // Its own chrome: one page, so not a cluster.
+      mkPage("https://example.com/solo", html(`<link rel="stylesheet" href="/solo.css">`, "tpl-c", "<p>s</p>")),
+    ];
+    for (const { page, parsed } of pages) {
+      await run(store.upsertPageFeatures(CRAWL, extractPageFeatures(page, parsed)));
+    }
+
+    const clusters = await run(createSiteQuery(store, CRAWL)).then((sq) => sq.templateClusters());
+    expect(clusters.map((c) => c.count)).toEqual([3, 2]);
+    expect(clusters.map((c) => c.urls)).toEqual([
+      ["https://example.com/a1", "https://example.com/a2", "https://example.com/a3"],
+      ["https://example.com/b1", "https://example.com/b2"],
+    ]);
+    // Distinct groups, and the singleton is absent (HAVING count > 1).
+    expect(new Set(clusters.map((c) => c.fp)).size).toBe(2);
+    expect(clusters.flatMap((c) => c.urls)).not.toContain("https://example.com/solo");
+
+    await run(store.close());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// One fingerprint per page, two consumers
+// ---------------------------------------------------------------------------
+
+const CONFIG = { rule_options: {}, rules: { enable: ["*"] } } as unknown as Config;
+const EMPTY_SITE_DATA = {
+  baseUrl: "http://synthetic.test",
+  pages: [],
+  robotsTxt: null,
+  sitemaps: null,
+} as unknown as SiteData;
+
+describe("streamPageRules — the fingerprint is built once and shared", () => {
+  test("the stored key is the reduction of the fingerprint the collector was handed", async () => {
+    // Value agreement between the two consumers. It does NOT prove the walk was
+    // paid once — a recomputed fingerprint of the same DOM is equal and hashes
+    // identically — which is what the walk-budget test below is for.
+    //
+    // The synthetic fixture is fine here and only here: this asserts a per-page
+    // invariant, not a cluster count, so it does not care that the generator's
+    // pages nearly all share one template.
+    const { storage, crawlId } = await writeCrawlToStorage(
+      generateSiteModel({ seed: 11, pageCount: 6 }),
+      ":memory:",
+    );
+
+    const seen: Array<{ url: string; shared: SharedPageSignals; live: PageFingerprint | null }> = [];
+    const streamed = await run(
+      streamPageRules(storage, crawlId, createRunner(CONFIG), EMPTY_SITE_DATA, {
+        batchSize: 4,
+        collectors: [
+          {
+            id: "capture",
+            collect(page, parsed, shared) {
+              seen.push({
+                url: page.normalizedUrl,
+                shared,
+                // Recomputed from the still-live DOM, to compare against.
+                live: fingerprintPage(parsed, page.normalizedUrl),
+              });
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(seen.length).toBe(streamed.extractedCount);
+    expect(seen.length).toBeGreaterThan(0);
+
+    for (const { url, shared, live } of seen) {
+      const stored = await run(storage.getPageFeatures(crawlId, url));
+      expect(stored).not.toBeNull();
+      // (a) the column holds the reduction of the fingerprint the collector saw…
+      expect(stored!.templateFp).toBe(templateFingerprintKey(shared.fingerprint));
+      // (b) …and that fingerprint is what a live walk of the same DOM produces,
+      // so `template-discontinuity` still compares exactly what it always did.
+      expect(shared.fingerprint).toEqual(live);
+      expect(shared.fingerprint).not.toBeNull();
+    }
+
+    await run(storage.close());
+  }, 120_000);
+
+  test("the streamed loop walks each DOM exactly once, whatever the collectors do", async () => {
+    // The residency/timing claim in #1949 is "a hash, not a second DOM walk", and
+    // no assertion on the OUTPUT can check it: walking the same document twice
+    // returns an equal fingerprint and the same key, so a loop that quietly stopped
+    // sharing would keep every other test in this file green. The walk counter is
+    // the only thing that separates them.
+    //
+    // The collector here is production's: `runStreamingRules` registers exactly one
+    // ("site-dom-signals"), and it builds a CollectedPageSignal from the shared
+    // fingerprint. Budget = one walk per scored page. Two failures it catches:
+    // `extractPageFeatures(page, parsed)` dropping the shared argument, and a
+    // collector calling `buildCollectedPageSignal` without threading it — each of
+    // which doubles the count.
+    const { storage, crawlId } = await writeCrawlToStorage(
+      generateSiteModel({ seed: 12, pageCount: 6 }),
+      ":memory:",
+    );
+
+    resetFingerprintWalkCount();
+    const streamed = await run(
+      streamPageRules(storage, crawlId, createRunner(CONFIG), EMPTY_SITE_DATA, {
+        batchSize: 4,
+        collectors: [
+          {
+            id: "site-dom-signals-shape",
+            collect(page, parsed, shared) {
+              buildCollectedPageSignal({
+                url: page.normalizedUrl,
+                finalUrl: page.finalUrl,
+                parsed,
+                fingerprint: shared.fingerprint,
+              });
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(streamed.extractedCount).toBeGreaterThan(0);
+    expect(fingerprintWalkCount()).toBe(streamed.extractedCount);
+
+    await run(storage.close());
+  }, 120_000);
+
+  test("buildCollectedPageSignal takes the supplied fingerprint instead of walking again", () => {
+    // The other half of the sharing: a collector that passes `shared.fingerprint`
+    // must not pay for a second walk. A sentinel that could not have been derived
+    // from this page is the only way to see the difference.
+    const { page, parsed } = mkPage("https://example.com/p1", html(CHROME_A, "tpl-a", "<p>1</p>"));
+    const sentinel = fp({ assetHosts: new Set(["sentinel.invalid"]) });
+
+    const supplied = buildCollectedPageSignal({
+      url: page.normalizedUrl,
+      parsed,
+      fingerprint: sentinel,
+    });
+    expect(supplied.fingerprint).toBe(sentinel);
+
+    // Omitted → computed, as before this change.
+    const computed = buildCollectedPageSignal({ url: page.normalizedUrl, parsed });
+    expect(computed.fingerprint).toEqual(fingerprintPage(parsed, page.normalizedUrl));
+    expect(computed.fingerprint).not.toBe(sentinel);
+
+    // An explicit null is honored too (a page whose DOM is gone).
+    expect(
+      buildCollectedPageSignal({ url: page.normalizedUrl, parsed, fingerprint: null }).fingerprint,
+    ).toBeNull();
+  });
+});

--- a/packages/rules/src/collected-signals.ts
+++ b/packages/rules/src/collected-signals.ts
@@ -69,6 +69,15 @@ export function buildCollectedPageSignal(input: {
   url: string;
   finalUrl?: string;
   parsed: ParsedPage;
+  /**
+   * The page's already-computed chrome fingerprint, when the caller built one.
+   * The streamed loop needs the SAME fingerprint for `page_features`' template
+   * cluster key (#1949), and `fingerprintPage` is five `querySelectorAll` passes
+   * over the live DOM — computing it in both places would put a second DOM walk
+   * per page back into the pipeline #1913 exists to keep flat. Passing
+   * `undefined` (or omitting it) computes it here, as before.
+   */
+  fingerprint?: PageFingerprint | null;
 }): CollectedPageSignal {
   const { url, finalUrl, parsed } = input;
   const doc = parsed.document;
@@ -105,7 +114,7 @@ export function buildCollectedPageSignal(input: {
     externalCssCount: byteSignal.externalCssCount,
     externalJsCount: byteSignal.externalJsCount,
     imageCount: byteSignal.imageCount,
-    fingerprint: fingerprintPage(parsed, url),
+    fingerprint: input.fingerprint !== undefined ? input.fingerprint : fingerprintPage(parsed, url),
     signals: [...detectPageSignals(signalCtx)],
     scriptSrcs: pageScriptSrcs(doc),
     subprocessorMatch: matchSubprocessorLink(doc, url),

--- a/packages/rules/src/index.ts
+++ b/packages/rules/src/index.ts
@@ -25,6 +25,19 @@ export {
   extractSiteChromeSignal,
   type SiteChromeSignal,
 } from "./social/asset-divergence";
+// Per-page chrome fingerprint. `template-discontinuity` consumes it by fuzzy
+// similarity; audit-engine reduces the SAME object to page_features' equality
+// cluster key (#1949) and hands it to `buildCollectedPageSignal`, so one DOM
+// walk per page feeds both.
+export {
+  buildBaseline,
+  fingerprintPage,
+  fingerprintWalkCount,
+  resetFingerprintWalkCount,
+  similarityToBaseline,
+  type PageFingerprint,
+  type SiteBaseline,
+} from "./integrity/fingerprint";
 
 // Domain re-exports
 export * as content from "./content";

--- a/packages/rules/src/integrity/fingerprint.ts
+++ b/packages/rules/src/integrity/fingerprint.ts
@@ -23,6 +23,31 @@ export interface PageFingerprint {
 
 const CSS_VAR_RE = /--[a-z0-9-]+\s*:/gi;
 
+/**
+ * DOM walks performed by `fingerprintPage` in this process.
+ *
+ * A test seam, mirroring `detachCounts` in audit-engine, and it exists because
+ * nothing about the OUTPUT can prove the walk was paid once. Walking the same
+ * document twice returns an equal fingerprint and an identical cluster key, so
+ * every value assertion still passes when a caller quietly stops sharing the one
+ * the streamed loop built (#1949) and puts a second five-`querySelectorAll` pass
+ * per page back into the pipeline #1913 exists to keep flat. Only the count
+ * distinguishes them.
+ *
+ * Counted after the no-document early return, so it is walks, not calls.
+ */
+let fingerprintWalks = 0;
+
+/** Walks since the last reset. See {@link fingerprintPage}. */
+export function fingerprintWalkCount(): number {
+  return fingerprintWalks;
+}
+
+/** Test seam: the count is process-wide, so a test asserting on it starts here. */
+export function resetFingerprintWalkCount(): void {
+  fingerprintWalks = 0;
+}
+
 /** Build a template fingerprint for one parsed page. */
 export function fingerprintPage(
   parsed: ParsedPage,
@@ -30,6 +55,7 @@ export function fingerprintPage(
 ): PageFingerprint | null {
   const doc = parsed.document;
   if (!doc) return null;
+  fingerprintWalks++;
 
   const assetHosts = new Set<string>();
   const stylesheetHrefs = new Set<string>();


### PR DESCRIPTION
`page_features.template_fp` shipped as an indexed column that `extractPageFeatures` set to `null` on every row, with no reader anywhere. This populates it with an equality cluster key, the prerequisite for template fan-out.

Tracks squirrelscan/repo#1949, part of squirrelscan/repo#1026.

## What the key is

`fingerprintPage` (`packages/rules/src/integrity/fingerprint.ts`) already builds a per-page chrome signal: external asset hosts, `<body>` class tokens, CSS custom-property names, stylesheet hrefs, nav/footer presence. `templateFingerprintKey` canonicalises it (every `Set` sorted, because `Set` iterates in insertion order, i.e. document order; JSON-of-arrays so a marker containing a delimiter cannot forge a field boundary) and reduces it through the same FNV-1a lane `findingFingerprint` uses.

Chrome, not an exact DOM skeleton. On real crawls the two definitions disagree completely:

| corpus | pages | chrome clusters | exact-skeleton clusters |
|---|---|---|---|
| gymshark.com | 247 | 13 (94.7% redundant) | 231 (6.5%) |
| openelectricity.org.au | 100 | 12 (88.0%) | 42 (58.0%) |

Real pages of one template share their chrome and differ in their body: different counts of variants, reviews, related items. The synthetic bench corpora are generated from 1-6 templates, so every clustering definition collapses to ~99% redundancy on them and agrees for the wrong reason.

## One DOM walk, not two

`fingerprintPage` is five `querySelectorAll` passes. The streamed loop builds it once per page and hands the same object to both consumers: `extractPageFeatures` reduces it to the stored key, and the registered page-signal collector keeps it whole for `integrity/template-discontinuity`'s fuzzy similarity, which is untouched.

Nothing about the output can prove that, because a second walk of the same DOM returns an equal fingerprint and hashes to the same key. `fingerprintWalkCount()` is the test seam that can, mirroring `detachCounts` in audit-engine. Removing the shared argument from the production call takes the streamed run from 6 walks to 12 and fails the gate.

## Verification

`apps/cli/scripts/template-cluster-census.ts` replays the shipped writer over a finished `project.db` into a scratch `:memory:` store and reads the clusters back through `getPageFeatureTemplateClusters` (`SiteQuery.templateClusters()`), so what agrees is the stored `GROUP BY`, not an in-memory grouping this script computed. It never writes to the crawl it reads, and it mirrors production's scored universe (rate-limited pages excluded, not just WAF challenges).

```
gymshark.com            247 scored, 13 clusters (8 multi-page), 94.7% redundant, GROUP BY agrees
openelectricity.org.au  100 scored, 12 clusters (3 multi-page), 88.0% redundant, GROUP BY agrees
```

Key cost measured there: 0.04 to 0.08 ms/page, against a 1.0 to 5.6 ms/page fingerprint walk that was already being paid.

## Report output

No rule reads `SiteQuery.templateClusters()`. This stores a key and changes no finding.

## Tests

`packages/audit-engine/tests/template-cluster-key-golden.test.ts` (named `*golden*` so the Golden Gates job actually runs it; `fingerprint-parity.test.ts` is not matched by that glob and has never run in CI, public #229). It covers the key's determinism, order-insensitivity, injectivity across fields, the null case, the write reaching the column, `GROUP BY` clustering over the stored value, and the walk budget.

The cluster counts above cannot be asserted from a fixture in this repo, and specifically not from the synthetic sites; proving fan-out parity on real multi-page clusters is squirrelscan/repo#1950.