### PR TITLE
build(deps): ignore GHSA-866g-f22w-33x8 in the dependency audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:release": "bash scripts/test-changelog-extraction.sh && bun test scripts/release-version.test.ts",
     "docs:check": "cd docs && bun run check",
     "docs:build": "cd docs && bun run build",
-    "audit:dependencies": "bun audit --ignore=GHSA-9wv6-86v2-598j --ignore=GHSA-mh99-v99m-4gvg --ignore=GHSA-mwp4-54f8-5fhr --ignore=GHSA-4xrf-jv44-h6hh --ignore=GHSA-22jq-vg5j-6vgg --ignore=GHSA-rgw5-rvv9-x895 --ignore=GHSA-fxqj-rqcc-2cmp --ignore=GHSA-8xcm-r25x-g524 --ignore=GHSA-4cwx-7wf7-3272 --ignore=GHSA-m8rv-5g2x-5cg5 --ignore=GHSA-jr45-8vmc-qm54 --ignore=GHSA-v3r7-h72x-cjcm --ignore=GHSA-7p8r-x3mc-p8w7 --ignore=GHSA-8j4g-w8fx-2239 --ignore=GHSA-2v37-7h3g-55p8",
+    "audit:dependencies": "bun audit --ignore=GHSA-9wv6-86v2-598j --ignore=GHSA-mh99-v99m-4gvg --ignore=GHSA-mwp4-54f8-5fhr --ignore=GHSA-4xrf-jv44-h6hh --ignore=GHSA-22jq-vg5j-6vgg --ignore=GHSA-rgw5-rvv9-x895 --ignore=GHSA-fxqj-rqcc-2cmp --ignore=GHSA-8xcm-r25x-g524 --ignore=GHSA-4cwx-7wf7-3272 --ignore=GHSA-m8rv-5g2x-5cg5 --ignore=GHSA-jr45-8vmc-qm54 --ignore=GHSA-v3r7-h72x-cjcm --ignore=GHSA-7p8r-x3mc-p8w7 --ignore=GHSA-8j4g-w8fx-2239 --ignore=GHSA-2v37-7h3g-55p8 --ignore=GHSA-866g-f22w-33x8",
     "notices:generate": "bun run scripts/generate-third-party-notices.ts",
     "notices:check": "bun run scripts/generate-third-party-notices.ts --check",
     "check:psl-freshness": "bun run scripts/check-tldts-freshness.ts",


### PR DESCRIPTION
A new low advisory (Uncontrolled Resource Consumption in @ai-sdk/provider-utils >=4.0.0-beta.10 <4.0.33, GHSA-866g-f22w-33x8) started failing the Dependency audit job on every PR (first seen on #294). Same ignore-list pattern as the 15 existing entries; the version bump is tracked separately.