### PR TITLE
build(deps): bump github/codeql-action init and analyze to 4.37.9 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: javascript-typescript
           build-mode: none
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9


### PR DESCRIPTION
Supersedes #204 and #205. Each dependabot PR bumped only one of the two actions, and the analyze post-step refuses a config written by a different version ("Loaded a configuration file for version '4.37.8', but running version '4.37.9'"), so each PR failed CodeQL on its own. Both pinned to the same 4.37.9 sha here.