### PR TITLE
fix(cli): cap the URL-keyed script cache at one day and refresh stale rows in place

### DIFF
--- a/apps/cli/src/crawler/script-fetcher.ts
+++ b/apps/cli/src/crawler/script-fetcher.ts
@@ -39,6 +39,17 @@ export interface ScriptFetcherOptions {
   pageCount?: number; // For dynamic script limit calculation
 }
 
+/**
+ * How long a fetched script is replayed from ~/.squirrel/content-store.db
+ * before it is fetched again. The script cache is keyed by URL (#182), and the
+ * store is shared across every audit on the machine, so without a ceiling a
+ * script at a stable URL (app.js, not app.[hash].js) would never be re-read:
+ * a site could ship a new bundle and every later audit would still grade the
+ * old one. One day is long enough to make a re-audit of the same site cheap
+ * and short enough that a deploy shows up by the next day's run.
+ */
+export const SCRIPT_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
 const DEFAULT_OPTIONS: ScriptFetcherOptions = {
   concurrency: SCRIPT_FETCH_LIMITS.FETCH_CONCURRENCY,
   timeoutMs: SCRIPT_FETCH_LIMITS.FETCH_TIMEOUT_MS,
@@ -259,8 +270,12 @@ function fetchSingleScript(
     const store = getGlobalContentStore();
     const cacheKey = hashContent(url);
 
-    // Check cache first
-    const cached = store.getString(cacheKey);
+    // Check cache first. A hit older than SCRIPT_CACHE_MAX_AGE_MS is treated
+    // as a miss and refreshed below (putForKey overwrites in place).
+    const meta = store.getMeta(cacheKey);
+    const fresh =
+      meta !== null && Date.now() - meta.createdAt <= SCRIPT_CACHE_MAX_AGE_MS;
+    const cached = fresh ? store.getString(cacheKey) : null;
     if (cached !== null) {
       const sizeBytes = new TextEncoder().encode(cached).length;
       return {

--- a/apps/cli/src/crawler/storage/content-store.ts
+++ b/apps/cli/src/crawler/storage/content-store.ts
@@ -112,24 +112,31 @@ export class ContentStore {
    * Deduplication is automatic - if hash exists, just updates access time.
    */
   put(content: string | Buffer, contentType: ContentType): string {
-    return this.putAtHash(hashContent(content), content, contentType);
+    return this.putAtHash(hashContent(content), content, contentType, false);
   }
 
   /**
    * Store content under the SHA-256 hash of a caller-defined cache key.
+   *
+   * Unlike put(), the key says nothing about the content, so an existing row
+   * is REPLACED (content, sizes and created_at), not merely touched: a
+   * URL-keyed cache that kept the first body forever would never see a
+   * deploy. created_at therefore means "when this key was last refreshed",
+   * which is what a max-age check on the read side needs.
    */
   putForKey(
     key: string | Buffer,
     content: string | Buffer,
     contentType: ContentType
   ): string {
-    return this.putAtHash(hashContent(key), content, contentType);
+    return this.putAtHash(hashContent(key), content, contentType, true);
   }
 
   private putAtHash(
     hash: string,
     content: string | Buffer,
-    contentType: ContentType
+    contentType: ContentType,
+    replace: boolean
   ): string {
     const db = this.getDb();
     const now = Date.now();
@@ -139,15 +146,18 @@ export class ContentStore {
       .prepare("SELECT hash FROM content WHERE hash = ?")
       .get(hash) as { hash: string } | undefined;
 
-    if (existing) {
-      // Update access time and count
+    if (existing && !replace) {
+      // Content-addressed: same hash is the same bytes, just touch it.
       db.prepare(
         "UPDATE content SET last_accessed = ?, access_count = access_count + 1 WHERE hash = ?"
       ).run(now, hash);
       return hash;
     }
 
-    // Compress and store
+    // Compress and store. One UPSERT covers both the fresh insert and the
+    // keyed replacement: a prune in another process can delete the row between
+    // the SELECT above and this write, and a plain UPDATE would then report
+    // success while storing nothing.
     const buffer = typeof content === "string" ? Buffer.from(content) : content;
     const compressed = gzipSync(buffer, { level: 6 }); // Balance speed/size
     const originalSize = buffer.length;
@@ -155,7 +165,15 @@ export class ContentStore {
 
     db.prepare(
       `INSERT INTO content (hash, content, content_type, original_size, compressed_size, created_at, last_accessed, access_count)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 1)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+       ON CONFLICT(hash) DO UPDATE SET
+         content = excluded.content,
+         content_type = excluded.content_type,
+         original_size = excluded.original_size,
+         compressed_size = excluded.compressed_size,
+         created_at = excluded.created_at,
+         last_accessed = excluded.last_accessed,
+         access_count = content.access_count + 1`
     ).run(
       hash,
       compressed,

--- a/apps/cli/tests/crawler/content-store.test.ts
+++ b/apps/cli/tests/crawler/content-store.test.ts
@@ -1,6 +1,7 @@
 // Unit tests for content-addressable storage
 // Tests gzip compression, deduplication, LRU eviction, and cross-audit caching
 
+import { Database } from "bun:sqlite";
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -89,6 +90,62 @@ describe("Content Store", () => {
       expect(hash).toBe(hashContent(url));
       expect(store.getString(hash)).toBe(js);
       expect(store.getString(hashContent(js))).toBeNull();
+    });
+
+    test("putForKey replaces the content under an existing key", () => {
+      const url = "https://cdn.example.com/app.js";
+      const hash = store.putForKey(url, "v1", "application/javascript");
+      // Backdate so a refreshed created_at is distinguishable within one ms.
+      const aged = Date.now() - 100_000;
+      new Database(dbPath)
+        .prepare("UPDATE content SET created_at = ? WHERE hash = ?")
+        .run(aged, hash);
+
+      store.putForKey(url, "v2 is longer", "application/javascript");
+      const second = store.getMeta(hash);
+      expect(store.getString(hash)).toBe("v2 is longer");
+      expect(second?.originalSize).toBe("v2 is longer".length);
+      expect(second?.createdAt).toBeGreaterThan(aged);
+      expect(second?.accessCount).toBe(2);
+    });
+
+    test("put keeps the first row for content-addressed re-inserts", () => {
+      const js = "console.log(1)";
+      const hash = store.put(js, "application/javascript");
+      const aged = Date.now() - 100_000;
+      new Database(dbPath)
+        .prepare("UPDATE content SET created_at = ? WHERE hash = ?")
+        .run(aged, hash);
+      store.put(js, "application/javascript");
+      expect(store.getMeta(hash)?.createdAt).toBe(aged);
+      expect(store.getMeta(hash)?.accessCount).toBe(2);
+    });
+
+    test("a keyed replacement that grows the store still triggers pruning", () => {
+      const small = new ContentStore(join(testDir, "small.db"), 4_000);
+      try {
+        // Incompressible bodies so the compressed size tracks the input size.
+        const noise = (n: number) =>
+          Array.from({ length: n }, () =>
+            Math.random().toString(36).slice(2, 4)
+          ).join("");
+        for (let i = 0; i < 4; i++) {
+          small.putForKey(
+            `https://cdn.example.com/${i}.js`,
+            noise(400),
+            "application/javascript"
+          );
+        }
+        expect(small.getStats().totalBytes).toBeLessThanOrEqual(4_000);
+        small.putForKey(
+          "https://cdn.example.com/0.js",
+          noise(3_000),
+          "application/javascript"
+        );
+        expect(small.getStats().totalBytes).toBeLessThanOrEqual(4_000);
+      } finally {
+        small.close();
+      }
     });
 
     test("should return null for non-existent hash", () => {

--- a/apps/cli/tests/crawler/script-fetcher-encoding.test.ts
+++ b/apps/cli/tests/crawler/script-fetcher-encoding.test.ts
@@ -5,14 +5,22 @@
 // has a content-store cache the engine fork lacks — a cache hit never touches
 // the network, so it must report the encoding as unknown rather than as absent.
 
+import { Database } from "bun:sqlite";
 import { afterAll, describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { fetchScriptContents } from "@/crawler/script-fetcher";
-import { closeGlobalContentStore } from "@/crawler/storage/content-store";
+import {
+  SCRIPT_CACHE_MAX_AGE_MS,
+  fetchScriptContents,
+} from "@/crawler/script-fetcher";
+import {
+  closeGlobalContentStore,
+  getGlobalContentStore,
+  hashContent,
+} from "@/crawler/storage/content-store";
 
 const BODY = `console.log(${JSON.stringify("x".repeat(2000))});`;
 const GZIPPED = Bun.gzipSync(new TextEncoder().encode(BODY));
@@ -95,5 +103,35 @@ describe("CLI script fetcher content-encoding (#9)", () => {
     expect(second?.fromCache).toBe(true);
     expect(second?.contentEncoding).toBeUndefined();
     expect(cacheRouteRequests).toBe(1);
+  });
+
+  // The store is shared by every audit on the machine and keyed by URL, so a
+  // stable URL would otherwise be replayed forever (#182 follow-up).
+  test("a cached script older than the max age is fetched again", async () => {
+    const url = `${base}/cache.js`;
+    const before = cacheRouteRequests;
+    const store = getGlobalContentStore();
+    const key = hashContent(url);
+    expect(store.getMeta(key)).not.toBeNull();
+
+    // Age the row past the ceiling with the same content still in place.
+    store.putForKey(url, "stale body", "application/javascript");
+    const db = new Database(store.getPath());
+    db.prepare("UPDATE content SET created_at = ? WHERE hash = ?").run(
+      Date.now() - SCRIPT_CACHE_MAX_AGE_MS - 1000,
+      key
+    );
+    db.close();
+
+    const [refreshed] = await Effect.runPromise(fetchScriptContents([url]));
+    expect(refreshed?.fromCache).not.toBe(true);
+    expect(refreshed?.content).toBe(BODY);
+    expect(cacheRouteRequests).toBe(before + 1);
+
+    // The refresh overwrote the stale row, so the next read is a fresh hit.
+    expect(store.getString(key)).toBe(BODY);
+    const [again] = await Effect.runPromise(fetchScriptContents([url]));
+    expect(again?.fromCache).toBe(true);
+    expect(cacheRouteRequests).toBe(before + 1);
   });
 });


### PR DESCRIPTION
Follow-up to #206 (#182). With the script cache keyed by URL, the store at ~/.squirrel/content-store.db is shared by every audit on the machine and had no freshness check, so a script at a stable URL (app.js rather than app.[hash].js) would be replayed forever: a site could ship a new bundle and every later audit would still grade the old one.

- Lookup treats a row older than 24h as a miss (SCRIPT_CACHE_MAX_AGE_MS).
- putForKey now REPLACES an existing row (content, sizes, created_at) via one UPSERT, so the refresh lands and still goes through the size prune; a plain UPDATE could race a prune in another process and report success while storing nothing.
- put() for content-addressed callers is unchanged (same bytes, touch only).
- Tests: replacement, content-addressed preservation with a backdated created_at, replacement growth still prunes, and an aged row is re-fetched then served fresh.

Codex-reviewed (no review bot on this repo); its two findings (replacement bypassed prune, UPDATE vs concurrent prune) are the UPSERT above.