### PR TITLE
feat(installer): stamp SQUIRREL_INSTALL_SOURCE so install channels are distinguishable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1034,7 +1034,12 @@ download_and_install() {
   # (#1538). PIPESTATUS[0] is the binary's code, not tee's.
   local self_install_log="$tmpdir/self-install.log"
   set +e
-  "$tmpdir/squirrel" self install --bin-dir "$bin_dir" 2>&1 | tee "$self_install_log"
+  # Stamp the install channel for the CLI's one-time install registration
+  # (self/install-meta.ts honors SQUIRREL_INSTALL_SOURCE; without it the
+  # managed-dir binary self-reports as the ambiguous "binary"). A caller's own
+  # value wins so wrappers (CI, package managers) can name themselves.
+  SQUIRREL_INSTALL_SOURCE="${SQUIRREL_INSTALL_SOURCE:-install.sh}" \
+    "$tmpdir/squirrel" self install --bin-dir "$bin_dir" 2>&1 | tee "$self_install_log"
   local rc=${PIPESTATUS[0]}
   set -e
   if [ "$rc" -ne 0 ]; then

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -221,6 +221,13 @@ async function main() {
   const result = spawnSync(binaryPath, ["self", "install"], {
     stdio: "inherit",
     windowsHide: true,
+    env: {
+      ...process.env,
+      // Stamp the install channel for the one-time install registration —
+      // the managed-dir binary would otherwise self-report as "binary",
+      // masking npm. A caller's own value wins.
+      SQUIRREL_INSTALL_SOURCE: process.env.SQUIRREL_INSTALL_SOURCE || "npm",
+    },
   });
 
   // Don't fail npm install if self install fails - binary still works via wrapper fallback


### PR DESCRIPTION
The CLI registers each install once (self/register-install.ts) and infers the channel from the binary's path (install-meta.ts). Because both the curl installer and the npm postinstall place the binary in the managed releases dir, every channel self-reports as `binary` — npm-channel installs are invisible (2 rows in 28 days against real npm usage), and install.sh installs can't be told apart from hand-placed ones.

`detectInstallSource()` already honors `SQUIRREL_INSTALL_SOURCE`; this PR makes the two installers export it at the `self install` call:

- `install.sh` → `install.sh` (env-prefix on the tee'd invocation; a caller's pre-set value wins so CI/package-manager wrappers can name themselves)
- `npm/scripts/postinstall.js` → `npm` (spawnSync env, same caller-wins rule)

No behavior change beyond the stamped env var. `bash -n` clean; `bun test npm/scripts/postinstall.test.ts` green (3 pass).

Ref: squirrelscan/repo#2029