### PR TITLE
feat(limits): raise the audit page ceiling to 10,000 (#1028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ How it works:
 
 ### Changed
 
+- **A local audit crawls up to 10,000 pages.** The hard cap on `--max-pages`
+  and `[crawler] max_pages` was 5,000; it is now 10,000, on every plan, local
+  audits being free either way. A 10,000-page audit needs roughly 4.5 GB of
+  memory and takes about fifteen minutes on a laptop, so the cap is a real
+  ceiling rather than a formality: past it, split the audit by section with
+  `include` patterns. Cloud audits follow their plan instead, and Team's
+  ceiling rises to 10,000 with this release.
+
+  Publishing a report from a crawl this size needs an API that accepts it, so
+  update the CLI only after the hosted side has: an older server rejects a
+  publish carrying more than 2,000 page statuses or 5,000 crawled URLs.
+
 - **A local audit no longer holds the whole site in memory.** The CLI's
   post-crawl phases ran the resident pipeline: one parsed page plus its DOM per
   crawled page, held from the end of the crawl through the entire rules pass,

--- a/apps/cli/tests/page-limit.test.ts
+++ b/apps/cli/tests/page-limit.test.ts
@@ -15,9 +15,10 @@ import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 
 describe("resolvePageLimit", () => {
   test("clamps above the cap and records what was asked for", () => {
-    const limit = resolvePageLimit(10_000);
+    const requested = MAX_PAGES_CAP * 2;
+    const limit = resolvePageLimit(requested);
     expect(limit.effective).toBe(MAX_PAGES_CAP);
-    expect(limit.requested).toBe(10_000);
+    expect(limit.requested).toBe(requested);
     expect(limit.clamped).toBe(true);
   });
 
@@ -70,17 +71,20 @@ describe("pageLimitNotice", () => {
   });
 
   test("keeps the digits of a fractional request", () => {
-    // `(5000.0001).toLocaleString()` is "5,000", which would print "Requested
-    // 5,000 pages, capped at 5,000" — a notice that reads as its own bug.
+    // `(10000.0001).toLocaleString()` is "10,000", which would print "Requested
+    // 10,000 pages, capped at 10,000" — a notice that reads as its own bug.
+    // Written against the cap rather than a literal so it keeps testing the
+    // rounding hazard after the cap moves (#1028 raised it 5,000 → 10,000).
     const notice =
       pageLimitNotice(resolvePageLimit(MAX_PAGES_CAP + 0.0001)) ?? "";
-    expect(notice).toContain("5000.0001");
+    expect(notice).toContain(`${MAX_PAGES_CAP}.0001`);
   });
 
   test("names both numbers when the cap bound", () => {
-    const notice = pageLimitNotice(resolvePageLimit(10_000));
+    const requested = MAX_PAGES_CAP * 2;
+    const notice = pageLimitNotice(resolvePageLimit(requested));
     expect(notice).toBeTruthy();
-    expect(notice).toContain("10,000");
+    expect(notice).toContain(requested.toLocaleString("en-US"));
     expect(notice).toContain(MAX_PAGES_CAP.toLocaleString("en-US"));
   });
 
@@ -90,9 +94,10 @@ describe("pageLimitNotice", () => {
   });
 
   test("does not name the flag, because config reaches the same clamp", () => {
-    // `[crawler] max_pages = 9000` produces this notice too, and telling that
-    // user to change `--max-pages` would send them to the wrong place.
-    const notice = pageLimitNotice(resolvePageLimit(9_000)) ?? "";
+    // `[crawler] max_pages = <over the cap>` produces this notice too, and
+    // telling that user to change `--max-pages` would send them to the wrong
+    // place. Derived from the cap so the request stays over it as it moves.
+    const notice = pageLimitNotice(resolvePageLimit(MAX_PAGES_CAP + 1)) ?? "";
     expect(notice).not.toContain("--max-pages");
   });
 });

--- a/docs/cli/crawl.mdx
+++ b/docs/cli/crawl.mdx
@@ -22,7 +22,7 @@ squirrel crawl <url> [options]
 
 | Option | Alias | Description | Default |
 |--------|-------|-------------|---------|
-| `--max-pages` | `-m` | Maximum pages to crawl (hard cap 5,000) | coverage default (`quick` = 25) |
+| `--max-pages` | `-m` | Maximum pages to crawl (hard cap 10,000) | coverage default (`quick` = 25) |
 | `--concurrency` | | Global crawl worker pool size (overrides `[crawler] concurrency`) | `5` |
 | `--per-host` | | Max concurrent requests per host (overrides `[crawler] per_host_concurrency`) | `5` |
 | `--coverage` | `-C` | Coverage mode: `quick`, `surface`, `full` | `quick` |
@@ -47,7 +47,7 @@ Unlike [`audit`](/cli/audit#coverage-modes), whose default coverage is auth-awar
 500 is `full` coverage's page budget, not the default.
 
 The page budget resolves as **`--max-pages` / `-m` > non-default `[crawler] max_pages` >
-coverage-mode default**, capped at 5,000 pages either way. Switch modes with
+coverage-mode default**, capped at 10,000 pages either way. Switch modes with
 `--coverage` (or `[crawler] coverage` in config), or override the budget directly
 with `--max-pages`. See [Crawling & Coverage](/crawl) for how each mode behaves.
 

--- a/docs/cloud/credits.mdx
+++ b/docs/cloud/credits.mdx
@@ -29,9 +29,11 @@ Audits triggered from the dashboard - on-demand ("Run now") and [scheduled](/clo
 |------|---------------------------|
 | Free | 500 |
 | Pro | 2,000 |
-| Team | 2,000 today, rising to 5,000 as report processing scales up |
+| Team | 10,000 |
 
-A crawl config above your plan's ceiling isn't an error - it's clamped automatically, the same way [`render_concurrency`](/configuration/cloud#render_concurrency) is. This limit is separate from the CLI's own crawl cap: `squirrel audit` run locally on your machine crawls up to **5,000 pages on every plan** - see [Crawl Limits](/configuration/crawler#max_pages).
+Free stays at 500 for a technical reason rather than a pricing one: free audits run on a smaller container, and a 10,000-page audit needs several gigabytes of memory to hold the crawl.
+
+A crawl config above your plan's ceiling isn't an error - it's clamped automatically, the same way [`render_concurrency`](/configuration/cloud#render_concurrency) is. This limit is separate from the CLI's own crawl cap: `squirrel audit` run locally on your machine crawls up to **10,000 pages on every plan** - see [Crawl Limits](/configuration/crawler#max_pages).
 
 If you're driving audits through the [REST API](/api/audits/create) or the [MCP server](/developers/mcp), a clamped run's response carries a `notice` field (`type: "page_limit_clamped"`, with the requested and applied page counts and an upgrade hint) so your integration or agent can surface it - the audit still runs normally either way.
 

--- a/docs/cloud/team.mdx
+++ b/docs/cloud/team.mdx
@@ -15,7 +15,7 @@ Team is the multi-person plan: invite teammates into an org, assign roles, and s
 | Credits | 3,000 per seat, pooled across the org |
 | Billing | Monthly or annual; credits arrive monthly either way |
 
-Everything on [Pro](/cloud/credits) carries over: scheduled audits, custom request headers, and render concurrency, raised again to 10 concurrent renders (Pro runs 5). Team's [max pages per cloud audit](/cloud/credits#max-pages-per-cloud-audit) ceiling is also the highest of the three plans, and rises further as report processing scales up.
+Everything on [Pro](/cloud/credits) carries over: scheduled audits, custom request headers, and render concurrency, raised again to 10 concurrent renders (Pro runs 5). Team also has the highest [max pages per cloud audit](/cloud/credits#max-pages-per-cloud-audit) ceiling of the three plans, at 10,000 pages against Pro's 2,000.
 
 Log in and go to **Settings → Team** in the [dashboard](/dashboard) to upgrade, pick a seat count, and check out.
 

--- a/docs/configuration/crawler.mdx
+++ b/docs/configuration/crawler.mdx
@@ -35,7 +35,7 @@ follow_redirects = true
 
 **Type:** `number`
 **Default:** `100`
-**Range:** `1` to `5000` (capped by CLI)
+**Range:** `1` to `10000` (capped by CLI)
 
 Maximum number of pages to crawl per audit. The literal config default is `100`, but when `max_pages` isn't explicitly set the effective budget follows the [coverage mode](/crawl): `quick` = 25, `surface` = 100, `full` = 500. The default coverage mode is auth-aware: any signed-in account (free or Pro) defaults to `surface`, only anonymous runs default to `quick` (see [Coverage Modes](/cli/audit#coverage-modes)).
 
@@ -60,7 +60,7 @@ squirrel audit https://example.com -m 100
 
 The resolution order is **`--max-pages` / `-m` > non-default `[crawler] max_pages` > coverage-mode default** (`quick` 25, `surface` 100, `full` 500).
 
-**Note:** The CLI enforces a hard cap (currently 5,000 pages) regardless of config or plan - local audits are free and unlimited, and this cap never changes based on your account. When a crawl stops because it hit the limit, the CLI prints a hint naming `--max-pages` and the cap; see [Hitting the page limit](/crawl#hitting-the-page-limit).
+**Note:** The CLI enforces a hard cap (currently 10,000 pages) regardless of config or plan - local audits are free and unlimited, and this cap never changes based on your account. When a crawl stops because it hit the limit, the CLI prints a hint naming `--max-pages` and the cap; see [Hitting the page limit](/crawl#hitting-the-page-limit).
 
 **Cloud audits are different:** an audit dispatched from the dashboard (on-demand or [scheduled](/cloud/scheduled-audits)) is capped per plan instead - see [max pages per cloud audit](/cloud/credits#max-pages-per-cloud-audit).
 

--- a/docs/crawl.mdx
+++ b/docs/crawl.mdx
@@ -69,14 +69,14 @@ Every crawl stops once it reaches the **max pages** limit. That limit comes from
 2. **`[crawler] max_pages = N`** in your config, when set to a non-default value.
 3. **Coverage-mode default**: `quick` = 25, `surface` = 100, `full` = 500.
 
-A **hard cap of 5,000 pages** applies on top: any higher value is clamped down to 5,000.
+A **hard cap of 10,000 pages** applies on top: any higher value is clamped down to 10,000.
 
 When the limit is the reason a crawl stopped, the CLI says so and tells you how to scan more:
 
 ```bash
 squirrel audit https://example.com
 # ✓ Audited 100 pages in 42.3s
-# ⚠ Reached max pages (100). Raise with --max-pages <N> or [crawler] max_pages (cap 5000); use -C full for full coverage.
+# ⚠ Reached max pages (100). Raise with --max-pages <N> or [crawler] max_pages (cap 10000); use -C full for full coverage.
 ```
 
 To scan a larger site, raise the limit or switch to `full` coverage:
@@ -97,7 +97,7 @@ max_pages = 2000
 ```
 
 <Note>
-If you've already set the limit to 5,000 (the hard cap) and still hit it, split the audit by section using `include` patterns (e.g. `include = ["/blog/**"]`) and audit each section separately.
+If you've already set the limit to 10,000 (the hard cap) and still hit it, split the audit by section using `include` patterns (e.g. `include = ["/blog/**"]`) and audit each section separately.
 </Note>
 
 See [Crawler Settings → `max_pages`](/configuration/crawler#max-pages) for the full config reference.

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -1508,14 +1508,18 @@ export interface PlanDefinition {
    */
   scheduleFrequencies?: readonly ScheduledAuditFrequency[];
   /**
-   * Raw per-plan cloud-audit page ceiling (#1020 ladder: Free 500 / Pro
-   * 2,000 / Team 5,000). This is the plan's OWN allowance, not the effective
-   * runtime ceiling — hosted dispatch sites clamp it further to
-   * `REPORT_LIMITS.maxPages`, the report/publish ingest cap. Team's raw value
-   * exceeds that cap today on purpose: raising the cap later (separate
-   * engine/report-pipeline work) auto-unlocks Team with no plan-data change.
-   * Local CLI audits are UNAFFECTED — they use their own generous
-   * MAX_PAGES_CAP regardless of plan.
+   * Raw per-plan cloud-audit page ceiling (#1028 ladder: Free 500 / Pro 2,000 /
+   * Team 10,000 / Enterprise 10,000). This is the plan's OWN allowance, not the
+   * effective runtime ceiling — hosted dispatch sites clamp it further to
+   * `REPORT_LIMITS.maxPages`, the report/publish ingest cap. Every ladder value
+   * is at or under that cap today, so nothing is silently clamped; the
+   * `Math.min` in `planMaxPages()` stays as the backstop for the case where the
+   * ingest cap is lowered without the ladder following.
+   *
+   * The ladder is bounded by container MEMORY, not by pricing: a 10,000-page
+   * audit retains ~4.4 GB, which fits the paid standard-4 class (#1869) and not
+   * free's 4 GiB. Local CLI audits are UNAFFECTED — they use MAX_PAGES_CAP
+   * regardless of plan.
    */
   maxPagesPerAudit: number;
   /**

--- a/packages/core-contracts/src/limits.ts
+++ b/packages/core-contracts/src/limits.ts
@@ -199,15 +199,29 @@ export const REPORT_LIMITS = {
   maxPayloadBytes: 20 * 1024 * 1024,
   // Report page-count ceiling for the CLOUD crawl config + sitemap arrays
   // (planMaxPages, cloud/custom-crawl caps all track this). Decoupled from the
-  // per-check pages cap below (#918): raising THIS would raise crawl cost.
-  maxPages: 2000,
+  // per-check pages cap below (#918): raising THIS raises crawl cost.
+  //
+  // 2,000 → 10,000 (#1028): the ceiling was set when a published report carried
+  // one entry per affected page, so payload grew with crawl size. #1167 made the
+  // publish payload FLAT in crawl size (PUBLISH_LIMITS.maxPagesPerCheckPublish
+  // samples each check to 100 pages) and #1023's chunked NDJSON findings ingest
+  // removed the single-body ceiling on findings, so the 20MB gate no longer
+  // scales with pages crawled. The binding constraint is now container MEMORY:
+  // a measured 10,000-page CLI audit peaked at 4,562 MB RSS / 4,425 MB heap
+  // (~0.39 MB retained per page, linear), which fits the standard-4 class paid
+  // plans run on (#1869) and does NOT fit free's 4 GiB — which is why the free
+  // plan's ladder value stays at 500 rather than tracking this.
+  maxPages: 10_000,
   // Max pages a single folded aggregate check may list (fold cap +
-  // checkResultSchema.pages). Set to MAX_PAGES_CAP so a CLI audit crawling up to
-  // the 5000-page ceiling keeps EVERY affected page in the published report
-  // instead of silently clipping past 2000 (#918). Larger than maxPages on
-  // purpose — the fold reduces N per-page checks to ONE aggregate, and the
-  // publish payload guard degrades to a signalled clip before the 20MB gate.
-  maxPagesPerCheck: 5000,
+  // checkResultSchema.pages). Set to MAX_PAGES_CAP so an audit crawling up to
+  // the crawl ceiling keeps EVERY affected page in the published report instead
+  // of silently clipping (#918) — the fold reduces N per-page checks to ONE
+  // aggregate, and the publish payload guard degrades to a signalled clip
+  // before the 20MB gate. Was strictly ABOVE maxPages while the cloud ceiling
+  // (2,000) sat below the CLI's (5,000); now that both ceilings are 10,000 it
+  // EQUALS maxPages, which is the same invariant ("covers a full crawl"), not
+  // a weakening of it.
+  maxPagesPerCheck: 10_000,
   maxChecksPerPage: 200,
   maxItemsPerCheck: 1000,
   maxUrlLength: 2048,
@@ -310,11 +324,19 @@ export const PUBLISH_LIMITS = {
 // dropped key, or a truncated hash set all fall back to pre-#1185 carry
 // behavior on the server — never to a wrong resolve.
 export const RESOLUTION_SIGNAL_LIMITS = {
-  // Full crawled-URL list cap — tracks the CLI crawl ceiling (MAX_PAGES_CAP).
-  maxCrawledUrls: 5_000,
+  // Full crawled-URL list cap — tracks the crawl ceiling (MAX_PAGES_CAP). These
+  // are raw URLs, not hashes, so this is the one axis of the signal that scales
+  // with crawl size: 10,000 typical URLs is ~0.8MB against the 20MB publish
+  // gate. The pathological case (every URL at maxUrlLength) is 20MB, but that
+  // was already 10MB at 5,000 — the ratio is what changed, not the class of
+  // risk. A crawl past this cap degrades safely: pages beyond it fall back to
+  // pre-#1185 carry behavior, never to a wrong resolve.
+  maxCrawledUrls: 10_000,
   // Per-check failing-hash cap — tracks REPORT_LIMITS.maxPagesPerCheck (the
   // fold's own page cap, past which the source list is already incomplete).
-  maxHashesPerCheck: 5_000,
+  // maxHashesTotal below is UNCHANGED, so the signal's total hash budget (and
+  // therefore its worst-case bytes) does not move with this.
+  maxHashesPerCheck: 10_000,
   // Per-MAP hash budget, enforced independently for `failing` and for
   // `notEvaluated` (both by the builder and by the publish schema's refines) —
   // so the schema-permitted worst case is ~200k hashes × ~11 bytes ≈ 2.2MB, not
@@ -336,6 +358,21 @@ export const PUBLISH_DEGRADE_LIMITS = {
   maxPagesPerCheck: 25,
   maxItems: 10,
   maxSourcePagesPerItem: 3,
+  // #1028: byte budget for `pageStatuses`, the one published field sized by
+  // PAGES CRAWLED rather than by findings and therefore invisible to the
+  // per-check caps above. It lists every non-2xx page, count-capped at the crawl
+  // ceiling, so at 10,000 pages of maxUrlLength URLs it is ~20MB on its own
+  // against a 20MB gate — the degrade pass would run, shrink nothing that
+  // mattered, and the publish would still fail. Clipping it only means fewer
+  // carried findings get staled (they carry instead), never a wrong resolve.
+  //
+  // 4MB is a fifth of the gate: generous for any real site (an ordinary URL is
+  // ~60 bytes, so this is tens of thousands of broken pages) while leaving the
+  // rest of the budget to the report. Bytes, not a count, because entry size
+  // varies by three orders of magnitude with URL length. See
+  // clipPageStatusesToBytes in the rules pkg, which also explains why
+  // `resolutionSignal` is left alone.
+  maxPageStatusBytes: 4 * 1024 * 1024,
 } as const;
 
 // ── Coverage Mode Page Limits ───────────────────────────────────
@@ -345,7 +382,17 @@ export const COVERAGE_PAGE_LIMITS = {
   full: 500,
 } as const satisfies Record<CoverageMode, number>;
 
-export const MAX_PAGES_CAP = 5_000;
+// Hard ceiling on a single crawl, applied by the CLI (resolvePageLimit) and by
+// every cloud dispatch path via REPORT_LIMITS.maxPages, which now equals it.
+// 5,000 → 10,000 (#1028): see the memory arithmetic on REPORT_LIMITS.maxPages.
+//
+// ROLLOUT: server before CLI. The API validates a publish against ITS OWN copy
+// of these constants, and rejects the whole payload rather than clamping it, so
+// a CLI binary built with this cap publishing to an API still on the old one
+// fails outright — for `pageStatuses` (was capped at the old maxPages) that
+// bites at 2,001 pages, well below the new ceiling. Deploy the hosted side
+// first, then cut the CLI release.
+export const MAX_PAGES_CAP = 10_000;
 
 // Upper bound for the CLI --concurrency / --per-host flags (#1068). Guards
 // against an absurd worker-pool size; mirrors MAX_PAGES_CAP's clamp posture.

--- a/packages/core-contracts/src/plans.ts
+++ b/packages/core-contracts/src/plans.ts
@@ -12,28 +12,16 @@ export const SCHEDULE_FREQUENCIES: readonly ScheduledAuditFrequency[] = [
   "monthly",
 ];
 
-/**
- * #1274 (follow-up to #1020): explicit gate for Team's 5,000-page ladder
- * value actually taking effect. Team's `maxPagesPerAudit` below stays a fixed
- * 5,000 unconditionally — that's the plan's nominal/marketing ceiling, and
- * pricing.tsx always displays it. This flag is a SEPARATE, narrower switch
- * consulted only by hosted plan enforcement, which uses Pro's 2,000 ceiling
- * for Team instead of the raw 5,000 while this is
- * `false`.
- *
- * Why not just gate on `REPORT_LIMITS.maxPages` rising (#1020's original
- * design)? That constant is shared with unrelated schema/crawl-cap concerns
- * and could rise for a reason that has nothing to do with #1023 — this flag
- * makes the ACTUAL gate condition ("has #1023 stage 1, chunked/streaming
- * publish past the 20MB payload gate, landed?") explicit and greppable
- * instead of an implicit side effect. `planMaxPages()` still applies
- * `Math.min(raw, REPORT_LIMITS.maxPages)` as a hard backstop regardless of
- * this flag, so even a premature flip here can't dispatch a crawl the
- * publish pipeline can't ingest.
- *
- * Flip to `true` in the #1023/#1021 finish-line PR — not before.
- */
-export const TEAM_MAX_PAGES_UNLOCKED = false;
+// #1274's TEAM_MAX_PAGES_UNLOCKED flag is GONE (#1028). It existed to stop an
+// unrelated rise in `REPORT_LIMITS.maxPages` from silently unlocking Team's
+// ladder step before #1023 stage 1 (chunked/streaming publish past the 20MB
+// payload gate) had landed. That work has landed — the API ingests findings as
+// streamed NDJSON chunks — and the ceilings below were raised deliberately for
+// exactly that reason, so the gate has nothing left to gate. A constant that is
+// permanently `true` is not a safety net, it is an extra hop every reader of
+// `planMaxPages()` has to follow. `Math.min(raw, REPORT_LIMITS.maxPages)` in
+// planMaxPages() remains the single hard backstop: no plan can ever dispatch a
+// crawl the report pipeline cannot ingest.
 
 // maxWebsites is a HIDDEN abuse cap (100 for every plan) — pricing is purely
 // subscription + credits. Never surface website limits in UI or marketing.
@@ -62,7 +50,9 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     // auth, which is evaluation, not a paid job.
     customHeaders: true,
     // #1020 ladder: matches Screaming Frog's free-tier crawl cap and today's
-    // `full` coverage preset ceiling.
+    // `full` coverage preset ceiling. Held at 500 through #1028's raise: free
+    // audits run on the 4 GiB container class, and a 10,000-page audit retains
+    // ~4.4 GB — the ceiling is a memory fact here, not a pricing choice.
     maxPagesPerAudit: 500,
     unlimitedCredits: false,
     selfServe: true,
@@ -93,7 +83,8 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     maxScheduledWebsites: -1,
     scheduleFrequencies: SCHEDULE_FREQUENCIES,
     customHeaders: true,
-    // #1020 ladder: today's cloud REPORT_LIMITS.maxPages ceiling.
+    // #1028 ladder: unchanged at 2,000. Pro is a single-seat plan for ordinary
+    // sites; Team is where the raised ceiling is the product.
     maxPagesPerAudit: 2000,
     unlimitedCredits: false,
     selfServe: true,
@@ -122,11 +113,11 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     maxScheduledWebsites: -1,
     scheduleFrequencies: SCHEDULE_FREQUENCIES,
     customHeaders: true,
-    // #1020 ladder: exceeds today's REPORT_LIMITS.maxPages (2,000) on purpose —
-    // Hosted plan enforcement clamps to that cap, so this only takes effect
-    // once the report/publish ingest ceiling is raised separately (see the
-    // maxPagesPerAudit doc comment on PlanDefinition in index.ts).
-    maxPagesPerAudit: 5000,
+    // #1028 ladder: Team is where large-site auditing lives. 10,000 is the
+    // measured ceiling of the paid standard-4 container class (#1869): a
+    // 10,000-page audit retains ~4.4 GB, which fits 8/12 GiB and does not fit
+    // free's 4 GiB. Equal to REPORT_LIMITS.maxPages, so nothing clamps it.
+    maxPagesPerAudit: 10000,
     unlimitedCredits: false,
     selfServe: true,
     perSeat: {
@@ -169,10 +160,12 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     maxScheduledWebsites: -1,
     scheduleFrequencies: SCHEDULE_FREQUENCIES,
     customHeaders: true,
-    // NOT subject to TEAM_MAX_PAGES_UNLOCKED — that flag gates Team's ladder
-    // step specifically (#1274). Enterprise carries its own allowance, still
-    // clamped at dispatch by `REPORT_LIMITS.maxPages` like every other plan.
-    maxPagesPerAudit: 5000,
+    // At least Team's ceiling, never below it (#1028) — a contracted plan that
+    // audited fewer pages than the tier under it would be a pricing bug. Kept
+    // as its own literal rather than a reference to Team's so a Team-tier
+    // change is a deliberate decision here too; still clamped at dispatch by
+    // `REPORT_LIMITS.maxPages` like every other plan.
+    maxPagesPerAudit: 10000,
     unlimitedCredits: true,
     selfServe: false,
   },

--- a/packages/core-contracts/src/resolution.ts
+++ b/packages/core-contracts/src/resolution.ts
@@ -77,12 +77,14 @@ const FNV32_PRIME = 0x01000193;
  * — which is why the builder computes that complement over normalized URLs
  * rather than over hashes (see rules/src/resolution.ts).
  *
- * The accepted cost of 32 bits is over-carrying: at the 5,000-page crawl
- * ceiling the birthday odds of any collision are ~0.3%, and each one merely
- * keeps one finding open a cycle longer. If per-signal page counts ever grow
- * well past that ceiling, widen the hash rather than reasoning about the
- * collision rate — but note that changing it breaks producer/consumer parity,
- * so it needs the golden-value test updated and a server-before-CLI rollout.
+ * The accepted cost of 32 bits is over-carrying: at the 10,000-page crawl
+ * ceiling (#1028, was 5,000) the birthday odds of any collision in one signal
+ * are ~1.2% (they were ~0.3% at 5,000 — the rate is quadratic in page count),
+ * and each one merely keeps one finding open a cycle longer. That is still the
+ * right trade at this size: the cost of a collision is bounded and benign,
+ * while widening the hash breaks producer/consumer parity and needs the
+ * golden-value test updated plus a server-before-CLI rollout. Revisit if the
+ * ceiling moves again — at 50,000 pages the odds pass 25%.
  */
 export function resolutionUrlHash(normalizedUrl: string): string {
   const bytes = new TextEncoder().encode(normalizedUrl);

--- a/packages/core-contracts/tests/plans.test.ts
+++ b/packages/core-contracts/tests/plans.test.ts
@@ -49,7 +49,10 @@ describe("plan definitions", () => {
     expect(plan.renderConcurrency).toBe(10);
     expect(plan.scheduledCrawls).toBe(true);
     expect(plan.customHeaders).toBe(true);
-    expect(plan.maxPagesPerAudit).toBe(5000);
+    expect(plan.maxPagesPerAudit).toBe(10000);
+    // #1028: a contracted plan must never audit fewer pages than the tier
+    // below it, whatever the two literals are set to.
+    expect(plan.maxPagesPerAudit).toBeGreaterThanOrEqual(PLANS.team.maxPagesPerAudit);
   });
 });
 

--- a/packages/rules/src/fold.ts
+++ b/packages/rules/src/fold.ts
@@ -158,6 +158,21 @@ export interface PublishSampleLimits {
   maxSourcePagesPerItem: number;
 }
 
+/**
+ * What {@link degradeAndRebuild} needs on top of the per-check sample caps.
+ *
+ * `maxPageStatusBytes` is OPTIONAL by design, and its absence is meaningful
+ * rather than a missing guard: it selects whether `pageStatuses` — sized by
+ * pages CRAWLED, so invisible to per-check sampling — is clipped too. A PRIMARY
+ * publish sample must leave it whole; only a DEGRADE pass, already clipping
+ * every finding's affected pages to fit the payload gate, may give it up. So
+ * `DEFAULT_PUBLISH_SAMPLE` omits it and `PUBLISH_DEGRADE_LIMITS` sets it.
+ */
+export interface PublishDegradeLimits extends PublishSampleLimits {
+  /** Byte budget for `pageStatuses`; omit to leave it whole. */
+  maxPageStatusBytes?: number;
+}
+
 /** Default publish sample: the primary caps applied on every publish (#1167). */
 export const DEFAULT_PUBLISH_SAMPLE: PublishSampleLimits = {
   maxPagesPerCheck: PUBLISH_LIMITS.maxPagesPerCheckPublish,
@@ -334,8 +349,9 @@ export function degradeAndRebuild<
   T extends {
     ruleResults?: Record<string, { checks?: CheckResult[] } | null | undefined> | null;
     siteChecks?: CheckResult[] | null;
+    pageStatuses?: { url: string; status: number }[] | null;
   },
->(report: T, limits: PublishSampleLimits): T {
+>(report: T, limits: PublishDegradeLimits): T {
   const ruleResults = report.ruleResults;
   if (ruleResults && typeof ruleResults === "object") {
     for (const rule of Object.values(ruleResults)) {
@@ -347,8 +363,65 @@ export function degradeAndRebuild<
   if (Array.isArray(report.siteChecks)) {
     report.siteChecks = sampleChecksForPublish(report.siteChecks, limits);
   }
+  if (limits.maxPageStatusBytes !== undefined) {
+    clipPageStatusesToBytes(report, limits.maxPageStatusBytes);
+  }
   return report;
 }
+
+/**
+ * Clip `pageStatuses` to a byte budget — the one part of a published report
+ * whose size tracks PAGES CRAWLED rather than findings found, and which the
+ * per-check sampling above therefore cannot shrink.
+ *
+ * It is a list of every non-2xx page, capped by COUNT at the crawl ceiling, so
+ * its worst case is `pages x REPORT_LIMITS.maxUrlLength`. At the 10,000-page
+ * ceiling (#1028) that is ~20MB against a 20MB gate on its own: the degrade pass
+ * would run, shrink nothing that mattered, and the publish would still fail.
+ *
+ * Clipping is safe in one direction only, which is the direction taken: the
+ * server uses these to STALE carried findings on pages that 404'd, so a shorter
+ * list stales fewer findings and they carry instead. Nothing resolves wrongly.
+ *
+ * A BYTE budget rather than an entry count because bytes are the actual
+ * constraint and entry size varies by three orders of magnitude between a
+ * `/a` and a 2048-character URL. Measured per entry in one pass, so a report
+ * with ordinary URLs keeps thousands of them and one with pathological URLs
+ * keeps few — both landing at the same size.
+ *
+ * `resolutionSignal` is deliberately NOT touched here even though it is the
+ * other crawl-scaled field. Its `crawledUrls` is the SCORING DENOMINATOR on the
+ * complete-store path (audit-engine reconstruct.ts counts clean pages as
+ * "crawled minus failing"), so shrinking it does not degrade the report, it
+ * silently understates the health score. A loud PAYLOAD_TOO_LARGE naming the
+ * page count is a better answer than a quietly wrong score. Reaching that
+ * needs ~10,000 pages whose URLs are all near the 2048-character maximum.
+ *
+ * Exported for direct testing; production callers reach it through
+ * {@link degradeAndRebuild}.
+ */
+export function clipPageStatusesToBytes<
+  T extends { pageStatuses?: { url: string; status: number }[] | null },
+>(report: T, maxBytes: number): T {
+  const statuses = report.pageStatuses;
+  if (!Array.isArray(statuses) || statuses.length === 0) return report;
+  const encoder = new TextEncoder();
+  let used = 2; // the enclosing "[]"
+  let kept = 0;
+  for (const entry of statuses) {
+    // +1 for the separating comma; the first entry over-counts by one byte,
+    // which only ever makes the result smaller than the budget.
+    const size = encoder.encode(JSON.stringify(entry)).length + 1;
+    if (used + size > maxBytes) break;
+    used += size;
+    kept++;
+  }
+  // Idempotent: a second pass over an already-clipped array measures the same
+  // entries and keeps the same count.
+  if (kept < statuses.length) report.pageStatuses = statuses.slice(0, kept);
+  return report;
+}
+
 
 export interface FoldLimits {
   /** Max checks per rule in the published report (REPORT_LIMITS.maxChecksPerRule). */

--- a/packages/rules/tests/degrade-and-rebuild.test.ts
+++ b/packages/rules/tests/degrade-and-rebuild.test.ts
@@ -10,15 +10,17 @@ import { describe, expect, test } from "bun:test";
 import { PUBLISH_DEGRADE_LIMITS } from "@squirrelscan/core-contracts/limits";
 
 import {
+  clipPageStatusesToBytes,
   degradeAndRebuild,
   DEFAULT_PUBLISH_SAMPLE,
   sampleChecksForPublish,
+  type PublishDegradeLimits,
   type PublishSampleLimits,
 } from "../src/fold";
 import type { CheckResult } from "../src/types";
 
 const PRIMARY: PublishSampleLimits = DEFAULT_PUBLISH_SAMPLE;
-const DEGRADE: PublishSampleLimits = PUBLISH_DEGRADE_LIMITS;
+const DEGRADE: PublishDegradeLimits = PUBLISH_DEGRADE_LIMITS;
 
 const pageList = (n: number) => Array.from({ length: n }, (_, i) => `https://x.test/p/${i}`);
 
@@ -125,5 +127,79 @@ describe("degradeAndRebuild", () => {
     // A null rule value in the record is skipped, not dereferenced.
     const r = { ruleResults: { bad: null }, siteChecks: [] };
     expect(() => degradeAndRebuild(r, DEGRADE)).not.toThrow();
+  });
+});
+
+// #1028: raising the crawl ceiling to 10,000 pages made `pageStatuses` big
+// enough to blow the 20MB publish gate on its own — it lists every non-2xx page,
+// is count-capped at the ceiling, and per-check sampling cannot see it. The
+// degrade pass has to reach it or it runs, shrinks nothing that matters, and the
+// publish fails anyway.
+describe("clipPageStatusesToBytes (#1028)", () => {
+  const budget = PUBLISH_DEGRADE_LIMITS.maxPageStatusBytes;
+  const statuses = (n: number, urlLen = 40) =>
+    Array.from({ length: n }, (_, i) => ({
+      url: `https://x.test/p/${i}`.padEnd(urlLen, "a"),
+      status: 404,
+    }));
+  const bytes = (arr: unknown) => new TextEncoder().encode(JSON.stringify(arr)).length;
+
+  test("leaves an array already inside the budget completely alone", () => {
+    const r = { pageStatuses: statuses(100) };
+    const before = r.pageStatuses;
+    clipPageStatusesToBytes(r, budget);
+    expect(r.pageStatuses).toBe(before);
+    expect(r.pageStatuses).toHaveLength(100);
+  });
+
+  test("clips an over-budget array to fit, and the result really is under", () => {
+    const r = { pageStatuses: statuses(20_000, 300) };
+    expect(bytes(r.pageStatuses)).toBeGreaterThan(budget);
+    clipPageStatusesToBytes(r, budget);
+    expect(r.pageStatuses.length).toBeLessThan(20_000);
+    expect(bytes(r.pageStatuses)).toBeLessThanOrEqual(budget);
+  });
+
+  // The point of budgeting BYTES rather than entries: entry size varies by three
+  // orders of magnitude with URL length, so a fixed count is either wasteful for
+  // short URLs or useless for long ones.
+  test("keeps far more short URLs than long ones for the same budget", () => {
+    // A budget both arrays overrun, so the comparison is about entry size and
+    // not about one of them happening to fit.
+    const small = 100_000;
+    const shortR = { pageStatuses: statuses(20_000, 40) };
+    const longR = { pageStatuses: statuses(20_000, 2000) };
+    clipPageStatusesToBytes(shortR, small);
+    clipPageStatusesToBytes(longR, small);
+    expect(shortR.pageStatuses.length).toBeGreaterThan(longR.pageStatuses.length * 10);
+    expect(bytes(shortR.pageStatuses)).toBeLessThanOrEqual(small);
+    expect(bytes(longR.pageStatuses)).toBeLessThanOrEqual(small);
+  });
+
+  test("idempotent: a second pass changes nothing", () => {
+    const r = { pageStatuses: statuses(20_000, 300) };
+    clipPageStatusesToBytes(r, budget);
+    const once = r.pageStatuses.length;
+    const ref = r.pageStatuses;
+    clipPageStatusesToBytes(r, budget);
+    expect(r.pageStatuses).toBe(ref);
+    expect(r.pageStatuses).toHaveLength(once);
+  });
+
+  test("degradeAndRebuild applies it, and a primary sample does NOT", () => {
+    const mk = () => ({ ruleResults: {}, siteChecks: [], pageStatuses: statuses(20_000, 300) });
+    const degraded = degradeAndRebuild(mk(), DEGRADE);
+    expect(bytes(degraded.pageStatuses)).toBeLessThanOrEqual(budget);
+
+    // DEFAULT_PUBLISH_SAMPLE carries no byte budget on purpose: a primary
+    // publish sample must leave the crawl-scaled field whole.
+    const sampled = degradeAndRebuild(mk(), PRIMARY);
+    expect(sampled.pageStatuses).toHaveLength(20_000);
+  });
+
+  test("tolerates a report with no pageStatuses at all", () => {
+    expect(() => degradeAndRebuild({}, DEGRADE)).not.toThrow();
+    expect(() => clipPageStatusesToBytes({ pageStatuses: null }, budget)).not.toThrow();
+    expect(() => clipPageStatusesToBytes({ pageStatuses: [] }, budget)).not.toThrow();
   });
 });

--- a/packages/rules/tests/fold.test.ts
+++ b/packages/rules/tests/fold.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { CHECK_DETAILS_LIMITS, REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
+import {
+  CHECK_DETAILS_LIMITS,
+  MAX_PAGES_CAP,
+  REPORT_LIMITS,
+} from "@squirrelscan/core-contracts/limits";
 
 import { clampItemId } from "@squirrelscan/core-contracts/clamp";
 
@@ -383,10 +387,15 @@ describe("unfoldAggregateCheck", () => {
 });
 
 describe("per-check pages cap (#918)", () => {
-  test("DEFAULT_FOLD_LIMITS.maxPagesPerCheck tracks REPORT_LIMITS, above the crawl ceiling", () => {
+  test("DEFAULT_FOLD_LIMITS.maxPagesPerCheck tracks REPORT_LIMITS and covers a full crawl", () => {
     expect(DEFAULT_FOLD_LIMITS.maxPagesPerCheck).toBe(REPORT_LIMITS.maxPagesPerCheck);
-    // Decoupled from + larger than the crawl-ceiling maxPages (#918).
-    expect(REPORT_LIMITS.maxPagesPerCheck).toBeGreaterThan(REPORT_LIMITS.maxPages);
+    // The point of #918's decoupling: a folded check can list every page of the
+    // largest crawl either surface can dispatch, so nothing is silently clipped.
+    // Asserted against BOTH ceilings rather than "strictly above maxPages" — the
+    // strict form only held while the cloud ceiling sat below the CLI's, and
+    // #1028 raised both to MAX_PAGES_CAP.
+    expect(REPORT_LIMITS.maxPagesPerCheck).toBe(MAX_PAGES_CAP);
+    expect(REPORT_LIMITS.maxPagesPerCheck).toBeGreaterThanOrEqual(REPORT_LIMITS.maxPages);
   });
 
   test("a >2000-page failure keeps every page (no clip at the old 2000 cap)", () => {


### PR DESCRIPTION
Raises the crawl page ceiling from 5,000 (CLI) / 2,000 (cloud) to 10,000 on both surfaces, and moves the plan ladder to Free 500 / Pro 2,000 / Team 10,000 / Enterprise 10,000.

## Why now

The old ceilings were set when a published report carried one entry per affected page, so the payload grew with crawl size. Two changes since removed that:

- #1167 publish sampling caps each check at 100 affected pages, making the payload flat in crawl size.
- #1023 chunked NDJSON findings ingest removed the single-body limit on findings.

The binding constraint is now container memory. A measured 10,000-page CLI audit:

| pages | wall | peak RSS | heapUsed |
|---|---|---|---|
| 5,000 | 448 s | 2,721 MB | 2,461 MB |
| 10,000 | 929 s | 4,562 MB | 4,425 MB |

Linear, about 0.39 MB retained per page. 4.4 GB fits the standard-4 class paid plans run on (#1869) and does not fit free's 4 GiB, which is why Free stays at 500. That is a memory fact, not a pricing choice, and the docs say so.

## What changed

- `MAX_PAGES_CAP` 5,000 to 10,000, and `REPORT_LIMITS.maxPages` 2,000 to 10,000.
- `maxPagesPerCheck` and the two per-crawl resolution-signal caps track the new ceiling.
- Plan ladder: Team and Enterprise to 10,000. Pro and Free unchanged.
- `TEAM_MAX_PAGES_UNLOCKED` deleted. It gated Team on #1023 stage 1 landing; that landed, so the flag would now be permanently true, which is an extra hop rather than a safety net. `Math.min(raw, REPORT_LIMITS.maxPages)` in `planMaxPages()` remains the one backstop. Its two consumers live in the private repo and are removed in the paired PR.
- Docs updated: crawl limits, crawler config reference, CLI flag table, cloud credits ceiling table, Team plan page. `make validate` passes.

## Review finding fixed before pushing

A codex pass found that the ceilings alone would break the 20 MB publish gate. `pageStatuses` lists every non-2xx page and is capped by count at the crawl ceiling, so per-check sampling cannot shrink it. A 10,000-page report of long URLs measured 22,271,057 bytes both before and after the degrade pass: the degrade ran, changed nothing that mattered, and the publish still failed.

`clipPageStatusesToBytes` in the shared degrade helper now clips it to a 4 MB budget, measured per entry rather than by a fixed count because entry size varies by three orders of magnitude with URL length. The same repro is now 15,224,701 bytes. Clipping is safe in one direction only, which is the direction taken: the server uses these to stale carried findings on pages that 404'd, so a shorter list stales fewer findings and they carry instead.

`resolutionSignal.crawledUrls` is the other crawl-scaled field and is deliberately left whole. It is the scoring denominator on the complete-store path, where clean pages are counted as crawled minus failing, so shrinking it would not degrade the report, it would silently understate the health score. A loud `PAYLOAD_TOO_LARGE` naming the page count is the better answer there. Reaching it needs roughly 10,000 pages whose URLs are all near the 2048-character maximum.

Only a degrade pass clips anything here. `DEFAULT_PUBLISH_SAMPLE` omits the budget on purpose, because a primary publish sample must leave the crawl-scaled field whole.

## Rollout: server before CLI

The API validates a publish against its own copy of these constants and rejects the payload rather than clamping it. A CLI binary built with the new caps publishing to an API still on the old ones fails outright, and for `pageStatuses` that bites at 2,001 pages, well below the new ceiling. Deploy the hosted side first, then cut the CLI release. Noted at `MAX_PAGES_CAP` and in the changelog.

## Tests

Ran locally: `page-limit`, `page-limit-hint`, `publish-size-bound`, `publish-slim`, `fold`, `resolution`, `degrade-and-rebuild`, `plans`, `cloud-merge`, `complete-store-parity`, and three golden suites. Assertions that pinned the old numbers were rewritten against the constants rather than re-pinned to new literals. The `maxPagesPerCheck > maxPages` invariant became `>=` plus `== MAX_PAGES_CAP`: the strict form only held while the cloud ceiling sat below the CLI's, and the real invariant it stood for is "a folded check covers a full crawl".

Refs #1028
