### PR TITLE
fix(cli): start light so self install is not OOM-killed at the last step of install.sh (#2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ How it works:
   names the fetcher and the deadline instead of `unknown` with the runtime's
   text, and a crawl whose preamble budget runs out records a warning naming the
   budget. squirrelscan/repo#1699
+
+- `squirrel` starts light. Every invocation used to evaluate the whole CLI
+  (the audit engine and every rule package included) before parsing a single
+  argument, which put `squirrel self install` at about 140 MB resident and got
+  it killed (exit 137) at the last step of `install.sh` on memory-capped
+  machines. Subcommands and the startup extras now load on demand, and the
+  standalone binary is built with `--splitting`, so `self install` and
+  `--version` peak at about 43 MB. Commands that need the engine load it when
+  they run. #2023
+- `install.sh` finishes the install itself when `self install` is killed by a
+  signal (the file work needs no memory), then checks that the binary runs. A
+  binary that will not run is reported under its own step with the binary and
+  link paths, a memory figure, the swap recipe, and the cloud dashboard as the
+  no-binary alternative, instead of "retry". #2023
 - `squirrel self update` now checks that the binary your PATH resolves is the one
   it just installed, and says so when it isn't. It used to flip the symlink
   recorded at install time and report success on that alone, so a stale

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-all: ci
 			linux-x64-musl) target="linux-x64-musl-baseline";; \
 			windows-x64) target="windows-x64-baseline";; \
 		esac; \
-		(cd $(APP_DIR) && bun build src/cli.ts --compile --minify \
+		(cd $(APP_DIR) && bun build src/cli.ts --compile --splitting --minify \
 			--target=bun-$$target \
 			--outfile=build/squirrel-$(VERSION)-$$platform$$ext); \
 	done

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run src/cli.ts",
-    "build": "bun build src/cli.ts --compile --outfile build/squirrelscan",
+    "build": "bun build src/cli.ts --compile --splitting --outfile build/squirrelscan",
     "test": "bun test",
     "typecheck": "tsgo --noEmit",
     "lint": "oxlint -c oxlint.config.mjs src/ tests/",

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -1,37 +1,24 @@
 // SquirrelScan CLI main entry
+//
+// Startup is split into a light path and a full path. The light path
+// (`--version`, `--help`, `self install|update|uninstall`, `self disk`, `mcp`,
+// `--offline`) evaluates citty, settings and the logger only; everything else
+// (the updater, telemetry, install registration, the banner, the config
+// loader, every subcommand) is a dynamic import bundled as its own chunk
+// (`bun build --compile --splitting`), so it is neither parsed nor evaluated
+// until a run actually needs it. Before this, every invocation paid for the
+// audit engine and every rule package up front: `squirrel self install` sat
+// at ~140 MB resident and was OOM-killed (exit 137) at the last step of
+// install.sh on memory-capped machines (#2023).
 
 import { defineCommand, runMain } from "citty";
 
 import type { UserSettings } from "@/self/types";
 
-import { printAutoUpdateAppliedNotice } from "@/cli/banner";
-import { setGlobalConfigPath } from "@/config";
-import { registerInstall } from "@/self/register-install";
 import { loadSettings } from "@/self/settings";
-import { showTelemetryNotice } from "@/self/telemetry";
-import {
-  applyPendingUpdateInForeground,
-  finishInlineAutoUpdate,
-  foregroundUpdateTarget,
-  runBackgroundUpdateCheck,
-} from "@/self/updater";
-import { rotateLogsIfNeeded } from "@/utils/log-rotation";
 import { setLogLevel } from "@/utils/logger";
 
 import { version } from "../../package.json";
-import { analyze } from "./commands/analyze";
-import { audit } from "./commands/audit";
-import { auth } from "./commands/auth";
-import { config } from "./commands/config";
-import { crawl } from "./commands/crawl";
-import { credits } from "./commands/credits";
-import { feedback } from "./commands/feedback";
-import { init } from "./commands/init";
-import { keys } from "./commands/keys";
-import { mcp } from "./commands/mcp";
-import { report } from "./commands/report";
-import { self } from "./commands/self";
-import { skills } from "./commands/skills";
 
 const main = defineCommand({
   meta: {
@@ -46,23 +33,35 @@ const main = defineCommand({
       description: "Path to config file",
     },
   },
-  setup({ args }) {
-    setGlobalConfigPath(args["config-file"]);
+  async setup({ args }) {
+    // The config loader is only evaluated when a path is given: with no flag
+    // the global stays at its initial undefined, which is what
+    // setGlobalConfigPath(undefined) would have set.
+    const configFile = args["config-file"];
+    if (configFile) {
+      const { setGlobalConfigPath } = await import("@/config");
+      setGlobalConfigPath(configFile);
+    }
   },
+  // Every subcommand is resolved lazily: citty only loads the one it runs
+  // (all of them for --help). A static import graph evaluated the audit
+  // engine and every rule package on EVERY invocation, which put the
+  // resident set of `squirrel self install` at ~140 MB and got the installer
+  // OOM-killed (exit 137) on memory-capped machines (#2023).
   subCommands: {
-    audit,
-    auth,
-    crawl,
-    credits,
-    analyze,
-    init,
-    config,
-    report,
-    feedback,
-    keys,
-    mcp,
-    self,
-    skills,
+    audit: () => import("./commands/audit").then((m) => m.audit),
+    auth: () => import("./commands/auth").then((m) => m.auth),
+    crawl: () => import("./commands/crawl").then((m) => m.crawl),
+    credits: () => import("./commands/credits").then((m) => m.credits),
+    analyze: () => import("./commands/analyze").then((m) => m.analyze),
+    init: () => import("./commands/init").then((m) => m.init),
+    config: () => import("./commands/config").then((m) => m.config),
+    report: () => import("./commands/report").then((m) => m.report),
+    feedback: () => import("./commands/feedback").then((m) => m.feedback),
+    keys: () => import("./commands/keys").then((m) => m.keys),
+    mcp: () => import("./commands/mcp").then((m) => m.mcp),
+    self: () => import("./commands/self").then((m) => m.self),
+    skills: () => import("./commands/skills").then((m) => m.skills),
   },
 });
 
@@ -74,27 +73,22 @@ export function run(): void {
   }
 
   const effectiveSettings = settings.ok ? settings.data : undefined;
-  const withBackgroundTasks = shouldRunBackgroundTasks(process.argv.slice(2));
 
-  // An update a previous run already discovered is applied BEFORE the command,
-  // and the original argv re-executed on the new binary, so a fresh run always
-  // gets the newest version the CLI knows about (#170). The decision is
-  // synchronous and settings-only: with nothing pending — the overwhelmingly
-  // common case — this is a null check and startup is byte-for-byte the old
-  // path, no await and no network.
-  if (
-    withBackgroundTasks &&
-    effectiveSettings &&
-    foregroundUpdateTarget(effectiveSettings)
-  ) {
-    void applyPendingUpdateInForeground(effectiveSettings)
-      // Failure-safe: a broken update must never break the user's command.
-      .catch(() => {})
-      .then(() => startCommand(effectiveSettings, withBackgroundTasks));
+  if (!shouldRunBackgroundTasks(process.argv.slice(2))) {
+    // Light path: nothing but the command. No updater, no telemetry, no
+    // registration, so none of their modules are loaded.
+    void runMain(main);
     return;
   }
 
-  startCommand(effectiveSettings, withBackgroundTasks);
+  // Failure-safe: the extras must never break the user's command. The
+  // rejection handler covers the LOAD only (a two-argument then, so a throw
+  // inside runWithStartupExtras cannot run the command a second time); the
+  // command itself reports its own errors through runMain.
+  void import("./startup").then(
+    ({ runWithStartupExtras }) => runWithStartupExtras(main, effectiveSettings),
+    () => void runMain(main)
+  );
 }
 
 /**
@@ -129,36 +123,4 @@ export function shouldRunBackgroundTasks(args: string[]): boolean {
     args[0] === "mcp";
 
   return !isSimpleCommand && !args.includes("--offline");
-}
-
-function startCommand(
-  settings: UserSettings | undefined,
-  withBackgroundTasks: boolean
-): void {
-  if (withBackgroundTasks) {
-    // Non-blocking background tasks
-    if (settings) showTelemetryNotice(settings);
-    runBackgroundUpdateCheck(settings);
-    registerInstall(settings);
-    rotateLogsIfNeeded().catch(() => {}); // Best effort, silent fail
-  }
-
-  // The one-time "✓ auto-updated" confirmation belongs to the RUN, not to any
-  // one command: an update applied before `squirrel config` must be announced
-  // by `squirrel config` (#170). Gated synchronously on the marker so the
-  // ordinary run stays free of the await. printAutoUpdateAppliedNotice itself
-  // only prints when this process IS the new version, and clears the marker.
-  if (withBackgroundTasks && settings?.auto_update_applied) {
-    void printAutoUpdateAppliedNotice(settings)
-      .catch(() => {})
-      .then(runCommand);
-    return;
-  }
-  runCommand();
-}
-
-function runCommand(): void {
-  // After the command settles, bound any in-process (Windows) auto-update so
-  // a still-downloading binary can't hold the CLI open indefinitely (#1074).
-  void runMain(main).finally(() => void finishInlineAutoUpdate());
 }

--- a/apps/cli/src/cli/startup.ts
+++ b/apps/cli/src/cli/startup.ts
@@ -1,0 +1,79 @@
+// Startup extras for a full CLI run: the foreground update, the telemetry
+// notice, the background update check, install registration and log
+// rotation. Loaded on demand by run() in ./index.ts so the light path
+// (`--version`, `self install`, `mcp`, --offline, ...) never evaluates the
+// updater/telemetry/banner graph: that graph alone put ~35 MB on the resident
+// set of every invocation, which is what got `self install` OOM-killed on
+// memory-capped machines (#2023). Keep this module free of command imports so
+// it can never pull a subcommand chunk into the entry.
+
+import type { ArgsDef, CommandDef } from "citty";
+
+import { runMain } from "citty";
+
+import type { UserSettings } from "@/self/types";
+
+import { printAutoUpdateAppliedNotice } from "@/cli/banner";
+import { registerInstall } from "@/self/register-install";
+import { showTelemetryNotice } from "@/self/telemetry";
+import {
+  applyPendingUpdateInForeground,
+  finishInlineAutoUpdate,
+  foregroundUpdateTarget,
+  runBackgroundUpdateCheck,
+} from "@/self/updater";
+import { rotateLogsIfNeeded } from "@/utils/log-rotation";
+
+/**
+ * Run `main` with every startup extra. `settings` is the snapshot run() took
+ * before deciding to load this module; undefined when settings were unreadable.
+ */
+export function runWithStartupExtras<T extends ArgsDef>(
+  main: CommandDef<T>,
+  settings: UserSettings | undefined
+): void {
+  // An update a previous run already discovered is applied BEFORE the command,
+  // and the original argv re-executed on the new binary, so a fresh run always
+  // gets the newest version the CLI knows about (#170). The decision is
+  // synchronous and settings-only: with nothing pending — the overwhelmingly
+  // common case — this is a null check and no network.
+  if (settings && foregroundUpdateTarget(settings)) {
+    void applyPendingUpdateInForeground(settings)
+      // Failure-safe: a broken update must never break the user's command.
+      .catch(() => {})
+      .then(() => startCommand(main, settings));
+    return;
+  }
+
+  startCommand(main, settings);
+}
+
+function startCommand<T extends ArgsDef>(
+  main: CommandDef<T>,
+  settings: UserSettings | undefined
+): void {
+  // Non-blocking background tasks
+  if (settings) showTelemetryNotice(settings);
+  runBackgroundUpdateCheck(settings);
+  registerInstall(settings);
+  rotateLogsIfNeeded().catch(() => {}); // Best effort, silent fail
+
+  // The one-time "✓ auto-updated" confirmation belongs to the RUN, not to any
+  // one command: an update applied before `squirrel config` must be announced
+  // by `squirrel config` (#170). Gated synchronously on the marker so the
+  // ordinary run stays free of the await. printAutoUpdateAppliedNotice itself
+  // only prints when this process IS the new version, and clears the marker.
+  if (settings?.auto_update_applied) {
+    void printAutoUpdateAppliedNotice(settings)
+      .catch(() => {})
+      .then(() => runCommand(main));
+    return;
+  }
+  runCommand(main);
+}
+
+function runCommand<T extends ArgsDef>(main: CommandDef<T>): void {
+  // After the command settles, bound any in-process (Windows) auto-update so
+  // a still-downloading binary can't hold the CLI open indefinitely (#1074).
+  void runMain(main).finally(() => void finishInlineAutoUpdate());
+}

--- a/apps/cli/tests/cli/startup.test.ts
+++ b/apps/cli/tests/cli/startup.test.ts
@@ -52,3 +52,66 @@ describe("shouldRunBackgroundTasks (#170)", () => {
     expect(shouldRunBackgroundTasks(["self", "doctor"])).toBe(true);
   });
 });
+
+// #2023: every invocation used to evaluate the whole CLI graph (the audit
+// engine and every rule package included) before citty had even parsed argv,
+// which put `squirrel self install` at ~140 MB resident and got it OOM-killed
+// at the last step of install.sh. The entry now loads subcommands and the
+// startup extras on demand, and the standalone build splits them into chunks
+// that are neither parsed nor evaluated until imported. Both halves are
+// source-level contracts: a static import quietly puts the module back on the
+// hot path, and a build without --splitting still parses every chunk up front.
+describe("light startup path (#2023)", () => {
+  const entry = new URL("../../src/cli/index.ts", import.meta.url);
+  const entrySource = () => Bun.file(entry).text();
+
+  test("the entry imports no command statically", async () => {
+    const source = await entrySource();
+    const staticImports = source
+      .split("\n")
+      .filter((line) => /^import\b/.test(line) || line.startsWith('} from "'))
+      .join("\n");
+    expect(staticImports).not.toMatch(/from "\.\/commands\//);
+    expect(staticImports).not.toMatch(/from "@\/cli\/commands\//);
+    // The extras (updater, telemetry, registration, banner, config) ride on
+    // ./startup, which is only imported when shouldRunBackgroundTasks says so.
+    expect(staticImports).not.toMatch(
+      /@\/self\/updater|@\/self\/telemetry|@\/self\/register-install|@\/cli\/banner|@\/config"/
+    );
+    expect(source).toContain('import("./startup")');
+  });
+
+  test("every subcommand is a lazy resolver", async () => {
+    const source = await entrySource();
+    for (const name of [
+      "audit",
+      "auth",
+      "crawl",
+      "credits",
+      "analyze",
+      "init",
+      "config",
+      "report",
+      "feedback",
+      "keys",
+      "mcp",
+      "self",
+      "skills",
+    ]) {
+      expect(source).toContain(`${name}: () => import("./commands/${name}")`);
+    }
+  });
+
+  test("the standalone build splits chunks", async () => {
+    const pkg = (await Bun.file(
+      new URL("../../package.json", import.meta.url)
+    ).json()) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.build).toContain("--compile --splitting");
+    const makefile = await Bun.file(
+      new URL("../../../../Makefile", import.meta.url)
+    ).text();
+    expect(makefile).toContain("--compile --splitting --minify");
+  });
+});

--- a/benchmarks/2026-09-perf-program.md
+++ b/benchmarks/2026-09-perf-program.md
@@ -1572,6 +1572,54 @@ the two v1 spans, which #252 stopped emitting. The CLI has computed the whole
 per-phase breakdown since #857 but only at debug level, so it now also writes one
 machine-readable line to the trace log — the flag whose entire job is timing
 attribution. Every rules-phase number in this section comes from it.
+## CLI startup: `self install` killed at the last step of install.sh
+
+Every invocation evaluated the whole CLI graph (the audit engine and every
+rule package) before citty had parsed a single argument, so `squirrel self
+install` cost as much as the engine and was OOM-killed (exit 137) at the last
+step of `install.sh` on memory-capped machines: one darwin/arm64 user retried
+eight times in 3.5 hours (squirrelscan/repo#2023). Fixed by loading
+subcommands and the startup extras on demand and building the standalone
+binary with `--splitting`, so a chunk is neither parsed nor evaluated until
+imported. Measured 2026-09-09, load average 2.4 on the laptop; the container
+rows are counts, not times.
+
+Peak resident set, `/usr/bin/time -l` on macOS arm64, scratch `HOME`:
+
+| command | shipped v0.0.92 | before (this tree, unsplit) | after |
+|---|---|---|---|
+| `squirrel self install --bin-dir <dir>` | 105 MB | 134 MB | 43 MB |
+| `squirrel --version` | | 136 MB | 44 MB |
+| `squirrel mcp --help` | | | 45 MB |
+| `squirrel self doctor` | | | 94 MB |
+| `squirrel audit --help` (loads the engine) | | | 155 MB |
+
+Where the memory went, measured by compiling one-import probes (bun's own
+floor is 21 MB): the statically imported startup graph (banner, config loader,
+updater, telemetry, registration) evaluated to 50 MB, and the bundled-but-never
+-imported command modules cost a further 60 MB just to be parsed, which is the
+part only `--splitting` removes. `--bytecode` was tried and fails to generate
+for this bundle on Bun 1.3.14.
+
+Linux arm64 container (`docker run --memory=N --memory-swap=N`, Debian
+bookworm), `self install` passes out of 3 runs per cap. The cgroup peak
+includes the page cache of the 100 MB binary copy, so the cap that passes sits
+above the resident set:
+
+| cap | shipped v0.0.92 | after (`--splitting`) |
+|---|---|---|
+| 40 MB | 0/3 | 3/3 |
+| 64 MB | 0/3 | 3/3 |
+| 72 MB | 0/3 | 3/3 |
+| 80 MB | 1/3 | 3/3 |
+| 96 MB | 2/3 | 3/3 |
+| 112 MB | 2/3 | 3/3 |
+| 128 MB | 3/3 | 3/3 |
+
+`install.sh` also finishes the install itself when `self install` is
+signal-killed (the file work needs no memory) and then runs the installed
+binary once; a binary that will not run reports under `verify_binary_killed`
+with the paths already in place instead of "retry".
 
 ## Still open
 

--- a/install.sh
+++ b/install.sh
@@ -441,6 +441,204 @@ self_install_kill_guidance() {
     https://github.com/${REPO}/releases"
 }
 
+# --- By-hand install after a killed self install ---------------------------
+# `self install` does trivial file work: copy the binary under
+# ~/.squirrel/releases/<version>/, symlink it from bin_dir, record the bin dir
+# in settings.json. When the kernel kills the binary before it gets to that
+# work, do it here in bash, which costs nothing, then check the binary can
+# actually run. A machine that cannot run `squirrel --version` gets a distinct
+# step, a memory figure, and the concrete state of the install (#2023).
+VERIFY_BINARY_STEP="verify_binary"
+VERIFY_BINARY_KILLED_STEP="verify_binary_killed"
+
+verify_binary_step_for_code() {
+  local code="$1" kill_code
+  for kill_code in $SELF_INSTALL_KILL_CODES; do
+    if [ "$code" = "$kill_code" ]; then
+      printf '%s' "$VERIFY_BINARY_KILLED_STEP"
+      return 0
+    fi
+  done
+  printf '%s' "$VERIFY_BINARY_STEP"
+}
+
+# The CLI reads settings from $HOME/.squirrel (apps/cli/src/self/paths.ts).
+squirrel_home_dir() {
+  printf '%s/.squirrel' "$HOME"
+}
+
+# True when a value can be dropped into a JSON string verbatim: printable
+# ASCII with no quote or backslash. Anything else is left unrecorded rather
+# than mangled — a wrong install_bin_dir sends every later `self update` to
+# the wrong link (#293), a missing one falls back to the default.
+is_plain_json_string() {
+  # [:print:] under LC_ALL=C is exactly ASCII 0x20-0x7E (bash 3.2 does not
+  # take a quoted space inside a bracket range, so no ' '-~ here).
+  case "$(LC_ALL=C printf '%s' "$1" | LC_ALL=C tr -d '[:print:]')" in
+    ?*) return 1 ;;
+  esac
+  case "$1" in
+    *'"'*|*'\'*|'') return 1 ;;
+  esac
+  return 0
+}
+
+# Record install_bin_dir in settings.json the way `self install` does, so a
+# later `self update` flips the link this installer created. Merges into an
+# existing file (jq when available, a keyed substitution otherwise) and writes
+# a fresh one when absent: the CLI parses settings as a partial, so a file
+# holding only install_bin_dir is valid. Never fatal: prints a warning and
+# returns 0, the install itself is already in place.
+record_install_bin_dir() {
+  local settings="$1" bin_dir="$2" tmp content
+  if ! is_plain_json_string "$bin_dir"; then
+    warn "Not recording the bin directory in $settings (unusual characters in the path)"
+    return 0
+  fi
+  tmp="$settings.tmp.$$"
+  if [ ! -f "$settings" ]; then
+    mkdir -p "$(dirname "$settings")" 2>/dev/null || true
+    if printf '{\n  "install_bin_dir": "%s"\n}\n' "$bin_dir" >"$tmp" 2>/dev/null \
+        && chmod 600 "$tmp" 2>/dev/null && mv -f "$tmp" "$settings" 2>/dev/null; then
+      return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    warn "Could not write $settings; run 'squirrel self install --bin-dir $bin_dir' later"
+    return 0
+  fi
+  if [ "${USE_JQ:-false}" = true ]; then
+    if jq --arg d "$bin_dir" '.install_bin_dir = $d' "$settings" >"$tmp" 2>/dev/null \
+        && [ -s "$tmp" ] && chmod 600 "$tmp" 2>/dev/null && mv -f "$tmp" "$settings" 2>/dev/null; then
+      return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+  fi
+  # No jq (or jq failed). Two shapes are handled by hand, neither through
+  # pattern replacement (bash's ${var/../..} and sed both give `&` and `\` in
+  # the path a meaning, and bash 3.2 mangles a `{` in the replacement): a
+  # missing key is inserted after the opening brace, and a `null` value is
+  # filled in. Anything else already recorded is left exactly as it is.
+  content=$(cat "$settings" 2>/dev/null) || content=""
+  local lead rest before after trimmed body
+  lead="${content%%'{'*}"
+  if [ "$lead" = "$content" ] || [ -n "${lead//[[:space:]]/}" ]; then
+    warn "Could not update $settings; run 'squirrel self install --bin-dir $bin_dir' later"
+    return 0
+  fi
+  rest="${content#*'{'}"
+  case "$content" in
+    *'"install_bin_dir"'*)
+      before="${content%%'"install_bin_dir"'*}"
+      after="${content#*'"install_bin_dir"'}"
+      trimmed="${after#"${after%%[![:space:]]*}"}"
+      if [ "${trimmed:0:1}" != ":" ]; then
+        warn "Could not update $settings; run 'squirrel self install --bin-dir $bin_dir' later"
+        return 0
+      fi
+      trimmed="${trimmed#:}"
+      trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+      if [ "${trimmed:0:4}" != "null" ]; then
+        # A directory is already recorded. It is very likely this one (the
+        # installer picks the same directory every time); if not, say so.
+        if [ "$bin_dir" != "$HOME/.local/bin" ]; then
+          warn "$settings already records an install directory; if it is not $bin_dir, run 'squirrel self install --bin-dir $bin_dir'"
+        fi
+        return 0
+      fi
+      content="${before}\"install_bin_dir\": \"${bin_dir}\"${trimmed#null}" ;;
+    *)
+      body="${rest#"${rest%%[![:space:]]*}"}"
+      if [ "${body:0:1}" = "}" ]; then
+        # An empty object: no trailing comma.
+        content="${lead}{
+  \"install_bin_dir\": \"${bin_dir}\"
+${rest}"
+      else
+        content="${lead}{
+  \"install_bin_dir\": \"${bin_dir}\",${rest}"
+      fi ;;
+  esac
+  if printf '%s\n' "$content" >"$tmp" 2>/dev/null && chmod 600 "$tmp" 2>/dev/null \
+      && mv -f "$tmp" "$settings" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null
+  warn "Could not update $settings; run 'squirrel self install --bin-dir $bin_dir' later"
+  return 0
+}
+
+# Lay the release out exactly as `self install` would. Prints the installed
+# binary path on success. Failure (a mkdir/cp/ln error) returns non-zero with
+# the reason on stderr; the caller decides how to report it.
+place_release_by_hand() {
+  local binary="$1" version="$2" bin_dir="$3"
+  local home release_dir target link
+  home=$(squirrel_home_dir)
+  release_dir="$home/releases/${version#v}"
+  target="$release_dir/squirrel"
+  link="$bin_dir/squirrel"
+
+  mkdir -p "$release_dir" "$bin_dir" || return 1
+  # Copy to a sibling and rename over: a reader never sees a half-written binary.
+  cp "$binary" "$target.tmp.$$" && chmod 755 "$target.tmp.$$" && mv -f "$target.tmp.$$" "$target" || {
+    rm -f "$target.tmp.$$" 2>/dev/null
+    return 1
+  }
+  # rm acts on the link itself, so a live, dangling or plain-file occupant all
+  # go the same way (the existsSync trap from #132 applies to `-e` too).
+  rm -f "$link" 2>/dev/null || true
+  ln -s "$target" "$link" || return 1
+  record_install_bin_dir "$home/settings.json" "$bin_dir"
+  printf '%s' "$target"
+}
+
+# What to tell a user whose binary is installed but will not run. Everything
+# the user needs is stated as a path or a command: nothing here says "retry".
+binary_unrunnable_guidance() {
+  local code="$1" target="$2" link="$3" mib="" out=""
+  mib=$( (available_memory_mib) 2>/dev/null || true)
+  out="  squirrel is installed, but this machine could not run it:
+    Binary: ${target}
+    Link:   ${link}
+  Nothing needs downloading again: once the machine can run it, use it as is.
+"
+  if [ "$code" = 137 ]; then
+    out="${out}
+  The system killed it (SIGKILL), which on a small VPS or a memory-capped
+  container is almost always the out-of-memory killer."
+    if [ -n "$mib" ]; then
+      out="${out}
+  Memory available right now: ${mib} MB"
+    fi
+    out="${out}
+
+  Give the machine more memory, then run: squirrel --version
+    Add 1GB of swap (usually the quickest fix on a VPS):
+      sudo fallocate -l 1G /swapfile && sudo chmod 600 /swapfile
+      sudo mkswap /swapfile && sudo swapon /swapfile
+    Or resize the machine, or raise the container memory limit, to 1GB or more."
+    if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+      out="${out}
+  On macOS, endpoint security (Santa, an MDM policy) kills binaries it has not
+  approved the same way: check its log and allow ${target}."
+    fi
+  elif [ "$code" = 143 ]; then
+    out="${out}
+  Something outside the installer stopped it (SIGTERM): a timeout wrapper, a
+  process supervisor or a cancelled job. Run it again outside that limit:
+    squirrel --version"
+  else
+    out="${out}
+  Run it yourself to see the failure:
+    ${link} --version"
+  fi
+  out="${out}
+
+  Cannot change this machine? Audits also run from the cloud dashboard, with
+  no binary at all: https://app.squirrelscan.com"
+  printf '%s' "$out"
+}
+
 # Single EXIT trap: cleans the temp dir and reports genuine failures. Replaces
 # the per-call tmpdir trap (a second `trap ... EXIT` would clobber this one).
 report_on_exit() {
@@ -847,13 +1045,53 @@ download_and_install() {
     LAST_ERROR_CODE="$rc"
     # A signal death is not a self-install bug: the binary never got to fail on
     # its own terms. Move it to its own step so it reports, and fingerprints,
-    # apart from real failures, and say what to actually do about it (#1654).
+    # apart from real failures (#1654), then finish the install by hand: the
+    # file work needs no memory, and a binary that only died mid-install can
+    # still run (#2023).
     CURRENT_STEP=$(self_install_step_for_code "$rc")
     if [ "$CURRENT_STEP" = "$SELF_INSTALL_KILLED_STEP" ]; then
-      error "$(self_install_kill_headline "$rc")" "$(self_install_kill_guidance "$rc")"
+      install_by_hand_and_verify "$tmpdir/squirrel" "$version" "$bin_dir" "$rc"
+      return 0
     fi
     error "Self install failed with exit code $rc"
   fi
+}
+
+# Recovery path for a signal-killed self install: place the files from bash,
+# then prove the binary runs. Reports under self_install_killed when even the
+# file work fails, and under verify_binary / verify_binary_killed when the
+# files are in place but the binary will not execute.
+install_by_hand_and_verify() {
+  local binary="$1" version="$2" bin_dir="$3" kill_rc="$4"
+  local target link
+
+  warn "$(self_install_kill_headline "$kill_rc")"
+  log "Finishing the install by hand..."
+  if ! target=$(place_release_by_hand "$binary" "$version" "$bin_dir"); then
+    LAST_ERROR_CODE="$kill_rc"
+    error "$(self_install_kill_headline "$kill_rc")" "$(self_install_kill_guidance "$kill_rc")"
+  fi
+  link="$bin_dir/squirrel"
+  info "Binary: $target"
+  info "Link:   $link"
+
+  CURRENT_STEP="$VERIFY_BINARY_STEP"
+  log "Checking the installed binary runs..."
+  local verify_log="$TMPDIR_TO_CLEAN/verify.log"
+  set +e
+  "$link" --version 2>&1 | tee "$verify_log"
+  local rc=${PIPESTATUS[0]}
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    LAST_ERROR_OUTPUT=$(tail -n 40 "$verify_log" 2>/dev/null || true)
+    LAST_ERROR_CODE="$rc"
+    CURRENT_STEP=$(verify_binary_step_for_code "$rc")
+    error "squirrel is installed at $target but cannot run on this machine (exit $rc)" \
+      "$(binary_unrunnable_guidance "$rc" "$target" "$link")"
+  fi
+  info "Installed by hand after self install was killed (exit $kill_rc); the binary runs."
+  echo "  If 'squirrel audit' is killed the same way, the machine needs more memory:" >&2
+  echo "    sudo fallocate -l 1G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile" >&2
 }
 
 # Detect user's shell and config file

--- a/scripts/install-contract.test.ts
+++ b/scripts/install-contract.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -632,8 +643,13 @@ describe("self install killed by a signal", () => {
     // The branch itself sits below the sourceable preamble, so pin the wiring.
     expect(shellInstaller).toContain('CURRENT_STEP=$(self_install_step_for_code "$rc")');
     expect(shellInstaller).toContain('if [ "$CURRENT_STEP" = "$SELF_INSTALL_KILLED_STEP" ]; then');
+    // #2023: a killed self install is finished by hand; the headline and the
+    // memory guidance still reach the user when even the file work fails.
     expect(shellInstaller).toContain(
-      'error "$(self_install_kill_headline "$rc")" "$(self_install_kill_guidance "$rc")"',
+      'install_by_hand_and_verify "$tmpdir/squirrel" "$version" "$bin_dir" "$rc"',
+    );
+    expect(shellInstaller).toContain(
+      'error "$(self_install_kill_headline "$kill_rc")" "$(self_install_kill_guidance "$kill_rc")"',
     );
     // Unchanged fallback for every non-signal failure.
     expect(shellInstaller).toContain('error "Self install failed with exit code $rc"');
@@ -808,6 +824,197 @@ describe("install.sh curl transport hardening", () => {
       expect(stderr).not.toContain("is unknown");
       // 2 is curl's "failed to initialize", which is what a bad option exits.
       expect(code).not.toBe(2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});
+
+// A self install killed by a signal now finishes by hand: install.sh lays the
+// release out itself (the binary never got to its trivial file work), then
+// proves the installed binary runs. A binary that will not run reports under
+// its own step with the paths already in place (#2023).
+describe("by-hand install after a killed self install (#2023)", () => {
+  const scratch = () => {
+    const dir = mkdtempSync(join(tmpdir(), "install-by-hand-"));
+    return { dir, home: join(dir, "home"), bin: join(dir, "bin"), tmp: join(dir, "tmp") };
+  };
+  const fakeBinary = (dir: string, name: string, body: string) => {
+    const path = join(dir, name);
+    writeFileSync(path, `#!/bin/bash\n${body}\n`);
+    chmodSync(path, 0o755);
+    return path;
+  };
+  const versionOnly = 'if [ "$1" = "--version" ]; then echo "9.9.9"; exit 0; fi\nkill -9 $$';
+  const alwaysKilled = "kill -9 $$";
+
+  test("kill codes map to verify_binary_killed, everything else to verify_binary", async () => {
+    const { stdout } = await runWithCurlShim(
+      'for c in 137 143 0 1 126; do printf "%s=%s\\n" "$c" "$(verify_binary_step_for_code "$c")"; done',
+      { cut: "preamble" },
+    );
+    expect(stdout.trim().split("\n")).toEqual([
+      "137=verify_binary_killed",
+      "143=verify_binary_killed",
+      "0=verify_binary",
+      "1=verify_binary",
+      "126=verify_binary",
+    ]);
+  });
+
+  test("place_release_by_hand lays the release out the way self install does", async () => {
+    const { dir, home, bin } = scratch();
+    try {
+      mkdirSync(bin, { recursive: true });
+      // A dangling link is what an upgrade over a pruned release leaves behind
+      // (#132): it must be replaced, not tripped over.
+      symlinkSync(join(dir, "gone"), join(bin, "squirrel"));
+      const binary = fakeBinary(dir, "downloaded", versionOnly);
+      const { stdout, code } = await runWithCurlShim(
+        `place_release_by_hand "${binary}" v9.9.9 "${bin}"`,
+        { cut: "preamble", env: { HOME: home } },
+      );
+      expect(code).toBe(0);
+      const target = join(home, ".squirrel", "releases", "9.9.9", "squirrel");
+      expect(stdout).toBe(target);
+      expect(statSync(target).mode & 0o755).toBe(0o755);
+      expect(readlinkSync(join(bin, "squirrel"))).toBe(target);
+      const settings = JSON.parse(readFileSync(join(home, ".squirrel", "settings.json"), "utf8"));
+      expect(settings).toEqual({ install_bin_dir: bin });
+      expect(statSync(join(home, ".squirrel", "settings.json")).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ["without jq, value replaced", "false", '{\n  "channel": "beta",\n  "install_bin_dir": null\n}\n'],
+    ["without jq, key inserted", "false", '{\n  "channel": "beta",\n  "telemetry": false\n}\n'],
+    ["without jq, one-line file", "false", '{"channel":"beta","install_bin_dir":null}'],
+    ["with jq", "true", '{"channel":"beta","install_bin_dir":"/old"}'],
+  ])("record_install_bin_dir keeps existing settings (%s)", async (_name, useJq, existing) => {
+    if (useJq === "true" && !Bun.which("jq")) return;
+    const { dir, home } = scratch();
+    // `&`, `#` and `$` are the characters a sed or ${var/../..} replacement
+    // would give a meaning to (codex review); the recorded path must be verbatim.
+    const bin = join(dir, "a&b#c$x");
+    try {
+      mkdirSync(join(home, ".squirrel"), { recursive: true });
+      const settingsPath = join(home, ".squirrel", "settings.json");
+      writeFileSync(settingsPath, existing);
+      // Single-quoted for bash: the path carries a `$`.
+      const { code, stderr } = await runWithCurlShim(
+        `record_install_bin_dir "${settingsPath}" '${bin}'`,
+        { cut: "preamble", env: { HOME: home, USE_JQ: useJq } },
+      );
+      expect(code).toBe(0);
+      expect(stderr).not.toContain("Warning");
+      const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+      expect(settings.channel).toBe("beta");
+      expect(settings.install_bin_dir).toBe(bin);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("without jq, an empty object gains the key with no trailing comma", async () => {
+    const { dir, home, bin } = scratch();
+    try {
+      mkdirSync(join(home, ".squirrel"), { recursive: true });
+      const settingsPath = join(home, ".squirrel", "settings.json");
+      writeFileSync(settingsPath, "{}\n");
+      const { code } = await runWithCurlShim(`record_install_bin_dir "${settingsPath}" "${bin}"`, {
+        cut: "preamble",
+        env: { HOME: home, USE_JQ: "false" },
+      });
+      expect(code).toBe(0);
+      expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual({ install_bin_dir: bin });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("without jq, a recorded directory is left byte-for-byte alone", async () => {
+    const { dir, home, bin } = scratch();
+    try {
+      mkdirSync(join(home, ".squirrel"), { recursive: true });
+      const settingsPath = join(home, ".squirrel", "settings.json");
+      // An escaped quote inside the value is what a naive regex stops at.
+      const existing = '{"install_bin_dir":"/old\\"name","telemetry":false}';
+      writeFileSync(settingsPath, existing);
+      const { code, stderr } = await runWithCurlShim(
+        `record_install_bin_dir "${settingsPath}" "${bin}"`,
+        { cut: "preamble", env: { HOME: home, USE_JQ: "false" } },
+      );
+      expect(code).toBe(0);
+      expect(stderr).toContain("already records an install directory");
+      expect(readFileSync(settingsPath, "utf8")).toBe(existing);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a path that cannot be a plain JSON string is left unrecorded, not mangled", async () => {
+    const { dir, home } = scratch();
+    try {
+      const settingsPath = join(home, ".squirrel", "settings.json");
+      const { code, stderr } = await runWithCurlShim(
+        `record_install_bin_dir "${settingsPath}" '${join(dir, 'we"ird')}'`,
+        { cut: "preamble", env: { HOME: home } },
+      );
+      expect(code).toBe(0);
+      expect(stderr).toContain("Not recording");
+      expect(existsSync(settingsPath)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a binary that runs after the kill completes the install", async () => {
+    const { dir, home, bin, tmp } = scratch();
+    try {
+      mkdirSync(tmp, { recursive: true });
+      const binary = fakeBinary(dir, "downloaded", versionOnly);
+      const { code, stdout, stderr, calls } = await runWithCurlShim(
+        `TMPDIR_TO_CLEAN="${tmp}"; install_by_hand_and_verify "${binary}" v9.9.9 "${bin}" 137`,
+        { env: { HOME: home } },
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain("9.9.9");
+      expect(stderr).toContain("killed by the system (exit 137, SIGKILL)");
+      expect(stderr).toContain("Installed by hand");
+      expect(readlinkSync(join(bin, "squirrel"))).toBe(
+        join(home, ".squirrel", "releases", "9.9.9", "squirrel"),
+      );
+      // A completed install is not a failure: nothing is reported.
+      expect(calls).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a binary that cannot run reports under verify_binary_killed with the paths in place", async () => {
+    const { dir, home, bin, tmp } = scratch();
+    try {
+      mkdirSync(tmp, { recursive: true });
+      const binary = fakeBinary(dir, "downloaded", alwaysKilled);
+      const { code, stderr, calls } = await runWithCurlShim(
+        `TMPDIR_TO_CLEAN="${tmp}"; install_by_hand_and_verify "${binary}" v9.9.9 "${bin}" 137`,
+        { env: { HOME: home, NO_TELEMETRY: undefined }, settleMs: 5000 },
+      );
+      expect(code).toBe(1);
+      const target = join(home, ".squirrel", "releases", "9.9.9", "squirrel");
+      // The files ARE installed; the message says where, and what to do that
+      // is not "retry".
+      expect(existsSync(target)).toBe(true);
+      expect(stderr).toContain(`Binary: ${target}`);
+      expect(stderr).toContain("squirrel --version");
+      expect(stderr).toContain("https://app.squirrelscan.com");
+      expect(stderr).not.toContain("Re-run this installer");
+      expect(calls).toHaveLength(1);
+      const report = JSON.parse(curlDataArg(calls[0])) as Record<string, unknown>;
+      expect(report.step).toBe("verify_binary_killed");
+      expect(report.exit_code).toBe(137);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fixes the private tracker's squirrelscan/repo#2023: one darwin/arm64 user was SIGKILLed (exit 137) at `self_install_killed` eight times in 3.5 hours and gave up.

## What was wrong

Every invocation of `squirrel` evaluated the whole CLI graph (the audit engine and every rule package) before citty had parsed a single argument. `squirrel self install`, whose real work is a copy, a symlink and a settings write, cost as much as an audit. Measured by compiling one-import probe binaries: bun's own floor is 21 MB, the statically imported startup graph (banner, config loader, updater, telemetry, registration) evaluated to 50 MB, and the bundled-but-never-imported command modules cost a further 60 MB just to be parsed.

## What changed

- `apps/cli/src/cli/index.ts`: subcommands are lazy citty resolvers. The startup extras (foreground update, telemetry notice, background update check, install registration, log rotation, the auto-updated notice) move to `apps/cli/src/cli/startup.ts` and are imported only when `shouldRunBackgroundTasks()` says so. `--config-file` lazily imports `@/config`.
- The standalone build gains `--splitting` (`apps/cli/package.json`, `Makefile` `build-all`). With it a lazily imported chunk is neither parsed nor evaluated until imported; without it lazy `import()` alone only got `self install` to 111 MB. Still one output file. All five release targets cross-compile with it. `--bytecode` was tried: it fails to generate for this bundle on Bun 1.3.14 and the result crashes.
- `install.sh`: when `self install` dies by signal (137/143), the script lays the release out itself (`place_release_by_hand`, `record_install_bin_dir`), then runs `<link> --version` once. Success completes the install. Failure reports under new steps `verify_binary` / `verify_binary_killed` with the binary and link paths, a memory figure, the swap recipe, a macOS endpoint-security hint, and the cloud dashboard as the no-binary route. `record_install_bin_dir` merges with jq when present and otherwise inserts or fills a `null` key by string concatenation (no sed / `${var/../..}`, which give `&`, `#`, `\` in a path a meaning); any other recorded value is left byte-for-byte alone.
- Tests: `apps/cli/tests/cli/startup.test.ts` pins that the entry has no static command or extras imports and that both build scripts carry `--splitting`; `scripts/install-contract.test.ts` covers the step mapping, the by-hand layout (dangling link replaced, settings written 0600), the settings merge with and without jq (paths with `&#$`, empty object, escaped existing value untouched), the recovered path (no report) and the unrunnable path (report step `verify_binary_killed`, exit 137, paths and no "retry" in the message).
- CHANGELOG entries and a section in `benchmarks/2026-09-perf-program.md`.

## Measurements (acceptance box 1)

Peak resident set, `/usr/bin/time -l`, macOS arm64, scratch `HOME`, load average 2.4:

| command | shipped v0.0.92 | before (this tree) | after |
|---|---|---|---|
| `squirrel self install --bin-dir <dir>` | 105 MB | 134 MB | **43 MB** |
| `squirrel --version` | | 136 MB | **44 MB** |
| `squirrel mcp --help` | | | 45 MB |
| `squirrel self doctor` | | | 94 MB |
| `squirrel audit --help` (loads the engine) | | | 155 MB |

Acceptance box 2, a machine with a memory ceiling: Linux arm64 container (`docker run --memory=N --memory-swap=N`, Debian bookworm), `self install` passes out of 3 runs per cap. The cgroup peak includes the page cache of the 100 MB binary copy, so the passing cap sits above the resident set.

| cap | shipped v0.0.92 | after |
|---|---|---|
| 40 MB | 0/3 | 3/3 |
| 64 MB | 0/3 | 3/3 |
| 72 MB | 0/3 | 3/3 |
| 80 MB | 1/3 | 3/3 |
| 96 MB | 2/3 | 3/3 |
| 112 MB | 2/3 | 3/3 |
| 128 MB | 3/3 | 3/3 |

Acceptance box 3 is the `verify_binary_killed` path above; exercised end to end with a fake binary that kills itself.

## Cross-repo

The installer worker pins `step` to an allowlist and rewrites unknown values to `other`, so the two new steps need squirrelscan/repo#2025 (one-line allowlist change, already open). Order does not matter: the worker deploys independently and `install.sh` is release-gated.

## Review

No auto-review bot runs on this repo. A codex (`gpt-6-astra`, medium) pass was run on the diff: it cleared the CLI side (foreground update ordering, double execution, light-path cleanup, citty async setup and lazy resolvers) and found three real bugs in the first no-jq settings edit (bash 3.2 `\{` in a replacement, `&` in the path, an empty `{}` gaining a trailing comma, an escaped quote in an existing value). All three are fixed by the concatenation rewrite above and covered by tests, verified under both `/bin/bash` 3.2 and bash 5.2.

Checks run: `tsgo --noEmit`, `oxlint`, `oxfmt --check`, `bash -n`, `shellcheck -S warning`, `bun test apps/cli/tests/cli/startup.test.ts` (25 pass), `bun test scripts/install-contract.test.ts` (64 pass), all five `--target` cross-compiles with `--splitting`.