### PR TITLE
fix(crawler): give the entry URL a second chance and name the deadline when it times out (repo#1699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ How it works:
 
 ### Fixed
 
+- A cloud audit of a site whose sitemap points at another domain no longer fails
+  with "No pages were crawled from <site>: The operation was aborted." when the
+  entry page's first fetch hits its deadline. The entry URL now gets one more
+  plain fetch with a doubled deadline before the audit is given up (a `warning`
+  event says so), an abort from a document fetcher classifies as a timeout that
+  names the fetcher and the deadline instead of `unknown` with the runtime's
+  text, and a crawl whose preamble budget runs out records a warning naming the
+  budget. squirrelscan/repo#1699
 - `squirrel self update` now checks that the binary your PATH resolves is the one
   it just installed, and says so when it isn't. It used to flip the symlink
   recorded at install time and report success on that alone, so a stale

--- a/packages/core-contracts/src/index.ts
+++ b/packages/core-contracts/src/index.ts
@@ -785,7 +785,21 @@ export type CrawlerEvent =
  * probe cannot see an apex→www redirect the whole audit describes the wrong
  * host. The page fetch is the first evidence that contradicts it.
  */
-export type CrawlWarningCode = "seed-base-mismatch";
+export type CrawlWarningCode =
+  | "seed-base-mismatch"
+  /**
+   * The entry URL's fetch timed out before any page was stored, and the crawl
+   * is retrying it once through a plain fetch with a relaxed deadline
+   * (squirrelscan/repo#1699). The message names both deadlines.
+   */
+  | "entry-fetch-retried"
+  /**
+   * The crawl preamble's wall-clock budget ran out, so the root probes that
+   * had not started were skipped and the crawl went ahead with what it had
+   * (squirrelscan/repo#1699). Their records carry the not-attempted marker,
+   * never a confirmed absence.
+   */
+  | "preamble-budget-exhausted";
 
 export interface AuditLifecycleEvent {
   type:

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -1,7 +1,7 @@
 // Main crawler implementation
 // Decoupled from AuditContext, uses storage layer and emits events
 
-import { Effect, Stream, PubSub, Duration, Deferred } from "effect";
+import { Effect, Stream, PubSub, Duration, Deferred, Either } from "effect";
 
 import type {
   AuditFailureDetail,
@@ -21,7 +21,7 @@ import { DEFAULT_MAX_DOCUMENT_BODY_BYTES, readBodyCapped } from "@squirrelscan/u
 import { isHttpOrHttpsUrl } from "@squirrelscan/utils/safe-fetch";
 import { urlHostKey } from "@squirrelscan/utils/url";
 
-import { createPhaseBudget, withRequestDeadline } from "../deadline";
+import { budgetRemainingMs, createPhaseBudget, withRequestDeadline } from "../deadline";
 import type { PhaseBudget } from "../deadline";
 import {
   computeSitemapUrlCap,
@@ -56,8 +56,10 @@ import type {
 import { createHostBackoff, type HostBackoffRegistry } from "../host-backoff";
 import {
   crawlErrorToFailureDetail,
+  CrawlError,
   fetchPageWithRetry,
   type CrawlFetcher,
+  type FetchOptions,
   type RateLimitControl,
 } from "../fetcher";
 import { normalizeUrl, isInScope, isOffSiteFinalUrl, resolveSeedRedirect } from "../frontier";
@@ -103,6 +105,74 @@ const PATTERN_SAMPLE_LIMIT = 1;
  */
 function failureSourceFor(source: FrontierSource): AuditFailureSource {
   return source === "seed" ? "entry" : "sitemap";
+}
+
+/**
+ * The relaxed deadline the entry URL gets on its second try (#1699): twice the
+ * crawl's per-request timeout. Two, not more, because it sits inside the same
+ * crawl-phase budget as everything else; a deadline that let one page eat the
+ * phase would trade a zero-page audit for a wedged one.
+ */
+export function entryRetryTimeoutMs(timeoutMs: number): number {
+  return Math.max(1, timeoutMs) * 2;
+}
+
+interface EntryRetry {
+  /** Deadline for the second attempt. */
+  timeoutMs: number;
+  /** Warning text naming the first attempt's failure and the second's deadline. */
+  message: string;
+}
+
+/**
+ * Whether a failed fetch of `entry` earns the one plain-fetch retry (#1699),
+ * and with what deadline. Only the seed, and only a failure that a longer wait
+ * could change: a timeout, or a transport failure from a document fetcher —
+ * that path gets a single attempt (see fetchPageWithRetry) where the standard
+ * one already retries. A refusal (403/429), a TLS failure (which has its own
+ * fallback) or a parse error is an answer, not a slow one.
+ */
+function entryRetryFor(
+  entry: { source: FrontierSource },
+  error: CrawlError,
+  config: { timeoutMs: number; documentFetcher?: unknown },
+): EntryRetry | undefined {
+  if (entry.source !== "seed") return undefined;
+  const slow =
+    error.type === "timeout" ||
+    // A transport failure with no status: the origin never answered. One that
+    // carries a status (a 5xx) did answer, and a longer wait changes nothing.
+    (error.type === "network" &&
+      error.status === undefined &&
+      config.documentFetcher !== undefined);
+  if (!slow) return undefined;
+  const timeoutMs = entryRetryTimeoutMs(config.timeoutMs);
+  return {
+    timeoutMs,
+    message:
+      `the entry page ${error.url} failed on its first fetch (${error.message}); ` +
+      `nothing has been stored yet, so retrying it once with a plain fetch and a ${timeoutMs}ms deadline`,
+  };
+}
+
+/**
+ * The error a zero-page crawl reports when the entry retry failed too. A
+ * second timeout folds both deadlines into one sentence so the reason line
+ * says what was tried; any other class (DNS, a refusal) is the newer, more
+ * specific answer and stands on its own.
+ */
+function entryRetryFailure(
+  second: CrawlError,
+  first: CrawlError,
+  retryTimeoutMs: number,
+): CrawlError {
+  if (second.type !== "timeout") return second;
+  // Short on purpose: the reason line's detail is capped at 120 characters
+  // (core-contracts MAX_DETAIL_LENGTH), and both deadlines have to survive it.
+  return CrawlError.timeout(
+    second.url,
+    `${first.message}; a plain retry gave up after ${retryTimeoutMs}ms`,
+  );
 }
 
 /**
@@ -1108,29 +1178,64 @@ export function createCrawler(
           });
 
           // Fetch page
-          const fetchResult = yield* Effect.either(
-            fetchPage(entry.normalizedUrl, {
-              userAgent: config.userAgent,
-              timeoutMs: config.timeoutMs,
-              followRedirects: config.followRedirects,
-              // Custom headers first; conditional (If-None-Match / If-Modified-Since) wins on collision.
-              headers: { ...config.headers, ...conditionalHeaders },
-              fetcher: config.documentFetcher,
-              // Stored normalized-source hash so the render-all gate can reuse the
-              // cached render when the origin rolls its validators (#839). Its
-              // presence also tells the gate a stored page exists, so it probes
-              // even when the cached entry had no etag/Last-Modified.
-              storedSourceHash: cachedPage?.sourceHash ?? undefined,
-              // Forward TLS/status-0 failures + standard-fetch fallbacks to the
-              // consumer's hook (CLI/cloud) — the single visibility sink, so
-              // events aren't double-logged. (page:failed events also carry the
-              // TLS-prefixed message for failed pages.)
-              onTlsEvent: config.onTlsEvent,
-              // Crawl-wide backoff (#1829): a rate-limit response here pauses
-              // every other worker aimed at this host, not just this fetch.
-              rateLimit: rateLimitControlFor(host, entry, startedAt),
-            }),
-          );
+          const fetchOptions: FetchOptions = {
+            userAgent: config.userAgent,
+            timeoutMs: config.timeoutMs,
+            followRedirects: config.followRedirects,
+            // Custom headers first; conditional (If-None-Match / If-Modified-Since) wins on collision.
+            headers: { ...config.headers, ...conditionalHeaders },
+            fetcher: config.documentFetcher,
+            // Stored normalized-source hash so the render-all gate can reuse the
+            // cached render when the origin rolls its validators (#839). Its
+            // presence also tells the gate a stored page exists, so it probes
+            // even when the cached entry had no etag/Last-Modified.
+            storedSourceHash: cachedPage?.sourceHash ?? undefined,
+            // Forward TLS/status-0 failures + standard-fetch fallbacks to the
+            // consumer's hook (CLI/cloud) — the single visibility sink, so
+            // events aren't double-logged. (page:failed events also carry the
+            // TLS-prefixed message for failed pages.)
+            onTlsEvent: config.onTlsEvent,
+            // Crawl-wide backoff (#1829): a rate-limit response here pauses
+            // every other worker aimed at this host, not just this fetch.
+            rateLimit: rateLimitControlFor(host, entry, startedAt),
+          };
+          let fetchResult = yield* Effect.either(fetchPage(entry.normalizedUrl, fetchOptions));
+
+          // #1699: the entry URL is the whole audit. When it is the only thing
+          // in the frontier (a sitemap that points at another host, quick mode
+          // with link discovery gated on the seed) and its fetch times out,
+          // the run ends with zero pages — on an origin the same crawl has just
+          // fetched robots.txt and a sitemap from. That first attempt ran under
+          // the crawl's per-request deadline (12s in the cloud) and, through a
+          // document fetcher, got exactly one try (see fetchPageWithRetry). So
+          // before giving the audit up, fetch the entry once more the plain
+          // way with a relaxed deadline. Pages, not just the seed: nothing
+          // stored yet is the condition, so a crawl that already has a corpus
+          // never pays this.
+          if (fetchResult._tag === "Left" && pagesCommitted === 0) {
+            const retry = entryRetryFor(entry, fetchResult.left, config);
+            if (retry) {
+              logger.warn("entry page fetch timed out", retry.message);
+              yield* emit({
+                type: "warning",
+                code: "entry-fetch-retried",
+                message: retry.message,
+                timestamp: Date.now(),
+              });
+              const second = yield* Effect.either(
+                fetchPage(entry.normalizedUrl, {
+                  ...fetchOptions,
+                  fetcher: undefined,
+                  timeoutMs: retry.timeoutMs,
+                  storedSourceHash: undefined,
+                }),
+              );
+              fetchResult =
+                second._tag === "Right"
+                  ? second
+                  : Either.left(entryRetryFailure(second.left, fetchResult.left, retry.timeoutMs));
+            }
+          }
 
           if (fetchResult._tag === "Left") {
             const error = fetchResult.left;
@@ -2377,6 +2482,24 @@ export function createCrawler(
 
         const rsl = yield* fetchRslLicensing(baseUrl, config.userAgent, config.headers, preamble);
         yield* storage.setRsl(crawlId, { ...rsl, fetchedAt: Date.now() });
+
+        // The budget running out is not a failure of the crawl — every probe
+        // above degrades to its not-attempted shape and the crawl goes on —
+        // but it is the one fact that explains a report whose AX probes are
+        // all "unknown", so say it once, here, where it is knowable (#1699).
+        if (budgetRemainingMs(preamble) <= 0) {
+          const message =
+            `the ${preambleBudgetMs(config.timeoutMs)}ms preamble budget ran out before every ` +
+            `root probe (robots, llms, markdown, well-known, agent access, RSL) had answered; ` +
+            `the rest were skipped and the crawl is going ahead with what it has`;
+          logger.warn("preamble budget exhausted", message);
+          yield* emit({
+            type: "warning",
+            code: "preamble-budget-exhausted",
+            message,
+            timestamp: Date.now(),
+          });
+        }
 
         // Discover and fetch sitemaps (from robots.txt and common locations)
         // Cap sitemap ingestion relative to the crawl budget — huge sites

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -131,11 +131,17 @@ interface EntryRetry {
  * that path gets a single attempt (see fetchPageWithRetry) where the standard
  * one already retries. A refusal (403/429), a TLS failure (which has its own
  * fallback) or a parse error is an answer, not a slow one.
+ *
+ * `watchdogRemainingMs` is what the per-URL watchdog has left for this entry:
+ * the retry is one deadline inside that window, never a reason to blow it —
+ * a watchdog interrupt would record "watchdog timeout" and lose the reason
+ * this retry exists to produce.
  */
 function entryRetryFor(
   entry: { source: FrontierSource },
   error: CrawlError,
   config: { timeoutMs: number; documentFetcher?: unknown },
+  watchdogRemainingMs: number,
 ): EntryRetry | undefined {
   if (entry.source !== "seed") return undefined;
   const slow =
@@ -147,6 +153,8 @@ function entryRetryFor(
       config.documentFetcher !== undefined);
   if (!slow) return undefined;
   const timeoutMs = entryRetryTimeoutMs(config.timeoutMs);
+  // A second's slack for the failure bookkeeping after the deadline fires.
+  if (watchdogRemainingMs < timeoutMs + 1_000) return undefined;
   return {
     timeoutMs,
     message:
@@ -157,21 +165,21 @@ function entryRetryFor(
 
 /**
  * The error a zero-page crawl reports when the entry retry failed too. A
- * second timeout folds both deadlines into one sentence so the reason line
- * says what was tried; any other class (DNS, a refusal) is the newer, more
- * specific answer and stands on its own.
+ * second timeout is summarised from the two DEADLINES, numbers first, so both
+ * survive the reason line's 120-character detail cap (core-contracts
+ * MAX_DETAIL_LENGTH) whatever the first attempt's message or fetcher id was;
+ * any other class (DNS, a refusal) is the newer, more specific answer and
+ * stands on its own.
  */
 function entryRetryFailure(
   second: CrawlError,
-  first: CrawlError,
-  retryTimeoutMs: number,
+  attempt: { timeoutMs: number; fetcherId?: string; retryTimeoutMs: number },
 ): CrawlError {
   if (second.type !== "timeout") return second;
-  // Short on purpose: the reason line's detail is capped at 120 characters
-  // (core-contracts MAX_DETAIL_LENGTH), and both deadlines have to survive it.
+  const via = attempt.fetcherId ? ` via ${attempt.fetcherId}` : "";
   return CrawlError.timeout(
     second.url,
-    `${first.message}; a plain retry gave up after ${retryTimeoutMs}ms`,
+    `entry page failed at ${attempt.timeoutMs}ms${via}, then a ${attempt.retryTimeoutMs}ms plain retry timed out`,
   );
 }
 
@@ -1213,7 +1221,12 @@ export function createCrawler(
           // stored yet is the condition, so a crawl that already has a corpus
           // never pays this.
           if (fetchResult._tag === "Left" && pagesCommitted === 0) {
-            const retry = entryRetryFor(entry, fetchResult.left, config);
+            const retry = entryRetryFor(
+              entry,
+              fetchResult.left,
+              config,
+              urlWatchdogMs(config.timeoutMs) - (Date.now() - startedAt),
+            );
             if (retry) {
               logger.warn("entry page fetch timed out", retry.message);
               yield* emit({
@@ -1227,13 +1240,22 @@ export function createCrawler(
                   ...fetchOptions,
                   fetcher: undefined,
                   timeoutMs: retry.timeoutMs,
+                  // One attempt: this IS the retry, and the standard path's
+                  // three would run past the per-URL watchdog.
+                  attempts: 1,
                   storedSourceHash: undefined,
                 }),
               );
               fetchResult =
                 second._tag === "Right"
                   ? second
-                  : Either.left(entryRetryFailure(second.left, fetchResult.left, retry.timeoutMs));
+                  : Either.left(
+                      entryRetryFailure(second.left, {
+                        timeoutMs: config.timeoutMs,
+                        fetcherId: config.documentFetcher?.id,
+                        retryTimeoutMs: retry.timeoutMs,
+                      }),
+                    );
             }
           }
 

--- a/packages/crawler/src/fetcher.ts
+++ b/packages/crawler/src/fetcher.ts
@@ -114,16 +114,18 @@ export class CrawlError extends Error {
 }
 
 /**
- * An abort is a deadline firing, in every runtime spelling: Bun's native
- * `DOMException` ("The operation was aborted."), Node's `AbortError`, and the
- * cloud fetcher's own ("Cloud render aborted"). Read off `name` first — the
- * message is the part that varies — and off the message only as a fallback for
- * an error whose name a wrapper rewrote.
+ * An abort is a deadline firing — ours, or the fetcher's own shorter one — in
+ * every runtime spelling: Bun's native `DOMException` ("The operation was
+ * aborted."), Node's `AbortError`, and the cloud fetcher's own ("Cloud render
+ * aborted"). A fiber interrupt also arrives this way, but Effect discards the
+ * result of an interrupted `tryPromise`, so that case never reaches a report.
  */
 function isAbortError(error: unknown): boolean {
-  const err = error as { name?: unknown; message?: unknown } | null;
-  if (err?.name === "AbortError") return true;
-  return typeof err?.message === "string" && /\baborted\b/i.test(err.message);
+  // `name` only. A message match ("connection aborted by peer") would turn a
+  // transport failure into a claimed deadline, and the fetchers this path
+  // sees all set the name: Bun's DOMException, Node's AbortError, and the
+  // cloud fetcher's own `abortError()`.
+  return (error as { name?: unknown } | null)?.name === "AbortError";
 }
 
 /** Hostname of a URL, for a failure reason. Never the path/query. */
@@ -500,6 +502,14 @@ export interface FetchOptions {
   headers?: Record<string, string>;
   fetcher?: DocumentFetcher;
   /**
+   * Outer attempts `fetchPageWithRetry` may make for a retryable transport
+   * failure. Unset, the path decides (one through a document fetcher, three
+   * standard). The entry URL's second-chance fetch sets 1 (#1699): it already
+   * IS the retry, and three more at a doubled deadline would run past the
+   * per-URL watchdog.
+   */
+  attempts?: number;
+  /**
    * Structured logging hook for TLS/status-0 failures and standard-fetch
    * fallbacks. Defaults to a no-op so the package stays silent unless the
    * consumer (CLI/crawler) wires a logger. Lets these failures be observed
@@ -766,10 +776,12 @@ function fetchWithDocumentFetcher(
         // the raw runtime text made a zero-page cloud audit say "No pages were
         // crawled from <site>: The operation was aborted." with reason code
         // `unknown`, when the truthful reason is a timeout naming the step.
+        // "deadline", not "after": the fetcher may have cut itself off ahead
+        // of the deadline it was handed, and the sentence must stay true.
         if (isAbortError(error)) {
           return CrawlError.timeout(
             url,
-            `page fetch via ${options.fetcher!.id} gave up after ${options.timeoutMs}ms`,
+            `page fetch via ${options.fetcher!.id} was aborted (deadline ${options.timeoutMs}ms)`,
           );
         }
         return CrawlError.network(url, (error as Error).message, undefined, fetchErrorCode(error));
@@ -1221,7 +1233,7 @@ export function fetchPageWithRetry(
   // minutes, not a burst. Collapsing it would mean threading "which layer
   // produced this error" through the fallback, which buys little for a
   // combination that needs a TLS-broken AND throttling origin.
-  const maxAttempts = options.fetcher ? 1 : 3;
+  const maxAttempts = options.attempts ?? (options.fetcher ? 1 : 3);
   const attemptOnce = withRetry(fetchPage(url, options), {
     ...defaultRetryPolicy,
     maxAttempts,

--- a/packages/crawler/src/fetcher.ts
+++ b/packages/crawler/src/fetcher.ts
@@ -32,6 +32,9 @@ import { detectWafChallengePage } from "@squirrelscan/utils/waf";
 
 export type CrawlErrorType = "timeout" | "network" | "parse" | "blocked" | "rate_limit" | "tls";
 
+/** The generic timeout sentence; a `timeout` error carrying anything else is naming its deadline. */
+const TIMEOUT_MESSAGE = "Crawl request timed out";
+
 export class CrawlError extends Error {
   constructor(
     readonly url: string,
@@ -64,8 +67,13 @@ export class CrawlError extends Error {
     this.name = "CrawlError";
   }
 
-  static timeout(url: string): CrawlError {
-    return new CrawlError(url, "timeout", "Crawl request timed out");
+  /**
+   * `message` names WHICH request gave up and at what deadline when the caller
+   * knows (#1699: "page fetch via cloud-render gave up after 12000ms"); the
+   * default is the generic sentence every per-request deadline has always used.
+   */
+  static timeout(url: string, message: string = TIMEOUT_MESSAGE): CrawlError {
+    return new CrawlError(url, "timeout", message);
   }
 
   static network(
@@ -105,6 +113,19 @@ export class CrawlError extends Error {
   }
 }
 
+/**
+ * An abort is a deadline firing, in every runtime spelling: Bun's native
+ * `DOMException` ("The operation was aborted."), Node's `AbortError`, and the
+ * cloud fetcher's own ("Cloud render aborted"). Read off `name` first — the
+ * message is the part that varies — and off the message only as a fallback for
+ * an error whose name a wrapper rewrote.
+ */
+function isAbortError(error: unknown): boolean {
+  const err = error as { name?: unknown; message?: unknown } | null;
+  if (err?.name === "AbortError") return true;
+  return typeof err?.message === "string" && /\baborted\b/i.test(err.message);
+}
+
 /** Hostname of a URL, for a failure reason. Never the path/query. */
 function failureHost(url: string): string | undefined {
   try {
@@ -136,7 +157,13 @@ export function crawlErrorToFailureDetail(
 
   switch (error.type) {
     case "timeout":
-      return auditFailureDetail({ ...base, code: "timeout" });
+      // A timeout that names its step and deadline (#1699) keeps that as the
+      // detail; the generic sentence adds nothing to the reason line.
+      return auditFailureDetail({
+        ...base,
+        code: "timeout",
+        ...(message !== TIMEOUT_MESSAGE ? { detail: message } : {}),
+      });
     case "tls":
       // `CrawlError.tls` prefixes the runtime message; drop the prefix so the
       // reason sentence does not say "TLS" twice.
@@ -732,10 +759,21 @@ function fetchWithDocumentFetcher(
           signal,
           storedSourceHash: options.storedSourceHash,
         }),
-      catch: (error) =>
-        isTlsError(error)
-          ? CrawlError.tls(url, (error as Error).message)
-          : CrawlError.network(url, (error as Error).message),
+      catch: (error) => {
+        if (isTlsError(error)) return CrawlError.tls(url, (error as Error).message);
+        // #1699: an abort is the fetcher's deadline (or ours) firing — the
+        // same class the standard path reports. Mapping it to `network` with
+        // the raw runtime text made a zero-page cloud audit say "No pages were
+        // crawled from <site>: The operation was aborted." with reason code
+        // `unknown`, when the truthful reason is a timeout naming the step.
+        if (isAbortError(error)) {
+          return CrawlError.timeout(
+            url,
+            `page fetch via ${options.fetcher!.id} gave up after ${options.timeoutMs}ms`,
+          );
+        }
+        return CrawlError.network(url, (error as Error).message, undefined, fetchErrorCode(error));
+      },
     });
 
     // status === 0 from the impersonation fetcher means the request never

--- a/packages/crawler/tests/entry-fetch-timeout.test.ts
+++ b/packages/crawler/tests/entry-fetch-timeout.test.ts
@@ -1,0 +1,294 @@
+// squirrelscan/repo#1699 (second failure mode) — an audit that rests on ONE
+// fetch must not die on that fetch's first deadline, and when it does die the
+// reason has to name the step and the deadline.
+//
+// The production shape: nuxt.daigo.ru's sitemap lists 449 urls, every one on
+// the sister domain, so the frontier is the seed alone; the seed fetch ran
+// through the cloud document fetcher under the cloud's 12s deadline, got one
+// attempt, and its abort surfaced as `unknown` with the raw runtime text —
+// "No pages were crawled from nuxt.daigo.ru: The operation was aborted."
+//
+// Bun origins here answer 200 with a large HTML body on every path (including
+// the soft-404s), carry a sitemap of a few hundred cross-domain urls, and add a
+// flat delay before every response. The per-request timeout is a few hundred
+// ms so the crawl's deadlines fire the way they do in production, only faster.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect, Fiber, Stream } from "effect";
+
+import type { DocumentFetcher } from "@squirrelscan/fetchers";
+import { auditFailureReasonText } from "@squirrelscan/core-contracts/failure-reason";
+
+import { createCrawler, entryRetryTimeoutMs } from "../src/core/crawler";
+import type { CrawlerConfig, CrawlerEvent } from "../src/core/types";
+import { crawlErrorToFailureDetail, fetchPage } from "../src/fetcher";
+
+const TIMEOUT_MS = 400;
+
+const BIG_PAGE = `<!doctype html><html><head><title>t</title></head><body>
+<a href="/one">one</a><a href="/two">two</a>
+${"<p>soft body padding so every response is a real download</p>\n".repeat(3_000)}
+</body></html>`;
+
+const CROSS_DOMAIN_SITEMAP = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${Array.from({ length: 300 }, (_, i) => `<url><loc>https://sister.example/page-${i}</loc></url>`).join("\n")}
+</urlset>`;
+
+// Quick mode, the cloud's shape: link discovery stays gated on the seed until
+// the sitemap turns out to have contributed nothing (#123).
+const CONFIG: Partial<CrawlerConfig> = {
+  maxPages: 5,
+  concurrency: 2,
+  perHostConcurrency: 2,
+  delayMs: 0,
+  perHostDelayMs: 0,
+  timeoutMs: TIMEOUT_MS,
+  userAgent: "squirrel-test",
+  respectRobots: false,
+  incremental: false,
+  useCacheControl: false,
+  breadthFirst: false,
+  coverageMode: "quick",
+  disableLinkDiscovery: true,
+};
+
+const servers: Array<{ stop: (closeActive?: boolean) => void }> = [];
+afterEach(() => {
+  for (const s of servers.splice(0)) s.stop(true);
+});
+
+interface Origin {
+  url: string;
+  hits: Map<string, number>;
+}
+
+// 200 on everything: the root and its pages, the sitemap, and a full HTML body
+// for every probe path (llms.txt, .well-known/*, index.md) — the soft-404 shape.
+function serveSlowSite(ttfbMs: number): Origin {
+  const hits = new Map<string, number>();
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    async fetch(req) {
+      const path = new URL(req.url).pathname;
+      hits.set(path, (hits.get(path) ?? 0) + 1);
+      await Bun.sleep(ttfbMs);
+      if (path === "/robots.txt") {
+        return new Response(`User-agent: *\nSitemap: ${new URL("/sitemap.xml", req.url)}\n`, {
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      if (path === "/sitemap.xml") {
+        return new Response(CROSS_DOMAIN_SITEMAP, {
+          headers: { "content-type": "application/xml" },
+        });
+      }
+      return new Response(BIG_PAGE, { headers: { "content-type": "text/html" } });
+    },
+  });
+  servers.push(server);
+  return { url: `http://localhost:${server.port}/`, hits };
+}
+
+// What the cloud document fetcher looks like from the crawler when both the
+// render and its plain fallback hit their deadline: one rejection carrying
+// Bun's native abort, with no HTTP response ever produced.
+function abortingFetcher(): DocumentFetcher & { calls: number } {
+  const fetcher = {
+    id: "cloud-render",
+    calls: 0,
+    capabilities: { jsRendering: true, cookies: false, screenshot: false },
+    async fetch() {
+      fetcher.calls++;
+      throw new DOMException("The operation was aborted.", "AbortError");
+    },
+  };
+  return fetcher;
+}
+
+interface CrawlOutcome {
+  pages: string[];
+  warnings: Array<{ code: string; message: string }>;
+  rootFailure: { code: string; detail?: string; host?: string } | undefined;
+  reason: string | undefined;
+}
+
+async function crawl(origin: string, config: Partial<CrawlerConfig>): Promise<CrawlOutcome> {
+  const crawler = await Effect.runPromise(createCrawler({ config: { ...CONFIG, ...config } }));
+  const warnings: CrawlOutcome["warnings"] = [];
+  const events = Effect.runFork(
+    Stream.runForEach(crawler.events, (event: CrawlerEvent) =>
+      Effect.sync(() => {
+        if (event.type === "warning") warnings.push({ code: event.code, message: event.message });
+      }),
+    ),
+  );
+  try {
+    const crawlId = await Effect.runPromise(crawler.start(origin, origin));
+    const pages = await Effect.runPromise(crawler.storage.getPages(crawlId));
+    const stats = await Effect.runPromise(crawler.storage.getStats(crawlId));
+    const rootFailure = stats?.rootFailure;
+    return {
+      pages: pages.map((p) => p.url),
+      warnings,
+      rootFailure,
+      reason: rootFailure ? auditFailureReasonText(rootFailure) : undefined,
+    };
+  } finally {
+    await Effect.runPromise(Fiber.interrupt(events));
+  }
+}
+
+describe("an abort from a document fetcher is a timeout, not an unknown failure (#1699)", () => {
+  test("fetchPage names the fetcher and the deadline instead of the runtime's abort text", async () => {
+    const result = await Effect.runPromise(
+      Effect.either(
+        fetchPage("https://example.com/", {
+          userAgent: "squirrel-test",
+          timeoutMs: 12_000,
+          followRedirects: true,
+          fetcher: abortingFetcher(),
+        }),
+      ),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag !== "Left") return;
+    expect(result.left.type).toBe("timeout");
+    expect(result.left.message).toBe("page fetch via cloud-render gave up after 12000ms");
+
+    // …and the reason line built from it is the timeout sentence with that
+    // detail, classified as `timeout`, never the sentence the run shipped.
+    const detail = crawlErrorToFailureDetail(result.left);
+    expect(detail.code).toBe("timeout");
+    expect(detail.detail).toBe("page fetch via cloud-render gave up after 12000ms");
+    const reason = auditFailureReasonText(detail);
+    expect(reason).toBe(
+      "No response from example.com within the request timeout: page fetch via cloud-render gave up after 12000ms",
+    );
+    expect(reason).not.toContain("The operation was aborted");
+  });
+});
+
+describe("the entry URL gets a second, relaxed-deadline fetch before the audit is given up (#1699)", () => {
+  test("a slow origin whose TTFB beats the per-request deadline still yields its entry page", async () => {
+    // Slower than the crawl's deadline, faster than the entry retry's.
+    const origin = serveSlowSite(TIMEOUT_MS + 200);
+
+    const out = await crawl(origin.url, {});
+
+    expect(out.pages).toContain(origin.url);
+    expect(out.warnings.map((w) => w.code)).toContain("entry-fetch-retried");
+    const retry = out.warnings.find((w) => w.code === "entry-fetch-retried")!;
+    expect(retry.message).toContain(`${entryRetryTimeoutMs(TIMEOUT_MS)}ms`);
+  }, 30_000);
+
+  test("a document fetcher that aborts the entry falls back to a plain fetch and collects pages", async () => {
+    const origin = serveSlowSite(0);
+    const fetcher = abortingFetcher();
+
+    const out = await crawl(origin.url, { documentFetcher: fetcher });
+
+    // The crawl reached its pages through the plain retry — the seed first, and
+    // link discovery (re-enabled because the sitemap contributed nothing) after.
+    expect(out.pages).toContain(origin.url);
+    // Discovered pages still go through the aborting fetcher and fail; they
+    // never get the retry, and their failure is recorded under `sitemap`, not
+    // as the ENTRY's failure — the entry landed.
+    expect(out.rootFailure?.source).not.toBe("entry");
+    expect(out.warnings.filter((w) => w.code === "entry-fetch-retried")).toHaveLength(1);
+  }, 30_000);
+
+  test("a corpus already stored never pays the retry", async () => {
+    const origin = serveSlowSite(0);
+    let seen = 0;
+    // Serves the seed, then aborts everything after it.
+    const fetcher: DocumentFetcher = {
+      id: "cloud-render",
+      capabilities: { jsRendering: true, cookies: false, screenshot: false },
+      async fetch(req) {
+        if (seen++ > 0) throw new DOMException("The operation was aborted.", "AbortError");
+        const res = await fetch(req.url);
+        const body = await res.text();
+        const now = Date.now();
+        return {
+          status: res.status,
+          headers: { "content-type": "text/html" },
+          body,
+          finalUrl: req.url,
+          redirectChain: {
+            sourceUrl: req.url,
+            finalUrl: req.url,
+            hops: [{ url: req.url, statusCode: res.status, type: "http" as const }],
+            chainLength: 0,
+            isLoop: false,
+            endsInError: false,
+            httpsToHttp: false,
+            httpToHttps: false,
+          },
+          timing: { startedAt: now, responseAt: now, finishedAt: now },
+        };
+      },
+    };
+
+    const out = await crawl(origin.url, { documentFetcher: fetcher });
+
+    expect(out.pages).toContain(origin.url);
+    expect(out.warnings.map((w) => w.code)).not.toContain("entry-fetch-retried");
+  }, 30_000);
+
+  test("when nothing at all can be fetched, the reason names the step and both deadlines", async () => {
+    // Slower than the retry's deadline too: the entry is genuinely unreachable
+    // inside any bound this crawl has.
+    const origin = serveSlowSite(entryRetryTimeoutMs(TIMEOUT_MS) + 400);
+
+    const out = await crawl(origin.url, { documentFetcher: abortingFetcher() });
+
+    expect(out.pages).toEqual([]);
+    expect(out.rootFailure?.code).toBe("timeout");
+    expect(out.rootFailure?.host).toBe("localhost");
+    expect(out.reason).toContain("within the request timeout");
+    expect(out.reason).toContain(`gave up after ${TIMEOUT_MS}ms`);
+    expect(out.reason).toContain(`gave up after ${entryRetryTimeoutMs(TIMEOUT_MS)}ms`);
+    expect(out.reason).not.toContain("The operation was aborted");
+  }, 30_000);
+});
+
+describe("preamble budget expiry degrades and says so (#1699)", () => {
+  test("an origin that stalls every root probe still crawls, with one warning naming the budget", async () => {
+    // 200 headers, then a body that never finishes — the shape that burns a
+    // whole budget on the first probe. Real pages serve normally.
+    const stalled = () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("<!doctype html><html><body>"));
+          },
+        }),
+        { headers: { "content-type": "text/html" } },
+      );
+    const server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        return path === "/" || path === "/one" || path === "/two"
+          ? new Response(BIG_PAGE, { headers: { "content-type": "text/html" } })
+          : stalled();
+      },
+    });
+    servers.push(server);
+
+    const out = await crawl(`http://localhost:${server.port}/`, {
+      coverageMode: "full",
+      disableLinkDiscovery: false,
+    });
+
+    expect(out.pages.length).toBeGreaterThan(0);
+    const exhausted = out.warnings.filter((w) => w.code === "preamble-budget-exhausted");
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0]!.message).toContain("preamble budget ran out");
+    // Every other failure surface stays quiet: nothing here is a crawl failure.
+    expect(out.rootFailure).toBeUndefined();
+  }, 30_000);
+});

--- a/packages/crawler/tests/entry-fetch-timeout.test.ts
+++ b/packages/crawler/tests/entry-fetch-timeout.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { Effect, Fiber, Stream } from "effect";
 
 import type { DocumentFetcher } from "@squirrelscan/fetchers";
+import type { AuditFailureDetail } from "@squirrelscan/core-contracts";
 import { auditFailureReasonText } from "@squirrelscan/core-contracts/failure-reason";
 
 import { createCrawler, entryRetryTimeoutMs } from "../src/core/crawler";
@@ -110,7 +111,7 @@ function abortingFetcher(): DocumentFetcher & { calls: number } {
 interface CrawlOutcome {
   pages: string[];
   warnings: Array<{ code: string; message: string }>;
-  rootFailure: { code: string; detail?: string; host?: string } | undefined;
+  rootFailure: AuditFailureDetail | undefined;
   reason: string | undefined;
 }
 
@@ -155,16 +156,16 @@ describe("an abort from a document fetcher is a timeout, not an unknown failure 
     expect(result._tag).toBe("Left");
     if (result._tag !== "Left") return;
     expect(result.left.type).toBe("timeout");
-    expect(result.left.message).toBe("page fetch via cloud-render gave up after 12000ms");
+    expect(result.left.message).toBe("page fetch via cloud-render was aborted (deadline 12000ms)");
 
     // …and the reason line built from it is the timeout sentence with that
     // detail, classified as `timeout`, never the sentence the run shipped.
     const detail = crawlErrorToFailureDetail(result.left);
     expect(detail.code).toBe("timeout");
-    expect(detail.detail).toBe("page fetch via cloud-render gave up after 12000ms");
+    expect(detail.detail).toBe("page fetch via cloud-render was aborted (deadline 12000ms)");
     const reason = auditFailureReasonText(detail);
     expect(reason).toBe(
-      "No response from example.com within the request timeout: page fetch via cloud-render gave up after 12000ms",
+      "No response from example.com within the request timeout: page fetch via cloud-render was aborted (deadline 12000ms)",
     );
     expect(reason).not.toContain("The operation was aborted");
   });
@@ -248,8 +249,9 @@ describe("the entry URL gets a second, relaxed-deadline fetch before the audit i
     expect(out.rootFailure?.code).toBe("timeout");
     expect(out.rootFailure?.host).toBe("localhost");
     expect(out.reason).toContain("within the request timeout");
-    expect(out.reason).toContain(`gave up after ${TIMEOUT_MS}ms`);
-    expect(out.reason).toContain(`gave up after ${entryRetryTimeoutMs(TIMEOUT_MS)}ms`);
+    expect(out.reason).toContain(
+      `entry page failed at ${TIMEOUT_MS}ms via cloud-render, then a ${entryRetryTimeoutMs(TIMEOUT_MS)}ms plain retry timed out`,
+    );
     expect(out.reason).not.toContain("The operation was aborted");
   }, 30_000);
 });


### PR DESCRIPTION
Fixes the second failure mode behind squirrelscan/repo#1699: a cloud audit of `nuxt.daigo.ru` (healthy origin, 200 on everything) failed with `No pages were crawled from nuxt.daigo.ru: The operation was aborted.` and reason code `unknown`. Root cause written up on the private issue; summary:

1. The site's sitemap lists 449 urls on the **sister domain** (`daigo.ru`), every one filtered as cross-domain, so the frontier is the seed alone and quick mode gates link discovery on that one fetch.
2. The seed fetch runs through the cloud document fetcher under the cloud's 12s per-request deadline and gets exactly one attempt (`fetchPageWithRetry`: `maxAttempts = options.fetcher ? 1 : 3`). Render and the plain fallback both hit the deadline.
3. `fetchWithDocumentFetcher` mapped the resulting Bun `AbortError` to `CrawlError.network(message)`, so the failure classified as `unknown` carrying the runtime's text. The standard path already mapped aborts to `timeout`.

## Changes (`packages/crawler`, `packages/core-contracts`)

- **Abort from a document fetcher is a timeout** that names the fetcher and the deadline (`page fetch via cloud-render gave up after 12000ms`); the runtime error code is forwarded for other transport failures, like the standard path. `CrawlError.timeout` takes an optional message; `crawlErrorToFailureDetail` keeps a non-generic timeout message as the detail.
- **The entry URL gets a second chance.** When its fetch times out (or fails transport-level through a document fetcher) and nothing has been stored yet, the crawl retries it once through a plain fetch with a doubled deadline and emits an `entry-fetch-retried` warning. A second timeout folds both deadlines into the reason (`…gave up after 12000ms; a plain retry gave up after 24000ms`), kept under the 120-char detail cap. A crawl that already has a corpus never pays this.
- **Preamble budget expiry says so.** Probes already degraded to the not-attempted shape (#194); `start()` now logs and emits a `preamble-budget-exhausted` warning naming the budget so a report whose AX probes are all unknown is explainable.
- `CrawlWarningCode` gains the two codes.

## Tests

`packages/crawler/tests/entry-fetch-timeout.test.ts` (6 tests): a synthetic Bun origin with a flat delay on every response, 200 + a large HTML body on every path (soft-404 shape), a 300-url cross-domain sitemap, and a document fetcher that aborts like the cloud one. Covers: abort → timeout classification and the exact reason sentence; slow-TTFB origin yields its entry page via the retry; aborting fetcher falls back to plain fetch and collects pages; an existing corpus never retries; nothing-fetchable names step and both deadlines and never says "The operation was aborted"; stalled probes crawl with one preamble warning.

Ran: `bun test` on the new file + root-failure-classification, preamble-budget, slow-origin-crawl, fetch-interrupt, crawler-stop-hard-cap, classifier-parity (all green); `tsgo --noEmit` in crawler, core-contracts, audit-engine, fetchers, apps/cli; `scripts/test-suites.ts --check`. Local run of the real crawler against nuxt.daigo.ru with the plain fetcher collects 10 pages in 12s.

Self-reviewed with a codex pass (`codex exec`, gpt-6-astra); findings addressed in follow-up commits on this branch where any.

No private-runtime change is required. Optional follow-up there: `CLOUD_CRAWLER.defaultTimeoutMs = 12_000` is the tightest bound in the system and also sizes the preamble budget and sitemap walk window.

Ref: squirrelscan/repo#1699
