### PR TITLE
perf(audit-engine): run a template-scoped rule once per cluster and fan its verdict out (#1951)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -246,7 +246,7 @@
         "filename": "docs/cli/debug.mdx",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 146
+        "line_number": 171
       }
     ],
     "packages/audit-engine/tests/fingerprint-parity.test.ts": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-08T03:02:41Z"
+  "generated_at": "2026-09-08T06:26:04Z"
 }

--- a/apps/cli/scripts/template-fanout-bench.ts
+++ b/apps/cli/scripts/template-fanout-bench.ts
@@ -1,0 +1,498 @@
+// What template fan-out (#1951) is worth, measured on a finished `project.db`.
+// No network, and no write to the crawl it reads.
+//
+//   bun run scripts/template-fanout-bench.ts --db ~/.squirrel/projects/rl-e2e/project.db
+//   bun run scripts/template-fanout-bench.ts --db <path> --verify       # equivalence, not timing
+//   bun run scripts/template-fanout-bench.ts --db <path> --profile      # per-rule attribution
+//
+// It measures the STREAMED PAGE-RULE PASS only (`streamPageRules`) — the phase
+// the change is in. That pass is pure sync CPU over stored HTML: no site rules, so
+// nothing here reaches the network, which two things in the site phase otherwise
+// do (`security/http-to-https` probes sample URLs, and the soft-404 confirmation
+// re-fetches candidates). A rules-phase number measured with either of those in it
+// is a number about the network.
+//
+// METHOD, and why each part is there (the traps are recorded in
+// benchmarks/2026-09-perf-program.md and cost several confident wrong headlines):
+//
+//  - **Every measurement runs in its own CHILD PROCESS.** Two arms in one process
+//    share a warm JIT, a warm linkedom and a warm SQLite page cache, and whichever
+//    runs second wins for reasons that have nothing to do with the change.
+//  - **The arms are INTERLEAVED and the report is the MEDIAN**, not the minimum of
+//    a block per arm: a machine that gets busier during the run otherwise loads
+//    the whole penalty onto whichever arm ran last. State the load average.
+//  - **CPU time is reported alongside wall time, and on a busy box it is the one
+//    to read.** Five repeats here swung 66 to 101 s on the SAME arm while the load
+//    average moved between 3.7 and 8; the CPU time for that work does not move
+//    with someone else's.
+//  - **Per-rule time comes from `durationUs`, never `durationMs`.** The profiler
+//    rounds `durationMs` to whole milliseconds, and a page rule runs once per page
+//    — thousands of sub-millisecond samples sum to zero and a rule that crosses
+//    1 ms on heavy pages jumps a whole unit. Invocation COUNTS are exact either
+//    way, and are the honest measure of what the fan-out removed.
+//  - **The corpus is a real crawl.** The synthetic bench sites are generated from
+//    1-6 templates, so every page is a cluster member and the saving comes out
+//    flattering and wrong (#1026). A synthetic corpus is worth measuring only as
+//    the "everything is one template" ceiling, clearly labelled as such.
+//
+// `--verify` is the other half and is not a timing run: it runs both arms in ONE
+// process over the same crawl and compares the complete per-page check lists, the
+// per-rule results and the folded tallies. That is the byte-identity claim checked
+// against a real corpus rather than against an authored fixture — the CI gates
+// (`template-fanout-equivalence-golden.test.ts`,
+// `template-fanout-parity-golden.test.ts`) only ever see the pages they contain.
+
+import type { CheckResult } from "@squirrelscan/core-contracts";
+import type { SiteData } from "@squirrelscan/rules";
+
+import { streamPageRules } from "@squirrelscan/audit-engine";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { createRunner } from "@squirrelscan/rules";
+import { Effect } from "effect";
+import { copyFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getGlobalContentStore } from "@/crawler/storage/content-store";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const arg = (name: string, fallback: string): string => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? (process.argv[i + 1] ?? fallback) : fallback;
+};
+const flag = (name: string): boolean => process.argv.includes(`--${name}`);
+
+const DB = arg("db", "");
+if (!DB) {
+  console.error(
+    "usage: bun run scripts/template-fanout-bench.ts --db <project.db> [--repeat 3] [--verify] [--profile] [--batch 200]"
+  );
+  process.exit(1);
+}
+// Validated as TEXT before conversion: `parseInt` turns "1.5" into 1 and "1e3"
+// into 1, both of which pass an is-integer check afterwards. A non-positive batch
+// makes storage omit its LIMIT and never advance the offset (see the invariance
+// script's note) — an infinite read of the whole crawl.
+function positiveInt(name: string, fallback: string): number {
+  const raw = arg(name, fallback);
+  if (!/^[1-9][0-9]{0,6}$/.test(raw)) {
+    console.error(
+      `--${name} must be a positive integer, got ${JSON.stringify(raw)}`
+    );
+    process.exit(1);
+  }
+  return Number.parseInt(raw, 10);
+}
+const REPEATS = positiveInt("repeat", "3");
+const BATCH = positiveInt("batch", "200");
+
+/**
+ * Open a DISPOSABLE COPY. `SQLiteStorage.init()` opens the file writable,
+ * switches it to WAL and runs migrations, so pointing it at a corpus would
+ * silently upgrade someone's crawl — and a mistyped path would create an empty
+ * database instead of failing. The -wal/-shm sidecars come too, or the copy is
+ * missing committed pages.
+ */
+function copyCorpus(source: string): { dir: string; db: string } {
+  if (!existsSync(source)) {
+    console.error(`no such database: ${source}`);
+    process.exit(1);
+  }
+  const dir = mkdtempSync(join(tmpdir(), "squirrel-fanout-bench-"));
+  const db = join(dir, "probe.db");
+  copyFileSync(source, db);
+  for (const suffix of ["-wal", "-shm"]) {
+    if (existsSync(source + suffix)) copyFileSync(source + suffix, db + suffix);
+  }
+  return { dir, db };
+}
+
+const CONFIG = {
+  rule_options: {},
+  rules: { enable: ["*"] },
+} as unknown as Parameters<typeof createRunner>[0];
+
+async function openCrawl(db: string) {
+  const storage = new SQLiteStorage(db, getGlobalContentStore());
+  await run(storage.init());
+  const wanted = arg("crawl", "");
+  const crawls = (await run(storage.listCrawls(50))) as Array<{
+    id: string;
+    baseUrl?: string;
+  }>;
+  const crawl = wanted ? crawls.find((c) => c.id === wanted) : crawls[0];
+  if (!crawl) {
+    console.error("no crawls in this db");
+    process.exit(1);
+  }
+  // Page rules read only the non-`pages` fields of SiteData, so this is the same
+  // context both arms get and it costs no fetch.
+  const siteData: SiteData = {
+    baseUrl: crawl.baseUrl ?? "",
+    pages: [],
+    robotsTxt: null,
+    sitemaps: null,
+  };
+  return { storage, crawlId: crawl.id, siteData };
+}
+
+// ── child: one measurement ───────────────────────────────────────────────────
+
+if (flag("child")) {
+  const fanout = arg("arm", "on") === "on";
+  // The parent hands the child the disposable COPY as --db, so the child never
+  // opens the corpus it was pointed at.
+  const { storage, crawlId, siteData } = await openCrawl(DB);
+  const started = performance.now();
+  const cpuStart = process.cpuUsage();
+  const result = await run(
+    streamPageRules(storage, crawlId, createRunner(CONFIG), siteData, {
+      batchSize: BATCH,
+      templateFanout: fanout,
+    })
+  );
+  // Wall time on a box running other work is mostly a measurement of the other
+  // work: five repeats of the SAME arm swung 66 to 101 s here while the load
+  // average moved between 3.7 and 8. CPU time for the same work does not, so both
+  // are reported and the CPU column is the one to read on a busy machine.
+  const cpu = process.cpuUsage(cpuStart);
+  const cpuMs = (cpu.user + cpu.system) / 1000;
+  const ms = performance.now() - started;
+  await run(storage.close());
+  console.log(
+    `CHILD ${JSON.stringify({
+      ms,
+      cpuMs,
+      pages: result.pageUrls.length,
+      clusters: result.templateFanout.clusters,
+      fannedPages: result.templateFanout.fannedPages,
+      fannedRuleRuns: result.templateFanout.fannedRuleRuns,
+    })}`
+  );
+  process.exit(0);
+}
+
+// ── parent ───────────────────────────────────────────────────────────────────
+
+const corpus = copyCorpus(DB);
+let exitCode = 0;
+try {
+  // Warm the COPY before anything is timed. `init()` runs migrations and switches
+  // the file to WAL, and the pass itself upserts a page_features row per page — so
+  // an unwarmed first run pays for a migration and for INSERTs where every later
+  // run pays for UPDATEs. Whichever arm went first would carry that, and it is
+  // exactly the arm this change is supposed to beat.
+  {
+    const warm = await openCrawl(corpus.db);
+    await run(
+      streamPageRules(
+        warm.storage,
+        warm.crawlId,
+        createRunner(CONFIG),
+        warm.siteData,
+        {
+          batchSize: BATCH,
+          templateFanout: false,
+        }
+      )
+    );
+    await run(warm.storage.close());
+  }
+
+  if (flag("verify")) {
+    // Not a timing run: one process, both arms, complete comparison.
+    const { storage, crawlId, siteData } = await openCrawl(corpus.db);
+    const plain = await run(
+      streamPageRules(storage, crawlId, createRunner(CONFIG), siteData, {
+        batchSize: BATCH,
+        templateFanout: false,
+      })
+    );
+    const fanned = await run(
+      streamPageRules(storage, crawlId, createRunner(CONFIG), siteData, {
+        batchSize: BATCH,
+        templateFanout: true,
+      })
+    );
+    await run(storage.close());
+
+    const canon = (checks: readonly CheckResult[]): string =>
+      JSON.stringify(checks);
+    let compared = 0;
+    const differing: string[] = [];
+    if (plain.pageResults.size !== fanned.pageResults.size) {
+      differing.push(
+        `page count ${plain.pageResults.size} vs ${fanned.pageResults.size}`
+      );
+    }
+    for (const [url, checks] of plain.pageResults) {
+      const other = fanned.pageResults.get(url);
+      compared++;
+      if (!other || canon(other) !== canon(checks)) differing.push(url);
+    }
+    for (const [ruleId, rr] of plain.ruleResultsMap) {
+      const other = fanned.ruleResultsMap.get(ruleId);
+      if (!other || canon(other.checks) !== canon(rr.checks))
+        differing.push(`rule ${ruleId}`);
+    }
+    for (const [ruleId, rt] of plain.tallies) {
+      const other = fanned.tallies.get(ruleId);
+      if (JSON.stringify(other?.tally) !== JSON.stringify(rt.tally)) {
+        differing.push(`tally ${ruleId}`);
+      }
+    }
+
+    console.log(`db          ${DB}`);
+    console.log(`pages       ${compared} compared`);
+    console.log(`clusters    ${fanned.templateFanout.clusters}`);
+    console.log(
+      `fanned      ${fanned.templateFanout.fannedPages} pages, ${fanned.templateFanout.fannedRuleRuns} rule runs removed`
+    );
+    if (differing.length > 0) {
+      console.log("");
+      console.log(`FAIL        ${differing.length} differences, first 10:`);
+      for (const d of differing.slice(0, 10)) console.log(`  ${d}`);
+      exitCode = 2;
+    } else if (fanned.templateFanout.fannedPages === 0) {
+      // A run where nothing was fanned out proves nothing, the same way a corpus
+      // of one template makes every rule look invariant.
+      console.log("");
+      console.log("INCONCLUSIVE  no page inherited a verdict on this corpus");
+      exitCode = 3;
+    } else {
+      console.log("");
+      console.log("PASS        byte-identical with and without fan-out");
+    }
+  } else {
+    // ── timing ─────────────────────────────────────────────────────────────────
+
+    interface Sample {
+      ms: number;
+      cpuMs: number;
+      pages: number;
+      clusters: number;
+      fannedPages: number;
+      fannedRuleRuns: number;
+    }
+    /** arm -> per-rule summed microseconds and invocation counts. */
+    const profiles = new Map<
+      string,
+      {
+        invocations: number;
+        us: Map<string, number>;
+        calls: Map<string, number>;
+      }
+    >();
+
+    function child(arm: "on" | "off"): Sample | null {
+      const proc = Bun.spawnSync({
+        cmd: [
+          process.execPath,
+          "run",
+          import.meta.path,
+          "--child",
+          "--arm",
+          arm,
+          "--db",
+          corpus.db,
+          "--batch",
+          String(BATCH),
+          ...(arg("crawl", "") ? ["--crawl", arg("crawl", "")] : []),
+        ],
+        // Read at module load in the rules logger, so it has to be in the child's
+        // environment rather than a flag the child would re-plumb.
+        env: flag("profile")
+          ? { ...process.env, SQUIRREL_RULE_PROFILE: "1" }
+          : process.env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = proc.stderr?.toString() ?? "";
+      if (proc.exitCode !== 0) {
+        console.error(
+          `  arm ${arm}: exit ${proc.exitCode}\n${stderr.slice(-800)}`
+        );
+        return null;
+      }
+      if (flag("profile")) recordProfile(arm, stderr);
+      const line = proc.stdout
+        .toString()
+        .split("\n")
+        .find((l) => l.startsWith("CHILD "));
+      if (!line) return null;
+      const sample = JSON.parse(line.slice(6)) as Sample;
+      // A field the child stopped emitting reaches the report as `undefined`,
+      // where `.toFixed` throws inside a `console.log` and takes the whole table
+      // with it — which is exactly how one run here produced a header and no rows.
+      // Fail on the sample instead, naming the field.
+      for (const field of ["ms", "cpuMs", "pages"] as const) {
+        if (typeof sample[field] !== "number" || Number.isNaN(sample[field])) {
+          console.error(`  arm ${arm}: child reported no usable ${field}`);
+          return null;
+        }
+      }
+      return sample;
+    }
+
+    function recordProfile(arm: string, stderr: string): void {
+      const acc = profiles.get(arm) ?? {
+        invocations: 0,
+        us: new Map<string, number>(),
+        calls: new Map<string, number>(),
+      };
+      for (const line of stderr.split("\n")) {
+        if (!line.startsWith("[rule-profile]")) continue;
+        try {
+          const d = JSON.parse(line.slice(14)) as {
+            ruleId: string;
+            pageUrl?: string;
+            durationUs?: number;
+          };
+          if (d.pageUrl === undefined) continue; // site rule; this pass runs none
+          acc.invocations += 1;
+          acc.calls.set(d.ruleId, (acc.calls.get(d.ruleId) ?? 0) + 1);
+          // durationUs, NOT durationMs: see the header.
+          acc.us.set(
+            d.ruleId,
+            (acc.us.get(d.ruleId) ?? 0) + (d.durationUs ?? 0)
+          );
+        } catch {
+          // A truncated line at the end of a pipe is not worth failing a run over.
+        }
+      }
+      profiles.set(arm, acc);
+    }
+
+    const samples: Record<"on" | "off", Sample[]> = { on: [], off: [] };
+    for (let i = 0; i < REPEATS; i++) {
+      // Interleaved, and off first on every repeat so neither arm is systematically
+      // the one that pays for a cold file cache.
+      for (const arm of ["off", "on"] as const) {
+        const got = child(arm);
+        if (got) samples[arm].push(got);
+        process.stderr.write(`\r  repeat ${i + 1}/${REPEATS} ${arm}   `);
+      }
+    }
+    process.stderr.write("\n");
+
+    const median = (xs: number[]): number => {
+      const s = [...xs].sort((a, b) => a - b);
+      const mid = s.length >> 1;
+      return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
+    };
+    // Reported alongside the median because noise on a timing bench ADDS work and
+    // never removes it, so the minimum is the closest thing to the cost — the same
+    // reading rules-scaling-bench.ts takes. With few repeats on a busy box the
+    // median is one sample, and one bad sample moves it: a run here had the arms
+    // 5.4% apart on the median and 9.3% apart on the minimum, because a single
+    // 106 s sample landed in the middle of three.
+    const lowest = (xs: number[]): number => Math.min(...xs);
+
+    if (samples.off.length === 0 || samples.on.length === 0) {
+      console.error("no successful runs");
+      process.exit(1);
+    }
+    const pages = samples.off[0]!.pages;
+    const offMs = median(samples.off.map((s) => s.ms));
+    const onMs = median(samples.on.map((s) => s.ms));
+    const offCpu = median(samples.off.map((s) => s.cpuMs));
+    const onCpu = median(samples.on.map((s) => s.cpuMs));
+    const offCpuMin = lowest(samples.off.map((s) => s.cpuMs));
+    const onCpuMin = lowest(samples.on.map((s) => s.cpuMs));
+    const offMsMin = lowest(samples.off.map((s) => s.ms));
+    const onMsMin = lowest(samples.on.map((s) => s.ms));
+    const last = samples.on[samples.on.length - 1]!;
+
+    console.log(`db            ${DB}`);
+    console.log(`pages         ${pages}`);
+    console.log(
+      `clusters      ${last.clusters} (${last.fannedPages} pages inherited a verdict)`
+    );
+    console.log(`rule runs     ${last.fannedRuleRuns} removed`);
+    console.log(`repeats       ${REPEATS} interleaved, median reported`);
+    console.log("");
+    console.log("              wall ms   wall ms/page    cpu ms   cpu ms/page");
+    console.log(
+      `fan-out off ${offMs.toFixed(0).padStart(9)} ${(offMs / pages).toFixed(2).padStart(13)} ${offCpu.toFixed(0).padStart(9)} ${(offCpu / pages).toFixed(2).padStart(13)}`
+    );
+    console.log(
+      `fan-out on  ${onMs.toFixed(0).padStart(9)} ${(onMs / pages).toFixed(2).padStart(13)} ${onCpu.toFixed(0).padStart(9)} ${(onCpu / pages).toFixed(2).padStart(13)}`
+    );
+    console.log(
+      `delta       ${(((offMs - onMs) / offMs) * 100).toFixed(1).padStart(8)}% ${"".padStart(13)} ${(((offCpu - onCpu) / offCpu) * 100).toFixed(1).padStart(8)}%`
+    );
+    console.log("");
+    console.log("minimum of the repeats — read this one on a busy box");
+    console.log(
+      `fan-out off ${offMsMin.toFixed(0).padStart(9)} ${(offMsMin / pages).toFixed(2).padStart(13)} ${offCpuMin.toFixed(0).padStart(9)} ${(offCpuMin / pages).toFixed(2).padStart(13)}`
+    );
+    console.log(
+      `fan-out on  ${onMsMin.toFixed(0).padStart(9)} ${(onMsMin / pages).toFixed(2).padStart(13)} ${onCpuMin.toFixed(0).padStart(9)} ${(onCpuMin / pages).toFixed(2).padStart(13)}`
+    );
+    console.log(
+      `delta       ${(((offMsMin - onMsMin) / offMsMin) * 100).toFixed(1).padStart(8)}% ${"".padStart(13)} ${(((offCpuMin - onCpuMin) / offCpuMin) * 100).toFixed(1).padStart(8)}%`
+    );
+    console.log("");
+    console.log(
+      `wall samples  off ${samples.off.map((s) => s.ms.toFixed(0)).join(", ")}`
+    );
+    console.log(
+      `              on  ${samples.on.map((s) => s.ms.toFixed(0)).join(", ")}`
+    );
+    console.log(
+      `cpu samples   off ${samples.off.map((s) => s.cpuMs.toFixed(0)).join(", ")}`
+    );
+    console.log(
+      `              on  ${samples.on.map((s) => s.cpuMs.toFixed(0)).join(", ")}`
+    );
+
+    if (flag("profile")) {
+      const off = profiles.get("off");
+      const on = profiles.get("on");
+      if (off && on) {
+        console.log("");
+        console.log(
+          `invocations   off ${off.invocations}   on ${on.invocations}`
+        );
+        console.log("");
+        console.log(
+          "rule                              calls    off ms    on ms     saved"
+        );
+        // ONLY rules whose invocation count actually fell. Every other rule's
+        // apparent movement between two profiled runs is noise, and printing it
+        // beside a real saving invites reading it as one.
+        const rows = [...off.calls.entries()]
+          .filter(([id]) => (on.calls.get(id) ?? 0) < (off.calls.get(id) ?? 0))
+          .map(([id, calls]) => ({
+            id,
+            calls: `${calls}\u2192${on.calls.get(id) ?? 0}`,
+            off: (off.us.get(id) ?? 0) / 1000,
+            on: (on.us.get(id) ?? 0) / 1000,
+          }))
+          .sort((a, b) => b.off - b.on - (a.off - a.on));
+        let saved = 0;
+        for (const r of rows) {
+          saved += r.off - r.on;
+          console.log(
+            `${r.id.padEnd(30)} ${r.calls.padStart(10)} ${r.off.toFixed(1).padStart(9)} ${r.on.toFixed(1).padStart(8)} ${(r.off - r.on).toFixed(1).padStart(9)}`
+          );
+        }
+        console.log(
+          `${"".padEnd(30)} ${"".padStart(10)} ${"".padStart(9)} ${"".padStart(8)} ${saved.toFixed(1).padStart(9)}`
+        );
+        console.log("");
+        console.log(
+          "(profiled runs are SLOWER than the timed ones above — the profiler stringifies a line per rule per page. Read these as attribution, not as the headline.)"
+        );
+      }
+    }
+  }
+} finally {
+  // `process.exit` inside the try would skip this and leak the copy — which for
+  // a 200 MB corpus is not a small leak. Exit after it instead.
+  rmSync(corpus.dir, { recursive: true, force: true });
+}
+process.exit(exitCode);

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -653,8 +653,9 @@ every member:
 | gymshark.com | 89 of 198 |
 | openelectricity.org.au | 142 of 198 |
 
-85 are constant on both. Only 26 are declared safe to fan out
-([#269](https://github.com/squirrelscan/squirrelscan/pull/269)): the rest are
+85 are constant on both. Only 26 were declared safe to fan out
+([#269](https://github.com/squirrelscan/squirrelscan/pull/269)), and #279 later
+demoted one of those to page scope, leaving 25: the rest are
 constant on those two crawls and page-scoped anyway, because the cluster key
 constrains no response header, the page url is per-page by construction, and a
 rule scanning the whole document can see body content. `perf/compression` is the
@@ -1136,6 +1137,98 @@ The phase table's `rules` and `site` columns read trace spans the resident
 pipeline used to emit. The streaming pipeline (#252) emits neither, so both had
 been printing `0s`, which reads as "the rules phase was free" when it is most of
 the wall time. They print `n/a` now.
+
+## Running a rule once per template: 13% of the page-rule pass, not 96%
+
+The clustering measurement above says 96.5% of gymshark's page-rule time is spent
+on pages that are not the first of their chrome cluster. That is the ceiling if
+every rule could be run once per template. 25 of 198 page rules are declared safe
+to fan out, and this is what those 25 are worth
+([#279](https://github.com/squirrelscan/squirrelscan/pull/279)).
+
+The measurement is of the streamed page-rule pass alone (`streamPageRules`), which
+is sync CPU over stored HTML and reaches no network. Each arm runs in its own
+child process, the arms are interleaved, and both the median and the minimum of
+the repeats are reported. **CPU time, minimum of the repeats, is the number to
+read.** Wall time on a shared box is mostly a measurement of what else is running
+on it: an earlier pair of seven repeats swung 66 to 101 s on the same arm, and
+with three repeats the median is one sample, so a single bad sample moved the same
+comparison from 9.3% to 5.4%. Load average 2.2 to 3.8 throughout the runs below.
+
+| corpus | pages | clusters | cpu off | cpu on | delta (min) | delta (median) |
+|---|---|---|---|---|---|---|
+| gymshark.com (real) | 247 | 13 | 233.6 ms/page | 203.5 ms/page | **12.9%** | 10.8% |
+| drscholls-shaped synthetic | 150 | 1 | 114.4 ms/page | 94.2 ms/page | **17.6%** | 16.8% |
+
+The synthetic corpus is the ceiling case for these 25 rules and not a site: all
+150 pages are one template, so 149 of 150 inherit every declared verdict. It buys
+17.6%, against the real storefront's 12.9%. **The saving is a property of the
+declared set, not of how redundant the corpus is**, and anyone reading 96.5% as
+the expected win will be disappointed by design. Reaching further means declaring
+more rules, which is a soundness decision rather than a code change.
+
+Rule invocations on gymshark fall from 48,906 to 43,056: each of the 25 declared
+rules goes from 247 calls to 13. Where the time was, from a profiled run (summed
+`durationUs`, never `durationMs` — the latter rounds to whole milliseconds and a
+page rule's thousands of sub-millisecond samples sum to nonsense):
+
+| rule | ms over 247 pages | ms over 13 |
+|---|---|---|
+| `perf/js-libraries` | 1795.3 | 74.4 |
+| `analytics/consent-mode` | 1447.1 | 56.2 |
+| `analytics/gtm-present` | 1015.8 | 38.8 |
+| `a11y/focus-visible` | 338.6 | 13.1 |
+| `core/favicon` | 277.7 | 11.5 |
+| `security/third-party-cookies` | 240.9 | 9.8 |
+| `local/geo-meta` | 234.5 | 9.3 |
+| `perf/legacy-js` | 228.0 | 9.3 |
+| the other 17 | 735.3 | 33.2 |
+| **total** | **6313.2** | **255.6** |
+
+The 6,058 ms those rule bodies give up accounts for 93% of the 6,531 ms of CPU
+that same profiled run moved, so the attribution and the delta agree. Three of
+those rules are most of it, and all three scan the page's whole HTML.
+
+### One rule was demoted rather than fanned
+
+`core/charset` came out of #269 declared "template" and is constant in every
+cluster of every corpus in every gate. It is page-scoped anyway, because its
+verdict can come from the `Content-Type` RESPONSE HEADER, which the cluster key
+constrains in no way: two pages of one template, one served
+`text/html; charset=utf-8` and the other bare `text/html`, give `pass` and `fail`.
+Every page of all three corpora declares its charset in a `<meta>` tag, so the
+header branch is never reached and no measurement over them could see it.
+
+That is the general shape of the residual risk, tracked as
+[#275](https://github.com/squirrelscan/squirrelscan/issues/275): the cluster key
+is chrome, so a constructed pair can share it and still differ in a declared
+rule's inputs. Two things are not left to the declaration — the fan-out groups by
+page ORIGIN as well as by template (`security/sri` compares it), and a rule
+reading a response header is disqualified outright.
+
+### Byte-identity
+
+The claim is that the output is indistinguishable from running every rule on every
+page, and it is checked three ways rather than asserted:
+
+- `template-fanout-equivalence-golden.test.ts` compares the fanned pass against a
+  resident loop that runs everything on everything, over an authored corpus with
+  three real multi-page clusters and two singletons, on the complete per-page check
+  lists, the per-rule results and the folded tallies.
+- `apps/cli/scripts/template-fanout-bench.ts --verify` does the same comparison
+  against a real crawl, because a CI fixture only ever proves something about the
+  pages it contains. Byte-identical on gymshark.com, openelectricity.org.au and the
+  150-page synthetic.
+- `packages/rules/tests/template-verdict-page-independence.test.ts` runs each
+  declaring rule on the same HTML under two urls that share only scheme and host.
+  Copying a verdict onto another page is only sound if it carries nothing about the
+  page it ran on, and the fan-out deliberately does not rewrite urls inside a copied
+  check: the normalisation that would have to be inverted is not injective.
+
+Equal output is also exactly what a feature that does nothing produces, so the
+gates count calls as well as compare values: a rule declaring
+`verdictScope: "template"` must run once per CLUSTER and an undeclared one once per
+PAGE, and the pass reports the invocations it removed.
 
 ## Still open
 

--- a/docs/cli/debug.mdx
+++ b/docs/cli/debug.mdx
@@ -137,6 +137,31 @@ the rules pass then prints its heap after a forced collection:
 Read `heapUsed`, not `rss`. Under memory pressure macOS compresses pages and the
 resident figure stops tracking what the process actually holds.
 
+## Rules that run once per template
+
+Most of a large site is a handful of templates repeated: a real storefront of 247
+pages has 13 distinct page chromes. A rule whose answer is a property of the
+template rather than of the page therefore gives the same verdict hundreds of
+times, so the audit runs those rules once per template and reports the result on
+every page of it. The findings are the same either way, and the audit is faster on
+exactly the sites where the rules phase hurts.
+
+Which rules qualify is a property of the rule, not a setting: a rule reading
+anything that varies page to page, including any response header and the page's
+own URL, keeps running everywhere.
+
+If you suspect a finding that looks copied from a sibling page, turn it off and
+compare:
+
+```bash
+SQUIRREL_TEMPLATE_FANOUT=0 squirrel audit https://example.com
+```
+
+`0`, `false`, `off` and `no` all disable it; anything else, including leaving it
+unset, leaves it on. A report produced with it off should be identical to one
+produced with it on, so a difference is a bug worth
+[reporting](https://github.com/squirrelscan/squirrelscan/issues).
+
 ## Sensitive data redaction
 
 Logs automatically redact sensitive data:

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -2352,6 +2352,12 @@ export function runStreamingRules(
      * anything itself: `process` is the caller's concern.
      */
     onPhase?: (phase: StreamingRulePhase, boundary: "start" | "end") => void;
+    /**
+     * Template fan-out (#1951), forwarded to {@link streamPageRules}. Omitted →
+     * the env default (ON, `SQUIRREL_TEMPLATE_FANOUT=0` to kill it). Benches and
+     * the equivalence test set it explicitly to run both arms in one process.
+     */
+    templateFanout?: boolean;
   },
 ): Effect.Effect<StreamingRuleExecutionResult, never, never> {
   return Effect.gen(function* () {
@@ -2427,6 +2433,7 @@ export function runStreamingRules(
       pageUniverse: new Set(pageDataMap.keys()),
       totalPages: pageDataMap.size,
       pageLoopHooks: opts?.pageLoopHooks,
+      templateFanout: opts?.templateFanout,
       }),
     );
     const collectedSignals: CollectedSiteSignals = { pages: collectedPages };

--- a/packages/audit-engine/src/detach.ts
+++ b/packages/audit-engine/src/detach.ts
@@ -13,6 +13,13 @@ export type DetachBoundary =
   | "external-links"
   /** Cloud-prefetch payloads collected during a streamed pre-rules walk (#1913). */
   | "cloud-payload"
+  /**
+   * A template representative's verdicts, kept for the rest of its cluster and
+   * re-copied onto each member (#1951). Detaching matters twice here: the cached
+   * copy outlives its page, and a member's copy must not alias the sibling's,
+   * or stamping `pageUrl` would rewrite the other pages' results.
+   */
+  | "template-fanout"
   /** Per-page fields the CLI's report keeps after its page batch is dropped (#1913). */
   | "report-page";
 

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -198,6 +198,17 @@ export { isHtmlContentType } from "./adapter";
 // stored on page_features.template_fp and grouped by SiteQuery.templateClusters().
 export { templateFingerprintKey, templateVerdictKey } from "./template-key";
 
+// Template fan-out (#1951) — run a rule declaring verdictScope "template" once
+// per cluster and give its verdict to the members. The kill switch is
+// SQUIRREL_TEMPLATE_FANOUT=0; `templateFanoutEnabled` is what reads it.
+export {
+  createTemplateFanout,
+  fanoutClusterKey,
+  templateFanoutEnabled,
+  DEFAULT_MAX_CLUSTERS,
+} from "./template-fanout";
+export type { TemplateFanout, TemplateFanoutStats } from "./template-fanout";
+
 // Streaming rules engine (#1021, PR-E) — batched page-rule pass with DOM-drop.
 export { streamPageRules, STREAM_PAGE_BATCH } from "./streaming";
 export type {

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -4,11 +4,11 @@
 // `runStreamingRules` (site-fetch phase + site pass + RuleExecutionResult
 // assembly) is built on top of it.
 //
-// No longer dark: the CLOUD audit path runs on this as of #1860. The CLI still
-// runs v1 (runRulesOnStorage), which is untouched, so the two paths must be kept
-// byte-identical by the golden diffs (blueprint §5) — and note those gates only
-// cover cases their fixtures contain. #1829's rate-limited-page handling landed
-// after they were written and diverged here unnoticed until #1860.
+// No longer dark: the CLOUD audit path runs on this as of #1860 and the CLI as of
+// #1913. `runRulesOnStorage` (v1) is still the reference the golden diffs compare
+// against (blueprint §5) — and note those gates only cover cases their fixtures
+// contain. #1829's rate-limited-page handling landed after they were written and
+// diverged here unnoticed until #1860.
 //
 // Page rules are per-page independent (verified: no page rule reads other pages —
 // the 8 touching ctx.site read only scripts/resourceSizes/siteMetadata), so
@@ -16,6 +16,12 @@
 // loop. Per-page results are folded into per-rule tallies via the proven-equal
 // foldRuleResultIntoTallies, so the growing O(pages) accumulation that drives v1's
 // superlinear per-batch wall-time is avoided.
+//
+// TEMPLATE FAN-OUT (#1951) rides on that independence: a rule declaring
+// `verdictScope: "template"` runs once per template cluster and its verdict is
+// copied onto the cluster's other members. It is ON here and only here — v1 has no
+// cluster key and is left alone — with `SQUIRREL_TEMPLATE_FANOUT=0` as the kill
+// switch. See template-fanout.ts for what makes it sound and what it can never do.
 
 import { Effect } from "effect";
 
@@ -31,6 +37,13 @@ import { detachFromPage } from "./detach";
 import { extractPageFeatures, isAuditablePage } from "./page-features";
 import type { PageRuleLoopHooks } from "./page-rule-executor";
 import { foldRuleResultIntoTallies, type RuleTally } from "./scoring";
+import { templateFingerprintKey } from "./template-key";
+import {
+  createTemplateFanout,
+  fanoutClusterKey,
+  templateFanoutEnabled,
+  type TemplateFanoutStats,
+} from "./template-fanout";
 
 /** Default page batch — bounds DOM residency to ≤ this many live docs at once. */
 export const STREAM_PAGE_BATCH = 200;
@@ -95,6 +108,13 @@ export interface StreamPageRulesResult {
   peakLiveDocs: number;
   /** Pages the extractor wrote page_features for (isAuditablePage-gated). */
   extractedCount: number;
+  /**
+   * What the template fan-out actually did (#1951). All zeros when it is off, and
+   * `fannedRuleRuns` is the number of page-rule invocations it removed — the only
+   * measure that distinguishes a working fan-out from one whose byte-identical
+   * output it produced by running everything anyway.
+   */
+  templateFanout: TemplateFanoutStats;
 }
 
 // Re-used shape; avoids pulling the CheckResult symbol name-collision into scope.
@@ -150,6 +170,17 @@ export function streamPageRules(
      * thing on both paths. Unset → the running done count is reported as total.
      */
     totalPages?: number;
+    /**
+     * Template fan-out (#1951): run each rule declaring `verdictScope: "template"`
+     * once per template cluster and give its verdict to the cluster's other
+     * members. Defaults to {@link templateFanoutEnabled} — ON, with
+     * `SQUIRREL_TEMPLATE_FANOUT=0` as the kill switch. Pass `false` to compare
+     * against the ordinary path; the two must produce byte-identical results,
+     * which is what `template-fanout-equivalence-golden.test.ts` asserts.
+     */
+    templateFanout?: boolean;
+    /** Test/bench seam: cap the cached clusters (see DEFAULT_MAX_CLUSTERS). */
+    templateFanoutMaxClusters?: number;
   }
 ): Effect.Effect<StreamPageRulesResult, never, never> {
   return Effect.gen(function* () {
@@ -163,6 +194,11 @@ export function streamPageRules(
     const heartbeatEvery = Math.max(1, opts?.pageLoopHooks?.heartbeatEveryPages ?? 1);
     const onLoopProgress = opts?.pageLoopHooks?.onProgress;
     let lastYieldAt = Date.now();
+    // #1951. Built per pass, so its cache and its counters belong to this run.
+    const fanout =
+      (opts?.templateFanout ?? templateFanoutEnabled())
+        ? createTemplateFanout(runner, { maxClusters: opts?.templateFanoutMaxClusters })
+        : null;
 
     const pageResults = new Map<string, CheckResultLike[]>();
     const pageRuleResults = new Map<string, Map<string, CheckResultLike[]>>();
@@ -210,6 +246,7 @@ export function streamPageRules(
         const confirmation = soft404?.get(page.normalizedUrl);
         if (confirmation !== undefined) parsed.soft404Confirmation = confirmation;
 
+        const pageUrl = page.normalizedUrl;
         const pageData: PageData = {
           url: page.url,
           html: page.html!,
@@ -224,8 +261,36 @@ export function streamPageRules(
           rendered: isRenderedFetch(page.fetcherId),
         };
 
+        // ONE fingerprint per page, three consumers now: `page_features.template_fp`
+        // reduces it to an equality cluster key (#1949), the collected signal keeps
+        // it whole for `template-discontinuity`'s fuzzy comparison, and the fan-out
+        // below groups on the same key. Built here rather than inside any consumer
+        // so the loop still walks each DOM exactly once.
+        //
+        // It moved ABOVE the rule run for #1951 — the cluster has to be known
+        // before the rules are dispatched, not after. That is safe because
+        // `fingerprintPage` reads only chrome (asset hosts, body classes, CSS
+        // custom properties, stylesheet hrefs, nav/footer) and page rules do not
+        // mutate the DOM; `template-cluster-key-golden.test.ts` pins the stored
+        // keys, so a rule that did would fail there.
+        const shared: SharedPageSignals = {
+          fingerprint: fingerprintPage(parsed, pageUrl),
+        };
+        // The grouping key is the template cluster AND this page's origin: a
+        // declared rule may resolve resources against the origin (`security/sri`
+        // decides "cross-origin" by comparing it), so a crawl spanning http:// and
+        // https:// must not copy a verdict across that boundary.
+        const clusterKey = fanout
+          ? fanoutClusterKey(templateFingerprintKey(shared.fingerprint), pageUrl)
+          : null;
+        const fanned = fanout?.take(clusterKey);
+
         const raw = yield* Effect.promise(() =>
-          runner.runPageRules(pageData, siteDataForPageRules)
+          runner.runPageRules(
+            pageData,
+            siteDataForPageRules,
+            fanned ? { fannedRuleChecks: fanned } : undefined
+          )
         );
 
         // Detach the findings from the page before retaining them (#1860). Every
@@ -266,7 +331,12 @@ export function streamPageRules(
           ),
         };
 
-        const pageUrl = page.normalizedUrl;
+        // Keep this page's template-scoped verdicts for the rest of its cluster,
+        // BEFORE `pageUrl` is stamped below, so what a member inherits is
+        // page-identity-free and its own stamp is a first write (#1951). Only when
+        // this page ran the rules itself — a member has nothing new to say.
+        if (!fanned) fanout?.record(clusterKey, result.ruleResults);
+
         pageResults.set(pageUrl, result.checks);
         const ruleChecksForPage = new Map<string, CheckResultLike[]>();
         for (const [ruleId, rr] of result.ruleResults) {
@@ -285,16 +355,8 @@ export function streamPageRules(
 
         // page_features + E-E2 collectors, DOM still live. The early
         // `!isAuditablePage(page)` continue above already guarantees this page is
-        // auditable, so no second gate is needed here.
-        //
-        // ONE fingerprint per page, two consumers: `page_features.template_fp`
-        // reduces it to an equality cluster key (#1949) and the collected signal
-        // keeps it whole for `template-discontinuity`'s fuzzy comparison. Built
-        // here rather than inside either consumer so the loop still walks each DOM
-        // exactly once.
-        const shared: SharedPageSignals = {
-          fingerprint: fingerprintPage(parsed, pageUrl),
-        };
+        // auditable, so no second gate is needed here. `shared` was built before
+        // the rules ran (see above); it is the same object either way.
         yield* storage
           .upsertPageFeatures(crawlId, extractPageFeatures(page, parsed, shared))
           .pipe(Effect.catchAll(() => Effect.void));
@@ -355,6 +417,12 @@ export function streamPageRules(
       pageUrls,
       peakLiveDocs,
       extractedCount,
+      templateFanout: fanout?.stats() ?? {
+        clusters: 0,
+        fannedPages: 0,
+        fannedRuleRuns: 0,
+        pagesOverCap: 0,
+      },
     };
   });
 }

--- a/packages/audit-engine/src/template-fanout.ts
+++ b/packages/audit-engine/src/template-fanout.ts
@@ -181,6 +181,15 @@ export interface TemplateFanout {
  * The set of fannable rule ids is resolved ONCE from the runner's enabled rules,
  * so a rule disabled by config never enters the cache and the per-page path costs
  * a `Set.has` rather than a `meta` read.
+ *
+ * `skipOnSoft404` DISQUALIFIES a rule here, whatever it declares. That gate is
+ * decided per page, so the two declarations contradict each other, and the runner's
+ * gate ordering only protects the recipient: a soft-404 member takes its own skip
+ * instead of a sibling's real verdict, but a soft-404 REPRESENTATIVE would
+ * otherwise cache its skip and hand it to healthy members. No built-in rule
+ * declares both and `template-verdict-page-independence.test.ts` keeps it that way,
+ * but a plugin registering one through `additionalNamespaces` reaches this at
+ * runtime, where a named test cannot.
  */
 export function createTemplateFanout(
   runner: RuleRunner,
@@ -190,7 +199,7 @@ export function createTemplateFanout(
   const fannable = new Set(
     runner
       .getEnabledRules()
-      .filter((r) => mayFanOutAcrossTemplate(r.meta))
+      .filter((r) => mayFanOutAcrossTemplate(r.meta) && !r.meta.skipOnSoft404)
       .map((r) => r.meta.id),
   );
 

--- a/packages/audit-engine/src/template-fanout.ts
+++ b/packages/audit-engine/src/template-fanout.ts
@@ -1,0 +1,263 @@
+// Template fan-out (#1951) — run a page rule ONCE per template cluster and hand
+// its verdict to the cluster's other members.
+//
+// This is the payoff for #1026. Measured by attributing the real page-rule pass
+// to pages that are not the first of their chrome cluster: 96.5% of gymshark's
+// page-rule time (70.5 s of 73.1 s) and 64.6% of openelectricity's is spent on
+// non-first members. Fan-out reclaims the share of that belonging to rules whose
+// verdict is a property of the template.
+//
+// WHAT MAKES IT SOUND. Fanning a verdict out asserts something about pages the
+// rule never visited, so it is gated on THREE things, none of which lives here:
+//
+//  1. `meta.verdictScope: "template"` (#1950) — the rule author's claim, read only
+//     through `mayFanOutAcrossTemplate`, which answers false for silence.
+//  2. The cluster key (#1949) — `page_features.template_fp`, the equality
+//     reduction of the chrome fingerprint, computed from the live DOM.
+//  3. Falsifiers that run the classified rules per page AND per cluster and require
+//     byte-identical verdicts: `template-fanout-parity-golden.test.ts` and
+//     `template-fanout-equivalence-golden.test.ts` in CI,
+//     `apps/cli/scripts/template-rule-invariance.ts --check` and
+//     `apps/cli/scripts/template-fanout-bench.ts --verify` against real crawls.
+//
+// WHAT THIS FILE IS RESPONSIBLE FOR: that a fanned member's checks are
+// indistinguishable from having run the rule on it. Three things follow.
+//
+// **Each member gets its OWN copy.** The checks are cloned per member, so the
+// caller's ordinary `check.pageUrl = pageUrl` stamp lands on this page's objects
+// and not on a sibling's. Aliasing here would be silent: the findings would look
+// right until the last member of a cluster overwrote every earlier member's
+// `pageUrl`, collapsing `affectedPages` onto one page and re-fingerprinting the
+// whole cluster onto it (#1880 keys findings on `(rule, check, locator)` and the
+// report attributes pages from `pageUrl`).
+//
+// **The cached copy carries no `pageUrl`.** It is taken before the caller stamps
+// the representative, so the stamp on a member is a first write, exactly as it is
+// on a page that really ran. Nothing here re-writes urls INSIDE a check, because
+// nothing should have to: a rule that emits its own page's url is not
+// template-scoped, and `template-verdict-page-independence.test.ts` fails a
+// declaration that does, by running the rule under two urls that share only scheme
+// and host.
+//
+// **A COPY THAT DID NOT COPY IS NOT USED.** `detachFromPage` is deliberately
+// forgiving — a value it cannot `structuredClone` is returned AS IS, because for
+// its usual callers the cost of that is retention and never a wrong finding. Here
+// it would be a wrong finding: the member would stamp `pageUrl` onto the cached
+// objects, the guard that stamps only an unset `pageUrl` would then leave every
+// later member reading the first one's url, and the whole cluster would collapse
+// onto one page. So every copy is checked by IDENTITY (`structuredClone` never
+// returns its argument) and anything that came back uncopied is dropped from the
+// cache or from the hand-out, which puts those pages back on the ordinary path.
+//
+// **A rule that threw is never cached.** `runOneRule` turns a throw into a
+// `<ruleId>-error` check whose message quotes the exception, which can carry page
+// content and need not recur on a sibling. Those clusters simply run the rule
+// per page.
+//
+// WHAT THE CLUSTER KEY DOES NOT CONSTRAIN, and what this file does about it. The
+// key (#1949) is chrome: asset hosts, body classes, CSS custom properties,
+// stylesheet hrefs, nav/footer presence. It is an APPROXIMATION of "same
+// template", chosen because the intuitive alternative — an exact DOM skeleton —
+// puts 224 of gymshark's 247 pages in a cluster of one (#1026). So two pages can
+// share a key and still differ in markup the key never looked at, and the reason
+// fan-out is nonetheless sound is the DECLARATION plus its falsifiers, not the key.
+// That is #1950's premise and it is empirical: a rule constant on two real crawls
+// can vary on a third.
+//
+// Two things are NOT left to that, because they are properties of the PAGE rather
+// than claims about a rule's markup inputs, and because a corpus of one origin can
+// never exhibit them:
+//
+//  - **The page's ORIGIN is part of the grouping key here.** Several declared rules
+//    resolve resources against it: `security/sri` reports a script as cross-origin
+//    by comparing `resolved.origin` to the page's, so the same markup at
+//    `https://shop.test/a` and `http://shop.test/b` genuinely gets different
+//    verdicts. Grouping by origin costs nothing on a real site, which has one, and
+//    it is exact rather than a claim about any rule.
+//  - **`core/charset` was DEMOTED to page scope** in this change, because its
+//    verdict can come from the `Content-Type` response header, which the key
+//    constrains in no way. See its meta and the counterexample pinned in
+//    packages/rules/tests/template-verdict-page-independence.test.ts.
+//
+// MEMORY (#1913). The cache holds one detached copy of the declared rules' checks
+// per cluster, and nothing else — no page, no DOM, no per-member entry. On a
+// site where every page is its own template that is still one entry per page, so
+// it is capped: past {@link DEFAULT_MAX_CLUSTERS} new clusters stop being cached
+// and their pages run the ordinary path. The cap changes cost, never output.
+
+import { detachFromPage } from "./detach";
+
+import type { CheckResult } from "@squirrelscan/core-contracts";
+import type { RuleRunResult, RuleRunner } from "@squirrelscan/rules";
+import { mayFanOutAcrossTemplate } from "@squirrelscan/rules";
+
+/**
+ * Clusters whose verdicts are kept. A real site has tens (13 on gymshark, 12 on
+ * openelectricity); the cap only binds on a crawl where clustering has failed and
+ * nearly every page is its own template, which is exactly the case where caching
+ * buys nothing and costs residency.
+ */
+export const DEFAULT_MAX_CLUSTERS = 1_000;
+
+/**
+ * The kill switch (#1951). Fan-out is ON for every streamed rules pass — the CLI
+ * and the cloud both run `runStreamingRules` — and `SQUIRREL_TEMPLATE_FANOUT` set
+ * to `0`, `false`, `off` or `no` turns it off for a run without a rebuild. The v1
+ * `runRulesOnStorage` path never consults this: it does not stream, has no cluster
+ * key, and is left exactly as it was.
+ *
+ * Read per pass rather than at module load so a test (or a support session) can
+ * flip it between runs in one process.
+ */
+export function templateFanoutEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  const raw = env.SQUIRREL_TEMPLATE_FANOUT;
+  if (raw === undefined) return true;
+  const v = raw.trim().toLowerCase();
+  return !(v === "0" || v === "false" || v === "off" || v === "no");
+}
+
+export interface TemplateFanoutStats {
+  /** Distinct template clusters that produced a representative. */
+  readonly clusters: number;
+  /** Pages that took at least one verdict from a sibling. */
+  readonly fannedPages: number;
+  /** Rule invocations skipped — the thing the saving is actually made of. */
+  readonly fannedRuleRuns: number;
+  /**
+   * Pages whose cluster was not cached because {@link DEFAULT_MAX_CLUSTERS} was
+   * reached. Counted per page rather than per cluster (holding the over-cap keys
+   * to count them distinctly would reintroduce the growth the cap exists to
+   * stop), so a non-zero value means "clustering is not paying here", not a count
+   * of templates.
+   */
+  readonly pagesOverCap: number;
+}
+
+/**
+ * The grouping key: the template cluster AND the page's origin.
+ *
+ * Origin is here rather than in `page_features.template_fp` deliberately —
+ * `template_fp` answers "same template?" for `SiteQuery.templateClusters()` and
+ * for #1950's gate, and a crawl that spans `http://` and `https://` should still
+ * report those pages as one template. What it must not do is let a verdict
+ * computed against one origin be copied onto a page with another.
+ *
+ * A url that will not parse gets its whole string as the origin, so it can only
+ * ever share a group with a byte-identical url — the conservative answer.
+ */
+export function fanoutClusterKey(templateKey: string | null, pageUrl: string): string | null {
+  if (!templateKey) return null;
+  let origin: string;
+  try {
+    origin = new URL(pageUrl).origin;
+  } catch {
+    origin = pageUrl;
+  }
+  // NUL cannot appear in an origin or in a 16-hex key, so the join is injective.
+  return `${origin}\u0000${templateKey}`;
+}
+
+export interface TemplateFanout {
+  /**
+   * The checks a member of `clusterKey` should use instead of running, or
+   * `undefined` for the first page of a cluster (and for every page while the
+   * cluster key is unknown). Freshly cloned, so the caller owns them.
+   *
+   * `clusterKey` is {@link fanoutClusterKey}'s output, not the raw template key.
+   */
+  take(clusterKey: string | null): ReadonlyMap<string, CheckResult[]> | undefined;
+  /**
+   * Keep this page's declared-template verdicts as the cluster's representative.
+   * Call it with the results of a page that really ran, BEFORE `pageUrl` is
+   * stamped on them. A second call for the same key is a no-op.
+   */
+  record(clusterKey: string | null, ruleResults: ReadonlyMap<string, RuleRunResult>): void;
+  stats(): TemplateFanoutStats;
+}
+
+/**
+ * Build a fan-out cache for one streamed rules pass.
+ *
+ * The set of fannable rule ids is resolved ONCE from the runner's enabled rules,
+ * so a rule disabled by config never enters the cache and the per-page path costs
+ * a `Set.has` rather than a `meta` read.
+ */
+export function createTemplateFanout(
+  runner: RuleRunner,
+  opts?: { maxClusters?: number },
+): TemplateFanout {
+  const maxClusters = Math.max(0, opts?.maxClusters ?? DEFAULT_MAX_CLUSTERS);
+  const fannable = new Set(
+    runner
+      .getEnabledRules()
+      .filter((r) => mayFanOutAcrossTemplate(r.meta))
+      .map((r) => r.meta.id),
+  );
+
+  /**
+   * Copy a checks array free of its page, or `null` when the copy did not happen.
+   * `detachFromPage` returns its ARGUMENT when `structuredClone` throws; that is
+   * the right answer for a retention-only caller and the wrong one here, so the
+   * identity check is the whole point of this wrapper.
+   */
+  const copyChecks = (checks: CheckResult[]): CheckResult[] | null => {
+    const copy = detachFromPage(checks, "template-fanout");
+    return copy === checks ? null : copy;
+  };
+
+  /** clusterKey -> ruleId -> the representative's checks, detached, unstamped. */
+  const cache = new Map<string, Map<string, CheckResult[]>>();
+  let fannedPages = 0;
+  let fannedRuleRuns = 0;
+  let pagesOverCap = 0;
+
+  return {
+    take(clusterKey) {
+      if (!clusterKey || fannable.size === 0) return undefined;
+      const entry = cache.get(clusterKey);
+      if (!entry || entry.size === 0) return undefined;
+      // One copy per member, and a rule whose copy did not happen is simply left
+      // out — it then runs on this page, which is always a correct answer.
+      const out = new Map<string, CheckResult[]>();
+      for (const [ruleId, checks] of entry) {
+        const copy = copyChecks(checks);
+        if (copy) out.set(ruleId, copy);
+      }
+      if (out.size === 0) return undefined;
+      fannedPages++;
+      fannedRuleRuns += out.size;
+      return out;
+    },
+
+    record(clusterKey, ruleResults) {
+      if (!clusterKey || fannable.size === 0 || cache.has(clusterKey)) return;
+      if (cache.size >= maxClusters) {
+        pagesOverCap++;
+        return;
+      }
+      const entry = new Map<string, CheckResult[]>();
+      for (const ruleId of fannable) {
+        const rr = ruleResults.get(ruleId);
+        if (!rr) continue; // not run on this page (disabled mid-run / unknown id)
+        // A rule that threw produced a `<ruleId>-error` check whose message is the
+        // exception's, which may quote this page. Not a template property.
+        if (rr.checks.some((c) => c.name === `${ruleId}-error`)) continue;
+        const copy = copyChecks(rr.checks as CheckResult[]);
+        // An uncopied array would be the LIVE result the caller is about to stamp.
+        if (copy) entry.set(ruleId, copy);
+      }
+      // Recorded even when empty: it marks the cluster as seen, so a later member
+      // does not re-record and the representative stays the first page.
+      cache.set(clusterKey, entry);
+    },
+
+    stats() {
+      return {
+        clusters: cache.size,
+        fannedPages,
+        fannedRuleRuns,
+        pagesOverCap,
+      };
+    },
+  };
+}

--- a/packages/audit-engine/tests/helpers/template-corpus.ts
+++ b/packages/audit-engine/tests/helpers/template-corpus.ts
@@ -1,0 +1,204 @@
+// The authored template corpus shared by #1950's parity gate and #1951's fan-out
+// equivalence gate.
+//
+// It lives here because the two files are falsifiers for the SAME claim — that a
+// rule declaring `verdictScope: "template"` gives one verdict per cluster — and a
+// second copy of the fixture is a second thing to drift. #1950's own lesson was
+// that both of its falsifiers must import one comparison function; this is the
+// same argument applied to the corpus.
+//
+// WHY IT IS SHAPED THIS WAY. A corpus whose pages are all one template passes
+// either gate vacuously, and the synthetic bench corpora are exactly that —
+// generated from 1-6 templates, so every clustering definition collapses to ~99%
+// redundancy on them (#1026). So this is authored: three templates with 4, 4 and 3
+// members plus two singletons, and the members of a template differ the way real
+// template siblings differ — different amounts of the same kind of content: more
+// paragraphs, more images, more links, different titles, different JSON-LD, an
+// image missing its alt on some pages. What they do NOT differ in is the KIND of
+// markup, because that is the template, and that distinction is the
+// classification's whole premise.
+//
+// The importing tests are what check the corpus is adversarial enough to mean
+// anything: it must produce several multi-page clusters AND a substantial number
+// of "page"-declared rules that genuinely disagree inside a cluster.
+
+import type { PageRecord } from "@squirrelscan/core-contracts";
+
+export const ORIGIN = "https://shop.test";
+
+export interface Template {
+  readonly id: string;
+  readonly stylesheet: string;
+  readonly scriptHost: string;
+  readonly imageHost: string;
+  readonly bodyClass: string;
+  readonly cssVars: string;
+  readonly footer: boolean;
+}
+
+export const TEMPLATES: Template[] = [
+  {
+    id: "product",
+    stylesheet: "/assets/product.css",
+    scriptHost: "cdn.shopkit.test",
+    imageHost: "img.shopkit.test",
+    bodyClass: "tpl-product theme-light",
+    cssVars: "--brand:#101010;--gutter:16px",
+    footer: true,
+  },
+  {
+    id: "article",
+    stylesheet: "/assets/article.css",
+    scriptHost: "cdn.editorial.test",
+    imageHost: "media.editorial.test",
+    bodyClass: "tpl-article theme-light",
+    cssVars: "--brand:#202020;--measure:68ch",
+    footer: true,
+  },
+  {
+    id: "landing",
+    stylesheet: "/assets/landing.css",
+    scriptHost: "cdn.campaign.test",
+    imageHost: "img.campaign.test",
+    bodyClass: "tpl-landing",
+    cssVars: "--brand:#303030",
+    // No footer: a chrome difference, so this cannot merge into another cluster.
+    footer: false,
+  },
+];
+
+/**
+ * The template's chrome, byte-identical for every member. Everything the cluster
+ * key reads lives here: stylesheet hrefs, asset hosts, body classes, CSS custom
+ * properties, nav and footer presence.
+ */
+export function chrome(t: Template): { head: string; nav: string; foot: string } {
+  return {
+    head:
+      `<meta charset="utf-8">` +
+      `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+      `<link rel="icon" href="/favicon.ico">` +
+      `<link rel="stylesheet" href="${t.stylesheet}">` +
+      `<script src="https://${t.scriptHost}/app.js" defer></script>` +
+      // An inline script, template-emitted and byte-identical across members, so
+      // the script-reading declarations (integrity/obfuscated-script,
+      // perf/legacy-js, perf/duplicate-js) are compared on something rather than
+      // passing by absence.
+      `<script>window.__cfg={locale:"en",tpl:"${t.id}"};</script>` +
+      `<style>:root{${t.cssVars}}</style>`,
+    nav:
+      `<nav aria-label="Primary"><ul>` +
+      `<li><a href="/">Home</a></li><li><a href="/about">About</a></li>` +
+      `</ul></nav>`,
+    foot: t.footer
+      ? `<footer><form action="/subscribe" method="post">` +
+        `<label for="em">Email</label><input id="em" type="email" name="email">` +
+        `<button type="submit">Subscribe</button></form>` +
+        `<p>&copy; 2026 Shop Test</p></footer>`
+      : "",
+  };
+}
+
+/**
+ * One member's body. `n` is the only thing that moves: more paragraphs, more
+ * images, more links, a different title and description, a different JSON-LD
+ * offer, and on every third page an image with no alt. That is how real siblings
+ * of one template differ, and it is what makes the "page"-declared rules disagree
+ * here.
+ */
+export function body(t: Template, n: number): string {
+  const paragraphs = Array.from(
+    { length: n + 1 },
+    (_, i) =>
+      `<p>Paragraph ${i + 1} of the ${t.id} page number ${n}. ` +
+      "It carries enough prose that word count, reading level and text-to-html ratio move with n. ".repeat(n) +
+      "</p>",
+  ).join("");
+  const images = Array.from({ length: n }, (_, i) =>
+    i === 0 && n % 3 === 0
+      ? `<img src="https://${t.imageHost}/${t.id}-${n}-${i}.jpg" width="800" height="600">`
+      : `<img src="https://${t.imageHost}/${t.id}-${n}-${i}.jpg" width="800" height="600" alt="${t.id} view ${i}">`,
+  ).join("");
+  const links = Array.from(
+    { length: n },
+    (_, i) => `<a href="/${t.id}/related-${i}">Related ${i}</a>`,
+  ).join(" ");
+  const jsonLd = JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": t.id === "article" ? "Article" : "Product",
+    name: `${t.id} ${n}`,
+    description: `A ${t.id} with ${n} related items.`,
+  });
+  return (
+    `<main><h1>${t.id} number ${n}</h1>` +
+    Array.from({ length: n }, (_, i) => `<h2>Section ${i + 1}</h2>`).join("") +
+    paragraphs +
+    images +
+    `<p>${links}</p>` +
+    `<script type="application/ld+json">${jsonLd}</script>` +
+    `</main>`
+  );
+}
+
+export function pageHtml(t: Template, n: number): string {
+  const c = chrome(t);
+  return (
+    `<!DOCTYPE html><html lang="en"><head><title>${t.id} ${n} | Shop Test</title>` +
+    `<meta name="description" content="The ${t.id} page numbered ${n}, with ${n} related items and ${n} images.">` +
+    `<link rel="canonical" href="${ORIGIN}/${t.id}/${n}">` +
+    c.head +
+    `</head><body class="${t.bodyClass}">${c.nav}${body(t, n)}${c.foot}</body></html>`
+  );
+}
+
+/** A page nothing else shares chrome with, so it lands in a cluster of one. */
+export function singletonHtml(slug: string): string {
+  return (
+    `<!DOCTYPE html><html lang="en"><head><title>${slug} | Shop Test</title>` +
+    `<meta name="description" content="A one-off ${slug} page.">` +
+    `<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` +
+    `<link rel="stylesheet" href="/assets/${slug}.css">` +
+    `<script src="https://cdn.${slug}.test/app.js" defer></script>` +
+    `<style>:root{--brand-${slug}:#404040}</style>` +
+    `</head><body class="tpl-${slug}"><nav aria-label="Primary"><a href="/">Home</a></nav>` +
+    `<main><h1>${slug}</h1><p>One of a kind.</p>` +
+    `<img src="https://img.${slug}.test/hero.jpg" width="100" height="100" alt="hero"></main></body></html>`
+  );
+}
+
+export interface Fixture {
+  readonly url: string;
+  readonly html: string;
+}
+
+export const CORPUS: Fixture[] = [
+  ...TEMPLATES.flatMap((t) =>
+    (t.id === "landing" ? [1, 2, 3] : [1, 2, 3, 4]).map((n) => ({
+      url: `${ORIGIN}/${t.id}/${n}`,
+      html: pageHtml(t, n),
+    })),
+  ),
+  { url: `${ORIGIN}/contact`, html: singletonHtml("contact") },
+  { url: `${ORIGIN}/status`, html: singletonHtml("status") },
+];
+
+export function mkPage(url: string, html: string): PageRecord {
+  return {
+    url,
+    normalizedUrl: url,
+    finalUrl: url,
+    depth: 1,
+    status: 200,
+    contentType: "text/html; charset=utf-8",
+    sizeBytes: html.length,
+    loadTimeMs: 12,
+    fetchedAt: 1,
+    etag: null,
+    lastModified: null,
+    contentHash: `h:${url}`,
+    html,
+    parsedData: null,
+    headers: { contentType: "text/html; charset=utf-8" },
+    securityHeaders: {},
+  } as unknown as PageRecord;
+}

--- a/packages/audit-engine/tests/template-fanout-equivalence-golden.test.ts
+++ b/packages/audit-engine/tests/template-fanout-equivalence-golden.test.ts
@@ -346,6 +346,53 @@ describe("what actually runs", () => {
     await run(storage.close());
   });
 
+  test("a rule that is also soft-404 gated is never fanned out at all", async () => {
+    // The two declarations contradict each other: the soft-404 gate is decided per
+    // page and the cluster key says nothing about it. The runner's gate ordering
+    // protects the RECIPIENT — a soft-404 member takes its own skip rather than a
+    // sibling's real verdict — but not the reverse: a soft-404 REPRESENTATIVE would
+    // cache its skip and hand it to healthy members, reporting "skipped: soft 404"
+    // for pages that are fine. No built-in declares both, and a named test in
+    // packages/rules keeps it that way, but a plugin registering one through
+    // `additionalNamespaces` only meets this at runtime.
+    const storage = await corpusStorage();
+    let ran = 0;
+    const gated: Rule = {
+      meta: {
+        id: "test/soft404-gated",
+        name: "Soft404 gated",
+        description: "declares both template scope and the soft-404 gate",
+        category: "core",
+        scope: "page",
+        severity: "info",
+        weight: 1,
+        verdictScope: "template",
+        skipOnSoft404: true,
+      },
+      run: () => {
+        ran++;
+        return { checks: [{ name: "gated", status: "pass" as const, message: "seen" }] };
+      },
+    };
+    const runner = new RuleRunner({
+      config: CONFIG,
+      additionalNamespaces: [{ name: "test", rules: [gated] }],
+    });
+
+    const result = await run(
+      streamPageRules(storage, CRAWL, runner, SITE_DATA, { templateFanout: true }),
+    );
+
+    // Declared "template" and still ran on every page — the contradiction costs
+    // speed, never a verdict copied onto a page nobody looked at.
+    expect(ran).toBe(CORPUS.length);
+    for (const url of result.pageUrls) {
+      expect(result.pageRuleResults.get(url)?.get("test/soft404-gated")).toHaveLength(1);
+    }
+
+    await run(storage.close());
+  });
+
   test("a singleton cluster runs its own rules, taking nothing from anyone", async () => {
     const storage = await corpusStorage();
     const counters = countingRules();
@@ -424,17 +471,36 @@ describe("a fanned finding names the page it is about", () => {
       buildStreamFindings(Object.fromEntries(r.ruleResultsMap), 1_000),
     );
 
+    // NOT sorted: each key is zipped back onto its own row below, so a sort
+    // here would pair a key with someone else's finding.
     const keyed = (rows: ReturnType<typeof buildStreamFindings>) =>
-      rows
-        .map((f) => `${f.normalizedUrl} ${f.ruleId} ${f.checkName} ${f.locator}`)
-        .sort();
-    // Identical (url, rule, check, locator) keys AND identical fingerprints. A
-    // fingerprint that keyed on the representative would make every re-audit
-    // resolve and re-open the whole cluster (#1880).
-    expect(keyed(withFanout!)).toEqual(keyed(without!));
-    expect(withFanout!.map((f) => f.fingerprint).sort()).toEqual(
-      without!.map((f) => f.fingerprint).sort(),
-    );
+      rows.map((f) => [f.normalizedUrl, f.ruleId, f.checkName, f.locator].join(" "));
+    // Compared BY the finding key, never as two independently sorted lists: the
+    // same values sitting on different rows compare equal when each list is sorted
+    // on its own. Each finding is checked against the one carrying the SAME
+    // (normalizedUrl, ruleId, checkName, locator), and the WHOLE row is compared —
+    // message, value and expected are what the fingerprint is computed from.
+    //
+    // WHAT THE KEY SET CATCHES AND WHAT THE FINGERPRINT CANNOT. The key comparison
+    // is the load-bearing one: a fanned finding stored against the representative's
+    // url shows up as a missing key here, and that is the failure #1880 cares about,
+    // because it would make every re-audit of an unchanged site resolve and re-open
+    // the whole cluster. The fingerprint comparison catches a value moved between
+    // DIFFERENT findings (verified by mutation), but it can never catch one swapped
+    // between members of one cluster — those fingerprints are legitimately equal,
+    // since the fingerprint is computed from status/message/value/expected and the
+    // classification's whole claim is that those do not vary across the cluster.
+    // No corpus can change that, so do not read this line as stronger than it is.
+    const fannedRows = new Map(keyed(withFanout!).map((k, i) => [k, withFanout![i]!]));
+    const plainRows = new Map(keyed(without!).map((k, i) => [k, without![i]!]));
+    expect(fannedRows.size).toBe(withFanout!.length); // no key collisions
+    expect([...fannedRows.keys()].sort()).toEqual([...plainRows.keys()].sort());
+    for (const [key, row] of plainRows) {
+      const other = fannedRows.get(key);
+      expect(other).toBeDefined();
+      expect(other!.fingerprint).toBe(row.fingerprint);
+      expect(other).toEqual(row);
+    }
 
     // And the fanned rule is genuinely represented per member here, not once.
     const forRule = withFanout!.filter((f) => f.ruleId === FANNED_RULE);

--- a/packages/audit-engine/tests/template-fanout-equivalence-golden.test.ts
+++ b/packages/audit-engine/tests/template-fanout-equivalence-golden.test.ts
@@ -1,0 +1,556 @@
+// TEMPLATE FAN-OUT EQUIVALENCE GATE (#1951).
+//
+// #1950 asserts that a rule declaring `verdictScope: "template"` gives one verdict
+// per cluster. This file asserts the thing built on top of that: running such a
+// rule ONCE per cluster and giving its verdict to the members produces output
+// indistinguishable from running it on every page.
+//
+// The reference arm is a RESIDENT loop that runs every rule on every page — the
+// same shape `streaming-page-rules-golden.test.ts` uses against the streamed pass,
+// deliberately, because it is the only reference that owes nothing to the code
+// under test. The corpus is the authored one from `helpers/template-corpus.ts`,
+// shared with #1950's gate: three templates with 4, 4 and 3 members plus two
+// singletons, whose members differ the way real template siblings differ.
+//
+// SIX THINGS BYTE-IDENTITY ON THIS CORPUS ALONE WOULD NOT CATCH, each with its own
+// test below:
+//
+//  1. **Fan-out that never happened.** Equal output is exactly what you get when
+//     the feature does nothing, so a value assertion cannot prove a rule was
+//     skipped — only a call counter can. Two rules registered here count their own
+//     invocations: the template-scoped one must run once per CLUSTER, the
+//     page-scoped one once per PAGE.
+//  2. **Members collapsing onto the representative.** If a member's checks aliased
+//     the sibling's objects instead of copying them, `pageUrl` would end up the
+//     same on all of them. That is invisible in a per-page comparison keyed by url
+//     and fatal downstream: `affectedPages` would name one page and every member's
+//     finding would re-key onto it (#1880 keys findings on (rule, check, locator);
+//     #1882 is the neighbouring surface that was already wrong once). Asserted
+//     through the REAL writers — `foldOverflowChecks` for the report's page union
+//     and `details.occurrences`, `buildStreamFindings` for the stored identity.
+//  3. **Fan-out reaching an undeclared rule.** Absence of `verdictScope` must mean
+//     page, never "fannable by default".
+//  4. **Singletons.** A cluster of one must take the ordinary path; 5 of
+//     gymshark's 13 chrome clusters are singletons.
+//  5. **A copy that did not copy.** `detachFromPage` returns its argument when
+//     `structuredClone` throws, which would put one page's live checks in the cache
+//     for the whole cluster to stamp over. A rule emitting an uncloneable check
+//     must fall back to running per page.
+//  6. **Crossing origins.** The chrome key sees no scheme, and `security/sri`
+//     decides "cross-origin" by comparing the page's origin to a resolved script's,
+//     so the same markup at `https://` and `http://` gets different verdicts. The
+//     fan-out groups by origin as well as by template; a corpus of one origin can
+//     never show that.
+//
+// Named `*golden*` so `bun run test:engine` runs it alongside the other
+// byte-identity gates and not only in the whole-package CI step.
+
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { RuleRunner, createRunner } from "@squirrelscan/rules";
+import type { Rule, RuleRunResult, SiteData } from "@squirrelscan/rules";
+import { foldOverflowChecks } from "@squirrelscan/rules/fold";
+import type { CheckResult, PageRecord } from "@squirrelscan/core-contracts";
+import type { Config } from "@squirrelscan/config";
+
+import { buildHeadersMap, buildSiteContext, isRenderedFetch } from "../src/adapter";
+import { isAuditablePage } from "../src/page-features";
+import { foldRuleResultIntoTallies, type RuleTally } from "../src/scoring";
+import { streamPageRules } from "../src/streaming";
+import { buildStreamFindings } from "../src/stream-findings";
+import { fanoutClusterKey, templateFanoutEnabled } from "../src/template-fanout";
+import { checkAffectedPages } from "@squirrelscan/report";
+import { CORPUS, ORIGIN, mkPage } from "./helpers/template-corpus";
+
+function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, never, never>);
+}
+
+const CRAWL = "crawl-1";
+// `enable: ["*"]` turns the whole rule set on; filterRules defaults every rule to
+// disabled, so an empty `rules` would make both arms trivially equal on nothing.
+const CONFIG = { rule_options: {}, rules: { enable: ["*"] } } as unknown as Config;
+const SITE_DATA = {
+  baseUrl: ORIGIN,
+  pages: [],
+  robotsTxt: null,
+  sitemaps: null,
+} as unknown as SiteData;
+
+/**
+ * A representative fannable rule for the per-member assertions. `security/sri`
+ * warns on every page of this corpus (so it reaches `buildStreamFindings`, which
+ * only streams fail/warn) and its items are RESOURCE urls rather than page urls —
+ * the exact shape #1882 miscounted, so the affected-page assertions below are
+ * being made on the surface that has actually been wrong.
+ */
+const FANNED_RULE = "security/sri";
+
+async function corpusStorage(): Promise<SQLiteStorage> {
+  const store = new SQLiteStorage(":memory:");
+  await run(store.init());
+  for (const { url, html } of CORPUS) {
+    await run(store.upsertPage(CRAWL, mkPage(url, html) as PageRecord));
+  }
+  return store;
+}
+
+/**
+ * The reference: parse every page, run every rule on every page, fold. No cluster
+ * key is consulted anywhere in here, which is the point.
+ */
+async function residentPageRules(storage: SQLiteStorage, runner: RuleRunner) {
+  const pages = await run(storage.getPages(CRAWL));
+  const ctx = await run(buildSiteContext(pages));
+  const pageResults = new Map<string, CheckResult[]>();
+  const pageRuleResults = new Map<string, Map<string, CheckResult[]>>();
+  const tallies = new Map<string, RuleTally>();
+  for (const { page, parsed } of ctx) {
+    if (!parsed || !isAuditablePage(page)) continue;
+    const result = await runner.runPageRules(
+      {
+        url: page.url,
+        html: page.html!,
+        statusCode: page.status,
+        loadTime: page.loadTimeMs,
+        ttfb: page.ttfb,
+        downloadTime: page.downloadTime,
+        headers: buildHeadersMap(page),
+        parsed,
+        finalUrl: page.finalUrl,
+        redirectChain: page.redirectChain,
+        rendered: isRenderedFetch(page.fetcherId),
+      },
+      SITE_DATA,
+    );
+    const pageUrl = page.normalizedUrl;
+    const byRule = new Map<string, CheckResult[]>();
+    for (const [ruleId, rr] of result.ruleResults) {
+      for (const check of rr.checks) if (!check.pageUrl) check.pageUrl = pageUrl;
+      foldRuleResultIntoTallies(tallies, ruleId, rr as RuleRunResult);
+      byRule.set(ruleId, rr.checks);
+    }
+    pageResults.set(pageUrl, result.checks);
+    pageRuleResults.set(pageUrl, byRule);
+    parsed.document = null;
+  }
+  return { pageResults, pageRuleResults, tallies };
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+describe("fanning a template verdict out is indistinguishable from running the rule", () => {
+  test("every page's checks, per-rule results and folded tallies are unchanged", async () => {
+    const storage = await corpusStorage();
+    const reference = await residentPageRules(storage, createRunner(CONFIG));
+    const fanned = await run(
+      streamPageRules(storage, CRAWL, createRunner(CONFIG), SITE_DATA, {
+        batchSize: 4, // < the corpus, so clusters straddle batch boundaries
+        templateFanout: true,
+      }),
+    );
+
+    expect([...fanned.pageResults.keys()].sort()).toEqual([...reference.pageResults.keys()].sort());
+    for (const [url, checks] of reference.pageResults) {
+      // The flat per-page list, in enabled-rule order — this is what catches a
+      // fanned rule landing in the wrong position as well as a wrong verdict.
+      expect(fanned.pageResults.get(url)).toEqual(checks as never);
+    }
+    for (const [url, byRule] of reference.pageRuleResults) {
+      const got = fanned.pageRuleResults.get(url);
+      expect(got).toBeDefined();
+      expect([...got!.keys()]).toEqual([...byRule.keys()]);
+      for (const [ruleId, checks] of byRule) {
+        expect(got!.get(ruleId)).toEqual(checks as never);
+      }
+    }
+    expect([...fanned.tallies.keys()].sort()).toEqual([...reference.tallies.keys()].sort());
+    for (const [ruleId, rt] of reference.tallies) {
+      // Health score is folded from these, so equal tallies is "the score did not
+      // move" without re-deriving a score here.
+      expect(fanned.tallies.get(ruleId)?.tally).toEqual(rt.tally);
+    }
+
+    await run(storage.close());
+  });
+
+  test("the fan-out actually ran: clusters found, rule invocations removed", async () => {
+    const storage = await corpusStorage();
+    const on = await run(
+      streamPageRules(storage, CRAWL, createRunner(CONFIG), SITE_DATA, { templateFanout: true }),
+    );
+    const off = await run(
+      streamPageRules(storage, CRAWL, createRunner(CONFIG), SITE_DATA, { templateFanout: false }),
+    );
+
+    // 3 templates + 2 singletons = 5 keys; 11 clustered pages - 3 representatives
+    // = 8 pages that inherited a verdict.
+    expect(on.templateFanout.clusters).toBe(5);
+    expect(on.templateFanout.fannedPages).toBe(8);
+    expect(on.templateFanout.fannedRuleRuns).toBeGreaterThan(8 * 20);
+    expect(on.templateFanout.pagesOverCap).toBe(0);
+
+    // Off is the untouched path, and says so in the stats rather than by absence.
+    expect(off.templateFanout).toEqual({
+      clusters: 0,
+      fannedPages: 0,
+      fannedRuleRuns: 0,
+      pagesOverCap: 0,
+    });
+
+    await run(storage.close());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Counting the calls — equal output proves nothing on its own
+// ---------------------------------------------------------------------------
+
+interface CountingRules {
+  readonly rules: Rule[];
+  counts(): { template: number; page: number };
+  reset(): void;
+}
+
+/**
+ * Two rules that differ ONLY in `verdictScope`, each counting its own `run()`.
+ * They are the falsifier for "the fan-out did something" and for "an undeclared
+ * rule is never fanned out", and having them differ in one field is what makes
+ * the second claim about the declaration rather than about the rule.
+ */
+function countingRules(): CountingRules {
+  let template = 0;
+  let page = 0;
+  const base = {
+    name: "Counter",
+    description: "counts its own invocations",
+    category: "core" as const,
+    scope: "page" as const,
+    severity: "info" as const,
+    weight: 1,
+  };
+  return {
+    rules: [
+      {
+        meta: { ...base, id: "test/counter-template", verdictScope: "template" as const },
+        run: () => {
+          template++;
+          return { checks: [{ name: "counter", status: "pass" as const, message: "seen" }] };
+        },
+      },
+      {
+        meta: { ...base, id: "test/counter-page", verdictScope: "page" as const },
+        run: () => {
+          page++;
+          return { checks: [{ name: "counter", status: "pass" as const, message: "seen" }] };
+        },
+      },
+    ],
+    counts: () => ({ template, page }),
+    reset: () => {
+      template = 0;
+      page = 0;
+    },
+  };
+}
+
+describe("what actually runs", () => {
+  test("a template-scoped rule runs once per cluster; a page-scoped one once per page", async () => {
+    const storage = await corpusStorage();
+    const counters = countingRules();
+    const runner = new RuleRunner({
+      config: CONFIG,
+      additionalNamespaces: [{ name: "test", rules: counters.rules }],
+    });
+
+    const result = await run(
+      streamPageRules(storage, CRAWL, runner, SITE_DATA, { templateFanout: true }),
+    );
+
+    // 13 pages, 5 clusters (3 templates + 2 singletons).
+    expect(result.pageUrls.length).toBe(CORPUS.length);
+    expect(counters.counts()).toEqual({ template: 5, page: CORPUS.length });
+
+    // …and both rules still reported on every page.
+    for (const url of result.pageUrls) {
+      expect(result.pageRuleResults.get(url)?.get("test/counter-template")).toHaveLength(1);
+      expect(result.pageRuleResults.get(url)?.get("test/counter-page")).toHaveLength(1);
+    }
+
+    // With fan-out off, the template-scoped rule runs per page like any other —
+    // the difference between the two numbers is the whole feature.
+    counters.reset();
+    await run(streamPageRules(storage, CRAWL, runner, SITE_DATA, { templateFanout: false }));
+    expect(counters.counts()).toEqual({ template: CORPUS.length, page: CORPUS.length });
+
+    await run(storage.close());
+  });
+
+  test("a verdict that cannot be copied is not fanned out", async () => {
+    // `detachFromPage` returns its ARGUMENT when structuredClone throws, which for
+    // its usual callers costs retention and never correctness. Handing that back
+    // here would alias one page's checks across a whole cluster, and the symptom
+    // would be every member reporting the FIRST member's url — silent, and only
+    // visible downstream. The cache checks the copy by identity instead.
+    const storage = await corpusStorage();
+    let ran = 0;
+    const uncloneable: Rule = {
+      meta: {
+        id: "test/uncloneable",
+        name: "Uncloneable",
+        description: "emits a check structuredClone refuses",
+        category: "core",
+        scope: "page",
+        severity: "info",
+        weight: 1,
+        verdictScope: "template",
+      },
+      run: () => {
+        ran++;
+        return {
+          checks: [
+            {
+              name: "uncloneable",
+              status: "pass",
+              message: "seen",
+              // A function is not structured-cloneable, and one failure aborts the
+              // whole clone of the array.
+              details: { onFix: () => undefined },
+            } as unknown as CheckResult,
+          ],
+        };
+      },
+    };
+    const runner = new RuleRunner({
+      config: CONFIG,
+      additionalNamespaces: [{ name: "test", rules: [uncloneable] }],
+    });
+
+    const result = await run(
+      streamPageRules(storage, CRAWL, runner, SITE_DATA, { templateFanout: true }),
+    );
+
+    // Declared "template", but it ran on every page because its verdict could not
+    // be copied — the degradation is in cost, never in what is reported.
+    expect(ran).toBe(CORPUS.length);
+    for (const url of result.pageUrls) {
+      const checks = result.pageRuleResults.get(url)?.get("test/uncloneable") ?? [];
+      expect(checks).toHaveLength(1);
+      expect(checks[0]!.pageUrl).toBe(url);
+    }
+
+    await run(storage.close());
+  });
+
+  test("a singleton cluster runs its own rules, taking nothing from anyone", async () => {
+    const storage = await corpusStorage();
+    const counters = countingRules();
+    const runner = new RuleRunner({
+      config: CONFIG,
+      additionalNamespaces: [{ name: "test", rules: counters.rules }],
+    });
+    const result = await run(
+      streamPageRules(storage, CRAWL, runner, SITE_DATA, { templateFanout: true }),
+    );
+
+    // The two one-off pages are 2 of the 5 invocations: a cluster of one costs
+    // exactly one run, which is what "no special case and no overhead" means.
+    const singles = [`${ORIGIN}/contact`, `${ORIGIN}/status`];
+    for (const url of singles) expect(result.pageUrls).toContain(url);
+    expect(counters.counts().template).toBe(5);
+    // 8 fanned pages + 5 that ran = 13, so no singleton was ever fanned.
+    expect(result.templateFanout.fannedPages + counters.counts().template).toBe(CORPUS.length);
+
+    await run(storage.close());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A fanned finding belongs to the MEMBER, not to the representative
+// ---------------------------------------------------------------------------
+
+describe("a fanned finding names the page it is about", () => {
+  test("affectedPages and details.occurrences cover every member, not the representative", async () => {
+    const storage = await corpusStorage();
+    const result = await run(
+      streamPageRules(storage, CRAWL, createRunner(CONFIG), SITE_DATA, { templateFanout: true }),
+    );
+
+    const checks = result.ruleResultsMap.get(FANNED_RULE)?.checks ?? [];
+    expect(checks.length).toBe(CORPUS.length);
+    // Every check carries its OWN page. Aliasing a sibling's objects would leave
+    // one url repeated here and the assertion below at 1.
+    expect(new Set(checks.map((c) => c.pageUrl)).size).toBe(CORPUS.length);
+
+    // Through the real fold: maxChecks 1 forces the whole rule into one aggregate,
+    // which is the shape the report renders for a rule that fires site-wide.
+    const folded = foldOverflowChecks(checks as CheckResult[], {
+      maxChecks: 1,
+      maxItemsPerCheck: 100,
+      maxPagesPerCheck: 100,
+      maxSourcePagesPerItem: 100,
+    });
+    expect(folded).toHaveLength(1);
+    const aggregate = folded[0]!;
+    expect(aggregate.details?.occurrences).toBe(CORPUS.length);
+    expect(new Set(aggregate.pages ?? [])).toEqual(new Set(CORPUS.map((c) => c.url)));
+    // …and the report's own accessor agrees, so this is not a claim about fold's
+    // internals (#1882: this surface has counted the wrong thing before).
+    expect(checkAffectedPages(aggregate).size).toBe(CORPUS.length);
+
+    await run(storage.close());
+  });
+
+  test("stored finding identity keys on the member, so a re-audit resolves nothing", async () => {
+    const storage = await corpusStorage();
+    // Sequential on purpose: both arms write page_features through the same
+    // storage handle, and interleaving two passes over one connection is a
+    // different thing to test than this.
+    const arms = [];
+    for (const templateFanout of [true, false]) {
+      arms.push(
+        await run(
+          streamPageRules(storage, CRAWL, createRunner(CONFIG), SITE_DATA, { templateFanout }),
+        ),
+      );
+    }
+
+    // The real writer: what the container streams into page_findings.
+    const [withFanout, without] = arms.map((r) =>
+      buildStreamFindings(Object.fromEntries(r.ruleResultsMap), 1_000),
+    );
+
+    const keyed = (rows: ReturnType<typeof buildStreamFindings>) =>
+      rows
+        .map((f) => `${f.normalizedUrl} ${f.ruleId} ${f.checkName} ${f.locator}`)
+        .sort();
+    // Identical (url, rule, check, locator) keys AND identical fingerprints. A
+    // fingerprint that keyed on the representative would make every re-audit
+    // resolve and re-open the whole cluster (#1880).
+    expect(keyed(withFanout!)).toEqual(keyed(without!));
+    expect(withFanout!.map((f) => f.fingerprint).sort()).toEqual(
+      without!.map((f) => f.fingerprint).sort(),
+    );
+
+    // And the fanned rule is genuinely represented per member here, not once.
+    const forRule = withFanout!.filter((f) => f.ruleId === FANNED_RULE);
+    expect(new Set(forRule.map((f) => f.normalizedUrl)).size).toBe(CORPUS.length);
+
+    await run(storage.close());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The grouping key carries the page's origin, not just its template
+// ---------------------------------------------------------------------------
+
+describe("a verdict is never copied across origins", () => {
+  test("two pages with identical markup but different schemes are separate groups", async () => {
+    // `security/sri` decides "cross-origin" by comparing a resolved script's
+    // origin to the page's, so the SAME markup gives different verdicts at
+    // `https://shop.test/a` and `http://shop.test/a`: the script is same-origin on
+    // one and cross-origin on the other. The chrome fingerprint sees neither, so
+    // grouping on the template key alone would copy one verdict onto the other —
+    // a security finding invented for, or erased from, a page nobody looked at.
+    const html =
+      `<!DOCTYPE html><html lang="en"><head><title>Same markup</title>` +
+      `<meta charset="utf-8">` +
+      `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+      `<link rel="stylesheet" href="/assets/site.css">` +
+      `<script src="https://shop.test/app.js"></script>` +
+      `<style>:root{--brand:#101010}</style>` +
+      `</head><body class="tpl-x"><nav><a href="/">Home</a></nav>` +
+      `<main><h1>Same markup</h1></main><footer>f</footer></body></html>`;
+    const secure = "https://shop.test/a";
+    const insecure = "http://shop.test/a";
+
+    const store = new SQLiteStorage(":memory:");
+    await run(store.init());
+    for (const url of [secure, insecure]) {
+      await run(store.upsertPage(CRAWL, mkPage(url, html) as PageRecord));
+    }
+
+    const result = await run(
+      streamPageRules(store, CRAWL, createRunner(CONFIG), SITE_DATA, { templateFanout: true }),
+    );
+
+    // Same template, two groups, and nothing inherited.
+    expect(result.pageUrls.sort()).toEqual([insecure, secure]);
+    expect(result.templateFanout.clusters).toBe(2);
+    expect(result.templateFanout.fannedPages).toBe(0);
+
+    // …and the verdicts really do differ, so the separation is load-bearing rather
+    // than a distinction the rules would not have noticed.
+    const sriOn = (url: string) => result.pageRuleResults.get(url)?.get(FANNED_RULE) ?? [];
+    expect(sriOn(secure).map((c) => c.status)).not.toEqual(sriOn(insecure).map((c) => c.status));
+
+    await run(store.close());
+  });
+
+  test("fanoutClusterKey separates origins and survives an unparseable url", () => {
+    expect(fanoutClusterKey("abc123", "https://shop.test/a")).not.toBe(
+      fanoutClusterKey("abc123", "http://shop.test/a"),
+    );
+    expect(fanoutClusterKey("abc123", "https://shop.test/a")).toBe(
+      fanoutClusterKey("abc123", "https://shop.test/b?q=1"),
+    );
+    // No template key means no group, whatever the url.
+    expect(fanoutClusterKey(null, "https://shop.test/a")).toBeNull();
+    // A url that will not parse falls back to itself, so it can only ever group
+    // with a byte-identical url.
+    expect(fanoutClusterKey("abc123", "not a url")).not.toBe(
+      fanoutClusterKey("abc123", "also not a url"),
+    );
+    expect(fanoutClusterKey("abc123", "not a url")).toBe(fanoutClusterKey("abc123", "not a url"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The cluster cap: it may change cost, never output
+// ---------------------------------------------------------------------------
+
+describe("the cache is bounded", () => {
+  test("past the cap, later clusters run the ordinary path and the output is unchanged", async () => {
+    const storage = await corpusStorage();
+    const reference = await residentPageRules(storage, createRunner(CONFIG));
+    // Room for one cluster only. On a crawl where clustering has failed and nearly
+    // every page is its own template, the cache would otherwise grow with the page
+    // count — the term #1913 exists to keep out of this loop.
+    const capped = await run(
+      streamPageRules(storage, CRAWL, createRunner(CONFIG), SITE_DATA, {
+        templateFanout: true,
+        templateFanoutMaxClusters: 1,
+      }),
+    );
+
+    expect(capped.templateFanout.clusters).toBe(1);
+    expect(capped.templateFanout.pagesOverCap).toBeGreaterThan(0);
+    // Fewer pages inherited than the uncapped 8, but every page still reported.
+    expect(capped.templateFanout.fannedPages).toBeLessThan(8);
+    expect(capped.templateFanout.fannedPages).toBeGreaterThan(0);
+    for (const [url, checks] of reference.pageResults) {
+      expect(capped.pageResults.get(url)).toEqual(checks as never);
+    }
+
+    await run(storage.close());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The kill switch
+// ---------------------------------------------------------------------------
+
+describe("SQUIRREL_TEMPLATE_FANOUT", () => {
+  test("defaults on, and every spelling of off turns it off", () => {
+    expect(templateFanoutEnabled({})).toBe(true);
+    expect(templateFanoutEnabled({ SQUIRREL_TEMPLATE_FANOUT: "1" })).toBe(true);
+    expect(templateFanoutEnabled({ SQUIRREL_TEMPLATE_FANOUT: "" })).toBe(true);
+    for (const off of ["0", "false", "FALSE", "off", "no", " 0 "]) {
+      expect(templateFanoutEnabled({ SQUIRREL_TEMPLATE_FANOUT: off })).toBe(false);
+    }
+  });
+});

--- a/packages/audit-engine/tests/template-fanout-parity-golden.test.ts
+++ b/packages/audit-engine/tests/template-fanout-parity-golden.test.ts
@@ -7,16 +7,10 @@
 // produce a byte-identical verdict for every member of every multi-page cluster of
 // a corpus that HAS multi-page clusters.
 //
-// WHY THE FIXTURE IS SHAPED THE WAY IT IS. A corpus whose pages are all one
-// template passes this vacuously, and the synthetic bench corpora are exactly that
-// — generated from 1-6 templates, so every clustering definition collapses to ~99%
-// redundancy on them (#1026). So the fixture below is authored: three templates
-// with 4, 4 and 3 members plus two singletons, and the members of a template differ
-// the way real template siblings differ — different amounts of the same kind of
-// content: more paragraphs, more images, more links, different titles, different
-// JSON-LD, an image missing its alt on some pages. What they do NOT differ in is
-// the KIND of markup, because that is the template, and that distinction is the
-// classification's whole premise.
+// WHY THE FIXTURE IS SHAPED THE WAY IT IS: see helpers/template-corpus.ts. In
+// short, a corpus whose pages are all one template passes this vacuously, so the
+// corpus is authored rather than generated, and its members differ the way real
+// template siblings differ.
 //
 // The corpus is checked for adversarialness before it is trusted: it must produce
 // several multi-page clusters AND a substantial number of "page"-declared rules
@@ -44,201 +38,23 @@ import { SQLiteStorage } from "@squirrelscan/crawler";
 import { createRunner, loadAllRules, mayFanOutAcrossTemplate } from "@squirrelscan/rules";
 import type { PageData, SiteData } from "@squirrelscan/rules";
 import type { Config } from "@squirrelscan/config";
-import type { PageRecord } from "@squirrelscan/core-contracts";
 
 import { createSiteQuery, extractPageFeatures, templateVerdictKey } from "../src/index";
 import { parseHtmlForRules } from "../src/adapter";
+import { CORPUS, mkPage, ORIGIN } from "./helpers/template-corpus";
 
 function run<A>(eff: Effect.Effect<A, unknown, never>): Promise<A> {
   return Effect.runPromise(eff as Effect.Effect<A, never, never>);
 }
 
 const CRAWL = "crawl-1";
-const ORIGIN = "https://shop.test";
-
-// ---------------------------------------------------------------------------
-// The corpus
-// ---------------------------------------------------------------------------
-
-interface Template {
-  readonly id: string;
-  readonly stylesheet: string;
-  readonly scriptHost: string;
-  readonly imageHost: string;
-  readonly bodyClass: string;
-  readonly cssVars: string;
-  readonly footer: boolean;
-}
-
-const TEMPLATES: Template[] = [
-  {
-    id: "product",
-    stylesheet: "/assets/product.css",
-    scriptHost: "cdn.shopkit.test",
-    imageHost: "img.shopkit.test",
-    bodyClass: "tpl-product theme-light",
-    cssVars: "--brand:#101010;--gutter:16px",
-    footer: true,
-  },
-  {
-    id: "article",
-    stylesheet: "/assets/article.css",
-    scriptHost: "cdn.editorial.test",
-    imageHost: "media.editorial.test",
-    bodyClass: "tpl-article theme-light",
-    cssVars: "--brand:#202020;--measure:68ch",
-    footer: true,
-  },
-  {
-    id: "landing",
-    stylesheet: "/assets/landing.css",
-    scriptHost: "cdn.campaign.test",
-    imageHost: "img.campaign.test",
-    bodyClass: "tpl-landing",
-    cssVars: "--brand:#303030",
-    // No footer: a chrome difference, so this cannot merge into another cluster.
-    footer: false,
-  },
-];
-
-/**
- * The template's chrome, byte-identical for every member. Everything the cluster
- * key reads lives here: stylesheet hrefs, asset hosts, body classes, CSS custom
- * properties, nav and footer presence.
- */
-function chrome(t: Template): { head: string; nav: string; foot: string } {
-  return {
-    head:
-      `<meta charset="utf-8">` +
-      `<meta name="viewport" content="width=device-width, initial-scale=1">` +
-      `<link rel="icon" href="/favicon.ico">` +
-      `<link rel="stylesheet" href="${t.stylesheet}">` +
-      `<script src="https://${t.scriptHost}/app.js" defer></script>` +
-      // An inline script, template-emitted and byte-identical across members, so
-      // the script-reading declarations (integrity/obfuscated-script,
-      // perf/legacy-js, perf/duplicate-js) are compared on something rather than
-      // passing by absence.
-      `<script>window.__cfg={locale:"en",tpl:"${t.id}"};</script>` +
-      `<style>:root{${t.cssVars}}</style>`,
-    nav:
-      `<nav aria-label="Primary"><ul>` +
-      `<li><a href="/">Home</a></li><li><a href="/about">About</a></li>` +
-      `</ul></nav>`,
-    foot: t.footer
-      ? `<footer><form action="/subscribe" method="post">` +
-        `<label for="em">Email</label><input id="em" type="email" name="email">` +
-        `<button type="submit">Subscribe</button></form>` +
-        `<p>&copy; 2026 Shop Test</p></footer>`
-      : "",
-  };
-}
-
-/**
- * One member's body. `n` is the only thing that moves: more paragraphs, more
- * images, more links, a different title and description, a different JSON-LD
- * offer, and on every third page an image with no alt. That is how real siblings
- * of one template differ, and it is what makes the "page"-declared rules disagree
- * here.
- */
-function body(t: Template, n: number): string {
-  const paragraphs = Array.from(
-    { length: n + 1 },
-    (_, i) =>
-      `<p>Paragraph ${i + 1} of the ${t.id} page number ${n}. ` +
-      "It carries enough prose that word count, reading level and text-to-html ratio move with n. ".repeat(n) +
-      "</p>",
-  ).join("");
-  const images = Array.from({ length: n }, (_, i) =>
-    i === 0 && n % 3 === 0
-      ? `<img src="https://${t.imageHost}/${t.id}-${n}-${i}.jpg" width="800" height="600">`
-      : `<img src="https://${t.imageHost}/${t.id}-${n}-${i}.jpg" width="800" height="600" alt="${t.id} view ${i}">`,
-  ).join("");
-  const links = Array.from(
-    { length: n },
-    (_, i) => `<a href="/${t.id}/related-${i}">Related ${i}</a>`,
-  ).join(" ");
-  const jsonLd = JSON.stringify({
-    "@context": "https://schema.org",
-    "@type": t.id === "article" ? "Article" : "Product",
-    name: `${t.id} ${n}`,
-    description: `A ${t.id} with ${n} related items.`,
-  });
-  return (
-    `<main><h1>${t.id} number ${n}</h1>` +
-    Array.from({ length: n }, (_, i) => `<h2>Section ${i + 1}</h2>`).join("") +
-    paragraphs +
-    images +
-    `<p>${links}</p>` +
-    `<script type="application/ld+json">${jsonLd}</script>` +
-    `</main>`
-  );
-}
-
-function pageHtml(t: Template, n: number): string {
-  const c = chrome(t);
-  return (
-    `<!DOCTYPE html><html lang="en"><head><title>${t.id} ${n} | Shop Test</title>` +
-    `<meta name="description" content="The ${t.id} page numbered ${n}, with ${n} related items and ${n} images.">` +
-    `<link rel="canonical" href="${ORIGIN}/${t.id}/${n}">` +
-    c.head +
-    `</head><body class="${t.bodyClass}">${c.nav}${body(t, n)}${c.foot}</body></html>`
-  );
-}
-
-/** A page nothing else shares chrome with, so it lands in a cluster of one. */
-function singletonHtml(slug: string): string {
-  return (
-    `<!DOCTYPE html><html lang="en"><head><title>${slug} | Shop Test</title>` +
-    `<meta name="description" content="A one-off ${slug} page.">` +
-    `<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` +
-    `<link rel="stylesheet" href="/assets/${slug}.css">` +
-    `<script src="https://cdn.${slug}.test/app.js" defer></script>` +
-    `<style>:root{--brand-${slug}:#404040}</style>` +
-    `</head><body class="tpl-${slug}"><nav aria-label="Primary"><a href="/">Home</a></nav>` +
-    `<main><h1>${slug}</h1><p>One of a kind.</p>` +
-    `<img src="https://img.${slug}.test/hero.jpg" width="100" height="100" alt="hero"></main></body></html>`
-  );
-}
-
-interface Fixture {
-  readonly url: string;
-  readonly html: string;
-}
-
-const CORPUS: Fixture[] = [
-  ...TEMPLATES.flatMap((t) =>
-    (t.id === "landing" ? [1, 2, 3] : [1, 2, 3, 4]).map((n) => ({
-      url: `${ORIGIN}/${t.id}/${n}`,
-      html: pageHtml(t, n),
-    })),
-  ),
-  { url: `${ORIGIN}/contact`, html: singletonHtml("contact") },
-  { url: `${ORIGIN}/status`, html: singletonHtml("status") },
-];
-
-function mkPage(url: string, html: string): PageRecord {
-  return {
-    url,
-    normalizedUrl: url,
-    finalUrl: url,
-    depth: 1,
-    status: 200,
-    contentType: "text/html; charset=utf-8",
-    sizeBytes: html.length,
-    loadTimeMs: 12,
-    fetchedAt: 1,
-    etag: null,
-    lastModified: null,
-    contentHash: `h:${url}`,
-    html,
-    parsedData: null,
-    headers: { contentType: "text/html; charset=utf-8" },
-    securityHeaders: {},
-  } as unknown as PageRecord;
-}
 
 // ---------------------------------------------------------------------------
 // Running it
+//
+// The corpus — three templates with 4/4/3 members plus two singletons — lives in
+// helpers/template-corpus.ts, shared with #1951's fan-out equivalence gate so the
+// two falsifiers cannot drift apart.
 // ---------------------------------------------------------------------------
 
 const CONFIG = { rule_options: {}, rules: { enable: ["*"] } } as unknown as Config;

--- a/packages/rules/src/core/charset.ts
+++ b/packages/rules/src/core/charset.ts
@@ -12,8 +12,19 @@ export const charsetRule: Rule = {
     solution:
       'Add <meta charset="UTF-8"> as the first element in your <head> section. This tells browsers how to interpret the text on your page. UTF-8 is the standard encoding that supports all languages and special characters. Placing it first ensures browsers know the encoding before parsing any other content.',
     category: "core",
+    // NOT "template", even though it is constant on both measured corpora and on
+    // the authored one. The charset can come from the `Content-Type` RESPONSE
+    // HEADER, which the template cluster key constrains in no way and which two
+    // pages of one template routinely differ in — an origin that sets
+    // `text/html; charset=utf-8` on some routes and a bare `text/html` on others
+    // makes this rule pass on one and fail on the other. Every corpus in the gates
+    // declares the charset in a `<meta>` tag, so the header branch is never
+    // reached there and no measurement could have caught it. This is the same
+    // disqualification VerdictScope already applies to `perf/cache-headers`,
+    // `security/cookie-flags` and `perf/compression`; the counterexample is pinned
+    // in packages/rules/tests/template-verdict-page-independence.test.ts (#1951).
     scope: "page",
-    verdictScope: "template",
+    verdictScope: "page",
     severity: "warning",
     weight: 5,
   },

--- a/packages/rules/src/runner.ts
+++ b/packages/rules/src/runner.ts
@@ -93,6 +93,30 @@ export interface PageRunResult {
   ruleResults: Map<string, RuleRunResult>;
 }
 
+/** Per-page options for {@link RuleRunner.runPageRules}. */
+export interface PageRuleRunOptions {
+  /**
+   * Template fan-out (#1951): `ruleId -> checks` for rules that must NOT run on
+   * this page because a page sharing its template cluster already produced the
+   * verdict. Only rules for which {@link mayFanOutAcrossTemplate} holds may
+   * appear here, and it is the CALLER that owns the cluster identity — the runner
+   * has no view of the crawl and simply trusts the map.
+   *
+   * The contract on the values:
+   *
+   *  - they are the sibling's checks CLONED, so stamping `pageUrl` on them cannot
+   *    reach back into another page's result (see `template-fanout.ts`);
+   *  - they carry no `pageUrl`, so the caller's ordinary stamping applies;
+   *  - they contain nothing derived from the sibling's URL, which is the property
+   *    `template-verdict-page-independence.test.ts` asserts for every declaring
+   *    rule by running it under two urls that share only scheme and host.
+   *
+   * A rule id absent from the map runs normally, so an empty or omitted map is
+   * exactly today's behaviour.
+   */
+  fannedRuleChecks?: ReadonlyMap<string, CheckResult[]>;
+}
+
 export interface SiteRunResult {
   checks: CheckResult[];
   ruleResults: Map<string, RuleRunResult>;
@@ -185,12 +209,19 @@ export class RuleRunner {
    * Returns synchronously when `run()` is sync (nearly all rules) and a Promise
    * only for the few async rules, so the common path pays no microtask overhead
    * (#521). Callers must handle either shape.
+   *
+   * `fanned` substitutes a template sibling's checks for `run()` (#1951). It is
+   * consulted AFTER both gates, because both are decided per PAGE and a
+   * representative's verdict says nothing about them: applicability happens to be
+   * run-constant, but the soft-404 gate is not, so a member that serves 404
+   * content must take its own skip rather than a sibling's real verdict.
    */
   private runOneRule(
     rule: Rule,
     ctx: RuleContext,
     siteMetadata: SiteMetadata | undefined,
-    scopeForLog?: "site"
+    scopeForLog?: "site",
+    fanned?: CheckResult[]
   ): RuleRunResult | Promise<RuleRunResult> {
     // Run-time applicability gate — emit a visible `skipped` check and skip
     // `run()` when the Stage-0 metadata excludes this rule.
@@ -215,6 +246,14 @@ export class RuleRunner {
           },
         ],
       };
+    }
+
+    // #1951: this rule already ran on a page sharing this one's template cluster
+    // and declared its verdict a property of the template, so the sibling's checks
+    // ARE this page's checks. Handed in pre-cloned and free of `pageUrl`, so the
+    // caller stamps this page's url onto them exactly as it does a real run's.
+    if (fanned) {
+      return { meta: rule.meta, checks: fanned };
     }
 
     const ruleStart = performance.now();
@@ -284,7 +323,8 @@ export class RuleRunner {
   // Optional siteData allows page rules to access site-level data (scripts, resourceSizes, etc.)
   async runPageRules(
     page: PageData,
-    siteData?: SiteData
+    siteData?: SiteData,
+    opts?: PageRuleRunOptions
   ): Promise<PageRunResult> {
     return logger.withTraceAsync(
       "runPageRules:page",
@@ -329,6 +369,7 @@ export class RuleRunner {
         // microtask; sync rules run straight through, no Promise overhead (#521).
         const ruleResults = new Map<string, RuleRunResult>();
         const allChecks: CheckResult[] = [];
+        const fannedChecks = opts?.fannedRuleChecks;
         for (const rule of pageRules) {
           const ctx: RuleContext = {
             page,
@@ -339,7 +380,17 @@ export class RuleRunner {
             intel,
             options: getRuleOptions(rule, this.config),
           };
-          const out = this.runOneRule(rule, ctx, siteMetadata);
+          // The substitution happens INSIDE this loop rather than by splicing
+          // afterwards, so a fanned rule occupies exactly the position a real run
+          // would: `allChecks` stays in enabled-rule order and `ruleResults` keeps
+          // its insertion order, which is what makes the output byte-identical.
+          const out = this.runOneRule(
+            rule,
+            ctx,
+            siteMetadata,
+            undefined,
+            fannedChecks?.get(rule.meta.id)
+          );
           const result = out instanceof Promise ? await out : out;
           ruleResults.set(rule.meta.id, result);
           allChecks.push(...result.checks);

--- a/packages/rules/src/types.ts
+++ b/packages/rules/src/types.ts
@@ -90,6 +90,17 @@ export type RuleSeverity = "error" | "warning" | "info";
  * and for `integrity/*` and `security/*` that is the expensive direction to be
  * wrong in.
  *
+ * WHAT THE CLUSTER KEY DOES NOT CHECK FOR YOU. The key is chrome only — asset
+ * hosts, body classes, CSS custom properties, stylesheet hrefs, nav/footer
+ * presence — so two pages can share it and still differ in markup it never looked
+ * at: a missing viewport `<meta>`, a second `<main>`, a script whose PATH differs
+ * on the same host (per-route hashed bundles do this). A declaration is therefore
+ * a claim about how the site's templates are BUILT, not something the key
+ * enforces, and it is why "constant on two crawls" is evidence rather than proof.
+ * Tracked as squirrelscan/squirrelscan#275. Two things are not left to the
+ * declaration: the fan-out groups by page ORIGIN as well as by template, and a
+ * rule reading a response header is disqualified outright (see `core/charset`).
+ *
  * A declaration is a claim, not a proof, and it has two falsifiers.
  * `template-fanout-parity-golden.test.ts` runs in CI over an authored corpus with
  * real multi-page clusters; `apps/cli/scripts/template-rule-invariance.ts --check`

--- a/packages/rules/tests/template-verdict-page-independence.test.ts
+++ b/packages/rules/tests/template-verdict-page-independence.test.ts
@@ -1,0 +1,214 @@
+// THE PRECONDITIONS #1951's FAN-OUT RESTS ON.
+//
+// #1950 says a rule declaring `verdictScope: "template"` gives the same verdict to
+// every member of a template cluster. #1951 acts on that by running the rule once
+// and COPYING the verdict onto the members. Copying is only sound if the verdict
+// carries nothing about the page it happened to be computed on, and that is a
+// stronger property than "the members agreed on a corpus": two members of one
+// cluster can agree on everything the parity gate compares while the rule still
+// resolves a relative href against its own path, or interpolates its own url.
+//
+// The fan-out deliberately does NOT rewrite urls inside a copied check. Rewriting
+// would need the inverse of a normalisation that is not injective (`pageUrl`, the
+// url without its trailing slash and the bare path all normalise to one token), so
+// the honest design is to require that there is nothing to rewrite and to fail a
+// declaration that breaks it. This file is that requirement.
+//
+// It is checked by RUNNING each declaring rule on the same HTML twice under two
+// urls that share nothing but the scheme and host. Anything the rule derives from
+// its url — an interpolated path, a resolved relative src, a hostname comparison
+// that happens to depend on depth — makes the two verdicts differ. A substring
+// scan alone would miss a resolution difference that lands in an item id; the
+// equality is the gate and the scan only names the field.
+//
+// The second precondition is a response header. `core/charset` came out of #269
+// declared "template" and is constant on every corpus in every gate, because all of
+// them declare the charset in a `<meta>` tag — so its fall-through to the
+// `Content-Type` header, which the cluster key constrains in no way, was never
+// reached by any measurement. #1951 demoted it, and the case that says why is
+// pinned below so a future re-declaration fails a named test.
+//
+// The third precondition is `skipOnSoft404`. That gate is decided PER PAGE
+// (`parsed.isSoft404`), so a rule carrying both declarations could have a sibling's
+// real verdict fanned onto a page that serves 404 content. The runner orders the
+// gates so this cannot happen, but a rule declaring both is a classification
+// mistake and should be a named failure rather than a silently degraded path.
+
+import { describe, expect, test } from "bun:test";
+
+import { RuleRunner } from "../src/runner";
+import { loadAllRules } from "../src/loader";
+import { mayFanOutAcrossTemplate } from "../src/types";
+import type { PageData, SiteData } from "../src/types";
+
+const rules = [...loadAllRules().values()];
+const fannable = rules.filter((r) => mayFanOutAcrossTemplate(r.meta));
+
+const ORIGIN = "https://shop.test";
+// Two urls that share ONLY scheme and host: different depth, different segment
+// spelling, one with a query. A rule that reads its url for any purpose other than
+// the origin produces different output under these.
+const URL_A = `${ORIGIN}/a`;
+const URL_B = `${ORIGIN}/collections/winter/products/parka-9271?variant=42`;
+
+/**
+ * One page of template chrome carrying the inputs the declared rules read, with
+ * every kind of reference a page can make: root-relative, DOCUMENT-relative (the
+ * one that actually depends on the url), protocol-relative and absolute. Without
+ * the document-relative ones the equality below would pass on rules that resolve
+ * against `ctx.page.url`, which is the failure most worth catching.
+ */
+const HTML =
+  `<!DOCTYPE html><html lang="en"><head><title>Chrome</title>` +
+  `<meta charset="utf-8">` +
+  `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+  `<meta http-equiv="refresh" content="7;url=/next">` +
+  `<link rel="icon" href="/favicon.ico">` +
+  `<link rel="stylesheet" href="/assets/site.css">` +
+  `<link rel="stylesheet" href="theme.css">` +
+  `<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap">` +
+  `<script src="https://cdn.shopkit.test/app.js" defer></script>` +
+  `<script src="bundle.js"></script>` +
+  `<script src="//cdn.other.test/widget.js"></script>` +
+  `<script src="https://cdn.shopkit.test/jquery-1.7.2.js"></script>` +
+  `<script>window.__cfg={locale:"en"};var x=document.all;</script>` +
+  `<style>:root{--brand:#101010}</style>` +
+  `</head><body class="tpl-chrome">` +
+  `<nav aria-label="Primary"><a href="/">Home</a></nav>` +
+  `<main><h1>Chrome</h1><img src="hero.jpg" width="8" height="6" alt="hero">` +
+  `<p>Body copy.</p></main>` +
+  `<footer><p>&copy; 2026</p></footer></body></html>`;
+
+/**
+ * The same page with its `<meta charset>` removed, so `core/charset` falls
+ * through to the `Content-Type` header. Kept next to HTML rather than inlined in
+ * the test, because the whole point of the case below is that the header branch
+ * is REACHED — a fixture that still declares a charset makes both arms pass and
+ * the counterexample proves nothing.
+ */
+const HEADER_ONLY_HTML = HTML.replace(`<meta charset="utf-8">`, "");
+
+function pageData(url: string, html: string = HTML): PageData {
+  return {
+    url,
+    html,
+    statusCode: 200,
+    loadTime: 12,
+    headers: { "content-type": "text/html; charset=utf-8" },
+    finalUrl: url,
+  };
+}
+
+const SITE_DATA = {
+  baseUrl: ORIGIN,
+  pages: [],
+  robotsTxt: null,
+  sitemaps: null,
+} as unknown as SiteData;
+
+const CONFIG = { rule_options: {}, rules: { enable: ["*"] } };
+
+const runner = new RuleRunner({ config: CONFIG });
+const [resultA, resultB] = await Promise.all([
+  runner.runPageRules(pageData(URL_A), SITE_DATA),
+  runner.runPageRules(pageData(URL_B), SITE_DATA),
+]);
+
+/** Every distinctive substring of a url that must not survive into a verdict. */
+function identities(url: string): string[] {
+  const u = new URL(url);
+  return [url, u.pathname + u.search, u.pathname, "parka-9271", "collections"].filter(
+    (s) => s.length > 1,
+  );
+}
+
+describe("the fixture exercises the declarations", () => {
+  test("the declared set is non-empty and every rule of it reported", () => {
+    expect(fannable.length).toBeGreaterThan(20);
+    for (const rule of fannable) {
+      // A rule that emitted nothing here is compared on nothing, so the gate
+      // below would pass on it vacuously — the per-rule vacuity hole #1950 hit.
+      expect(resultA.ruleResults.get(rule.meta.id)?.checks.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  test("the two urls really do differ everywhere but the origin", () => {
+    expect(new URL(URL_A).origin).toBe(new URL(URL_B).origin);
+    expect(new URL(URL_A).pathname).not.toBe(new URL(URL_B).pathname);
+  });
+});
+
+describe("a template-scoped verdict does not depend on the page it ran on", () => {
+  test.each(fannable.map((r) => [r.meta.id] as const))(
+    "%s gives the same verdict under two different urls",
+    (ruleId) => {
+      const a = resultA.ruleResults.get(ruleId)?.checks ?? [];
+      const b = resultB.ruleResults.get(ruleId)?.checks ?? [];
+      const leaked = identities(URL_B).find((id) => JSON.stringify(b).includes(id));
+      if (leaked) {
+        throw new Error(
+          `${ruleId} declares verdictScope "template" but its verdict quotes the page ` +
+            `it ran on (${leaked}). #1951 copies this verdict onto the cluster's other ` +
+            "members verbatim, which would attribute this page's url to them. Either " +
+            'stop deriving output from `ctx.page.url`, or declare verdictScope "page".',
+        );
+      }
+      expect(b).toEqual(a);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The counterexample that demoted a rule
+// ---------------------------------------------------------------------------
+
+describe("core/charset reads a response header, so it is page-scoped", () => {
+  test("two pages with identical markup disagree on the Content-Type header alone", async () => {
+    // #269 declared this rule "template". It is constant on gymshark.com, on
+    // openelectricity.org.au and on the authored parity corpus — because every
+    // page of all three declares its charset in a `<meta>` tag, so the header
+    // branch below is never reached and no measurement over those corpora could
+    // see it. The cluster key constrains no response header, and an origin that
+    // sets `charset=utf-8` on some routes and a bare `text/html` on others is
+    // ordinary. #1951 demoted it; this is the case that says why, and it is here
+    // so that re-declaring it fails a named test rather than shipping a `pass`
+    // fanned onto a page that fails.
+    const a = await runner.runPageRules(
+      {
+        ...pageData(URL_A, HEADER_ONLY_HTML),
+        headers: { "content-type": "text/html; charset=utf-8" },
+      },
+      SITE_DATA,
+    );
+    const b = await runner.runPageRules(
+      { ...pageData(URL_A, HEADER_ONLY_HTML), headers: { "content-type": "text/html" } },
+      SITE_DATA,
+    );
+
+    const charsetOf = (r: Awaited<ReturnType<typeof runner.runPageRules>>) =>
+      r.ruleResults.get("core/charset")?.checks ?? [];
+    expect(charsetOf(a).map((c) => c.status)).toEqual(["pass"]);
+    expect(charsetOf(b).map((c) => c.status)).toEqual(["fail"]);
+
+    // The fixture has to reach the header branch for the above to mean anything:
+    // a `<meta charset>` anywhere in the head would make both arms pass.
+    expect(HEADER_ONLY_HTML).not.toContain("charset");
+
+    const rule = rules.find((r) => r.meta.id === "core/charset");
+    expect(rule?.meta.verdictScope).toBe("page");
+    expect(mayFanOutAcrossTemplate(rule!.meta)).toBe(false);
+  });
+});
+
+describe("a template-scoped rule is never also soft-404 gated", () => {
+  test.each(fannable.map((r) => [r.meta.id, r.meta] as const))(
+    "%s does not declare skipOnSoft404",
+    (_id, meta) => {
+      // The soft-404 gate is per page and the cluster key says nothing about it,
+      // so the two declarations contradict each other. The runner consults a
+      // fanned verdict only AFTER this gate, so the live behaviour is safe either
+      // way — this keeps the contradiction from being introduced silently.
+      expect(meta.skipOnSoft404).toBeUndefined();
+    },
+  );
+});


### PR DESCRIPTION
Implements squirrelscan/repo#1951, the payoff for the #1026 template-clustering
work. Builds on #267 (the cluster key) and #269 (the classification and its gate).

In the streamed page-rule pass, a rule declaring `verdictScope: "template"` now
runs ONCE per template cluster and its verdict is copied onto the cluster's other
members. On gymshark.com that removes 5,850 of 48,906 rule invocations.

## What makes it sound

Fanning a verdict out asserts something about pages the rule never visited, so
copying is only allowed where the copy cannot carry the page it was computed on:

- **Each member gets its own copy**, checked by IDENTITY. `detachFromPage` is
  deliberately forgiving and returns its argument when `structuredClone` throws,
  which for its usual callers costs retention and never a wrong finding. Here it
  would be a wrong finding: the member would stamp `pageUrl` onto the cached
  objects and every later member would read the first one's url, collapsing the
  cluster onto one page. Anything that comes back uncopied is dropped from the
  cache, and those pages run the ordinary path.
- **The cached copy carries no `pageUrl`**, so a member's stamp is a first write
  exactly as it is on a page that really ran. Nothing rewrites urls INSIDE a
  copied check, because the normalisation that would have to be inverted is not
  injective — the requirement is that there is nothing to rewrite, and
  `template-verdict-page-independence.test.ts` fails a declaration that breaks it
  by running each declaring rule under two urls sharing only scheme and host.
- **The grouping key is (template cluster, page ORIGIN).** `security/sri` decides
  "cross-origin" by comparing a resolved script's origin to the page's, so the
  same markup at `https://` and `http://` genuinely differs. Origin stays out of
  `page_features.template_fp`, which should still call those one template.
- **A rule that threw is never cached** — `runOneRule` turns a throw into a
  `<ruleId>-error` check quoting the exception, which can carry page content.
- **The soft-404 gate is consulted before a fanned verdict**, because it is
  per-page where applicability is run-constant. No declared rule sets
  `skipOnSoft404`, and a test keeps it that way.

## One rule demoted

**`core/charset` moves from "template" to "page".** Two pages with byte-identical
markup and no `<meta charset>`, one served `Content-Type: text/html; charset=utf-8`
and the other bare `text/html`, give `pass` and `fail`. The cluster key constrains
no response header. It measures constant on gymshark.com, openelectricity.org.au
and the authored parity corpus only because every page of all three declares the
charset in a `<meta>` tag, so the header branch is never reached and no
measurement over those corpora could have caught it. #269's own `VerdictScope` doc
already disqualifies header-readers; this one was missed. It is the only one of
the 26 that reads `ctx.page.headers`. The counterexample is pinned as a test.

## Evidence

Three falsifiers, because a gate only proves something about the pages it runs:

| gate | what it runs |
|---|---|
| `template-fanout-equivalence-golden.test.ts` | the fanned pass vs a RESIDENT loop that runs everything on everything, over an authored corpus with three multi-page clusters and two singletons |
| `template-fanout-bench.ts --verify` | the same comparison against real crawls: gymshark.com (247 pages, 13 clusters), openelectricity.org.au (100, 12), a 150-page synthetic (1) — byte-identical on all three |
| `template-verdict-page-independence.test.ts` | each declaring rule under two different urls, plus the charset counterexample and the soft-404 exclusion |

Equal output is also what a feature that does nothing produces, so the gates count
calls: a rule declaring "template" must run once per CLUSTER and an undeclared one
once per PAGE, asserted with two rules that differ only in that field.

## Flag

ON for the streamed pass, which is what both the CLI and the cloud run.
`SQUIRREL_TEMPLATE_FANOUT=0` (or `false`/`off`/`no`) turns it off for a run.
The v1 `runRulesOnStorage` path is untouched: it does not stream and has no
cluster key.

## Follow-ups filed

- #275 (P2): the cluster key is chrome only, so a constructed pair can share it
  and differ in a declared rule's inputs. Unreachable on all three corpora,
  constructible, and #269's accepted premise rather than something this
  introduces. The issue holds the options and the measurement they need.
- #274 (P3): the rule runner builds a nine-key profile payload and runs three
  `filter` passes per invocation whether or not `SQUIRREL_RULE_PROFILE` is set.

Part of squirrelscan/repo#1026.
