### PR TITLE
fix(core-contracts): quick crawl phase covers the entry retry (repo#1699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ How it works:
 
 ## [Unreleased]
 
+### Fixed
+
+- A quick cloud audit's crawl phase now holds the entry page's worst case. The
+  130 s phase ended before the entry retry added in v0.0.93 could report, so a
+  slow origin still failed with "no pages collected". Quick runs get a 210 s
+  crawl phase and a 330 s runtime (the post-crawl slice is unchanged); surface
+  and full are untouched. squirrelscan/repo#1699 squirrelscan/repo#2026
+
 ## v0.0.93
 
 A release for the audits that never started. Two cloud fixes stop a slow or

--- a/packages/core-contracts/src/limits.ts
+++ b/packages/core-contracts/src/limits.ts
@@ -11,14 +11,25 @@ import type { CoverageMode } from "./index";
 // quick raised 170s→240s / 90s→130s (#578): ~20+ page Wix sites finished at
 // ~174s on a cold cache and tipped the old 170s cap; 240s gives headroom without
 // unbounding the budget.
+// quick raised again 240s→330s / 130s→210s (squirrelscan/repo#1699, #2026):
+// the crawl phase must be able to hold the ENTRY page's worst case before the
+// first page can exist, or a slow origin fails with "no pages collected" before
+// the entry retry from #304 ever reports. That worst case, all bounds from
+// CLOUD_CRAWLER below: preamble 45s + sitemap walk 20s + entry outer deadline
+// 30s + plain entry retry 60s = 155s, plus one page round at the outer deadline
+// (30s) so a stored entry page is followed by at least one more fetch, plus
+// margin: 210s. The 130s phase ended at 95s of preamble + entry and cut the 60s
+// retry short every time (nuxt.daigo.ru, verified 2026-09-09 on v0.0.93). The
+// runtime moves by the same 80s so the post-crawl slice (rules, prefetch,
+// publish) keeps its 110s and both invariants above hold.
 export const AUDIT_RUNTIME = {
   timeoutByCoverageMs: {
-    quick: 240_000,
+    quick: 330_000,
     surface: 900_000,
     full: 2_400_000,
   } satisfies Record<CoverageMode, number>,
   crawlPhaseTimeoutByCoverageMs: {
-    quick: 130_000,
+    quick: 210_000,
     surface: 540_000,
     full: 1_800_000,
   } satisfies Record<CoverageMode, number>,


### PR DESCRIPTION
Verified on v0.0.93 in prod 2026-09-09: nuxt.daigo.ru still fails with "Crawl phase timed out with no pages collected" (run 01M22DM8MBNA81C3RDYHY28DPC), no page event at all, because the quick crawl phase (130 s) ends before the entry page's worst case (preamble 45 + sitemap 20 + entry 30 + plain retry 60 = 155 s) can report. daigoevo.ru on the same IP crawls fine on the new engine, and a control audit completes in 45 s, so the origin is reachable-but-slow from Cloudflare egress and this is the last bound in the way.

- quick crawlPhase 130 s to 210 s (derivation in the comment next to the constant)
- quick runtime 240 s to 330 s, same +80 s, so the post-crawl slice stays 110 s and both AUDIT_RUNTIME invariants hold
- surface/full unchanged; the API reaper reads the same table (run-staleness.ts), so no private change

Constants only; tsgo clean. Goes out in v0.0.94 with a pin move.