### PR TITLE
fix(audit-engine): reserve plain-fetch headroom inside the cloud page deadline and raise it to 30s (repo#2026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ How it works:
 
 ### Fixed
 
+- Cloud rendering now reserves time for its plain-HTTP fallback inside each
+  page's fetch deadline: the render has the deadline minus 12 seconds to
+  itself, then the plain fetch starts and races it, and whichever lands first
+  serves the page. A render that finishes late but inside the deadline is still
+  used, and a crawl stop mid-submit no longer leaves the server's render debit
+  unrecorded. The cloud runner's per-page deadline rises from 12 to 30 seconds
+  (the CLI's default) so a far-away origin no longer decides the audit; the
+  preamble budget, sitemap walk window and entry-page retry that derive from
+  it are documented next to the constant. squirrelscan/repo#2026
+
 - A cloud audit of a site whose sitemap points at another domain no longer fails
   with "No pages were crawled from <site>: The operation was aborted." when the
   entry page's first fetch hits its deadline. The entry URL now gets one more

--- a/packages/audit-engine/src/cloud-fetcher.ts
+++ b/packages/audit-engine/src/cloud-fetcher.ts
@@ -18,6 +18,21 @@
 // 3 consecutive 5xx/transport failures) the fetcher flips PERMANENTLY to the
 // provided plain-HTTP fallback fetcher (announcing via onFallback once); a
 // one-off render failure/timeout falls back for that url only.
+//
+// DEADLINE STRUCTURE (squirrelscan/repo#2026): each request's `timeoutMs` is the
+// OUTER deadline of the whole fetch, render and fallback included. Render has
+// `outer - headroom` to itself; at that point, if nothing has landed, the plain
+// fallback starts with the remaining `headroom` and RACES the render, and
+// whichever settles first serves the page. So the fallback is guaranteed its
+// headroom inside any outer deadline (before this, the render machinery ran
+// under a 45s batch budget of its own and a caller enforcing a shorter deadline
+// aborted the waiter before the fallback ever dispatched), and a render that
+// lands late but inside the deadline is still used rather than discarded — it
+// was charged on submit. The in-flight render job is never cancelled: its
+// result lands in the server's render cache either way. A caller abort (the
+// crawler's watchdog / stop) still rejects without a fallback, but no longer
+// cancels the SUBMIT: the server debits on submit, so the submit runs to its
+// own bound and the debit is recorded whether or not anyone still wants the page.
 
 import type {
   RenderChargeLine,
@@ -25,7 +40,7 @@ import type {
   RenderResultItem,
 } from "@squirrelscan/core-contracts";
 import { CREDIT_COSTS } from "@squirrelscan/core-contracts/credits";
-import { SERVICE_LIMITS } from "@squirrelscan/core-contracts/limits";
+import { CLOUD_CRAWLER, SERVICE_LIMITS } from "@squirrelscan/core-contracts/limits";
 import {
   type DocumentFetcher,
   type FetchRequest,
@@ -57,8 +72,19 @@ export interface CloudFetcherOptions {
   batchWindowMs?: number;
   /** Max urls per batched job (default `SERVICE_LIMITS.renderBatchUrls`). */
   maxBatchUrls?: number;
-  /** Per-batch budget: submit + poll until this elapses (default 45s). */
+  /**
+   * Per-batch poll budget (default 45s), and the outer per-fetch deadline for a
+   * request that carries no `timeoutMs` of its own. A batch polls until every
+   * url is settled or `max(this, the batch's largest outer deadline)` elapses.
+   */
   timeoutMs?: number;
+  /**
+   * Time reserved for the plain-HTTP fallback INSIDE each request's outer
+   * deadline (default `CLOUD_CRAWLER.fallbackHeadroomMs`, clamped to half the
+   * outer): render has the rest to itself, then the fallback starts and races
+   * it. See the deadline-structure note at the top of the file.
+   */
+  fallbackHeadroomMs?: number;
   /** Called ONCE when the fetcher permanently switches to the fallback. */
   onFallback?: (reason: string) => void;
   /**
@@ -115,6 +141,19 @@ interface Waiter {
    * sweeps skip an already-handled waiter instead of double-fetching.
    */
   dispatched: boolean;
+  /**
+   * The fallback was started by the headroom timer while the render is still
+   * in flight, and the two are racing: a good render item may still resolve
+   * this waiter, and no second fallback may start for it. Cleared once a
+   * render item settles it. Only ever true together with `dispatched`.
+   */
+  racing: boolean;
+  /** When `fetch()` accepted the request; the outer deadline counts from here. */
+  enqueuedAt: number;
+  /** Outer deadline for the whole fetch (render + fallback), in ms. */
+  outerMs: number;
+  /** Headroom timer that starts the racing fallback at `outer - headroom`. */
+  raceTimer?: ReturnType<typeof setTimeout>;
   onAbort?: () => void;
 }
 
@@ -280,6 +319,7 @@ export function createCloudDocumentFetcher(
   const batchWindowMs = opts.batchWindowMs ?? DEFAULT_BATCH_WINDOW_MS;
   const maxBatchUrls = Math.max(1, opts.maxBatchUrls ?? SERVICE_LIMITS.renderBatchUrls);
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fallbackHeadroomMs = opts.fallbackHeadroomMs ?? CLOUD_CRAWLER.fallbackHeadroomMs;
 
   let fallbackActive = false;
   let consecutiveServerFailures = 0;
@@ -302,11 +342,26 @@ export function createCloudDocumentFetcher(
       w.req.signal.removeEventListener("abort", w.onAbort);
     }
     w.onAbort = undefined;
+    if (w.raceTimer !== undefined) {
+      clearTimeout(w.raceTimer);
+      w.raceTimer = undefined;
+    }
+  }
+
+  /** What is left of a waiter's outer deadline, never below 1ms. */
+  function remainingOuterMs(w: Waiter): number {
+    return Math.max(1, w.enqueuedAt + w.outerMs - Date.now());
+  }
+
+  /** Headroom the fallback is guaranteed inside this waiter's outer deadline. */
+  function headroomFor(w: Waiter): number {
+    return Math.max(1, Math.min(fallbackHeadroomMs, Math.floor(w.outerMs / 2)));
   }
 
   function resolveWaiter(w: Waiter, resp: FetchResponse): void {
     if (w.settled) return;
     w.settled = true;
+    w.racing = false;
     detach(w);
     w.resolve(resp);
   }
@@ -319,10 +374,11 @@ export function createCloudDocumentFetcher(
   }
 
   // Claim a waiter for terminal handling exactly once. Returns false if another
-  // poll or fallback path already resolved it or started its fallback fetch, so
-  // callers skip it — this makes re-sent `completed` items (#992) and overlapping
-  // fallback sweeps idempotent (no double-fetch, no double-settle). Synchronous:
-  // no await between the check and the set, so within a demux pass it can't race.
+  // poll or fallback path already resolved it or started its fallback fetch
+  // (racing included: that fallback is the one and only), so callers skip it —
+  // this makes re-sent `completed` items (#992) and overlapping fallback sweeps
+  // idempotent (no double-fetch, no double-settle). Synchronous: no await
+  // between the check and the set, so within a demux pass it can't race.
   function claim(w: Waiter): boolean {
     if (w.settled || w.dispatched) return false;
     w.dispatched = true;
@@ -333,6 +389,9 @@ export function createCloudDocumentFetcher(
   // rejects (so its fiber unwinds and releases its host slot) rather than
   // starting a fallback fetch that would just abort too. `fallbackReason` tags
   // why we fell back (e.g. "render-block") so the report can surface it (#512).
+  // The fallback gets what is LEFT of the outer deadline, never the request's
+  // full timeout again: render + fallback fit inside one deadline (#2026). The
+  // headroom timer guarantees that remainder is at least the headroom.
   async function fallbackWaiter(w: Waiter, fallbackReason?: string): Promise<void> {
     if (w.settled) return;
     if (w.req.signal?.aborted) {
@@ -340,11 +399,39 @@ export function createCloudDocumentFetcher(
       return;
     }
     try {
-      const resp = await opts.fallback.fetch(w.req);
+      const resp = await opts.fallback.fetch({ ...w.req, timeoutMs: remainingOuterMs(w) });
       resolveWaiter(w, fallbackReason ? { ...resp, fallbackReason } : resp);
     } catch (err) {
+      // A racing fallback that fails FAST (refused, DNS) while the render is
+      // still in flight must not throw the render away: hold the failure until
+      // the outer deadline, and let a render item that lands first win. The
+      // caller's own abort still rejects at once through onAbort.
+      if (w.racing && !w.settled && !w.req.signal?.aborted) {
+        w.raceTimer = setTimeout(() => {
+          w.raceTimer = undefined;
+          rejectWaiter(w, err);
+        }, remainingOuterMs(w));
+        return;
+      }
       rejectWaiter(w, err);
     }
+  }
+
+  // Arm the headroom timer: at `outer - headroom`, a waiter the render has not
+  // settled starts its fallback and keeps racing the render (#2026). Fires
+  // during a slow submit too — the fallback must not wait on the cloud.
+  function armRace(w: Waiter): void {
+    if (w.settled || w.dispatched || w.raceTimer !== undefined) return;
+    const startAt = w.enqueuedAt + w.outerMs - headroomFor(w);
+    w.raceTimer = setTimeout(
+      () => {
+        w.raceTimer = undefined;
+        if (!claim(w)) return;
+        w.racing = true;
+        void fallbackWaiter(w);
+      },
+      Math.max(0, startAt - Date.now()),
+    );
   }
 
   function settleAllViaFallback(waiters: Waiter[]): Promise<void[]> {
@@ -391,11 +478,16 @@ export function createCloudDocumentFetcher(
         if (fallbackUnmatched && claim(w)) void fallbackWaiter(w);
         continue;
       }
-      if (!claim(w)) continue;
+      // A racing waiter (#2026) is already dispatched — its fallback is in
+      // flight — but a GOOD render item still wins it (paid work, inside the
+      // deadline). A bad item changes nothing: the running fallback covers it,
+      // and a second one must not start.
+      const racing = w.racing && !w.settled;
+      if (!racing && !claim(w)) continue;
       if (item.error) {
         // Per-url render error (truthy string) → fall back for this url only.
         // `error: null`/absent is not an error and falls through to success.
-        void fallbackWaiter(w);
+        if (!racing) void fallbackWaiter(w);
       } else if (isRenderBlocked(item)) {
         // #490: headless/CF egress was blocked (401/403/429/503 or WAF
         // challenge). Retry from the local egress via plain HTTP before
@@ -408,7 +500,7 @@ export function createCloudDocumentFetcher(
         } catch {
           /* ignore */
         }
-        void fallbackWaiter(w, "render-block");
+        if (!racing) void fallbackWaiter(w, "render-block");
       } else if (item.html !== undefined) {
         resolveWaiter(
           w,
@@ -420,7 +512,7 @@ export function createCloudDocumentFetcher(
         );
       } else {
         // Succeeded but no HTML and not a known block — fall back to be safe.
-        void fallbackWaiter(w);
+        if (!racing) void fallbackWaiter(w);
       }
     }
   }
@@ -470,12 +562,15 @@ export function createCloudDocumentFetcher(
     // delivery a waiter can settle before its batch finishes; the old
     // all-aborted counter never counted those, so if the remaining urls then
     // aborted it would never reach zero and the detached loop would zombie-poll
-    // to the deadline (#992 R-001).
-    const allRetired = () => active.every((w) => w.settled || w.dispatched);
+    // to the deadline (#992 R-001). A RACING waiter is not retired (#2026): its
+    // fallback is in flight but a render item can still win it, so the loop
+    // keeps polling for it until one of the two settles it.
+    const allRetired = () =>
+      active.every((w) => w.settled || (w.dispatched && !w.racing));
 
     // Shared cancellation: a single url's watchdog rejects just that waiter and
-    // keeps the rest of the batch rendering; the cloud job is aborted only once
-    // nothing live remains — which wakes a sleeping poll loop to unwind.
+    // keeps the rest of the batch rendering; the cloud POLLING is abandoned only
+    // once nothing live remains — which wakes a sleeping poll loop to unwind.
     const batchAbort = new AbortController();
     for (const w of active) {
       const onAbort = () => {
@@ -488,18 +583,30 @@ export function createCloudDocumentFetcher(
 
     const urls = active.map((w) => w.req.url);
     const startedAt = Date.now();
-    const deadline = startedAt + timeoutMs;
+    // The batch lives as long as its slowest url's outer deadline, floored at
+    // the batch budget (#2026): a racing waiter needs the poll loop alive until
+    // its own deadline, not until a budget that knows nothing about it.
+    const batchBudgetMs = Math.max(timeoutMs, ...active.map((w) => w.outerMs));
+    const deadline = startedAt + batchBudgetMs;
     // Per-page render budget; the server clamps to BROWSER_QUEUE bounds.
     const reqTimeoutMs = Math.max(0, ...active.map((w) => w.req.timeoutMs ?? 0)) || undefined;
+
+    // The headroom timers start now, before the submit: a fallback that is
+    // guaranteed its slice of the deadline cannot wait on the cloud to answer.
+    for (const w of active) armRace(w);
 
     let job: RenderJobResponse;
     try {
       // Resolve the run id at submit time (a CLI resolver may only now have the
       // async-registered id). #1134
       const runId = typeof opts.runId === "function" ? opts.runId() : opts.runId;
+      // The submit is bounded by the batch budget, NOT by the callers' aborts:
+      // the server debits on submit, so cancelling it mid-flight would leave a
+      // debit nobody records (#2026). Aborted waiters are already rejected and
+      // wait for nothing; the charge below still lands in the accounting.
       job = await client.render(
         { urls, timeoutMs: reqTimeoutMs, ...(runId ? { runId } : {}) },
-        { signal: batchAbort.signal },
+        { signal: AbortSignal.timeout(batchBudgetMs) },
       );
     } catch (error) {
       // Nothing was debited — free the preflight reservation.
@@ -537,6 +644,9 @@ export function createCloudDocumentFetcher(
     try {
       while (Date.now() < deadline) {
         if (batchAbort.signal.aborted) throw new RenderJobError("Cloud render aborted");
+        // Every url may already be retired (a race settled the last one while
+        // the submit was in flight) — nothing left to poll for.
+        if (allRetired()) return;
         await sleep(Math.min(pollDelay, Math.max(1, deadline - Date.now())), batchAbort.signal);
         const result = await client.renderResult(job.jobId, { signal: batchAbort.signal });
         if (result.status === "done") {
@@ -569,7 +679,7 @@ export function createCloudDocumentFetcher(
         if (allRetired()) return;
         pollDelay = Math.min(pollDelay * POLL_BACKOFF_FACTOR, pollIntervalMs);
       }
-      throw new RenderJobError(`Cloud render timed out after ${timeoutMs}ms`);
+      throw new RenderJobError(`Cloud render timed out after ${batchBudgetMs}ms`);
     } catch (error) {
       // Caller cancellation (all urls aborted) is not a cloud failure — see above.
       if (!batchAbort.signal.aborted) classifyCloudError(error);
@@ -626,7 +736,18 @@ export function createCloudDocumentFetcher(
       // Interrupted before we even buffer it → unwind now (no submit/fallback).
       if (req.signal?.aborted) return Promise.reject(abortError());
       return new Promise<FetchResponse>((resolve, reject) => {
-        enqueue({ req, resolve, reject, settled: false, dispatched: false });
+        enqueue({
+          req,
+          resolve,
+          reject,
+          settled: false,
+          dispatched: false,
+          racing: false,
+          enqueuedAt: Date.now(),
+          // The request's own timeout is the outer deadline of the whole fetch;
+          // a request without one gets the batch budget (#2026).
+          outerMs: Math.max(1, req.timeoutMs ?? timeoutMs),
+        });
       });
     },
   };

--- a/packages/audit-engine/src/cloud-fetcher.ts
+++ b/packages/audit-engine/src/cloud-fetcher.ts
@@ -155,6 +155,8 @@ interface Waiter {
   /** Headroom timer that starts the racing fallback at `outer - headroom`. */
   raceTimer?: ReturnType<typeof setTimeout>;
   onAbort?: () => void;
+  /** Batch hook run once the waiter settles, so the poll loop can retire. */
+  onSettled?: () => void;
 }
 
 function abortError(): Error {
@@ -364,13 +366,16 @@ export function createCloudDocumentFetcher(
     w.racing = false;
     detach(w);
     w.resolve(resp);
+    w.onSettled?.();
   }
 
   function rejectWaiter(w: Waiter, err: unknown): void {
     if (w.settled) return;
     w.settled = true;
+    w.racing = false;
     detach(w);
     w.reject(err);
+    w.onSettled?.();
   }
 
   // Claim a waiter for terminal handling exactly once. Returns false if another
@@ -572,10 +577,16 @@ export function createCloudDocumentFetcher(
     // keeps the rest of the batch rendering; the cloud POLLING is abandoned only
     // once nothing live remains — which wakes a sleeping poll loop to unwind.
     const batchAbort = new AbortController();
+    // Whether the batch was retired by its CALLERS aborting every url (a crawl
+    // stop / watchdog) rather than by its urls settling. Only the former makes
+    // a cloud error not a cloud failure for the breaker.
+    let callerRetired = false;
     for (const w of active) {
+      // rejectWaiter runs onSettled, which retires the batch once nothing live
+      // remains; the hook is installed below, before the submit.
       const onAbort = () => {
         rejectWaiter(w, abortError());
-        if (allRetired()) batchAbort.abort();
+        if (allRetired()) callerRetired = true;
       };
       w.onAbort = onAbort;
       w.req.signal?.addEventListener("abort", onAbort, { once: true });
@@ -591,9 +602,15 @@ export function createCloudDocumentFetcher(
     // Per-page render budget; the server clamps to BROWSER_QUEUE bounds.
     const reqTimeoutMs = Math.max(0, ...active.map((w) => w.req.timeoutMs ?? 0)) || undefined;
 
-    // The headroom timers start now, before the submit: a fallback that is
-    // guaranteed its slice of the deadline cannot wait on the cloud to answer.
-    for (const w of active) armRace(w);
+    // A waiter settling by any path (a racing fallback landing during a poll
+    // sleep, say) must retire the batch the same way an abort does: wake the
+    // sleep and stop polling once nothing live remains, instead of one more
+    // renderResult round trip for nobody.
+    for (const w of active) {
+      w.onSettled = () => {
+        if (allRetired()) batchAbort.abort();
+      };
+    }
 
     let job: RenderJobResponse;
     try {
@@ -611,11 +628,11 @@ export function createCloudDocumentFetcher(
     } catch (error) {
       // Nothing was debited — free the preflight reservation.
       reservedCredits -= reserved;
-      // batchAbort fires only when EVERY url aborted (caller cancellation) — the
-      // resulting transport error is not a cloud failure, so skip classification
-      // (mirrors the legacy `if (req.signal.aborted) throw` guard). Waiters are
-      // already rejected by their abort listeners.
-      if (!batchAbort.signal.aborted) classifyCloudError(error);
+      // Every url aborted by its caller (crawl cancellation) — a failure of the
+      // submit is then not a cloud failure, so skip classification (mirrors the
+      // legacy `if (req.signal.aborted) throw` guard). Waiters are already
+      // rejected by their abort listeners.
+      if (!callerRetired) classifyCloudError(error);
       await settleAllViaFallback(active);
       return;
     }
@@ -648,7 +665,16 @@ export function createCloudDocumentFetcher(
         // the submit was in flight) — nothing left to poll for.
         if (allRetired()) return;
         await sleep(Math.min(pollDelay, Math.max(1, deadline - Date.now())), batchAbort.signal);
-        const result = await client.renderResult(job.jobId, { signal: batchAbort.signal });
+        // The sleep may have been woken by the last live waiter settling.
+        if (allRetired()) return;
+        // Bounded by the batch deadline as well as retirement, so a poll that
+        // hangs cannot outlive the batch it belongs to.
+        const result = await client.renderResult(job.jobId, {
+          signal: AbortSignal.any([
+            batchAbort.signal,
+            AbortSignal.timeout(Math.max(1, deadline - Date.now())),
+          ]),
+        });
         if (result.status === "done") {
           // Full round-trip success → the cloud is healthy; clear the
           // transport-failure streak (only `done` resets, per legacy parity).
@@ -682,7 +708,9 @@ export function createCloudDocumentFetcher(
       throw new RenderJobError(`Cloud render timed out after ${batchBudgetMs}ms`);
     } catch (error) {
       // Caller cancellation (all urls aborted) is not a cloud failure — see above.
-      if (!batchAbort.signal.aborted) classifyCloudError(error);
+      // (A batch retired by settlement throws RenderJobError here, which leaves
+      // the breaker untouched by construction.)
+      if (!callerRetired) classifyCloudError(error);
       await settleAllViaFallback(active);
     }
   }
@@ -716,6 +744,12 @@ export function createCloudDocumentFetcher(
   }
 
   function enqueue(w: Waiter): void {
+    // The outer deadline counts from acceptance, so the headroom timer is armed
+    // here, not at batch start: the coalescing window and a slow submit are
+    // both time the fallback's guaranteed slice must not lose. A waiter whose
+    // race fires while still buffered is submitted with its batch regardless
+    // (a render may still win it); demux and the fallback sweeps skip it.
+    armRace(w);
     pending.push(w);
     if (pending.length >= maxBatchUrls) {
       flushOneBatch();

--- a/packages/audit-engine/tests/cloud-fetch-headroom.test.ts
+++ b/packages/audit-engine/tests/cloud-fetch-headroom.test.ts
@@ -364,3 +364,48 @@ describe("through the crawler: a wedged render never costs the page (#2026)", ()
     }
   }, 15_000);
 });
+
+describe("codex review follow-ups (#2026)", () => {
+  test("the headroom timer counts from acceptance: a coalescing window longer than the render's share cannot eat the fallback's slice", async () => {
+    const origin = serveOrigin(20);
+    const fetcher = createCloudDocumentFetcher(neverReturningClient(), {
+      ...fastPolling,
+      // Buffer for longer than outer - headroom; the race must still start on time.
+      batchWindowMs: OUTER_MS - HEADROOM_MS + 100,
+      fallback: createFetchDocumentFetcher(),
+      timeoutMs: 10_000,
+    });
+    const startedAt = Date.now();
+    const resp = await fetcher.fetch({
+      url: origin.url,
+      timeoutMs: OUTER_MS,
+      signal: AbortSignal.timeout(OUTER_MS),
+    });
+    expect(resp.fetcherMethod).toBe("fetch");
+    expect(Date.now() - startedAt).toBeLessThan(OUTER_MS);
+  });
+
+  test("the poll loop stops as soon as the last racing waiter settles, instead of polling on to the deadline", async () => {
+    let polls = 0;
+    const client = {
+      render: async () => ({ jobId: "job-1", status: "queued" as const, charged: 2 }),
+      renderResult: async (jobId: string) => {
+        polls++;
+        return { jobId, status: "running" as const };
+      },
+    } as unknown as CloudServicesClient;
+    const fallback = fallbackFetcher({ delayMs: 30 });
+    const fetcher = createCloudDocumentFetcher(client, {
+      ...fastPolling,
+      pollIntervalMs: 200,
+      fallback: fallback.fetcher,
+      timeoutMs: 5_000,
+    });
+    const resp = await fetcher.fetch({ url: URL_A, timeoutMs: OUTER_MS });
+    expect(resp.body).toBe("fallback");
+    const after = polls;
+    await Bun.sleep(300);
+    // At most one poll already in flight can still land after settlement.
+    expect(polls).toBeLessThanOrEqual(after + 1);
+  });
+});

--- a/packages/audit-engine/tests/cloud-fetch-headroom.test.ts
+++ b/packages/audit-engine/tests/cloud-fetch-headroom.test.ts
@@ -1,0 +1,366 @@
+// squirrelscan/repo#2026 — the cloud fetcher's deadline structure. Each
+// request's `timeoutMs` is the OUTER deadline of the whole fetch; render has
+// `outer - headroom` to itself, then the plain fallback starts with the
+// remaining headroom and races it. The class fix under #1699: a caller that
+// enforces the outer deadline used to abort the waiter before the fallback
+// ever dispatched, because render ran under a 45s batch budget of its own.
+//
+// Synthetic origins only (egress is blocked in the harness). Deadlines are a
+// few hundred ms so the structure fires the way it does in production, faster.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect, Fiber, Stream } from "effect";
+
+import type { CloudServicesClient } from "@squirrelscan/cloud-client";
+import type { RenderChargeLine, RenderRequest } from "@squirrelscan/core-contracts";
+import { createCrawler, type CrawlerConfig, type CrawlerEvent } from "@squirrelscan/crawler";
+import {
+  createFetchDocumentFetcher,
+  type DocumentFetcher,
+  type FetchRequest,
+  type FetchResponse,
+} from "@squirrelscan/fetchers";
+
+import { createCloudDocumentFetcher } from "../src/cloud-fetcher";
+
+const OUTER_MS = 400;
+// Headroom is clamped to half the outer, so at 400ms the fallback starts at 200ms.
+const HEADROOM_MS = 200;
+
+const servers: Array<{ stop: (closeActive?: boolean) => void }> = [];
+afterEach(() => {
+  for (const s of servers.splice(0)) s.stop(true);
+});
+
+/** A Bun origin answering 200 HTML on every path after `ttfbMs`. */
+function serveOrigin(ttfbMs: number): { url: string; hits: string[] } {
+  const hits: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    async fetch(req) {
+      const path = new URL(req.url).pathname;
+      hits.push(path);
+      if (ttfbMs > 0) await Bun.sleep(ttfbMs);
+      return new Response(
+        `<!doctype html><html><head><title>${path}</title></head><body><a href="/one">one</a><a href="/two">two</a><p>plain</p></body></html>`,
+        { headers: { "content-type": "text/html" } },
+      );
+    },
+  });
+  servers.push(server);
+  return { url: `http://localhost:${server.port}/`, hits };
+}
+
+/** A render whose job never turns terminal — the "render never returns" shape. */
+function neverReturningClient(charged = 2): CloudServicesClient {
+  return {
+    render: async () => ({ jobId: "job-1", status: "queued" as const, charged }),
+    renderResult: async (jobId: string) => ({ jobId, status: "running" as const }),
+  } as unknown as CloudServicesClient;
+}
+
+/** A recording fallback that answers `body` after `delayMs` (or throws `error`). */
+function fallbackFetcher(opts: { delayMs?: number; body?: string; error?: Error } = {}) {
+  const requests: FetchRequest[] = [];
+  const fetcher: DocumentFetcher = {
+    id: "fallback",
+    capabilities: { jsRendering: false, cookies: false, screenshot: false },
+    async fetch(req): Promise<FetchResponse> {
+      requests.push(req);
+      if (opts.delayMs) await Bun.sleep(opts.delayMs);
+      if (opts.error) throw opts.error;
+      return {
+        url: req.url,
+        finalUrl: req.url,
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: opts.body ?? "fallback",
+        timing: { startedAt: 0, responseAt: 1, finishedAt: 1 },
+        redirectChain: {
+          sourceUrl: req.url,
+          finalUrl: req.url,
+          hops: [{ url: req.url, statusCode: 200, type: "http" as const }],
+          chainLength: 0,
+          isLoop: false,
+          endsInError: false,
+          httpsToHttp: false,
+          httpToHttps: false,
+        },
+        fetcherMethod: "fetch",
+      };
+    },
+  };
+  return { fetcher, requests };
+}
+
+const fastPolling = { batchWindowMs: 1, firstPollDelayMs: 5, pollIntervalMs: 20 };
+const URL_A = "https://example.com/a";
+
+describe("fallback headroom inside the outer deadline (#2026)", () => {
+  test("a render that never returns + a plain origin inside the headroom: the page lands, no abort surfaces", async () => {
+    const origin = serveOrigin(20);
+    const fetcher = createCloudDocumentFetcher(neverReturningClient(), {
+      ...fastPolling,
+      fallback: createFetchDocumentFetcher(),
+      // A batch budget far past the outer deadline, as in production (45s vs
+      // a 30s page): the request's own deadline must be what bounds the fetch.
+      timeoutMs: 10_000,
+    });
+
+    const startedAt = Date.now();
+    // The caller enforces the outer deadline too, the way the crawler's
+    // watchdog does — before the fix this abort landed first and the page was
+    // lost as "The operation was aborted."
+    const resp = await fetcher.fetch({
+      url: origin.url,
+      timeoutMs: OUTER_MS,
+      signal: AbortSignal.timeout(OUTER_MS),
+    });
+    const elapsed = Date.now() - startedAt;
+
+    expect(resp.status).toBe(200);
+    expect(resp.fetcherMethod).toBe("fetch");
+    expect(resp.body).toContain("<p>plain</p>");
+    expect(origin.hits).toEqual(["/"]);
+    // Landed inside the outer deadline, after the render's exclusive share.
+    expect(elapsed).toBeLessThan(OUTER_MS);
+    expect(elapsed).toBeGreaterThanOrEqual(HEADROOM_MS - 20);
+  });
+
+  test("the fallback gets what is LEFT of the outer deadline, never the request's full timeout again", async () => {
+    // Render fails at once → the fallback starts early with (almost) the whole
+    // outer deadline; a racing fallback starts at outer - headroom with the
+    // headroom. Neither is handed `timeoutMs` = outer a second time.
+    const early = fallbackFetcher();
+    const failingClient = {
+      render: async () => ({ jobId: "job-1", status: "queued" as const, charged: 2 }),
+      renderResult: async (jobId: string) => ({
+        jobId,
+        status: "done" as const,
+        results: [{ url: URL_A, status: null, error: "render failed" }],
+      }),
+    } as unknown as CloudServicesClient;
+    await createCloudDocumentFetcher(failingClient, { ...fastPolling, fallback: early.fetcher }).fetch(
+      { url: URL_A, timeoutMs: OUTER_MS },
+    );
+    expect(early.requests).toHaveLength(1);
+    expect(early.requests[0]!.timeoutMs).toBeLessThanOrEqual(OUTER_MS);
+    expect(early.requests[0]!.timeoutMs).toBeGreaterThan(OUTER_MS - 100);
+
+    const racing = fallbackFetcher();
+    await createCloudDocumentFetcher(neverReturningClient(), {
+      ...fastPolling,
+      fallback: racing.fetcher,
+    }).fetch({ url: URL_A, timeoutMs: OUTER_MS });
+    expect(racing.requests).toHaveLength(1);
+    expect(racing.requests[0]!.timeoutMs).toBeLessThanOrEqual(HEADROOM_MS);
+    expect(racing.requests[0]!.timeoutMs).toBeGreaterThan(HEADROOM_MS - 60);
+  });
+
+  test("a render that lands during the race, inside the deadline, still wins: paid work is used", async () => {
+    // Fallback starts at 200ms and needs 150ms more; the render turns done at
+    // ~260ms. The rendered page must be the one served, with ONE charge and
+    // the fallback's late answer discarded.
+    const fallback = fallbackFetcher({ delayMs: 150 });
+    const startedAt = Date.now();
+    const client = {
+      render: async () => ({ jobId: "job-1", status: "queued" as const, charged: 2 }),
+      renderResult: async (jobId: string) =>
+        Date.now() - startedAt < 260
+          ? { jobId, status: "running" as const }
+          : {
+              jobId,
+              status: "done" as const,
+              results: [{ url: URL_A, status: 200, html: "<html>rendered</html>", headers: {} }],
+            },
+    } as unknown as CloudServicesClient;
+    const charges: Array<[number, number]> = [];
+    const fetcher = createCloudDocumentFetcher(client, {
+      ...fastPolling,
+      fallback: fallback.fetcher,
+      onRenderCharged: (units, credits) => charges.push([units, credits]),
+    });
+
+    const resp = await fetcher.fetch({ url: URL_A, timeoutMs: OUTER_MS });
+
+    expect(resp.fetcherMethod).toBe("cloud-render");
+    expect(resp.body).toBe("<html>rendered</html>");
+    // The race did start (the fallback was dispatched at the headroom mark)…
+    expect(fallback.requests).toHaveLength(1);
+    // …and exactly one render was charged for the page.
+    expect(charges).toEqual([[1, 2]]);
+  });
+
+  test("a racing fallback that fails fast does not throw a render away that lands inside the deadline", async () => {
+    const fallback = fallbackFetcher({ error: new Error("connection refused") });
+    const startedAt = Date.now();
+    const client = {
+      render: async () => ({ jobId: "job-1", status: "queued" as const, charged: 2 }),
+      renderResult: async (jobId: string) =>
+        Date.now() - startedAt < 300
+          ? { jobId, status: "running" as const }
+          : {
+              jobId,
+              status: "done" as const,
+              results: [{ url: URL_A, status: 200, html: "<html>late render</html>", headers: {} }],
+            },
+    } as unknown as CloudServicesClient;
+    const fetcher = createCloudDocumentFetcher(client, { ...fastPolling, fallback: fallback.fetcher });
+
+    const resp = await fetcher.fetch({ url: URL_A, timeoutMs: OUTER_MS });
+
+    expect(fallback.requests).toHaveLength(1);
+    expect(resp.body).toBe("<html>late render</html>");
+  });
+
+  test("neither lands by the outer deadline: the fetch fails with the fallback's error, once, at the deadline", async () => {
+    const fallback = fallbackFetcher({ error: new Error("connection refused") });
+    const fetcher = createCloudDocumentFetcher(neverReturningClient(), {
+      ...fastPolling,
+      fallback: fallback.fetcher,
+    });
+    const startedAt = Date.now();
+    await expect(fetcher.fetch({ url: URL_A, timeoutMs: OUTER_MS })).rejects.toThrow(
+      "connection refused",
+    );
+    const elapsed = Date.now() - startedAt;
+    expect(elapsed).toBeGreaterThanOrEqual(OUTER_MS - 20);
+    expect(elapsed).toBeLessThan(OUTER_MS + 300);
+    expect(fallback.requests).toHaveLength(1);
+  });
+
+  test("a per-url render error arriving after the race started does not start a second fallback", async () => {
+    const fallback = fallbackFetcher({ delayMs: 120 });
+    const startedAt = Date.now();
+    const client = {
+      render: async () => ({ jobId: "job-1", status: "queued" as const, charged: 2 }),
+      renderResult: async (jobId: string) =>
+        Date.now() - startedAt < 260
+          ? { jobId, status: "running" as const }
+          : {
+              jobId,
+              status: "done" as const,
+              results: [{ url: URL_A, status: null, error: "render failed" }],
+            },
+    } as unknown as CloudServicesClient;
+    const fetcher = createCloudDocumentFetcher(client, { ...fastPolling, fallback: fallback.fetcher });
+
+    const resp = await fetcher.fetch({ url: URL_A, timeoutMs: OUTER_MS });
+
+    expect(resp.body).toBe("fallback");
+    expect(fallback.requests).toHaveLength(1);
+  });
+});
+
+describe("the charge path is abort-aware (#2026)", () => {
+  test("a caller abort during the submit no longer cancels it: the server's debit is still recorded", async () => {
+    // Before: the submit ran under the batch's abort signal, so a caller abort
+    // (crawl stop / watchdog) mid-submit cancelled the HTTP call, the server
+    // had already debited on submit, and nothing recorded it — onRenderCharged
+    // never fired and `budget.spent` stayed short by a batch. Run against the
+    // old fetcher this test fails on both charge assertions.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const submitted: RenderRequest[] = [];
+    const client = {
+      render: async (req: RenderRequest, opts?: { signal?: AbortSignal }) => {
+        submitted.push(req);
+        await gate;
+        // The real client rejects when its signal aborts; the old code passed
+        // the callers' abort through here.
+        if (opts?.signal?.aborted) throw new DOMException("aborted", "AbortError");
+        return { jobId: "job-1", status: "queued" as const, charged: 2 };
+      },
+      renderResult: async (jobId: string) => ({ jobId, status: "running" as const }),
+    } as unknown as CloudServicesClient;
+    const charges: Array<{ units: number; credits: number; breakdown: RenderChargeLine[] }> = [];
+    const budget = { spent: 0, cap: 100 };
+    const fallback = fallbackFetcher();
+    const fetcher = createCloudDocumentFetcher(client, {
+      ...fastPolling,
+      fallback: fallback.fetcher,
+      budget,
+      onRenderCharged: (units, credits, breakdown) => charges.push({ units, credits, breakdown }),
+    });
+
+    const ctrl = new AbortController();
+    const pending = fetcher.fetch({ url: URL_A, timeoutMs: OUTER_MS, signal: ctrl.signal });
+    // Wait for the submit to be in flight, then abort the caller.
+    while (submitted.length === 0) await Bun.sleep(1);
+    ctrl.abort();
+    // The waiter unwinds at once — it does not wait for the submit.
+    await expect(pending).rejects.toThrow("Cloud render aborted");
+    expect(charges).toEqual([]);
+
+    // The submit completes; the server debited 2cr on it.
+    release();
+    await Bun.sleep(20);
+
+    expect(charges).toEqual([
+      { units: 1, credits: 2, breakdown: [{ feature: "render", units: 1, credits: 2 }] },
+    ]);
+    expect(budget.spent).toBe(2);
+    // No fallback for an aborted caller (unchanged).
+    expect(fallback.requests).toHaveLength(0);
+  });
+});
+
+// ── End to end through the real crawler ─────────────────────────────────────
+
+const CRAWL_CONFIG: Partial<CrawlerConfig> = {
+  maxPages: 3,
+  concurrency: 2,
+  perHostConcurrency: 2,
+  delayMs: 0,
+  perHostDelayMs: 0,
+  timeoutMs: OUTER_MS,
+  userAgent: "squirrel-test",
+  respectRobots: false,
+  incremental: false,
+  useCacheControl: false,
+  breadthFirst: false,
+  coverageMode: "quick",
+};
+
+describe("through the crawler: a wedged render never costs the page (#2026)", () => {
+  test("every page lands via the fallback inside the per-page deadline; no abort, no entry retry", async () => {
+    const origin = serveOrigin(20);
+    const documentFetcher = createCloudDocumentFetcher(neverReturningClient(), {
+      ...fastPolling,
+      fallback: createFetchDocumentFetcher(),
+      timeoutMs: 10_000,
+    });
+    const crawler = await Effect.runPromise(
+      createCrawler({ config: { ...CRAWL_CONFIG, documentFetcher } }),
+    );
+    const warnings: string[] = [];
+    const failed: string[] = [];
+    const events = Effect.runFork(
+      Stream.runForEach(crawler.events, (event: CrawlerEvent) =>
+        Effect.sync(() => {
+          if (event.type === "warning") warnings.push(event.code);
+          if (event.type === "page:failed") failed.push(event.error);
+        }),
+      ),
+    );
+    try {
+      const startedAt = Date.now();
+      const crawlId = await Effect.runPromise(crawler.start(origin.url, origin.url));
+      const pages = await Effect.runPromise(crawler.storage.getPages(crawlId));
+      const stats = await Effect.runPromise(crawler.storage.getStats(crawlId));
+
+      expect(pages.map((p) => p.url)).toContain(origin.url);
+      expect(pages.length).toBe(3);
+      expect(failed).toEqual([]);
+      expect(stats?.rootFailure).toBeUndefined();
+      // The #1699 second chance never had to fire: the first attempt landed.
+      expect(warnings).not.toContain("entry-fetch-retried");
+      // Three pages, two at a time, each ~headroom deep: well inside what a
+      // wedged render used to cost (the batch budget per page).
+      expect(Date.now() - startedAt).toBeLessThan(OUTER_MS * 3);
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(events));
+    }
+  }, 15_000);
+});

--- a/packages/core-contracts/src/limits.ts
+++ b/packages/core-contracts/src/limits.ts
@@ -146,10 +146,51 @@ export const BROWSER_QUEUE = {
 } as const;
 
 // ── Cloud Crawler ───────────────────────────────────────────────
+// The cloud runner's per-page fetch deadline (`config.crawler.timeout_ms` in
+// the container; worker-agent resolves it from SQUIRREL_CRAWLER_TIMEOUT_MS
+// clamped to [min, max]). It is the OUTER deadline of one page fetch through
+// the cloud document fetcher, and the fetcher splits it (squirrelscan/repo#2026):
+//
+//   render gets `outer - fallbackHeadroomMs` to itself, then the plain-HTTP
+//   fallback starts and races it for the last `fallbackHeadroomMs`, whichever
+//   lands first serving the page. The fallback is therefore guaranteed its
+//   headroom INSIDE the outer deadline, so any outer deadline still yields a
+//   page whenever plain HTTP can fetch it in that time, and a render that
+//   finishes late but inside the deadline is still used (it was charged on
+//   submit). The headroom is clamped to half the outer so render always keeps
+//   at least half. At the defaults: render 18s alone, then 12s racing.
+//
+// 12s → 30s (squirrelscan/repo#2026, the class fix under #1699): 12s was the
+// tightest per-request bound in the system and, on its own, decided the audit
+// for a far-away origin (nuxt.daigo.ru: ~1s TTFB from a dev box, slower from
+// the container's egress) whose frontier was the seed alone. 30s is what the
+// CLI's plain path and the crawler default already give a page. Rationale
+// against the run budget: this is a CEILING only a stalled page pays, the
+// crawl-phase budget (AUDIT_RUNTIME.crawlPhaseTimeoutByCoverageMs) still
+// bounds the run, and the tail a stalled site can add is concurrency × 30s.
+//
+// THREE windows derive from it in packages/crawler, so raising it moves them:
+//   - preamble budget  = min(45s, 3 × T)  → 45s (was 36s); the sequential root
+//     probes (robots, llms, markdown, well-known, agent access, RSL) share it.
+//   - sitemap walk window = min(20s, 3 × T) → 20s (unchanged, already capped);
+//     the walk's hard stop (60s) does not derive from T.
+//   - entry fetch: the seed's first attempt is one outer deadline through the
+//     document fetcher (render + fallback as above); when that times out with
+//     nothing stored, the plain retry from #1699 gets 2 × T → 60s (was 24s).
+//   Also the per-URL watchdog, max(120s, 6 × T) → 180s (was 120s).
+// Worst case on a quick run (130s crawl phase) with every stage at its bound:
+// 45 + 20 + 30 = 95s before the entry retry, which the crawl-phase stop can
+// then cut short. The old numbers summed to 36 + 20 + 45 (the render batch
+// budget) + 12 = 113s with NO retry inside the phase, so this is not a
+// regression on that path, and a healthy origin never approaches any of it.
 export const CLOUD_CRAWLER = {
-  defaultTimeoutMs: 12_000,
+  defaultTimeoutMs: 30_000,
   minTimeoutMs: 3_000,
-  maxTimeoutMs: 30_000,
+  maxTimeoutMs: 60_000,
+  // Reserved for the plain-HTTP fallback inside the outer deadline (see above).
+  // 12s = what the WHOLE page fetch used to get, so the fallback never has less
+  // than it had before the raise.
+  fallbackHeadroomMs: 12_000,
 } as const;
 
 // ── Crawler Worker (DO) ─────────────────────────────────────────

--- a/packages/crawler/src/core/crawler.ts
+++ b/packages/crawler/src/core/crawler.ts
@@ -1214,7 +1214,7 @@ export function createCrawler(
           // with link discovery gated on the seed) and its fetch times out,
           // the run ends with zero pages — on an origin the same crawl has just
           // fetched robots.txt and a sitemap from. That first attempt ran under
-          // the crawl's per-request deadline (12s in the cloud) and, through a
+          // the crawl's per-request deadline (30s in the cloud, #2026) and, through a
           // document fetcher, got exactly one try (see fetchPageWithRetry). So
           // before giving the audit up, fetch the entry once more the plain
           // way with a relaxed deadline. Pages, not just the seed: nothing


### PR DESCRIPTION
Class fix under squirrelscan/repo#1699 (public #304 was the entry-URL second chance). Tracker: squirrelscan/repo#2026.

## The new deadline structure

Each request's `timeoutMs` is now the **outer deadline of the whole cloud fetch**, render and fallback included. Render has `outer - headroom` to itself. At that point, if nothing has landed, the plain-HTTP fallback starts with the remaining headroom and **races** the render; whichever settles first serves the page. The headroom is `CLOUD_CRAWLER.fallbackHeadroomMs` (12s, what the whole page fetch used to get), clamped to half the outer so render always keeps at least half. At the new cloud default of 30s: render alone for 18s, then 12s racing.

Consequences, each pinned by a test in `packages/audit-engine/tests/cloud-fetch-headroom.test.ts`:

- A render that never returns plus an origin that answers inside the headroom yields the page inside the outer deadline, even with a caller enforcing that deadline via `signal`. Before: the caller's abort landed first and the page was lost as "The operation was aborted."
- The fallback gets what is **left** of the outer deadline, never the request's full timeout again (render 10s + fallback 30s no longer happens).
- A render landing during the race, inside the deadline, still wins: paid work is used, one charge.
- A racing fallback that fails fast (refused/DNS) holds its failure until the outer deadline so a late render can still win.
- A per-url render error after the race started does not start a second fallback.
- **Charge path is abort-aware**: the submit is no longer cancelled by caller aborts (crawl stop / watchdog). The server debits on submit, so the old code could cancel the HTTP call mid-flight and leave a debit that nothing recorded (`onRenderCharged` never fired, `budget.spent` short by a batch). Now the submit runs to the batch budget and the debit lands in the accounting; aborted waiters still reject at once and never get a fallback.
- Through the real crawler: a wedged render on every page still collects every page, no `page:failed`, no `entry-fetch-retried`.

The in-flight render job is never cancelled by any of this, so its result lands in the server's render cache either way (a later render of the url is `render_cached`, same customer price).

Running the new test file against the old fetcher: 7 of 8 fail (the charge test fails on both charge assertions). After: 8 of 8 pass.

## The per-page deadline: 12s to 30s, with rationale

`CLOUD_CRAWLER.defaultTimeoutMs` 12s → 30s (max 30s → 60s), documented in `limits.ts` with the three derived windows:

| window | derivation | before | after |
|---|---|---|---|
| preamble budget | `min(45s, 3 × T)` | 36s | 45s |
| sitemap walk window | `min(20s, 3 × T)` | 20s | 20s |
| entry fetch | one outer deadline through the fetcher, then the #1699 plain retry at `2 × T` | 12s (+45s batch) +12s, retry 24s | 30s, retry 60s |
| per-URL watchdog | `max(120s, 6 × T)` | 120s | 180s |

Rationale against the run budget: T is a ceiling only a stalled page pays; the crawl-phase budget still bounds the run; the tail a stalled site can add is concurrency × 30s. On a quick run (130s crawl phase) with every stage at its bound: 45 + 20 + 30 = 95s before the entry retry, which the crawl-phase stop can cut short. The old path summed to 36 + 20 + 45 + 12 = 113s with no retry inside the phase, so this is not a regression there.

**Note for the cloud**: worker-agent's `component-runtime.ts` hardcodes `DEFAULT_CLOUD_CRAWLER_TIMEOUT_MS = 12_000` instead of importing `CLOUD_CRAWLER`; the constant change reaches the container only with that private 3-line swap (reported to the lead). The fetcher-level headroom structure applies at 12s too (render 6s alone, then 6s racing).

## Acceptance

- [x] Deadline structure reserves fallback headroom inside the outer per-fetch deadline; covered by a never-returning render + plain origin test where the page lands and no abort surfaces
- [x] Per-page deadline raised with a written rationale against the run budget; the three derived windows (preamble budget, sitemap walk, entry fetch) documented next to the constant
- [x] An aborted render leaves no charged-but-unrecorded render: the submit is never cancelled by a caller abort, the in-flight job is never cancelled, and a late render inside the deadline is used; charge on abort proven before (unrecorded) and after (recorded)
- [x] No behaviour change for the CLI plain path: `packages/crawler` fetch path untouched except a comment; golden and parity suites byte-identical (audit-engine `test:golden` set, crawler deadline suites, both cloud-fetcher suites all green)

## Verification

- `tsgo --noEmit` in core-contracts, crawler, audit-engine: clean
- audit-engine golden gate (22 files, chunks of 5): 161 pass, 0 fail
- crawler entry-fetch-timeout / slow-origin-crawl / preamble-budget / fetch-interrupt / deadline: 28 pass
- apps/cli `tests/crawler/cloud-fetcher.test.ts`: 38 pass; audit-engine `cloud-fetcher.test.ts`: 7 pass
- Codex review (gpt-6-astra, medium) run by the author; findings addressed or rebutted in a comment below.

No auto review bot on this repo; DCO signed.
