### PR TITLE
fix(cli): verify an update landed on the squirrel PATH resolves (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,22 @@ How it works:
   A stable `## vX.Y.Z` matches any `## vX.Y.Z-<suffix>` heading (e.g. `-beta.N`,
   `-rc.1`), so a stable cut can reuse a pre-release section when no plain one exists.
 - Use `###` (or deeper) for sub-sections within an entry — a `## ` heading marks a new version.
-- A `## [Unreleased]
+- A `## [Unreleased]` section collects merged changes that have not been cut into
+  a release yet; rename it to the version when the release goes out.
+
+## [Unreleased]
+
+### Fixed
+
+- `squirrel self update` now checks that the binary your PATH resolves is the one
+  it just installed, and says so when it isn't. It used to flip the symlink
+  recorded at install time and report success on that alone, so a stale
+  `install_bin_dir` (or a second `squirrel` earlier on PATH) left you running the
+  old version after every "Updated to vX". A recorded bin directory that no longer
+  exists is now dropped, and the update falls back to the default one. #293
+- `squirrel self doctor` gained an Install location check: the recorded
+  `install_bin_dir`, the link and the release version it points at, and the
+  `squirrel` your PATH actually resolves, with a warning when they disagree. #293
 
 ## v0.0.92
 

--- a/apps/cli/src/cli/banner.ts
+++ b/apps/cli/src/cli/banner.ts
@@ -26,6 +26,7 @@ import { trackTelemetryEvent } from "@/self/telemetry";
 import {
   isAutoUpdateEligible,
   isAutoUpdateFallbackActive,
+  updateLandingWarnings,
 } from "@/self/updater";
 
 import { version } from "../../package.json";
@@ -183,8 +184,14 @@ export function printEndOfRunUpdateReminder(settings: UserSettings): void {
 
 /**
  * One-time notice after a background auto-update has taken effect.
- * Prints only when this process is already running the new version,
- * then clears the marker.
+ * Prints when this process is running the new version, then clears the marker.
+ *
+ * It also prints when it ISN'T — but only for an update the silent updater
+ * recorded as landing off the user's PATH (#293). That case is precisely the
+ * one where the new version can never arrive on its own: the old binary keeps
+ * being resolved, the marker keeps being deferred, and the user is told
+ * nothing while every later update repeats the trick. Nik ran v0.0.81 for five
+ * weeks that way. Warning is worth breaking the "new version only" rule for.
  */
 export async function printAutoUpdateAppliedNotice(
   settings: UserSettings
@@ -192,13 +199,27 @@ export async function printAutoUpdateAppliedNotice(
   const applied = settings.auto_update_applied;
   if (!applied) return;
 
-  // Still running the old binary (e.g. resolved before the symlink flip) —
-  // keep the marker for the run that actually lands on the new version.
-  if (applied.to_version !== version) return;
+  const onNewVersion = applied.to_version === version;
+  const warnings = applied.landing
+    ? updateLandingWarnings(applied.landing)
+    : [];
+
+  // Still running the old binary (e.g. resolved before the symlink flip) with
+  // nothing to warn about — keep the marker for the run that lands on the new
+  // version.
+  if (!onNewVersion && warnings.length === 0) return;
 
   if (settings.notifications) {
-    const msg = `✓ squirrel auto-updated v${applied.from_version} → v${applied.to_version}`;
-    console.error(useColor ? pc.green(msg) : msg);
+    if (onNewVersion) {
+      const msg = `✓ squirrel auto-updated v${applied.from_version} → v${applied.to_version}`;
+      console.error(useColor ? pc.green(msg) : msg);
+    } else {
+      const msg = `squirrel installed v${applied.to_version}, but this command is still v${version}.`;
+      console.error(useColor ? pc.yellow(msg) : msg);
+    }
+    for (const warning of warnings) {
+      console.error(useColor ? pc.yellow(warning) : warning);
+    }
   }
 
   const { updateSettings } = await import("@/self/settings");

--- a/apps/cli/src/cli/banner.ts
+++ b/apps/cli/src/cli/banner.ts
@@ -203,11 +203,18 @@ export async function printAutoUpdateAppliedNotice(
   const warnings = applied.landing
     ? updateLandingWarnings(applied.landing)
     : [];
+  // The narrow reason to speak up on the old binary: PATH does not resolve
+  // what was installed, so the run that would print this normally is never
+  // coming. Anything else (a stale bin dir the updater already routed around)
+  // still waits, or an old process racing the symlink flip would eat the
+  // confirmation the next run owes the user.
+  const unreachable = applied.landing
+    ? applied.landing.on_path !== "same"
+    : false;
 
-  // Still running the old binary (e.g. resolved before the symlink flip) with
-  // nothing to warn about — keep the marker for the run that lands on the new
-  // version.
-  if (!onNewVersion && warnings.length === 0) return;
+  // Still running the old binary (e.g. resolved before the symlink flip) and
+  // the new one IS reachable — keep the marker for the run that lands on it.
+  if (!onNewVersion && !unreachable) return;
 
   if (settings.notifications) {
     if (onNewVersion) {

--- a/apps/cli/src/self/doctor.ts
+++ b/apps/cli/src/self/doctor.ts
@@ -311,9 +311,11 @@ export function checkInstallLocation(
       name,
       status: "warn",
       message: `${recordedNote}; ${linkNote}; ${pathNote} (updates land on the link, not on what you run)`,
+      // Same reasoning as updateLandingWarnings: the safe PATH re-order leads,
+      // because what PATH resolves may be a launcher owned by another tool.
       fix: onPath.via
         ? "Run 'squirrel self install' so the npm wrapper finds the managed release, or 'npm install -g squirrelscan@latest'"
-        : `squirrel self install --bin-dir ${dirname(onPath.binary)}, or put ${dirname(linkPath)} ahead of it in PATH`,
+        : `Put ${dirname(linkPath)} ahead of ${dirname(onPath.binary)} in PATH, or re-install with: squirrel self install --bin-dir ${dirname(onPath.binary)}`,
     };
   }
 

--- a/apps/cli/src/self/doctor.ts
+++ b/apps/cli/src/self/doctor.ts
@@ -7,7 +7,7 @@ import {
   readlinkSync,
 } from "node:fs";
 import { platform } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import { type Result, ok } from "@/controllers/types";
 
@@ -24,6 +24,10 @@ import {
   getLogsPath,
   getUnmanagedUpdateHint,
   isManagedInstall,
+  isValidReleaseVersion,
+  resolveSquirrelOnPath,
+  safeRealpath,
+  samePath,
 } from "./paths";
 import {
   loadSettings,
@@ -38,6 +42,7 @@ export function runDoctorChecks(): Result<DoctorReport> {
   checks.push(checkSymlink());
   checks.push(checkBinaryExecutable());
   checks.push(checkPathEnv());
+  checks.push(checkInstallLocation());
   checks.push(checkReleasesDir());
   checks.push(checkUpdateStatus());
   checks.push(checkLogging());
@@ -218,6 +223,84 @@ function checkPathEnv(): DoctorCheck {
     name: "PATH",
     status: "pass",
     message: "bin directory in PATH",
+  };
+}
+
+/** Release version owning a binary at <releases>/<version>/squirrel, if any. */
+function releaseVersionOf(binaryPath: string): string | null {
+  const candidate = basename(dirname(binaryPath));
+  return isValidReleaseVersion(candidate) ? candidate : null;
+}
+
+/**
+ * The one check that answers "will my next `squirrel` be the version I just
+ * installed?" — the question `self update` used to answer by assumption.
+ *
+ * Reports the three paths that have to agree: the recorded install_bin_dir
+ * (the link `self update` flips), that link's target version, and what PATH
+ * actually resolves. #293: they disagreed on Nik's machine for five weeks and
+ * nothing in the CLI said so.
+ *
+ * deps injectable for tests only — production callers omit.
+ */
+export function checkInstallLocation(
+  deps: {
+    loadUser?: typeof loadUserSettings;
+    which?: (command: string) => string | null;
+    realpath?: (path: string) => string;
+    isWindows?: boolean;
+  } = {}
+): DoctorCheck {
+  const name = "Install location";
+  const settings = (deps.loadUser ?? loadUserSettings)();
+  const recorded = settings.ok ? (settings.data.install_bin_dir ?? null) : null;
+  const recordedNote = recorded
+    ? `install_bin_dir: ${recorded}`
+    : "install_bin_dir: default";
+
+  let linkPath: string;
+  try {
+    linkPath = getSymlinkPath(recorded ?? undefined);
+  } catch (error) {
+    return {
+      name,
+      status: "warn",
+      message: `${recordedNote} is unusable: ${(error as Error).message}`,
+      fix: "Re-run 'squirrel self install' to record a valid bin directory",
+    };
+  }
+
+  const isWindows = deps.isWindows ?? platform() === "win32";
+  const linkTarget = safeRealpath(linkPath, deps.realpath);
+  const linkVersion = releaseVersionOf(linkTarget);
+  const linkNote = `link ${linkPath} -> ${linkVersion ? `v${linkVersion}` : linkTarget}`;
+
+  const onPath = resolveSquirrelOnPath({ ...deps, isWindows });
+  if (!onPath) {
+    return {
+      name,
+      status: "warn",
+      message: `${recordedNote}; ${linkNote}; PATH: no 'squirrel' found`,
+      fix: `Add ${dirname(linkPath)} to PATH`,
+    };
+  }
+
+  const pathVersion = releaseVersionOf(onPath.target);
+  const pathNote = `PATH: ${onPath.binary} -> ${pathVersion ? `v${pathVersion}` : onPath.target}`;
+
+  if (!samePath(onPath.target, linkTarget, isWindows)) {
+    return {
+      name,
+      status: "warn",
+      message: `${recordedNote}; ${linkNote}; ${pathNote} (updates land on the link, not on what you run)`,
+      fix: `squirrel self install --bin-dir ${dirname(onPath.binary)}, or put ${dirname(linkPath)} ahead of it in PATH`,
+    };
+  }
+
+  return {
+    name,
+    status: "pass",
+    message: `${recordedNote}; ${linkNote}; ${pathNote}`,
   };
 }
 

--- a/apps/cli/src/self/doctor.ts
+++ b/apps/cli/src/self/doctor.ts
@@ -285,7 +285,12 @@ export function checkInstallLocation(
   // rather than printing the same path twice and implying it is fine.
   const linkNote = `link ${linkPath} -> ${describeBinary(linkTarget, exists(linkTarget))}`;
 
-  const onPath = resolveSquirrelOnPath({ ...deps, isWindows });
+  const onPath = resolveSquirrelOnPath({
+    which: deps.which,
+    realpath: deps.realpath,
+    exists: deps.exists,
+    isWindows,
+  });
   if (!onPath) {
     return {
       name,
@@ -295,14 +300,20 @@ export function checkInstallLocation(
     };
   }
 
-  const pathNote = `PATH: ${onPath.binary} -> ${describeBinary(onPath.target, exists(onPath.target))}`;
+  // The npm wrapper is not the binary: it dispatches to the first managed
+  // location that exists, so say so rather than reporting a .js file as what
+  // the user runs.
+  const viaNote = onPath.via ? " -> npm wrapper" : "";
+  const pathNote = `PATH: ${onPath.binary}${viaNote} -> ${describeBinary(onPath.target, exists(onPath.target))}`;
 
   if (!samePath(onPath.target, linkTarget, isWindows)) {
     return {
       name,
       status: "warn",
       message: `${recordedNote}; ${linkNote}; ${pathNote} (updates land on the link, not on what you run)`,
-      fix: `squirrel self install --bin-dir ${dirname(onPath.binary)}, or put ${dirname(linkPath)} ahead of it in PATH`,
+      fix: onPath.via
+        ? "Run 'squirrel self install' so the npm wrapper finds the managed release, or 'npm install -g squirrelscan@latest'"
+        : `squirrel self install --bin-dir ${dirname(onPath.binary)}, or put ${dirname(linkPath)} ahead of it in PATH`,
     };
   }
 

--- a/apps/cli/src/self/doctor.ts
+++ b/apps/cli/src/self/doctor.ts
@@ -232,6 +232,13 @@ function releaseVersionOf(binaryPath: string): string | null {
   return isValidReleaseVersion(candidate) ? candidate : null;
 }
 
+/** "v0.0.92" for a managed release binary, the path otherwise. */
+function describeBinary(target: string, present: boolean): string {
+  if (!present) return `${target} (missing)`;
+  const releaseVersion = releaseVersionOf(target);
+  return releaseVersion ? `v${releaseVersion}` : target;
+}
+
 /**
  * The one check that answers "will my next `squirrel` be the version I just
  * installed?" — the question `self update` used to answer by assumption.
@@ -248,6 +255,7 @@ export function checkInstallLocation(
     loadUser?: typeof loadUserSettings;
     which?: (command: string) => string | null;
     realpath?: (path: string) => string;
+    exists?: (path: string) => boolean;
     isWindows?: boolean;
   } = {}
 ): DoctorCheck {
@@ -271,9 +279,11 @@ export function checkInstallLocation(
   }
 
   const isWindows = deps.isWindows ?? platform() === "win32";
+  const exists = deps.exists ?? existsSync;
   const linkTarget = safeRealpath(linkPath, deps.realpath);
-  const linkVersion = releaseVersionOf(linkTarget);
-  const linkNote = `link ${linkPath} -> ${linkVersion ? `v${linkVersion}` : linkTarget}`;
+  // A link whose release dir was pruned resolves to itself, so say "missing"
+  // rather than printing the same path twice and implying it is fine.
+  const linkNote = `link ${linkPath} -> ${describeBinary(linkTarget, exists(linkTarget))}`;
 
   const onPath = resolveSquirrelOnPath({ ...deps, isWindows });
   if (!onPath) {
@@ -285,8 +295,7 @@ export function checkInstallLocation(
     };
   }
 
-  const pathVersion = releaseVersionOf(onPath.target);
-  const pathNote = `PATH: ${onPath.binary} -> ${pathVersion ? `v${pathVersion}` : onPath.target}`;
+  const pathNote = `PATH: ${onPath.binary} -> ${describeBinary(onPath.target, exists(onPath.target))}`;
 
   if (!samePath(onPath.target, linkTarget, isWindows)) {
     return {

--- a/apps/cli/src/self/index.ts
+++ b/apps/cli/src/self/index.ts
@@ -13,6 +13,8 @@ export type {
   DoctorReport,
   InstallResult,
   UpdateResult,
+  UpdateLanding,
+  OnPathStatus,
 } from "./types";
 
 // Path utilities
@@ -24,8 +26,11 @@ export {
   getSymlinkPath,
   detectPlatformArch,
   isBinInPath,
+  resolveSquirrelOnPath,
+  safeRealpath,
+  samePath,
 } from "./paths";
-export type { SquirrelPaths } from "./paths";
+export type { SquirrelPaths, PathBinary } from "./paths";
 
 // Settings management
 export {
@@ -58,4 +63,5 @@ export {
   checkOnly,
   installVersion,
   updateSymlink,
+  updateLandingWarnings,
 } from "./updater";

--- a/apps/cli/src/self/paths.ts
+++ b/apps/cli/src/self/paths.ts
@@ -307,12 +307,23 @@ export interface ResolveOnPathDeps {
 
 /**
  * True for the npm package's `bin/squirrel.js` wrapper (npm links it onto PATH
- * as `squirrel`). The `node_modules` test is the same one
- * getUnmanagedUpdateHint uses; `.js` is what separates the wrapper from the
- * binary the package bundles beside it.
+ * as `squirrel`).
+ *
+ * The full installed path is matched, not merely "a .js under node_modules":
+ * emulating this wrapper's dispatch means reporting the managed binary as what
+ * runs, so mistaking SOMEONE ELSE'S launcher for it would turn a real mismatch
+ * into a confident "same" and hide the very thing #293 is about. The
+ * `node_modules` half of the test is the same one getUnmanagedUpdateHint uses.
+ *
+ * Known misses, both erring toward an honest "different": npm on Windows
+ * installs a `squirrel.cmd` shim rather than a link to the .js, and `npm link`
+ * points at a checkout outside node_modules.
  */
 export function isNpmWrapper(path: string): boolean {
-  return path.includes(`${sep}node_modules${sep}`) && path.endsWith(".js");
+  return (
+    path.includes(`${sep}node_modules${sep}`) &&
+    path.endsWith(`${sep}squirrelscan${sep}bin${sep}squirrel.js`)
+  );
 }
 
 /**

--- a/apps/cli/src/self/paths.ts
+++ b/apps/cli/src/self/paths.ts
@@ -1,4 +1,4 @@
-import { realpathSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { dirname, isAbsolute, join, parse, sep } from "node:path";
 
@@ -289,14 +289,64 @@ export function safeRealpath(
 export interface PathBinary {
   /** The entry PATH resolves, e.g. /usr/local/bin/squirrel. */
   binary: string;
-  /** What that entry actually runs (symlinks followed). */
+  /** What that entry actually runs, symlinks and the npm wrapper followed. */
   target: string;
+  /**
+   * The npm wrapper script standing between the two, when PATH resolves to an
+   * `npm install -g squirrelscan`. null for a direct binary.
+   */
+  via: string | null;
 }
 
 export interface ResolveOnPathDeps {
   which?: (command: string) => string | null;
   realpath?: (path: string) => string;
+  exists?: (path: string) => boolean;
   isWindows?: boolean;
+}
+
+/**
+ * True for the npm package's `bin/squirrel.js` wrapper (npm links it onto PATH
+ * as `squirrel`). The `node_modules` test is the same one
+ * getUnmanagedUpdateHint uses; `.js` is what separates the wrapper from the
+ * binary the package bundles beside it.
+ */
+export function isNpmWrapper(path: string): boolean {
+  return path.includes(`${sep}node_modules${sep}`) && path.endsWith(".js");
+}
+
+/**
+ * The binaries npm/bin/squirrel.js tries, in its order, ending with the copy
+ * bundled in the package.
+ *
+ * MIRRORS that file deliberately: a wrapper on PATH runs the FIRST of these
+ * that exists, so "will my next squirrel be the version I just installed?"
+ * cannot be answered without walking the same list. The managed default bin
+ * path leads it, which is why an ordinary npm install DOES pick up
+ * `self update` and must not be warned about. tests/self/paths.test.ts asserts
+ * this list still matches the wrapper.
+ */
+export function npmWrapperCandidates(
+  wrapperPath: string,
+  isWindows: boolean
+): string[] {
+  const home = homedir();
+  const bundled = join(
+    dirname(wrapperPath),
+    `squirrel${isWindows ? ".exe" : ""}`
+  );
+  return isWindows
+    ? [
+        join(home, "AppData", "Local", "squirrel", "bin", "squirrel.exe"),
+        join(home, ".local", "bin", "squirrel.exe"),
+        bundled,
+      ]
+    : [
+        join(home, ".local", "bin", "squirrel"),
+        "/usr/local/bin/squirrel",
+        "/opt/homebrew/bin/squirrel",
+        bundled,
+      ];
 }
 
 /**
@@ -308,6 +358,12 @@ export interface ResolveOnPathDeps {
  * all leave the update landing somewhere invisible while the CLI reports
  * success (#293). Answering "what will actually run next time" needs the PATH
  * lookup, not the recorded path.
+ *
+ * An npm install puts a WRAPPER on PATH, not a binary, so the lookup follows
+ * its dispatch too: the wrapper runs the first of npmWrapperCandidates that
+ * exists, which is normally the managed link `self update` just flipped.
+ * Stopping at the wrapper would report every npm user as running something
+ * else and warn them after every single update.
  */
 export function resolveSquirrelOnPath(
   deps: ResolveOnPathDeps = {}
@@ -329,7 +385,25 @@ export function resolveSquirrelOnPath(
   }
   if (!found) return null;
 
-  return { binary: found, target: safeRealpath(found, deps.realpath) };
+  const resolved = safeRealpath(found, deps.realpath);
+  if (!isNpmWrapper(resolved)) {
+    return { binary: found, target: resolved, via: null };
+  }
+
+  // existsSync, matching the wrapper: it FOLLOWS symlinks, so a link whose
+  // release directory was pruned is skipped there and must be skipped here.
+  const exists = deps.exists ?? existsSync;
+  for (const candidate of npmWrapperCandidates(resolved, isWindows)) {
+    if (!exists(candidate)) continue;
+    return {
+      binary: found,
+      target: safeRealpath(candidate, deps.realpath),
+      via: resolved,
+    };
+  }
+
+  // No candidate exists: the wrapper would print its "binary not found" error.
+  return { binary: found, target: resolved, via: resolved };
 }
 
 /**

--- a/apps/cli/src/self/paths.ts
+++ b/apps/cli/src/self/paths.ts
@@ -270,6 +270,77 @@ export function getUnmanagedUpdateHint(): string {
   return "re-install from https://install.squirrelscan.com";
 }
 
+/**
+ * realpathSync that degrades to the input instead of throwing. A dangling
+ * symlink (release directory pruned) and a path that simply isn't there both
+ * still have to be reportable — the caller is diagnosing exactly that.
+ */
+export function safeRealpath(
+  path: string,
+  realpath: (p: string) => string = realpathSync
+): string {
+  try {
+    return realpath(path);
+  } catch {
+    return path;
+  }
+}
+
+export interface PathBinary {
+  /** The entry PATH resolves, e.g. /usr/local/bin/squirrel. */
+  binary: string;
+  /** What that entry actually runs (symlinks followed). */
+  target: string;
+}
+
+export interface ResolveOnPathDeps {
+  which?: (command: string) => string | null;
+  realpath?: (path: string) => string;
+  isWindows?: boolean;
+}
+
+/**
+ * The `squirrel` the user's PATH would run, or null when PATH has none.
+ *
+ * `self update` flips the link recorded at install time, which is not
+ * necessarily the binary the user's shell resolves: a stale `install_bin_dir`,
+ * a second install earlier on PATH, or a bin dir that was never added to PATH
+ * all leave the update landing somewhere invisible while the CLI reports
+ * success (#293). Answering "what will actually run next time" needs the PATH
+ * lookup, not the recorded path.
+ */
+export function resolveSquirrelOnPath(
+  deps: ResolveOnPathDeps = {}
+): PathBinary | null {
+  const isWindows = deps.isWindows ?? platform() === "win32";
+  const which =
+    deps.which ??
+    ((command: string) =>
+      typeof Bun === "undefined" ? null : Bun.which(command));
+
+  let found: string | null = null;
+  try {
+    found = which("squirrel");
+    // Bun.which resolves PATHEXT itself, but ask for the explicit name too so
+    // a lookup that only matches the extension still finds the binary.
+    if (!found && isWindows) found = which("squirrel.exe");
+  } catch {
+    return null;
+  }
+  if (!found) return null;
+
+  return { binary: found, target: safeRealpath(found, deps.realpath) };
+}
+
+/**
+ * Path equality for comparing resolved binaries. Windows paths are compared
+ * case-insensitively; POSIX paths are not (two names differing only in case
+ * are two different files there).
+ */
+export function samePath(a: string, b: string, isWindows: boolean): boolean {
+  return isWindows ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
 export function isBinInPath(customBinDir?: string): boolean {
   const binDir = customBinDir ?? getSquirrelPaths().bin;
   const pathEnv = process.env.PATH ?? "";

--- a/apps/cli/src/self/types.ts
+++ b/apps/cli/src/self/types.ts
@@ -28,8 +28,13 @@ export const UpdateLandingSchema = z.object({
   link_path: z.string(),
   /** The `squirrel` PATH resolves, or null when PATH has none. */
   path_binary: z.string().nullable(),
-  /** What that PATH entry actually runs, symlinks followed. */
+  /** What that PATH entry actually runs, symlinks and the wrapper followed. */
   path_target: z.string().nullable(),
+  /**
+   * The npm wrapper script between the two, when PATH resolves to an
+   * `npm install -g squirrelscan`. Absent/null for a direct binary.
+   */
+  path_via: z.string().nullable().optional(),
   /** "different"/"missing" ⇒ the update is invisible to the user's shell. */
   on_path: z.enum(["same", "different", "missing"]),
   /**

--- a/apps/cli/src/self/types.ts
+++ b/apps/cli/src/self/types.ts
@@ -13,6 +13,35 @@ export const AuthSchema = z
 
 export type AuthState = z.infer<typeof AuthSchema>;
 
+/**
+ * Where an update actually landed, and whether the user's PATH agrees.
+ *
+ * `self update` flips the link recorded at install time and used to report
+ * success on that alone. When the recorded directory isn't what the shell
+ * resolves — a stale `install_bin_dir`, a second install earlier on PATH, a
+ * bin dir never added to PATH — the user keeps running the old binary and the
+ * CLI says nothing (#293). Recorded in settings by the silent updater so the
+ * next run can warn, and returned to the interactive one so it can warn now.
+ */
+export const UpdateLandingSchema = z.object({
+  /** The symlink (a copy on Windows) this update flipped. */
+  link_path: z.string(),
+  /** The `squirrel` PATH resolves, or null when PATH has none. */
+  path_binary: z.string().nullable(),
+  /** What that PATH entry actually runs, symlinks followed. */
+  path_target: z.string().nullable(),
+  /** "different"/"missing" ⇒ the update is invisible to the user's shell. */
+  on_path: z.enum(["same", "different", "missing"]),
+  /**
+   * A recorded `install_bin_dir` that no longer exists. The update fell back
+   * to the default bin dir and cleared the setting.
+   */
+  stale_bin_dir: z.string().nullable(),
+});
+
+export type UpdateLanding = z.infer<typeof UpdateLandingSchema>;
+export type OnPathStatus = UpdateLanding["on_path"];
+
 // Background update-check cadence bounds (hours), the single source of truth
 // for both the Zod schema below and the write-path validation in settings.ts.
 // Floor keeps shared-IP runs under GitHub's 60/hr rate limit (2 calls/check);
@@ -68,6 +97,9 @@ export const UserSettingsSchema = z.object({
       from_version: z.string(),
       to_version: z.string(),
       at: z.string(),
+      // Only set when the install landed somewhere the user's PATH won't run,
+      // so the next run can say so out loud (#293). Absent = nothing to warn.
+      landing: UpdateLandingSchema.optional(),
     })
     .nullable()
     .optional(),
@@ -240,4 +272,6 @@ export interface UpdateResult {
   from_version: string;
   to_version: string | null;
   release_url: string | null;
+  /** Absent when nothing was installed. */
+  landing?: UpdateLanding;
 }

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -17,7 +17,12 @@ import { AUTO_UPDATE_FALLBACK_THRESHOLD } from "@/constants";
 import { type Result, ok, err, commandError } from "@/controllers/types";
 import { logger } from "@/utils/logger";
 
-import type { ReleaseManifest, UpdateResult, UserSettings } from "./types";
+import type {
+  ReleaseManifest,
+  UpdateLanding,
+  UpdateResult,
+  UserSettings,
+} from "./types";
 
 import { version } from "../../package.json";
 import { updateSuppressedReason } from "./install-meta";
@@ -31,6 +36,9 @@ import {
   isValidReleaseVersion,
   isManagedInstall,
   detectPlatformArch,
+  resolveSquirrelOnPath,
+  safeRealpath,
+  samePath,
 } from "./paths";
 import { checkForUpdates, downloadBinary } from "./releases";
 import {
@@ -889,6 +897,8 @@ export async function runAutoUpdate(options?: {
    * (which is doing the work) never counts toward the #1085 fallback box.
    */
   onStart?: () => void;
+  /** Test seam for the PATH/bin-dir landing check. */
+  landingDeps?: LandingDeps;
 }): Promise<string | null> {
   const settingsResult = loadSettings();
   if (!settingsResult.ok) return null;
@@ -965,11 +975,17 @@ export async function runAutoUpdate(options?: {
       return null;
     }
 
+    // A silent update can't warn at the time it runs, so the landing rides in
+    // the marker and the next run prints it (#293). Recorded only when there
+    // is something to say; otherwise the marker keeps its old shape.
+    const landing = applyResult.data;
+    const warned = updateLandingWarnings(landing).length > 0;
     updateSettings({
       auto_update_applied: {
         from_version: version,
         to_version: manifest.version,
         at: new Date().toISOString(),
+        ...(warned ? { landing } : {}),
       },
     });
     trackTelemetryEvent("update_auto", settings);
@@ -993,15 +1009,126 @@ export async function runAutoUpdate(options?: {
 }
 
 /**
+ * Injectable filesystem/PATH seams for the landing check. Production callers
+ * omit them; tests drive every branch without a real install on PATH.
+ */
+export interface LandingDeps {
+  which?: (command: string) => string | null;
+  realpath?: (path: string) => string;
+  stat?: (path: string) => { isDirectory(): boolean };
+  isWindows?: boolean;
+}
+
+/**
+ * Does the recorded `install_bin_dir` still exist?
+ *
+ * "unknown" is deliberate: existsSync reports an unreadable directory
+ * (EACCES on a parent) exactly like a deleted one, and treating that as
+ * deleted would clear a perfectly good setting and start flipping a link the
+ * user never asked for. Only ENOENT/ENOTDIR — the directory is provably gone
+ * — counts as missing.
+ */
+export function classifyBinDir(
+  dir: string,
+  deps: LandingDeps = {}
+): "present" | "missing" | "unknown" {
+  const stat = deps.stat ?? statSync;
+  try {
+    return stat(dir).isDirectory() ? "present" : "missing";
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return "missing";
+    return "unknown";
+  }
+}
+
+/**
+ * Compare the binary the user's PATH resolves with the one this update put in
+ * place. Both comparands matter: on POSIX the flipped link resolves to the
+ * release binary, while on Windows `self install` lands a COPY at the bin path
+ * (link-binary.ts), so the release binary and the thing on PATH are two
+ * different files even when the install is perfect.
+ */
+export function classifyOnPath(
+  version: string,
+  linkPath: string,
+  deps: LandingDeps = {}
+): Pick<UpdateLanding, "path_binary" | "path_target" | "on_path"> {
+  const isWindows = deps.isWindows ?? platform() === "win32";
+  const resolved = resolveSquirrelOnPath({ ...deps, isWindows });
+  if (!resolved) {
+    return { path_binary: null, path_target: null, on_path: "missing" };
+  }
+
+  const installed = safeRealpath(getBinaryPath(version), deps.realpath);
+  const link = safeRealpath(linkPath, deps.realpath);
+  const same =
+    samePath(resolved.target, installed, isWindows) ||
+    samePath(resolved.target, link, isWindows);
+
+  return {
+    path_binary: resolved.binary,
+    path_target: resolved.target,
+    on_path: same ? "same" : "different",
+  };
+}
+
+/**
+ * Warnings for an update that landed somewhere the user's shell won't run.
+ * Empty when PATH and the flipped link agree — the overwhelmingly common case.
+ * Shared so the interactive update and the next-run notice after a silent one
+ * can never describe the same situation differently.
+ */
+export function updateLandingWarnings(landing: UpdateLanding): string[] {
+  const lines: string[] = [];
+
+  if (landing.stale_bin_dir) {
+    lines.push(
+      `Warning: the recorded install directory ${landing.stale_bin_dir} no longer exists. ` +
+        `Linked ${landing.link_path} instead and cleared install_bin_dir.`
+    );
+  }
+
+  const linkDir = dirname(landing.link_path);
+
+  if (landing.on_path === "different" && landing.path_binary) {
+    const via =
+      landing.path_target && landing.path_target !== landing.path_binary
+        ? ` (${landing.path_target})`
+        : "";
+    lines.push(
+      `Warning: 'squirrel' on your PATH is ${landing.path_binary}${via}, not the ${landing.link_path} this update changed. ` +
+        "That command keeps running the old version.",
+      `Fix: squirrel self install --bin-dir ${dirname(landing.path_binary)}, or put ${linkDir} ahead of it in PATH.`
+    );
+  } else if (landing.on_path === "missing") {
+    lines.push(
+      `Warning: no 'squirrel' on your PATH. The update landed at ${landing.link_path}.`,
+      `Fix: add ${linkDir} to PATH.`
+    );
+  }
+
+  return lines;
+}
+
+/**
  * Download, verify, install, and flip the symlink for a release.
  * Shared by interactive and silent updates. Clears the pending
  * notification state on success.
+ *
+ * Returns where the update landed (#293) — installing is not the same as
+ * being the binary the user's next `squirrel` will run, and every caller has
+ * to be able to say so.
  */
 async function performUpdate(
   manifest: ReleaseManifest,
   settings: UserSettings,
-  options?: { signal?: AbortSignal; abortIfDismissed?: boolean }
-): Promise<Result<void>> {
+  options?: {
+    signal?: AbortSignal;
+    abortIfDismissed?: boolean;
+    landingDeps?: LandingDeps;
+  }
+): Promise<Result<UpdateLanding>> {
   const platformArch = detectPlatformArch();
   const downloadResult = await downloadBinary(manifest, platformArch, {
     signal: options?.signal,
@@ -1031,11 +1158,41 @@ async function performUpdate(
   );
   if (!installResult.ok) return installResult;
 
-  const symlinkResult = updateSymlink(
-    manifest.version,
-    settings.install_bin_dir ?? undefined
-  );
+  const landingDeps = options?.landingDeps ?? {};
+
+  // A recorded --bin-dir that has since been deleted (a scratch dir from a
+  // test install, an unmounted volume) would otherwise have the update flip a
+  // link nobody can run, forever, in silence. Fall back to the default bin dir
+  // and forget the dead value — but only when it is provably gone.
+  const recordedBinDir = settings.install_bin_dir ?? null;
+  const staleBinDir =
+    recordedBinDir !== null &&
+    classifyBinDir(recordedBinDir, landingDeps) === "missing"
+      ? recordedBinDir
+      : null;
+  const binDir =
+    staleBinDir === null ? (recordedBinDir ?? undefined) : undefined;
+
+  let linkPath: string;
+  try {
+    linkPath = getSymlinkPath(binDir);
+  } catch (error) {
+    return err(
+      commandError(
+        "INVALID_BIN_DIR",
+        `Invalid bin directory: ${(error as Error).message}`
+      )
+    );
+  }
+
+  const symlinkResult = updateSymlink(manifest.version, binDir);
   if (!symlinkResult.ok) return symlinkResult;
+
+  const landing: UpdateLanding = {
+    link_path: linkPath,
+    stale_bin_dir: staleBinDir,
+    ...classifyOnPath(manifest.version, linkPath, landingDeps),
+  };
 
   const saved = updateSettings({
     last_update_check: new Date().toISOString(),
@@ -1045,10 +1202,13 @@ async function performUpdate(
     // The install landed — clear the failed-attempt counter so the loud
     // fallback box never shows for a version that actually updated (#1085).
     auto_update_attempts: null,
+    // Spread, never a bare `install_bin_dir: undefined`: updateSettings merges
+    // by spread, so the explicit key would erase a live value.
+    ...(staleBinDir === null ? {} : { install_bin_dir: null }),
   });
   if (!saved.ok) return saved;
 
-  return ok(undefined);
+  return ok(landing);
 }
 
 /**
@@ -1057,6 +1217,8 @@ async function performUpdate(
 export async function runInteractiveUpdate(options?: {
   /** Update even when the running binary isn't the managed install */
   force?: boolean;
+  /** Test seam for the PATH/bin-dir landing check. */
+  landingDeps?: LandingDeps;
 }): Promise<Result<UpdateResult>> {
   const settingsResult = loadSettings();
   if (!settingsResult.ok) return settingsResult;
@@ -1109,14 +1271,25 @@ export async function runInteractiveUpdate(options?: {
     console.log(`Downloading v${manifest.version}...`);
     console.log("Installing...");
 
-    const applyResult = await performUpdate(manifest, settings);
+    const applyResult = await performUpdate(manifest, settings, {
+      landingDeps: options?.landingDeps,
+    });
     if (!applyResult.ok) return applyResult;
+
+    // Say where it went, always: "Updated to vX" on its own was true and
+    // useless on the machines where the link isn't what PATH runs (#293).
+    const landing = applyResult.data;
+    console.log(`Linked: ${landing.link_path}`);
+    for (const warning of updateLandingWarnings(landing)) {
+      console.warn(warning);
+    }
 
     return ok({
       updated: true,
       from_version: version,
       to_version: manifest.version,
       release_url,
+      landing,
     });
   } finally {
     releaseUpdateLock();

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -1116,10 +1116,14 @@ export function updateLandingWarnings(landing: UpdateLanding): string[] {
     // npm owns would overwrite npm's wrapper, and the next `npm install -g`
     // would put it back. The wrapper prefers the DEFAULT managed link, so the
     // fix is to give it one, or to update the npm copy on its own terms.
+    // The PATH re-order leads because it is safe whatever that binary is: the
+    // thing on PATH can be a launcher script somebody else owns (npm's Windows
+    // .cmd shim, an `npm link`ed checkout), and re-installing over its
+    // directory would clobber it. --bin-dir stays available, conditionally.
     lines.push(
       landing.path_via
         ? `Fix: that is the npm wrapper (${landing.path_via}); run 'squirrel self install' so it finds the managed release, or 'npm install -g squirrelscan@latest'.`
-        : `Fix: squirrel self install --bin-dir ${dirname(landing.path_binary)}, or put ${linkDir} ahead of it in PATH.`
+        : `Fix: put ${linkDir} ahead of ${dirname(landing.path_binary)} in PATH. If ${dirname(landing.path_binary)} is where you want updates to land, re-install with: squirrel self install --bin-dir ${dirname(landing.path_binary)}`
     );
   } else if (landing.on_path === "missing") {
     lines.push(

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -1164,11 +1164,13 @@ async function performUpdate(
   // take minutes, and `self install --bin-dir` (which the update lock does not
   // cover) may have recorded a live directory in the meantime. Clearing that
   // one because the OLD value was dead would be a worse bug than #293.
+  // A fresh explicit null means "the default", not "fall back to what the
+  // snapshot said" — only an unreadable re-read defers to the snapshot.
   const freshSettings = loadSettings();
   const recordedBinDir =
-    (freshSettings.ok ? freshSettings.data.install_bin_dir : null) ??
-    settings.install_bin_dir ??
-    null;
+    (freshSettings.ok
+      ? freshSettings.data.install_bin_dir
+      : settings.install_bin_dir) ?? null;
 
   // A recorded --bin-dir that has since been deleted (a scratch dir from a
   // test install, an unmounted volume) would otherwise have the update flip a

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -1160,33 +1160,67 @@ async function performUpdate(
 
   const landingDeps = options?.landingDeps ?? {};
 
+  // Re-read rather than trust the snapshot: it predates a download that can
+  // take minutes, and `self install --bin-dir` (which the update lock does not
+  // cover) may have recorded a live directory in the meantime. Clearing that
+  // one because the OLD value was dead would be a worse bug than #293.
+  const freshSettings = loadSettings();
+  const recordedBinDir =
+    (freshSettings.ok ? freshSettings.data.install_bin_dir : null) ??
+    settings.install_bin_dir ??
+    null;
+
   // A recorded --bin-dir that has since been deleted (a scratch dir from a
   // test install, an unmounted volume) would otherwise have the update flip a
-  // link nobody can run, forever, in silence. Fall back to the default bin dir
-  // and forget the dead value — but only when it is provably gone.
-  const recordedBinDir = settings.install_bin_dir ?? null;
-  const staleBinDir =
+  // link nobody can run, forever, in silence. Prefer the default bin dir when
+  // that happens — but only when the recorded one is provably gone.
+  const recordedIsStale =
     recordedBinDir !== null &&
-    classifyBinDir(recordedBinDir, landingDeps) === "missing"
-      ? recordedBinDir
-      : null;
-  const binDir =
-    staleBinDir === null ? (recordedBinDir ?? undefined) : undefined;
+    classifyBinDir(recordedBinDir, landingDeps) === "missing";
 
-  let linkPath: string;
-  try {
-    linkPath = getSymlinkPath(binDir);
-  } catch (error) {
-    return err(
-      commandError(
-        "INVALID_BIN_DIR",
-        `Invalid bin directory: ${(error as Error).message}`
-      )
+  // Destinations in order of preference. The recorded directory stays as a
+  // last resort even when it is stale: updateSymlink would recreate it, which
+  // is what happened before this change, and falling back must never turn an
+  // update that used to succeed into a failure (an unwritable or obstructed
+  // default). The PATH check below still tells the user where it went.
+  const destinations: Array<string | undefined> = recordedIsStale
+    ? [undefined, recordedBinDir ?? undefined]
+    : [recordedBinDir ?? undefined];
+
+  let linked: { path: string; binDir: string | undefined } | null = null;
+  let failure: Result<UpdateLanding> | null = null;
+  for (const destination of destinations) {
+    let candidate: string;
+    try {
+      candidate = getSymlinkPath(destination);
+    } catch (error) {
+      failure = err(
+        commandError(
+          "INVALID_BIN_DIR",
+          `Invalid bin directory: ${(error as Error).message}`
+        )
+      );
+      continue;
+    }
+    const attempt = updateSymlink(manifest.version, destination);
+    if (attempt.ok) {
+      linked = { path: candidate, binDir: destination };
+      break;
+    }
+    failure = attempt;
+  }
+  if (!linked) {
+    return (
+      failure ?? err(commandError("SYMLINK_FAILED", "Failed to update symlink"))
     );
   }
 
-  const symlinkResult = updateSymlink(manifest.version, binDir);
-  if (!symlinkResult.ok) return symlinkResult;
+  // Only a fallback that actually took effect makes the recorded value stale;
+  // if the link went to the recorded directory after all, the setting is still
+  // in use and must not be cleared.
+  const staleBinDir =
+    recordedIsStale && linked.binDir === undefined ? recordedBinDir : null;
+  const linkPath = linked.path;
 
   const landing: UpdateLanding = {
     link_path: linkPath,

--- a/apps/cli/src/self/updater.ts
+++ b/apps/cli/src/self/updater.ts
@@ -1016,6 +1016,7 @@ export interface LandingDeps {
   which?: (command: string) => string | null;
   realpath?: (path: string) => string;
   stat?: (path: string) => { isDirectory(): boolean };
+  exists?: (path: string) => boolean;
   isWindows?: boolean;
 }
 
@@ -1053,11 +1054,21 @@ export function classifyOnPath(
   version: string,
   linkPath: string,
   deps: LandingDeps = {}
-): Pick<UpdateLanding, "path_binary" | "path_target" | "on_path"> {
+): Pick<UpdateLanding, "path_binary" | "path_target" | "path_via" | "on_path"> {
   const isWindows = deps.isWindows ?? platform() === "win32";
-  const resolved = resolveSquirrelOnPath({ ...deps, isWindows });
+  const resolved = resolveSquirrelOnPath({
+    which: deps.which,
+    realpath: deps.realpath,
+    exists: deps.exists,
+    isWindows,
+  });
   if (!resolved) {
-    return { path_binary: null, path_target: null, on_path: "missing" };
+    return {
+      path_binary: null,
+      path_target: null,
+      path_via: null,
+      on_path: "missing",
+    };
   }
 
   const installed = safeRealpath(getBinaryPath(version), deps.realpath);
@@ -1069,6 +1080,7 @@ export function classifyOnPath(
   return {
     path_binary: resolved.binary,
     path_target: resolved.target,
+    path_via: resolved.via,
     on_path: same ? "same" : "different",
   };
 }
@@ -1092,14 +1104,22 @@ export function updateLandingWarnings(landing: UpdateLanding): string[] {
   const linkDir = dirname(landing.link_path);
 
   if (landing.on_path === "different" && landing.path_binary) {
-    const via =
+    const runs =
       landing.path_target && landing.path_target !== landing.path_binary
         ? ` (${landing.path_target})`
         : "";
     lines.push(
-      `Warning: 'squirrel' on your PATH is ${landing.path_binary}${via}, not the ${landing.link_path} this update changed. ` +
-        "That command keeps running the old version.",
-      `Fix: squirrel self install --bin-dir ${dirname(landing.path_binary)}, or put ${linkDir} ahead of it in PATH.`
+      `Warning: 'squirrel' on your PATH is ${landing.path_binary}${runs}, not the ${landing.link_path} this update changed. ` +
+        "That command keeps running the old version."
+    );
+    // Telling an npm user to point `self install --bin-dir` at the directory
+    // npm owns would overwrite npm's wrapper, and the next `npm install -g`
+    // would put it back. The wrapper prefers the DEFAULT managed link, so the
+    // fix is to give it one, or to update the npm copy on its own terms.
+    lines.push(
+      landing.path_via
+        ? `Fix: that is the npm wrapper (${landing.path_via}); run 'squirrel self install' so it finds the managed release, or 'npm install -g squirrelscan@latest'.`
+        : `Fix: squirrel self install --bin-dir ${dirname(landing.path_binary)}, or put ${linkDir} ahead of it in PATH.`
     );
   } else if (landing.on_path === "missing") {
     lines.push(

--- a/apps/cli/tests/cli/banner.test.ts
+++ b/apps/cli/tests/cli/banner.test.ts
@@ -278,6 +278,38 @@ describe("printAutoUpdateAppliedNotice (#170)", () => {
     expect(out.text()).toBe("");
   });
 
+  // The stale-bin-dir fallback already routed around the problem: PATH runs
+  // the new binary, so the confirmation still belongs to the run that lands on
+  // it. An old process must not eat the marker on the strength of a warning.
+  test("a stale bin dir alone does NOT make the old version consume the marker", async () => {
+    const applied = {
+      from_version: version,
+      to_version: "99.99.99",
+      at: new Date().toISOString(),
+      landing: {
+        link_path: "/home/u/.local/bin/squirrel",
+        path_binary: "/home/u/.local/bin/squirrel",
+        path_target: "/home/u/.squirrel/releases/99.99.99/squirrel",
+        on_path: "same" as const,
+        stale_bin_dir: "/home/u/scratch/bin-beta",
+      },
+    };
+    updateSettings({ auto_update_applied: applied });
+
+    const out = captureStderr();
+    await printAutoUpdateAppliedNotice(
+      settingsWith({ auto_update_applied: applied })
+    );
+    out.spy.mockRestore();
+
+    expect(out.text()).toBe("");
+    const saved = loadUserSettings();
+    expect(saved.ok).toBe(true);
+    if (saved.ok) {
+      expect(saved.data.auto_update_applied?.to_version).toBe("99.99.99");
+    }
+  });
+
   test("silent in the process that applied the update (still the old version)", async () => {
     const out = captureStderr();
     await printAutoUpdateAppliedNotice(

--- a/apps/cli/tests/cli/banner.test.ts
+++ b/apps/cli/tests/cli/banner.test.ts
@@ -219,6 +219,65 @@ describe("printAutoUpdateAppliedNotice (#170)", () => {
     expect(second.text()).toBe("");
   });
 
+  // #293: the ONE case worth breaking the "new version only" rule for — the
+  // silent updater recorded that the install landed off PATH, so the new
+  // version can never arrive on its own and the deferred marker would sit
+  // there forever saying nothing.
+  test("warns on the old version when the update landed off PATH, then clears the marker", async () => {
+    const applied = {
+      from_version: version,
+      to_version: "99.99.99",
+      at: new Date().toISOString(),
+      landing: {
+        link_path: "/home/u/scratch/bin-beta/squirrel",
+        path_binary: "/home/u/.local/bin/squirrel",
+        path_target: "/home/u/.squirrel/releases/0.0.81/squirrel",
+        on_path: "different" as const,
+        stale_bin_dir: null,
+      },
+    };
+    updateSettings({ auto_update_applied: applied });
+
+    const out = captureStderr();
+    await printAutoUpdateAppliedNotice(
+      settingsWith({ auto_update_applied: applied })
+    );
+    out.spy.mockRestore();
+
+    const text = out.text();
+    expect(text).toContain("installed v99.99.99");
+    expect(text).toContain("/home/u/.local/bin/squirrel");
+    expect(text).toContain("/home/u/scratch/bin-beta/squirrel");
+    expect(text).toContain("self install --bin-dir /home/u/.local/bin");
+
+    const saved = loadUserSettings();
+    expect(saved.ok).toBe(true);
+    if (saved.ok) expect(saved.data.auto_update_applied ?? null).toBeNull();
+  });
+
+  test("notifications off suppresses the mismatch warning too", async () => {
+    const out = captureStderr();
+    await printAutoUpdateAppliedNotice(
+      settingsWith({
+        notifications: false,
+        auto_update_applied: {
+          from_version: version,
+          to_version: "99.99.99",
+          at: new Date().toISOString(),
+          landing: {
+            link_path: "/home/u/bin/squirrel",
+            path_binary: null,
+            path_target: null,
+            on_path: "missing" as const,
+            stale_bin_dir: null,
+          },
+        },
+      })
+    );
+    out.spy.mockRestore();
+    expect(out.text()).toBe("");
+  });
+
   test("silent in the process that applied the update (still the old version)", async () => {
     const out = captureStderr();
     await printAutoUpdateAppliedNotice(

--- a/apps/cli/tests/self/doctor.test.ts
+++ b/apps/cli/tests/self/doctor.test.ts
@@ -111,3 +111,88 @@ describe("checkSettingsFile", () => {
     expect(check.fix).not.toContain("Delete");
   });
 });
+
+// #293: `self update` flips the link recorded at install time and reported
+// success on that alone, while the shell kept resolving an older binary
+// somewhere else. Doctor has to lay the three paths side by side.
+import { checkInstallLocation } from "../../src/self/doctor";
+import { getSymlinkPath } from "../../src/self/paths";
+
+describe("checkInstallLocation (#293)", () => {
+  const user = (binDir: string | null) => () =>
+    ok({ channel: "stable", install_bin_dir: binDir } as UserSettings);
+
+  test("PATH resolving the recorded link passes, and names version and paths", () => {
+    const link = "/home/u/.local/bin/squirrel";
+    const target = "/home/u/.squirrel/releases/0.0.92/squirrel";
+
+    const check = checkInstallLocation({
+      loadUser: user("/home/u/.local/bin"),
+      which: () => link,
+      realpath: (p) => (p === link ? target : p),
+      isWindows: false,
+    });
+
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("install_bin_dir: /home/u/.local/bin");
+    expect(check.message).toContain(`link ${link} -> v0.0.92`);
+    expect(check.message).toContain(`PATH: ${link} -> v0.0.92`);
+  });
+
+  test("an unrecorded bin dir reports 'default', not an empty value", () => {
+    const link = getSymlinkPath();
+    const check = checkInstallLocation({
+      loadUser: user(null),
+      which: () => link,
+      realpath: (p) => p,
+      isWindows: false,
+    });
+
+    expect(check.message).toContain("install_bin_dir: default");
+    expect(check.status).toBe("pass");
+  });
+
+  test("the exact #293 shape: updates land in a scratch dir, PATH runs an old release", () => {
+    const scratch = "/home/u/scratch/bin-beta";
+    const onPath = "/home/u/.local/bin/squirrel";
+
+    const check = checkInstallLocation({
+      loadUser: user(scratch),
+      which: () => onPath,
+      realpath: (p) =>
+        p === onPath ? "/home/u/.squirrel/releases/0.0.81/squirrel" : p,
+      isWindows: false,
+    });
+
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain(`install_bin_dir: ${scratch}`);
+    expect(check.message).toContain(`link ${scratch}/squirrel`);
+    expect(check.message).toContain(`PATH: ${onPath} -> v0.0.81`);
+    expect(check.fix).toContain("--bin-dir /home/u/.local/bin");
+  });
+
+  test("nothing on PATH warns with the link's directory to add", () => {
+    const check = checkInstallLocation({
+      loadUser: user("/home/u/.local/bin"),
+      which: () => null,
+      realpath: (p) => p,
+      isWindows: false,
+    });
+
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain("no 'squirrel' found");
+    expect(check.fix).toBe("Add /home/u/.local/bin to PATH");
+  });
+
+  test("a recorded bin dir that can't be a link target warns instead of throwing", () => {
+    const check = checkInstallLocation({
+      loadUser: user("relative/bin"),
+      which: () => null,
+      realpath: (p) => p,
+      isWindows: false,
+    });
+
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain("unusable");
+  });
+});

--- a/apps/cli/tests/self/doctor.test.ts
+++ b/apps/cli/tests/self/doctor.test.ts
@@ -115,6 +115,8 @@ describe("checkSettingsFile", () => {
 // #293: `self update` flips the link recorded at install time and reported
 // success on that alone, while the shell kept resolving an older binary
 // somewhere else. Doctor has to lay the three paths side by side.
+import { homedir } from "node:os";
+
 import { checkInstallLocation } from "../../src/self/doctor";
 import { getSymlinkPath } from "../../src/self/paths";
 
@@ -204,6 +206,42 @@ describe("checkInstallLocation (#293)", () => {
     expect(check.message).toContain(
       "link /home/u/scratch/bin-beta/squirrel -> /home/u/scratch/bin-beta/squirrel (missing)"
     );
+  });
+
+  // npm puts a wrapper on PATH, and it dispatches to the managed link. The
+  // check must follow that, or every npm user reads as a mismatch.
+  test("an npm wrapper dispatching to the managed link passes, and is labelled", () => {
+    const managed = join(homedir(), ".local", "bin", "squirrel");
+    const wrapper = "/usr/lib/node_modules/squirrelscan/bin/squirrel.js";
+
+    const check = checkInstallLocation({
+      loadUser: user(null),
+      which: () => "/usr/bin/squirrel",
+      realpath: (p) => (p === "/usr/bin/squirrel" ? wrapper : p),
+      exists: (p) => p === managed,
+      isWindows: false,
+    });
+
+    expect(check.status).toBe("pass");
+    expect(check.message).toContain("PATH: /usr/bin/squirrel -> npm wrapper");
+  });
+
+  test("an npm wrapper stuck on the bundled binary warns with npm advice", () => {
+    const wrapper = "/usr/lib/node_modules/squirrelscan/bin/squirrel.js";
+    const bundled = "/usr/lib/node_modules/squirrelscan/bin/squirrel";
+
+    const check = checkInstallLocation({
+      loadUser: user("/home/u/scratch/bin-beta"),
+      which: () => "/usr/bin/squirrel",
+      realpath: (p) => (p === "/usr/bin/squirrel" ? wrapper : p),
+      exists: (p) => p === bundled,
+      isWindows: false,
+    });
+
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain("npm wrapper");
+    expect(check.fix).toContain("npm install -g squirrelscan@latest");
+    expect(check.fix).not.toContain("--bin-dir");
   });
 
   test("a recorded bin dir that can't be a link target warns instead of throwing", () => {

--- a/apps/cli/tests/self/doctor.test.ts
+++ b/apps/cli/tests/self/doctor.test.ts
@@ -130,6 +130,7 @@ describe("checkInstallLocation (#293)", () => {
       loadUser: user("/home/u/.local/bin"),
       which: () => link,
       realpath: (p) => (p === link ? target : p),
+      exists: () => true,
       isWindows: false,
     });
 
@@ -145,6 +146,7 @@ describe("checkInstallLocation (#293)", () => {
       loadUser: user(null),
       which: () => link,
       realpath: (p) => p,
+      exists: () => true,
       isWindows: false,
     });
 
@@ -161,6 +163,7 @@ describe("checkInstallLocation (#293)", () => {
       which: () => onPath,
       realpath: (p) =>
         p === onPath ? "/home/u/.squirrel/releases/0.0.81/squirrel" : p,
+      exists: () => true,
       isWindows: false,
     });
 
@@ -176,12 +179,31 @@ describe("checkInstallLocation (#293)", () => {
       loadUser: user("/home/u/.local/bin"),
       which: () => null,
       realpath: (p) => p,
+      exists: () => true,
       isWindows: false,
     });
 
     expect(check.status).toBe("warn");
     expect(check.message).toContain("no 'squirrel' found");
     expect(check.fix).toBe("Add /home/u/.local/bin to PATH");
+  });
+
+  // The link left behind by an update into a directory that has since been
+  // deleted resolves to itself; printing the same path twice would read like
+  // a healthy install.
+  test("a dangling link is reported as missing, not as its own target", () => {
+    const check = checkInstallLocation({
+      loadUser: user("/home/u/scratch/bin-beta"),
+      which: () => "/home/u/.local/bin/squirrel",
+      realpath: (p) => p,
+      exists: (p) => p === "/home/u/.local/bin/squirrel",
+      isWindows: false,
+    });
+
+    expect(check.status).toBe("warn");
+    expect(check.message).toContain(
+      "link /home/u/scratch/bin-beta/squirrel -> /home/u/scratch/bin-beta/squirrel (missing)"
+    );
   });
 
   test("a recorded bin dir that can't be a link target warns instead of throwing", () => {

--- a/apps/cli/tests/self/doctor.test.ts
+++ b/apps/cli/tests/self/doctor.test.ts
@@ -173,6 +173,9 @@ describe("checkInstallLocation (#293)", () => {
     expect(check.message).toContain(`install_bin_dir: ${scratch}`);
     expect(check.message).toContain(`link ${scratch}/squirrel`);
     expect(check.message).toContain(`PATH: ${onPath} -> v0.0.81`);
+    expect(check.fix).toContain(
+      "Put /home/u/scratch/bin-beta ahead of /home/u/.local/bin in PATH"
+    );
     expect(check.fix).toContain("--bin-dir /home/u/.local/bin");
   });
 

--- a/apps/cli/tests/self/paths.test.ts
+++ b/apps/cli/tests/self/paths.test.ts
@@ -330,6 +330,27 @@ describe("npm wrapper dispatch (#293)", () => {
     expect(isNpmWrapper(managed)).toBe(false);
   });
 
+  // Emulating the wrapper means REPORTING the managed binary as what runs, so
+  // mistaking another tool's launcher for it would turn a real mismatch into a
+  // confident "same" — the exact failure #293 is about.
+  test("does not claim someone else's launcher under node_modules", () => {
+    const foreign = "/opt/node_modules/other-cli/bin/cli.js";
+    expect(isNpmWrapper(foreign)).toBe(false);
+
+    const resolved = resolveSquirrelOnPath({
+      which: () => "/usr/bin/squirrel",
+      realpath: (p) => (p === "/usr/bin/squirrel" ? foreign : p),
+      exists: () => true,
+      isWindows: false,
+    });
+
+    expect(resolved).toEqual({
+      binary: "/usr/bin/squirrel",
+      target: foreign,
+      via: null,
+    });
+  });
+
   // Anti-drift: the list below is a copy of the wrapper's own, and a silent
   // divergence would make the CLI predict the wrong binary.
   test("the candidate list still matches npm/bin/squirrel.js", () => {

--- a/apps/cli/tests/self/paths.test.ts
+++ b/apps/cli/tests/self/paths.test.ts
@@ -305,3 +305,111 @@ describe("findLocalSettingsPath", () => {
     }
   );
 });
+
+// #293 / npm: PATH usually resolves the npm WRAPPER, not a binary. It runs the
+// first of its hardcoded locations that exists, so the CLI has to follow the
+// same dispatch before deciding an update is invisible.
+import { readFileSync } from "node:fs";
+
+import {
+  isNpmWrapper,
+  npmWrapperCandidates,
+  resolveSquirrelOnPath,
+} from "../../src/self/paths";
+
+describe("npm wrapper dispatch (#293)", () => {
+  const wrapper = "/opt/homebrew/lib/node_modules/squirrelscan/bin/squirrel.js";
+  const managed = join(homedir(), ".local", "bin", "squirrel");
+  const release = join(homedir(), ".squirrel", "releases", "9.9.9", "squirrel");
+
+  test("recognises the wrapper, not the binary bundled beside it", () => {
+    expect(isNpmWrapper(wrapper)).toBe(true);
+    expect(
+      isNpmWrapper("/opt/homebrew/lib/node_modules/squirrelscan/bin/squirrel")
+    ).toBe(false);
+    expect(isNpmWrapper(managed)).toBe(false);
+  });
+
+  // Anti-drift: the list below is a copy of the wrapper's own, and a silent
+  // divergence would make the CLI predict the wrong binary.
+  test("the candidate list still matches npm/bin/squirrel.js", () => {
+    const source = readFileSync(
+      join(
+        import.meta.dir,
+        "..",
+        "..",
+        "..",
+        "..",
+        "npm",
+        "bin",
+        "squirrel.js"
+      ),
+      "utf-8"
+    );
+    for (const fragment of [
+      'path.join(homeDir, ".local", "bin", "squirrel")',
+      '"/usr/local/bin/squirrel"',
+      '"/opt/homebrew/bin/squirrel"',
+      'path.join(homeDir, "AppData", "Local", "squirrel", "bin", "squirrel.exe")',
+    ]) {
+      expect(source).toContain(fragment);
+    }
+    // A regex, not a string: the bundled path is a template literal in the
+    // wrapper and a string copy of it trips no-template-curly-in-string.
+    expect(source).toMatch(/path\.join\(__dirname, `squirrel\$\{ext\}`\)/);
+
+    expect(npmWrapperCandidates(wrapper, false)).toEqual([
+      managed,
+      "/usr/local/bin/squirrel",
+      "/opt/homebrew/bin/squirrel",
+      "/opt/homebrew/lib/node_modules/squirrelscan/bin/squirrel",
+    ]);
+  });
+
+  test("an ordinary npm install resolves THROUGH the wrapper to the managed release", () => {
+    const resolved = resolveSquirrelOnPath({
+      which: () => "/opt/homebrew/bin/squirrel",
+      realpath: (p) =>
+        p === "/opt/homebrew/bin/squirrel"
+          ? wrapper
+          : p === managed
+            ? release
+            : p,
+      exists: (p) => p === managed,
+      isWindows: false,
+    });
+
+    expect(resolved).toEqual({
+      binary: "/opt/homebrew/bin/squirrel",
+      target: release,
+      via: wrapper,
+    });
+  });
+
+  // existsSync FOLLOWS symlinks, in the wrapper and here: a managed link whose
+  // release directory was pruned is skipped by both.
+  test("a dangling managed link falls through to the bundled binary", () => {
+    const bundled = "/opt/homebrew/lib/node_modules/squirrelscan/bin/squirrel";
+    const resolved = resolveSquirrelOnPath({
+      which: () => "/opt/homebrew/bin/squirrel",
+      realpath: (p) => (p === "/opt/homebrew/bin/squirrel" ? wrapper : p),
+      exists: (p) => p === bundled,
+      isWindows: false,
+    });
+
+    expect(resolved?.target).toBe(bundled);
+    expect(resolved?.via).toBe(wrapper);
+  });
+
+  test("a wrapper with nothing to dispatch to reports itself", () => {
+    const resolved = resolveSquirrelOnPath({
+      which: () => "/opt/homebrew/bin/squirrel",
+      realpath: (p) => (p === "/opt/homebrew/bin/squirrel" ? wrapper : p),
+      exists: () => false,
+      isWindows: false,
+    });
+
+    expect(resolved?.target).toBe(wrapper);
+    expect(resolved?.via).toBe(wrapper);
+  });
+});

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -22,7 +22,11 @@ import * as os from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { ReleaseManifest, UserSettings } from "@/self/types";
+import type {
+  ReleaseManifest,
+  UpdateLanding,
+  UserSettings,
+} from "@/self/types";
 
 import * as pathsModule from "@/self/paths";
 import * as releasesModule from "@/self/releases";
@@ -34,6 +38,8 @@ import {
 } from "@/self/settings";
 import {
   applyPendingUpdateInForeground,
+  classifyBinDir,
+  classifyOnPath,
   finishInlineAutoUpdate,
   FOREGROUND_UPDATE_ENV,
   foregroundUpdateTarget,
@@ -44,6 +50,7 @@ import {
   runAutoUpdate,
   safeExit,
   startInlineAutoUpdate,
+  updateLandingWarnings,
 } from "@/self/updater";
 
 const originalEnv = { ...process.env };
@@ -1455,5 +1462,277 @@ describe("updater", () => {
         });
       }
     );
+  });
+
+  // #293: flipping a link the user's PATH never resolves is not an update.
+  // The verdict, the stale-bin-dir fallback, and the words both callers print.
+  describe("update landing (#293)", () => {
+    const LINK = "/home/u/.local/bin/squirrel";
+
+    describe("classifyOnPath", () => {
+      test("PATH resolving the flipped link is same", () => {
+        expect(
+          classifyOnPath("9.9.9", LINK, {
+            which: () => LINK,
+            realpath: (p) => p,
+            isWindows: false,
+          })
+        ).toEqual({
+          path_binary: LINK,
+          path_target: LINK,
+          on_path: "same",
+        });
+      });
+
+      test("another link onto the SAME release binary is still same", () => {
+        const installed = pathsModule.getBinaryPath("9.9.9");
+        expect(
+          classifyOnPath("9.9.9", LINK, {
+            which: () => "/opt/homebrew/bin/squirrel",
+            realpath: (p) =>
+              p === "/opt/homebrew/bin/squirrel" ? installed : p,
+            isWindows: false,
+          }).on_path
+        ).toBe("same");
+      });
+
+      test("an older squirrel earlier on PATH is different, and both paths are reported", () => {
+        const result = classifyOnPath("9.9.9", LINK, {
+          which: () => "/usr/local/bin/squirrel",
+          realpath: (p) =>
+            p === "/usr/local/bin/squirrel"
+              ? "/home/u/.squirrel/releases/0.0.81/squirrel"
+              : p,
+          isWindows: false,
+        });
+        expect(result).toEqual({
+          path_binary: "/usr/local/bin/squirrel",
+          path_target: "/home/u/.squirrel/releases/0.0.81/squirrel",
+          on_path: "different",
+        });
+      });
+
+      test("no squirrel on PATH at all is missing", () => {
+        expect(
+          classifyOnPath("9.9.9", LINK, {
+            which: () => null,
+            isWindows: false,
+          })
+        ).toEqual({ path_binary: null, path_target: null, on_path: "missing" });
+      });
+
+      // Windows installs a COPY at the bin path, so the release binary is never
+      // the PATH target there — the link is the honest comparand — and its
+      // paths are case-insensitive.
+      test("Windows matches the copy at the bin path, ignoring case", () => {
+        const win = "C:\\Users\\u\\.local\\bin\\squirrel.exe";
+        expect(
+          classifyOnPath("9.9.9", win, {
+            which: (command) =>
+              command === "squirrel.exe" ? win.toUpperCase() : null,
+            realpath: (p) => p,
+            isWindows: true,
+          }).on_path
+        ).toBe("same");
+      });
+    });
+
+    describe("classifyBinDir", () => {
+      const throwing = (code: string) => () => {
+        throw Object.assign(new Error(code), { code });
+      };
+
+      test("a live directory is present", () => {
+        expect(
+          classifyBinDir("/x", { stat: () => ({ isDirectory: () => true }) })
+        ).toBe("present");
+      });
+
+      test("a deleted directory is missing", () => {
+        expect(classifyBinDir("/x", { stat: throwing("ENOENT") })).toBe(
+          "missing"
+        );
+      });
+
+      test("a file where the bin dir should be is missing", () => {
+        expect(
+          classifyBinDir("/x", { stat: () => ({ isDirectory: () => false }) })
+        ).toBe("missing");
+      });
+
+      // The whole point of not using existsSync: an unreadable parent must not
+      // read as deleted, or a live install_bin_dir gets cleared.
+      test("an unreadable directory is unknown, never missing", () => {
+        expect(classifyBinDir("/x", { stat: throwing("EACCES") })).toBe(
+          "unknown"
+        );
+      });
+    });
+
+    describe("updateLandingWarnings", () => {
+      const landed: UpdateLanding = {
+        link_path: LINK,
+        path_binary: LINK,
+        path_target: LINK,
+        on_path: "same",
+        stale_bin_dir: null,
+      };
+
+      test("says nothing when PATH already runs the new binary", () => {
+        expect(updateLandingWarnings(landed)).toEqual([]);
+      });
+
+      test("a mismatch names both paths and both fixes", () => {
+        const text = updateLandingWarnings({
+          ...landed,
+          path_binary: "/usr/local/bin/squirrel",
+          path_target: "/home/u/.squirrel/releases/0.0.81/squirrel",
+          on_path: "different",
+        }).join("\n");
+
+        expect(text).toContain("/usr/local/bin/squirrel");
+        expect(text).toContain("/home/u/.squirrel/releases/0.0.81/squirrel");
+        expect(text).toContain(LINK);
+        expect(text).toContain("self install --bin-dir /usr/local/bin");
+        expect(text).toContain("/home/u/.local/bin ahead of it in PATH");
+      });
+
+      test("nothing on PATH points at the link's directory", () => {
+        const text = updateLandingWarnings({
+          ...landed,
+          path_binary: null,
+          path_target: null,
+          on_path: "missing",
+        }).join("\n");
+
+        expect(text).toContain(LINK);
+        expect(text).toContain("add /home/u/.local/bin to PATH");
+      });
+
+      test("a stale bin dir is reported even when PATH is fine", () => {
+        const lines = updateLandingWarnings({
+          ...landed,
+          stale_bin_dir: "/home/u/scratch/bin-beta",
+        });
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain("/home/u/scratch/bin-beta");
+        expect(lines[0]).toContain("cleared install_bin_dir");
+      });
+    });
+
+    // The exact shape of #293: settings point the updater at a scratch dir that
+    // no longer exists. The unattended path has to notice, link the default
+    // instead, forget the dead value, and leave the next run something to say.
+    test("a deleted install_bin_dir falls back to the default link and clears the setting", async () => {
+      spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
+      spyOn(os, "platform").mockReturnValue("linux");
+      captureTelemetry();
+
+      const deadBinDir = join(tempHome, "scratch", "bin-beta");
+      spyOn(pathsModule, "getReleasePath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v)
+      );
+      spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v, "squirrel")
+      );
+      spyOn(pathsModule, "getSymlinkPath").mockImplementation((dir?: string) =>
+        join(dir ?? join(tempHome, "bin"), "squirrel")
+      );
+      spyOn(releasesModule, "checkForUpdates").mockResolvedValue({
+        ok: true,
+        data: {
+          available: true,
+          current_version: "0.0.1",
+          latest_version: "9.9.9",
+          release_url: null,
+          manifest: { version: "9.9.9", binaries: {} } as ReleaseManifest,
+        },
+      } as Awaited<ReturnType<typeof releasesModule.checkForUpdates>>);
+      spyOn(releasesModule, "downloadBinary").mockResolvedValue({
+        ok: true,
+        data: new TextEncoder().encode("bin").buffer as ArrayBuffer,
+      });
+
+      updateSettings({
+        auto_update: true,
+        install_bin_dir: deadBinDir,
+        pending_update_notification: {
+          from_version: "0.0.1",
+          to_version: "9.9.9",
+          release_url: null,
+        },
+      });
+
+      const installed = await runAutoUpdate({
+        landingDeps: { which: () => null, isWindows: false },
+      });
+
+      expect(installed).toBe("9.9.9");
+      expect(existsSync(join(tempHome, "bin", "squirrel"))).toBe(true);
+      expect(existsSync(join(deadBinDir, "squirrel"))).toBe(false);
+
+      const saved = loadUserSettings();
+      expect(saved.ok).toBe(true);
+      if (saved.ok) {
+        expect(saved.data.install_bin_dir ?? null).toBeNull();
+        const landing = saved.data.auto_update_applied?.landing;
+        expect(landing?.stale_bin_dir).toBe(deadBinDir);
+        expect(landing?.link_path).toBe(join(tempHome, "bin", "squirrel"));
+        // Nothing on PATH in this run, so the next one gets both warnings.
+        expect(landing?.on_path).toBe("missing");
+      }
+    });
+
+    // A landing PATH agrees with must not bloat settings or make the next run
+    // print anything beyond the ordinary "auto-updated" confirmation.
+    test("a landing PATH agrees with records no landing at all", async () => {
+      spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
+      spyOn(os, "platform").mockReturnValue("linux");
+      captureTelemetry();
+
+      const linkPath = join(tempHome, "bin", "squirrel");
+      spyOn(pathsModule, "getReleasePath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v)
+      );
+      spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v, "squirrel")
+      );
+      spyOn(pathsModule, "getSymlinkPath").mockReturnValue(linkPath);
+      spyOn(releasesModule, "checkForUpdates").mockResolvedValue({
+        ok: true,
+        data: {
+          available: true,
+          current_version: "0.0.1",
+          latest_version: "9.9.9",
+          release_url: null,
+          manifest: { version: "9.9.9", binaries: {} } as ReleaseManifest,
+        },
+      } as Awaited<ReturnType<typeof releasesModule.checkForUpdates>>);
+      spyOn(releasesModule, "downloadBinary").mockResolvedValue({
+        ok: true,
+        data: new TextEncoder().encode("bin").buffer as ArrayBuffer,
+      });
+
+      updateSettings({
+        auto_update: true,
+        pending_update_notification: {
+          from_version: "0.0.1",
+          to_version: "9.9.9",
+          release_url: null,
+        },
+      });
+
+      await runAutoUpdate({
+        landingDeps: { which: () => linkPath, isWindows: false },
+      });
+
+      const saved = loadUserSettings();
+      expect(saved.ok).toBe(true);
+      if (saved.ok) {
+        expect(saved.data.auto_update_applied?.to_version).toBe("9.9.9");
+        expect(saved.data.auto_update_applied?.landing).toBeUndefined();
+      }
+    });
   });
 });

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -1638,7 +1638,9 @@ describe("updater", () => {
         expect(text).toContain("/home/u/.squirrel/releases/0.0.81/squirrel");
         expect(text).toContain(LINK);
         expect(text).toContain("self install --bin-dir /usr/local/bin");
-        expect(text).toContain("/home/u/.local/bin ahead of it in PATH");
+        expect(text).toContain(
+          "put /home/u/.local/bin ahead of /usr/local/bin in PATH"
+        );
       });
 
       // `self install --bin-dir <npm's dir>` would overwrite npm's wrapper and

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -1752,6 +1752,65 @@ describe("updater", () => {
       }
     });
 
+    // The mirror of the case above: a bare `self install` during the download
+    // records null, meaning "the default". Falling back to the snapshot there
+    // would keep updating a custom directory the user just stopped using.
+    test("a bin dir CLEARED during the download means the default, not the snapshot", async () => {
+      spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
+      spyOn(os, "platform").mockReturnValue("linux");
+      captureTelemetry();
+
+      // Live, not stale: only the concurrent write may move the destination.
+      const customBinDir = join(tempHome, "custom", "bin");
+      mkdirSync(customBinDir, { recursive: true });
+
+      spyOn(pathsModule, "getReleasePath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v)
+      );
+      spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v, "squirrel")
+      );
+      spyOn(pathsModule, "getSymlinkPath").mockImplementation((dir?: string) =>
+        join(dir ?? join(tempHome, "bin"), "squirrel")
+      );
+      spyOn(releasesModule, "checkForUpdates").mockResolvedValue({
+        ok: true,
+        data: {
+          available: true,
+          current_version: "0.0.1",
+          latest_version: "9.9.9",
+          release_url: null,
+          manifest: { version: "9.9.9", binaries: {} } as ReleaseManifest,
+        },
+      } as Awaited<ReturnType<typeof releasesModule.checkForUpdates>>);
+      spyOn(releasesModule, "downloadBinary").mockImplementation(async () => {
+        updateSettings({ install_bin_dir: null });
+        return {
+          ok: true,
+          data: new TextEncoder().encode("bin").buffer as ArrayBuffer,
+        };
+      });
+
+      updateSettings({
+        auto_update: true,
+        install_bin_dir: customBinDir,
+        pending_update_notification: {
+          from_version: "0.0.1",
+          to_version: "9.9.9",
+          release_url: null,
+        },
+      });
+
+      expect(
+        await runAutoUpdate({
+          landingDeps: { which: () => null, isWindows: false },
+        })
+      ).toBe("9.9.9");
+
+      expect(existsSync(join(tempHome, "bin", "squirrel"))).toBe(true);
+      expect(existsSync(join(customBinDir, "squirrel"))).toBe(false);
+    });
+
     // Falling back must never turn an update that used to succeed into a
     // failure: updateSymlink would have recreated the recorded directory.
     test("an unusable default falls back to recreating the recorded dir, and keeps the setting", async () => {

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -1480,6 +1480,7 @@ describe("updater", () => {
         ).toEqual({
           path_binary: LINK,
           path_target: LINK,
+          path_via: null,
           on_path: "same",
         });
       });
@@ -1508,6 +1509,7 @@ describe("updater", () => {
         expect(result).toEqual({
           path_binary: "/usr/local/bin/squirrel",
           path_target: "/home/u/.squirrel/releases/0.0.81/squirrel",
+          path_via: null,
           on_path: "different",
         });
       });
@@ -1518,7 +1520,12 @@ describe("updater", () => {
             which: () => null,
             isWindows: false,
           })
-        ).toEqual({ path_binary: null, path_target: null, on_path: "missing" });
+        ).toEqual({
+          path_binary: null,
+          path_target: null,
+          path_via: null,
+          on_path: "missing",
+        });
       });
 
       // Windows installs a COPY at the bin path, so the release binary is never
@@ -1534,6 +1541,42 @@ describe("updater", () => {
             isWindows: true,
           }).on_path
         ).toBe("same");
+      });
+
+      // npm puts a WRAPPER on PATH, and it dispatches to the managed link
+      // first. Reporting the .js as "something else" would warn every npm user
+      // after every update.
+      test("an npm wrapper that dispatches to the flipped link is same", () => {
+        const wrapper = "/usr/lib/node_modules/squirrelscan/bin/squirrel.js";
+        // The wrapper's first candidate is the DEFAULT managed link, built
+        // from the real home, so that is the link this update flipped.
+        const managed = join(os.homedir(), ".local", "bin", "squirrel");
+        const result = classifyOnPath("9.9.9", managed, {
+          which: () => "/usr/bin/squirrel",
+          realpath: (p) => (p === "/usr/bin/squirrel" ? wrapper : p),
+          exists: (p) => p === managed,
+          isWindows: false,
+        });
+
+        expect(result.on_path).toBe("same");
+        expect(result.path_binary).toBe("/usr/bin/squirrel");
+        expect(result.path_target).toBe(managed);
+        expect(result.path_via).toBe(wrapper);
+      });
+
+      test("an npm wrapper that falls through to the bundled binary is different", () => {
+        const wrapper = "/usr/lib/node_modules/squirrelscan/bin/squirrel.js";
+        const bundled = "/usr/lib/node_modules/squirrelscan/bin/squirrel";
+        const result = classifyOnPath("9.9.9", LINK, {
+          which: () => "/usr/bin/squirrel",
+          realpath: (p) => (p === "/usr/bin/squirrel" ? wrapper : p),
+          exists: (p) => p === bundled,
+          isWindows: false,
+        });
+
+        expect(result.on_path).toBe("different");
+        expect(result.path_target).toBe(bundled);
+        expect(result.path_via).toBe(wrapper);
       });
     });
 
@@ -1574,6 +1617,7 @@ describe("updater", () => {
         link_path: LINK,
         path_binary: LINK,
         path_target: LINK,
+        path_via: null,
         on_path: "same",
         stale_bin_dir: null,
       };
@@ -1595,6 +1639,24 @@ describe("updater", () => {
         expect(text).toContain(LINK);
         expect(text).toContain("self install --bin-dir /usr/local/bin");
         expect(text).toContain("/home/u/.local/bin ahead of it in PATH");
+      });
+
+      // `self install --bin-dir <npm's dir>` would overwrite npm's wrapper and
+      // be undone by the next `npm install -g`, so the npm case gets its own
+      // advice.
+      test("the npm wrapper gets npm advice, never --bin-dir into node_modules", () => {
+        const text = updateLandingWarnings({
+          ...landed,
+          path_binary: "/usr/bin/squirrel",
+          path_target: "/usr/lib/node_modules/squirrelscan/bin/squirrel",
+          path_via: "/usr/lib/node_modules/squirrelscan/bin/squirrel.js",
+          on_path: "different",
+        }).join("\n");
+
+        expect(text).toContain("npm wrapper");
+        expect(text).toContain("squirrel self install");
+        expect(text).toContain("npm install -g squirrelscan@latest");
+        expect(text).not.toContain("--bin-dir");
       });
 
       test("nothing on PATH points at the link's directory", () => {

--- a/apps/cli/tests/self/updater.test.ts
+++ b/apps/cli/tests/self/updater.test.ts
@@ -1684,6 +1684,138 @@ describe("updater", () => {
       }
     });
 
+    // The snapshot handed to performUpdate predates the download. A
+    // `self install --bin-dir` finishing during it records a LIVE directory,
+    // and clearing that because the OLD value was dead is worse than #293.
+    test("a bin dir recorded DURING the download is used, and not cleared", async () => {
+      spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
+      spyOn(os, "platform").mockReturnValue("linux");
+      captureTelemetry();
+
+      const deadBinDir = join(tempHome, "scratch", "bin-beta");
+      const liveBinDir = join(tempHome, "live", "bin");
+      mkdirSync(liveBinDir, { recursive: true });
+
+      spyOn(pathsModule, "getReleasePath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v)
+      );
+      spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v, "squirrel")
+      );
+      spyOn(pathsModule, "getSymlinkPath").mockImplementation((dir?: string) =>
+        join(dir ?? join(tempHome, "bin"), "squirrel")
+      );
+      spyOn(releasesModule, "checkForUpdates").mockResolvedValue({
+        ok: true,
+        data: {
+          available: true,
+          current_version: "0.0.1",
+          latest_version: "9.9.9",
+          release_url: null,
+          manifest: { version: "9.9.9", binaries: {} } as ReleaseManifest,
+        },
+      } as Awaited<ReturnType<typeof releasesModule.checkForUpdates>>);
+      spyOn(releasesModule, "downloadBinary").mockImplementation(async () => {
+        // `self install --bin-dir <live>` lands while the bytes are in flight.
+        updateSettings({ install_bin_dir: liveBinDir });
+        return {
+          ok: true,
+          data: new TextEncoder().encode("bin").buffer as ArrayBuffer,
+        };
+      });
+
+      updateSettings({
+        auto_update: true,
+        install_bin_dir: deadBinDir,
+        pending_update_notification: {
+          from_version: "0.0.1",
+          to_version: "9.9.9",
+          release_url: null,
+        },
+      });
+
+      const installed = await runAutoUpdate({
+        landingDeps: { which: () => null, isWindows: false },
+      });
+
+      expect(installed).toBe("9.9.9");
+      expect(existsSync(join(liveBinDir, "squirrel"))).toBe(true);
+      expect(existsSync(join(tempHome, "bin", "squirrel"))).toBe(false);
+
+      const saved = loadUserSettings();
+      expect(saved.ok).toBe(true);
+      if (saved.ok) {
+        expect(saved.data.install_bin_dir).toBe(liveBinDir);
+        expect(
+          saved.data.auto_update_applied?.landing?.stale_bin_dir ?? null
+        ).toBeNull();
+      }
+    });
+
+    // Falling back must never turn an update that used to succeed into a
+    // failure: updateSymlink would have recreated the recorded directory.
+    test("an unusable default falls back to recreating the recorded dir, and keeps the setting", async () => {
+      spyOn(pathsModule, "isManagedInstall").mockReturnValue(true);
+      spyOn(os, "platform").mockReturnValue("linux");
+      captureTelemetry();
+
+      const deadBinDir = join(tempHome, "scratch", "bin-beta");
+      // A FILE where the default bin dir belongs: mkdirSync -> ENOTDIR/EEXIST.
+      writeFileSync(join(tempHome, "bin"), "not a directory");
+
+      spyOn(pathsModule, "getReleasePath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v)
+      );
+      spyOn(pathsModule, "getBinaryPath").mockImplementation((v: string) =>
+        join(tempHome, "releases", v, "squirrel")
+      );
+      spyOn(pathsModule, "getSymlinkPath").mockImplementation((dir?: string) =>
+        join(dir ?? join(tempHome, "bin"), "squirrel")
+      );
+      spyOn(releasesModule, "checkForUpdates").mockResolvedValue({
+        ok: true,
+        data: {
+          available: true,
+          current_version: "0.0.1",
+          latest_version: "9.9.9",
+          release_url: null,
+          manifest: { version: "9.9.9", binaries: {} } as ReleaseManifest,
+        },
+      } as Awaited<ReturnType<typeof releasesModule.checkForUpdates>>);
+      spyOn(releasesModule, "downloadBinary").mockResolvedValue({
+        ok: true,
+        data: new TextEncoder().encode("bin").buffer as ArrayBuffer,
+      });
+
+      updateSettings({
+        auto_update: true,
+        install_bin_dir: deadBinDir,
+        pending_update_notification: {
+          from_version: "0.0.1",
+          to_version: "9.9.9",
+          release_url: null,
+        },
+      });
+
+      const installed = await runAutoUpdate({
+        landingDeps: { which: () => null, isWindows: false },
+      });
+
+      expect(installed).toBe("9.9.9");
+      expect(existsSync(join(deadBinDir, "squirrel"))).toBe(true);
+
+      const saved = loadUserSettings();
+      expect(saved.ok).toBe(true);
+      if (saved.ok) {
+        // The link went to the recorded directory after all, so it is still
+        // in use and must survive.
+        expect(saved.data.install_bin_dir).toBe(deadBinDir);
+        const landing = saved.data.auto_update_applied?.landing;
+        expect(landing?.stale_bin_dir ?? null).toBeNull();
+        expect(landing?.link_path).toBe(join(deadBinDir, "squirrel"));
+      }
+    });
+
     // A landing PATH agrees with must not bloat settings or make the next run
     // print anything beyond the ordinary "auto-updated" confirmation.
     test("a landing PATH agrees with records no landing at all", async () => {


### PR DESCRIPTION
Closes #293.

`squirrel self update` flipped the symlink recorded at install time and reported success on that alone. Nothing ever checked what the user's PATH resolves, so an update could land somewhere invisible and print `Updated to v0.0.92` while `squirrel` kept starting v0.0.81. That is what happened on a machine here: `install_bin_dir` pointed at a scratch directory from an old `self install --bin-dir <tmp>` that had since been deleted, and the updater dutifully flipped a link inside it for five weeks.

## What changed

`performUpdate` now returns where the update landed instead of `ok(undefined)`:

```ts
{ link_path, path_binary, path_target, on_path: "same" | "different" | "missing", stale_bin_dir }
```

`same` means the `squirrel` PATH resolves is the same file as either the release binary or the link that was just flipped. Both comparands are needed: on POSIX the link resolves to the release binary, but on Windows `self install` lands a *copy* at the bin path, so the release binary and the thing on PATH are two different files even when the install is perfect. Windows paths are compared case-insensitively.

Both callers now speak:

- **`squirrel self update`** prints `Linked: <path>` always, and on a mismatch a warning naming the PATH binary, what it really runs, the link this update changed, and both fixes. It never fails the update: the install did land.
- **The silent auto-update** cannot print at the time it runs, so it records the landing in `auto_update_applied` and the next run prints it. That notice now also fires when the run is still the **old** version, which is exactly the case that could never self-correct: the old binary keeps being resolved, the marker keeps being deferred to a run that never comes, and the user is told nothing. Only a recorded mismatch breaks the "new version only" rule; a clean landing stores no `landing` key at all.

When the recorded `install_bin_dir` is provably gone (`ENOENT`/`ENOTDIR` only, never an unreadable one), the update prefers the default bin dir and clears the dead setting. `existsSync` is deliberately not used: it reports an unreadable directory exactly like a deleted one, and clearing a live setting would be worse than the bug. If the default itself cannot be linked, the recorded directory is recreated instead, exactly as before, and the setting stays.

`squirrel self doctor` gains an **Install location** check putting the three paths that have to agree on one line:

```
[PASS] Install location: install_bin_dir: default; link /Users/n/.local/bin/squirrel -> v0.0.92; PATH: /Users/n/.local/bin/squirrel -> v0.0.92
```

and, for the shape this issue is about:

```
[WARN] Install location: install_bin_dir: /private/tmp/.../bin-beta; link /private/tmp/.../bin-beta/squirrel -> /private/tmp/.../bin-beta/squirrel (missing); PATH: /Users/n/.local/bin/squirrel -> v0.0.81 (updates land on the link, not on what you run)
    Fix: squirrel self install --bin-dir /Users/n/.local/bin, or put /private/tmp/.../bin-beta ahead of it in PATH
```

## The npm surface

`npm/package.json` maps the `squirrel` bin to `npm/bin/squirrel.js`, so an `npm install -g squirrelscan` puts a **wrapper** on PATH, not a binary. The wrapper spawns the first of these that exists:

1. `~/.local/bin/squirrel` (the managed default link, the one `self update` flips)
2. `/usr/local/bin/squirrel`
3. `/opt/homebrew/bin/squirrel`
4. `<package>/bin/squirrel`, the copy bundled by the postinstall

So the answer to "managed release or bundled binary" is **the managed release**, as long as one of the first three exists. An ordinary npm install therefore does pick up `self update`. Two consequences, both handled here:

- Stopping the PATH check at the wrapper would have reported **every npm user** as running something else and warned them after every single update. `resolveSquirrelOnPath` now follows the wrapper's dispatch, with `existsSync` to match its symlink-following semantics, and records the wrapper as `path_via`.
- The bundled fall-through (nothing managed exists) is a genuine mismatch and does warn, but with npm advice. Telling that user to run `self install --bin-dir <npm's directory>` would overwrite the wrapper npm owns, and the next `npm install -g` would put it back. They get `squirrel self install` (so the wrapper finds a managed release) or `npm install -g squirrelscan@latest` instead.

A test asserts the candidate list still matches `npm/bin/squirrel.js`; a silent divergence there would make the CLI predict the wrong binary. The wrapper never consults `install_bin_dir`, so a `--bin-dir` install plus the npm wrapper on PATH stays divergent by construction, which is now visible in both the update warning and `self doctor`. Known gap: on Windows npm installs a `squirrel.cmd` shim rather than a symlink to the `.js`, so that case reads as a plain mismatch rather than a wrapper.

## Out of scope

Criterion 5 of the issue (changing what `self install --bin-dir` persists) is deliberately **not** in this PR. The two installers still disagree about it and that is worth its own change:

- `install.sh` always runs `self install --bin-dir "$bin_dir"` with whatever `find_bin_dir` picked, so **every** install.sh user gets `install_bin_dir` recorded, even when it is the default `~/.local/bin`.
- The npm postinstall runs a bare `self install`, which records `null`.

So the last installer to run decides where every future update lands, and a `--bin-dir` used once for a test is permanent until something rewrites it. This PR makes that state visible and self-healing when the directory is gone; it does not change what gets written.

## Tests

Injected `which` / `realpath` / `stat` / `exists` seams, no real install touched:

- `classifyOnPath`: same (the flipped link), same (another link onto the same release binary), different (an older squirrel earlier on PATH), missing, and the Windows copy with case-insensitive matching.
- `classifyBinDir`: present, deleted, a file where the directory should be, and unreadable resolving to `unknown` rather than `missing`.
- `updateLandingWarnings`: silent on a clean landing; both paths and both fixes on a mismatch; the stale-bin-dir line on its own.
- `runAutoUpdate` end to end with a deleted `install_bin_dir`: links the default, leaves nothing in the dead directory, clears the setting, records the landing. And the clean case recording no landing.
- `printAutoUpdateAppliedNotice`: warns on the old version and clears the marker; stays silent with `notifications: false`.
- `checkInstallLocation`: pass, "default" wording, the exact #293 shape, nothing on PATH, a dangling link reported as missing, and an unusable recorded directory warning instead of throwing.

## Review

A codex pass raised three P2s, all fixed in `3f1c9f1` with regression tests:

- The bin dir was decided from a settings snapshot taken **before** the download. A `self install --bin-dir` finishing during it recorded a live directory that the stale-value clear then erased. Settings are re-read before the decision, and only a value the fallback actually replaced is cleared.
- Falling back to the default could **fail** an update that used to succeed, when the default is unwritable or obstructed and the recorded directory was merely deleted (`updateSymlink` would have recreated it). Destinations are now tried in order: the default first when the recorded one is provably gone, then the recorded one.
- The next-run notice consumed the marker on **any** warning, so an old process carrying only a stale-bin-dir warning could eat the confirmation the run on the new version was owed. It now speaks up early only when PATH cannot reach the install.

Drive-by: `CHANGELOG.md` had a truncated bullet (`- A \`## [Unreleased]`) since the v0.0.92 notes landed; completed it while adding the `## [Unreleased]` section.
