### PR TITLE
docs(changelog): correct two v0.0.92 figures against the benchmark record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Every figure is from the checked-in record in
 | SQL statements compiled on a warm 120-page re-crawl | 1,482 | 48 |
 | Rules pass on a 1 MB script-heavy page | 274 ms | 165 ms |
 | Page-rule CPU on a templated site (25 template-scoped rules) | | 13% less |
-| Report assembly at 1,000 pages, peak memory | | 340 MB less |
+| Report assembly at 1,000 pages, peak memory | | about 150 MB less |
 | Hosted publish merge carrying 60,000 prior findings | 330 MB | under 100 MB |
 | Hosted re-audit of an unchanged 150-page site | 115 pages rendered | 17 rendered, report byte-identical |
 | Project database after six audits of a 40-page site | 14.7 MB | 11.9 MB |
@@ -115,7 +115,7 @@ Every figure is from the checked-in record in
 
 - **The report reads a crawl's checks once, not twice.** Assembling the report
   loaded every rule result twice; it now loads them once and reuses the rows,
-  which is about 340 MB less peak memory at 1,000 pages. The report also stops
+  which is about 150 MB less peak memory at 1,000 pages. The report also stops
   building per-page fields (response headers, image lists, structured data)
   that no output format or renderer ever read.
 
@@ -137,8 +137,8 @@ Every figure is from the checked-in record in
 
 - **A local audit crawls up to 10,000 pages.** The hard cap on `--max-pages`
   and `[crawler] max_pages` was 5,000; it is now 10,000, on every plan, local
-  audits being free either way. A 10,000-page audit needs roughly 4.5 GB of
-  memory and takes about fifteen minutes on a laptop, so the cap is a real
+  audits being free either way. A 10,000-page audit peaks at about 5.4 GB of
+  memory and takes about twelve minutes on a laptop, so the cap is a real
   ceiling rather than a formality: past it, split the audit by section with
   `include` patterns. Cloud audits follow their plan instead, and Team's
   ceiling rises to 10,000 with this release.


### PR DESCRIPTION
Two figures in the v0.0.92 notes disagreed with benchmarks/2026-09-perf-program.md: the report-assembly saving is about 150 MB at 1,000 pages (two reads +341 to +368 MB vs one materialization +202 to +206 MB; 340 was the BEFORE value), and the 10,000-page audit row is 746 s / 5,447 MiB, so 'about twelve minutes, 5.4 GB peak', not 'fifteen minutes, 4.5 GB'. Found by the w37 email facts pass. The GitHub release body gets the same edit after merge.