### PR TITLE
perf(rules): cut the rules phase on script-heavy pages from 274 to 165 ms/page (#1864)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -291,42 +291,42 @@
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 399
+        "line_number": 408
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "daefe0b4345a654580dcad25c7c11ff4c944a8c0",
         "is_verified": false,
-        "line_number": 404
+        "line_number": 413
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "f0778f3e140a61d5bbbed5430773e52af2f5fba4",
         "is_verified": false,
-        "line_number": 409
+        "line_number": 418
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
         "is_verified": false,
-        "line_number": 414
+        "line_number": 423
       },
       {
         "type": "Private Key",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
         "is_verified": false,
-        "line_number": 419
+        "line_number": 428
       },
       {
         "type": "Secret Keyword",
         "filename": "packages/rules/src/security/leaked-secrets.ts",
         "hashed_secret": "4943aa13155461952d25cf9ad001698351bf2734",
         "is_verified": false,
-        "line_number": 1383
+        "line_number": 1397
       }
     ],
     "packages/tech-detect/tests/fingerprints.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-07T19:26:19Z"
+  "generated_at": "2026-09-08T03:02:41Z"
 }

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -720,8 +720,9 @@ literal at all** — `[0-9]{8,10}:[a-zA-Z0-9_-]{35}` has nothing to prove — an
 those 18 are the top of the remaining cost, led by the Telegram bot token at
 2.0 ms per page.
 
-Three soundness bugs were found in the prefilter before it shipped, all of them
-silent false negatives, which in this rule means a deleted security finding:
+Nine soundness bugs were found in the prefilter before it shipped, all of them
+silent false negatives, which in this rule means a deleted security finding. The
+first three came from reading the diff:
 
 - The rolling hash was masked with the TABLE's width rather than the window's,
   so a table wider than 20 bits kept the low bit of the character BEFORE the
@@ -737,14 +738,37 @@ silent false negatives, which in this rule means a deleted security finding:
   U+0130 and U+212A KELVIN SIGN. `postmar<U+212A>_server_token` lowercases to
   `postmark_server_token`, and the index rightly said `postmark` was absent.
 
-The generative soundness test that was supposed to catch the first two could not
-run at all: its own string generator looped forever on `\d`, `\w` and `\s`, so
-three of its hand-written expectations described an implementation that no longer
-existed. **A skipped or hanging test is read as evidence.** Every regression test
-here was mutation-checked by restoring the bug it claims to catch, and two of
-them did not bite until the fixture varied the character immediately before the
-literal — `"` is even and `'` is odd, and a corpus that quotes everything the
-same way is blind to the whole class.
+Three more were escapes read as shorter than they are, each leaving its own tail
+behind as literal text no match contains: `\12` (a backreference to group 12,
+read as `\1` then `2`), `\k<x>`, and `\u{41}`, which is a code point only under
+the `u` flag and otherwise the letter `u` repeated 41 times.
+
+An adversarial review pass found three more of the same kind, all counterexamples
+rather than reproductions from the shipped tables: `.` was in the character class
+the group shortcut accepts as literal, so `/(abcd.efgh)/` proved a wildcard as
+itself; `[]` is an EMPTY class in JavaScript, not a literal bracket, so reading
+past its `]` in `/abcd[]|efgh/` hid the `|` and left one branch where there are
+two; and under the `u` flag the `i` flag folds beyond ASCII, so `/secret/iu`
+matches `ſecret`, which does not contain `secret`. Unicode-mode patterns are now
+declined whole.
+
+The pattern in all nine is the same: **the extractor read the regex as something
+the engine does not.** The defence that works is a counterexample corpus of
+(pattern, subject-it-really-matches) pairs, because that comparison does not
+depend on anyone's reading being right.
+
+The generative soundness test that was supposed to catch several of them could
+not run at all: its own string generator looped forever on `\d`, `\w` and `\s`,
+so three of its hand-written expectations described an implementation that no
+longer existed. Its random number generator also multiplied past 2^53 and lost
+its low bits, so 60 of 60 Redis samples took the same alternative and no Generic
+Secret Assignment sample ever chose `password` — a generator that walks one
+branch cannot notice an extractor that proves one branch. **A skipped, hanging or
+degenerate test is read as evidence.** Every regression test here was
+mutation-checked by restoring the bug it claims to catch, and two of them did not
+bite until the fixture varied the character immediately before the literal — `"`
+is even and `'` is odd, and a corpus that quotes everything the same way is blind
+to the whole class.
 
 ## Still open
 

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -752,10 +752,18 @@ two; and under the `u` flag the `i` flag folds beyond ASCII, so `/secret/iu`
 matches `ſecret`, which does not contain `secret`. Unicode-mode patterns are now
 declined whole.
 
+A second review pass found two more of the same family, both legacy escapes
+whose length is not knowable from the source: `\c` is a control escape only
+before an ASCII letter and otherwise the two characters `\` and `c`, and
+`\k<name>` is a named backreference only when the pattern declares a named
+group. Guessing either length walked the scan into a character class.
+
 The pattern in every one is the same: **the extractor read the regex as something
-the engine does not.** The defence that works is a counterexample corpus of
-(pattern, subject-it-really-matches) pairs, because that comparison does not
-depend on anyone's reading being right.
+the engine does not**, and the specific move that caused half of them was
+searching forward for a delimiter — `}`, `>`, `]` — which lands inside whatever
+structure happens to contain one. The defence that works is a counterexample
+corpus of (pattern, subject-it-really-matches) pairs, because that comparison
+does not depend on anyone's reading being right.
 
 The generative soundness test that was supposed to catch several of them could
 not run at all: its own string generator looped forever on `\d`, `\w` and `\s`,

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -720,9 +720,9 @@ literal at all** — `[0-9]{8,10}:[a-zA-Z0-9_-]{35}` has nothing to prove — an
 those 18 are the top of the remaining cost, led by the Telegram bot token at
 2.0 ms per page.
 
-Nine soundness bugs were found in the prefilter before it shipped, all of them
-silent false negatives, which in this rule means a deleted security finding. The
-first three came from reading the diff:
+Soundness bugs kept turning up in the prefilter before it shipped, all of them
+silent false negatives, which in this rule means a deleted security finding.
+Reading the diff found these three:
 
 - The rolling hash was masked with the TABLE's width rather than the window's,
   so a table wider than 20 bits kept the low bit of the character BEFORE the
@@ -752,7 +752,7 @@ two; and under the `u` flag the `i` flag folds beyond ASCII, so `/secret/iu`
 matches `ſecret`, which does not contain `secret`. Unicode-mode patterns are now
 declined whole.
 
-The pattern in all nine is the same: **the extractor read the regex as something
+The pattern in every one is the same: **the extractor read the regex as something
 the engine does not.** The defence that works is a counterexample corpus of
 (pattern, subject-it-really-matches) pairs, because that comparison does not
 depend on anyone's reading being right.

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -656,6 +656,96 @@ with `apps/cli/scripts/template-cluster-census.ts` and
 `apps/cli/scripts/template-rule-invariance.ts` against a finished `project.db`;
 they need no network and do not write to the crawl they read.
 
+## The rules phase on a script-heavy page
+
+A 500-page cloud audit of drscholls.com failed its 2400 s run budget after the
+memory ceiling had been raised, because the rules phase cost about 2 s per page
+on the container. Every page there is ~1 MB with ~800 KB of inline script, and
+that shape is not what the mixed estate above measures — it dilutes it to a
+tenth. `harness/script-heavy-site.ts` serves N byte-unique copies of one real
+saved page instead ([squirrelscan/repo#1864](https://github.com/squirrelscan/repo/issues/1864)).
+
+Fixture: a real 1.13 MB product page, 59 inline scripts, 791 KB of inline
+JavaScript, 40 internal links woven into each copy, 150 pages. Command
+`squirrel audit --coverage full --max-pages 150 --http --offline --refresh
+--trace` with `SQUIRREL_RULE_PROFILE=1`, a fresh project and a per-run title
+salt so the global content store cannot serve one arm's pages to the other.
+Three interleaved rounds per arm, medians, load average 3.2 to 5.0 throughout.
+
+| | before | after |
+|---|---|---|
+| **whole rules phase** | **274.1 ms/page** | **164.5 ms/page** |
+| `security/leaked-secrets` | 64.5 | 29.3 |
+| `a11y/skip-link` | 38.5 | 2.4 |
+| `perf/js-libraries` | 31.2 | 7.2 |
+| `perf/unminified-js` | 15.6 | 4.1 |
+| `legal/cookie-consent` | 8.2 | 8.0 |
+| `social/share-buttons` | 6.4 | 6.4 |
+| audit wall time | 56 s | 42 s |
+
+The four changed rules go from 149.9 to 43.0 ms/page. The last two rows are the
+control: nothing else in the phase moves, and the run-to-run spread is 265.5 to
+281.6 ms/page before and 164.4 to 173.9 after, so the 110 ms is not noise.
+
+Findings are byte-identical over the same 150 pages, `perf/ttfb` excepted — it
+grades the test server's response time and disagrees with itself between any two
+runs on a loaded box.
+
+Three of the four were ordinary waste. `a11y/skip-link` built `body.innerHTML`
+inside its loop over headings, serialising the whole megabyte once per heading,
+and then searched all of it for a heading that only counts inside the first 2000
+characters. `perf/unminified-js` counted with `String.match` and a `/g` pattern
+five times per script, building an array of every match to read its length.
+`shared/comment-scan` compared single-character STRINGS on its per-character
+path; comparing code points is about thirteen times faster (10.3 ms against
+0.8 ms over one 390 KB bundle).
+
+The fourth is the interesting one. `security/leaked-secrets` runs 70 patterns and
+`perf/js-libraries` about 130 over the same text, and a pass over 1 MB costs the
+same whether it finds anything or not — so the cost is the pass COUNT. One pass
+that records which 4-grams the text contains lets a pattern be skipped when a
+literal every match of it must contain is provably absent. Per page, over the
+58 bodies of text (the serialised document and 57 inline scripts, 1.9 MB in all):
+
+| | ms |
+|---|---|
+| build the 4-gram index over every body | 5.4 |
+| all 70 secret patterns, no prefilter | 42.4 |
+| only the patterns that survive the index | 14.6 |
+| `toLowerCase` every body (now built only on demand) | 3.8 |
+
+48% of secret-pattern invocations are skipped and 99% of the context-keyword
+scans. The residual is mostly irreducible: **18 of the 70 patterns prove no
+literal at all** — `[0-9]{8,10}:[a-zA-Z0-9_-]{35}` has nothing to prove — and
+those 18 are the top of the remaining cost, led by the Telegram bot token at
+2.0 ms per page.
+
+Three soundness bugs were found in the prefilter before it shipped, all of them
+silent false negatives, which in this rule means a deleted security finding:
+
+- The rolling hash was masked with the TABLE's width rather than the window's,
+  so a table wider than 20 bits kept the low bit of the character BEFORE the
+  4-character window. Present needles were denied whenever their predecessor was
+  odd — 8 of 16 on a 40 KB text. The table only reaches that width past about
+  32 KB, which every fixture in the suite sat below.
+- An element that can repeat was expanded as though it occurred at most once,
+  gluing a run together across it: `abcdz{0,3}efgh` proved `abcdefgh` or
+  `abcdzefgh` and denied `abcdzzefgh`, which it matches.
+- The index folds ASCII case, which over-approximates the text but not
+  `text.toLowerCase()`, where the context keywords are looked up. Exactly two
+  characters in Unicode lowercase into ASCII the text does not itself have:
+  U+0130 and U+212A KELVIN SIGN. `postmar<U+212A>_server_token` lowercases to
+  `postmark_server_token`, and the index rightly said `postmark` was absent.
+
+The generative soundness test that was supposed to catch the first two could not
+run at all: its own string generator looped forever on `\d`, `\w` and `\s`, so
+three of its hand-written expectations described an implementation that no longer
+existed. **A skipped or hanging test is read as evidence.** Every regression test
+here was mutation-checked by restoring the bug it claims to catch, and two of
+them did not bite until the fixture varied the character immediately before the
+literal — `"` is even and `'` is odd, and a corpus that quotes everything the
+same way is blind to the whole class.
+
 ## Still open
 
 - Site rules are quadratic in page count (4 s at 400 pages, 99 s at 2,500,
@@ -665,6 +755,14 @@ they need no network and do not write to the crawl they read.
   rather than twice is done (above); dropping the passing rows needs a decision
   about the publish payload first.
 - `--max-pages` above 5,000 is silently clamped: squirrelscan/repo#1909.
+- `legal/cookie-consent` (8.2 ms/page) and `social/share-buttons` (6.4) are now
+  the top of the script-heavy rules phase and were left alone. The first is
+  seven full-document `querySelectorAll` passes with substring attribute
+  selectors, which is a linkedom cost rather than a regex one. The second
+  lowercases the whole page for four `/i` patterns that do not need it — and
+  removing that is NOT a no-op, because `String.toLowerCase` and the `i` flag
+  disagree: `"K".toLowerCase()` is `"k"` while `/k/i` does not match
+  `K`, and the same for `İ` and `i`. It needs a decision, not a patch.
 - The finalize rewrites every carried finding to stamp `provenance`, even when it
   already reads "carried" from an earlier run. A no-op write is most of the write
   traffic on a site that carries the same backlog audit after audit.

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -743,14 +743,17 @@ behind as literal text no match contains: `\12` (a backreference to group 12,
 read as `\1` then `2`), `\k<x>`, and `\u{41}`, which is a code point only under
 the `u` flag and otherwise the letter `u` repeated 41 times.
 
-An adversarial review pass found three more of the same kind, all counterexamples
-rather than reproductions from the shipped tables: `.` was in the character class
+An adversarial review pass found five more of the same kind, all counterexamples
+rather than reproductions from the shipped tables. `.` was in the character class
 the group shortcut accepts as literal, so `/(abcd.efgh)/` proved a wildcard as
-itself; `[]` is an EMPTY class in JavaScript, not a literal bracket, so reading
-past its `]` in `/abcd[]|efgh/` hid the `|` and left one branch where there are
-two; and under the `u` flag the `i` flag folds beyond ASCII, so `/secret/iu`
-matches `ſecret`, which does not contain `secret`. Unicode-mode patterns are now
-declined whole.
+itself. An atom that proves nothing was dropping its quantifier, so
+`/abcd\d{1000}efgh/` handed `1000` to the scanner as four literal characters.
+`[]` is an EMPTY class in JavaScript, not a literal bracket, so reading past its
+`]` in `/abcd[]|efgh/` hid the `|` and left one branch where there are two. The
+`\p{` and `\u{` reads searched forward for a `}` that in legacy mode belongs to
+a character class. And under the `u` flag the `i` flag folds beyond ASCII, so
+`/secret/iu` matches `ſecret`, which does not contain `secret` — Unicode-mode
+patterns are now declined whole.
 
 A second review pass found two more of the same family, both legacy escapes
 whose length is not knowable from the source: `\c` is a control escape only

--- a/benchmarks/harness/script-heavy-site.ts
+++ b/benchmarks/harness/script-heavy-site.ts
@@ -1,0 +1,76 @@
+/**
+ * Uniform script-heavy synthetic site — the fixture for squirrelscan/repo#1864.
+ *
+ * `site.ts` serves a MIXED estate (10% heavy product pages) which is the right
+ * shape for storage and crawl work. It is the wrong shape for rule cost on a
+ * script-heavy site: the case #1864 is about is drscholls.com, where EVERY page
+ * is ~1 MB with ~820 KB of inline script, and the mixed estate dilutes that to a
+ * tenth. This server serves N copies of one real saved page so the per-page rule
+ * cost measured here is the per-page rule cost the container pays.
+ *
+ * Every page is byte-unique (the page id is woven into the title, h1 and
+ * canonical) so the content-hash store cannot dedupe them, and each page links
+ * to 40 siblings so the whole estate is reachable from "/".
+ *
+ * Usage: bun script-heavy-site.ts <base-page.html> <N> [--port P] [--salt S]
+ * Prints the chosen port on stdout, then serves until killed.
+ */
+
+const basePath = process.argv[2];
+if (!basePath) throw new Error("usage: script-heavy-site.ts <base-page.html> <N>");
+const N = Number(process.argv[3] ?? 150);
+const portArgIdx = process.argv.indexOf("--port");
+const wantPort = portArgIdx > -1 ? Number(process.argv[portArgIdx + 1]) : 0;
+const saltIdx = process.argv.indexOf("--salt");
+const SALT = saltIdx > -1 ? String(process.argv[saltIdx + 1]) : "";
+
+const BASE = await Bun.file(basePath).text();
+
+const cache = new Map<number, string>();
+
+function render(i: number): string {
+  const hit = cache.get(i);
+  if (hit) return hit;
+  const links = Array.from({ length: 40 }, (_, k) => {
+    const t = (i * 7 + k * 13) % N;
+    return `<a href="/p/${t}">Product ${t}</a>`;
+  }).join("\n");
+  const html = BASE
+    // byte-unique per page, and the salt makes a whole run cold against the
+    // global content store without touching anyone's cache
+    .replace(/<title>[^<]*<\/title>/, `<title>Page ${i}${SALT ? ` ${SALT}` : ""} Dr Scholls</title>`)
+    .replace("</body>", `<nav id="syn" aria-label="Related">${links}</nav></body>`);
+  // only memoise a working set; N copies of a 1 MB page is not worth holding
+  if (cache.size < 24) cache.set(i, html);
+  return html;
+}
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${Array.from(
+  { length: N },
+  (_, i) => `<url><loc>__ORIGIN__/p/${i}</loc></url>`
+).join("\n")}\n</urlset>`;
+
+const srv = Bun.serve({
+  port: wantPort,
+  fetch(req) {
+    const url = new URL(req.url);
+    const p = url.pathname;
+    if (p === "/robots.txt") {
+      return new Response(`User-agent: *\nAllow: /\nSitemap: ${url.origin}/sitemap.xml\n`, {
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    if (p === "/sitemap.xml") {
+      return new Response(sitemap.replaceAll("__ORIGIN__", url.origin), {
+        headers: { "content-type": "application/xml" },
+      });
+    }
+    const m = p.match(/^\/p\/(\d+)$/);
+    const i = m ? Number(m[1]) % N : 0;
+    return new Response(render(i), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  },
+});
+console.log(srv.port);
+await new Promise(() => {});

--- a/packages/rules/src/a11y/skip-link.ts
+++ b/packages/rules/src/a11y/skip-link.ts
@@ -3,6 +3,10 @@
 
 import type { Rule, RuleContext, RuleResult, CheckResult } from "../types";
 
+// How far into the body a heading still counts as "early" — enough for a nav,
+// not enough for real content.
+const EARLY_HEADING_LIMIT = 2000;
+
 export const skipLinkRule: Rule = {
   meta: {
     id: "a11y/skip-link",
@@ -60,13 +64,23 @@ export const skipLinkRule: Rule = {
     const body = doc.querySelector("body");
     if (body) {
       const headings = body.querySelectorAll("h1, h2");
+      // `body.innerHTML` serialises the whole page, so building it INSIDE the
+      // loop cost one full serialisation per heading — 12 ms on a 1 MB page with
+      // eleven of them (#1864). It does not change between iterations.
+      const html = headings.length > 0 ? body.innerHTML || "" : "";
       for (const h of headings) {
         // Check if heading appears early in the document
-        const html = body.innerHTML || "";
         const hOuterHTML = (h as Element).outerHTML || "";
-        const position = html.indexOf(hOuterHTML);
+        // Only the first 2000 characters can satisfy the test below, so searching
+        // the whole megabyte for a heading that is not there is wasted. A match
+        // starting before 2000 lies entirely inside this prefix, and any match
+        // found only outside it is at or past 2000 either way, so the answer to
+        // `position >= 0 && position < 2000` is unchanged.
+        const position = html
+          .slice(0, EARLY_HEADING_LIMIT + hOuterHTML.length)
+          .indexOf(hOuterHTML);
         // Consider "early" if within first 2000 chars (allows for nav, but not much content)
-        if (position >= 0 && position < 2000) {
+        if (position >= 0 && position < EARLY_HEADING_LIMIT) {
           bypassMethods.push("early heading");
           break;
         }

--- a/packages/rules/src/collected-signals.ts
+++ b/packages/rules/src/collected-signals.ts
@@ -19,6 +19,7 @@ import type { LeakedSecret } from "./security/leaked-secrets";
 import type { PageFingerprint } from "./integrity/fingerprint";
 import type { ParsedPage } from "./types";
 
+import { logger, profileRules } from "./logger";
 import { detectPageSignals } from "./integrity/signals";
 import { extractPageByteSignal } from "./performance/total-byte-weight";
 import { fingerprintPage } from "./integrity/fingerprint";
@@ -104,19 +105,51 @@ export function buildCollectedPageSignal(input: {
   // silent golden-only divergence between the collector and the legacy site pass.
   const signalCtx: PageSignalContext = { parsed, page: { url, finalUrl } };
 
-  const byteSignal = extractPageByteSignal(doc);
+  // The collector moved six site rules' per-page DOM work OUT of the site pass,
+  // which also moved it out of the per-rule profile: leaked-secrets' ~100 ms/page
+  // scan stopped showing up anywhere (#1864). Time each extractor under
+  // SQUIRREL_RULE_PROFILE and report it against the rule that owns it, so the
+  // profile still accounts for the page's whole rules-phase cost.
+  const timed = profileRules
+    ? <T>(ruleId: string, fn: () => T): T => {
+        const started = performance.now();
+        const out = fn();
+        const elapsedMs = performance.now() - started;
+        logger.debug("rule", {
+          ruleId,
+          scope: "collect",
+          pageUrl: url,
+          checks: 0,
+          passed: 0,
+          failed: 0,
+          warned: 0,
+          durationMs: Math.round(elapsedMs),
+          durationUs: Math.round(elapsedMs * 1000),
+        });
+        return out;
+      }
+    : <T>(_ruleId: string, fn: () => T): T => fn();
+
+  const byteSignal = timed("perf/total-byte-weight", () => extractPageByteSignal(doc));
 
   return {
     url,
-    secrets: scanPageForSecrets(doc, url),
+    secrets: timed("security/leaked-secrets", () => scanPageForSecrets(doc, url)),
     inlineCssLen: byteSignal.inlineCssLen,
     inlineJsLen: byteSignal.inlineJsLen,
     externalCssCount: byteSignal.externalCssCount,
     externalJsCount: byteSignal.externalJsCount,
     imageCount: byteSignal.imageCount,
-    fingerprint: input.fingerprint !== undefined ? input.fingerprint : fingerprintPage(parsed, url),
-    signals: [...detectPageSignals(signalCtx)],
-    scriptSrcs: pageScriptSrcs(doc),
-    subprocessorMatch: matchSubprocessorLink(doc, url),
+    // Only the branch that actually computes is timed: a caller that hands in a
+    // fingerprint (#1949) does no work here and should not be charged for one.
+    fingerprint:
+      input.fingerprint !== undefined
+        ? input.fingerprint
+        : timed("integrity/template-discontinuity", () => fingerprintPage(parsed, url)),
+    signals: timed("integrity/orphan-page", () => [...detectPageSignals(signalCtx)]),
+    scriptSrcs: timed("adblock/blocked-links", () => pageScriptSrcs(doc)),
+    subprocessorMatch: timed("legal/subprocessor-disclosure", () =>
+      matchSubprocessorLink(doc, url)
+    ),
   };
 }

--- a/packages/rules/src/logger.ts
+++ b/packages/rules/src/logger.ts
@@ -3,7 +3,9 @@
 
 // Set SQUIRREL_RULE_PROFILE=1 to emit per-rule timings to stderr (used when
 // profiling the rules phase, e.g. via apps/cli/scripts/bench-audit.ts).
-const profileRules = !!process.env.SQUIRREL_RULE_PROFILE;
+/** True when SQUIRREL_RULE_PROFILE=1. Exported so a hot path can skip building
+ *  timings at all rather than paying for them and throwing them away. */
+export const profileRules = !!process.env.SQUIRREL_RULE_PROFILE;
 
 export const logger = {
   debug: (category: string, data?: Record<string, unknown>) => {

--- a/packages/rules/src/performance/js-libraries.ts
+++ b/packages/rules/src/performance/js-libraries.ts
@@ -306,10 +306,10 @@ function compareVersions(v1: string, v2: string): number {
 }
 
 // Every library's inline signatures run against every inline script AND the whole
-// HTML, so on a page with 800 KB of inline script this rule was making ~250 passes
-// over a megabyte to find nothing (#1864). The literals each signature must
-// contain are derived once here; a per-content gram index then skips the ones that
-// cannot match.
+// HTML: 62 signatures against the 58 bodies of text on one real 1.1 MB page is
+// 3,596 passes to find nothing (#1864). The literals each signature must contain
+// are derived once here; a per-content gram index then skips the ones that cannot
+// match.
 const PREFILTERED_LIBRARIES = libraryPatterns.map((lib) => ({
   ...lib,
   inlinePatterns: lib.inlinePatterns.map((pattern) => ({

--- a/packages/rules/src/performance/js-libraries.ts
+++ b/packages/rules/src/performance/js-libraries.ts
@@ -3,6 +3,14 @@
 
 import type { CheckResult, Rule, RuleContext, RuleResult } from "../types";
 
+import {
+  buildGramIndex,
+  mandatoryLiterals,
+  mayMatch,
+  type GramIndex,
+  type MandatoryLiterals,
+} from "../shared/literal-prefilter";
+
 // Known library detection patterns
 interface LibraryPattern {
   name: string;
@@ -297,6 +305,25 @@ function compareVersions(v1: string, v2: string): number {
   return 0;
 }
 
+// Every library's inline signatures run against every inline script AND the whole
+// HTML, so on a page with 800 KB of inline script this rule was making ~250 passes
+// over a megabyte to find nothing (#1864). The literals each signature must
+// contain are derived once here; a per-content gram index then skips the ones that
+// cannot match.
+const PREFILTERED_LIBRARIES = libraryPatterns.map((lib) => ({
+  ...lib,
+  inlinePatterns: lib.inlinePatterns.map((pattern) => ({
+    pattern,
+    literals: mandatoryLiterals(pattern) as MandatoryLiterals,
+  })),
+}));
+
+/** Exported for tests/literal-prefilter.test.ts, which proves the derived
+ *  literals really are mandatory for every one of these. */
+export const LIBRARY_INLINE_PATTERNS: readonly RegExp[] = libraryPatterns.flatMap(
+  (lib) => lib.inlinePatterns
+);
+
 export const jsLibrariesRule: Rule = {
   meta: {
     id: "perf/js-libraries",
@@ -358,8 +385,13 @@ export const jsLibrariesRule: Rule = {
     // Check HTML for runtime markers (framework signatures in DOM)
     const htmlContent = html;
 
+    // One pass per distinct body of text, reused by every library below. Short
+    // scripts index to null and are simply scanned, as before.
+    const inlineIndexes: Array<GramIndex | null> = inlineScripts.map((c) => buildGramIndex(c));
+    const htmlIndex = buildGramIndex(htmlContent);
+
     // Check for libraries
-    for (const lib of libraryPatterns) {
+    for (const lib of PREFILTERED_LIBRARIES) {
       let detected = false;
       let detectedVersion: string | undefined;
       let detectionSource: string | undefined;
@@ -386,8 +418,11 @@ export const jsLibrariesRule: Rule = {
 
       // Check inline/bundled scripts for library signatures
       if (!detected && lib.inlinePatterns.length > 0) {
-        for (const content of inlineScripts) {
-          for (const pattern of lib.inlinePatterns) {
+        for (let si = 0; si < inlineScripts.length; si++) {
+          const content = inlineScripts[si]!;
+          const contentIndex = inlineIndexes[si] ?? null;
+          for (const { pattern, literals } of lib.inlinePatterns) {
+            if (!mayMatch(contentIndex, literals)) continue;
             if (pattern.test(content)) {
               detected = true;
               detectionSource = "inline code";
@@ -408,7 +443,8 @@ export const jsLibrariesRule: Rule = {
 
       // Check HTML for framework signatures (e.g., ng-version attribute)
       if (!detected && lib.inlinePatterns.length > 0) {
-        for (const pattern of lib.inlinePatterns) {
+        for (const { pattern, literals } of lib.inlinePatterns) {
+          if (!mayMatch(htmlIndex, literals)) continue;
           if (pattern.test(htmlContent)) {
             detected = true;
             detectionSource = "HTML markers";

--- a/packages/rules/src/performance/unminified-js.ts
+++ b/packages/rules/src/performance/unminified-js.ts
@@ -16,11 +16,24 @@ export const optionsSchema = z.object({
 // Thresholds for detecting unminified JavaScript
 const NEWLINE_RATIO_THRESHOLD = 0.005; // 0.5% newlines = likely unminified
 const COMMENT_COUNT_THRESHOLD = 3;
+const LONG_FUNCTION_THRESHOLD = 5;
 const LONG_VAR_THRESHOLD = 0.002; // Long vars per character
 
 // Matches ONE leading `/*! ... */` or `//! ...` banner (plus surrounding whitespace), anchored to string start.
 // `.` never crosses a line terminator, so CRLF needs the explicit `\r?` before `\n`.
 const LEADING_BANNER_RE = /^\s*(?:\/\*!(?:[^*]|\*(?!\/))*\*\/|\/\/!.*(?:\r?\n|$))/;
+
+const LONG_VAR_RE = /(?:var|let|const)\s+[a-zA-Z_$][a-zA-Z0-9_$]{5,}/g;
+const LONG_FUNCTION_RE = /function\s+[a-zA-Z_$][a-zA-Z0-9_$]{10,}/g;
+const INDENT_RE = /\n[ \t]{2,}/g;
+const WHITESPACE_RUN_RE = /\s{2,}/g;
+
+/** Occurrences of a single character, without materialising a match array. */
+function countChar(text: string, ch: string): number {
+  let n = 0;
+  for (let i = text.indexOf(ch); i !== -1; i = text.indexOf(ch, i + 1)) n += 1;
+  return n;
+}
 
 // #698: strips bundler-preserved license banners (leading only, never mid-file) before the minification heuristic runs.
 function stripLeadingLicenseBanners(js: string): string {
@@ -54,8 +67,11 @@ function analyzeJs(rawJs: string): {
   const issues: string[] = [];
   let potentialSavings = 0;
 
-  // Count newlines
-  const newlines = (js.match(/\n/g) || []).length;
+  // Every counter below used to run `String.match` with a /g pattern, which
+  // builds an array of every match before throwing it away — on a 400 KB bundle
+  // that is tens of thousands of throwaway strings per counter (#1864). The
+  // counts and totals are identical; only the arrays are gone.
+  const newlines = countChar(js, "\n");
   const newlineRatio = newlines / js.length;
 
   if (newlineRatio > NEWLINE_RATIO_THRESHOLD) {
@@ -74,34 +90,48 @@ function analyzeJs(rawJs: string): {
   }
 
   // Check for readable variable names (minified typically has single-char vars)
-  const longVarDeclarations = js.match(/(?:var|let|const)\s+[a-zA-Z_$][a-zA-Z0-9_$]{5,}/g) || [];
-  const longVarRatio = longVarDeclarations.length / js.length;
+  let longVarCount = 0;
+  let longVarSavings = 0;
+  LONG_VAR_RE.lastIndex = 0;
+  for (let m = LONG_VAR_RE.exec(js); m !== null; m = LONG_VAR_RE.exec(js)) {
+    longVarCount += 1;
+    const varName = m[0].split(/\s+/)[1]!;
+    longVarSavings += Math.max(0, varName.length - 2);
+  }
+  const longVarRatio = longVarCount / js.length;
 
   if (longVarRatio > LONG_VAR_THRESHOLD) {
     issues.push("long variable names");
     // Estimate savings: assume minified names are 1-2 chars
-    potentialSavings += longVarDeclarations.reduce((sum, v) => {
-      const varName = v.split(/\s+/)[1];
-      return sum + Math.max(0, varName.length - 2);
-    }, 0);
+    potentialSavings += longVarSavings;
   }
 
-  // Check for function declarations with long names
-  const longFunctions = js.match(/function\s+[a-zA-Z_$][a-zA-Z0-9_$]{10,}/g) || [];
-  if (longFunctions.length > 5) {
+  // Check for function declarations with long names. Only "more than five"
+  // matters, so stop counting at six.
+  let longFunctions = 0;
+  LONG_FUNCTION_RE.lastIndex = 0;
+  while (longFunctions <= LONG_FUNCTION_THRESHOLD && LONG_FUNCTION_RE.exec(js) !== null) {
+    longFunctions += 1;
+  }
+  if (longFunctions > LONG_FUNCTION_THRESHOLD) {
     issues.push("long function names");
   }
 
   // Check for consistent indentation (sign of unminified code)
-  const indentedLines = (js.match(/\n[ \t]{2,}/g) || []).length;
+  let indentedLines = 0;
+  INDENT_RE.lastIndex = 0;
+  while (INDENT_RE.exec(js) !== null) indentedLines += 1;
   if (indentedLines > js.length / 200) {
     issues.push("formatted code");
     potentialSavings += indentedLines * 2; // Average 2 spaces per indent
   }
 
   // Check for excessive whitespace
-  const whitespaceMatches = js.match(/\s{2,}/g) || [];
-  const excessiveWhitespace = whitespaceMatches.reduce((sum, ws) => sum + ws.length - 1, 0);
+  let excessiveWhitespace = 0;
+  WHITESPACE_RUN_RE.lastIndex = 0;
+  for (let m = WHITESPACE_RUN_RE.exec(js); m !== null; m = WHITESPACE_RUN_RE.exec(js)) {
+    excessiveWhitespace += m[0].length - 1;
+  }
   if (excessiveWhitespace > js.length * 0.05) {
     issues.push("excessive whitespace");
     potentialSavings += excessiveWhitespace;

--- a/packages/rules/src/runner.ts
+++ b/packages/rules/src/runner.ts
@@ -228,6 +228,7 @@ export class RuleRunner {
       const passed = ruleChecks.filter((c) => c.status === "pass").length;
       const failed = ruleChecks.filter((c) => c.status === "fail").length;
       const warned = ruleChecks.filter((c) => c.status === "warn").length;
+      const elapsedMs = performance.now() - ruleStart;
       logger.debug("rule", {
         ruleId: rule.meta.id,
         ...(scopeForLog ? { scope: scopeForLog } : { pageUrl: ctx.page.url }),
@@ -235,7 +236,12 @@ export class RuleRunner {
         passed,
         failed,
         warned,
-        durationMs: Math.round(performance.now() - ruleStart),
+        durationMs: Math.round(elapsedMs),
+        // Whole-ms rounding above sums to nonsense across hundreds of pages
+        // (a sub-ms rule sums to zero, a 1.4 ms rule sums 40% high), so the
+        // profiler also emits unrounded microseconds. Keep both: `durationMs`
+        // is what the older bench scripts read.
+        durationUs: Math.round(elapsedMs * 1000),
       });
       return { meta: rule.meta, checks: ruleChecks };
     };

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -7,6 +7,13 @@ import {
   SECRET_KEY_LOOKBEHIND_SIZE,
 } from "@squirrelscan/utils/constants";
 
+import {
+  buildGramIndex,
+  mayContain,
+  mayMatch,
+  withPrefilter,
+} from "../shared/literal-prefilter";
+
 // Secret detection patterns with service names
 // Sources: secrets-patterns-db, secret-regex-list, gitleaks patterns
 
@@ -60,7 +67,9 @@ type ContextPattern = {
 // secret key and the three generic assignments — carry `keyAnchored` instead,
 // a much narrower check: the key they matched part-way through must not be a
 // digest key. `cache-api-key` is a cache key however it ends.
-const FAST_PATTERNS: FastPattern[] = [
+// Exported for tests/literal-prefilter.test.ts, which proves that the mandatory
+// literals derived from every one of these really are mandatory.
+export const FAST_PATTERNS: FastPattern[] = [
   // AI/ML Services
   {
     name: "OpenAI API Key",
@@ -500,7 +509,8 @@ const FAST_PATTERNS: FastPattern[] = [
 // Context patterns - generic patterns that need keyword presence check first
 // These previously used (?=.*keyword) lookaheads which caused O(n²) backtracking
 // Now we check for keyword via fast includes() before running the regex
-const CONTEXT_PATTERNS: ContextPattern[] = [
+// Exported alongside FAST_PATTERNS for the prefilter soundness test.
+export const CONTEXT_PATTERNS: ContextPattern[] = [
   // AI/ML Services (need context)
   {
     name: "Cohere API Key",
@@ -1372,6 +1382,10 @@ export function createSeenValues(contentLength: number): SeenValues {
   return { has: (value) => values.has(value), add, overlaps };
 }
 
+// The mandatory literals are derived from each pattern's SOURCE, so they are
+// computed once at module load rather than per page.
+const PREFILTERED_FAST_PATTERNS = withPrefilter(FAST_PATTERNS);
+
 export function scanContent(
   content: string,
   location: "html" | "inline-script" | "external-script",
@@ -1384,6 +1398,12 @@ export function scanContent(
   // AIza key the public-by-design tier reported — is a duplicate, not a new
   // finding. Specific patterns run first, so first classification wins.
   const seenValues = createSeenValues(content.length);
+
+  // One pass over the content that lets both passes below skip every pattern
+  // whose mandatory literals it does not contain (#1864). Null on short content,
+  // where the index would cost more than the scans it saves, and then nothing is
+  // skipped and behaviour is exactly as it was.
+  const gramIndex = buildGramIndex(content);
 
   // Helper to process regex matches on given text
   const processMatches = (
@@ -1429,13 +1449,19 @@ export function scanContent(
   };
 
   // Pass 1: Run all fast patterns (distinctive prefixes, O(n) safe)
+  //
+  // A pass over the content costs the same whether it finds anything or not, and
+  // on a 1 MB script-heavy page 64 of these 70 patterns cannot match at all. The
+  // gram index answers that for the price of one pass instead of seventy.
   for (const {
     name,
     pattern,
     confidence,
     publicByDesign,
     keyAnchored,
-  } of FAST_PATTERNS) {
+    literals,
+  } of PREFILTERED_FAST_PATTERNS) {
+    if (!mayMatch(gramIndex, literals)) continue;
     processMatches(
       content,
       name,
@@ -1449,8 +1475,14 @@ export function scanContent(
   // Pass 2: Run context patterns only on windows around keyword occurrences
   // This avoids scanning the entire content with generic patterns like /[a-f0-9]{32}/
   // Additional filtering: require assignment context and filter code identifiers
-  const contentLower = content.toLowerCase();
+  //
+  // The lowercase copy exists only to locate the keywords, so it is built the
+  // first time a keyword survives the index: on a page where none does, the pass
+  // costs nothing and the megabyte-sized allocation never happens.
+  let contentLower: string | null = null;
   for (const { name, keyword, pattern, confidence } of CONTEXT_PATTERNS) {
+    if (gramIndex && !mayContain(gramIndex, keyword)) continue;
+    contentLower ??= content.toLowerCase();
     // Extract small windows around each keyword occurrence
     const windows = extractKeywordWindows(content, contentLower, keyword);
     if (windows.length === 0) continue;

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -1451,8 +1451,10 @@ export function scanContent(
   // Pass 1: Run all fast patterns (distinctive prefixes, O(n) safe)
   //
   // A pass over the content costs the same whether it finds anything or not, and
-  // on a 1 MB script-heavy page 64 of these 70 patterns cannot match at all. The
-  // gram index answers that for the price of one pass instead of seventy.
+  // on a 1 MB script-heavy page 34 of these 70 cannot match the body being
+  // scanned. The gram index answers that for the price of one pass instead of
+  // seventy. 18 of the 70 prove no literal at all — `[0-9]{8,10}:[a-zA-Z0-9_-]{35}`
+  // has nothing to prove — and those always run.
   for (const {
     name,
     pattern,

--- a/packages/rules/src/security/leaked-secrets.ts
+++ b/packages/rules/src/security/leaked-secrets.ts
@@ -1479,9 +1479,16 @@ export function scanContent(
   // The lowercase copy exists only to locate the keywords, so it is built the
   // first time a keyword survives the index: on a page where none does, the pass
   // costs nothing and the megabyte-sized allocation never happens.
+  //
+  // The index folds ASCII case, which over-approximates `content` but NOT
+  // `content.toLowerCase()` — the keyword is looked for in the latter. Two
+  // characters lowercase into ASCII the content does not itself contain, and on
+  // a page carrying either of them the keyword tier runs unfiltered rather than
+  // risk skipping a keyword the lowercased copy really has.
   let contentLower: string | null = null;
+  const keywordFilter = gramIndex && !gramIndex.lowercaseAddsAscii ? gramIndex : null;
   for (const { name, keyword, pattern, confidence } of CONTEXT_PATTERNS) {
-    if (gramIndex && !mayContain(gramIndex, keyword)) continue;
+    if (keywordFilter && !mayContain(keywordFilter, keyword)) continue;
     contentLower ??= content.toLowerCase();
     // Extract small windows around each keyword occurrence
     const windows = extractKeywordWindows(content, contentLower, keyword);

--- a/packages/rules/src/shared/comment-scan.ts
+++ b/packages/rules/src/shared/comment-scan.ts
@@ -34,14 +34,44 @@ const REGEX_KEYWORDS = new Set([
   "yield",
 ]);
 
-function isIdentPart(ch: string): boolean {
+// Character CLASSIFICATION is on the per-character path of a scan that runs over
+// every inline script on every page, and comparing single-character strings
+// (`ch >= "a" && ch <= "z"`) is about thirteen times slower than comparing the
+// code point: 10.3 ms against 0.8 ms over one 390 KB bundle (#1864). The string
+// forms are kept as wrappers for the handful of callers that already hold a
+// character rather than a code.
+const CH_TAB = 9;
+const CH_LF = 10;
+const CH_CR = 13;
+const CH_DOLLAR = 36;
+const CH_QUOTE = 34;
+const CH_APOS = 39;
+const CH_STAR = 42;
+const CH_SLASH = 47;
+const CH_COLON = 58;
+const CH_LPAREN = 40;
+const CH_RPAREN = 41;
+const CH_BACKSLASH = 92;
+const CH_BACKTICK = 96;
+const CH_LBRACKET = 91;
+const CH_RBRACKET = 93;
+const CH_LBRACE = 123;
+const CH_RBRACE = 125;
+const CH_LS = 0x2028;
+const CH_PS = 0x2029;
+
+function isIdentCode(code: number): boolean {
   return (
-    (ch >= "a" && ch <= "z") ||
-    (ch >= "A" && ch <= "Z") ||
-    (ch >= "0" && ch <= "9") ||
-    ch === "_" ||
-    ch === "$"
+    (code >= 97 && code <= 122) || // a-z
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 48 && code <= 57) || // 0-9
+    code === 95 || // _
+    code === 36 // $
   );
+}
+
+function isIdentPart(ch: string): boolean {
+  return isIdentCode(ch.charCodeAt(0));
 }
 
 // Non-ASCII ECMAScript WhiteSpace and LineTerminator code points: NBSP, OGHAM
@@ -54,11 +84,11 @@ const NON_ASCII_SPACES = new Set([
   0x200a, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000, 0xfeff,
 ]);
 
-function isWhitespace(ch: string): boolean {
-  if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "\f" || ch === "\v") {
+function isWhitespaceCode(code: number): boolean {
+  // space, tab, LF, CR, form feed, vertical tab
+  if (code === 32 || code === 9 || code === 10 || code === 13 || code === 12 || code === 11) {
     return true;
   }
-  const code = ch.charCodeAt(0);
   return code > 0x7f && NON_ASCII_SPACES.has(code);
 }
 
@@ -181,20 +211,20 @@ function regexCanStartAfter(
 }
 
 /** Index just past the closing quote, or at the line terminator that ended it. */
-function skipQuoted(src: string, start: number, quote: string): number {
+function skipQuoted(src: string, start: number, quote: number): number {
   let i = start + 1;
   while (i < src.length) {
-    const ch = src[i] as string;
-    if (ch === "\\") {
+    const code = src.charCodeAt(i);
+    if (code === CH_BACKSLASH) {
       // A backslash before CRLF is a single line continuation. Stepping over
       // only two characters would land on the `\n` and end the string early.
-      i += src[i + 1] === "\r" && src[i + 2] === "\n" ? 3 : 2;
+      i += src.charCodeAt(i + 1) === CH_CR && src.charCodeAt(i + 2) === CH_LF ? 3 : 2;
       continue;
     }
-    if (ch === quote) return i + 1;
+    if (code === quote) return i + 1;
     // An unterminated string must not swallow the rest of the file, and an
     // unescaped line terminator ends a quoted string anyway.
-    if (ch === "\n" || ch === "\r" || ch === "\u2028" || ch === "\u2029") return i;
+    if (code === CH_LF || code === CH_CR || code === CH_LS || code === CH_PS) return i;
     i++;
   }
   return src.length;
@@ -205,23 +235,23 @@ function skipRegex(src: string, start: number): number {
   let i = start + 1;
   let inClass = false;
   while (i < src.length) {
-    const ch = src[i] as string;
-    if (ch === "\\") {
+    const code = src.charCodeAt(i);
+    if (code === CH_BACKSLASH) {
       i += 2;
       continue;
     }
-    if (ch === "\n") return -1; // regex literals cannot span lines
+    if (code === CH_LF) return -1; // regex literals cannot span lines
     if (inClass) {
-      if (ch === "]") inClass = false;
-    } else if (ch === "[") {
+      if (code === CH_RBRACKET) inClass = false;
+    } else if (code === CH_LBRACKET) {
       inClass = true;
-    } else if (ch === "/") {
+    } else if (code === CH_SLASH) {
       // A regex whose closing delimiter is immediately followed by `/` or `*`
       // would be a regex being divided or multiplied, which is never real code.
       // `i++ / n // real` is division followed by a comment, so refusing here
       // keeps the comment countable instead of swallowing it as a regex body.
-      const after = src[i + 1];
-      if (after === "/" || after === "*") return -1;
+      const after = src.charCodeAt(i + 1);
+      if (after === CH_SLASH || after === CH_STAR) return -1;
       return i + 1;
     }
     i++;
@@ -264,14 +294,14 @@ export function scanJsComments(src: string): CommentScan {
   let i = 0;
 
   while (i < src.length) {
-    const ch = src[i] as string;
+    const code = src.charCodeAt(i);
 
     if (mode === "template") {
-      if (ch === "\\") {
+      if (code === CH_BACKSLASH) {
         i += 2;
         continue;
       }
-      if (ch === "`") {
+      if (code === CH_BACKTICK) {
         const frame = frames.pop();
         mode = frame?.mode ?? "code";
         braceDepth = frame?.braceDepth ?? 0;
@@ -279,7 +309,7 @@ export function scanJsComments(src: string): CommentScan {
         i++;
         continue;
       }
-      if (ch === "$" && src[i + 1] === "{") {
+      if (code === CH_DOLLAR && src.charCodeAt(i + 1) === CH_LBRACE) {
         frames.push({ mode: "template", braceDepth });
         mode = "code";
         braceDepth = 0;
@@ -291,16 +321,16 @@ export function scanJsComments(src: string): CommentScan {
       continue;
     }
 
-    if (ch === "/") {
-      const next = src[i + 1];
-      if (next === "/") {
+    if (code === CH_SLASH) {
+      const next = src.charCodeAt(i + 1);
+      if (next === CH_SLASH) {
         // Backstop for a URL that reached code context anyway, e.g. inside a
         // regex this scanner read as division. A real comment never abuts the
         // colon of a URL scheme, and a URL always has a host right after the
         // slashes, so `http:// text` stays a comment on a label named `http`.
         if (
           i > 0 &&
-          src[i - 1] === ":" &&
+          src.charCodeAt(i - 1) === CH_COLON &&
           isUrlHostStart(src[i + 2]) &&
           endsUrlScheme(src, i - 1)
         ) {
@@ -309,13 +339,13 @@ export function scanJsComments(src: string): CommentScan {
           continue;
         }
         let end = i + 2;
-        while (end < src.length && src[end] !== "\n") end++;
+        while (end < src.length && src.charCodeAt(end) !== CH_LF) end++;
         scan.lineComments++;
         scan.commentBytes += end - i;
         i = end;
         continue;
       }
-      if (next === "*") {
+      if (next === CH_STAR) {
         const close = src.indexOf("*/", i + 2);
         if (close === -1) {
           // Unterminated: the old regex did not match it either, so it is not
@@ -342,21 +372,21 @@ export function scanJsComments(src: string): CommentScan {
       continue;
     }
 
-    if (ch === '"' || ch === "'") {
-      const end = skipQuoted(src, i, ch);
+    if (code === CH_QUOTE || code === CH_APOS) {
+      const end = skipQuoted(src, i, code);
       lastCode = end - 1;
       i = end;
       continue;
     }
 
-    if (ch === "`") {
+    if (code === CH_BACKTICK) {
       frames.push({ mode: "code", braceDepth });
       mode = "template";
       i++;
       continue;
     }
 
-    if (ch === "(") {
+    if (code === CH_LPAREN) {
       const head = opensControlFlowHead(src, lastCode, ident);
       if (parens.length < PAREN_STACK_LIMIT) parens.push(head);
       else parenOverflow++;
@@ -365,7 +395,7 @@ export function scanJsComments(src: string): CommentScan {
       continue;
     }
 
-    if (ch === ")") {
+    if (code === CH_RPAREN) {
       if (parenOverflow > 0) {
         parenOverflow--;
       } else if (parens.pop() === true) {
@@ -376,14 +406,14 @@ export function scanJsComments(src: string): CommentScan {
       continue;
     }
 
-    if (ch === "{") {
+    if (code === CH_LBRACE) {
       braceDepth++;
       lastCode = i;
       i++;
       continue;
     }
 
-    if (ch === "}") {
+    if (code === CH_RBRACE) {
       const frame = frames[frames.length - 1];
       if (braceDepth === 0 && frame?.mode === "template") {
         frames.pop();
@@ -398,7 +428,7 @@ export function scanJsComments(src: string): CommentScan {
       continue;
     }
 
-    if (isIdentPart(ch)) {
+    if (isIdentCode(code)) {
       // `ident.end !== i` means this character opens a new identifier token
       // rather than continuing the one already being consumed.
       if (ident.end !== i) {
@@ -416,7 +446,7 @@ export function scanJsComments(src: string): CommentScan {
       }
       lastCode = i;
       ident.end = i + 1;
-    } else if (!isWhitespace(ch)) {
+    } else if (!isWhitespaceCode(code)) {
       lastCode = i;
     }
     i++;
@@ -434,14 +464,14 @@ export function scanCssComments(src: string): CommentScan {
   let i = 0;
 
   while (i < src.length) {
-    const ch = src[i] as string;
+    const code = src.charCodeAt(i);
 
-    if (ch === '"' || ch === "'") {
-      i = skipQuoted(src, i, ch);
+    if (code === CH_QUOTE || code === CH_APOS) {
+      i = skipQuoted(src, i, code);
       continue;
     }
 
-    if (ch === "/" && src[i + 1] === "*") {
+    if (code === CH_SLASH && src.charCodeAt(i + 1) === CH_STAR) {
       const close = src.indexOf("*/", i + 2);
       if (close === -1) break;
       scan.blockComments++;

--- a/packages/rules/src/shared/literal-prefilter.ts
+++ b/packages/rules/src/shared/literal-prefilter.ts
@@ -221,12 +221,11 @@ function readEscape(src: string, i: number): { char: string | null; end: number 
   if (n === "u") {
     // `\u{...}` is a code point only under the `u` flag; without it the same
     // source is the letter `u` repeated. The two readings share no characters,
-    // so neither is claimed: skip past the brace and end the run. (The four-hex
-    // form below is a code point either way.)
-    if (src[i + 2] === "{") {
-      const close = src.indexOf("}", i + 3);
-      return { char: null, end: close === -1 ? i + 2 : close + 1 };
-    }
+    // so neither is claimed. Consume only `\u` and let the main loop meet the
+    // brace: SEARCHING for the closing `}` is what lands inside somebody else's
+    // structure, since in legacy mode `\u{[abcd}efgh]` has its `}` inside a
+    // character class and skipping to it leaves `efgh]` behind as literal text.
+    if (src[i + 2] === "{") return { char: null, end: i + 2 };
     const hex = src.slice(i + 2, i + 6);
     if (!/^[0-9a-fA-F]{4}$/.test(hex)) return { char: null, end: i + 2 };
     return { char: String.fromCharCode(Number.parseInt(hex, 16)), end: i + 6 };
@@ -245,10 +244,10 @@ function readEscape(src: string, i: number): { char: string | null; end: number 
   if (LITERAL_ESCAPE.has(n)) return { char: n, end: i + 2 };
   // \d \w \s \D \W \S \b \B \p{..} \1 … — a class or an assertion, not a
   // character. Everything but the two-character form is skipped wholesale.
-  if (n === "p" || n === "P") {
-    const close = src.indexOf("}", i + 2);
-    return { char: null, end: close === -1 ? i + 2 : close + 1 };
-  }
+  // `\p{...}` is a property escape only under the `u` flag; in legacy mode it is
+  // the letter `p` and the brace belongs to whatever follows. Consume two
+  // characters either way, for the same reason as `\u{` above.
+  if (n === "p" || n === "P") return { char: null, end: i + 2 };
   // `\k<name>` is a named backreference, and stopping after `\k` would leave
   // `<name>` behind as literal text the match never contains.
   if (n === "k" && src[i + 2] === "<") {
@@ -351,7 +350,15 @@ function matchingParen(src: string, open: number): number {
   return -1;
 }
 
-/** Index of the `]` closing the class that opens at `open`, or -1. */
+/**
+ * Index of the `]` closing the class that opens at `open`, or -1.
+ *
+ * JavaScript has no Perl `[]]`: `[]` is an EMPTY class that matches nothing and
+ * ends at its first `]`. Treating that `]` as literal walks the scan past the
+ * class and into whatever follows — `/abcd[]|efgh/` then looks like one branch
+ * rather than two, and `abcd` gets proved for a pattern that matches `efgh`.
+ * `[^]` is the one case where the first `]` is not at `open + 1`.
+ */
 function closeClass(src: string, open: number): number {
   for (let i = open + 1; i < src.length; i++) {
     const c = src[i];
@@ -359,8 +366,7 @@ function closeClass(src: string, open: number): number {
       i += 1;
       continue;
     }
-    if (c === "]" && i > open + 1) return i;
-    if (c === "]" && i === open + 1) continue; // `[]]` — a literal ]
+    if (c === "]") return i;
   }
   return -1;
 }
@@ -423,6 +429,13 @@ function cross(variants: string[], suffixes: string[]): string[] | null {
  * the pattern running exactly as it does today.
  */
 export function mandatoryLiterals(pattern: RegExp): MandatoryLiterals {
+  // Unicode mode changes both halves of the reasoning below and is declined
+  // whole. Under `u`/`v` the `i` flag uses simple case folding, so `/secret/iu`
+  // matches `ſecret` and `/mark/iu` matches `marK` — neither subject contains
+  // the ASCII literal, and the index only folds ASCII. `v` additionally nests
+  // character classes, which the class scanner does not parse. Every pattern the
+  // rules ship today is legacy; one that is not simply runs unfiltered.
+  if (pattern.unicode || pattern.unicodeSets) return [];
   const out: string[][] = [];
   extractInto(pattern.source, out, 0);
   return out;
@@ -499,8 +512,13 @@ function extractInto(source: string, out: string[][], depth: number): void {
       const esc = readEscape(source, i);
       const lit = esc.char;
       if (lit === null || !isAscii(lit)) {
+        // The atom proves nothing, but its QUANTIFIER still has to be consumed:
+        // leaving `\d{1000}` half-read hands `1000` to the main loop as four
+        // literal characters, and a match of `abcd\d{1000}efgh` contains no
+        // `1000` at all.
+        const unprovableQ = readQuantifier(source, esc.end);
         flush();
-        i = esc.end;
+        i = unprovableQ ? unprovableQ.end : esc.end;
         continue;
       }
       const q = readQuantifier(source, esc.end);
@@ -535,7 +553,11 @@ function extractInto(source: string, out: string[][], depth: number): void {
       const body = groupBody(source.slice(i + 1, close));
       const alts = body === null ? null : splitAlternatives(body);
       const pureLiterals =
-        alts && alts.every((a) => a.length > 0 && /^[A-Za-z0-9_@#/:.\-]+$/.test(a)) ? alts : null;
+        // Every character here must mean ITSELF. `.` is a wildcard, so
+        // `/(abcd.efgh)/` proved `abcd.efgh` and denied `abcdXefgh`, which it
+        // matches. Groups holding anything else fall through to extractInto,
+        // which reads the regex properly.
+        alts && alts.every((a) => a.length > 0 && /^[A-Za-z0-9_@#/:\-]+$/.test(a)) ? alts : null;
       if (pureLiterals) {
         append(pureLiterals, q);
       } else {
@@ -557,8 +579,13 @@ function extractInto(source: string, out: string[][], depth: number): void {
     }
 
     if (META.has(c)) {
+      // A `{n,m}` that reaches here quantifies something already flushed, so its
+      // digits are not literal text to be collected. Skipping the whole brace
+      // costs precision in the one case where it really is literal (`^{2}abc`
+      // matches `{2}abc` in legacy mode) and never invents a literal.
+      const braceQ = c === "{" ? readQuantifier(source, i) : null;
       flush();
-      i += 1;
+      i = braceQ ? braceQ.end : i + 1;
       continue;
     }
 

--- a/packages/rules/src/shared/literal-prefilter.ts
+++ b/packages/rules/src/shared/literal-prefilter.ts
@@ -53,7 +53,27 @@ const MAX_VARIANTS = 32;
 export interface GramIndex {
   readonly bits: Uint8Array;
   readonly mask: number;
+  /**
+   * True when the text contains a character whose `toLowerCase()` INTRODUCES an
+   * ASCII character that the text itself does not have.
+   *
+   * The index folds ASCII case and nothing else, which is a sound
+   * over-approximation of the text — but not of `text.toLowerCase()`. A caller
+   * that searches a lowercased copy (security/leaked-secrets locates its context
+   * keywords that way) can find a keyword the index will swear is absent:
+   * `LINKEDIN` lowercases to `linkedin`, and the index, which leaves
+   * U+212A alone, has no `linkedin` in it. Exactly two characters do this in the
+   * whole of Unicode, so the flag costs one comparison per non-ASCII character
+   * and lets such a caller fall back instead of being silently wrong.
+   */
+  readonly lowercaseAddsAscii: boolean;
 }
+
+// U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE lowercases to "i" + U+0307, and
+// U+212A KELVIN SIGN lowercases to "k". Enumerated over every code point, they
+// are the only two whose lowercase introduces an ASCII character.
+const LOWERCASE_ADDS_ASCII_I = 0x0130;
+const LOWERCASE_ADDS_ASCII_K = 0x212a;
 
 // Each character contributes 5 bits of the window hash, so the window is exactly
 // GRAM * SHIFT = 20 bits wide and `WINDOW_MASK` is what drops the character that
@@ -95,9 +115,14 @@ export function buildGramIndex(text: string): GramIndex | null {
   const mask = bytes * 8 - 1;
   const bits = new Uint8Array(bytes);
   let h = 0;
+  let lowercaseAddsAscii = false;
   for (let i = 0; i < text.length; i++) {
     let c = text.charCodeAt(i);
-    if (c >= 65 && c <= 90) c += 32; // fold ASCII case
+    if (c >= 65 && c <= 90) {
+      c += 32; // fold ASCII case
+    } else if (c > 0x7f && (c === LOWERCASE_ADDS_ASCII_I || c === LOWERCASE_ADDS_ASCII_K)) {
+      lowercaseAddsAscii = true;
+    }
     // Four characters of 5 bits each fill the window exactly, so the fifth
     // character back falls off the top. WINDOW_MASK, not `mask`, is what makes
     // it fall off: see the note on WINDOW_MASK.
@@ -107,7 +132,7 @@ export function buildGramIndex(text: string): GramIndex | null {
       bits[slot >> 3]! |= 1 << (slot & 7);
     }
   }
-  return { bits, mask };
+  return { bits, mask, lowercaseAddsAscii };
 }
 
 /**

--- a/packages/rules/src/shared/literal-prefilter.ts
+++ b/packages/rules/src/shared/literal-prefilter.ts
@@ -1,0 +1,533 @@
+// A one-pass prefilter that answers "can this regex match this text at all?"
+// without running it (#1864).
+//
+// The rules that hurt on a script-heavy page run a LIST of patterns over the same
+// megabyte: security/leaked-secrets runs 70, perf/js-libraries runs one set per
+// library. Each pass over 1 MB costs ~0.3 ms even when the regex engine is doing
+// nothing but a vectorised literal search, so the cost is the pass COUNT, not the
+// work each pass finds. Combining the patterns into one alternation makes it
+// WORSE (measured: 70 patterns as one alternation took 29 ms against 20 ms run
+// separately) — JSC does not build a trie for an alternation.
+//
+// So: make one pass, record which 4-grams the text contains in a bitmap, and use
+// that to skip every pattern whose mandatory literal is provably absent. On the
+// drscholls fixture that skips 60 of 70 secret patterns and 14 of 17 keyword
+// scans for the price of a single pass.
+//
+// Soundness is the whole point, since a false negative silently deletes a
+// finding. Two invariants carry it:
+//
+//   1. Every 4-gram of the text sets its bit, so a needle that IS present has
+//      every one of its 4-grams set. `mayContain` can therefore only err
+//      towards "maybe" (hash collisions, or the grams appearing apart). It can
+//      never say "no" about a needle that is present.
+//   2. `mandatoryLiterals` only ever returns literals that EVERY match of the
+//      pattern must contain, and returns nothing at all when it cannot prove
+//      that. A pattern with no proven literal is simply always run.
+
+/** Roughly 32 bits of table per character of content. Below ~10% population a
+ *  four-character literal is filtered on merit rather than on luck. */
+const BITS_PER_CHAR = 32;
+
+/** Below this the pass to build the index costs more than the scans it saves.
+ *  Low, deliberately: a 1 KB inline script still pays 70 regex invocations in
+ *  security/leaked-secrets, and a page can carry sixty of them. */
+const MIN_INDEXED_LENGTH = 256;
+
+/** The window width, and so the shortest literal that can be filtered at all.
+ *  Indexing 3-grams as well was tried and reverted: it doubled the population of
+ *  the table (and with it the false-positive rate for every OTHER literal) to buy
+ *  one extra skip out of seventy. A shorter literal simply proves nothing and its
+ *  pattern always runs. */
+const GRAM = 4;
+const MIN_LITERAL_LENGTH = GRAM;
+
+/** How many variants an optional element may expand a literal run into. */
+const MAX_VARIANTS = 32;
+
+/**
+ * One text's 4-gram presence bitmap. ASCII case is folded on both sides, so
+ * needles are matched case-insensitively — sound for a case-SENSITIVE pattern
+ * too, since folding only widens what the filter admits.
+ */
+export interface GramIndex {
+  readonly bits: Uint8Array;
+  readonly mask: number;
+}
+
+// Each character contributes 5 bits of the window hash, so the window is exactly
+// GRAM * SHIFT = 20 bits wide and `WINDOW_MASK` is what drops the character that
+// falls off the front.
+//
+// Masking with the TABLE's mask instead is the bug this constant exists to
+// prevent, and it is silent and severe. A 21-bit table keeps bit 20, which is
+// where the low bit of the character BEFORE the window lands, so the text's hash
+// for a window and the needle's hash for the same four characters disagree
+// whenever the preceding character is odd. `mayContain` then returns FALSE about
+// a needle that is present — the one direction that deletes findings. Measured on
+// a 40 KB text (the size that first reaches the widest table): 8 of 16 present
+// needles denied, one per odd predecessor. Nothing failed; the soundness test
+// happened to size every fixture below the widest table.
+const SHIFT = 5;
+const WINDOW_MASK = (1 << (GRAM * SHIFT)) - 1;
+
+/** Ceiling on the table: the widest a 20-bit window hash can address, 2^20 bits
+ *  = 128 KB. A megabyte of minified JS sets about 25% of it, which is what
+ *  decides how often a short literal survives on a collision rather than on
+ *  being present. */
+const GRAM_BYTES = (WINDOW_MASK + 1) >> 3;
+
+/**
+ * Index `text`'s 4-grams, or return null when the text is too short to be worth
+ * indexing (the caller then runs every pattern, exactly as before).
+ *
+ * The bitmap is allocated per call rather than shared. A shared scratch buffer
+ * would be faster by a hair and would alias the moment two scans overlapped, and
+ * an index that silently belongs to someone else's text is a wrong answer in the
+ * one direction that deletes findings.
+ */
+export function buildGramIndex(text: string): GramIndex | null {
+  if (text.length < MIN_INDEXED_LENGTH) return null;
+  // Size the table to the content: a 5 KB script does not need 128 KB of bitmap,
+  // and a smaller table is both cheaper to allocate and no less sound.
+  let bytes = 1 << 7; // 2^10 bits
+  while (bytes < GRAM_BYTES && bytes * 8 < text.length * BITS_PER_CHAR) bytes <<= 1;
+  const mask = bytes * 8 - 1;
+  const bits = new Uint8Array(bytes);
+  let h = 0;
+  for (let i = 0; i < text.length; i++) {
+    let c = text.charCodeAt(i);
+    if (c >= 65 && c <= 90) c += 32; // fold ASCII case
+    // Four characters of 5 bits each fill the window exactly, so the fifth
+    // character back falls off the top. WINDOW_MASK, not `mask`, is what makes
+    // it fall off: see the note on WINDOW_MASK.
+    h = ((h << SHIFT) ^ c) & WINDOW_MASK;
+    if (i >= GRAM - 1) {
+      const slot = h & mask;
+      bits[slot >> 3]! |= 1 << (slot & 7);
+    }
+  }
+  return { bits, mask };
+}
+
+/**
+ * True when `needle` MAY appear in the indexed text. False is a proof of absence
+ * for any ASCII needle; true is a maybe. ASCII case is folded here exactly as it
+ * is in `buildGramIndex`, so the caller does not have to pre-lowercase.
+ */
+export function mayContain(index: GramIndex, needle: string): boolean {
+  if (needle.length < GRAM) return true;
+  const { bits, mask } = index;
+  let h = 0;
+  for (let i = 0; i < needle.length; i++) {
+    let c = needle.charCodeAt(i);
+    if (c >= 65 && c <= 90) c += 32;
+    h = ((h << SHIFT) ^ c) & WINDOW_MASK;
+    if (i >= GRAM - 1) {
+      const slot = h & mask;
+      if ((bits[slot >> 3]! & (1 << (slot & 7))) === 0) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * A conjunction of any-of sets: EVERY entry has at least one member that every
+ * match of the pattern contains. An empty array means "nothing proven".
+ */
+export type MandatoryLiterals = readonly (readonly string[])[];
+
+/**
+ * True when the pattern behind `literals` may match the indexed text. An empty
+ * `literals` (nothing proven) always returns true.
+ */
+export function mayMatch(index: GramIndex | null, literals: MandatoryLiterals): boolean {
+  if (!index || literals.length === 0) return true;
+  for (const anyOf of literals) {
+    let possible = false;
+    for (const lit of anyOf) {
+      if (mayContain(index, lit)) {
+        possible = true;
+        break;
+      }
+    }
+    if (!possible) return false;
+  }
+  return true;
+}
+
+// ── mandatory-literal extraction ────────────────────────────────────────────
+
+const META = new Set([".", "*", "+", "?", "(", ")", "[", "]", "{", "}", "|", "^", "$", "\\"]);
+// Escapes that stand for a literal character rather than a class.
+const LITERAL_ESCAPE = new Set([
+  ".", "*", "+", "?", "(", ")", "[", "]", "{", "}", "|", "^", "$", "\\", "/", "-", "@", "#", "&",
+  "=", ":", ";", ",", "<", ">", "'", '"', "`", "~", "!", "%", "_",
+]);
+
+function isAscii(s: string): boolean {
+  for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) > 127) return false;
+  return true;
+}
+
+/**
+ * The escape starting at `src[i] === "\\"`: the single character it denotes, or
+ * null when it denotes a CLASS (`\\d`, `\\w`, `\\b`) rather than a character.
+ *
+ * `end` matters as much as `char`. Reading `\\u0275cmp` as a two-character escape
+ * leaves `0275cmp` behind as literal text, and a literal the pattern cannot
+ * actually contain is exactly the filter answer that deletes a finding — this was
+ * a live bug caught by the soundness test, on Angular's `\\["\u0275cmp"\\]`.
+ */
+function readEscape(src: string, i: number): { char: string | null; end: number } {
+  const n = src[i + 1];
+  if (n === undefined) return { char: null, end: i + 1 };
+  if (n === "u") {
+    if (src[i + 2] === "{") {
+      const close = src.indexOf("}", i + 3);
+      if (close === -1) return { char: null, end: i + 2 };
+      const code = Number.parseInt(src.slice(i + 3, close), 16);
+      return {
+        char: Number.isNaN(code) || code > 0x10ffff ? null : String.fromCodePoint(code),
+        end: close + 1,
+      };
+    }
+    const hex = src.slice(i + 2, i + 6);
+    if (!/^[0-9a-fA-F]{4}$/.test(hex)) return { char: null, end: i + 2 };
+    return { char: String.fromCharCode(Number.parseInt(hex, 16)), end: i + 6 };
+  }
+  if (n === "x") {
+    const hex = src.slice(i + 2, i + 4);
+    if (!/^[0-9a-fA-F]{2}$/.test(hex)) return { char: null, end: i + 2 };
+    return { char: String.fromCharCode(Number.parseInt(hex, 16)), end: i + 4 };
+  }
+  if (n === "c") return { char: null, end: i + 3 };
+  if (n === "n") return { char: "\n", end: i + 2 };
+  if (n === "t") return { char: "\t", end: i + 2 };
+  if (n === "r") return { char: "\r", end: i + 2 };
+  if (n === "f") return { char: "\f", end: i + 2 };
+  if (n === "v") return { char: "\v", end: i + 2 };
+  if (LITERAL_ESCAPE.has(n)) return { char: n, end: i + 2 };
+  // \d \w \s \D \W \S \b \B \p{..} \1 … — a class or an assertion, not a
+  // character. Everything but the two-character form is skipped wholesale.
+  if (n === "p" || n === "P") {
+    const close = src.indexOf("}", i + 2);
+    return { char: null, end: close === -1 ? i + 2 : close + 1 };
+  }
+  return { char: null, end: i + 2 };
+}
+
+/**
+ * The quantifier starting at `i`, or null. `min0` means it can match zero times;
+ * `max1` means it can match at most once.
+ *
+ * `max1` is load-bearing and was missing. A literal run is only a run because its
+ * characters are ADJACENT, so an element that can repeat inserts characters the
+ * variants do not have: expanding `abcdz{0,3}efgh` to {`abcdefgh`, `abcdzefgh`}
+ * denies `abcdzzefgh`, which the pattern matches. Every element that can repeat
+ * therefore ends the run instead of expanding it.
+ */
+function readQuantifier(
+  src: string,
+  i: number
+): { end: number; min0: boolean; max1: boolean } | null {
+  const c = src[i];
+  if (c === "?") {
+    return { end: src[i + 1] === "?" ? i + 2 : i + 1, min0: true, max1: true };
+  }
+  if (c === "*") {
+    return { end: src[i + 1] === "?" ? i + 2 : i + 1, min0: true, max1: false };
+  }
+  if (c === "+") {
+    return { end: src[i + 1] === "?" ? i + 2 : i + 1, min0: false, max1: false };
+  }
+  if (c === "{") {
+    const close = src.indexOf("}", i);
+    if (close === -1) return null;
+    const body = src.slice(i + 1, close);
+    if (!/^\d+(,\d*)?$/.test(body)) return null;
+    const [minText, maxText] = body.split(",");
+    const min = Number(minText);
+    // `{n}` is exactly n; `{n,}` is unbounded; `{n,m}` is at most m.
+    const max = maxText === undefined ? min : maxText === "" ? Number.POSITIVE_INFINITY : Number(maxText);
+    return {
+      end: src[close + 1] === "?" ? close + 2 : close + 1,
+      min0: min === 0,
+      max1: max <= 1,
+    };
+  }
+  return null;
+}
+
+/** The characters a single-character class `[abc]` can match, or null. */
+function simpleClassChars(body: string): string[] | null {
+  if (body.startsWith("^")) return null;
+  const out: string[] = [];
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i]!;
+    if (c === "\\") {
+      const esc = readEscape(body, i);
+      if (esc.char === null) return null;
+      out.push(esc.char);
+      i = esc.end - 1;
+      continue;
+    }
+    if (c === "-" && i > 0 && i < body.length - 1) return null; // a range, not a set
+    out.push(c);
+  }
+  return out.length > 0 && out.length <= 4 ? out : null;
+}
+
+/** Index of the `)` closing the group that opens at `open`, or -1. */
+function matchingParen(src: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === "\\") {
+      i += 1;
+      continue;
+    }
+    if (c === "[") {
+      const close = closeClass(src, i);
+      if (close === -1) return -1;
+      i = close;
+      continue;
+    }
+    if (c === "(") depth += 1;
+    else if (c === ")") {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** Index of the `]` closing the class that opens at `open`, or -1. */
+function closeClass(src: string, open: number): number {
+  for (let i = open + 1; i < src.length; i++) {
+    const c = src[i];
+    if (c === "\\") {
+      i += 1;
+      continue;
+    }
+    if (c === "]" && i > open + 1) return i;
+    if (c === "]" && i === open + 1) continue; // `[]]` — a literal ]
+  }
+  return -1;
+}
+
+/** Split a group body on its TOP-LEVEL `|`. */
+function splitAlternatives(src: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    if (c === "\\") {
+      i += 1;
+      continue;
+    }
+    if (c === "[") {
+      const close = closeClass(src, i);
+      if (close === -1) break;
+      i = close;
+      continue;
+    }
+    if (c === "(") depth += 1;
+    else if (c === ")") depth -= 1;
+    else if (c === "|" && depth === 0) {
+      parts.push(src.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(src.slice(start));
+  return parts;
+}
+
+/** Strip a group's `(?:` / `(?<name>` / `(` prefix, returning the body. */
+function groupBody(inner: string): string | null {
+  if (inner.startsWith("?:")) return inner.slice(2);
+  if (inner.startsWith("?<") && !inner.startsWith("?<=") && !inner.startsWith("?<!")) {
+    const close = inner.indexOf(">");
+    return close === -1 ? null : inner.slice(close + 1);
+  }
+  if (inner.startsWith("?")) return null; // lookaround, flags — no mandatory content
+  return inner;
+}
+
+function cross(variants: string[], suffixes: string[]): string[] | null {
+  const out: string[] = [];
+  for (const v of variants) {
+    for (const s of suffixes) {
+      out.push(v + s);
+      if (out.length > MAX_VARIANTS) return null;
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract literals that every match of `source` must contain.
+ *
+ * Conservative by construction: anything it cannot reason about ends the current
+ * literal run and contributes nothing, so the worst case is an empty result and
+ * the pattern running exactly as it does today.
+ */
+export function mandatoryLiterals(pattern: RegExp): MandatoryLiterals {
+  const out: string[][] = [];
+  extractInto(pattern.source, out, 0);
+  return out;
+}
+
+function extractInto(source: string, out: string[][], depth: number): void {
+  if (depth > 4) return;
+
+  const branches = splitAlternatives(source);
+  if (branches.length > 1) {
+    // A match takes exactly one branch, so one literal per branch forms an
+    // any-of set. If ANY branch proves nothing, the alternation proves nothing.
+    const anyOf: string[] = [];
+    for (const branch of branches) {
+      const sub: string[][] = [];
+      extractInto(branch, sub, depth + 1);
+      // A match down this branch has at least one member of each of the branch's
+      // proven sets. Take the set whose WEAKEST member is longest and union it in:
+      // whichever branch runs, one of the union's members is present.
+      let best: string[] | null = null;
+      for (const set of sub) {
+        const weakest = Math.min(...set.map((s) => s.length));
+        if (best === null || weakest > Math.min(...best.map((s) => s.length))) best = set;
+      }
+      if (best === null) return;
+      anyOf.push(...best);
+    }
+    if (anyOf.length > 0) out.push(anyOf);
+    return;
+  }
+
+  let variants: string[] = [""];
+  const flush = () => {
+    const usable = variants.filter((v) => v.length >= MIN_LITERAL_LENGTH && isAscii(v));
+    if (usable.length === variants.length && usable.length > 0) {
+      out.push(usable.map((v) => v.toLowerCase()));
+    }
+    variants = [""];
+  };
+
+  /**
+   * Extend the run under construction by one element, which matches any of
+   * `members`, under quantifier `q` (null meaning exactly once).
+   *
+   * The run's whole value is that its characters are ADJACENT in the subject, so
+   * the only elements that can extend it are the ones that contribute a bounded,
+   * known number of characters. Anything that can repeat ends the run: what comes
+   * after it is no longer adjacent to what came before.
+   */
+  const append = (members: string[], q: { min0: boolean; max1: boolean } | null): void => {
+    if (!q || q.max1) {
+      // Exactly once, or none-or-once: every possibility is still one run.
+      const next = cross(variants, q?.min0 ? ["", ...members] : members);
+      if (next) variants = next;
+      else flush();
+      return;
+    }
+    if (!q.min0) {
+      // At least once and possibly more: the run reaches through exactly one
+      // occurrence and stops there.
+      variants = cross(variants, members) ?? variants;
+      flush();
+      return;
+    }
+    // Zero or more: nothing is guaranteed and nothing after it is adjacent.
+    flush();
+  };
+
+  for (let i = 0; i < source.length; ) {
+    const c = source[i]!;
+
+    // escape
+    if (c === "\\") {
+      const esc = readEscape(source, i);
+      const lit = esc.char;
+      if (lit === null || !isAscii(lit)) {
+        flush();
+        i = esc.end;
+        continue;
+      }
+      const q = readQuantifier(source, esc.end);
+      append([lit], q);
+      i = q ? q.end : esc.end;
+      continue;
+    }
+
+    // character class
+    if (c === "[") {
+      const close = closeClass(source, i);
+      if (close === -1) {
+        flush();
+        break;
+      }
+      const q = readQuantifier(source, close + 1);
+      const chars = simpleClassChars(source.slice(i + 1, close));
+      if (chars) append(chars, q);
+      else flush();
+      i = q ? q.end : close + 1;
+      continue;
+    }
+
+    // group
+    if (c === "(") {
+      const close = matchingParen(source, i);
+      if (close === -1) {
+        flush();
+        break;
+      }
+      const q = readQuantifier(source, close + 1);
+      const body = groupBody(source.slice(i + 1, close));
+      const alts = body === null ? null : splitAlternatives(body);
+      const pureLiterals =
+        alts && alts.every((a) => a.length > 0 && /^[A-Za-z0-9_@#/:.\-]+$/.test(a)) ? alts : null;
+      if (pureLiterals) {
+        append(pureLiterals, q);
+      } else {
+        flush();
+        // The group's own mandatory literals hold only if the group is certain
+        // to run: `(?:…)?` and `(?:…)*` prove nothing about the subject.
+        if (body !== null && !q?.min0) extractInto(body, out, depth + 1);
+      }
+      i = q ? q.end : close + 1;
+      continue;
+    }
+
+    // anchors and dot
+    if (c === "^" || c === "$" || c === ".") {
+      const q = c === "." ? readQuantifier(source, i + 1) : null;
+      flush();
+      i = q ? q.end : i + 1;
+      continue;
+    }
+
+    if (META.has(c)) {
+      flush();
+      i += 1;
+      continue;
+    }
+
+    // plain literal character
+    const q = readQuantifier(source, i + 1);
+    append([c], q);
+    i = q ? q.end : i + 1;
+  }
+  flush();
+}
+
+/**
+ * Pair a pattern with the literals it must contain, computed once at module
+ * load. `mandatoryLiterals` walks the regex SOURCE, so doing it per page would
+ * be its own per-page cost.
+ */
+export function withPrefilter<T extends { pattern: RegExp }>(
+  entries: readonly T[]
+): Array<T & { literals: MandatoryLiterals }> {
+  return entries.map((e) => ({ ...e, literals: mandatoryLiterals(e.pattern) }));
+}

--- a/packages/rules/src/shared/literal-prefilter.ts
+++ b/packages/rules/src/shared/literal-prefilter.ts
@@ -2,17 +2,27 @@
 // without running it (#1864).
 //
 // The rules that hurt on a script-heavy page run a LIST of patterns over the same
-// megabyte: security/leaked-secrets runs 70, perf/js-libraries runs one set per
-// library. Each pass over 1 MB costs ~0.3 ms even when the regex engine is doing
-// nothing but a vectorised literal search, so the cost is the pass COUNT, not the
-// work each pass finds. Combining the patterns into one alternation makes it
-// WORSE (measured: 70 patterns as one alternation took 29 ms against 20 ms run
-// separately) — JSC does not build a trie for an alternation.
+// megabyte: security/leaked-secrets runs 70, perf/js-libraries runs 62 inline
+// signatures. Each pass costs the same whether it finds anything or not, so the
+// cost is the pass COUNT, not the work each pass finds.
+//
+// Merging the list into one alternation per flag group and using that as a gate
+// is much worse, not better, and the measurement is worth keeping because the
+// intuition points the other way. Over the 58 bodies of text on one real 1.1 MB
+// page (medians of seven):
+//
+//   every pattern, no prefilter                      38.9 ms
+//   this gram index, then the survivors              18.0 ms
+//   alternation gate, then every pattern on a hit    89.0 ms
+//
+// The gate loses twice: an alternation of 59 patterns gives up the per-pattern
+// literal-prefix search that makes each one fast on its own, and it still admits
+// the page (it matched 5 of the 58 bodies), so the 70 passes happen anyway.
 //
 // So: make one pass, record which 4-grams the text contains in a bitmap, and use
-// that to skip every pattern whose mandatory literal is provably absent. On the
-// drscholls fixture that skips 60 of 70 secret patterns and 14 of 17 keyword
-// scans for the price of a single pass.
+// that to skip every pattern whose mandatory literal is provably absent. On that
+// page it skips 34 of the 70 secret patterns and 17 of the 17 keyword scans per
+// body, for the price of a single pass (5.4 ms across all 58).
 //
 // Soundness is the whole point, since a false negative silently deletes a
 // finding. Two invariants carry it:
@@ -34,11 +44,12 @@ const BITS_PER_CHAR = 32;
  *  security/leaked-secrets, and a page can carry sixty of them. */
 const MIN_INDEXED_LENGTH = 256;
 
-/** The window width, and so the shortest literal that can be filtered at all.
- *  Indexing 3-grams as well was tried and reverted: it doubled the population of
- *  the table (and with it the false-positive rate for every OTHER literal) to buy
- *  one extra skip out of seventy. A shorter literal simply proves nothing and its
- *  pattern always runs. */
+/** The window width, and so the shortest literal that can be filtered at all: a
+ *  shorter literal proves nothing and its pattern always runs. Four is what a
+ *  20-bit window buys at 5 bits a character, and 20 bits is the widest table a
+ *  32-bit shift-and-xor hash addresses without the window leaking (see
+ *  WINDOW_MASK). Narrowing to 3 would admit `sk-`, `re_` and `AC`, at the cost of
+ *  a 15-bit window and a table that saturates on a megabyte. */
 const GRAM = 4;
 const MIN_LITERAL_LENGTH = GRAM;
 
@@ -92,9 +103,9 @@ const SHIFT = 5;
 const WINDOW_MASK = (1 << (GRAM * SHIFT)) - 1;
 
 /** Ceiling on the table: the widest a 20-bit window hash can address, 2^20 bits
- *  = 128 KB. A megabyte of minified JS sets about 25% of it, which is what
- *  decides how often a short literal survives on a collision rather than on
- *  being present. */
+ *  = 128 KB. A 1.1 MB serialised page sets 5.9% of it, and the population is
+ *  what decides how often a literal survives on a collision rather than on being
+ *  present. */
 const GRAM_BYTES = (WINDOW_MASK + 1) >> 3;
 
 /**

--- a/packages/rules/src/shared/literal-prefilter.ts
+++ b/packages/rules/src/shared/literal-prefilter.ts
@@ -219,14 +219,13 @@ function readEscape(src: string, i: number): { char: string | null; end: number 
   const n = src[i + 1];
   if (n === undefined) return { char: null, end: i + 1 };
   if (n === "u") {
+    // `\u{...}` is a code point only under the `u` flag; without it the same
+    // source is the letter `u` repeated. The two readings share no characters,
+    // so neither is claimed: skip past the brace and end the run. (The four-hex
+    // form below is a code point either way.)
     if (src[i + 2] === "{") {
       const close = src.indexOf("}", i + 3);
-      if (close === -1) return { char: null, end: i + 2 };
-      const code = Number.parseInt(src.slice(i + 3, close), 16);
-      return {
-        char: Number.isNaN(code) || code > 0x10ffff ? null : String.fromCodePoint(code),
-        end: close + 1,
-      };
+      return { char: null, end: close === -1 ? i + 2 : close + 1 };
     }
     const hex = src.slice(i + 2, i + 6);
     if (!/^[0-9a-fA-F]{4}$/.test(hex)) return { char: null, end: i + 2 };
@@ -249,6 +248,20 @@ function readEscape(src: string, i: number): { char: string | null; end: number 
   if (n === "p" || n === "P") {
     const close = src.indexOf("}", i + 2);
     return { char: null, end: close === -1 ? i + 2 : close + 1 };
+  }
+  // `\k<name>` is a named backreference, and stopping after `\k` would leave
+  // `<name>` behind as literal text the match never contains.
+  if (n === "k" && src[i + 2] === "<") {
+    const close = src.indexOf(">", i + 3);
+    return { char: null, end: close === -1 ? i + 2 : close + 1 };
+  }
+  // A backreference or octal escape runs to the end of its digits. Consuming
+  // only two characters leaves `\12`'s `2` behind as literal text, and what
+  // group 12 matched is not the digit 2.
+  if (n >= "0" && n <= "9") {
+    let end = i + 2;
+    while (end < src.length && src[end]! >= "0" && src[end]! <= "9") end += 1;
+    return { char: null, end };
   }
   return { char: null, end: i + 2 };
 }

--- a/packages/rules/src/shared/literal-prefilter.ts
+++ b/packages/rules/src/shared/literal-prefilter.ts
@@ -206,6 +206,9 @@ function isAscii(s: string): boolean {
   return true;
 }
 
+/** `end` sentinel: this escape's length is not knowable, so stop reading here. */
+const UNPARSEABLE = -1;
+
 /**
  * The escape starting at `src[i] === "\\"`: the single character it denotes, or
  * null when it denotes a CLASS (`\\d`, `\\w`, `\\b`) rather than a character.
@@ -235,7 +238,15 @@ function readEscape(src: string, i: number): { char: string | null; end: number 
     if (!/^[0-9a-fA-F]{2}$/.test(hex)) return { char: null, end: i + 2 };
     return { char: String.fromCharCode(Number.parseInt(hex, 16)), end: i + 4 };
   }
-  if (n === "c") return { char: null, end: i + 3 };
+  // `\cX` is a control character only when X is an ASCII letter. Otherwise
+  // Annex B reads `\c` as the two literal characters `\` and `c`, and consuming
+  // three steps over whatever follows: `/\c[abcd]/` matches `\ca`, and eating
+  // the `[` left `abcd]` behind as literal text no match contains.
+  if (n === "c") {
+    const x = src[i + 2];
+    const isControlLetter = x !== undefined && ((x >= "a" && x <= "z") || (x >= "A" && x <= "Z"));
+    return { char: null, end: isControlLetter ? i + 3 : i + 2 };
+  }
   if (n === "n") return { char: "\n", end: i + 2 };
   if (n === "t") return { char: "\t", end: i + 2 };
   if (n === "r") return { char: "\r", end: i + 2 };
@@ -248,12 +259,14 @@ function readEscape(src: string, i: number): { char: string | null; end: number 
   // the letter `p` and the brace belongs to whatever follows. Consume two
   // characters either way, for the same reason as `\u{` above.
   if (n === "p" || n === "P") return { char: null, end: i + 2 };
-  // `\k<name>` is a named backreference, and stopping after `\k` would leave
-  // `<name>` behind as literal text the match never contains.
-  if (n === "k" && src[i + 2] === "<") {
-    const close = src.indexOf(">", i + 3);
-    return { char: null, end: close === -1 ? i + 2 : close + 1 };
-  }
+  // `\k<name>` is a named backreference ONLY when the pattern declares a named
+  // group; otherwise `\k` is a legacy identity escape and `<name>` is literal
+  // text. The two readings consume different lengths, and either guess steps
+  // over real structure: stopping after `\k` leaves `<name>` behind as literal
+  // text a backreference never contains, and searching for the `>` walks into a
+  // character class in `/\k<[abcd>efgh]/`, which matches `k<a`. Neither is
+  // knowable from the source alone, so give up on the rest of this branch.
+  if (n === "k" && src[i + 2] === "<") return { char: null, end: UNPARSEABLE };
   // A backreference or octal escape runs to the end of its digits. Consuming
   // only two characters leaves `\12`'s `2` behind as literal text, and what
   // group 12 matched is not the digit 2.
@@ -510,6 +523,10 @@ function extractInto(source: string, out: string[][], depth: number): void {
     // escape
     if (c === "\\") {
       const esc = readEscape(source, i);
+      if (esc.end === UNPARSEABLE) {
+        flush();
+        break;
+      }
       const lit = esc.char;
       if (lit === null || !isAscii(lit)) {
         // The atom proves nothing, but its QUANTIFIER still has to be consumed:

--- a/packages/rules/tests/js-libraries-prefilter.test.ts
+++ b/packages/rules/tests/js-libraries-prefilter.test.ts
@@ -1,0 +1,89 @@
+// perf/js-libraries — #1864 put a prefilter in front of the signature loop: one
+// pass over each inline script builds a 4-gram index, and a signature whose
+// mandatory literals the index does not contain is skipped instead of run.
+//
+// The failure mode is a library that stops being detected, and it only appears
+// on content large enough for the index to be built at all (256 characters) —
+// and the arrangement that broke the index in review only appeared past 32 KB,
+// where its table reaches full width. So every case here embeds the signature in
+// a bundle-sized script and asserts the padded answer still carries everything
+// the unpadded answer had.
+
+import { describe, expect, test } from "bun:test";
+
+import { parsePage } from "@squirrelscan/parser";
+
+import { jsLibrariesRule } from "../src/performance/js-libraries";
+import type { RuleContext } from "../src/types";
+
+// Minified-looking filler that matches no library signature on its own.
+const PAD = "function q0(a,b){return a+b*2}var z9=[1,2,3].map(q0);".repeat(1400);
+
+function detected(script: string): string[] {
+  const url = "https://example.com/";
+  const html = `<!DOCTYPE html><html><head><title>t</title></head><body><script>${script}</script></body></html>`;
+  const ctx = {
+    page: { url, html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: parsePage(html, url),
+    site: { baseUrl: "https://example.com", pages: [], robotsTxt: null, sitemaps: null, scripts: [] },
+    options: {},
+  } as unknown as RuleContext;
+  const check = jsLibrariesRule.run(ctx).checks.find((c) => c.name === "js-libraries-detected");
+  return (check?.items ?? []).map((i) => i.id).sort();
+}
+
+// One inline signature per library, taken from the shipped `inlinePatterns`.
+// Each token is written so the MATCH begins at its first character, because the
+// character before the match is the one the tests below vary.
+const SIGNATURES: Array<[string, string]> = [
+  ["jQuery", "jQuery.fn.jquery"],
+  ["React", "__REACT_DEVTOOLS_GLOBAL_HOOK__"],
+  ["Angular", "getAllAngularRootElements"],
+  ["Svelte", "SvelteComponent"],
+  ["Next.js", "__NEXT_DATA__"],
+  ["Nuxt", "__NUXT__"],
+];
+
+describe("perf/js-libraries: the inline prefilter never loses a detection", () => {
+  test("the pad on its own detects nothing", () => {
+    expect(detected(PAD)).toEqual([]);
+  });
+
+  // The character IMMEDIATELY BEFORE a signature's match is what the index's
+  // window hash must not depend on, and a mis-masked hash leaks its low bit. One
+  // lead-in character alone leaves that whole class of bug undetected.
+  const LEAD_INS = [";", "(", "=", "!", "'", "-", "1", "a", " ", "\n"];
+  // The rule ignores inline scripts of 50 characters or fewer.
+  const SHORT_PAD = `var ${"z".repeat(60)}=1`;
+
+  test("every signature detected in a short script is detected in a 70 KB one", () => {
+    const lost: string[] = [];
+    for (const [name, token] of SIGNATURES) {
+      for (const lead of LEAD_INS) {
+        const bare = detected(`${SHORT_PAD}${lead}${token}`);
+        // A signature that does not detect unpadded proves nothing about padding.
+        expect(bare).toContain(name);
+        const padded = detected(`${PAD}${lead}${token}\n${PAD}`);
+        for (const id of bare) {
+          if (!padded.includes(id)) lost.push(`${name} after ${JSON.stringify(lead)}: lost ${id}`);
+        }
+      }
+    }
+    expect(lost).toEqual([]);
+  });
+
+  test("a signature in the HTML rather than a script is still found at page size", () => {
+    // The HTML body gets its own index, and Angular's `ng-version` marker is
+    // matched against the markup rather than against any script.
+    const url = "https://example.com/";
+    const html = `<!DOCTYPE html><html><head><title>t</title></head><body><app-root ng-version="17.1.0"></app-root><p>${"filler ".repeat(9000)}</p></body></html>`;
+    const ctx = {
+      page: { url, html, statusCode: 200, loadTime: 0, headers: {} },
+      parsed: parsePage(html, url),
+      site: { baseUrl: "https://example.com", pages: [], robotsTxt: null, sitemaps: null, scripts: [] },
+      options: {},
+    } as unknown as RuleContext;
+    const check = jsLibrariesRule.run(ctx).checks.find((c) => c.name === "js-libraries-detected");
+    expect((check?.items ?? []).map((i) => i.id)).toContain("Angular v17.1.0");
+  });
+});

--- a/packages/rules/tests/js-libraries-prefilter.test.ts
+++ b/packages/rules/tests/js-libraries-prefilter.test.ts
@@ -28,8 +28,11 @@ function detected(script: string): string[] {
     site: { baseUrl: "https://example.com", pages: [], robotsTxt: null, sitemaps: null, scripts: [] },
     options: {},
   } as unknown as RuleContext;
+  // The whole item, not just its id: the label carries WHERE the library was
+  // detected ("inline code" against "HTML markers"), and a prefilter that skips
+  // the inline pass but not the HTML one changes that without changing the id.
   const check = jsLibrariesRule.run(ctx).checks.find((c) => c.name === "js-libraries-detected");
-  return (check?.items ?? []).map((i) => i.id).sort();
+  return (check?.items ?? []).map((i) => JSON.stringify(i)).sort();
 }
 
 // One inline signature per library, taken from the shipped `inlinePatterns`.
@@ -62,10 +65,10 @@ describe("perf/js-libraries: the inline prefilter never loses a detection", () =
       for (const lead of LEAD_INS) {
         const bare = detected(`${SHORT_PAD}${lead}${token}`);
         // A signature that does not detect unpadded proves nothing about padding.
-        expect(bare).toContain(name);
+        expect(bare.join(" ")).toContain(`"${name}"`);
         const padded = detected(`${PAD}${lead}${token}\n${PAD}`);
-        for (const id of bare) {
-          if (!padded.includes(id)) lost.push(`${name} after ${JSON.stringify(lead)}: lost ${id}`);
+        for (const item of bare) {
+          if (!padded.includes(item)) lost.push(`${name} after ${JSON.stringify(lead)}: ${item}`);
         }
       }
     }
@@ -85,5 +88,6 @@ describe("perf/js-libraries: the inline prefilter never loses a detection", () =
     } as unknown as RuleContext;
     const check = jsLibrariesRule.run(ctx).checks.find((c) => c.name === "js-libraries-detected");
     expect((check?.items ?? []).map((i) => i.id)).toContain("Angular v17.1.0");
+    expect((check?.items ?? []).find((i) => i.id === "Angular v17.1.0")?.label).toBe("HTML markers");
   });
 });

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -393,16 +393,25 @@ describe("security/leaked-secrets: the content prefilter never loses a finding",
   ];
   const fixtures = ['"', "'"].flatMap(fixturesQuotedWith);
 
-  test("every fixture found unpadded is still found inside 70 KB of bundle", () => {
+  // WHOLE findings, not just their values: a prefilter that skipped the pattern
+  // which classifies a value would let a broader pattern claim it instead, and
+  // the type, confidence, publicByDesign flag and location would all change
+  // while the value stayed the same.
+  test("every finding made unpadded is still made, unchanged, inside 70 KB of bundle", () => {
     const lost: string[] = [];
     for (const fixture of fixtures) {
-      const bare = scanContent(fixture, "inline-script").map((f) => f.value);
+      const bare = scanContent(fixture, "inline-script");
       expect(bare.length).toBeGreaterThan(0); // a vacuous fixture proves nothing
-      const padded = new Set(
-        scanContent(`${PAD}\n;\n${fixture}\n;\n${PAD}`, "inline-script").map((f) => f.value)
+      const padded = scanContent(`${PAD}\n;\n${fixture}\n;\n${PAD}`, "inline-script").map((f) =>
+        JSON.stringify(f)
       );
-      for (const value of bare) {
-        if (!padded.has(value)) lost.push(`${fixture.slice(0, 48)} → lost ${value.slice(0, 24)}`);
+      for (const finding of bare) {
+        if (!padded.includes(JSON.stringify(finding))) {
+          const near = padded.find((p) => p.includes(finding.value));
+          lost.push(
+            `${fixture.slice(0, 40)} → ${JSON.stringify(finding)} became ${near ?? "nothing"}`
+          );
+        }
       }
     }
     expect(lost).toEqual([]);

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -357,6 +357,62 @@ describe("security/leaked-secrets: real credentials still report", () => {
   });
 });
 
+// #1864 put a prefilter in front of the pattern loop: one pass over the content
+// builds a 4-gram index, and a pattern whose mandatory literals the index does
+// not contain is skipped instead of run. Every fixture above is a few hundred
+// characters, which is BELOW the size at which the index is built at all, so
+// none of them exercise it — the whole suite would stay green with the filter
+// deleting findings on every real page.
+//
+// These pin the only property the filter has to have: padding a fixture out to
+// the size of a real bundle must not lose anything it found unpadded. The pad
+// is deliberately larger than 32 KB, the point at which the index reaches its
+// widest table and the one arrangement its own unit tests did not reach.
+describe("security/leaked-secrets: the content prefilter never loses a finding", () => {
+  // Minified-looking JavaScript, so the gram index is populated the way a real
+  // bundle populates it. Nothing here is a credential shape.
+  const PAD = "function q0(a,b){return a+b*2}var z9=[1,2,3].map(q0);".repeat(1400);
+
+  const PREFIX = { github: "ghp_", stripe: "sk_live_", aws: "AKIA", slack: "xoxb-" };
+
+  // The quote is varied because the character IMMEDIATELY BEFORE a pattern's
+  // literal is what the index's window hash must not depend on, and `"` (34)
+  // and `'` (39) differ in the bit that a mis-masked hash leaks. One quote alone
+  // makes this suite blind to that whole class of bug.
+  const fixturesQuotedWith = (q: string): string[] => [
+    `const togetherKey = ${q}${TOGETHER_KEY}${q}`, // pragma: allowlist secret
+    `{${q}together_secret${q}:${q}${TOGETHER_KEY}${q}}`, // pragma: allowlist secret
+    `together\nAuthorization: Bearer ${TOGETHER_KEY}`, // pragma: allowlist secret
+    `const v = ${q}${PREFIX.github}016b3f2c9d4e7a815c0b2d6f39ea47c1b5d8${q};`, // pragma: allowlist secret
+    `const v = ${q}${PREFIX.stripe}51HxQ2mKz9pLvA3nR7dTfJw8Y${q};`, // pragma: allowlist secret
+    `const v = ${q}${PREFIX.aws}2XJQ7LP4RNVD3KEB${q};`, // pragma: allowlist secret
+    `const v = ${q}${PREFIX.slack}2094857361-3948572610-Kj8dPqR2mTvX5nB7wLcH1sZa${q};`, // pragma: allowlist secret
+    `const v = ${q}-----BEGIN RSA PRIVATE KEY-----${q};`, // pragma: allowlist secret
+    `var t={};t.a=${q}${TOGETHER_KEY}${q};/* together.ai client */`, // pragma: allowlist secret
+    `cfg[${q}apiKey${q}] = ${q}${TOGETHER_KEY}${q}; // together`, // pragma: allowlist secret
+  ];
+  const fixtures = ['"', "'"].flatMap(fixturesQuotedWith);
+
+  test("every fixture found unpadded is still found inside 70 KB of bundle", () => {
+    const lost: string[] = [];
+    for (const fixture of fixtures) {
+      const bare = scanContent(fixture, "inline-script").map((f) => f.value);
+      expect(bare.length).toBeGreaterThan(0); // a vacuous fixture proves nothing
+      const padded = new Set(
+        scanContent(`${PAD}\n;\n${fixture}\n;\n${PAD}`, "inline-script").map((f) => f.value)
+      );
+      for (const value of bare) {
+        if (!padded.has(value)) lost.push(`${fixture.slice(0, 48)} → lost ${value.slice(0, 24)}`);
+      }
+    }
+    expect(lost).toEqual([]);
+  });
+
+  test("the pad on its own is not a credential", () => {
+    expect(scanContent(PAD, "inline-script")).toEqual([]);
+  });
+});
+
 describe("classifyKeyContext", () => {
   test("names the key in front of a value", () => {
     expect(classifyKeyContext(`{filename:"x",sha256:"`, "together")).toBe("digest");

--- a/packages/rules/tests/leaked-secrets.test.ts
+++ b/packages/rules/tests/leaked-secrets.test.ts
@@ -411,6 +411,28 @@ describe("security/leaked-secrets: the content prefilter never loses a finding",
   test("the pad on its own is not a credential", () => {
     expect(scanContent(PAD, "inline-script")).toEqual([]);
   });
+
+  // The context tier looks its keyword up in `content.toLowerCase()`, while the
+  // index folds ASCII case and leaves everything else alone. Two characters in
+  // Unicode lowercase INTO ASCII: U+212A KELVIN SIGN → "k" and U+0130 → "i" plus
+  // a combining dot. On a page carrying one, a keyword can be in the lowercased
+  // copy and absent from the index, and filtering on the index alone drops the
+  // finding.
+  test("a keyword that only exists after lowercasing is not filtered away", () => {
+    const KELVIN = String.fromCharCode(0x212a);
+    const UUID = "550e8400-e29b-41d4-a716-446655440000"; // pragma: allowlist secret
+    const pad = "var q=1;".repeat(60);
+    const ascii = `${pad}\npostmark_server_token = "${UUID}";\n${pad}`; // pragma: allowlist secret
+    // `postmar` + KELVIN lowercases to exactly `postmark`.
+    const folded = `${pad}\npostmar${KELVIN}_server_token = "${UUID}";\n${pad}`; // pragma: allowlist secret
+
+    expect(folded.toLowerCase().includes("postmark")).toBe(true);
+    expect(folded.includes("postmark")).toBe(false);
+
+    const expected = scanContent(ascii, "inline-script").map((f) => f.value);
+    expect(expected).toContain(UUID);
+    expect(scanContent(folded, "inline-script").map((f) => f.value)).toEqual(expected);
+  });
 });
 
 describe("classifyKeyContext", () => {

--- a/packages/rules/tests/literal-prefilter.test.ts
+++ b/packages/rules/tests/literal-prefilter.test.ts
@@ -475,6 +475,17 @@ describe("mandatoryLiterals extraction", () => {
       // contain the ASCII literal at all.
       [/secret/iu, `${LONG_S}ecret`],
       [/mark/iu, `mar${KELVIN}`],
+      // `\c` is a control escape only before an ASCII letter; otherwise it is
+      // the two literal characters `\` and `c`, and eating three walks into the
+      // class.
+      [/\c[abcd]/, "\\ca"],
+      // `\k<…>` is a named backreference only when the pattern declares a named
+      // group. Here it does not, so the `>` searched for is inside a class.
+      [/\k<[abcd>efgh]/, "k<a"],
+      // The readings that ARE determinate must still be read: `\cA` is U+0001,
+      // not the letter A, and a real named backreference is not literal text.
+      [/wxyz\cAabcd/, `wxyz${String.fromCharCode(1)}abcd`],
+      [/(?<x>zz)wxyz\k<x>abcd/, "zzwxyzzzabcd"],
     ];
     const failures: string[] = [];
     for (const [pattern, subject] of cases) {

--- a/packages/rules/tests/literal-prefilter.test.ts
+++ b/packages/rules/tests/literal-prefilter.test.ts
@@ -28,10 +28,16 @@ import { LIBRARY_INLINE_PATTERNS } from "../src/performance/js-libraries";
 // and alternation. Anything else throws, which fails the test loudly rather than
 // quietly generating a string that does not exercise the pattern.
 
+// `seed * 1103515245` runs past 2^53 and loses its low bits as a double, so the
+// masked result was nearly periodic: every one of 60 Redis samples took the same
+// alternative and every Generic Secret Assignment sample chose `secret`, never
+// `password`. A generator that only ever walks one branch cannot notice an
+// extractor that only ever proves one branch. `Math.imul` keeps the arithmetic
+// exact, and the returned bits come off the top, where an LCG is not periodic.
 let seed = 0x2f6e2b1;
 function rnd(n: number): number {
-  seed = (seed * 1103515245 + 12345) & 0x7fffffff;
-  return seed % n;
+  seed = (Math.imul(seed, 1103515245) + 12345) >>> 0;
+  return (seed >>> 16) % n;
 }
 const SAFE = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -345,6 +351,19 @@ describe("mandatoryLiterals extraction", () => {
     [/mongodb(\+srv)?:\/\/[^\s"'<>]+/i, [["mongodb"]]],
     // a top-level alternation yields one any-of set
     [/redis(s)?:\/\//i, [["redis://", "rediss://"]]],
+    // EVERY branch has to be in the any-of set. An extractor that kept only the
+    // first would prove `alpha`, which two thirds of the matches do not contain,
+    // and the generative test alone does not reliably reach the later branches.
+    [/alpha|bravo|charlie/, [["alpha", "bravo", "charlie"]]],
+    [/(?:alpha|bravo|charlie)wxyz/, [["alphawxyz", "bravowxyz", "charliewxyz"]]],
+    // The shipped Generic Secret Assignment alternation proves NOTHING, because
+    // `pwd` is below the four-character floor and one unprovable branch sinks
+    // the set. Pinned because narrowing this alternation to its first branch is
+    // a plausible "improvement" that deletes every `password = "…"` finding.
+    [
+      /(?:secret|password|passwd|pwd)(?:[_-]?(?:key|token))?(?:['"]\s*\]|['"]?)\s*(?:[:=]|\|\|=?|\?\?=?)\s*['"][^'"]{8,}['"]/gi,
+      [],
+    ],
     // an optional single-character class expands into variants
     [/apikeys?[_-]?value/i, [["apikeyvalue", "apikey_value", "apikey-value", "apikeysvalue", "apikeys_value", "apikeys-value"]]],
     // a `+` keeps its own character but ends the run after it
@@ -424,6 +443,45 @@ describe("mandatoryLiterals extraction", () => {
         continue;
       }
       if (!admits(pattern, subject)) failures.push(`${pattern.source}: filter REJECTED a real match`);
+    }
+    expect(failures).toEqual([]);
+  });
+
+  // Five more shapes where the extractor read the regex as something other than
+  // what the engine reads. Each pair is a pattern and a subject it really
+  // matches; each was denied before.
+  test("regex syntax the extractor does not model is declined, not guessed", () => {
+    const KELVIN = String.fromCharCode(0x212a);
+    const LONG_S = String.fromCharCode(0x017f);
+    const cases: Array<[RegExp, string]> = [
+      // `.` is a wildcard, so a group holding one is not a run of literals.
+      [/(abcd.efgh)/, "abcdXefgh"],
+      // An atom that proves nothing still owns its quantifier: `{1000}` is not
+      // four literal characters.
+      [/abcd\d{1000}efgh/, `abcd${"2".repeat(1000)}efgh`],
+      [/abcd\w{1000}efgh/, `abcd${"q".repeat(1000)}efgh`],
+      // JavaScript has no Perl `[]]`: `[]` is an empty class, and reading past
+      // it hides the `|` that makes this two branches.
+      [/abcd[]|efgh/, "efgh"],
+      // In legacy mode `\p` and `\u{` are identity escapes and the `}` searched
+      // for belongs to a character class, not to them.
+      [/\p{[abcd}efgh]/, "p{a"],
+      [/\u{[abcd}efgh]/, "u{a"],
+      // Under `u`, `i` folds beyond ASCII: these match subjects that do not
+      // contain the ASCII literal at all.
+      [/secret/iu, `${LONG_S}ecret`],
+      [/mark/iu, `mar${KELVIN}`],
+    ];
+    const failures: string[] = [];
+    for (const [pattern, subject] of cases) {
+      const probe = new RegExp(pattern.source, pattern.flags.replace("g", ""));
+      if (!probe.test(subject)) {
+        failures.push(`/${pattern.source}/${pattern.flags}: fixture does not match`);
+        continue;
+      }
+      if (!admits(pattern, subject)) {
+        failures.push(`/${pattern.source}/${pattern.flags}: filter REJECTED a real match`);
+      }
     }
     expect(failures).toEqual([]);
   });

--- a/packages/rules/tests/literal-prefilter.test.ts
+++ b/packages/rules/tests/literal-prefilter.test.ts
@@ -1,15 +1,19 @@
-// The prefilter behind #1864 decides, from a one-pass 3-gram index, that a
+// The prefilter behind #1864 decides, from a one-pass 4-gram index, that a
 // pattern CANNOT match a page and skips running it. A wrong answer in that
 // direction silently deletes a security finding, so the tests here are about
 // one property and nothing else: `mandatoryLiterals` must only ever return
 // literals that every match of the pattern really does contain.
 //
-// Proving that by inspection does not scale to 70 secret patterns and 130
-// library patterns, so the main test GENERATES strings from each pattern's own
-// source, keeps the ones the pattern actually matches, and asserts the filter
-// admits every one of them. A regression in the extractor — treating an optional
-// group as mandatory, walking into a lookahead, mishandling `{0,3}` — shows up
-// as an admitted string the filter rejects.
+// Proving that by inspection does not scale to 70 secret patterns, 17 context
+// keywords and 62 library signatures, so the main test GENERATES strings from
+// each pattern's own source, keeps the ones the pattern actually matches, and
+// asserts the filter admits every one of them. A regression in the extractor —
+// treating an optional group as mandatory, walking into a lookahead,
+// mishandling `{0,3}` — shows up as an admitted string the filter rejects.
+//
+// The cases below it are counterexamples: a pattern plus a subject it really
+// matches. That comparison does not depend on anyone's reading of the regex
+// grammar being right, which is the only reason it caught the bugs it did.
 
 import { describe, expect, test } from "bun:test";
 
@@ -291,7 +295,7 @@ describe("mandatoryLiterals is sound on every pattern the rules ship", () => {
 
 describe("the gram index", () => {
   test("never denies a substring that is present", () => {
-    const text = `${"x".repeat(5000)}AKIAIOSFODNN7EXAMPLE${"y".repeat(5000)}`;
+    const text = `${"x".repeat(5000)}AKIAIOSFODNN7EXAMPLE${"y".repeat(5000)}`; // pragma: allowlist secret
     const index = buildGramIndex(text)!;
     expect(index).not.toBeNull();
     for (let len = 3; len <= 12; len++) {
@@ -312,7 +316,7 @@ describe("the gram index", () => {
     // The leak was the low bit of the character BEFORE the window, so the
     // predecessor has to be varied: with the bug this denied every odd one.
     for (const prev of [..."abcdefghxyz0123456789"]) {
-      const text = `${"q".repeat(40_000)}${prev}AKIAIOSFODNN7EXAMPLE${"w".repeat(40_000)}`;
+      const text = `${"q".repeat(40_000)}${prev}AKIAIOSFODNN7EXAMPLE${"w".repeat(40_000)}`; // pragma: allowlist secret
       const index = buildGramIndex(text)!;
       if (!mayContain(index, needle)) denied.push(prev);
     }
@@ -321,7 +325,7 @@ describe("the gram index", () => {
 
   test("folds ASCII case on the needle as well, so an uppercase literal is found", () => {
     const index = buildGramIndex(`${"q".repeat(40_000)}akiaiosfodnn7example`)!;
-    expect(mayContain(index, "AKIAIOSFODNN7EXAMPLE")).toBe(true);
+    expect(mayContain(index, "AKIAIOSFODNN7EXAMPLE")).toBe(true); // pragma: allowlist secret
   });
 
   test("denies literals that are absent", () => {
@@ -331,7 +335,7 @@ describe("the gram index", () => {
   });
 
   test("folds ASCII case so a lowercase needle finds uppercase text", () => {
-    const index = buildGramIndex(`${"q".repeat(6000)}AKIAIOSFODNN7EXAMPLE`)!;
+    const index = buildGramIndex(`${"q".repeat(6000)}AKIAIOSFODNN7EXAMPLE`)!; // pragma: allowlist secret
     expect(mayContain(index, "akiaiosfodnn7example")).toBe(true);
   });
 

--- a/packages/rules/tests/literal-prefilter.test.ts
+++ b/packages/rules/tests/literal-prefilter.test.ts
@@ -265,10 +265,16 @@ describe("mandatoryLiterals is sound on every pattern the rules ship", () => {
   test("every generated match is admitted by the prefilter", () => {
     const failures: string[] = [];
     let checked = 0;
+    let shapes = 0;
     for (const { label, pattern } of ALL_PATTERNS) {
       const probe = new RegExp(pattern.source, pattern.flags.replace("g", ""));
+      // 400 samples rather than 60, because the point of generating is to reach
+      // the branches an extractor might drop, and a pattern with four
+      // alternatives times three optional groups has more shapes than 60 draws
+      // will cover. Distinct shapes per pattern are counted, not just draws.
+      const seen = new Set<string>();
       let admittedAny = false;
-      for (let n = 0; n < 60; n++) {
+      for (let n = 0; n < 400; n++) {
         let sample: string;
         try {
           sample = generate(pattern.source);
@@ -278,6 +284,7 @@ describe("mandatoryLiterals is sound on every pattern the rules ship", () => {
         }
         // Only samples the pattern really matches say anything about soundness.
         if (!probe.test(sample)) continue;
+        seen.add(sample.length > 40 ? sample.slice(0, 40) : sample);
         admittedAny = true;
         checked += 1;
         if (!admits(pattern, sample)) {
@@ -286,10 +293,13 @@ describe("mandatoryLiterals is sound on every pattern the rules ship", () => {
         }
       }
       if (!admittedAny) failures.push(`${label}: generator produced no matching sample`);
+      shapes += seen.size;
     }
     expect(failures).toEqual([]);
     // Guard against the loop silently doing nothing.
-    expect(checked).toBeGreaterThan(ALL_PATTERNS.length * 10);
+    expect(checked).toBeGreaterThan(ALL_PATTERNS.length * 80);
+    // A draw count says the loop ran; a DISTINCT-shape count says it explored.
+    expect(shapes).toBeGreaterThan(ALL_PATTERNS.length * 8);
   });
 });
 

--- a/packages/rules/tests/literal-prefilter.test.ts
+++ b/packages/rules/tests/literal-prefilter.test.ts
@@ -403,6 +403,31 @@ describe("mandatoryLiterals extraction", () => {
     expect(failures).toEqual([]);
   });
 
+  // An escape read as shorter than it is leaves its own tail behind as "literal
+  // text", and that text is exactly what no match contains. All three of these
+  // denied a real match.
+  test("an escape whose length is misread does not invent a literal", () => {
+    const cases: Array<[RegExp, string]> = [
+      // `\12` is a backreference to group 12, not `\1` followed by the digit 2.
+      [/(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)wxyz\12abcd/, "abcdefghijklwxyzlabcd"],
+      // `\k<x>` is a named backreference, not `\k` followed by `<x>`.
+      [/(?<x>zz)wxyz\k<x>abcd/, "zzwxyzzzabcd"],
+      // Without the `u` flag `\u{41}` is the letter `u` repeated 41 times, not
+      // the code point 0x41 — and the two readings share no characters, so
+      // neither may be claimed.
+      [/wxyz\u{41}abcd/, `wxyz${"u".repeat(41)}abcd`],
+    ];
+    const failures: string[] = [];
+    for (const [pattern, subject] of cases) {
+      if (!pattern.test(subject)) {
+        failures.push(`${pattern.source}: fixture does not match`);
+        continue;
+      }
+      if (!admits(pattern, subject)) failures.push(`${pattern.source}: filter REJECTED a real match`);
+    }
+    expect(failures).toEqual([]);
+  });
+
   test("an unproven pattern is always run", () => {
     const index = buildGramIndex("z".repeat(9000))!;
     expect(mayMatch(index, mandatoryLiterals(/[0-9]{8,10}:[a-zA-Z0-9_-]{35}/))).toBe(true);

--- a/packages/rules/tests/literal-prefilter.test.ts
+++ b/packages/rules/tests/literal-prefilter.test.ts
@@ -1,0 +1,410 @@
+// The prefilter behind #1864 decides, from a one-pass 3-gram index, that a
+// pattern CANNOT match a page and skips running it. A wrong answer in that
+// direction silently deletes a security finding, so the tests here are about
+// one property and nothing else: `mandatoryLiterals` must only ever return
+// literals that every match of the pattern really does contain.
+//
+// Proving that by inspection does not scale to 70 secret patterns and 130
+// library patterns, so the main test GENERATES strings from each pattern's own
+// source, keeps the ones the pattern actually matches, and asserts the filter
+// admits every one of them. A regression in the extractor — treating an optional
+// group as mandatory, walking into a lookahead, mishandling `{0,3}` — shows up
+// as an admitted string the filter rejects.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildGramIndex,
+  mandatoryLiterals,
+  mayContain,
+  mayMatch,
+} from "../src/shared/literal-prefilter";
+import { CONTEXT_PATTERNS, FAST_PATTERNS } from "../src/security/leaked-secrets";
+import { LIBRARY_INLINE_PATTERNS } from "../src/performance/js-libraries";
+
+// ── a tiny generator: build strings FROM a regex source ─────────────────────
+// Supports the syntax the rule tables actually use: literals, escapes, classes
+// with ranges and negation, `\d \w \s \S \w`, the four quantifier forms, groups,
+// and alternation. Anything else throws, which fails the test loudly rather than
+// quietly generating a string that does not exercise the pattern.
+
+let seed = 0x2f6e2b1;
+function rnd(n: number): number {
+  seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+  return seed % n;
+}
+const SAFE = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+function expandClass(body: string): string {
+  let negated = false;
+  let i = 0;
+  if (body[0] === "^") {
+    negated = true;
+    i = 1;
+  }
+  const chars: string[] = [];
+  for (; i < body.length; i++) {
+    const c = body[i]!;
+    if (c === "\\") {
+      const n = body[++i]!;
+      if (n === "d") chars.push(..."0123456789");
+      else if (n === "w") chars.push(..."abcxyzABCXYZ0189_");
+      else if (n === "s") chars.push(" ");
+      else chars.push(n);
+      continue;
+    }
+    if (body[i + 1] === "-" && i + 2 < body.length && body[i + 2] !== "]") {
+      const from = body.charCodeAt(i);
+      const to = body.charCodeAt(i + 2);
+      for (let c2 = from; c2 <= to && c2 - from < 64; c2++) chars.push(String.fromCharCode(c2));
+      i += 2;
+      continue;
+    }
+    chars.push(c);
+  }
+  if (!negated) return chars.join("");
+  const banned = new Set(chars);
+  return [...SAFE].filter((c) => !banned.has(c)).join("");
+}
+
+function closeAt(src: string, open: number, openCh: string, closeCh: string): number {
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === "\\") {
+      i++;
+      continue;
+    }
+    if (c === "[" && openCh !== "[") {
+      i = closeAt(src, i, "[", "]");
+      continue;
+    }
+    if (c === openCh) depth++;
+    else if (c === closeCh) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  throw new Error(`unbalanced ${openCh} in ${src}`);
+}
+
+function splitTop(src: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    if (c === "\\") {
+      i++;
+      continue;
+    }
+    if (c === "[") {
+      i = closeAt(src, i, "[", "]");
+      continue;
+    }
+    if (c === "(") depth++;
+    else if (c === ")") depth--;
+    else if (c === "|" && depth === 0) {
+      parts.push(src.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(src.slice(start));
+  return parts;
+}
+
+function generate(src: string, depth = 0): string {
+  if (depth > 6) return "";
+  const alts = splitTop(src);
+  if (alts.length > 1) return generate(alts[rnd(alts.length)]!, depth + 1);
+
+  let out = "";
+  for (let i = 0; i < src.length; ) {
+    let unit: string[] | null = null; // the characters this unit may emit
+    let literal: string | null = null;
+
+    const c = src[i]!;
+    if (c === "\\") {
+      const n = src[i + 1]!;
+      // Every branch here MUST advance `i`. A class escape that set `unit` and
+      // left `i` alone appended its character forever, which is how this whole
+      // file came to have never run.
+      if (n === "d") {
+        unit = [..."0123456789"];
+        i += 2;
+      } else if (n === "w") {
+        unit = [..."abcxyzABCXYZ0189_"];
+        i += 2;
+      } else if (n === "s") {
+        unit = [" "];
+        i += 2;
+      } else if (n === "S") {
+        unit = [..."abcXYZ019"];
+        i += 2;
+      } else if (n === "D") {
+        unit = [..."abcXYZ_-"];
+        i += 2;
+      } else if (n === "b" || n === "B") {
+        i += 2;
+        continue;
+      } else if (n === "u" && src[i + 2] === "{") {
+        const close = src.indexOf("}", i + 3);
+        literal = String.fromCodePoint(Number.parseInt(src.slice(i + 3, close), 16));
+        i = close + 1;
+        // fall through to the quantifier read below
+        const q0 = src[i];
+        if (q0 === undefined) {
+          out += literal;
+          continue;
+        }
+      } else if (n === "u") {
+        literal = String.fromCharCode(Number.parseInt(src.slice(i + 2, i + 6), 16));
+        i += 6;
+      } else if (n === "x") {
+        literal = String.fromCharCode(Number.parseInt(src.slice(i + 2, i + 4), 16));
+        i += 4;
+      } else if (n === "n") {
+        literal = "\n";
+        i += 2;
+      } else if (n === "t") {
+        literal = "\t";
+        i += 2;
+      } else if (n === "r") {
+        literal = "\r";
+        i += 2;
+      } else {
+        literal = n;
+        i += 2;
+      }
+    } else if (c === "[") {
+      const close = closeAt(src, i, "[", "]");
+      unit = [...expandClass(src.slice(i + 1, close))];
+      i = close + 1;
+    } else if (c === "(") {
+      const close = closeAt(src, i, "(", ")");
+      let inner = src.slice(i + 1, close);
+      i = close + 1;
+      if (inner.startsWith("?=") || inner.startsWith("?!")) continue;
+      if (inner.startsWith("?:")) inner = inner.slice(2);
+      else if (inner.startsWith("?<") && !inner.startsWith("?<=") && !inner.startsWith("?<!"))
+        inner = inner.slice(inner.indexOf(">") + 1);
+      literal = generate(inner, depth + 1);
+    } else if (c === "." ) {
+      unit = [..."abcXYZ019-_."];
+      i += 1;
+    } else if (c === "^" || c === "$") {
+      i += 1;
+      continue;
+    } else if (c === "*" || c === "+" || c === "?" || c === "{" || c === ")" || c === "]") {
+      throw new Error(`dangling ${c} in ${src}`);
+    } else {
+      literal = c;
+      i += 1;
+    }
+
+    // quantifier
+    let lo = 1;
+    let hi = 1;
+    const q = src[i];
+    if (q === "?") {
+      lo = 0;
+      hi = 1;
+      i += 1;
+    } else if (q === "*") {
+      lo = 0;
+      hi = 3;
+      i += 1;
+    } else if (q === "+") {
+      lo = 1;
+      hi = 3;
+      i += 1;
+    } else if (q === "{") {
+      const close = src.indexOf("}", i);
+      const body = src.slice(i + 1, close);
+      const [a, b] = body.split(",");
+      lo = Number(a);
+      hi = b === undefined ? lo : b === "" ? lo + 2 : Number(b);
+      i = close + 1;
+    }
+    if (src[i] === "?") i += 1; // lazy
+
+    const times = lo + rnd(Math.max(1, Math.min(hi, lo + 3) - lo + 1));
+    for (let k = 0; k < times; k++) {
+      out += unit ? unit[rnd(unit.length)] : literal;
+    }
+  }
+  return out;
+}
+
+// Filler that contains no 3-gram of any pattern literal by construction: a long
+// run of one character has exactly one 3-gram.
+const FILLER = "\u0007".repeat(8000);
+
+function admits(pattern: RegExp, sample: string): boolean {
+  const text = `${FILLER}${sample}${FILLER}`;
+  return mayMatch(buildGramIndex(text), mandatoryLiterals(pattern));
+}
+
+const ALL_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  ...FAST_PATTERNS.map((p) => ({ label: `secret/${p.name}`, pattern: p.pattern })),
+  ...CONTEXT_PATTERNS.map((p) => ({ label: `context/${p.name}`, pattern: p.pattern })),
+  ...LIBRARY_INLINE_PATTERNS.map((p, i) => ({ label: `lib/${i}:${p.source}`, pattern: p })),
+];
+
+describe("mandatoryLiterals is sound on every pattern the rules ship", () => {
+  test("every generated match is admitted by the prefilter", () => {
+    const failures: string[] = [];
+    let checked = 0;
+    for (const { label, pattern } of ALL_PATTERNS) {
+      const probe = new RegExp(pattern.source, pattern.flags.replace("g", ""));
+      let admittedAny = false;
+      for (let n = 0; n < 60; n++) {
+        let sample: string;
+        try {
+          sample = generate(pattern.source);
+        } catch (e) {
+          failures.push(`${label}: generator: ${(e as Error).message}`);
+          break;
+        }
+        // Only samples the pattern really matches say anything about soundness.
+        if (!probe.test(sample)) continue;
+        admittedAny = true;
+        checked += 1;
+        if (!admits(pattern, sample)) {
+          failures.push(`${label}: filter REJECTED a real match: ${JSON.stringify(sample.slice(0, 120))}`);
+          break;
+        }
+      }
+      if (!admittedAny) failures.push(`${label}: generator produced no matching sample`);
+    }
+    expect(failures).toEqual([]);
+    // Guard against the loop silently doing nothing.
+    expect(checked).toBeGreaterThan(ALL_PATTERNS.length * 10);
+  });
+});
+
+describe("the gram index", () => {
+  test("never denies a substring that is present", () => {
+    const text = `${"x".repeat(5000)}AKIAIOSFODNN7EXAMPLE${"y".repeat(5000)}`;
+    const index = buildGramIndex(text)!;
+    expect(index).not.toBeNull();
+    for (let len = 3; len <= 12; len++) {
+      for (let start = 0; start + len <= text.length; start += 97) {
+        const needle = text.slice(start, start + len).toLowerCase();
+        expect(mayContain(index, needle)).toBe(true);
+      }
+    }
+  });
+
+  // The table doubles with the content until it hits its ceiling, and only the
+  // widest table exercised the window mask. Every fixture above sits below it,
+  // which is why the leak went unnoticed; a script-heavy page reaches it on its
+  // first 40 KB bundle.
+  test("never denies a present substring in text wide enough for the largest table", () => {
+    const needle = "akiaiosfodnn7example";
+    const denied: string[] = [];
+    // The leak was the low bit of the character BEFORE the window, so the
+    // predecessor has to be varied: with the bug this denied every odd one.
+    for (const prev of [..."abcdefghxyz0123456789"]) {
+      const text = `${"q".repeat(40_000)}${prev}AKIAIOSFODNN7EXAMPLE${"w".repeat(40_000)}`;
+      const index = buildGramIndex(text)!;
+      if (!mayContain(index, needle)) denied.push(prev);
+    }
+    expect(denied).toEqual([]);
+  });
+
+  test("folds ASCII case on the needle as well, so an uppercase literal is found", () => {
+    const index = buildGramIndex(`${"q".repeat(40_000)}akiaiosfodnn7example`)!;
+    expect(mayContain(index, "AKIAIOSFODNN7EXAMPLE")).toBe(true);
+  });
+
+  test("denies literals that are absent", () => {
+    const index = buildGramIndex("z".repeat(9000))!;
+    expect(mayContain(index, "akia")).toBe(false);
+    expect(mayContain(index, "-----begin rsa private key-----")).toBe(false);
+  });
+
+  test("folds ASCII case so a lowercase needle finds uppercase text", () => {
+    const index = buildGramIndex(`${"q".repeat(6000)}AKIAIOSFODNN7EXAMPLE`)!;
+    expect(mayContain(index, "akiaiosfodnn7example")).toBe(true);
+  });
+
+  test("is skipped below the size floor, and a null index admits everything", () => {
+    expect(buildGramIndex("short")).toBeNull();
+    expect(mayMatch(null, [["definitely-absent"]])).toBe(true);
+  });
+});
+
+describe("mandatoryLiterals extraction", () => {
+  const cases: Array<[RegExp, string[][]]> = [
+    [/AKIA[A-Z0-9]{16}/, [["akia"]]],
+    // a literal shorter than the four-character window proves nothing, so only
+    // the second run survives here
+    [/sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}/, [["t3blbkfj"]]],
+    // an optional group contributes nothing and must not glue the runs together
+    [/mongodb(\+srv)?:\/\/[^\s"'<>]+/i, [["mongodb"]]],
+    // a top-level alternation yields one any-of set
+    [/redis(s)?:\/\//i, [["redis://", "rediss://"]]],
+    // an optional single-character class expands into variants
+    [/apikeys?[_-]?value/i, [["apikeyvalue", "apikey_value", "apikey-value", "apikeysvalue", "apikeys_value", "apikeys-value"]]],
+    // a `+` keeps its own character but ends the run after it
+    [/abcde+fghij/, [["abcde"], ["fghij"]]],
+    // `{0,3}` can repeat, so it ENDS the run: gluing the two sides would deny
+    // `abcdzzefgh`, which the pattern matches
+    [/abcdz{0,3}efgh/, [["abcd"], ["efgh"]]],
+    // `{0,1}` cannot repeat, so it expands in place
+    [/abcdz{0,1}efgh/, [["abcdefgh", "abcdzefgh"]]],
+    // a lookahead proves nothing
+    [/(?=foo)barbaz/, [["barbaz"]]],
+    // a literal shorter than the floor proves nothing
+    [/AC[0-9a-f]{32}/, []],
+    // a \uXXXX escape is ONE character, so the run restarts AFTER it and its hex
+    // digits never become literal text: `0275cmp` here would be a literal no
+    // match can contain. Angular's real signature, and the case that first
+    // proved readEscape has to consume all six characters.
+    [/\["\u0275cmp"\]/, [['cmp"]']]],
+    // the same signature written with the character itself: non-ASCII ends the
+    // run and the run is discarded, so nothing is proven
+    [new RegExp(`\\["${String.fromCharCode(0x0275)}cmp"\\]`), []],
+    [/prefix\u0041\u0042suffix/, [["prefixabsuffix"]]],
+  ];
+  for (const [re, expected] of cases) {
+    test(`${re.source} → ${JSON.stringify(expected)}`, () => {
+      expect(mandatoryLiterals(re).map((s) => [...s])).toEqual(expected);
+    });
+  }
+
+  // Both cases below are regressions, and both were silent: the filter denied a
+  // literal that was present, and nothing failed.
+  test("an element that can REPEAT ends the run instead of gluing it", () => {
+    // Each subject is one the pattern really matches, with the repeatable
+    // element appearing more than once — which is exactly what a glued run
+    // (`abcd` + `z` + `efgh`) is not a substring of.
+    const cases: Array<[RegExp, string]> = [
+      [/abcdz{0,3}efgh/, "abcdzzefgh"],
+      [/abcdz*efgh/, "abcdzzzefgh"],
+      [/abcd[xy]*efgh/, "abcdxyefgh"],
+      [/abcd[xy]{0,4}efgh/, "abcdxxefgh"],
+      [/abcd(?:xy)*efgh/, "abcdxyxyefgh"],
+      [/abcd(?:xy)+efgh/, "abcdxyxyefgh"],
+      [/abcdz+efgh/, "abcdzzefgh"],
+      [/abcd\.{0,2}efgh/, "abcd..efgh"],
+    ];
+    const failures: string[] = [];
+    for (const [pattern, subject] of cases) {
+      if (!pattern.test(subject)) {
+        failures.push(`${pattern.source}: fixture does not match ${subject}`);
+        continue;
+      }
+      if (!admits(pattern, subject)) {
+        failures.push(`${pattern.source}: filter REJECTED ${subject}`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  test("an unproven pattern is always run", () => {
+    const index = buildGramIndex("z".repeat(9000))!;
+    expect(mayMatch(index, mandatoryLiterals(/[0-9]{8,10}:[a-zA-Z0-9_-]{35}/))).toBe(true);
+  });
+});

--- a/packages/rules/tests/skip-link.test.ts
+++ b/packages/rules/tests/skip-link.test.ts
@@ -1,0 +1,71 @@
+// a11y/skip-link — the "early heading" bypass asks whether a heading's markup
+// appears in the first 2000 characters of `body.innerHTML`.
+//
+// #1864 stopped serialising the whole body once per heading, and stopped
+// searching the whole megabyte for a heading that can only count if it is in the
+// first 2000 characters. The searched prefix has to run to 2000 PLUS the
+// heading's own length: a heading that starts at 1999 and ends at 2012 counts,
+// and slicing at a flat 2000 truncates it and silently loses the bypass.
+
+import { describe, expect, test } from "bun:test";
+
+import { parsePage } from "@squirrelscan/parser";
+
+import { skipLinkRule } from "../src/a11y/skip-link";
+import type { RuleContext } from "../src/types";
+
+const HEADING = "<h2>Section</h2>";
+
+/** A body whose only h1/h2 starts at exactly `at` characters into innerHTML. */
+function bodyWithHeadingAt(at: number, trailing = 0): string {
+  const wrapper = "<div></div>".length; // the filler div's own markup
+  const filler = "x".repeat(at - wrapper);
+  const tail = trailing > 0 ? `<p>${"y".repeat(trailing)}</p>` : "";
+  return `<div>${filler}</div>${HEADING}${tail}`;
+}
+
+function methods(bodyHtml: string): string[] {
+  const url = "https://example.com/";
+  const html = `<!DOCTYPE html><html><head><title>t</title></head><body>${bodyHtml}</body></html>`;
+  const ctx = {
+    page: { url, html, statusCode: 200, loadTime: 0, headers: {} },
+    parsed: parsePage(html, url),
+    site: { baseUrl: "https://example.com", pages: [], robotsTxt: null, sitemaps: null, scripts: [] },
+    options: {},
+  } as unknown as RuleContext;
+  const check = skipLinkRule.run(ctx).checks[0];
+  // The passing branch reports the bypasses under `methods`, the warning branch
+  // under `found`; this rule is about which bypasses were seen either way.
+  const details = check?.details as { methods?: string[]; found?: string[] } | undefined;
+  return [...(details?.methods ?? details?.found ?? [])];
+}
+
+describe("a11y/skip-link: the early-heading window", () => {
+  test("the fixture puts the heading where it claims to", () => {
+    // If linkedom reserialises the filler differently the offsets below are
+    // meaningless, so pin the offset itself before asserting on it.
+    const url = "https://example.com/";
+    const html = `<!DOCTYPE html><html><head><title>t</title></head><body>${bodyWithHeadingAt(1999)}</body></html>`;
+    const body = parsePage(html, url).document!.querySelector("body")!;
+    expect(body.innerHTML.indexOf(HEADING)).toBe(1999);
+  });
+
+  test("a heading starting at 1999 counts, and it straddles the 2000 boundary", () => {
+    expect(methods(bodyWithHeadingAt(1999))).toContain("early heading");
+  });
+
+  test("a heading starting at exactly 2000 does not count", () => {
+    expect(methods(bodyWithHeadingAt(2000))).not.toContain("early heading");
+  });
+
+  test("a heading far past the window does not count, whatever follows it", () => {
+    expect(methods(bodyWithHeadingAt(40_000))).not.toContain("early heading");
+  });
+
+  test("content after the heading does not change the answer", () => {
+    // The searched prefix is shorter than the document; a rule that only looked
+    // at the prefix would still have to agree with one that looked at all of it.
+    expect(methods(bodyWithHeadingAt(1999, 50_000))).toContain("early heading");
+    expect(methods(bodyWithHeadingAt(2000, 50_000))).not.toContain("early heading");
+  });
+});


### PR DESCRIPTION
Cuts the rules phase on ~1 MB script-heavy pages from 274 to 165 ms/page, with
identical findings. squirrelscan/repo#1864.

## The measurement

150 byte-unique copies of a real 1.13 MB product page (59 inline scripts, 791 KB
of inline JavaScript), served by `benchmarks/harness/script-heavy-site.ts`.
`squirrel audit --coverage full --max-pages 150 --http --offline --refresh
--trace` with `SQUIRREL_RULE_PROFILE=1`, a fresh project and a per-run title
salt so the content store cannot serve one arm's pages to the other. Three
interleaved rounds per arm, medians, load average 3.2 to 5.0 on a 16 GB Apple
Silicon laptop.

| | before | after |
|---|---|---|
| **whole rules phase** | **274.1 ms/page** | **164.5 ms/page** |
| `security/leaked-secrets` | 64.5 | 29.3 |
| `a11y/skip-link` | 38.5 | 2.4 |
| `perf/js-libraries` | 31.2 | 7.2 |
| `perf/unminified-js` | 15.6 | 4.1 |
| `legal/cookie-consent` | 8.2 | 8.0 |
| `social/share-buttons` | 6.4 | 6.4 |
| audit wall time | 56 s | 42 s |

The last two rows are the control: nothing else in the phase moves. Run-to-run
spread is 265.5 to 281.6 before and 164.4 to 173.9 after.

Both arms were measured against a2905cf, this branch's base, so the comparison is
this change and nothing else. Two merges from main landed afterwards and are not
in the numbers.

**Findings are identical.** A same-salt before/after pair over the same 150
pages is byte-identical across 46 of the 47 rules that report. The 47th is
`perf/ttfb`, which grades the test server's response time and disagrees with
itself between any two runs on a loaded box (80 against 106 affected pages here).

## What changed

Three of the four were ordinary waste, and none of them changes an answer:

- **`a11y/skip-link`** built `body.innerHTML` inside its loop over headings,
  serialising the whole megabyte once per heading, then searched all of it for a
  heading that only counts inside the first 2000 characters.
- **`perf/unminified-js`** counted with `String.match` and a `/g` pattern five
  times per script, building an array of every match to read its length.
- **`shared/comment-scan`** compared single-character strings on its
  per-character path; comparing code points is about thirteen times faster
  (10.3 ms against 0.8 ms over one 390 KB bundle).

The fourth is `packages/rules/src/shared/literal-prefilter.ts`. `leaked-secrets`
runs 70 patterns and `js-libraries` 62 signatures over the same text, and a pass
costs the same whether it finds anything or not — so the cost is the pass count.
One pass records which 4-grams the text contains; a pattern whose mandatory
literals are provably absent is then skipped. Per page, over the 58 bodies of
text:

| | ms |
|---|---|
| build the index over every body | 5.4 |
| all 70 secret patterns, no prefilter | 42.4 |
| only the patterns that survive | 14.6 |
| `toLowerCase` every body (now on demand) | 3.8 |

Merging the patterns into one alternation per flag group and gating on it is
much worse — 89.0 ms against 38.9 for running them separately — because the
alternation gives up each pattern's literal-prefix search and admits the page
anyway.

The worst case is a page where nothing can be skipped: the index is then pure
overhead, 5.4 ms per page over 1.9 MB of text, about 8% of what the rule used to
cost. Content under 256 characters is not indexed at all and behaves exactly as
before.

## Why the tests look the way they do

A false negative here silently deletes a security finding, so `mandatoryLiterals`
returns literals every match must contain and nothing at all when it cannot prove
one, and the index can only err towards "maybe". Bugs that broke exactly that
kept turning up, every one of them silent, every one fixed here and pinned by a
test that fails on the old code. Reading the diff found these four:

1. The rolling hash was masked with the TABLE's width rather than the window's,
   so a table wider than 20 bits kept the low bit of the character BEFORE the
   window. Present needles were denied whenever their predecessor was odd — 8 of
   16 on a 40 KB text. The table only reaches that width past ~32 KB, which every
   fixture sat below.
2. An element that can repeat was expanded as if it occurred at most once, gluing
   a run across it: `abcdz{0,3}efgh` proved `abcdefgh` or `abcdzefgh` and denied
   `abcdzzefgh`, which it matches.
3. The index folds ASCII case, which over-approximates the text but not
   `text.toLowerCase()`, where the context keywords are looked up. Exactly two
   characters in Unicode lowercase into ASCII the text does not have: U+0130 and
   U+212A. `postmar<U+212A>_server_token` lowercases to `postmark_server_token`.
4. Three escapes were read as shorter than they are, leaving their own tails
   behind as literal text no match contains: `\12` (a backreference to group 12,
   read as `\1` then `2`), `\k<x>` (a named backreference, read as `\k` then
   `<x>`), and `\u{41}`, which is a code point only under the `u` flag and
   otherwise the letter `u` repeated 41 times.

A codex review found five more, each a pattern the engine reads one way and the
extractor read another:

| pattern | it matches | the extractor proved |
|---|---|---|
| `/(abcd.efgh)/` | `abcdXefgh` | `abcd.efgh` — `.` was in the group shortcut's literal class |
| `/abcd\d{1000}efgh/` | `abcd` + 1000 digits + `efgh` | `1000` — an atom that proves nothing still owns its quantifier |
| `/abcd[]\|efgh/` | `efgh` | `abcd` — JavaScript has no Perl `[]]`, so reading past the empty class hid the `\|` |
| `/\p{[abcd}efgh]/` | `p{a` | `efgh` — in legacy mode the `}` scanned for is inside a character class |
| `/secret/iu` | `ſecret` | `secret` — under `u`, `i` folds beyond ASCII |

Unicode-mode patterns are now declined whole. None of the five is reachable from
the pattern tables the rules ship today, which is why they were still there, and
the skip rate is unchanged at 33.7 of 70 patterns per body.

The generative soundness test that should have caught several of these could not
run at all — its own string generator looped forever on `\d`, `\w` and `\s` — so
three of its hand-written expectations described an implementation that no longer
existed. Its random number generator also multiplied past 2^53 and lost its low
bits, so 60 of 60 Redis samples took the same alternative and no Generic Secret
Assignment sample ever chose `password`: a generator that walks one branch cannot
notice an extractor that proves one branch.

Every regression test here was mutation-checked by restoring the bug it claims to
catch. Two only bite because the fixtures vary the character immediately before
the literal, and the two integration suites now compare whole findings rather
than sets of values, which tolerated a changed type, confidence or location.

## Not done

`legal/cookie-consent` (8.2 ms/page) and `social/share-buttons` (6.4) are now the
top of the phase. The first is seven full-document `querySelectorAll` passes with
substring attribute selectors, a linkedom cost rather than a regex one. The
second lowercases the whole page for four `/i` patterns that do not need it, and
removing that is not a no-op: `"K".toLowerCase()` is `"k"` while `/k/i` does
not match `K`. Both are noted in the benchmark record.
