### PR TITLE
chore(release): bump to 0.0.92

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "repository": "https://github.com/squirrelscan/squirrelscan",
   "license": "MIT",
   "keywords": ["seo", "audit", "website", "performance", "security", "accessibility", "crawler"],
-  "version": "0.0.91"
+  "version": "0.0.92"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "squirrelscan",
   "displayName": "squirrelscan",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "author": {
     "name": "squirrelscan"
   },

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squirrelscan/cli",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "description": "Free CLI for SEO, performance & security audits. Built for Claude Code, Cursor, and AI workflows.",
   "bin": {
     "squirrelscan": "./build/squirrelscan"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squirrelscan",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "description": "Website QA tool built for coding agents. 260+ rules across SEO, performance, security, accessibility & agent experience, from the CLI, cloud, or MCP.",
   "bin": {
     "squirrel": "bin/squirrel.js"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "squirrelscan",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "description": "Website QA tool built for coding agents (Claude Code, Cursor). 260+ rules across SEO, performance, security, accessibility & agent experience: audit from the CLI, fix findings in code, publish reports, and connect over MCP.",
   "author": {
     "name": "squirrelscan",


### PR DESCRIPTION
Version bump for the v0.0.92 cut: apps/cli/package.json plus the four synced manifests via scripts/sync-plugin-manifests.ts. The CHANGELOG section is already on main (#283, #285, #290).