### PR TITLE
perf(audit-engine): replay an unchanged page's rule results instead of re-running them (#1990)

### DIFF
--- a/apps/cli/src/audit/adapter.ts
+++ b/apps/cli/src/audit/adapter.ts
@@ -10,6 +10,8 @@ import {
   setAdapterLogger,
   STREAM_BATCH_BYTES,
   type AdapterLogger,
+  type RuleCacheStats,
+  type RuleCacheStore,
   type StreamingRulePhase,
 } from "@squirrelscan/audit-engine";
 import {
@@ -828,8 +830,14 @@ export function runStreamingRules(
   opts?: {
     batchSize?: number;
     onPhase?: (phase: StreamingRulePhase, boundary: "start" | "end") => void;
+    /** Per-page rule-result cache (#1990); omitted → every page runs. */
+    ruleCache?: { store: RuleCacheStore; engineVersion: string };
   }
-): Effect.Effect<RuleExecutionResult, never, never> {
+): Effect.Effect<
+  RuleExecutionResult & { ruleCache: RuleCacheStats },
+  never,
+  never
+> {
   return runStreamingRulesCore(storage, crawlId, config, assets, scope, opts);
 }
 

--- a/apps/cli/src/audit/rule-cache-store.ts
+++ b/apps/cli/src/audit/rule-cache-store.ts
@@ -1,0 +1,119 @@
+// project.db-backed store for the per-page rule-result cache (#1990).
+//
+// The engine owns the KEY (only it holds the run context) and the PAYLOAD shape;
+// this file owns nothing but persistence, which is why the interface it implements
+// speaks in opaque strings. Two things it is responsible for:
+//
+//  - **Bounded residency.** Writes are buffered and flushed at every page-batch
+//    boundary, so at most one batch of encoded payloads is ever held. Buffering
+//    the whole run instead would hold tens of megabytes of JSON on the exact path
+//    #1913 exists to keep flat.
+//  - **A cheap warm run.** A replayed page is carried forward by SQL row copy
+//    rather than re-encoded, so the run that replays everything does no
+//    serialization work at all.
+
+import type { RuleCacheStore } from "@squirrelscan/audit-engine";
+
+import { Effect } from "effect";
+
+import type { SQLiteStorage } from "@/crawler/storage/sqlite";
+
+import { logger } from "@/utils/logger";
+
+/**
+ * The kill switch, mirroring `SQUIRREL_TEMPLATE_FANOUT` (#1951): the cache is ON,
+ * and `SQUIRREL_RULE_CACHE` set to `0`, `false`, `off` or `no` turns it off for a
+ * run without a rebuild. It exists for the same two reasons that one does — a
+ * support session needs a way to rule the cache out of a wrong-looking report, and
+ * a benchmark needs both arms in ONE build, because an A/B across two builds is an
+ * A/B across two of everything.
+ *
+ * Read per run rather than at module load, so a bench can flip it between stages.
+ */
+export function ruleCacheEnabled(
+  env: Record<string, string | undefined> = process.env
+): boolean {
+  const raw = env.SQUIRREL_RULE_CACHE;
+  if (raw === undefined) return true;
+  const value = raw.trim().toLowerCase();
+  return !(
+    value === "0" ||
+    value === "false" ||
+    value === "off" ||
+    value === "no"
+  );
+}
+
+export interface ProjectRuleCacheStore extends RuleCacheStore {
+  /** Rows written for this crawl, for the audit's summary line. */
+  readonly written: () => number;
+}
+
+/**
+ * A store over one crawl's rows in `project.db`.
+ *
+ * Every failure here is swallowed to a debug line: a cache that cannot be read
+ * costs a page's rules, and a cache that cannot be written costs the NEXT audit's.
+ * Neither is worth failing an audit the user is waiting on.
+ */
+export function createProjectRuleCacheStore(
+  storage: SQLiteStorage,
+  crawlId: string
+): ProjectRuleCacheStore {
+  const pendingFresh: Array<{
+    normalizedUrl: string;
+    cacheKey: string;
+    payload: string;
+  }> = [];
+  const pendingCarry: Array<{ normalizedUrl: string; cacheKey: string }> = [];
+  let written = 0;
+
+  return {
+    written: () => written,
+
+    async load(keys) {
+      if (keys.length === 0) return new Map<string, string>();
+      try {
+        return await Effect.runPromise(storage.loadPageRuleCache(keys));
+      } catch (error) {
+        logger.debug(
+          "rule cache read failed, running pages fresh",
+          String(error)
+        );
+        return new Map<string, string>();
+      }
+    },
+
+    putFresh(key, normalizedUrl, payload) {
+      pendingFresh.push({ normalizedUrl, cacheKey: key, payload });
+    },
+
+    carryForward(key, normalizedUrl) {
+      pendingCarry.push({ normalizedUrl, cacheKey: key });
+    },
+
+    async flush() {
+      const fresh = pendingFresh.splice(0);
+      const carry = pendingCarry.splice(0);
+      if (fresh.length === 0 && carry.length === 0) return;
+      try {
+        if (fresh.length > 0) {
+          await Effect.runPromise(
+            storage.savePageRuleCacheBatch(crawlId, fresh)
+          );
+        }
+        if (carry.length > 0) {
+          await Effect.runPromise(
+            storage.carryForwardPageRuleCache(crawlId, carry)
+          );
+        }
+        written += fresh.length + carry.length;
+      } catch (error) {
+        logger.debug(
+          "rule cache write failed, next audit runs cold",
+          String(error)
+        );
+      }
+    },
+  };
+}

--- a/apps/cli/src/controllers/audit.ts
+++ b/apps/cli/src/controllers/audit.ts
@@ -51,6 +51,10 @@ import {
   auditMayRetire,
   retainRecentAudits,
 } from "@/audit/retention";
+import {
+  createProjectRuleCacheStore,
+  ruleCacheEnabled,
+} from "@/audit/rule-cache-store";
 import { resolveRulesConfig } from "@/audit/rule-filter";
 import { runSmartAudits } from "@/audit/smart-audits";
 import {
@@ -96,6 +100,8 @@ import {
   parseUserUrl,
 } from "@/utils/url";
 import { resolveStickyUserAgent } from "@/utils/user-agent";
+
+import { version as cliVersion } from "../../package.json";
 
 /**
  * Fields that affect crawl scope - changes require fresh crawl_id
@@ -1478,6 +1484,17 @@ export async function runAudit(
       phaseTimer.enter("rules");
       logger.debug("step 2.5: analyzing", crawlId);
 
+      // Per-page rule-result cache (#1990). A page whose inputs are unchanged
+      // since a previous audit skips its parse AND its rules; `--refresh` is the
+      // documented way to force everything to run, so it turns the cache off
+      // rather than merely forcing a re-fetch. `cliVersion` is in the key, so a
+      // `squirrel self update` invalidates every entry — rule CODE can change
+      // without any rule id or option changing.
+      const ruleCacheStore =
+        options.refresh || !ruleCacheEnabled()
+          ? undefined
+          : createProjectRuleCacheStore(sqliteStorage, crawlId);
+
       // Thread cloud results + the resolved Stage-0 profile into the rules phase
       // per audit run — no process-global singleton. The metadata drives
       // `appliesWhen` rule gating; undefined = run as today.
@@ -1490,7 +1507,15 @@ export async function runAudit(
           cloudResults: cloudResult?.store,
           siteMetadata: cloudResult?.siteMetadata ?? undefined,
         },
-        { batchSize: streamBatchSize, onPhase: streamPhaseMemoryLogger() }
+        {
+          batchSize: streamBatchSize,
+          onPhase: streamPhaseMemoryLogger(),
+          ...(ruleCacheStore
+            ? {
+                ruleCache: { store: ruleCacheStore, engineVersion: cliVersion },
+              }
+            : {}),
+        }
       );
       const rulesPhaseTimeoutMs = options.rulesPhaseTimeoutMs;
       let ruleResults: Effect.Effect.Success<typeof rulesEffect>;
@@ -1659,6 +1684,22 @@ export async function runAudit(
           capped: report.pages.length >= scopeMaxPages,
         };
       }
+
+      // Rule-result cache disclosure (#1990). REPORT-ONLY, and stripped on
+      // publish: it says how this run was produced, not what the site is like.
+      // Recorded even when nothing replayed, so "0 replayed" is a statement
+      // rather than a silence an agent has to interpret.
+      report.rulesCache = {
+        pagesReplayed: ruleResults.ruleCache.replayedPages,
+        pagesEvaluated: ruleResults.ruleCache.freshPages,
+        ...(ruleResults.ruleCache.disabledReason
+          ? { disabledReason: ruleResults.ruleCache.disabledReason }
+          : options.refresh
+            ? { disabledReason: "refresh-requested" }
+            : ruleCacheStore
+              ? {}
+              : { disabledReason: "disabled-by-env" }),
+      };
 
       // Report-only technologies section (never affects the health score).
       // Cloud tech-detect (credited, cross-scan diff) wins; otherwise fall back to
@@ -1840,6 +1881,12 @@ export async function runAudit(
       // map to telemetry.
       report.phaseTimingsMs = phaseTimer.timingsMs;
       logger.debug("phase timings", formatPhaseTimings(phaseTimer.timingsMs));
+      // Also under --trace, the flag whose whole job is timing attribution. The
+      // streamed pipeline stopped emitting the two v1 rule spans, so a trace of a
+      // modern audit could not say what the rules phase cost, and the benchmark
+      // harness printed "rules n/a". One machine-readable line at the end of the
+      // run, and `phaseTimingsMs` in the report is unchanged.
+      logger.trace("phase timings", phaseTimer.timingsMs);
 
       // ============================================
       // STEP 4: RETENTION (#1912)

--- a/apps/cli/src/controllers/report/publish.ts
+++ b/apps/cli/src/controllers/report/publish.ts
@@ -646,6 +646,11 @@ export function slimForPublish(
   return {
     ...report,
     pages: [], // Drop all page-level data — renderers use ruleResults only
+    // #1990 provenance describes how THIS machine produced the report (what
+    // replayed from its local cache), not the site. It has no meaning to a reader
+    // of the hosted report and no place in the publish schema, so it is dropped
+    // here rather than left to ride along on the spread above.
+    rulesCache: undefined,
     generatorVersion: version, // stamp the CLI version for the report footer
     lockedRules: computeLockedRules(report), // cloud/Pro checks not run → upsell
     ...(pageStatuses.length > 0 ? { pageStatuses } : {}),

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -547,6 +547,18 @@ export interface AuditReport {
     pagesCrawled: number;
     capped: boolean;
   };
+  /**
+   * Rule-result cache disclosure (#1990): how many pages replayed a previous
+   * audit's rule results instead of being evaluated now. The findings are
+   * identical by construction, so nothing else in the report tells an agent
+   * which happened (#1981). LOCAL ONLY — stripped by `slimForPublish`.
+   * REPORT-ONLY. Mirrors core-contracts `AuditReport`.
+   */
+  rulesCache?: {
+    pagesReplayed: number;
+    pagesEvaluated: number;
+    disabledReason?: string;
+  };
   /** Generator (`squirrel` CLI) version, stamped at publish for the report footer. */
   generatorVersion?: string;
   /**

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -1518,8 +1518,8 @@ rather than a permanent second copy accumulating.
 
 ### What two adversarial review rounds found that the gates did not
 
-Thirteen findings across two `codex` passes, all fixed or accounted for. The four
-worth recording:
+Sixteen findings across three `codex` passes, all fixed. The third pass returned
+nothing above P2. The four worth recording:
 
 **Fan-out composition, twice.** The first round found that a replayed page
 abstaining from fan-out changes which page is elected representative. The fix —
@@ -1537,10 +1537,14 @@ have replayed one page's verdicts onto another's markup, and every gate would ha
 stayed green, because no fixture contains that pair. The cache keys on a new
 exact-bytes hash, which the content store had already computed.
 
-**A cache changes what the clock means.** `content/stale-copyright` reads
-`new Date().getUTCFullYear()` at execution and is the only page rule that reads a
-clock at all, so a pass cached on 31 December would replay on 1 January. The
-current UTC year is now part of the run context.
+**A cache changes what the clock and the calendar mean.**
+`content/stale-copyright` reads `new Date().getUTCFullYear()` at execution, so a
+pass cached on 31 December would replay on 1 January; the current UTC year is now
+part of the run context, and replay stops for the rest of any run that crosses the
+boundary while it is going. `content/date-agreement` resolves a bare schema date
+through `Date.parse`, which reads it in LOCAL time, so the same page yields a
+different year under `UTC` and under `Australia/Sydney`; the runtime time zone is
+in the key too. Neither was reachable by reasoning about the page.
 
 **Hashing the run context whole made the cache do nothing, silently.** The first
 implementation hashed the `SiteData` fields page rules read as whole objects. One

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -1444,23 +1444,23 @@ Site-scope rules always run.
 Both arms are the SAME build. `SQUIRREL_RULE_CACHE=0` is the only difference,
 which is the point: an A/B across two builds is an A/B across two of everything.
 2,500 pages of the mixed synthetic estate, one pinned origin across each pair, a
-fresh content store per pair, load average 2.2 to 4.5 throughout.
+fresh content store per pair, load average 2.4 to 4.1 except where noted.
 
 | stage | wall | rules phase | report phase | crawl | project.db |
 |---|---|---|---|---|---|
-| cache off, cold | 170 s | 114 s | 19 s | 34 s | 258 MB |
-| cache off, warm | 140 s | 106 s | 18 s | 14 s | 514 MB |
-| cache on, cold | 161 s | 110 s | 17 s | 33 s | 290 MB |
-| **cache on, warm** | **46 s** | **13 s** | 18 s | 14 s | 579 MB |
+| cache off, cold | 178 s | 116 s | 22 s | 39 s | 258 MB |
+| cache off, warm | 143 s | 110 s | 18 s | 13 s | 514 MB |
+| cache on, cold | 177 s | 124 s | 19 s | 33 s | 291 MB |
+| **cache on, warm** | **44 s** | **12 s** | 18 s | 13 s | 581 MB |
 
-**The warm rules phase falls from 106 s to 13 s, and the warm run from 140 s to
-46 s.** All 2,500 pages replayed, which the report says and nothing else in it
+**The warm rules phase falls from 110 s to 12 s, and the warm run from 143 s to
+44 s.** All 2,500 pages replayed, which the report says and nothing else in it
 does — the findings are identical by construction.
 
 Read the rules-phase column rather than the wall, and compare WITHIN a pair. The
-cache-off rules phase came in at 131 s on a loaded evening and 106 s on a quiet
+cache-off rules phase came in at 131 s on a loaded evening and 110 s on a quiet
 one, which is most of the spread this table would otherwise be asked to explain;
-13 s against 106 s in the same pair is not inside it.
+12 s against 110 s in the same pair is not inside it.
 
 **Byte-identity holds at scale.** The cache-on cold and warm reports are
 identical, all 3,039,997 bytes of them, once `meta.timestamp` and the replay
@@ -1470,57 +1470,64 @@ evaluated, on the full default rule surface.
 Two things the warm row makes visible that were hidden behind the rules phase:
 
 - **Report reconstruction is now the largest phase of a re-audit** — 18 s of a
-  46 s run, against 13 s of rules. squirrelscan/repo#1920 was already open on it;
+  44 s run, against 12 s of rules. squirrelscan/repo#1920 was already open on it;
   it is now the thing to work.
-- **A warm crawl still costs 14 s** with nothing to fetch, which is frontier and
+- **A warm crawl still costs 13 s** with nothing to fetch, which is frontier and
   bookkeeping work rather than bytes.
+
+### The cache and template fan-out do not compose, and the cache wins
+
+Fan-out (above) and this cache are two ways of not running a rule, and enabling
+the cache turns fan-out OFF for that run. The reason is not performance:
+
+A fanned verdict belongs to the page's CLUSTER, so no per-page key can capture
+what it depends on. Cache two pages of one cluster, then change the FIRST one —
+the cluster's representative. It is fresh and records its new verdict; the second
+page replays the verdict it inherited from the representative's PREVIOUS run, and
+every fully-replayed audit after that repeats the stale value. A fresh audit gives
+it the new one. Nothing about the second page changed, so nothing about its key
+can notice. Making them compose means caching the cluster's verdict against its
+representative's identity, which is a whole-crawl property the streamed loop
+resolves as it goes — a design rather than a patch, and a follow-up.
+
+What that costs, in the cold row above: **the rules phase goes from 116 s to
+124 s, 6.9%**, which is fan-out's share of the fannable rules plus the cache's own
+writes. Cold wall time is unchanged (178 s against 177). Every audit after the
+first takes the 89%.
+
+It also changes the report. The cache-on cold report is 3,039,997 bytes against
+3,043,863 with fan-out on: turning fan-out off is the more accurate of the two,
+because every rule then really runs on every page rather than inheriting a
+cluster-mate's verdict. That difference is #275's open question about the
+chrome-only cluster key, now visible rather than argued.
 
 ### What it costs a cold run, and what that took to establish
 
-The cache-on cold arm comes in FASTER than cache-off, on both the wall (161 s to
-170) and the rules phase (110 s to 114), which it cannot actually be: a cold run
-with the cache on does strictly more work. **The cost is below what this box can
-resolve**, and the honest statement is that and not "free".
+At gzip's default level 6, four interleaved cold stages put the cache-on rules
+phase 9.4% above cache-off at the minimum of two repeats (127 s to 139 s) — one
+payload per page serialized and compressed on the run that gets nothing back for
+it. Dropping to level 1 moved the compression cost under the noise floor, and it
+is the right trade because these rows are retired with their crawl: the extra
+bytes live no longer than the audit does, while the cold run's cost is paid by
+every first-time user. What remains in the 6.9% above is mostly fan-out's absence.
 
-It was not always below it. At gzip's default level 6 the same comparison, run as
-four interleaved cold stages, put the cache-on rules phase 9.4% above cache-off
-at the minimum of two repeats (127 s to 139 s) — one payload per page serialized
-and compressed on the run that gets nothing back for it. Dropping to level 1 is
-what moved it under the noise floor, and it is the right trade here because these
-rows are retired with their crawl: the extra bytes live no longer than the audit
-does, while the cold run's cost is paid by every first-time user.
+Storage: `project.db` grows about 12.8% (258 to 291 MiB cold, 514 to 581 warm).
+The rows are retired with their crawl, so `squirrel self disk --prune` reclaims
+them with everything else that audit holds and the retention window bounds them,
+rather than a permanent second copy accumulating.
 
-Storage: `project.db` grows about 12.5% (258 to 290 MiB cold, 514 to 579 warm). The rows
-are retired with their crawl, so `squirrel self disk --prune` reclaims them with
-everything else that audit holds and the retention window bounds them, rather than
-a permanent second copy accumulating.
+### What two adversarial review rounds found that the gates did not
 
-### What an adversarial review found that the gates did not
+Thirteen findings across two `codex` passes, all fixed or accounted for. The four
+worth recording:
 
-Seven findings, all fixed. Two are worth recording because they are about
-composition rather than about this code:
-
-**A replayed page has to be able to represent its template cluster.** Fan-out
-(#279) runs a declared rule once per cluster and copies the verdict to the rest.
-The first design had replayed pages abstain from it entirely — they did not run
-the rules, so they had nothing to record. That makes WHICH page runs a
-template-scoped rule depend on what happens to be cached: on the audit after one
-page changes, the changed page is the only fresh one and keeps its own verdict,
-where a fresh audit would have the first page of the cluster fan its verdict onto
-it. The next fully-replayed audit then disagrees with a fresh audit of identical
-content, and the disagreement is persisted. Reproduced on the synthetic estate by
-adding a `<meta name="viewport">` to one page — none of the five things the chrome
-fingerprint reads — which moved three checks. The fix is that a replayed page
-records too, keyed on the `page_features.template_fp` its own run stored, which
-restores the fresh audit's election exactly.
-
-**A cache changes what the clock means.** `content/stale-copyright` reads
-`new Date().getUTCFullYear()` at execution and is the only page rule that reads a
-clock at all, so a pass cached on 31 December would replay on 1 January. The
-current UTC year is now part of the run context — year and not day, because a day
-would make every re-audit after midnight cold for nothing.
-
-### Two findings from building it
+**Fan-out composition, twice.** The first round found that a replayed page
+abstaining from fan-out changes which page is elected representative. The fix —
+letting a replayed page record, keyed on its stored `template_fp` — closed that
+direction and the second round showed the other one: when the REPRESENTATIVE is
+what changed, its cluster-mates' cached verdicts are stale and no per-page key can
+see it. That is what made the two features mutually exclusive. Both rounds
+reproduced their case; the first is now a regression test, mutation-checked.
 
 **`pages.content_hash` cannot be the key, and looks like it can.** It is a
 whitespace-NORMALIZED hash, so the incremental crawler can call a reformatted page
@@ -1528,7 +1535,12 @@ unchanged. Two pages that differ only in whitespace share it and parse to
 different word counts, inline-script lengths and `<pre>` text. Keying on it would
 have replayed one page's verdicts onto another's markup, and every gate would have
 stayed green, because no fixture contains that pair. The cache keys on a new
-exact-bytes hash instead, which the content store had already computed.
+exact-bytes hash, which the content store had already computed.
+
+**A cache changes what the clock means.** `content/stale-copyright` reads
+`new Date().getUTCFullYear()` at execution and is the only page rule that reads a
+clock at all, so a pass cached on 31 December would replay on 1 January. The
+current UTC year is now part of the run context.
 
 **Hashing the run context whole made the cache do nothing, silently.** The first
 implementation hashed the `SiteData` fields page rules read as whole objects. One

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -1444,41 +1444,42 @@ Site-scope rules always run.
 Both arms are the SAME build. `SQUIRREL_RULE_CACHE=0` is the only difference,
 which is the point: an A/B across two builds is an A/B across two of everything.
 2,500 pages of the mixed synthetic estate, one pinned origin across each pair, a
-fresh content store per pair, load average 3.5 to 4.3 throughout.
+fresh content store per pair, load average 2.2 to 4.5 throughout.
 
 | stage | wall | rules phase | report phase | crawl | project.db |
 |---|---|---|---|---|---|
-| cache off, cold | 186 s | 128 s | 22 s | 34 s | 258 MB |
-| cache off, warm | 171 s | 131 s | 23 s | 15 s | 516 MB |
-| cache on, cold | 186 s | 124 s | 17 s | 44 s | 291 MB |
-| **cache on, warm** | **44 s** | **12 s** | 19 s | 13 s | 579 MB |
+| cache off, cold | 170 s | 114 s | 19 s | 34 s | 258 MB |
+| cache off, warm | 140 s | 106 s | 18 s | 14 s | 514 MB |
+| cache on, cold | 161 s | 110 s | 17 s | 33 s | 290 MB |
+| **cache on, warm** | **46 s** | **13 s** | 18 s | 14 s | 579 MB |
 
-**The warm rules phase falls from 131 s to 12 s, and the warm run from 171 s to
-44 s.** All 2,500 pages replayed, which the report says and nothing else in it
+**The warm rules phase falls from 106 s to 13 s, and the warm run from 140 s to
+46 s.** All 2,500 pages replayed, which the report says and nothing else in it
 does — the findings are identical by construction.
 
-Read the rules-phase column rather than the wall. The rules phase is where the
-change is, it is 12 s against 131, and no plausible amount of box noise closes
-that; the wall carries the crawl and report phases, which this does not touch.
+Read the rules-phase column rather than the wall, and compare WITHIN a pair. The
+cache-off rules phase came in at 131 s on a loaded evening and 106 s on a quiet
+one, which is most of the spread this table would otherwise be asked to explain;
+13 s against 106 s in the same pair is not inside it.
 
 **Byte-identity holds at scale.** The cache-on cold and warm reports are
-identical, all 3,044,401 bytes of them, once `meta.timestamp` and the replay
+identical, all 3,039,997 bytes of them, once `meta.timestamp` and the replay
 disclosure itself are removed. That is 2,500 pages replayed against 2,500 pages
 evaluated, on the full default rule surface.
 
 Two things the warm row makes visible that were hidden behind the rules phase:
 
-- **Report reconstruction is now the largest phase of a re-audit** — 19 s of a
-  44 s run, against 12 s of rules. squirrelscan/repo#1920 was already open on it;
+- **Report reconstruction is now the largest phase of a re-audit** — 18 s of a
+  46 s run, against 13 s of rules. squirrelscan/repo#1920 was already open on it;
   it is now the thing to work.
-- **A warm crawl still costs 13 s** with nothing to fetch, which is frontier and
+- **A warm crawl still costs 14 s** with nothing to fetch, which is frontier and
   bookkeeping work rather than bytes.
 
 ### What it costs a cold run, and what that took to establish
 
-The cold arms come in at the same wall (186 s each) and the cache-on rules phase
-is 4 s FASTER than the cache-off one, which it cannot actually be: a cold run with
-the cache on does strictly more work. **The cost is below what this box can
+The cache-on cold arm comes in FASTER than cache-off, on both the wall (161 s to
+170) and the rules phase (110 s to 114), which it cannot actually be: a cold run
+with the cache on does strictly more work. **The cost is below what this box can
 resolve**, and the honest statement is that and not "free".
 
 It was not always below it. At gzip's default level 6 the same comparison, run as
@@ -1489,10 +1490,35 @@ what moved it under the noise floor, and it is the right trade here because thes
 rows are retired with their crawl: the extra bytes live no longer than the audit
 does, while the cold run's cost is paid by every first-time user.
 
-Storage: `project.db` grows 12.8% (258 to 291 MiB cold, 516 to 579 warm). The rows
+Storage: `project.db` grows about 12.5% (258 to 290 MiB cold, 514 to 579 warm). The rows
 are retired with their crawl, so `squirrel self disk --prune` reclaims them with
 everything else that audit holds and the retention window bounds them, rather than
 a permanent second copy accumulating.
+
+### What an adversarial review found that the gates did not
+
+Seven findings, all fixed. Two are worth recording because they are about
+composition rather than about this code:
+
+**A replayed page has to be able to represent its template cluster.** Fan-out
+(#279) runs a declared rule once per cluster and copies the verdict to the rest.
+The first design had replayed pages abstain from it entirely — they did not run
+the rules, so they had nothing to record. That makes WHICH page runs a
+template-scoped rule depend on what happens to be cached: on the audit after one
+page changes, the changed page is the only fresh one and keeps its own verdict,
+where a fresh audit would have the first page of the cluster fan its verdict onto
+it. The next fully-replayed audit then disagrees with a fresh audit of identical
+content, and the disagreement is persisted. Reproduced on the synthetic estate by
+adding a `<meta name="viewport">` to one page — none of the five things the chrome
+fingerprint reads — which moved three checks. The fix is that a replayed page
+records too, keyed on the `page_features.template_fp` its own run stored, which
+restores the fresh audit's election exactly.
+
+**A cache changes what the clock means.** `content/stale-copyright` reads
+`new Date().getUTCFullYear()` at execution and is the only page rule that reads a
+clock at all, so a pass cached on 31 December would replay on 1 January. The
+current UTC year is now part of the run context — year and not day, because a day
+would make every re-audit after midnight cold for nothing.
 
 ### Two findings from building it
 

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -1426,6 +1426,104 @@ gates count calls as well as compare values: a rule declaring
 `verdictScope: "template"` must run once per CLUSTER and an undeclared one once per
 PAGE, and the pass reports the invocations it removed.
 
+## Caching a page's rule results: the re-audit that was not faster
+
+The re-audit measurement above ends on a flat statement: a second audit of an
+unchanged 2,500-page estate fetched nothing and was not faster, because parse,
+page rules, the page-time collectors and report reconstruction re-run in full on
+every page whether or not that page changed. This is what caching that work
+instead of the bytes is worth
+([squirrelscan/repo#1990](https://github.com/squirrelscan/repo/issues/1990)).
+
+A page replays its stored rule results when every input those rules read is
+unchanged: the page's exact HTML bytes, its status, headers, redirect chain and
+response timings, the build that produced the results, and the enabled rules with
+their resolved options. A replayed page is never parsed and its rules never run.
+Site-scope rules always run.
+
+Both arms are the SAME build. `SQUIRREL_RULE_CACHE=0` is the only difference,
+which is the point: an A/B across two builds is an A/B across two of everything.
+2,500 pages of the mixed synthetic estate, one pinned origin across each pair, a
+fresh content store per pair, load average 3.5 to 4.3 throughout.
+
+| stage | wall | rules phase | report phase | crawl | project.db |
+|---|---|---|---|---|---|
+| cache off, cold | 186 s | 128 s | 22 s | 34 s | 258 MB |
+| cache off, warm | 171 s | 131 s | 23 s | 15 s | 516 MB |
+| cache on, cold | 186 s | 124 s | 17 s | 44 s | 291 MB |
+| **cache on, warm** | **44 s** | **12 s** | 19 s | 13 s | 579 MB |
+
+**The warm rules phase falls from 131 s to 12 s, and the warm run from 171 s to
+44 s.** All 2,500 pages replayed, which the report says and nothing else in it
+does — the findings are identical by construction.
+
+Read the rules-phase column rather than the wall. The rules phase is where the
+change is, it is 12 s against 131, and no plausible amount of box noise closes
+that; the wall carries the crawl and report phases, which this does not touch.
+
+**Byte-identity holds at scale.** The cache-on cold and warm reports are
+identical, all 3,044,401 bytes of them, once `meta.timestamp` and the replay
+disclosure itself are removed. That is 2,500 pages replayed against 2,500 pages
+evaluated, on the full default rule surface.
+
+Two things the warm row makes visible that were hidden behind the rules phase:
+
+- **Report reconstruction is now the largest phase of a re-audit** — 19 s of a
+  44 s run, against 12 s of rules. squirrelscan/repo#1920 was already open on it;
+  it is now the thing to work.
+- **A warm crawl still costs 13 s** with nothing to fetch, which is frontier and
+  bookkeeping work rather than bytes.
+
+### What it costs a cold run, and what that took to establish
+
+The cold arms come in at the same wall (186 s each) and the cache-on rules phase
+is 4 s FASTER than the cache-off one, which it cannot actually be: a cold run with
+the cache on does strictly more work. **The cost is below what this box can
+resolve**, and the honest statement is that and not "free".
+
+It was not always below it. At gzip's default level 6 the same comparison, run as
+four interleaved cold stages, put the cache-on rules phase 9.4% above cache-off
+at the minimum of two repeats (127 s to 139 s) — one payload per page serialized
+and compressed on the run that gets nothing back for it. Dropping to level 1 is
+what moved it under the noise floor, and it is the right trade here because these
+rows are retired with their crawl: the extra bytes live no longer than the audit
+does, while the cold run's cost is paid by every first-time user.
+
+Storage: `project.db` grows 12.8% (258 to 291 MiB cold, 516 to 579 warm). The rows
+are retired with their crawl, so `squirrel self disk --prune` reclaims them with
+everything else that audit holds and the retention window bounds them, rather than
+a permanent second copy accumulating.
+
+### Two findings from building it
+
+**`pages.content_hash` cannot be the key, and looks like it can.** It is a
+whitespace-NORMALIZED hash, so the incremental crawler can call a reformatted page
+unchanged. Two pages that differ only in whitespace share it and parse to
+different word counts, inline-script lengths and `<pre>` text. Keying on it would
+have replayed one page's verdicts onto another's markup, and every gate would have
+stayed green, because no fixture contains that pair. The cache keys on a new
+exact-bytes hash instead, which the content store had already computed.
+
+**Hashing the run context whole made the cache do nothing, silently.** The first
+implementation hashed the `SiteData` fields page rules read as whole objects. One
+of their fields is `cacheReason`: "cache-hit reason if reused from a prior crawl;
+null on a real fetch". Null on every cold run and set on every warm one, so the
+run context differed between exactly the two runs that are supposed to match,
+every page missed, and the feature reported success while saving nothing. The key
+now covers only the entry fields rules actually read, and a test proxies those
+entries to fail if a rule reads one outside the list. **A cache that stops hitting
+is indistinguishable from a cache that is working unless something counts the
+hits** — which is why the replayed-page count is in the report and asserted in the
+gates rather than inferred from a wall-clock delta.
+
+### Attributing the rules phase at all
+
+`phases.ts` printed `rules n/a` for every run on the streamed pipeline: it read
+the two v1 spans, which #252 stopped emitting. The CLI has computed the whole
+per-phase breakdown since #857 but only at debug level, so it now also writes one
+machine-readable line to the trace log — the flag whose entire job is timing
+attribution. Every rules-phase number in this section comes from it.
+
 ## Still open
 
 - Site rules were measured as quadratic in page count (4 s at 400 pages, 99 s

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -1512,9 +1512,16 @@ bytes live no longer than the audit does, while the cold run's cost is paid by
 every first-time user. What remains in the 6.9% above is mostly fan-out's absence.
 
 Storage: `project.db` grows about 12.8% (258 to 291 MiB cold, 514 to 581 warm).
-The rows are retired with their crawl, so `squirrel self disk --prune` reclaims
-them with everything else that audit holds and the retention window bounds them,
-rather than a permanent second copy accumulating.
+The rows are retired with their crawl, so the automatic retention window bounds
+them rather than letting a permanent second copy accumulate. Verified against the
+window that landed the same evening: five audits of a 40-page project leave two
+crawls retired and cache rows under exactly the three that remain (120 rows for
+3 x 40 pages), while every audit after the first still replays all 40. That is
+what the carry-forward is for — an entry is copied into each new crawl, so
+retiring the crawl that produced it never makes the next audit cold.
+
+The table above was measured just before that window landed; retention adds tens
+of milliseconds to an audit, against a 44-second warm run.
 
 ### What two adversarial review rounds found that the gates did not
 

--- a/benchmarks/harness/phases.ts
+++ b/benchmarks/harness/phases.ts
@@ -22,7 +22,7 @@ rows.push([
   "reqs",
   "pageReqs",
   "rules",
-  "site",
+  "report",
   "parse",
   "peakRSS",
   "db",
@@ -53,16 +53,34 @@ for (const dir of process.argv.slice(2)) {
 
   // phases from the trace log
   const tr = read(`${dir}/trace.log`);
-  // The streaming pipeline (#252) no longer emits these two spans, so a run on
-  // it has no rules attribution in the trace at all. Report that as "n/a" —
+  // The streaming pipeline (#252) stopped emitting the two v1 spans, so a run on
+  // it had no rules attribution in the trace at all and this printed "n/a" —
   // printing 0s reads as "the rules phase was free", which is the opposite of
-  // true (it is most of the wall time on a large crawl).
-  const rulesMs = /\[runPageRules:all\] duration=([\d.]+)ms/.test(tr)
-    ? num(/\[runPageRules:all\] duration=([\d.]+)ms/, tr)
-    : null;
-  const siteMs = /\[runSiteRules\] duration=([\d.]+)ms/.test(tr)
-    ? num(/\[runSiteRules\] duration=([\d.]+)ms/, tr)
-    : null;
+  // true (it is most of the wall time on a large crawl). #1990 put the CLI's own
+  // per-phase breakdown into the trace, so the columns are real again. The
+  // "report" column is the CLI's report phase, not the v1 site-rule span.
+  // #1990: the CLI now emits its whole per-phase breakdown (#857's PhaseTimer)
+  // under --trace as one JSON line, so the streamed pipeline can be attributed at
+  // all. Prefer it; fall back to the v1 spans for a trace from an older build.
+  const phaseLine = /\[phase timings\] (\{.*\})/.exec(tr)?.[1];
+  let phases: Record<string, number> | null = null;
+  if (phaseLine) {
+    try {
+      phases = JSON.parse(phaseLine) as Record<string, number>;
+    } catch {
+      phases = null;
+    }
+  }
+  const rulesMs =
+    phases?.rules ??
+    (/\[runPageRules:all\] duration=([\d.]+)ms/.test(tr)
+      ? num(/\[runPageRules:all\] duration=([\d.]+)ms/, tr)
+      : null);
+  const siteMs =
+    phases?.report ??
+    (/\[runSiteRules\] duration=([\d.]+)ms/.test(tr)
+      ? num(/\[runSiteRules\] duration=([\d.]+)ms/, tr)
+      : null);
   const parseMs = (tr.match(/\[parsePageRecord\] duration=([\d.]+)ms/g) ?? [])
     .map((s) => Number(/([\d.]+)/.exec(s)![1]))
     .reduce((a, b) => a + b, 0);

--- a/docs/cli/audit.mdx
+++ b/docs/cli/audit.mdx
@@ -339,12 +339,43 @@ Changing scope-affecting config (`include`, `exclude`, `allow_query_params`, `dr
 
 ## Caching
 
-SquirrelScan caches page content locally. On subsequent audits:
+squirrelscan caches page content locally. On subsequent audits:
 
 - **304 Not Modified**: Uses cached content (fast)
 - **200 OK**: Fetches fresh content (slower)
 
 Use `--refresh` to bypass the cache entirely.
+
+### Rule results
+
+Skipping the fetch only saves the download. squirrelscan also caches the rule
+results for each page, so a re-audit of a page nothing has touched replays its
+findings instead of parsing the page and running its rules again. On a site that
+has not changed, this is most of the audit.
+
+A page replays only when every input its rules read is unchanged:
+
+- the page's exact HTML, byte for byte
+- its status, headers, redirect chain and response timings
+- the version of squirrel that produced the results
+- which rules are enabled, and the options they run with
+
+Change any of them and that page is audited again. Rules that read the whole site
+rather than one page always run.
+
+Every report says what happened, so you never have to guess whether you are
+reading a fresh measurement:
+
+```json
+"rulesCache": { "pagesReplayed": 2480, "pagesEvaluated": 20 }
+```
+
+`--refresh` turns it off along with the page cache. To turn off only the rule
+cache, set `SQUIRREL_RULE_CACHE=0`.
+
+Cached results live in the project database and are removed with the audit they
+belong to, so [`squirrel self disk --prune`](/cli/self#disk) reclaims them along
+with everything else that audit is holding.
 
 ## Audit history
 

--- a/docs/cli/audit.mdx
+++ b/docs/cli/audit.mdx
@@ -373,6 +373,11 @@ reading a fresh measurement:
 `--refresh` turns it off along with the page cache. To turn off only the rule
 cache, set `SQUIRREL_RULE_CACHE=0`.
 
+While the rule cache is on, squirrelscan runs every rule on every page rather than
+running a template-shared rule once per template and reusing its verdict. That
+makes the first audit of a site slightly slower and every audit after it much
+faster, and it makes the report the one every rule actually computed.
+
 Cached results live in the project database and are removed with the audit they
 belong to, so [`squirrel self disk --prune`](/cli/self#disk) reclaims them along
 with everything else that audit is holding.

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -2457,6 +2457,7 @@ export function runStreamingRules(
               (config.rules as { ignore_applicability?: boolean } | undefined)
                 ?.ignore_applicability === true,
             utcYear: new Date().getUTCFullYear(),
+            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           }),
         );
         if ("hash" in ctxHash) ruleCache = bindRuleCache(ruleCacheOpts.store, ctxHash.hash);

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -106,6 +106,14 @@ import {
   type PageSignalCollector,
   type StreamPageRulesHooks,
 } from "./streaming";
+import {
+  bindRuleCache,
+  computeRunContextHash,
+  type RuleCacheDisabledReason,
+  type RuleCacheStats,
+  type RuleCacheStore,
+  type StreamRuleCache,
+} from "./rule-cache";
 import { collectDroppedBatch } from "./batch-gc";
 import { detachFromPage, detachParsedPage } from "./detach";
 import { resolveCloakingProbes } from "./cloaking-probe";
@@ -2311,6 +2319,12 @@ export interface StreamingRuleExecutionResult extends RuleExecutionResult {
    * explicitly so a caller sizing a large crawl reads the right number.
    */
   peakLiveDocsPageStream: number;
+  /**
+   * What the per-page rule-result cache did this run (#1990). Zeros with no
+   * `disabledReason` mean no cache was supplied (the cloud); zeros WITH one mean a
+   * cache was supplied and deliberately not used.
+   */
+  ruleCache: RuleCacheStats;
 }
 
 /**
@@ -2358,6 +2372,22 @@ export function runStreamingRules(
      * the equivalence test set it explicitly to run both arms in one process.
      */
     templateFanout?: boolean;
+    /**
+     * Per-page rule-result cache (#1990). A store here turns on replay: a page
+     * whose inputs are unchanged since a previous audit skips its parse and its
+     * rules. Omitted → every page runs, exactly as before, which is what the
+     * cloud does (it has no project.db to cache into).
+     */
+    ruleCache?: {
+      /** Where entries live. The CLI backs this with `project.db`. */
+      store: RuleCacheStore;
+      /**
+       * The build identity of the rules that produced (and will consume) the
+       * entries — the CLI's release version. Part of the key, so upgrading the
+       * binary invalidates every entry even when no rule id or option changed.
+       */
+      engineVersion: string;
+    };
   },
 ): Effect.Effect<StreamingRuleExecutionResult, never, never> {
   return Effect.gen(function* () {
@@ -2399,25 +2429,61 @@ export function runStreamingRules(
     // signal (leaked-secrets, byte weight, template fingerprint + integrity signals,
     // script srcs, sub-processor links) while each DOM is live (#1021 E-E2), so the
     // site pass reads `ctx.collectedSignals` instead of re-materializing every DOM.
+    // #1990: the run context — every input a page rule can read that is not the
+    // page itself. Resolved AFTER the site-fetch phase because two of its
+    // ingredients (`scripts`, `resourceSizes`) come from it, and before the page
+    // loop because every key depends on it. Threat intel is a hard OFF rather than
+    // an ingredient: its verdicts come from feeds behind a memoized handle with no
+    // exact identity to hash, so an unchanged key would not mean an unchanged
+    // answer. See rule-cache.ts.
+    let ruleCache: StreamRuleCache | undefined;
+    let ruleCacheDisabled: RuleCacheDisabledReason | undefined;
+    const ruleCacheOpts = opts?.ruleCache;
+    if (ruleCacheOpts) {
+      if (effectiveScope?.intel) {
+        ruleCacheDisabled = "threat-intel-enabled";
+      } else {
+        const ctxHash = yield* Effect.promise(() =>
+          computeRunContextHash({
+            engineVersion: ruleCacheOpts.engineVersion,
+            pageRules: runner.pageRuleSignature(),
+            siteData: siteDataForPageRules,
+            siteMetadata: effectiveScope?.siteMetadata,
+            cloudResults: effectiveScope?.cloudResults,
+          }),
+        );
+        if ("hash" in ctxHash) ruleCache = bindRuleCache(ruleCacheOpts.store, ctxHash.hash);
+        else ruleCacheDisabled = ctxHash.disabled;
+      }
+    }
+
     const collectedPages: CollectedPageSignal[] = [];
     const signalCollector: PageSignalCollector = {
       id: "site-dom-signals",
       collect(page, parsed, shared) {
-        collectedPages.push(
-          detachFromPage(
-            // `shared.fingerprint` is the one the loop already built for
-            // page_features' cluster key (#1949) — reusing it keeps this pass at
-            // one DOM walk per page. detachFromPage clones it, so the signal this
-            // array retains does not hold the loop's copy or its page.
-            buildCollectedPageSignal({
-              url: page.normalizedUrl,
-              finalUrl: page.finalUrl,
-              parsed,
-              fingerprint: shared.fingerprint,
-            }),
-            "collected-signal",
-          ),
+        const signal = detachFromPage(
+          // `shared.fingerprint` is the one the loop already built for
+          // page_features' cluster key (#1949) — reusing it keeps this pass at
+          // one DOM walk per page. detachFromPage clones it, so the signal this
+          // array retains does not hold the loop's copy or its page.
+          buildCollectedPageSignal({
+            url: page.normalizedUrl,
+            finalUrl: page.finalUrl,
+            parsed,
+            fingerprint: shared.fingerprint,
+          }),
+          "collected-signal",
         );
+        collectedPages.push(signal);
+        // The value the rule cache stores for this page. It is already detached
+        // and holds no DOM, so it is exactly what a replay needs (#1990).
+        return signal;
+      },
+      // A replayed page contributes at the same point in the stream, so
+      // `collectedPages` stays in crawl order whether a page ran or replayed —
+      // which matters because the site rules aggregate over that order.
+      replay(_page, snapshot) {
+        collectedPages.push(snapshot as CollectedPageSignal);
       },
     };
     const streamed = yield* phase("page-rules", () =>
@@ -2434,6 +2500,7 @@ export function runStreamingRules(
       totalPages: pageDataMap.size,
       pageLoopHooks: opts?.pageLoopHooks,
       templateFanout: opts?.templateFanout,
+      ruleCache,
       }),
     );
     const collectedSignals: CollectedSiteSignals = { pages: collectedPages };
@@ -2503,6 +2570,9 @@ export function runStreamingRules(
       sitemapUrlStatuses: assets.sitemapUrlStatuses,
       tallies,
       peakLiveDocsPageStream: streamed.peakLiveDocs,
+      ruleCache: ruleCacheDisabled
+        ? { ...streamed.ruleCache, disabledReason: ruleCacheDisabled }
+        : streamed.ruleCache,
     };
   });
 }

--- a/packages/audit-engine/src/adapter.ts
+++ b/packages/audit-engine/src/adapter.ts
@@ -2450,6 +2450,13 @@ export function runStreamingRules(
             siteData: siteDataForPageRules,
             siteMetadata: effectiveScope?.siteMetadata,
             cloudResults: effectiveScope?.cloudResults,
+            // Read through the runner's own view of config (`RulesConfig`), which
+            // is where the escape hatch is declared; the engine's `Config` type
+            // predates it and does not carry it.
+            ignoreApplicability:
+              (config.rules as { ignore_applicability?: boolean } | undefined)
+                ?.ignore_applicability === true,
+            utcYear: new Date().getUTCFullYear(),
           }),
         );
         if ("hash" in ctxHash) ruleCache = bindRuleCache(ruleCacheOpts.store, ctxHash.hash);

--- a/packages/audit-engine/src/index.ts
+++ b/packages/audit-engine/src/index.ts
@@ -211,6 +211,26 @@ export type { TemplateFanout, TemplateFanoutStats } from "./template-fanout";
 
 // Streaming rules engine (#1021, PR-E) — batched page-rule pass with DOM-drop.
 export { streamPageRules, STREAM_PAGE_BATCH } from "./streaming";
+// Per-page rule-result cache (#1990).
+export {
+  bindRuleCache,
+  canonicalJson,
+  computePageCacheKey,
+  computeRunContextHash,
+  decodePageRuleCacheEntry,
+  emptyRuleCacheStats,
+  encodePageRuleCacheEntry,
+  PAGE_RULE_SITE_FIELDS,
+  RULE_CACHE_FORMAT,
+  sha256Hex,
+} from "./rule-cache";
+export type {
+  PageRuleCacheEntry,
+  RuleCacheDisabledReason,
+  RuleCacheStats,
+  RuleCacheStore,
+  StreamRuleCache,
+} from "./rule-cache";
 export type {
   PageSignalCollector,
   SharedPageSignals,

--- a/packages/audit-engine/src/rule-cache.ts
+++ b/packages/audit-engine/src/rule-cache.ts
@@ -61,10 +61,14 @@
 //    `SiteData`, down to the individual script and resource entries, and fails on
 //    any read outside the declared sets.
 //
-// TEMPLATE FAN-OUT (#1951) COMPOSES, by abstention: a replayed page neither takes
-// a cluster verdict nor becomes a representative, because it did not run the
-// rules. A cluster whose representative replayed simply elects the next fresh
-// member, and #1951's own parity gate is what says the two are the same verdict.
+// TEMPLATE FAN-OUT (#1951) DOES NOT COMPOSE WITH THIS, and the cache wins: a run
+// with a cache does not build a fan-out at all (see streaming.ts). A fanned
+// verdict belongs to the page's CLUSTER, so no per-page key can capture what it
+// depends on — change a cluster's representative and its members' cached verdicts
+// are stale with nothing about those members having changed. Two designs were
+// tried and rejected before this one; the reasoning is in streaming.ts, and making
+// them compose means caching the cluster's verdict against its representative's
+// identity, which is a whole-crawl property rather than a per-page one.
 
 import type { CheckResult, PageFeatureRow, PageRecord } from "@squirrelscan/core-contracts";
 import type { ParsedPage, RuleMeta, SiteData } from "@squirrelscan/rules";
@@ -302,6 +306,15 @@ export interface RunContextInput {
    * midnight already gives its earlier and later pages different verdicts.
    */
   readonly utcYear: number;
+  /**
+   * The runtime's IANA time zone. `content/date-agreement` resolves a schema date
+   * through `Date.parse`, which reads a bare "01/01/2026 00:30:00" in LOCAL time,
+   * so the same page yields a different year under `UTC` and under
+   * `Australia/Sydney`. A laptop that moved, or a CI runner that does not match the
+   * machine that filled the cache, is otherwise an unchanged key over a changed
+   * answer.
+   */
+  readonly timeZone: string;
 }
 
 /**
@@ -323,6 +336,7 @@ export async function computeRunContextHash(
       input.cloudResults ?? null,
       input.ignoreApplicability,
       input.utcYear,
+      input.timeZone,
     ]);
     // A cache that quietly stops hitting looks exactly like a cache that is
     // working, so the one question worth answering cheaply is "which ingredient
@@ -341,6 +355,7 @@ export async function computeRunContextHash(
         ["cloudResults", input.cloudResults ?? null],
         ["ignoreApplicability", input.ignoreApplicability],
         ["utcYear", input.utcYear],
+        ["timeZone", input.timeZone],
       ];
       for (const [name, value] of parts) {
         const digest = (await sha256Hex(canonicalJson(value))).slice(0, 16);
@@ -601,9 +616,18 @@ export function emptyRuleCacheStats(disabledReason?: RuleCacheDisabledReason): R
  * half-written or older-format row costs a page's rules and never a wrong report.
  */
 export function bindRuleCache(store: RuleCacheStore, runContextHash: string): StreamRuleCache {
+  // The year the run context was hashed under. A long audit can cross UTC New
+  // Year while it runs, and `content/stale-copyright` reads the clock itself: a
+  // page replayed after midnight would serve last year's verdict while a fresh
+  // evaluation of it warns. Rather than freeze a year the rule cannot be told
+  // about, replay simply stops for the rest of the run once the year moves — those
+  // pages are audited normally, which is always a correct answer.
+  const boundYear = new Date().getUTCFullYear();
   return {
     keyFor: (page, soft404Confirmation) =>
-      computePageCacheKey(runContextHash, page, soft404Confirmation),
+      new Date().getUTCFullYear() === boundYear
+        ? computePageCacheKey(runContextHash, page, soft404Confirmation)
+        : Promise.resolve(null),
     async load(keys) {
       const raw = await store.load(keys);
       const out = new Map<string, PageRuleCacheEntry>();

--- a/packages/audit-engine/src/rule-cache.ts
+++ b/packages/audit-engine/src/rule-cache.ts
@@ -207,7 +207,12 @@ export function canonicalJson(value: unknown, seen: Set<unknown> = new Set()): s
   if (value === undefined) return "u";
   if (value === null) return "null";
   const t = typeof value;
-  if (t === "number") return Number.isFinite(value as number) ? JSON.stringify(value) : "nf";
+  if (t === "number") {
+    // Distinct forms, not one "not finite" bucket: NaN, Infinity and -Infinity are
+    // three different rule-option values and must not share a key.
+    if (Number.isFinite(value as number)) return JSON.stringify(value);
+    return Number.isNaN(value as number) ? "nan" : (value as number) > 0 ? "inf" : "-inf";
+  }
   if (t === "string" || t === "boolean") return JSON.stringify(value);
   if (t === "bigint") return `bi:${(value as bigint).toString()}`;
   if (t === "function" || t === "symbol") {
@@ -217,7 +222,12 @@ export function canonicalJson(value: unknown, seen: Set<unknown> = new Set()): s
   seen.add(value);
   try {
     if (Array.isArray(value)) {
-      return `[${value.map((v) => canonicalJson(v, seen)).join(",")}]`;
+      // LENGTH-prefixed, and holes read as `undefined` rather than as nothing:
+      // `.map` skips holes, so `new Array(1)` and `[]` would otherwise both
+      // canonicalize to the same string.
+      const items: string[] = [];
+      for (let i = 0; i < value.length; i++) items.push(canonicalJson(value[i], seen));
+      return `[${value.length}|${items.join(",")}]`;
     }
     if (value instanceof Set) {
       // Insertion order preserved: it is observable through iteration, so two Sets
@@ -264,6 +274,21 @@ export interface RunContextInput {
   readonly siteMetadata: unknown;
   /** `RunnerScope.cloudResults` — plain `Map<service, Map<key, envelope>>`. */
   readonly cloudResults: unknown;
+  /**
+   * `rules.ignore_applicability` — the escape hatch that makes every enabled rule
+   * run regardless of the Stage-0 profile. It changes a rule's output from a
+   * `skipped` check to its real verdict WITHOUT changing the rule list or any
+   * rule's options, so it has to be here or flipping it replays the skips.
+   */
+  readonly ignoreApplicability: boolean;
+  /**
+   * The current UTC year. `content/stale-copyright` is the only PAGE rule that
+   * reads a clock (`new Date().getUTCFullYear()`), so this is the exact
+   * granularity the cache has to invalidate on: a pass cached on 31 December must
+   * not replay on 1 January. Year and not day, because a day would make every
+   * re-audit after midnight cold for nothing.
+   */
+  readonly utcYear: number;
 }
 
 /**
@@ -283,6 +308,8 @@ export async function computeRunContextHash(
       projection,
       input.siteMetadata ?? null,
       input.cloudResults ?? null,
+      input.ignoreApplicability,
+      input.utcYear,
     ]);
     // A cache that quietly stops hitting looks exactly like a cache that is
     // working, so the one question worth answering cheaply is "which ingredient
@@ -299,6 +326,8 @@ export async function computeRunContextHash(
         ["resourceSizes", projection.resourceSizes],
         ["siteMetadata", input.siteMetadata ?? null],
         ["cloudResults", input.cloudResults ?? null],
+        ["ignoreApplicability", input.ignoreApplicability],
+        ["utcYear", input.utcYear],
       ];
       for (const [name, value] of parts) {
         const digest = (await sha256Hex(canonicalJson(value))).slice(0, 16);
@@ -329,6 +358,18 @@ export async function computePageCacheKey(
     RULE_CACHE_FORMAT,
     runContextHash,
     page.htmlHash,
+    // The NORMALIZED hash too, because `extractPageFeatures` copies it verbatim
+    // into `page_features.content_hash`, where the duplicate-content grouping
+    // reads it. Implied by the exact hash for anything the crawler wrote, but a
+    // record whose normalized hash was written independently is not the crawler's
+    // to imply.
+    page.contentHash,
+    // The stored parse, which `buildSiteContext` PREFERS over re-extracting from
+    // the HTML. For a crawler-written record it is a pure function of the HTML and
+    // the parser, both already covered — but a record whose parsed data was
+    // repaired or imported separately would otherwise replay the old parse's
+    // verdicts under an unchanged key.
+    page.parsedData,
     page.url,
     page.normalizedUrl,
     page.finalUrl,
@@ -370,6 +411,9 @@ interface TaggedUndefined {
 interface TaggedEscape {
   $e: Record<string, unknown>;
 }
+interface TaggedDate {
+  $d: number;
+}
 
 function isTagged(value: object): boolean {
   for (const key of Object.keys(value)) if (key.startsWith("$")) return true;
@@ -387,8 +431,12 @@ export function encodeCacheValue(value: unknown): unknown {
       $m: [...value].map(([k, v]) => [encodeCacheValue(k), encodeCacheValue(v)]),
     } satisfies TaggedMap;
   }
+  // A Date reaches `JSON.stringify` as an ISO string on a fresh run; walked as a
+  // plain object it has no own keys and would come back `{}`. No built-in rule
+  // puts one in `check.details` today, but the field's type permits it.
+  if (value instanceof Date) return { $d: value.getTime() } satisfies TaggedDate;
   const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value)) out[k] = encodeCacheValue(v);
+  for (const [k, v] of Object.entries(value)) setOwn(out, k, encodeCacheValue(v));
   // A plain object whose own keys start with "$" would decode as a tag; wrap it.
   return isTagged(out) ? ({ $e: out } satisfies TaggedEscape) : out;
 }
@@ -409,14 +457,32 @@ export function decodeCacheValue(value: unknown): unknown {
   // without running the tag checks over it again — recursing into
   // decodeCacheValue here would read `{"$u": "text"}` as the undefined tag and
   // return undefined for the whole object.
+  if ("$d" in obj) return new Date(obj.$d as number);
   if ("$e" in obj) return decodePlainObject(obj.$e as Record<string, unknown>);
   return decodePlainObject(obj);
 }
 
 function decodePlainObject(obj: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) out[k] = decodeCacheValue(v);
+  for (const [k, v] of Object.entries(obj)) setOwn(out, k, decodeCacheValue(v));
   return out;
+}
+
+/**
+ * Assign an OWN property, even when the key is `__proto__`.
+ *
+ * `JSON.parse` produces `__proto__` as an ordinary own key, but `out[k] = v`
+ * routes it to the prototype setter and the key vanishes. A rule is free to put
+ * one in `check.details`, and losing it would make the replayed report differ from
+ * the fresh one in a way no round-trip written with `=` can see.
+ */
+function setOwn(target: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
 }
 
 /** Serialize one entry for storage. */

--- a/packages/audit-engine/src/rule-cache.ts
+++ b/packages/audit-engine/src/rule-cache.ts
@@ -1,0 +1,554 @@
+// Per-page rule-result cache (#1990) — what makes a re-audit of an unchanged
+// page cheap.
+//
+// THE PROBLEM. Crawl reuse already skips the fetch: a second audit of an
+// unchanged 2,500-page site fetches nothing (`pagesFetched: 0`) and is 11% faster,
+// all of it crawl. Parse, page rules, the page-time collectors and the report are
+// paid again in full on every page, so the saving is capped at the crawl's share
+// of the run — 9-14% against a local origin. This module removes the rest: a page
+// whose inputs are byte-for-byte what they were last time replays its stored
+// verdicts and is never parsed.
+//
+// WHAT MAKES IT SOUND. Replay asserts that re-running the page rules would
+// produce exactly what is stored, so the key has to cover every input those rules
+// read. There are four groups, and each one is here for a reason:
+//
+//  1. **The page's exact bytes** — `PageRecord.htmlHash`, NOT `contentHash`.
+//     `contentHash` is whitespace-NORMALIZED (`computeNormalizedContentHash`) so
+//     the incremental crawler can call a reformatted page unchanged; two pages
+//     that differ only in whitespace share it and parse to different word counts,
+//     inline-script lengths and `<pre>` text. Keying on it would replay one page's
+//     verdicts onto another's markup. A page with no `htmlHash` never caches.
+//  2. **Everything else on the page record the rules or `extractPageFeatures`
+//     read** — url, final url, status, depth, size, the response + security
+//     headers (`buildHeadersMap`), the redirect chain, the fetcher id (which is
+//     how `rendered` is decided, so the render mode is covered), and the three
+//     timings, because `performance/ttfb` reads `page.ttfb` and
+//     `page.downloadTime`. Timings are why replay pays off on a REUSED page and
+//     not on a re-fetched one: a genuine re-fetch of identical bytes gets new
+//     timings, a different key, and runs its rules again. That is the conservative
+//     answer, and it is the case crawl reuse already avoids.
+//  3. **The page's soft-404 confirmation**, which the site-fetch phase computes
+//     per page (it can hit the network) and threads onto `parsed` before the rules
+//     run.
+//  4. **The run context** — {@link computeRunContextHash}: the engine build (the
+//     CLI's release version, because the `@squirrelscan/rules` package version
+//     never moves), the enabled page rules IN ORDER with their resolved options,
+//     the Stage-0 site metadata, the prefetched cloud results, and the three
+//     `SiteData` fields page rules actually read.
+//
+// WHAT IS GATED OUT RATHER THAN APPROXIMATED. Two run-level inputs cannot be
+// reduced to a hash, so their presence turns the cache OFF for the whole run
+// instead of being ignored:
+//
+//  - **Threat intel** (`ctx.intel`). `IntelContext` is `lookupUrl` +
+//    `matchSignatures` over feeds that refresh daily behind a memoized handle.
+//    Its `providers` + `signatureCount` are an identity of the CONFIGURATION, not
+//    of the verdicts, so a feed that changed overnight would replay yesterday's
+//    answer under an unchanged key. There is no cheap exact identity available, so
+//    an intel-enabled run does not replay.
+//  - **A `SiteData` field no page rule reads today.** The three that ARE read
+//    (`baseUrl`, `scripts`, `resourceSizes`) are hashed, and within the last two
+//    only the ENTRY fields rules read — see {@link PAGE_RULE_SCRIPT_FIELDS} and
+//    {@link PAGE_RULE_RESOURCE_FIELDS}. Hashing whole entries looked safer and was
+//    not: `cacheReason` is null on a cold run and set on a warm one, so it made
+//    the run context differ between exactly the two runs meant to match, and the
+//    cache silently returned nothing. `pages` is excluded outright, because it
+//    holds every page's scalars and hashing it would make any single page's change
+//    invalidate the whole site — precisely the case this feature exists for.
+//    All of that is a claim about the rule set, so it is a DECLARATION with a
+//    falsifier: `page-rule-site-context.test.ts` hands the page-rule pass a proxied
+//    `SiteData`, down to the individual script and resource entries, and fails on
+//    any read outside the declared sets.
+//
+// TEMPLATE FAN-OUT (#1951) COMPOSES, by abstention: a replayed page neither takes
+// a cluster verdict nor becomes a representative, because it did not run the
+// rules. A cluster whose representative replayed simply elects the next fresh
+// member, and #1951's own parity gate is what says the two are the same verdict.
+
+import type { CheckResult, PageFeatureRow, PageRecord } from "@squirrelscan/core-contracts";
+import type { ParsedPage, RuleMeta, SiteData } from "@squirrelscan/rules";
+
+/** Bumped when the payload shape or the key's ingredients change; old rows then miss. */
+export const RULE_CACHE_FORMAT = "prc-1";
+
+/**
+ * The `SiteData` keys page-scope rules read, and therefore the only ones the run
+ * context hashes.
+ *
+ * Derived by inspection (`content/dev-leakage` reads `baseUrl`;
+ * `integrity/kit-signature`, `performance/js-libraries`, `performance/source-maps`
+ * and `performance/unminified-js` read `scripts`; `performance/unminified-css`
+ * reads `resourceSizes`) and held there by `page-rule-site-context.test.ts`, which
+ * fails on any other key being read. Widening this list is safe; forgetting to
+ * widen it when a rule starts reading another field is what the test exists to
+ * catch, because the cost of that mistake is a stale verdict, not a crash.
+ */
+export const PAGE_RULE_SITE_FIELDS = ["baseUrl", "scripts", "resourceSizes"] as const;
+
+/**
+ * The fields of a `ctx.site.scripts` entry page rules read.
+ *
+ * The rest of `ScriptContentData` is not hashed, and one of them is why this list
+ * exists rather than hashing the whole entry: `contentEncoding` is documented as
+ * `undefined` on a content-store cache hit, so it says how THIS run obtained the
+ * script, not what the script is. Hashing it would move the key on the second
+ * audit of an unchanged site and hand back zero reuse — the exact failure this
+ * feature exists to fix, arriving silently as "the cache does nothing".
+ */
+export const PAGE_RULE_SCRIPT_FIELDS = [
+  "url",
+  "finalUrl",
+  "sizeBytes",
+  "content",
+  "sourceMapHeader",
+  "sourcePages",
+] as const;
+
+/**
+ * The fields of a `ctx.site.resourceSizes` entry page rules read
+ * (`performance/unminified-css` reads url + size; nothing page-scoped reads more).
+ *
+ * `cacheReason` is the field that forced this: "cache-hit reason if reused from a
+ * prior crawl; null on a real fetch". It is null on every cold run and set on
+ * every warm one, so hashing the whole entry made the run context differ between
+ * exactly the two runs that are supposed to match.
+ */
+export const PAGE_RULE_RESOURCE_FIELDS = ["url", "sizeBytes"] as const;
+
+/** Keep only `fields`, in a fixed order, from each entry of `entries`. */
+function projectEntries(
+  entries: unknown,
+  fields: readonly string[]
+): Array<Array<unknown>> | null {
+  if (!Array.isArray(entries)) return null;
+  return entries.map((entry) => {
+    const record = (entry ?? {}) as Record<string, unknown>;
+    return fields.map((field) => record[field]);
+  });
+}
+
+/**
+ * The site context a page rule can see, reduced to what it can actually READ.
+ *
+ * Array ORDER is preserved rather than sorted: a rule iterates these arrays, so
+ * order is potentially observable in its output. If it ever churned between runs
+ * the key would churn with it and the run would lose its reuse — conservative,
+ * and never a stale verdict.
+ */
+export function pageRuleSiteContext(siteData: SiteData): Record<string, unknown> {
+  const resourceSizes = siteData.resourceSizes;
+  return {
+    baseUrl: siteData.baseUrl,
+    scripts: projectEntries(siteData.scripts, PAGE_RULE_SCRIPT_FIELDS),
+    resourceSizes: resourceSizes
+      ? {
+          css: projectEntries(resourceSizes.css, PAGE_RULE_RESOURCE_FIELDS),
+          images: projectEntries(resourceSizes.images, PAGE_RULE_RESOURCE_FIELDS),
+        }
+      : null,
+  };
+}
+
+/** One page's cached rules-phase output, exactly as the streamed loop produced it. */
+export interface PageRuleCacheEntry {
+  /**
+   * `[ruleId, checks]` in the order the runner emitted them, which is enabled-rule
+   * order. The flat `pageResults` list is the concatenation, so it is rebuilt
+   * rather than stored twice. `RuleRunResult.meta` is per-RULE and comes from the
+   * live registry, never from the cache — a stale `meta` would be a different bug.
+   */
+  readonly ruleResults: ReadonlyArray<readonly [string, CheckResult[]]>;
+  /** What `extractPageFeatures` returned, replayed via `upsertPageFeatures`. */
+  readonly features: PageFeatureRow;
+  /** Per-collector snapshot: collector id -> whatever its `collect` returned. */
+  readonly signals: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Why a run is not replaying anything, when a cache WAS available.
+ *
+ * These two are the engine's; a caller may report its own reason (the CLI reports
+ * `refresh-requested` and `disabled-by-env`), which is why the report field is a
+ * plain string rather than this union.
+ */
+export type RuleCacheDisabledReason = "threat-intel-enabled" | "unhashable-run-context";
+
+// ============================================
+// HASHING
+// ============================================
+
+/**
+ * SHA-256 of a string, hex. `crypto.subtle` rather than `node:crypto` because
+ * this package is deliberately Worker-clean — it has no `node:` imports and the
+ * cloud audit path bundles it.
+ */
+export async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const view = new Uint8Array(digest);
+  let out = "";
+  for (const byte of view) out += byte.toString(16).padStart(2, "0");
+  return out;
+}
+
+/**
+ * Deterministic JSON for hashing: object keys sorted, `undefined` distinguished
+ * from absent, `Map`/`Set` given an explicit form, and anything that is not plain
+ * data (a function, a symbol, a class instance, a cycle) THROWN on rather than
+ * silently serialized to `{}`.
+ *
+ * Throwing is the whole point. A run context that quietly hashed a live handle to
+ * `{}` would give two genuinely different runs the same key and replay the wrong
+ * verdicts; the callers turn a throw into "no cache this run", which costs time
+ * and never correctness.
+ */
+export function canonicalJson(value: unknown, seen: Set<unknown> = new Set()): string {
+  if (value === undefined) return "u";
+  if (value === null) return "null";
+  const t = typeof value;
+  if (t === "number") return Number.isFinite(value as number) ? JSON.stringify(value) : "nf";
+  if (t === "string" || t === "boolean") return JSON.stringify(value);
+  if (t === "bigint") return `bi:${(value as bigint).toString()}`;
+  if (t === "function" || t === "symbol") {
+    throw new TypeError(`canonicalJson: cannot hash a ${t}`);
+  }
+  if (seen.has(value)) throw new TypeError("canonicalJson: cycle");
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return `[${value.map((v) => canonicalJson(v, seen)).join(",")}]`;
+    }
+    if (value instanceof Set) {
+      // Insertion order preserved: it is observable through iteration, so two Sets
+      // holding the same members in a different order are not interchangeable.
+      return `S[${[...value].map((v) => canonicalJson(v, seen)).join(",")}]`;
+    }
+    if (value instanceof Map) {
+      return `M[${[...value].map(([k, v]) => `${canonicalJson(k, seen)}:${canonicalJson(v, seen)}`).join(",")}]`;
+    }
+    if (value instanceof Date) return `D:${value.getTime()}`;
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) {
+      throw new TypeError(`canonicalJson: not plain data (${proto?.constructor?.name ?? "?"})`);
+    }
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const body = keys
+      .map((k) => `${JSON.stringify(k)}:${canonicalJson((value as Record<string, unknown>)[k], seen)}`)
+      .join(",");
+    return `{${body}}`;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+// ============================================
+// KEYS
+// ============================================
+
+/** Everything outside a single page that a page rule's verdict can depend on. */
+export interface RunContextInput {
+  /**
+   * The build the rules came from. It must change whenever any rule's CODE can
+   * have changed, which the `@squirrelscan/rules` package version does not: it has
+   * sat at 0.0.1 since the repo began and is never bumped, so keying on it would
+   * happily replay pre-upgrade verdicts after a `squirrel self update`. The CLI
+   * passes its release version, which is what actually moves.
+   */
+  readonly engineVersion: string;
+  /** The enabled PAGE rules, in execution order, with their resolved options. */
+  readonly pageRules: ReadonlyArray<{ id: string; options: unknown }>;
+  /** The site data handed to page rules; only {@link PAGE_RULE_SITE_FIELDS} is read. */
+  readonly siteData: SiteData;
+  /** `RunnerScope.siteMetadata` — drives `appliesWhen` gating and `ctx.siteMetadata`. */
+  readonly siteMetadata: unknown;
+  /** `RunnerScope.cloudResults` — plain `Map<service, Map<key, envelope>>`. */
+  readonly cloudResults: unknown;
+}
+
+/**
+ * One hash standing for every non-page input, or a reason the run cannot cache.
+ *
+ * `pages` is excluded from the site-data projection on purpose; see the header.
+ */
+export async function computeRunContextHash(
+  input: RunContextInput
+): Promise<{ hash: string } | { disabled: RuleCacheDisabledReason }> {
+  try {
+    const projection = pageRuleSiteContext(input.siteData);
+    const canonical = canonicalJson([
+      RULE_CACHE_FORMAT,
+      input.engineVersion,
+      input.pageRules.map((r) => [r.id, r.options]),
+      projection,
+      input.siteMetadata ?? null,
+      input.cloudResults ?? null,
+    ]);
+    // A cache that quietly stops hitting looks exactly like a cache that is
+    // working, so the one question worth answering cheaply is "which ingredient
+    // moved?". `SQUIRREL_RULE_CACHE_DEBUG=1` prints a digest per ingredient; run
+    // two audits and compare. It found the defect this projection exists for —
+    // `cacheReason`, null on a cold run and set on a warm one, was moving the
+    // whole run context and every page was missing.
+    if (process.env.SQUIRREL_RULE_CACHE_DEBUG === "1") {
+      const parts: Array<[string, unknown]> = [
+        ["engineVersion", input.engineVersion],
+        ["pageRules", input.pageRules.map((r) => [r.id, r.options])],
+        ["baseUrl", projection.baseUrl],
+        ["scripts", projection.scripts],
+        ["resourceSizes", projection.resourceSizes],
+        ["siteMetadata", input.siteMetadata ?? null],
+        ["cloudResults", input.cloudResults ?? null],
+      ];
+      for (const [name, value] of parts) {
+        const digest = (await sha256Hex(canonicalJson(value))).slice(0, 16);
+        console.error(`[rule-cache] run-context ${name} = ${digest}`);
+      }
+    }
+    return { hash: await sha256Hex(canonical) };
+  } catch {
+    return { disabled: "unhashable-run-context" };
+  }
+}
+
+/**
+ * The cache key for one page under a run context, or null when the page cannot
+ * participate (no exact HTML hash — see {@link PageRecord.htmlHash}).
+ *
+ * The page's own url is one of the hashed inputs, so the key identifies an entry
+ * on its own: two different urls serving identical bytes get different keys, and a
+ * replay can never attribute one page's findings to another.
+ */
+export async function computePageCacheKey(
+  runContextHash: string,
+  page: PageRecord,
+  soft404Confirmation: ParsedPage["soft404Confirmation"] | undefined
+): Promise<string | null> {
+  if (!page.htmlHash) return null;
+  const canonical = canonicalJson([
+    RULE_CACHE_FORMAT,
+    runContextHash,
+    page.htmlHash,
+    page.url,
+    page.normalizedUrl,
+    page.finalUrl,
+    page.depth,
+    page.status,
+    page.contentType,
+    page.sizeBytes,
+    page.loadTimeMs,
+    page.ttfb ?? null,
+    page.downloadTime ?? null,
+    page.headers,
+    page.securityHeaders,
+    page.redirectChain ?? null,
+    page.fetcherId ?? null,
+    soft404Confirmation ?? null,
+  ]);
+  return sha256Hex(canonical);
+}
+
+// ============================================
+// PAYLOAD CODEC
+// ============================================
+//
+// JSON cannot round-trip the payload as-is: `PageFingerprint` (inside the
+// collected page signal) holds four `Set<string>`, and `JSON.stringify` turns a
+// Set into `{}`. Tagging is generic rather than a hand-written per-field codec so
+// a Set added to any of these shapes later keeps working instead of silently
+// decoding as an empty object — the failure mode a bespoke codec would have.
+
+interface TaggedSet {
+  $s: unknown[];
+}
+interface TaggedMap {
+  $m: Array<[unknown, unknown]>;
+}
+interface TaggedUndefined {
+  $u: 1;
+}
+interface TaggedEscape {
+  $e: Record<string, unknown>;
+}
+
+function isTagged(value: object): boolean {
+  for (const key of Object.keys(value)) if (key.startsWith("$")) return true;
+  return false;
+}
+
+/** Encode a data graph to something `JSON.stringify` round-trips exactly. */
+export function encodeCacheValue(value: unknown): unknown {
+  if (value === undefined) return { $u: 1 } satisfies TaggedUndefined;
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(encodeCacheValue);
+  if (value instanceof Set) return { $s: [...value].map(encodeCacheValue) } satisfies TaggedSet;
+  if (value instanceof Map) {
+    return {
+      $m: [...value].map(([k, v]) => [encodeCacheValue(k), encodeCacheValue(v)]),
+    } satisfies TaggedMap;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value)) out[k] = encodeCacheValue(v);
+  // A plain object whose own keys start with "$" would decode as a tag; wrap it.
+  return isTagged(out) ? ({ $e: out } satisfies TaggedEscape) : out;
+}
+
+/** Inverse of {@link encodeCacheValue}. */
+export function decodeCacheValue(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(decodeCacheValue);
+  const obj = value as Record<string, unknown>;
+  if ("$u" in obj) return undefined;
+  if ("$s" in obj) return new Set((obj.$s as unknown[]).map(decodeCacheValue));
+  if ("$m" in obj) {
+    return new Map(
+      (obj.$m as Array<[unknown, unknown]>).map(([k, v]) => [decodeCacheValue(k), decodeCacheValue(v)])
+    );
+  }
+  // An escaped object's OWN keys start with "$", so its values must be decoded
+  // without running the tag checks over it again — recursing into
+  // decodeCacheValue here would read `{"$u": "text"}` as the undefined tag and
+  // return undefined for the whole object.
+  if ("$e" in obj) return decodePlainObject(obj.$e as Record<string, unknown>);
+  return decodePlainObject(obj);
+}
+
+function decodePlainObject(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) out[k] = decodeCacheValue(v);
+  return out;
+}
+
+/** Serialize one entry for storage. */
+export function encodePageRuleCacheEntry(entry: PageRuleCacheEntry): string {
+  return JSON.stringify(encodeCacheValue(entry));
+}
+
+/** Parse one stored entry, or null when it cannot be read (treated as a miss). */
+export function decodePageRuleCacheEntry(payload: string): PageRuleCacheEntry | null {
+  try {
+    const decoded = decodeCacheValue(JSON.parse(payload)) as PageRuleCacheEntry;
+    if (!decoded || !Array.isArray(decoded.ruleResults) || !decoded.features) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================
+// THE STREAM'S VIEW OF THE CACHE
+// ============================================
+
+/**
+ * The persistence half of the cache, in the terms a store can actually speak:
+ * opaque keys and encoded payloads, no page records and no rule types.
+ *
+ * `runStreamingRules` owns the key derivation (it is the only place that holds
+ * the run context) and wraps a store into the {@link StreamRuleCache} the stream
+ * consumes. The CLI supplies a `project.db`-backed store; the cloud supplies
+ * none; tests supply a Map.
+ */
+export interface RuleCacheStore {
+  /** Stored payloads for whichever of `keys` exist. */
+  load(keys: readonly string[]): Promise<ReadonlyMap<string, string>>;
+  /** Record a freshly-produced payload for this crawl. */
+  putFresh(key: string, normalizedUrl: string, payload: string): void;
+  /** Copy an existing entry into this crawl WITHOUT re-encoding it. */
+  carryForward(key: string, normalizedUrl: string): void;
+  /** Called per page batch and at the end; buffered writes land here. */
+  flush?(): Promise<void>;
+}
+
+/**
+ * What {@link streamPageRules} needs of a cache. Kept to four methods so the
+ * engine stays storage-free: the CLI supplies an implementation backed by
+ * `project.db`, the cloud supplies none, and the tests supply an in-memory one.
+ */
+export interface StreamRuleCache {
+  /** Key for this page, or null if it cannot participate. */
+  keyFor(
+    page: PageRecord,
+    soft404Confirmation: ParsedPage["soft404Confirmation"] | undefined
+  ): Promise<string | null>;
+  /** Entries for whichever of `keys` are cached. */
+  load(keys: readonly string[]): Promise<ReadonlyMap<string, PageRuleCacheEntry>>;
+  /** Persist what a freshly-run page produced, under this crawl. */
+  putFresh(key: string, page: PageRecord, entry: PageRuleCacheEntry): void;
+  /**
+   * Carry a REPLAYED page's existing entry forward into this crawl.
+   *
+   * Split from {@link StreamRuleCache.putFresh} because it must not cost what a
+   * fresh write costs: the stored bytes are already exactly right, so an
+   * implementation copies the row and never re-encodes or re-compresses. Without
+   * the carry-forward, `retireCrawls` deleting the crawl the entry came from would
+   * make the audit after it cold again.
+   */
+  carryForward(key: string, page: PageRecord): void;
+  /**
+   * Called at every page-batch boundary and once at the end, so an implementation
+   * that buffers writes never holds more than one batch of them.
+   */
+  flush?(): Promise<void>;
+}
+
+/** What the pass did with the cache, for the report and the benchmarks. */
+export interface RuleCacheStats {
+  /** Pages whose rules ran fresh (cache off, miss, or not cacheable). */
+  freshPages: number;
+  /** Pages that skipped parse + page rules and replayed stored verdicts. */
+  replayedPages: number;
+  /** Entries written for this crawl (fresh + replayed carried forward). */
+  storedEntries: number;
+  /** Set when the run is not replaying at all. */
+  disabledReason?: RuleCacheDisabledReason;
+}
+
+/** The stats a run with no cache reports. */
+export function emptyRuleCacheStats(disabledReason?: RuleCacheDisabledReason): RuleCacheStats {
+  return { freshPages: 0, replayedPages: 0, storedEntries: 0, ...(disabledReason ? { disabledReason } : {}) };
+}
+
+/**
+ * Bind a {@link RuleCacheStore} to a run context, producing the cache the stream
+ * consumes: keys derived here, payloads encoded and decoded here, storage left to
+ * speak only in keys and strings.
+ *
+ * A payload that will not decode is treated as a MISS, not an error — a
+ * half-written or older-format row costs a page's rules and never a wrong report.
+ */
+export function bindRuleCache(store: RuleCacheStore, runContextHash: string): StreamRuleCache {
+  return {
+    keyFor: (page, soft404Confirmation) =>
+      computePageCacheKey(runContextHash, page, soft404Confirmation),
+    async load(keys) {
+      const raw = await store.load(keys);
+      const out = new Map<string, PageRuleCacheEntry>();
+      for (const [key, payload] of raw) {
+        const entry = decodePageRuleCacheEntry(payload);
+        if (entry) out.set(key, entry);
+      }
+      return out;
+    },
+    putFresh(key, page, entry) {
+      store.putFresh(key, page.normalizedUrl, encodePageRuleCacheEntry(entry));
+    },
+    carryForward(key, page) {
+      store.carryForward(key, page.normalizedUrl);
+    },
+    flush: store.flush ? () => store.flush!() : undefined,
+  };
+}
+
+/**
+ * The page rules of a runner, in execution order, with their resolved options —
+ * the run-context ingredient that makes a rule added, removed, reordered,
+ * disabled or reconfigured invalidate every entry.
+ */
+export function pageRuleSelection(
+  rules: ReadonlyArray<{ meta: RuleMeta }>,
+  optionsOf: (rule: { meta: RuleMeta }) => unknown
+): Array<{ id: string; options: unknown }> {
+  return rules
+    .filter((r) => r.meta.scope === "page")
+    .map((r) => ({ id: r.meta.id, options: optionsOf(r) }));
+}

--- a/packages/audit-engine/src/rule-cache.ts
+++ b/packages/audit-engine/src/rule-cache.ts
@@ -210,7 +210,11 @@ export function canonicalJson(value: unknown, seen: Set<unknown> = new Set()): s
   if (t === "number") {
     // Distinct forms, not one "not finite" bucket: NaN, Infinity and -Infinity are
     // three different rule-option values and must not share a key.
-    if (Number.isFinite(value as number)) return JSON.stringify(value);
+    // `Object.is` distinguishes -0 from 0 and `JSON.stringify` does not, so the
+    // sign is spelled out rather than lost.
+    if (Number.isFinite(value as number)) {
+      return Object.is(value, -0) ? "-0" : JSON.stringify(value);
+    }
     return Number.isNaN(value as number) ? "nan" : (value as number) > 0 ? "inf" : "-inf";
   }
   if (t === "string" || t === "boolean") return JSON.stringify(value);
@@ -222,11 +226,13 @@ export function canonicalJson(value: unknown, seen: Set<unknown> = new Set()): s
   seen.add(value);
   try {
     if (Array.isArray(value)) {
-      // LENGTH-prefixed, and holes read as `undefined` rather than as nothing:
-      // `.map` skips holes, so `new Array(1)` and `[]` would otherwise both
-      // canonicalize to the same string.
+      // LENGTH-prefixed, and a HOLE is its own token: `.map` skips holes, so
+      // `new Array(1)` and `[]` would otherwise canonicalize the same, and a hole
+      // is observable (`0 in arr`) so it is not `undefined` either.
       const items: string[] = [];
-      for (let i = 0; i < value.length; i++) items.push(canonicalJson(value[i], seen));
+      for (let i = 0; i < value.length; i++) {
+        items.push(i in value ? canonicalJson(value[i], seen) : "h");
+      }
       return `[${value.length}|${items.join(",")}]`;
     }
     if (value instanceof Set) {
@@ -287,6 +293,13 @@ export interface RunContextInput {
    * granularity the cache has to invalidate on: a pass cached on 31 December must
    * not replay on 1 January. Year and not day, because a day would make every
    * re-audit after midnight cold for nothing.
+   *
+   * It is resolved once, before the pages run, so an audit that STRADDLES midnight
+   * on 31 December stores the new year's verdicts under the old year's key. Those
+   * rows are then unreachable — the next audit resolves the new year and misses
+   * every one of them — so the cost is one run's writes, once a year, and never a
+   * stale verdict served. The straddle itself is not new: a fresh audit crossing
+   * midnight already gives its earlier and later pages different verdicts.
    */
   readonly utcYear: number;
 }
@@ -412,7 +425,7 @@ interface TaggedEscape {
   $e: Record<string, unknown>;
 }
 interface TaggedDate {
-  $d: number;
+  $d: number | null;
 }
 
 function isTagged(value: object): boolean {
@@ -434,7 +447,12 @@ export function encodeCacheValue(value: unknown): unknown {
   // A Date reaches `JSON.stringify` as an ISO string on a fresh run; walked as a
   // plain object it has no own keys and would come back `{}`. No built-in rule
   // puts one in `check.details` today, but the field's type permits it.
-  if (value instanceof Date) return { $d: value.getTime() } satisfies TaggedDate;
+  // An INVALID date serializes to `null` through `JSON.stringify`, so `$d` carries
+  // null for it rather than a NaN that decodes to the epoch.
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return { $d: Number.isNaN(time) ? null : time } satisfies TaggedDate;
+  }
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value)) setOwn(out, k, encodeCacheValue(v));
   // A plain object whose own keys start with "$" would decode as a tag; wrap it.
@@ -457,7 +475,7 @@ export function decodeCacheValue(value: unknown): unknown {
   // without running the tag checks over it again — recursing into
   // decodeCacheValue here would read `{"$u": "text"}` as the undefined tag and
   // return undefined for the whole object.
-  if ("$d" in obj) return new Date(obj.$d as number);
+  if ("$d" in obj) return obj.$d === null ? new Date(NaN) : new Date(obj.$d as number);
   if ("$e" in obj) return decodePlainObject(obj.$e as Record<string, unknown>);
   return decodePlainObject(obj);
 }

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -229,11 +229,6 @@ export function streamPageRules(
     const heartbeatEvery = Math.max(1, opts?.pageLoopHooks?.heartbeatEveryPages ?? 1);
     const onLoopProgress = opts?.pageLoopHooks?.onProgress;
     let lastYieldAt = Date.now();
-    // #1951. Built per pass, so its cache and its counters belong to this run.
-    const fanout =
-      (opts?.templateFanout ?? templateFanoutEnabled())
-        ? createTemplateFanout(runner, { maxClusters: opts?.templateFanoutMaxClusters })
-        : null;
 
     // #1990. A cache is only usable if EVERY registered collector can replay: a
     // page that skipped its parse cannot re-run one that has no `replay`, and
@@ -243,6 +238,30 @@ export function streamPageRules(
         ? opts.ruleCache
         : undefined;
     const ruleCacheStats = emptyRuleCacheStats();
+
+    // TEMPLATE FAN-OUT AND THE RULE CACHE ARE MUTUALLY EXCLUSIVE, and the cache
+    // wins (#1990 x #1951). They are two ways of not running a rule, and they do
+    // not compose:
+    //
+    // A fanned verdict is a property of the page's CLUSTER, not of the page, so no
+    // per-page key can capture what it depends on. Cache A and B of one cluster,
+    // then change A — the cluster's representative. A is fresh and records its new
+    // verdict; B replays the OLD verdict it inherited from A's previous run, and a
+    // fully-replayed audit after that reports B's stale value forever. A fresh
+    // audit of the same content gives B the new one. Keying B on its own inputs
+    // cannot see this, because nothing about B changed.
+    //
+    // Fixing it properly means caching the CLUSTER's verdict against its
+    // representative's identity, which is a whole-crawl property the streamed loop
+    // resolves as it goes. That is a design, not a patch.
+    //
+    // The trade this makes: a COLD audit gives up fan-out's 13% of the page-rule
+    // pass; every audit after it takes the cache's ~88%. `SQUIRREL_RULE_CACHE=0`
+    // gets fan-out back, and the cloud is unaffected — it passes no cache.
+    const fanout =
+      !ruleCache && (opts?.templateFanout ?? templateFanoutEnabled())
+        ? createTemplateFanout(runner, { maxClusters: opts?.templateFanoutMaxClusters })
+        : null;
 
     const pageResults = new Map<string, CheckResultLike[]>();
     const pageRuleResults = new Map<string, Map<string, CheckResultLike[]>>();
@@ -327,7 +346,6 @@ export function streamPageRules(
             crawlId,
             storage,
             collectors,
-            fanout,
             pageResults,
             pageRuleResults,
             ruleResultsMap,
@@ -502,9 +520,7 @@ export function streamPageRules(
           // adds no residency — the implementation is what decides when to
           // serialize them.
           ruleCache.putFresh(cacheKey, page, {
-            ruleResults: [...result.ruleResults].map(
-              ([ruleId, rr]) => [ruleId, stripOwnPageUrl(rr.checks, pageUrl)] as const,
-            ),
+            ruleResults: [...result.ruleResults].map(([ruleId, rr]) => [ruleId, rr.checks] as const),
             features,
             signals,
           });
@@ -582,25 +598,6 @@ export function streamPageRules(
 }
 
 /**
- * A page's checks with its OWN `pageUrl` stamp removed, for storage (#1990).
- *
- * The loop stamps `pageUrl` only where a rule left it unset, so a rule that set
- * its own — pointing at a DIFFERENT page — must keep it. Stripping only the value
- * equal to this page's url preserves that distinction exactly, and it is what lets
- * a replayed page be recorded as a template-cluster representative: what the
- * fan-out caches has to be page-identity-free, exactly as on the fresh path.
- *
- * Returns new check objects; the run's own copies keep their stamp.
- */
-function stripOwnPageUrl(checks: readonly CheckResultLike[], pageUrl: string): CheckResultLike[] {
-  return checks.map((check) => {
-    if (check.pageUrl !== pageUrl) return check;
-    const { pageUrl: _own, ...rest } = check;
-    return rest as CheckResultLike;
-  });
-}
-
-/**
  * Put one page's CACHED rules-phase output back into the stream, in the place the
  * fresh path would have filled (#1990).
  *
@@ -626,7 +623,6 @@ function replayPage(
   crawlId: string,
   storage: SQLiteStorage,
   collectors: readonly PageSignalCollector[],
-  fanout: ReturnType<typeof createTemplateFanout> | null,
   pageResults: Map<string, CheckResultLike[]>,
   pageRuleResults: Map<string, Map<string, CheckResultLike[]>>,
   ruleResultsMap: Map<string, RuleRunResult>,
@@ -636,27 +632,12 @@ function replayPage(
   return Effect.gen(function* () {
     const pageUrl = page.normalizedUrl;
 
-    // Assemble the per-rule results FIRST, still page-identity-free (the stored
-    // checks have this page's own `pageUrl` stripped), so the fan-out sees exactly
-    // what the fresh path hands it.
+    // `meta` comes from the LIVE registry, never from the cache.
     const byRule = new Map<string, RuleRunResult>();
     for (const [ruleId, checks] of entry.ruleResults) {
       const meta = runner.getRuleMeta(ruleId);
       if (meta) byRule.set(ruleId, { meta, checks });
     }
-
-    // A REPLAYED page must be able to represent its cluster (#1990 x #1951).
-    // Otherwise which page runs a template-scoped rule depends on what happens to
-    // be cached, and a fully-replayed audit can differ from a fresh one on a
-    // cluster whose first member replayed: the fresh audit fans the first page's
-    // verdict onto the rest, the replaying one lets the second page compute its
-    // own. Recording here restores the fresh audit's election exactly, because the
-    // cluster key comes from the STORED `page_features.template_fp` — the same key
-    // this page's live fingerprint produced when it ran.
-    const clusterKey = fanout
-      ? fanoutClusterKey(entry.features.templateFp, pageUrl)
-      : null;
-    fanout?.record(clusterKey, byRule);
 
     const flat: CheckResultLike[] = [];
     const ruleChecksForPage = new Map<string, CheckResultLike[]>();

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -327,6 +327,7 @@ export function streamPageRules(
             crawlId,
             storage,
             collectors,
+            fanout,
             pageResults,
             pageRuleResults,
             ruleResultsMap,
@@ -501,7 +502,9 @@ export function streamPageRules(
           // adds no residency — the implementation is what decides when to
           // serialize them.
           ruleCache.putFresh(cacheKey, page, {
-            ruleResults: [...result.ruleResults].map(([ruleId, rr]) => [ruleId, rr.checks] as const),
+            ruleResults: [...result.ruleResults].map(
+              ([ruleId, rr]) => [ruleId, stripOwnPageUrl(rr.checks, pageUrl)] as const,
+            ),
             features,
             signals,
           });
@@ -579,6 +582,25 @@ export function streamPageRules(
 }
 
 /**
+ * A page's checks with its OWN `pageUrl` stamp removed, for storage (#1990).
+ *
+ * The loop stamps `pageUrl` only where a rule left it unset, so a rule that set
+ * its own — pointing at a DIFFERENT page — must keep it. Stripping only the value
+ * equal to this page's url preserves that distinction exactly, and it is what lets
+ * a replayed page be recorded as a template-cluster representative: what the
+ * fan-out caches has to be page-identity-free, exactly as on the fresh path.
+ *
+ * Returns new check objects; the run's own copies keep their stamp.
+ */
+function stripOwnPageUrl(checks: readonly CheckResultLike[], pageUrl: string): CheckResultLike[] {
+  return checks.map((check) => {
+    if (check.pageUrl !== pageUrl) return check;
+    const { pageUrl: _own, ...rest } = check;
+    return rest as CheckResultLike;
+  });
+}
+
+/**
  * Put one page's CACHED rules-phase output back into the stream, in the place the
  * fresh path would have filled (#1990).
  *
@@ -604,6 +626,7 @@ function replayPage(
   crawlId: string,
   storage: SQLiteStorage,
   collectors: readonly PageSignalCollector[],
+  fanout: ReturnType<typeof createTemplateFanout> | null,
   pageResults: Map<string, CheckResultLike[]>,
   pageRuleResults: Map<string, Map<string, CheckResultLike[]>>,
   ruleResultsMap: Map<string, RuleRunResult>,
@@ -612,6 +635,29 @@ function replayPage(
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
     const pageUrl = page.normalizedUrl;
+
+    // Assemble the per-rule results FIRST, still page-identity-free (the stored
+    // checks have this page's own `pageUrl` stripped), so the fan-out sees exactly
+    // what the fresh path hands it.
+    const byRule = new Map<string, RuleRunResult>();
+    for (const [ruleId, checks] of entry.ruleResults) {
+      const meta = runner.getRuleMeta(ruleId);
+      if (meta) byRule.set(ruleId, { meta, checks });
+    }
+
+    // A REPLAYED page must be able to represent its cluster (#1990 x #1951).
+    // Otherwise which page runs a template-scoped rule depends on what happens to
+    // be cached, and a fully-replayed audit can differ from a fresh one on a
+    // cluster whose first member replayed: the fresh audit fans the first page's
+    // verdict onto the rest, the replaying one lets the second page compute its
+    // own. Recording here restores the fresh audit's election exactly, because the
+    // cluster key comes from the STORED `page_features.template_fp` — the same key
+    // this page's live fingerprint produced when it ran.
+    const clusterKey = fanout
+      ? fanoutClusterKey(entry.features.templateFp, pageUrl)
+      : null;
+    fanout?.record(clusterKey, byRule);
+
     const flat: CheckResultLike[] = [];
     const ruleChecksForPage = new Map<string, CheckResultLike[]>();
     for (const [ruleId, checks] of entry.ruleResults) {
@@ -623,10 +669,7 @@ function replayPage(
     }
     pageResults.set(pageUrl, flat);
     pageRuleResults.set(pageUrl, ruleChecksForPage);
-    for (const [ruleId, checks] of entry.ruleResults) {
-      const meta = runner.getRuleMeta(ruleId);
-      if (!meta) continue;
-      const rr: RuleRunResult = { meta, checks };
+    for (const [ruleId, rr] of byRule) {
       mergeRuleRunResult(ruleResultsMap, ruleId, rr);
       foldRuleResultIntoTallies(tallies, ruleId, rr);
     }

--- a/packages/audit-engine/src/streaming.ts
+++ b/packages/audit-engine/src/streaming.ts
@@ -36,6 +36,12 @@ import { collectDroppedBatch } from "./batch-gc";
 import { detachFromPage } from "./detach";
 import { extractPageFeatures, isAuditablePage } from "./page-features";
 import type { PageRuleLoopHooks } from "./page-rule-executor";
+import {
+  emptyRuleCacheStats,
+  type PageRuleCacheEntry,
+  type RuleCacheStats,
+  type StreamRuleCache,
+} from "./rule-cache";
 import { foldRuleResultIntoTallies, type RuleTally } from "./scoring";
 import { templateFingerprintKey } from "./template-key";
 import {
@@ -75,7 +81,21 @@ export interface SharedPageSignals {
  */
 export interface PageSignalCollector {
   readonly id: string;
-  collect(page: PageRecord, parsed: ParsedPage, shared: SharedPageSignals): void;
+  /**
+   * Returns the value this page contributed, so the rule-result cache (#1990) can
+   * store it and {@link PageSignalCollector.replay} can re-contribute it on a
+   * later run without the DOM. Return `undefined` to say "not cacheable" — a
+   * collector that does blocks replay for every page, which is the safe default
+   * for one whose contribution cannot be reproduced from data alone.
+   */
+  collect(page: PageRecord, parsed: ParsedPage, shared: SharedPageSignals): unknown;
+  /**
+   * Re-contribute a snapshot a previous run's `collect` returned, at the same
+   * point in the stream, so the collected order is the crawl order either way.
+   * Absent => this collector cannot replay, and no page is replayed while it is
+   * registered.
+   */
+  replay?(page: PageRecord, snapshot: unknown): void;
 }
 
 export interface StreamPageRulesHooks {
@@ -115,6 +135,13 @@ export interface StreamPageRulesResult {
    * output it produced by running everything anyway.
    */
   templateFanout: TemplateFanoutStats;
+  /**
+   * What the per-page rule-result cache did (#1990). All zeros when no cache was
+   * supplied. `replayedPages` is the number of pages that were never parsed and
+   * whose rules never ran — the measure that distinguishes a working cache from
+   * one whose byte-identical output it produced by running everything anyway.
+   */
+  ruleCache: RuleCacheStats;
 }
 
 // Re-used shape; avoids pulling the CheckResult symbol name-collision into scope.
@@ -181,6 +208,14 @@ export function streamPageRules(
     templateFanout?: boolean;
     /** Test/bench seam: cap the cached clusters (see DEFAULT_MAX_CLUSTERS). */
     templateFanoutMaxClusters?: number;
+    /**
+     * Per-page rule-result cache (#1990). Supplied → a page whose key matches a
+     * stored entry is NOT parsed and its rules do NOT run; its stored verdicts,
+     * `page_features` row and collector signals are replayed in its place, and
+     * every page's entry (replayed ones included) is handed back for this crawl to
+     * store. Omitted → every page runs, byte-identically to before.
+     */
+    ruleCache?: StreamRuleCache;
   }
 ): Effect.Effect<StreamPageRulesResult, never, never> {
   return Effect.gen(function* () {
@@ -199,6 +234,15 @@ export function streamPageRules(
       (opts?.templateFanout ?? templateFanoutEnabled())
         ? createTemplateFanout(runner, { maxClusters: opts?.templateFanoutMaxClusters })
         : null;
+
+    // #1990. A cache is only usable if EVERY registered collector can replay: a
+    // page that skipped its parse cannot re-run one that has no `replay`, and
+    // silently dropping its contribution would change the site pass's input.
+    const ruleCache =
+      opts?.ruleCache && collectors.every((c) => typeof c.replay === "function")
+        ? opts.ruleCache
+        : undefined;
+    const ruleCacheStats = emptyRuleCacheStats();
 
     const pageResults = new Map<string, CheckResultLike[]>();
     const pageRuleResults = new Map<string, Map<string, CheckResultLike[]>>();
@@ -221,15 +265,91 @@ export function streamPageRules(
       if (batch.length === 0) break;
 
       const batchStart = Date.now();
-      // Parse the whole batch (≤ batchSize DOMs live at the peak here).
-      const parsedBatch = yield* buildSiteContext(batch);
-      peakLiveDocs = Math.max(peakLiveDocs, parsedBatch.filter((p) => p.parsed?.document).length);
 
-      for (const { page, parsed } of parsedBatch) {
+      // #1990: decide what can be REPLAYED before anything is parsed — that is the
+      // whole saving. Keys are built from the stored page record alone (exact HTML
+      // hash + the fields the rules read + the run context), so resolving them
+      // costs no DOM, and a hit means this batch never materializes one.
+      const replayByUrl = new Map<string, PageRuleCacheEntry>();
+      const keyByUrl = new Map<string, string>();
+      if (ruleCache) {
+        const cache = ruleCache;
+        const keys = yield* Effect.promise(async () => {
+          const wanted: string[] = [];
+          for (const page of batch) {
+            // A page outside the universe never ran rules, so it can have no
+            // entry; skip the key work rather than looking up a certain miss.
+            const inUniverse = universe
+              ? universe.has(page.normalizedUrl)
+              : isAuditablePage(page);
+            if (!inUniverse) continue;
+            const key = await cache.keyFor(page, soft404?.get(page.normalizedUrl));
+            if (key) {
+              keyByUrl.set(page.normalizedUrl, key);
+              wanted.push(key);
+            }
+          }
+          return wanted;
+        });
+        const loaded = yield* Effect.promise(() => cache.load(keys));
+        for (const [url, key] of keyByUrl) {
+          const entry = loaded.get(key);
+          // An entry missing a registered collector's snapshot is a MISS, not a
+          // replay with a hole in it: `replay(page, undefined)` would push an
+          // undefined signal into the site pass's input and change its answer
+          // silently. The engine version in the key already makes this unreachable
+          // today, since the collector set is code — this is what keeps it
+          // unreachable when it stops being.
+          if (!entry) continue;
+          if (collectors.every((c) => c.id in entry.signals)) replayByUrl.set(url, entry);
+        }
+      }
+
+      // Parse only what has to be parsed (≤ batchSize DOMs live at the peak).
+      const toParse =
+        replayByUrl.size === 0 ? batch : batch.filter((p) => !replayByUrl.has(p.normalizedUrl));
+      const parsedBatch = yield* buildSiteContext(toParse);
+      peakLiveDocs = Math.max(peakLiveDocs, parsedBatch.filter((p) => p.parsed?.document).length);
+      const parsedByUrl = new Map(parsedBatch.map((e) => [e.page.normalizedUrl, e.parsed]));
+
+      for (const page of batch) {
         // Per-page interruption checkpoint, matching SerialPageRuleExecutor's.
         // Checking only per batch would let a `rulesPhaseTimeoutMs` breach run a
         // whole batch of heavy pages to completion before it took effect.
         opts?.signal?.throwIfAborted();
+
+        const replayEntry = replayByUrl.get(page.normalizedUrl);
+        if (replayEntry) {
+          yield* replayPage(
+            page,
+            replayEntry,
+            runner,
+            crawlId,
+            storage,
+            collectors,
+            pageResults,
+            pageRuleResults,
+            ruleResultsMap,
+            tallies,
+            pageUrls,
+          );
+          extractedCount++;
+          ruleCacheStats.replayedPages++;
+          ruleCache?.carryForward(keyByUrl.get(page.normalizedUrl)!, page);
+          ruleCacheStats.storedEntries++;
+          pagesDone++;
+          if (onLoopProgress && pagesDone % heartbeatEvery === 0) {
+            onLoopProgress(pagesDone, opts?.totalPages ?? pagesDone);
+          }
+          if (yieldEveryMs != null && yieldEveryMs > 0 && Date.now() - lastYieldAt >= yieldEveryMs) {
+            yield* Effect.promise(() => yieldToEventLoop());
+            lastYieldAt = Date.now();
+            opts?.signal?.throwIfAborted();
+          }
+          continue;
+        }
+
+        const parsed = parsedByUrl.get(page.normalizedUrl);
         if (!parsed) continue; // non-HTML / failed parse — v1 skips these too
         // WAF-challenge pages are excluded from page-level scoring (v1 parity).
         // With a `pageUniverse` that set is v1's own, so WAF *and* rate-limited
@@ -357,11 +477,36 @@ export function streamPageRules(
         // `!isAuditablePage(page)` continue above already guarantees this page is
         // auditable, so no second gate is needed here. `shared` was built before
         // the rules ran (see above); it is the same object either way.
+        const features = extractPageFeatures(page, parsed, shared);
         yield* storage
-          .upsertPageFeatures(crawlId, extractPageFeatures(page, parsed, shared))
+          .upsertPageFeatures(crawlId, features)
           .pipe(Effect.catchAll(() => Effect.void));
         extractedCount++;
-        for (const c of collectors) c.collect(page, parsed, shared);
+        const signals: Record<string, unknown> = {};
+        let signalsCacheable = true;
+        for (const c of collectors) {
+          const snapshot = c.collect(page, parsed, shared);
+          // `undefined` is a collector saying its contribution cannot be
+          // reproduced from data; the page is then scored normally and simply
+          // never cached, rather than cached with a hole in it.
+          if (snapshot === undefined) signalsCacheable = false;
+          else signals[c.id] = snapshot;
+        }
+        ruleCacheStats.freshPages++;
+        const cacheKey = keyByUrl.get(pageUrl);
+        if (ruleCache && cacheKey && signalsCacheable) {
+          // The checks stored are the ones whose `pageUrl` was just stamped, so a
+          // replay's own stamping loop is a no-op and the two paths agree. They
+          // are the SAME objects the run already retains, so recording them here
+          // adds no residency — the implementation is what decides when to
+          // serialize them.
+          ruleCache.putFresh(cacheKey, page, {
+            ruleResults: [...result.ruleResults].map(([ruleId, rr]) => [ruleId, rr.checks] as const),
+            features,
+            signals,
+          });
+          ruleCacheStats.storedEntries++;
+        }
 
         // Drop this page's DOM before moving on — the residency bound.
         parsed.document = null;
@@ -392,6 +537,10 @@ export function streamPageRules(
       // rather than the collector's timing (see batch-gc.ts).
       collectDroppedBatch();
 
+      // Bound what an implementation that buffers cache writes is holding to one
+      // batch of them (#1990).
+      if (ruleCache?.flush) yield* Effect.promise(() => ruleCache.flush!());
+
       batchIndex++;
       opts?.hooks?.onBatch?.({
         batchIndex,
@@ -408,6 +557,7 @@ export function streamPageRules(
     if (onLoopProgress && (pagesDone === 0 || pagesDone % heartbeatEvery !== 0)) {
       onLoopProgress(pagesDone, opts?.totalPages ?? pagesDone);
     }
+    if (ruleCache?.flush) yield* Effect.promise(() => ruleCache.flush!());
 
     return {
       pageResults,
@@ -423,6 +573,68 @@ export function streamPageRules(
         fannedRuleRuns: 0,
         pagesOverCap: 0,
       },
+      ruleCache: ruleCacheStats,
     };
+  });
+}
+
+/**
+ * Put one page's CACHED rules-phase output back into the stream, in the place the
+ * fresh path would have filled (#1990).
+ *
+ * Everything the fresh path contributes has to be contributed here, in the same
+ * order, or the report stops being byte-identical: the flat check list, the
+ * per-rule map, the merged `ruleResultsMap`, the folded tallies, the page url in
+ * `pageUrls`, the `page_features` row and every collector's per-page signal. The
+ * flat list is REBUILT from the per-rule entries rather than stored twice — the
+ * runner produces it by concatenating each rule's checks in enabled-rule order,
+ * and the stored entries are in that order.
+ *
+ * `meta` comes from the LIVE registry, never from the cache: a stored copy could
+ * drift from the running rules package, and the key already guarantees the version
+ * matches. A rule id the runner no longer knows means the entry belongs to a
+ * different rule set than the key claims, so the page is left unscored by the
+ * caller's standards — which cannot happen, because the rule id list is part of
+ * the key.
+ */
+function replayPage(
+  page: PageRecord,
+  entry: PageRuleCacheEntry,
+  runner: RuleRunner,
+  crawlId: string,
+  storage: SQLiteStorage,
+  collectors: readonly PageSignalCollector[],
+  pageResults: Map<string, CheckResultLike[]>,
+  pageRuleResults: Map<string, Map<string, CheckResultLike[]>>,
+  ruleResultsMap: Map<string, RuleRunResult>,
+  tallies: Map<string, RuleTally>,
+  pageUrls: string[],
+): Effect.Effect<void, never, never> {
+  return Effect.gen(function* () {
+    const pageUrl = page.normalizedUrl;
+    const flat: CheckResultLike[] = [];
+    const ruleChecksForPage = new Map<string, CheckResultLike[]>();
+    for (const [ruleId, checks] of entry.ruleResults) {
+      for (const check of checks) {
+        if (!check.pageUrl) check.pageUrl = pageUrl;
+        flat.push(check);
+      }
+      ruleChecksForPage.set(ruleId, checks);
+    }
+    pageResults.set(pageUrl, flat);
+    pageRuleResults.set(pageUrl, ruleChecksForPage);
+    for (const [ruleId, checks] of entry.ruleResults) {
+      const meta = runner.getRuleMeta(ruleId);
+      if (!meta) continue;
+      const rr: RuleRunResult = { meta, checks };
+      mergeRuleRunResult(ruleResultsMap, ruleId, rr);
+      foldRuleResultIntoTallies(tallies, ruleId, rr);
+    }
+    pageUrls.push(pageUrl);
+
+    yield* storage
+      .upsertPageFeatures(crawlId, entry.features)
+      .pipe(Effect.catchAll(() => Effect.void));
+    for (const c of collectors) c.replay!(page, entry.signals[c.id]);
   });
 }

--- a/packages/audit-engine/tests/page-rule-site-context.test.ts
+++ b/packages/audit-engine/tests/page-rule-site-context.test.ts
@@ -1,0 +1,188 @@
+// THE DECLARATION FALSIFIER for the rule-result cache's run context (#1990).
+//
+// The cache hashes only three `SiteData` fields — `baseUrl`, `scripts`,
+// `resourceSizes` — because those are the only ones page-scope rules read. That is
+// a claim about the rule set, and the cost of it being wrong is the worst kind:
+// not a crash, but a stale verdict served under a key that says nothing changed.
+//
+// `pages` is the field that makes this necessary. It is deliberately NOT hashed,
+// because it holds every page's scalars and hashing it would make one page's edit
+// invalidate the whole site — exactly the case the feature exists for. So a page
+// rule that started reading `ctx.site.pages` would silently get cached results
+// computed against a different set of pages.
+//
+// This test runs the REAL page-rule pass over a real crawl with `SiteData` behind a
+// recording proxy and fails if any key outside the declared set is read.
+//
+// What it cannot do: prove a rule never reads another field on an input this
+// fixture does not produce (the lesson of #1860 — a gate only covers the cases its
+// fixtures contain). It covers the default rule surface over a mixed synthetic
+// site, which is the same standard the streaming engine's own golden gates hold.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Effect } from "effect";
+
+import { generateSiteModel, writeCrawlToStorage } from "@squirrelscan/synthetic-site";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import { createRunner, type SiteData } from "@squirrelscan/rules";
+
+import {
+  PAGE_RULE_RESOURCE_FIELDS,
+  PAGE_RULE_SCRIPT_FIELDS,
+  PAGE_RULE_SITE_FIELDS,
+} from "../src/rule-cache";
+import { streamPageRules } from "../src/streaming";
+import { getGoldenBaselineConfig } from "./helpers/golden-baseline";
+
+const run = <A>(e: Effect.Effect<A, never, never>) => Effect.runPromise(e);
+const tmpDir = mkdtempSync(join(tmpdir(), "squirrelscan-site-context-"));
+afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+describe("page rules read only the SiteData fields the cache key covers", () => {
+  test("no page rule touches a field outside PAGE_RULE_SITE_FIELDS", async () => {
+    const model = generateSiteModel({
+      seed: "page-rule-site-context",
+      pageCount: 40,
+      templateCount: 3,
+      minPageSizeBytes: 8_000,
+      maxPageSizeBytes: 24_000,
+      cleanRatio: 0.3,
+      issues: {
+        longH1: { ratio: 0.1 },
+        oversizeTitle: { ratio: 0.1 },
+        oversizeDescription: { ratio: 0.1 },
+        duplicateTitles: { groupCount: 2, groupSize: 3 },
+        brokenLinks: { count: 4 },
+        redirectChains: { count: 2, chainLength: 2 },
+      },
+    });
+    const dbPath = join(tmpDir, "site-context.sqlite");
+    const { storage: writer } = await writeCrawlToStorage(model, dbPath);
+    const crawls = await run(writer.listCrawls(1));
+    const crawlId = crawls[0]!.id;
+    await run(writer.close());
+
+    const storage = new SQLiteStorage(dbPath);
+    await run(storage.init());
+    try {
+      const runner = createRunner(getGoldenBaselineConfig());
+      const readKeys = new Set<string>();
+      const scriptFieldReads = new Set<string>();
+      const resourceFieldReads = new Set<string>();
+      /** Record every own-property read on an entry, so the ENTRY field lists are
+       *  falsified too — hashing whole entries is what let `cacheReason` (per-run
+       *  transport metadata) into the key and silently zeroed the cache. */
+      const recordFields = <T extends object>(entry: T, into: Set<string>): T =>
+        new Proxy(entry, {
+          get(target, key, receiver) {
+            if (typeof key === "string") into.add(key);
+            return Reflect.get(target, key, receiver);
+          },
+        });
+      // A realistic shape: every field populated the way `buildStreamingSiteData`
+      // populates it, so a rule that looks for one finds it rather than
+      // short-circuiting on undefined and never recording the read.
+      const siteData: SiteData = {
+        baseUrl: "http://synthetic.test",
+        pages: [],
+        robotsTxt: null,
+        sitemaps: null,
+        llmsTxt: null,
+        markdownResponse: null,
+        wellKnown: null,
+        agentAccess: null,
+        rsl: null,
+        externalLinks: [],
+        // Populated, and proxied per entry: an empty array records no field reads
+        // at all, so the entry-level half of this test would be vacuous.
+        resourceSizes: {
+          css: [
+            recordFields(
+              {
+                url: "http://synthetic.test/app.css",
+                status: 200,
+                error: null,
+                contentType: "text/css",
+                sizeBytes: 40_000,
+                sourcePages: ["http://synthetic.test/"],
+                cacheControl: "public, max-age=3600",
+                cacheReason: null,
+                contentEncoding: null,
+                transferBytes: 12_000,
+                etag: null,
+                lastModified: null,
+                vary: null,
+              },
+              resourceFieldReads,
+            ),
+          ],
+          images: [],
+        },
+        scripts: [
+          recordFields(
+            {
+              url: "http://synthetic.test/app.js",
+              status: 200,
+              error: null,
+              contentType: "application/javascript",
+              sizeBytes: 90_000,
+              content: "var a = 1;\n//# sourceMappingURL=app.js.map\n",
+              sourcePages: ["http://synthetic.test/"],
+              redirected: false,
+              finalUrl: "http://synthetic.test/app.js",
+              sourceMapHeader: "app.js.map",
+              contentEncoding: null,
+            },
+            scriptFieldReads,
+          ),
+        ],
+        pdfSizes: [],
+        sitemapUrlStatuses: [],
+        cloakingProbes: [],
+        crawlLimits: { pagesCrawled: 40, maxPages: 100 },
+      };
+      const recording = new Proxy(siteData, {
+        get(target, key, receiver) {
+          if (typeof key === "string") readKeys.add(key);
+          return Reflect.get(target, key, receiver);
+        },
+      });
+
+      const result = await run(
+        streamPageRules(storage, crawlId, runner, recording, { batchSize: 20 }),
+      );
+      // Guard against a vacuous pass: rules must actually have run.
+      expect(result.pageUrls.length).toBeGreaterThan(20);
+
+      const undeclared = [...readKeys].filter(
+        (key) => !(PAGE_RULE_SITE_FIELDS as readonly string[]).includes(key),
+      );
+      const undeclaredScript = [...scriptFieldReads].filter(
+        (key) => !(PAGE_RULE_SCRIPT_FIELDS as readonly string[]).includes(key),
+      );
+      const undeclaredResource = [...resourceFieldReads].filter(
+        (key) => !(PAGE_RULE_RESOURCE_FIELDS as readonly string[]).includes(key),
+      );
+      // Not vacuous: rules must have looked at the entries at all.
+      expect(scriptFieldReads.size).toBeGreaterThan(0);
+      expect(resourceFieldReads.size).toBeGreaterThan(0);
+      expect(undeclaredScript).toEqual([]);
+      expect(undeclaredResource).toEqual([]);
+      if (undeclared.length > 0) {
+        throw new Error(
+          `page rules read SiteData fields the rule-result cache key does not cover: ` +
+            `${undeclared.join(", ")}. Either add them to PAGE_RULE_SITE_FIELDS (and accept ` +
+            `that a change to one invalidates every cached page) or stop reading them from a ` +
+            `page rule. Leaving this unfixed means #1990 replays stale verdicts.`,
+        );
+      }
+      expect(undeclared).toEqual([]);
+    } finally {
+      await run(storage.close());
+    }
+  }, 120_000);
+});

--- a/packages/audit-engine/tests/rule-cache-codec.test.ts
+++ b/packages/audit-engine/tests/rule-cache-codec.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   canonicalJson,
+  computeRunContextHash,
   decodeCacheValue,
   decodePageRuleCacheEntry,
   encodeCacheValue,
@@ -49,6 +50,17 @@ describe("canonicalJson", () => {
   test("keeps Set and Map iteration order, which is observable", () => {
     expect(canonicalJson(new Set(["a", "b"]))).not.toBe(canonicalJson(new Set(["b", "a"])));
     expect(canonicalJson(new Map([["a", 1]]))).not.toBe(canonicalJson({ a: 1 }));
+  });
+
+  // Three inputs that a single "not finite" token would have merged, and two
+  // arrays that a hole-skipping `.map` would have. A rule option distinguishing
+  // any of these pairs would otherwise change behaviour under an unchanged key.
+  test("does not merge distinct numbers or array shapes", () => {
+    const forms = [NaN, Infinity, -Infinity].map((n) => canonicalJson({ limit: n }));
+    expect(new Set(forms).size).toBe(3);
+    expect(canonicalJson([])).not.toBe(canonicalJson(new Array(1)));
+    expect(canonicalJson([undefined])).toBe(canonicalJson(new Array(1)));
+    expect(canonicalJson([1, 2])).not.toBe(canonicalJson([12]));
   });
 
   // The reason this throws rather than degrading: a run context holding a live
@@ -134,8 +146,82 @@ describe("cache payload codec", () => {
     expect(signal.fingerprint.assetHosts).toBeInstanceOf(Set);
   });
 
+  // `JSON.stringify` renders a Date as an ISO string on a fresh run; walked as a
+  // plain object it has no own keys and would come back `{}`. `check.details` is
+  // `Record<string, unknown>`, so a rule may put one there.
+  test("round-trips a Date, which a plain-object walk would empty", () => {
+    const value = { details: { when: new Date("2026-01-01T00:00:00.000Z") } };
+    const back = decodeCacheValue(JSON.parse(JSON.stringify(encodeCacheValue(value)))) as typeof value;
+    expect(back.details.when).toBeInstanceOf(Date);
+    expect(JSON.stringify(back)).toBe(JSON.stringify(value));
+  });
+
+  // `JSON.parse` makes `__proto__` an ordinary own key, but `out[k] = v` routes it
+  // to the prototype setter and it disappears.
+  test("keeps an own __proto__ key through the round-trip", () => {
+    const value = JSON.parse('{"details":{"__proto__":"kept","other":1}}') as {
+      details: Record<string, unknown>;
+    };
+    const back = decodeCacheValue(JSON.parse(JSON.stringify(encodeCacheValue(value)))) as typeof value;
+    expect(Object.hasOwn(back.details, "__proto__")).toBe(true);
+    expect(JSON.stringify(back)).toBe(JSON.stringify(value));
+  });
+
   test("an unreadable payload is a miss, not a throw", () => {
     expect(decodePageRuleCacheEntry("{not json")).toBeNull();
     expect(decodePageRuleCacheEntry(JSON.stringify({ nothing: true }))).toBeNull();
+  });
+});
+
+describe("run context", () => {
+  const base = {
+    engineVersion: "0.0.91",
+    pageRules: [{ id: "core/meta-title", options: { max_length: 75 } }],
+    siteData: { baseUrl: "http://x.test", pages: [], robotsTxt: null, sitemaps: null } as never,
+    siteMetadata: undefined,
+    cloudResults: undefined,
+    ignoreApplicability: false,
+    utcYear: 2026,
+  };
+  const hashOf = async (over: Partial<typeof base>) => {
+    const out = await computeRunContextHash({ ...base, ...over });
+    if (!("hash" in out)) throw new Error(`disabled: ${out.disabled}`);
+    return out.hash;
+  };
+
+  test("is stable for the same inputs", async () => {
+    expect(await hashOf({})).toBe(await hashOf({}));
+  });
+
+  // `content/stale-copyright` reads `new Date().getUTCFullYear()` at execution, so
+  // a pass cached on 31 December must not replay on 1 January.
+  test("moves with the UTC year", async () => {
+    expect(await hashOf({ utcYear: 2027 })).not.toBe(await hashOf({}));
+  });
+
+  // The escape hatch changes a gated rule from a `skipped` check to its real
+  // verdict without touching the rule list or any rule's options.
+  test("moves with the applicability escape hatch", async () => {
+    expect(await hashOf({ ignoreApplicability: true })).not.toBe(await hashOf({}));
+  });
+
+  test("moves with the build, the rule list and a rule's options", async () => {
+    expect(await hashOf({ engineVersion: "0.0.92" })).not.toBe(await hashOf({}));
+    expect(await hashOf({ pageRules: [] })).not.toBe(await hashOf({}));
+    expect(
+      await hashOf({ pageRules: [{ id: "core/meta-title", options: { max_length: 12 } }] }),
+    ).not.toBe(await hashOf({}));
+  });
+
+  // Fail CLOSED: a run context holding something that is not plain data must not
+  // hash to a value it shares with a different one.
+  test("refuses to hash a live handle", async () => {
+    class IntelHandle {
+      lookupUrl() {
+        return null;
+      }
+    }
+    const out = await computeRunContextHash({ ...base, siteMetadata: new IntelHandle() });
+    expect(out).toEqual({ disabled: "unhashable-run-context" });
   });
 });

--- a/packages/audit-engine/tests/rule-cache-codec.test.ts
+++ b/packages/audit-engine/tests/rule-cache-codec.test.ts
@@ -1,0 +1,141 @@
+// The two pure halves of the rule-result cache (#1990): the hash the key is built
+// from, and the codec the payload survives a round-trip through.
+//
+// Both are places where being SUBTLY wrong is worse than failing: a canonical form
+// that collapses two different run contexts to one string replays the wrong
+// verdicts, and a codec that turns a `Set` into `{}` silently empties the template
+// fingerprint every replayed page contributes to `template-discontinuity`.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  canonicalJson,
+  decodeCacheValue,
+  decodePageRuleCacheEntry,
+  encodeCacheValue,
+  encodePageRuleCacheEntry,
+  sha256Hex,
+} from "../src/rule-cache";
+
+describe("sha256Hex", () => {
+  // Published NIST vectors. The point is not that SHA-256 works, it is that this
+  // wrapper's byte handling does — a TextEncoder or hex-padding slip would give a
+  // stable but wrong digest, which no round-trip test can see.
+  test("matches the published vectors", async () => {
+    expect(await sha256Hex("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+    expect(await sha256Hex("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  test("is sensitive to non-ASCII bytes", async () => {
+    expect(await sha256Hex("é")).not.toBe(await sha256Hex("e"));
+  });
+});
+
+describe("canonicalJson", () => {
+  test("is insensitive to key order and sensitive to everything else", () => {
+    expect(canonicalJson({ a: 1, b: 2 })).toBe(canonicalJson({ b: 2, a: 1 }));
+    expect(canonicalJson({ a: 1 })).not.toBe(canonicalJson({ a: "1" }));
+    expect(canonicalJson([1, 2])).not.toBe(canonicalJson([2, 1]));
+  });
+
+  test("distinguishes an absent key from an undefined one", () => {
+    expect(canonicalJson({ a: undefined })).not.toBe(canonicalJson({}));
+  });
+
+  test("keeps Set and Map iteration order, which is observable", () => {
+    expect(canonicalJson(new Set(["a", "b"]))).not.toBe(canonicalJson(new Set(["b", "a"])));
+    expect(canonicalJson(new Map([["a", 1]]))).not.toBe(canonicalJson({ a: 1 }));
+  });
+
+  // The reason this throws rather than degrading: a run context holding a live
+  // handle must not hash to the same string as one holding a different live
+  // handle. The callers turn the throw into "no cache this run".
+  test("throws on anything that is not plain data", () => {
+    expect(() => canonicalJson({ f: () => 1 })).toThrow();
+    expect(() => canonicalJson({ s: Symbol("x") })).toThrow();
+    expect(() => canonicalJson({ r: /x/ })).toThrow();
+    class Handle {
+      lookup() {
+        return 1;
+      }
+    }
+    expect(() => canonicalJson({ intel: new Handle() })).toThrow();
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => canonicalJson(cyclic)).toThrow();
+  });
+});
+
+describe("cache payload codec", () => {
+  test("round-trips a Set, which plain JSON would empty", () => {
+    const value = { assetHosts: new Set(["a.test", "b.test"]) };
+    const back = decodeCacheValue(JSON.parse(JSON.stringify(encodeCacheValue(value)))) as typeof value;
+    expect(back.assetHosts).toBeInstanceOf(Set);
+    expect([...back.assetHosts]).toEqual(["a.test", "b.test"]);
+    // The failure this exists to stop: without tagging, the Set is `{}`.
+    expect(JSON.parse(JSON.stringify(value)).assetHosts).toEqual({});
+  });
+
+  test("round-trips Maps, undefined, null and nesting", () => {
+    const value = {
+      m: new Map<string, unknown>([["k", { deep: new Set([1]) }]]),
+      u: undefined,
+      n: null,
+      list: [1, "two", { three: undefined }],
+    };
+    const back = decodeCacheValue(JSON.parse(JSON.stringify(encodeCacheValue(value)))) as typeof value;
+    expect(back.m).toBeInstanceOf(Map);
+    expect((back.m.get("k") as { deep: Set<number> }).deep).toBeInstanceOf(Set);
+    expect("u" in back).toBe(true);
+    expect(back.u).toBeUndefined();
+    expect(back.n).toBeNull();
+    expect(back.list).toEqual([1, "two", { three: undefined }]);
+  });
+
+  // A rule is free to put whatever it likes in `check.details`, including a key
+  // that collides with a tag. Escaping is what keeps that from decoding as a Set.
+  test("survives a data object whose own key looks like a tag", () => {
+    const value = { details: { $s: ["not-a-set"], $m: 1, $u: "text" } };
+    const back = decodeCacheValue(JSON.parse(JSON.stringify(encodeCacheValue(value)))) as typeof value;
+    expect(back).toEqual(value);
+    expect(back.details.$s).toEqual(["not-a-set"]);
+  });
+
+  test("an entry round-trips through the stored string form", () => {
+    const entry = {
+      ruleResults: [
+        ["core/title", [{ name: "title-present", status: "pass" as const, message: "ok" }]],
+        [
+          "core/meta",
+          [
+            {
+              name: "description",
+              status: "fail" as const,
+              message: "missing",
+              value: 42,
+              details: { pages: ["/a"] },
+            },
+          ],
+        ],
+      ] as const,
+      features: { normalizedUrl: "/a", status: 200, depth: 0 } as never,
+      signals: { "site-dom-signals": { url: "/a", fingerprint: { assetHosts: new Set(["x"]) } } },
+    };
+    const back = decodePageRuleCacheEntry(encodePageRuleCacheEntry(entry as never));
+    expect(back).not.toBeNull();
+    // The number stays a number. `rule_results` cannot serve as this cache
+    // precisely because it stores value through String().
+    expect(back!.ruleResults[1]![1][0]!.value).toBe(42);
+    const signal = back!.signals["site-dom-signals"] as { fingerprint: { assetHosts: Set<string> } };
+    expect(signal.fingerprint.assetHosts).toBeInstanceOf(Set);
+  });
+
+  test("an unreadable payload is a miss, not a throw", () => {
+    expect(decodePageRuleCacheEntry("{not json")).toBeNull();
+    expect(decodePageRuleCacheEntry(JSON.stringify({ nothing: true }))).toBeNull();
+  });
+});

--- a/packages/audit-engine/tests/rule-cache-codec.test.ts
+++ b/packages/audit-engine/tests/rule-cache-codec.test.ts
@@ -59,7 +59,9 @@ describe("canonicalJson", () => {
     const forms = [NaN, Infinity, -Infinity].map((n) => canonicalJson({ limit: n }));
     expect(new Set(forms).size).toBe(3);
     expect(canonicalJson([])).not.toBe(canonicalJson(new Array(1)));
-    expect(canonicalJson([undefined])).toBe(canonicalJson(new Array(1)));
+    // A hole is observable (`0 in arr`), so it is not `undefined` either.
+    expect(canonicalJson([undefined])).not.toBe(canonicalJson(new Array(1)));
+    expect(canonicalJson({ x: -0 })).not.toBe(canonicalJson({ x: 0 }));
     expect(canonicalJson([1, 2])).not.toBe(canonicalJson([12]));
   });
 
@@ -164,6 +166,16 @@ describe("cache payload codec", () => {
     };
     const back = decodeCacheValue(JSON.parse(JSON.stringify(encodeCacheValue(value)))) as typeof value;
     expect(Object.hasOwn(back.details, "__proto__")).toBe(true);
+    expect(JSON.stringify(back)).toBe(JSON.stringify(value));
+  });
+
+  // `JSON.stringify(new Date(NaN))` is `null`, so a replay must give back an
+  // invalid Date and not the epoch.
+  test("round-trips an invalid Date as invalid", () => {
+    const value = { details: { when: new Date(NaN) } };
+    const back = decodeCacheValue(JSON.parse(JSON.stringify(encodeCacheValue(value)))) as typeof value;
+    expect(back.details.when).toBeInstanceOf(Date);
+    expect(Number.isNaN(back.details.when.getTime())).toBe(true);
     expect(JSON.stringify(back)).toBe(JSON.stringify(value));
   });
 

--- a/packages/audit-engine/tests/rule-cache-codec.test.ts
+++ b/packages/audit-engine/tests/rule-cache-codec.test.ts
@@ -194,6 +194,7 @@ describe("run context", () => {
     cloudResults: undefined,
     ignoreApplicability: false,
     utcYear: 2026,
+    timeZone: "UTC",
   };
   const hashOf = async (over: Partial<typeof base>) => {
     const out = await computeRunContextHash({ ...base, ...over });
@@ -215,6 +216,13 @@ describe("run context", () => {
   // verdict without touching the rule list or any rule's options.
   test("moves with the applicability escape hatch", async () => {
     expect(await hashOf({ ignoreApplicability: true })).not.toBe(await hashOf({}));
+  });
+
+  // `content/date-agreement` resolves a bare schema date through `Date.parse`,
+  // which reads it in LOCAL time, so the same page yields a different year in a
+  // different zone.
+  test("moves with the runtime time zone", async () => {
+    expect(await hashOf({ timeZone: "Australia/Sydney" })).not.toBe(await hashOf({}));
   });
 
   test("moves with the build, the rule list and a rule's options", async () => {

--- a/packages/audit-engine/tests/rule-cache-codec.test.ts
+++ b/packages/audit-engine/tests/rule-cache-codec.test.ts
@@ -23,11 +23,13 @@ describe("sha256Hex", () => {
   // wrapper's byte handling does — a TextEncoder or hex-padding slip would give a
   // stable but wrong digest, which no round-trip test can see.
   test("matches the published vectors", async () => {
+    // The published SHA-256 vectors for "" and "abc". The entropy detector cannot
+    // tell a digest from a credential, and these are neither secret nor ours.
     expect(await sha256Hex("")).toBe(
-      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", // pragma: allowlist secret
     );
     expect(await sha256Hex("abc")).toBe(
-      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", // pragma: allowlist secret
     );
   });
 

--- a/packages/audit-engine/tests/rule-cache-replay-golden.test.ts
+++ b/packages/audit-engine/tests/rule-cache-replay-golden.test.ts
@@ -1,0 +1,300 @@
+// REPLAY PARITY GATE (#1990): a fully-cached re-audit must produce byte-identical
+// output to a fresh one over the same crawl.
+//
+// The cache asserts that re-running a page's rules would produce exactly what is
+// stored, and nothing about a report can prove that on its own — a replay and a
+// fresh evaluation are meant to be indistinguishable, so an assertion on the
+// findings alone passes just as happily when the cache silently did nothing. Every
+// test here therefore pins BOTH sides: the serialized output AND the number of
+// pages that actually replayed.
+//
+// Three runs over one crawl:
+//   cold   — no cache at all, the reference.
+//   warm-1 — cache supplied and empty: every page runs, every entry is written.
+//   warm-2 — same cache, now full: every page replays, nothing parses.
+//
+// The invalidation cases then change ONE input at a time and require the affected
+// pages to run again.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Effect } from "effect";
+
+import { generateSiteModel, writeCrawlToStorage } from "@squirrelscan/synthetic-site";
+import { SQLiteStorage } from "@squirrelscan/crawler";
+import type { ContentStoreAdapter } from "@squirrelscan/crawler";
+import type { PreFetchedAssets } from "@squirrelscan/audit-engine";
+
+import type { Config } from "../src/adapter";
+import { generateReportFromStorage, runStreamingRules } from "../src/adapter";
+import type { RuleCacheStore } from "../src/rule-cache";
+import { getGoldenBaselineConfig } from "./helpers/golden-baseline";
+
+const run = <A>(e: Effect.Effect<A, never, never>) => Effect.runPromise(e);
+const tmpDir = mkdtempSync(join(tmpdir(), "squirrelscan-rule-cache-"));
+afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const PAGE_COUNT = 60;
+
+function emptyAssets(): PreFetchedAssets {
+  return { resourceSizes: { css: [], images: [] }, scripts: [], pdfSizes: [], sitemapUrlStatuses: [] };
+}
+
+/**
+ * A content store, because `pages.html_hash` — the exact-bytes identity the key
+ * needs — is only written on the content-store path, which is the CLI's. Without
+ * one every page reports a null hash and nothing caches, so a test that forgot
+ * this would pass by never exercising the feature at all.
+ *
+ * One store PER DATABASE, shared across connections, because that is what the CLI
+ * has: the store outlives any single audit. A per-connection store loses every
+ * page body the moment the connection closes, which reads as "no auditable pages"
+ * rather than as an error — the exact shape of a vacuously-passing test.
+ */
+const contentStores = new Map<string, ContentStoreAdapter>();
+function contentStoreFor(dbPath: string): ContentStoreAdapter {
+  const existing = contentStores.get(dbPath);
+  if (existing) return existing;
+  const blobs = new Map<string, string>();
+  const store: ContentStoreAdapter = {
+    put(content) {
+      const hash = new Bun.CryptoHasher("sha256").update(content).digest("hex");
+      blobs.set(hash, content);
+      return hash;
+    },
+    getString(hash) {
+      return blobs.get(hash) ?? null;
+    },
+  };
+  contentStores.set(dbPath, store);
+  return store;
+}
+
+/** An in-memory {@link RuleCacheStore}, with the counters the assertions need. */
+function memoryCacheStore() {
+  const rows = new Map<string, string>();
+  let pendingFresh: Array<[string, string]> = [];
+  let pendingCarry: string[] = [];
+  const counts = { fresh: 0, carried: 0 };
+  const store: RuleCacheStore = {
+    async load(keys) {
+      const out = new Map<string, string>();
+      for (const key of keys) {
+        const value = rows.get(key);
+        if (value !== undefined) out.set(key, value);
+      }
+      return out;
+    },
+    putFresh(key, _url, payload) {
+      pendingFresh.push([key, payload]);
+    },
+    carryForward(key) {
+      pendingCarry.push(key);
+    },
+    async flush() {
+      for (const [key, payload] of pendingFresh) rows.set(key, payload);
+      counts.fresh += pendingFresh.length;
+      counts.carried += pendingCarry.length;
+      pendingFresh = [];
+      pendingCarry = [];
+    },
+  };
+  return { store, rows, counts };
+}
+
+/** Build a crawl DB whose pages carry an exact HTML hash. */
+async function buildCrawl(name: string): Promise<{ dbPath: string; crawlId: string }> {
+  const dbPath = join(tmpDir, `${name}.sqlite`);
+  const model = generateSiteModel({
+    seed: `rule-cache-${name}`,
+    pageCount: PAGE_COUNT,
+    templateCount: 3,
+    minPageSizeBytes: 8_000,
+    maxPageSizeBytes: 20_000,
+    cleanRatio: 0.4,
+    issues: {
+      longH1: { ratio: 0.1 },
+      oversizeTitle: { ratio: 0.1 },
+      duplicateTitles: { groupCount: 2, groupSize: 3 },
+      brokenLinks: { count: 4 },
+    },
+  });
+  const { storage } = await writeCrawlToStorage(model, dbPath);
+  const crawls = await run(storage.listCrawls(1));
+  const crawlId = crawls[0]!.id;
+  await run(storage.close());
+  // Re-write every page through a content-store-backed connection so the real
+  // upsert path stamps html_hash, exactly as a CLI audit does.
+  await withStorage(dbPath, async (s) => {
+    const pages = await run(s.getPages(crawlId));
+    for (const page of pages) await run(s.upsertPage(crawlId, page));
+  });
+  return { dbPath, crawlId };
+}
+
+async function withStorage<T>(dbPath: string, fn: (s: SQLiteStorage) => Promise<T>): Promise<T> {
+  const storage = new SQLiteStorage(dbPath, contentStoreFor(dbPath));
+  try {
+    await run(storage.init());
+    return await fn(storage);
+  } finally {
+    await run(storage.close());
+  }
+}
+
+interface RunOutcome {
+  serialized: string;
+  replayedPages: number;
+  freshPages: number;
+  storedEntries: number;
+  disabledReason?: string;
+}
+
+/**
+ * One rules pass + report over an existing crawl. The report is serialized with
+ * `meta.timestamp` and the cache disclosure removed: the first moves every run and
+ * the second is the very thing being measured, so neither can be part of the
+ * identity being asserted. Everything else must match to the byte.
+ */
+async function runOnce(
+  dbPath: string,
+  crawlId: string,
+  opts: { store?: RuleCacheStore; engineVersion?: string; config?: Config } = {},
+): Promise<RunOutcome> {
+  return withStorage(dbPath, async (storage) => {
+    const config = opts.config ?? getGoldenBaselineConfig();
+    const results = await run(
+      runStreamingRules(storage, crawlId, config, emptyAssets(), undefined, {
+        ...(opts.store
+          ? { ruleCache: { store: opts.store, engineVersion: opts.engineVersion ?? "test-1" } }
+          : {}),
+      }),
+    );
+    const report = await run(generateReportFromStorage(storage, crawlId, results));
+    const stripped = JSON.parse(JSON.stringify(report)) as Record<string, unknown>;
+    delete stripped.timestamp;
+    const meta = stripped.meta as Record<string, unknown> | undefined;
+    if (meta) delete meta.timestamp;
+    delete stripped.rulesCache;
+    return {
+      serialized: JSON.stringify(stripped),
+      replayedPages: results.ruleCache.replayedPages,
+      freshPages: results.ruleCache.freshPages,
+      storedEntries: results.ruleCache.storedEntries,
+      disabledReason: results.ruleCache.disabledReason,
+    };
+  });
+}
+
+/** Byte equality, but reported as the first differing span. */
+function expectSameSerialization(actual: string, expected: string): void {
+  if (actual === expected) return;
+  const limit = Math.min(actual.length, expected.length);
+  let i = 0;
+  while (i < limit && actual[i] === expected[i]) i++;
+  throw new Error(
+    `replayed report diverges at byte ${i} of ${expected.length} (actual length ${actual.length})\n` +
+      `  expected: ...${expected.slice(Math.max(0, i - 120), i + 120)}\n` +
+      `  actual:   ...${actual.slice(Math.max(0, i - 120), i + 120)}`,
+  );
+}
+
+describe("per-page rule-result cache — replay parity", () => {
+  test("a fully-replayed re-audit is byte-identical to a fresh one", async () => {
+    const { dbPath, crawlId } = await buildCrawl("parity");
+    const cache = memoryCacheStore();
+
+    const cold = await runOnce(dbPath, crawlId);
+    expect(cold.replayedPages).toBe(0);
+    expect(cold.storedEntries).toBe(0);
+
+    const warm1 = await runOnce(dbPath, crawlId, { store: cache.store });
+    // First warm run: nothing to replay, everything stored.
+    expect(warm1.replayedPages).toBe(0);
+    // Not merely > 0: the fixture must really be feeding the loop, or every
+    // assertion below is vacuous.
+    expect(warm1.freshPages).toBeGreaterThan(PAGE_COUNT / 2);
+    expect(warm1.storedEntries).toBe(warm1.freshPages);
+    expect(cache.rows.size).toBe(warm1.freshPages);
+
+    const warm2 = await runOnce(dbPath, crawlId, { store: cache.store });
+    // The claim: every page replayed, and NOTHING ran.
+    expect(warm2.replayedPages).toBe(warm1.freshPages);
+    expect(warm2.freshPages).toBe(0);
+    // And every one of them was carried forward, so retiring the crawl that
+    // produced them cannot make the next audit cold.
+    expect(cache.counts.carried).toBe(warm2.replayedPages);
+
+    // The gate. Reported with the first divergence rather than two 3 MB strings,
+    // so a failure says WHERE the replay diverged.
+    expectSameSerialization(warm2.serialized, cold.serialized);
+    expectSameSerialization(warm1.serialized, cold.serialized);
+  }, 120_000);
+
+  test("a changed page runs again, and only that page", async () => {
+    const { dbPath, crawlId } = await buildCrawl("invalidate-content");
+    const cache = memoryCacheStore();
+    const first = await runOnce(dbPath, crawlId, { store: cache.store });
+
+    // Whitespace-only edit. It is deliberately the change `content_hash` is
+    // designed NOT to notice — the normalized hash is identical either way — so a
+    // key built on that field would replay stale verdicts here.
+    const changedUrl = await withStorage(dbPath, async (storage) => {
+      const pages = await run(storage.getPages(crawlId, { limit: 1, offset: 0 }));
+      const page = pages[0]!;
+      const edited = { ...page, html: page.html!.replace("<body", "<body\n  ") };
+      await run(storage.upsertPage(crawlId, edited));
+      return page.normalizedUrl;
+    });
+    expect(changedUrl).toBeTruthy();
+
+    const second = await runOnce(dbPath, crawlId, { store: cache.store });
+    expect(second.freshPages).toBe(1);
+    expect(second.replayedPages).toBe(first.freshPages - 1);
+  }, 120_000);
+
+  test("a new engine version invalidates every entry", async () => {
+    const { dbPath, crawlId } = await buildCrawl("invalidate-version");
+    const cache = memoryCacheStore();
+    const first = await runOnce(dbPath, crawlId, { store: cache.store, engineVersion: "0.0.91" });
+    const upgraded = await runOnce(dbPath, crawlId, { store: cache.store, engineVersion: "0.0.92" });
+    expect(upgraded.replayedPages).toBe(0);
+    expect(upgraded.freshPages).toBe(first.freshPages);
+  }, 120_000);
+
+  test("a changed rule selection invalidates every entry", async () => {
+    const { dbPath, crawlId } = await buildCrawl("invalidate-rules");
+    const cache = memoryCacheStore();
+    const base = getGoldenBaselineConfig();
+    const first = await runOnce(dbPath, crawlId, { store: cache.store, config: base });
+
+    // Turn one page rule off. Every page's key moves, because the rule id list is
+    // part of the run context — a rule that stops running changes the flat check
+    // list of every page, not just the ones it failed on.
+    const fewer = {
+      ...base,
+      rules: { ...base.rules, disable: [...base.rules.disable, "core/meta-title"] },
+    } as Config;
+    const second = await runOnce(dbPath, crawlId, { store: cache.store, config: fewer });
+    expect(second.replayedPages).toBe(0);
+    expect(second.freshPages).toBe(first.freshPages);
+  }, 120_000);
+
+  test("changing a rule's options invalidates every entry", async () => {
+    const { dbPath, crawlId } = await buildCrawl("invalidate-options");
+    const cache = memoryCacheStore();
+    const base = getGoldenBaselineConfig();
+    const first = await runOnce(dbPath, crawlId, { store: cache.store, config: base });
+
+    const retuned = {
+      ...base,
+      rule_options: { ...(base.rule_options ?? {}), "core/meta-title": { max_length: 12 } },
+    } as Config;
+    const second = await runOnce(dbPath, crawlId, { store: cache.store, config: retuned });
+    expect(second.replayedPages).toBe(0);
+    expect(second.freshPages).toBe(first.freshPages);
+  }, 120_000);
+});

--- a/packages/audit-engine/tests/rule-cache-replay-golden.test.ts
+++ b/packages/audit-engine/tests/rule-cache-replay-golden.test.ts
@@ -25,11 +25,14 @@ import { Effect } from "effect";
 
 import { generateSiteModel, writeCrawlToStorage } from "@squirrelscan/synthetic-site";
 import { SQLiteStorage } from "@squirrelscan/crawler";
+import { createRunner } from "@squirrelscan/rules";
 import type { ContentStoreAdapter } from "@squirrelscan/crawler";
 import type { PreFetchedAssets } from "@squirrelscan/audit-engine";
 
 import type { Config } from "../src/adapter";
 import { generateReportFromStorage, runStreamingRules } from "../src/adapter";
+import { bindRuleCache } from "../src/rule-cache";
+import { streamPageRules } from "../src/streaming";
 import type { RuleCacheStore } from "../src/rule-cache";
 import { getGoldenBaselineConfig } from "./helpers/golden-baseline";
 
@@ -207,9 +210,12 @@ describe("per-page rule-result cache — replay parity", () => {
     const { dbPath, crawlId } = await buildCrawl("parity");
     const cache = memoryCacheStore();
 
-    const cold = await runOnce(dbPath, crawlId);
+    // The reference is a cold run WITH THE CACHE ENABLED and an empty store, not a
+    // run without one: enabling the cache turns template fan-out off (they do not
+    // compose — see streaming.ts), so a cache-off run is a different
+    // configuration and comparing against it would be comparing two changes.
+    const cold = await runOnce(dbPath, crawlId, { store: memoryCacheStore().store });
     expect(cold.replayedPages).toBe(0);
-    expect(cold.storedEntries).toBe(0);
 
     const warm1 = await runOnce(dbPath, crawlId, { store: cache.store });
     // First warm run: nothing to replay, everything stored.
@@ -256,15 +262,13 @@ describe("per-page rule-result cache — replay parity", () => {
     expect(second.replayedPages).toBe(first.freshPages - 1);
   }, 120_000);
 
-  // Codex's counterexample, and the reason a replayed page records into the
-  // template fan-out (#1951) instead of abstaining from it.
+  // The case that made the cache and template fan-out (#1951) mutually exclusive.
   //
-  // With abstention, WHICH page runs a template-scoped rule depends on what
-  // happens to be cached: on the audit after a change, the changed page is the
-  // only fresh one, so it becomes the cluster's representative and keeps its own
-  // verdict — where a fresh audit would have the FIRST page record and fan its
-  // verdict onto the changed one. The next fully-replayed audit then disagrees
-  // with a fresh audit of identical content, and the disagreement is persisted.
+  // A fanned verdict belongs to the page's CLUSTER, so no per-page key can capture
+  // what it depends on: change one page of a cluster and the OTHER pages' cached
+  // verdicts can be stale without anything about those pages changing. This runs
+  // that shape end to end and requires the fully-replayed audit to say what a
+  // fresh audit of the same content says.
   test("a fully-replayed audit matches a fresh one across a template cluster", async () => {
     const { dbPath, crawlId } = await buildCrawl("fanout-composition");
     const cache = memoryCacheStore();
@@ -304,8 +308,53 @@ describe("per-page rule-result cache — replay parity", () => {
     const fullyReplayed = await runOnce(dbPath, crawlId, { store: cache.store });
     expect(fullyReplayed.freshPages).toBe(0);
     // ...and it must say what a fresh audit of this same content says.
-    const fresh = await runOnce(dbPath, crawlId);
+    const fresh = await runOnce(dbPath, crawlId, { store: memoryCacheStore().store });
+    expect(fresh.replayedPages).toBe(0);
     expectSameSerialization(fullyReplayed.serialized, fresh.serialized);
+  }, 180_000);
+
+  // The mechanism, asserted directly rather than through an output difference.
+  //
+  // A fanned verdict belongs to the cluster, so the divergence it causes shows up
+  // only on a page whose CLUSTER-MATE changed — which a fixture cannot be relied
+  // on to produce, and a test that happens not to produce it passes while proving
+  // nothing. What can be pinned exactly is that the two features never run
+  // together: with a cache supplied, the fan-out does no work at all.
+  test("supplying a cache turns template fan-out off", async () => {
+    const { dbPath, crawlId } = await buildCrawl("fanout-exclusive");
+    const cache = memoryCacheStore();
+    await withStorage(dbPath, async (storage) => {
+      const runner = createRunner(getGoldenBaselineConfig());
+      const siteData = {
+        baseUrl: "http://synthetic.test",
+        pages: [],
+        robotsTxt: null,
+        sitemaps: null,
+      } as unknown as Parameters<typeof streamPageRules>[3];
+
+      const withoutCache = await run(
+        streamPageRules(storage, crawlId, runner, siteData, {
+          batchSize: 20,
+          templateFanout: true,
+        }),
+      );
+      // The fixture really does cluster, or the assertion below proves nothing.
+      expect(withoutCache.templateFanout.fannedRuleRuns).toBeGreaterThan(0);
+
+      const withCache = await run(
+        streamPageRules(storage, crawlId, runner, siteData, {
+          batchSize: 20,
+          templateFanout: true,
+          collectors: [],
+          ruleCache: bindRuleCache(cache.store, "run-context-for-this-test"),
+        }),
+      );
+      expect(withCache.templateFanout.fannedRuleRuns).toBe(0);
+      expect(withCache.templateFanout.clusters).toBe(0);
+      // And the cache really was in play, so this is exclusivity and not an
+      // accidentally-disabled fan-out.
+      expect(withCache.ruleCache.storedEntries).toBeGreaterThan(0);
+    });
   }, 180_000);
 
   test("turning off applicability gating invalidates every entry", async () => {

--- a/packages/audit-engine/tests/rule-cache-replay-golden.test.ts
+++ b/packages/audit-engine/tests/rule-cache-replay-golden.test.ts
@@ -256,6 +256,76 @@ describe("per-page rule-result cache — replay parity", () => {
     expect(second.replayedPages).toBe(first.freshPages - 1);
   }, 120_000);
 
+  // Codex's counterexample, and the reason a replayed page records into the
+  // template fan-out (#1951) instead of abstaining from it.
+  //
+  // With abstention, WHICH page runs a template-scoped rule depends on what
+  // happens to be cached: on the audit after a change, the changed page is the
+  // only fresh one, so it becomes the cluster's representative and keeps its own
+  // verdict — where a fresh audit would have the FIRST page record and fan its
+  // verdict onto the changed one. The next fully-replayed audit then disagrees
+  // with a fresh audit of identical content, and the disagreement is persisted.
+  test("a fully-replayed audit matches a fresh one across a template cluster", async () => {
+    const { dbPath, crawlId } = await buildCrawl("fanout-composition");
+    const cache = memoryCacheStore();
+
+    // Populate: no synthetic page carries a viewport meta, so `mobile/viewport`
+    // (verdictScope: "template") fails uniformly across every cluster.
+    await runOnce(dbPath, crawlId, { store: cache.store });
+
+    // Give ONE page a viewport, and not the first one in crawl order — the
+    // divergence needs a page that a fresh audit would never elect. The meta is
+    // none of the five things the chrome fingerprint reads, so the page stays in
+    // its cluster, which is what makes this a fan-out question at all.
+    await withStorage(dbPath, async (storage) => {
+      const pages = await run(storage.getPages(crawlId));
+      // The LAST auditable page: with three templates over sixty pages every
+      // cluster has many members, so this one is never the first of its own.
+      const auditable = pages.filter((p) => p.html && p.status === 200);
+      expect(auditable.length).toBeGreaterThan(10);
+      const target = auditable[auditable.length - 1]!;
+      await run(
+        storage.upsertPage(crawlId, {
+          ...target,
+          html: target.html!.replace(
+            "<head>",
+            '<head>\n<meta name="viewport" content="width=device-width, initial-scale=1">',
+          ),
+        }),
+      );
+    });
+
+    // The audit right after the change: one fresh page, the rest replayed.
+    const afterChange = await runOnce(dbPath, crawlId, { store: cache.store });
+    expect(afterChange.freshPages).toBe(1);
+    expect(afterChange.replayedPages).toBeGreaterThan(0);
+
+    // Now nothing has changed, so everything replays...
+    const fullyReplayed = await runOnce(dbPath, crawlId, { store: cache.store });
+    expect(fullyReplayed.freshPages).toBe(0);
+    // ...and it must say what a fresh audit of this same content says.
+    const fresh = await runOnce(dbPath, crawlId);
+    expectSameSerialization(fullyReplayed.serialized, fresh.serialized);
+  }, 180_000);
+
+  test("turning off applicability gating invalidates every entry", async () => {
+    const { dbPath, crawlId } = await buildCrawl("invalidate-applicability");
+    const cache = memoryCacheStore();
+    const base = getGoldenBaselineConfig();
+    const first = await runOnce(dbPath, crawlId, { store: cache.store, config: base });
+
+    // `ignore_applicability` changes a gated rule's output from a `skipped` check
+    // to its real verdict without touching the rule list or any rule's options,
+    // so nothing else in the key moves with it.
+    const forced = {
+      ...base,
+      rules: { ...base.rules, ignore_applicability: true },
+    } as unknown as Config;
+    const second = await runOnce(dbPath, crawlId, { store: cache.store, config: forced });
+    expect(second.replayedPages).toBe(0);
+    expect(second.freshPages).toBe(first.freshPages);
+  }, 120_000);
+
   test("a new engine version invalidates every entry", async () => {
     const { dbPath, crawlId } = await buildCrawl("invalidate-version");
     const cache = memoryCacheStore();

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -356,6 +356,28 @@ export interface AuditReport {
    */
   scanScope?: ScanScope;
   /**
+   * Rule-result cache disclosure (#1990): how much of this audit's rules phase was
+   * REPLAYED from a previous audit rather than evaluated now.
+   *
+   * An agent reading a report has to be able to tell a replay from a fresh
+   * evaluation — the findings are identical by construction, so nothing else in
+   * the report distinguishes them (#1981). LOCAL ONLY: `slimForPublish` strips it,
+   * because it describes how this machine produced the report and not the site.
+   * REPORT-ONLY — never feeds `healthScore`.
+   */
+  rulesCache?: {
+    /** Pages that skipped parse + page rules and replayed stored verdicts. */
+    pagesReplayed: number;
+    /** Pages whose rules ran this audit. */
+    pagesEvaluated: number;
+    /**
+     * Present when the cache was available but deliberately not used, e.g.
+     * `refresh-requested` for `--refresh` or `threat-intel-enabled`. Absent when
+     * the cache was in use, whether or not anything actually hit.
+     */
+    disabledReason?: string;
+  };
+  /**
    * Smart audits CLOUD (#195): compact per-page HTTP status for THIS run, used
    * by the server-side finding merge at publish. `pages[]` is dropped on publish
    * (renderers use `ruleResults`), so this is the only signal the API has to tell

--- a/packages/core-contracts/src/storage.ts
+++ b/packages/core-contracts/src/storage.ts
@@ -373,6 +373,20 @@ export interface PageRecord {
    * unchanged. Absent on records written before #839 and on pages never probed.
    */
   sourceHash?: string | null;
+
+  /**
+   * sha256 of the page's EXACT stored HTML bytes (#1990), or null when the write
+   * path could not produce one.
+   *
+   * Deliberately NOT {@link contentHash}, which is whitespace-NORMALIZED
+   * (`computeNormalizedContentHash`) so the incremental crawler can call a
+   * reformatted page unchanged. Two pages that differ only in whitespace share a
+   * `contentHash` and parse to different word counts, inline-script lengths and
+   * `<pre>` text — so keying a rule-result cache on it would replay one page's
+   * verdicts onto another's markup. This field is the exact identity that key
+   * needs; a null simply means the page does not participate in the cache.
+   */
+  htmlHash?: string | null;
 }
 
 // ============================================

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -60,7 +60,7 @@ export interface ContentStoreAdapter {
 // Schema version - increment when schema changes.
 // Exported so migration tests can assert "this DB reached the CURRENT version" rather than pinning a
 // literal, which turned every schema bump into two unrelated test failures.
-export const SCHEMA_VERSION = 27;
+export const SCHEMA_VERSION = 28;
 
 // Migrations to run when upgrading from older versions
 const MIGRATIONS: Record<number, string[]> = {
@@ -374,6 +374,26 @@ const MIGRATIONS: Record<number, string[]> = {
   // another process could otherwise retire a crawl that is still being read.
   // NULL for every crawl written before this. ADDITIVE; local sqlite only.
   27: [`ALTER TABLE crawls ADD COLUMN report_status TEXT`],
+  // Version 28: the per-page rule-result cache (squirrelscan/repo#1990) and the
+  // exact-bytes HTML hash its key is built on. `pages.content_hash` is
+  // whitespace-normalized, so it cannot serve as that key — see
+  // `PageRecord.htmlHash`. ADDITIVE; both statements are idempotent, and
+  // `html_hash` is also in PAGES_ALTER_COLUMNS so a version-collision cannot
+  // leave it missing.
+  28: [
+    `ALTER TABLE pages ADD COLUMN html_hash TEXT`,
+    `CREATE TABLE IF NOT EXISTS page_rule_cache (
+      crawl_id TEXT NOT NULL,
+      normalized_url TEXT NOT NULL,
+      cache_key TEXT NOT NULL,
+      payload BLOB NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (crawl_id, normalized_url),
+      FOREIGN KEY (crawl_id) REFERENCES crawls(id)
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_page_rule_cache_key
+      ON page_rule_cache(cache_key, created_at DESC)`,
+  ],
 };
 
 // Nullable columns added to `pages` via ALTER migrations over time, with the
@@ -397,6 +417,7 @@ const PAGES_ALTER_COLUMNS: ReadonlyArray<{ name: string; type: string }> = [
   { name: "fetcher_id", type: "TEXT" },
   { name: "fallback_reason", type: "TEXT" },
   { name: "source_hash", type: "TEXT" },
+  { name: "html_hash", type: "TEXT" },
 ];
 
 // Same guard for `sitemaps`. Migration 21 added is_news_sitemap; a DB stamped
@@ -504,6 +525,7 @@ CREATE TABLE IF NOT EXISTS pages (
   fetcher_id TEXT,
   fallback_reason TEXT,
   source_hash TEXT,
+  html_hash TEXT,
   PRIMARY KEY (crawl_id, normalized_url),
   FOREIGN KEY (crawl_id) REFERENCES crawls(id)
 );
@@ -857,6 +879,33 @@ CREATE TABLE IF NOT EXISTS page_features (
   FOREIGN KEY (crawl_id) REFERENCES crawls(id)
 );
 
+-- Per-page rule-result cache (#1990): what the streamed page-rule loop produced
+-- for one page, so a later audit whose inputs are unchanged can replay it instead
+-- of re-parsing the page and re-running its rules. One row per page per crawl,
+-- retired with the crawl by retireCrawls: the newest audit always holds a
+-- complete copy, so pruning older audits never makes the next one cold.
+CREATE TABLE IF NOT EXISTS page_rule_cache (
+  crawl_id TEXT NOT NULL,
+  normalized_url TEXT NOT NULL,
+  -- The full input tuple, hashed: exact HTML bytes, every page field the rules
+  -- read, and the run context (rules version, rule selection + options, the
+  -- three SiteData fields page rules touch). Sufficient on its own to identify
+  -- an entry, because the page's own url is one of the hashed inputs.
+  cache_key TEXT NOT NULL,
+  -- gzipped JSON of the encoded entry. Gzip because the uncompressed per-page
+  -- checks are ~30 KB and this table would otherwise add a quarter to project.db.
+  payload BLOB NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (crawl_id, normalized_url),
+  FOREIGN KEY (crawl_id) REFERENCES crawls(id)
+);
+
+-- The lookup: newest entry for a key, across crawls. created_at DESC is in the
+-- index so a hit is a single index seek and never a scan of a url's history
+-- (#1908 — nothing here may grow a per-audit full scan).
+CREATE INDEX IF NOT EXISTS idx_page_rule_cache_key
+  ON page_rule_cache(cache_key, created_at DESC);
+
 -- Duplicate-title / -description / -content grouping (GROUP BY hash within a crawl).
 CREATE INDEX IF NOT EXISTS idx_page_features_title_hash
   ON page_features(crawl_id, title_hash);
@@ -871,6 +920,20 @@ CREATE INDEX IF NOT EXISTS idx_page_features_template
 CREATE INDEX IF NOT EXISTS idx_page_features_type
   ON page_features(crawl_id, page_type, normalized_url);
 `;
+
+// gzip a payload into a buffer bun:sqlite will bind as a BLOB. Wrapped so the
+// `Uint8Array<ArrayBufferLike>` bun's gzipSync returns is narrowed once, here,
+// rather than at every call site.
+//
+// LEVEL 1, not the default 6. This runs once per page on every COLD audit, which
+// is the run that gets nothing back from the cache, so its cost is the one paid
+// by a first-time user. Level 1 is several times faster and the rows are retired
+// with their crawl, so the extra bytes live no longer than the audit does — the
+// wrong end of the trade to optimise.
+function gzipped(payload: string): Uint8Array<ArrayBuffer> {
+  const out = Bun.gzipSync(Buffer.from(payload), { level: 1 });
+  return new Uint8Array(out.buffer as ArrayBuffer, out.byteOffset, out.byteLength);
+}
 
 const SQLITE_BUSY_TIMEOUT_MS = 15000;
 
@@ -1371,9 +1434,21 @@ export class SQLiteStorage implements CrawlStorage {
         // When not available (cloud), store HTML inline in the DB.
         let htmlToStore: string | null = page.html;
         let contentHashToStore = page.contentHash;
+        // The EXACT-bytes hash of the HTML (#1990), distinct from
+        // `content_hash`, which is whitespace-NORMALIZED so the incremental
+        // crawler can call a reformatted page unchanged. Written only on the
+        // content-store path, where it costs nothing: the store is
+        // content-addressed by `sha256(bytes)`, so `put` has already computed
+        // it. Without a store (the cloud, which inlines HTML in the DB and has
+        // no project.db to cache into) it stays NULL rather than paying a second
+        // hash over every page on the path #1862 made memory-critical — a NULL
+        // means "this page does not participate in the rule-result cache", which
+        // is the safe answer, never a wrong one.
+        let exactHtmlHash: string | null = null;
         if (page.html && this.contentStore) {
           const htmlHash = this.contentStore.put(page.html, "text/html");
           contentHashToStore = htmlHash;
+          exactHtmlHash = htmlHash;
           htmlToStore = null; // HTML is in content-store, not local DB
         }
 
@@ -1385,8 +1460,8 @@ export class SQLiteStorage implements CrawlStorage {
             crawl_id, url, normalized_url, final_url, depth, parent_url,
             redirect_chain, status, content_type, size_bytes, load_time_ms, ttfb, download_time, fetched_at,
             etag, last_modified, content_hash, html, parsed_data, headers, security_headers, request_headers,
-            fetcher_id, fallback_reason, source_hash
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            fetcher_id, fallback_reason, source_hash, html_hash
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `);
         stmt.run(
           crawlId,
@@ -1413,7 +1488,8 @@ export class SQLiteStorage implements CrawlStorage {
           page.requestHeaders ? JSON.stringify(page.requestHeaders) : null,
           page.fetcherId ?? null,
           page.fallbackReason ?? null,
-          page.sourceHash ?? null
+          page.sourceHash ?? null,
+          exactHtmlHash
         );
       },
       catch: (e) => StorageError.write(e),
@@ -1660,6 +1736,7 @@ export class SQLiteStorage implements CrawlStorage {
       fetcherId: (row.fetcher_id as string | null) ?? undefined,
       fallbackReason: (row.fallback_reason as string | null) ?? undefined,
       sourceHash: (row.source_hash as string | null) ?? null,
+      htmlHash: (row.html_hash as string | null) ?? null,
     };
   }
 
@@ -3017,6 +3094,132 @@ export class SQLiteStorage implements CrawlStorage {
   /**
    * Batch save rule results for multiple pages in a single transaction
    */
+  /**
+   * Newest cached page-rule payload for each of `cacheKeys` (#1990).
+   *
+   * The key already encodes the page's url and every input its rules read, so a
+   * hit is exact and a miss is silent. Read across crawls: a warm audit looks up
+   * what the PREVIOUS audit stored. Chunked because SQLite caps bound parameters
+   * (default 32k) and a page batch could otherwise exceed it on a large crawl.
+   *
+   * Returns the payload as the JSON text that was stored; decoding it is the
+   * engine's business, not storage's.
+   */
+  loadPageRuleCache(
+    cacheKeys: readonly string[]
+  ): Effect.Effect<Map<string, string>, StorageError, never> {
+    return Effect.try({
+      try: () => {
+        const out = new Map<string, string>();
+        if (cacheKeys.length === 0) return out;
+        const db = this.getDb();
+        const CHUNK = 400;
+        for (let i = 0; i < cacheKeys.length; i += CHUNK) {
+          const chunk = cacheKeys.slice(i, i + CHUNK);
+          const placeholders = chunk.map(() => "?").join(",");
+          const rows = db
+            .query(
+              `SELECT cache_key, payload, created_at FROM page_rule_cache
+               WHERE cache_key IN (${placeholders})
+               ORDER BY created_at ASC`
+            )
+            .all(...chunk) as Array<{ cache_key: string; payload: Uint8Array<ArrayBuffer> }>;
+          // Several crawls can hold a row for one key; ORDER BY created_at ASC
+          // plus overwrite prefers the newest, whose crawl is furthest from being
+          // retired. It is a preference and not a guarantee — rows written in the
+          // same millisecond tie, and SQLite resolves a tie by the index plan
+          // rather than by the query. That is harmless HERE and only here: the key
+          // covers every input that determines the payload, so two rows sharing a
+          // key hold the same bytes and are interchangeable.
+          for (const row of rows) {
+            out.set(row.cache_key, Buffer.from(Bun.gunzipSync(row.payload)).toString("utf8"));
+          }
+        }
+        return out;
+      },
+      catch: (e) => StorageError.read(e),
+    });
+  }
+
+  /**
+   * Write this crawl's page-rule cache entries (#1990), gzipped, in one
+   * transaction.
+   *
+   * Called with EVERY page the audit scored, replayed pages included — that
+   * carry-forward is what lets `retireCrawls` delete an older crawl's rows
+   * without making the next audit cold.
+   */
+  savePageRuleCacheBatch(
+    crawlId: string,
+    entries: ReadonlyArray<{ normalizedUrl: string; cacheKey: string; payload: string }>
+  ): Effect.Effect<void, StorageError, never> {
+    return Effect.try({
+      try: () => {
+        if (entries.length === 0) return;
+        const db = this.getDb();
+        const stmt = db.prepare(`
+          INSERT OR REPLACE INTO page_rule_cache (
+            crawl_id, normalized_url, cache_key, payload, created_at
+          ) VALUES (?, ?, ?, ?, ?)
+        `);
+        const now = Date.now();
+        const transaction = db.transaction(() => {
+          for (const entry of entries) {
+            stmt.run(
+              crawlId,
+              entry.normalizedUrl,
+              entry.cacheKey,
+              gzipped(entry.payload),
+              now
+            );
+          }
+        });
+        transaction();
+      },
+      catch: (e) => StorageError.write(e),
+    });
+  }
+
+  /**
+   * Copy existing cache entries into this crawl, by key (#1990).
+   *
+   * A replayed page's stored bytes are already exactly right, so this is a pure
+   * SQL row copy: no decode, no re-encode, no re-compress. Doing it the other way
+   * would put a full serialize + gzip of every page back on the warm run, which is
+   * the run the whole feature exists to make cheap.
+   *
+   * Silently skips a key with no row — the only way that happens is the entry
+   * being retired between the read and the write, and a missing carry-forward
+   * costs the NEXT audit a page's rules, never this one's correctness.
+   */
+  carryForwardPageRuleCache(
+    crawlId: string,
+    entries: ReadonlyArray<{ normalizedUrl: string; cacheKey: string }>
+  ): Effect.Effect<void, StorageError, never> {
+    return Effect.try({
+      try: () => {
+        if (entries.length === 0) return;
+        const db = this.getDb();
+        const stmt = db.prepare(`
+          INSERT OR REPLACE INTO page_rule_cache (
+            crawl_id, normalized_url, cache_key, payload, created_at
+          )
+          SELECT ?, ?, cache_key, payload, ?
+          FROM page_rule_cache WHERE cache_key = ?
+          ORDER BY created_at DESC LIMIT 1
+        `);
+        const now = Date.now();
+        const transaction = db.transaction(() => {
+          for (const entry of entries) {
+            stmt.run(crawlId, entry.normalizedUrl, now, entry.cacheKey);
+          }
+        });
+        transaction();
+      },
+      catch: (e) => StorageError.write(e),
+    });
+  }
+
   saveRuleResultsBatch(
     crawlId: string,
     pageResults: Map<string, { ruleId: string; checks: CheckResult[] }[]>
@@ -3391,6 +3594,11 @@ export class SQLiteStorage implements CrawlStorage {
    */
   private static readonly RETIREABLE_TABLES = [
     "rule_results",
+    // Safe to retire even though the NEXT audit reads it (#1990), unlike `links`
+    // and `images` below: every audit writes a row for every page it scored,
+    // replayed pages included, so the newest crawl always holds a complete cache
+    // and retiring an older one costs nothing. Recomputable by definition.
+    "page_rule_cache",
     "sitemap_urls",
     "sitemaps",
     "sitemap_url_statuses",

--- a/packages/crawler/src/storage/sqlite.ts
+++ b/packages/crawler/src/storage/sqlite.ts
@@ -3117,20 +3117,26 @@ export class SQLiteStorage implements CrawlStorage {
         for (let i = 0; i < cacheKeys.length; i += CHUNK) {
           const chunk = cacheKeys.slice(i, i + CHUNK);
           const placeholders = chunk.map(() => "?").join(",");
+          // ONE row per key, chosen in SQL. Every retained audit holds a row for
+          // an unchanged page, so selecting them all and letting the last write
+          // win would decompress (pages x retained audits) payloads per audit —
+          // work that grows with history rather than with the crawl, which is
+          // exactly what a per-page cache must not do (#1908).
+          //
+          // `max(created_at)` with bare columns is SQLite's documented
+          // min/max-aggregate case: the other columns come from the row holding
+          // the maximum. Rows tie when two audits land in the same millisecond and
+          // SQLite may then return either — harmless HERE and only here, because
+          // the key covers every input that determines the payload, so two rows
+          // sharing a key hold the same bytes.
           const rows = db
             .query(
-              `SELECT cache_key, payload, created_at FROM page_rule_cache
+              `SELECT cache_key, payload, max(created_at) AS newest
+               FROM page_rule_cache
                WHERE cache_key IN (${placeholders})
-               ORDER BY created_at ASC`
+               GROUP BY cache_key`
             )
             .all(...chunk) as Array<{ cache_key: string; payload: Uint8Array<ArrayBuffer> }>;
-          // Several crawls can hold a row for one key; ORDER BY created_at ASC
-          // plus overwrite prefers the newest, whose crawl is furthest from being
-          // retired. It is a preference and not a guarantee — rows written in the
-          // same millisecond tie, and SQLite resolves a tie by the index plan
-          // rather than by the query. That is harmless HERE and only here: the key
-          // covers every input that determines the payload, so two rows sharing a
-          // key hold the same bytes and are interchangeable.
           for (const row of rows) {
             out.set(row.cache_key, Buffer.from(Bun.gunzipSync(row.payload)).toString("utf8"));
           }

--- a/packages/crawler/tests/page-rule-cache-store.test.ts
+++ b/packages/crawler/tests/page-rule-cache-store.test.ts
@@ -131,23 +131,34 @@ describe("page_rule_cache storage", () => {
   // sharing a key hold the same bytes. Pinning "newest" would be pinning SQLite's
   // tie-break on two rows written in the same millisecond, which is the index
   // plan's choice and not the query's.
-  test("a key held by two crawls resolves to one payload", async () => {
+  // Every retained audit holds a row for an unchanged page, so a lookup that
+  // returned them all would decompress (pages x retained audits) payloads per
+  // audit — work that grows with history rather than with the crawl. The SQL
+  // picks one row per key, so the result size is the assertion.
+  //
+  // WHICH row is deliberately not asserted: the key covers every input that
+  // determines the payload, so rows sharing a key hold the same bytes, and
+  // pinning "newest" would be pinning SQLite's tie-break on rows written in the
+  // same millisecond.
+  test("a key held by many crawls resolves to exactly one payload", async () => {
     await withStorage(async (storage, firstCrawl) => {
       const payload = '{"gen":"identical-by-construction"}';
-      await run(
-        storage.savePageRuleCacheBatch(firstCrawl, [
-          { normalizedUrl: "http://x.test/a", cacheKey: "k1", payload },
-        ])
-      );
-      const secondCrawl = await run(storage.createCrawl(crawlMeta(2_000)));
-      await run(
-        storage.savePageRuleCacheBatch(secondCrawl, [
-          { normalizedUrl: "http://x.test/a", cacheKey: "k1", payload },
-        ])
-      );
-      const loaded = await run(storage.loadPageRuleCache(["k1"]));
-      expect(loaded.size).toBe(1);
+      const crawls = [firstCrawl];
+      for (let i = 0; i < 9; i++) {
+        crawls.push(await run(storage.createCrawl(crawlMeta(2_000 + i))));
+      }
+      for (const crawlId of crawls) {
+        await run(
+          storage.savePageRuleCacheBatch(crawlId, [
+            { normalizedUrl: "http://x.test/a", cacheKey: "k1", payload },
+            { normalizedUrl: "http://x.test/b", cacheKey: "k2", payload },
+          ])
+        );
+      }
+      const loaded = await run(storage.loadPageRuleCache(["k1", "k2"]));
+      expect(loaded.size).toBe(2);
       expect(loaded.get("k1")).toBe(payload);
+      expect(loaded.get("k2")).toBe(payload);
     });
   });
 

--- a/packages/crawler/tests/page-rule-cache-store.test.ts
+++ b/packages/crawler/tests/page-rule-cache-store.test.ts
@@ -1,0 +1,230 @@
+// The SQL half of the per-page rule-result cache (#1990).
+//
+// The engine's parity gate runs against an in-memory store, so nothing there
+// exercises the statements: the gzip round-trip, the newest-row-wins lookup, the
+// carry-forward copy, or the retirement that keeps project.db from growing a
+// permanent second copy of every audit.
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Effect } from "effect";
+
+import { SQLiteStorage } from "../src/storage/sqlite";
+import type { CrawlMetadata, PageRecord } from "../src/storage/types";
+
+const STATS = {
+  pagesTotal: 0,
+  pagesFetched: 0,
+  pagesFailed: 0,
+  pagesSkipped: 0,
+  pagesUnchanged: 0,
+  linksTotal: 0,
+  imagesTotal: 0,
+  bytesTotal: 0,
+  avgLoadTimeMs: 0,
+};
+
+const crawlMeta = (startedAt: number): Omit<CrawlMetadata, "id"> => ({
+  baseUrl: "http://x.test",
+  startedAt,
+  status: "completed",
+  config: {} as CrawlMetadata["config"],
+  stats: STATS,
+});
+
+const run = <A, E>(e: Effect.Effect<A, E, never>) => Effect.runPromise(e);
+
+function tmpDb(name: string): string {
+  return join(mkdtempSync(join(tmpdir(), "squirrelscan-prc-")), `${name}.sqlite`);
+}
+
+async function withStorage<T>(fn: (s: SQLiteStorage, crawlId: string) => Promise<T>): Promise<T> {
+  const dir = tmpDb("store");
+  const storage = new SQLiteStorage(dir);
+  try {
+    await run(storage.init());
+    const crawlId = await run(
+      storage.createCrawl(crawlMeta(1_000)));
+    return await fn(storage, crawlId);
+  } finally {
+    await run(storage.close());
+    rmSync(join(dir, ".."), { recursive: true, force: true });
+  }
+}
+
+describe("page_rule_cache storage", () => {
+  test("round-trips a payload through gzip", async () => {
+    await withStorage(async (storage, crawlId) => {
+      const payload = JSON.stringify({ ruleResults: [["core/meta-title", []]], big: "x".repeat(5000) });
+      await run(
+        storage.savePageRuleCacheBatch(crawlId, [
+          { normalizedUrl: "http://x.test/a", cacheKey: "k1", payload },
+        ])
+      );
+      const loaded = await run(storage.loadPageRuleCache(["k1", "missing"]));
+      expect(loaded.get("k1")).toBe(payload);
+      expect(loaded.has("missing")).toBe(false);
+    });
+  });
+
+  test("an empty key list does no query and returns nothing", async () => {
+    await withStorage(async (storage) => {
+      expect((await run(storage.loadPageRuleCache([]))).size).toBe(0);
+    });
+  });
+
+  test("carry-forward copies the row into a new crawl without re-encoding", async () => {
+    await withStorage(async (storage, firstCrawl) => {
+      const payload = JSON.stringify({ ruleResults: [], marker: "original" });
+      await run(
+        storage.savePageRuleCacheBatch(firstCrawl, [
+          { normalizedUrl: "http://x.test/a", cacheKey: "k1", payload },
+        ])
+      );
+      const secondCrawl = await run(
+        storage.createCrawl(crawlMeta(2_000)));
+      await run(
+        storage.carryForwardPageRuleCache(secondCrawl, [
+          { normalizedUrl: "http://x.test/a", cacheKey: "k1" },
+        ])
+      );
+      // Retiring the crawl the entry came FROM must not lose it: that is the whole
+      // point of carrying it forward.
+      await run(storage.retireCrawls([firstCrawl]));
+      const loaded = await run(storage.loadPageRuleCache(["k1"]));
+      expect(loaded.get("k1")).toBe(payload);
+    });
+  });
+
+  test("carrying forward a key with no row is a no-op, not an error", async () => {
+    await withStorage(async (storage, crawlId) => {
+      await run(
+        storage.carryForwardPageRuleCache(crawlId, [
+          { normalizedUrl: "http://x.test/gone", cacheKey: "never-stored" },
+        ])
+      );
+      expect((await run(storage.loadPageRuleCache(["never-stored"]))).size).toBe(0);
+    });
+  });
+
+  test("retiring a crawl reclaims its cache rows", async () => {
+    await withStorage(async (storage, crawlId) => {
+      await run(
+        storage.savePageRuleCacheBatch(crawlId, [
+          { normalizedUrl: "http://x.test/a", cacheKey: "k1", payload: "{}" },
+          { normalizedUrl: "http://x.test/b", cacheKey: "k2", payload: "{}" },
+        ])
+      );
+      const preview = await run(storage.previewRetireCrawls([crawlId]));
+      expect(preview.rowsByTable.page_rule_cache).toBe(2);
+      await run(storage.retireCrawls([crawlId]));
+      expect((await run(storage.loadPageRuleCache(["k1", "k2"]))).size).toBe(0);
+    });
+  });
+
+  // Two crawls holding a row for one key is the ordinary steady state, and the
+  // lookup must resolve to exactly one payload. WHICH one is deliberately not
+  // asserted: the key covers every input that determines the payload, so rows
+  // sharing a key hold the same bytes. Pinning "newest" would be pinning SQLite's
+  // tie-break on two rows written in the same millisecond, which is the index
+  // plan's choice and not the query's.
+  test("a key held by two crawls resolves to one payload", async () => {
+    await withStorage(async (storage, firstCrawl) => {
+      const payload = '{"gen":"identical-by-construction"}';
+      await run(
+        storage.savePageRuleCacheBatch(firstCrawl, [
+          { normalizedUrl: "http://x.test/a", cacheKey: "k1", payload },
+        ])
+      );
+      const secondCrawl = await run(storage.createCrawl(crawlMeta(2_000)));
+      await run(
+        storage.savePageRuleCacheBatch(secondCrawl, [
+          { normalizedUrl: "http://x.test/a", cacheKey: "k1", payload },
+        ])
+      );
+      const loaded = await run(storage.loadPageRuleCache(["k1"]));
+      expect(loaded.size).toBe(1);
+      expect(loaded.get("k1")).toBe(payload);
+    });
+  });
+
+  // SQLite's default bound-parameter limit is 32k; a page batch on a large crawl
+  // plus a caller that batched more aggressively would blow past it as one IN list.
+  test("a key list larger than one chunk is still resolved in full", async () => {
+    await withStorage(async (storage, crawlId) => {
+      const entries = Array.from({ length: 950 }, (_, i) => ({
+        normalizedUrl: `http://x.test/${i}`,
+        cacheKey: `k${i}`,
+        payload: `{"i":${i}}`,
+      }));
+      await run(storage.savePageRuleCacheBatch(crawlId, entries));
+      const loaded = await run(storage.loadPageRuleCache(entries.map((e) => e.cacheKey)));
+      expect(loaded.size).toBe(950);
+      expect(loaded.get("k949")).toBe('{"i":949}');
+    });
+  });
+});
+
+describe("pages.html_hash", () => {
+  // The exact-bytes identity the cache key needs. Without a content store there is
+  // none, and the cache simply does not engage — which must read as null rather
+  // than as the NORMALIZED content hash, or a whitespace-only edit would look
+  // unchanged.
+  test("is null without a content store, and the exact hash with one", async () => {
+    const dir = tmpDb("hash");
+    const blobs = new Map<string, string>();
+    const contentStore = {
+      put(content: string) {
+        const hash = new Bun.CryptoHasher("sha256").update(content).digest("hex");
+        blobs.set(hash, content);
+        return hash;
+      },
+      getString(hash: string) {
+        return blobs.get(hash) ?? null;
+      },
+    };
+
+    const bare = new SQLiteStorage(dir);
+    await run(bare.init());
+    const crawlId = await run(bare.createCrawl(crawlMeta(1_000)));
+    const page: PageRecord = {
+      url: "http://x.test/a",
+      normalizedUrl: "http://x.test/a",
+      finalUrl: "http://x.test/a",
+      depth: 0,
+      status: 200,
+      contentType: "text/html",
+      sizeBytes: 20,
+      loadTimeMs: 5,
+      fetchedAt: 1,
+      etag: null,
+      lastModified: null,
+      contentHash: "normalized-hash",
+      html: "<html> <body>hi</body></html>",
+      parsedData: null,
+      headers: {} as never,
+      securityHeaders: {} as never,
+    };
+    await run(bare.upsertPage(crawlId, page));
+    expect((await run(bare.getPage(crawlId, page.normalizedUrl)))!.htmlHash).toBeNull();
+    await run(bare.close());
+
+    const withStore = new SQLiteStorage(dir, contentStore);
+    await run(withStore.init());
+    await run(withStore.upsertPage(crawlId, page));
+    const stored = await run(withStore.getPage(crawlId, page.normalizedUrl));
+    const expected = new Bun.CryptoHasher("sha256").update(page.html!).digest("hex");
+    expect(stored!.htmlHash).toBe(expected);
+    // Whitespace-only edit: the exact hash moves even though a normalized one
+    // would not. This is the property the cache key depends on.
+    const reformatted = { ...page, html: "<html>  <body>hi</body></html>" };
+    await run(withStore.upsertPage(crawlId, reformatted));
+    const after = await run(withStore.getPage(crawlId, page.normalizedUrl));
+    expect(after!.htmlHash).not.toBe(expected);
+    await run(withStore.close());
+    rmSync(join(dir, ".."), { recursive: true, force: true });
+  });
+});

--- a/packages/report/src/output/json.ts
+++ b/packages/report/src/output/json.ts
@@ -203,6 +203,11 @@ function buildSlimReport(report: AuditReport, version: string): SlimJsonReport {
         ? { requestedMaxPages: report.scanScope.requestedMaxPages }
         : {}),
       ...(report.coverage ? { coverage: report.coverage } : {}),
+      // #1990: how much of this audit's rules phase was replayed from a previous
+      // audit rather than evaluated now. A replay and a fresh evaluation produce
+      // identical findings by construction, so this is the only thing in the
+      // report that distinguishes them (#1981).
+      ...(report.rulesCache ? { rulesCache: report.rulesCache } : {}),
     },
     status: report.status ?? "completed",
     ...(report.statusReason ? { statusReason: report.statusReason } : {}),

--- a/packages/report/src/output/llm.ts
+++ b/packages/report/src/output/llm.ts
@@ -220,6 +220,17 @@ export function renderLlm(report: AuditReport, options?: LlmRenderOptions): stri
     );
   }
 
+  // Rule-result cache disclosure (#1990). An agent asking "is this a fresh
+  // reading of my site?" cannot tell from the findings — a replay is identical by
+  // construction — so the answer has to be stated (#1981).
+  if (report.rulesCache) {
+    const rc = report.rulesCache;
+    const why = rc.disabledReason ? ` disabled-reason="${rc.disabledReason}"` : "";
+    lines.push(
+      `<rules-cache pages-replayed="${rc.pagesReplayed}" pages-evaluated="${rc.pagesEvaluated}"${why}/>`,
+    );
+  }
+
   // Editor's summary — report-only exec narrative for the agent (does not affect the score).
   const es = editorSummaryView(report.editorSummary);
   if (es) {

--- a/packages/rules/src/runner.ts
+++ b/packages/rules/src/runner.ts
@@ -17,6 +17,7 @@ import type {
   ParsedPage,
   Rule,
   RuleContext,
+  RuleMeta,
   RuleRunResult,
   SiteData,
 } from "./types";
@@ -198,6 +199,29 @@ export class RuleRunner {
   // Get list of enabled rules
   getEnabledRules(): Rule[] {
     return this.enabledRuleIds.map((id) => this.rules.get(id)!);
+  }
+
+  /**
+   * The enabled PAGE rules in execution order, each with the options it will
+   * actually run with (squirrelscan/repo#1990).
+   *
+   * This is what a per-page rule-result cache keys on, so it must be the resolved
+   * options and not the raw config: a rule's Zod defaults are part of its verdict,
+   * and a rules-package upgrade that changes a default has to invalidate cached
+   * results even when nobody edited squirrel.toml. Returned as an ARRAY because
+   * order is part of the identity — reordering the rule set reorders the flat
+   * per-page check list, which the report renders.
+   */
+  pageRuleSignature(): Array<{ id: string; options: Record<string, unknown> }> {
+    return this.getEnabledRules()
+      .filter((rule) => rule.meta.scope === "page")
+      .map((rule) => ({ id: rule.meta.id, options: getRuleOptions(rule, this.config) }));
+  }
+
+  /** `meta` for an enabled rule, or undefined. Lets a cached result be re-assembled
+   *  into a {@link RuleRunResult} with the LIVE meta rather than a stored copy. */
+  getRuleMeta(ruleId: string): RuleMeta | undefined {
+    return this.rules.get(ruleId)?.meta;
   }
 
   /**


### PR DESCRIPTION
A second audit of an unchanged site already fetches nothing. It was not faster, because parse, page rules, the page-time collectors and report reconstruction re-ran in full on every page whether or not that page changed. Crawl reuse is a bandwidth feature; this is the one that makes a re-audit cheap.

A page now replays its stored rule results when every input its rules read is unchanged. It is never parsed and its rules never run. Site-scope rules always run.

## What it is worth

2,500 pages of the mixed synthetic estate, both arms on the SAME build with `SQUIRREL_RULE_CACHE=0` as the only difference, one pinned origin per pair, fresh content store per pair, load average 2.4 to 4.1.

| stage | wall | rules phase | report phase | project.db |
|---|---|---|---|---|
| cache off, cold | 178 s | 116 s | 22 s | 258 MB |
| cache off, warm | 143 s | 110 s | 18 s | 514 MB |
| cache on, cold | 177 s | 124 s | 19 s | 291 MB |
| **cache on, warm** | **44 s** | **12 s** | 18 s | 581 MB |

The warm rules phase falls from 110 s to 12 s, against the 50% the issue asked for. All 2,500 pages replayed, and the cache-on cold and warm reports are byte-identical across all 3,039,997 bytes once `meta.timestamp` and the replay disclosure are removed.

Full write-up in `benchmarks/2026-09-perf-program.md`.

## NIK: this turns template fan-out (#279) off whenever the cache is on

They do not compose, and the reason is structural rather than fixable here. A fanned verdict belongs to the page's CLUSTER, so no per-page key can capture what it depends on: cache two pages of one cluster, change the FIRST one, and the second page replays the verdict it inherited from the representative's previous run while a fresh audit gives it the new one. Nothing about the second page changed, so nothing about its key can notice. Two designs that tried to keep both were written and rejected; the review reproduced the failure in each.

The trade, measured in the cold row above: **the rules phase goes from 116 s to 124 s, 6.9%**, with cold wall time unchanged. Every audit after the first takes the 89%. It also makes the report the one every rule actually computed rather than one where some verdicts were inherited: the cache-on cold report is 3,039,997 bytes against 3,043,863 with fan-out on, which is #275's open question about the chrome-only cluster key made visible.

If you would rather keep fan-out, `SQUIRREL_RULE_CACHE=0` does that today and the alternative is the follow-up design (cache the cluster's verdict against its representative's identity). Say the word and I will file it.

## What makes it sound

The key covers every input a page rule reads:

- **The page's exact HTML bytes.** NOT `content_hash`, which is whitespace-NORMALIZED so the incremental crawler can call a reformatted page unchanged. Two pages differing only in whitespace share it and parse to different word counts, inline-script lengths and `<pre>` text, so keying on it would have replayed one page's verdicts onto another's markup — with every existing gate green, because no fixture contains that pair. A new `pages.html_hash` carries the exact hash, and it costs nothing to produce: the content store is already addressed by `sha256(bytes)`.
- **The rest of the page record** the rules and `extractPageFeatures` read, including the three response timings, because `performance/ttfb` reads them. That is why replay pays off on a REUSED page and not on a re-fetched one, and the benchmark shows why it must: two independent crawls of the same estate disagree on 27 pages of `performance/ttfb`.
- **The run context**: the build (the CLI's release version, since `@squirrelscan/rules` has sat at 0.0.1 forever), the enabled page rules in order with their resolved options, the applicability escape hatch, the Stage-0 metadata, the prefetched cloud results, the `SiteData` entry fields page rules read, the current UTC year and the runtime time zone.

Gated out rather than approximated: a run with **threat intel** enabled does not replay at all. `IntelContext` is two functions over feeds that refresh daily behind a memoized handle, so its configuration identity is not an identity of its verdicts.

## Review

Sixteen findings across three adversarial `codex` passes, all fixed. The third returned nothing above P2. Beyond the fan-out story:

- `content/date-agreement` resolves a bare schema date through `Date.parse`, which reads it in LOCAL time, so the same page yields a different year under `UTC` and under `Australia/Sydney`. The time zone is in the key.
- A long audit can cross UTC New Year while it runs, where `content/stale-copyright` reads the clock itself. Replay stops for the rest of such a run rather than freezing a year the rule cannot be told about.
- `rules.ignore_applicability` changes a gated rule from a `skipped` check to its real verdict without touching the rule list or any option.
- The warm lookup picks one row per key in SQL. It was selecting every retained audit's copy and decompressing all of them, which is work that grows with history rather than with the crawl.
- The codec keeps `Date`s (including invalid ones, which serialize to `null`) and own `__proto__` keys; the canonical form no longer merges `NaN`/`Infinity`/`-Infinity`, `[]` with `new Array(1)`, a hole with `undefined`, or `-0` with `0`.

## Gates

- `rule-cache-replay-golden.test.ts` — cold, warm-populating and warm-replaying runs over one crawl; the full report must be byte-identical AND the replayed-page count must be right, because a cache that silently does nothing produces identical findings. Plus the template-cluster composition case, the exclusivity itself, and one invalidation case each for content (a whitespace-only edit), engine version, rule selection, rule options and applicability. The composition test was mutation-checked: it fails with the fix removed.
- `page-rule-site-context.test.ts` — the declaration falsifier. Runs the real page-rule pass with `SiteData` behind a recording proxy, down to individual script and resource entries, and fails if a rule reads a field the key does not cover.
- `page-rule-cache-store.test.ts` — the SQL half: gzip round-trip, carry-forward surviving retirement of the crawl it came from, retirement reclaiming the rows, chunked lookup, one payload per key across ten crawls, and `html_hash` null without a content store and moving on a whitespace-only edit.
- `rule-cache-codec.test.ts` — SHA-256 vectors, canonical-form sensitivity, run-context ingredients, and the tagged codec.
- Re-run green: the canonical 518-page v1↔v2 merge gate, both template fan-out gates, the streaming page-rule and collector goldens, the crawler retire and migration tests.

## Surface

- `report.rulesCache` — `{ pagesReplayed, pagesEvaluated, disabledReason? }`, in the JSON `meta` and as `<rules-cache/>` in the LLM report. An agent cannot otherwise tell a replay from a fresh audit (#1981). LOCAL ONLY: `slimForPublish` strips it, because it describes how this machine produced the report rather than the site.
- `--refresh` bypasses it, alongside the page cache. `SQUIRREL_RULE_CACHE=0` is the kill switch, mirroring `SQUIRREL_TEMPLATE_FANOUT`. `SQUIRREL_RULE_CACHE_DEBUG=1` prints a digest per run-context ingredient, which is how a cache that silently stops hitting gets diagnosed — it found one such defect during this work.
- Docs: a "Rule results" section under Caching in `docs/cli/audit.mdx`. `make validate` passes.

Schema 28 adds `page_rule_cache` and `pages.html_hash`, both additive, both in the ALTER-columns guard, and `page_rule_cache` is retired with its crawl by `retireCrawls`. Every audit writes an entry for every page it scored, replayed pages included by SQL row copy rather than re-encoding, so pruning older audits never makes the next one cold.

Rebased onto the automatic retention window (#285) that landed while this was in review, and verified against it: five audits of a 40-page project leave two crawls retired, cache rows under exactly the three that remain, and every audit after the first still replays every page. That is what the carry-forward is for. The benchmark table was taken just before retention landed; retention adds tens of milliseconds to an audit, against a 44-second warm run.

The cloud passes no store and is unchanged: it has no `project.db` to cache into, and `html_hash` is written only on the content-store path, so nothing is added to the crawl that #1862 made memory-critical.

Closes squirrelscan/repo#1990.
