### PR TITLE
docs(rules): search-first rewrite, security, integrity, crawl, url, links, images, content, eeat, seo, mobile, social, video, legal, i18n, analytics, adblock, gaps

### DIFF
--- a/docs/rules/adblock/blocked-links.mdx
+++ b/docs/rules/adblock/blocked-links.mdx
@@ -15,13 +15,13 @@ The rule is site-wide and reads a result the cloud blocklist service produced be
 
 - Skipped when no result is available. Message: `Ad-blocker link check skipped`, with a readable skip reason.
 - Pass when nothing matched. Message: `No links or resources match EasyList ad-blocking rules`.
-- Warn once per match, up to `maxMatchesToReport`. Message: `Blocked by ad blockers: ads-twitter.com — X/Twitter ad pixel — https://static.ads-twitter.com/uwt.js`, naming the vendor where the domain is recognised and falling back to the bare hostname where it is not, with a note of the page it appeared on. Severity warning, weight 2.
+- Warn once per match, up to `maxMatchesToReport` and always at least one, so a misconfigured `0` does not drop the finding. Message: `Blocked by ad blockers: static.ads-twitter.com — X/Twitter ad pixel — https://static.ads-twitter.com/uwt.js (1 page)`, naming the vendor where the registrable domain is recognised and falling back to the bare hostname where it is not, with a page count when the source pages are known. Severity warning, weight 2.
 
 The three blocking rules share one blocklist check per audit.
 
 ## How to fix it
 
-Move anything the page needs off a blocked host. For measurement, a first-party or server-side collector survives blocking; for advertising, the finding is a description of your audience rather than a defect.
+Move anything the page needs off a blocked host. For measurement, a first-party or server-side collector may reduce blocking, though it is not a guarantee: filters can match a first-party endpoint too, and server-side forwarding cannot recover an event whose browser request never left. For advertising, the finding is a description of your audience rather than a defect.
 
 Check what each match actually is before acting. The report names the vendor for the domains it recognises, which is usually enough to tell an ad pixel from something the page depends on.
 
@@ -82,6 +82,7 @@ Blocking findings ship in every audit next to the SEO, performance and agent exp
 ## References
 
 - [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
+- [HTMLScriptElement, MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement)
 
 ## Check your site
 

--- a/docs/rules/adblock/blocked-links.mdx
+++ b/docs/rules/adblock/blocked-links.mdx
@@ -5,7 +5,7 @@ description: "A resource on an EasyList domain never loads for a visitor running
 
 ## What a blocked request is
 
-EasyList's network rules stop requests to advertising and tracking hosts. A visitor running uBlock Origin, AdBlock or a browser with built-in blocking never fetches them, so whatever the resource does simply does not happen for that visitor.
+EasyList's network rules stop requests to advertising and tracking hosts. A visitor running uBlock Origin, AdBlock or a browser with built-in blocking never fetches them, so whatever the resource does never happens for that visitor.
 
 The consequence depends on what it is. An advertising pixel not firing means missing revenue data. A conversion tag not firing means the conversion is not recorded. And when something essential to the page has ended up on a blocked host, the page itself breaks for a share of visitors that is large in some audiences and small in others.
 

--- a/docs/rules/adblock/blocked-links.mdx
+++ b/docs/rules/adblock/blocked-links.mdx
@@ -1,11 +1,29 @@
 ---
-title: "Blocked Tracking Links"
-description: "Checks for links and resources pointing to blocked tracking domains"
+title: "Requests ad blockers stop: links and resources on EasyList"
+description: "A resource on an EasyList domain never loads for a visitor running a blocker. squirrel reports each one with what it is."
 ---
 
-<Note>**Cloud rule** - requires login (`squirrel auth login`). All three [adblock rules](/rules/adblock) share a single blocklist check per audit, **included in the audit base charge**. Skipped when not logged in. See [Cloud rules](/cloud/rules).</Note>
+## What a blocked request is
 
-Checks for links and resources pointing to blocked tracking domains (matched server-side against the full EasyList filter rules)
+EasyList's network rules stop requests to advertising and tracking hosts. A visitor running uBlock Origin, AdBlock or a browser with built-in blocking never fetches them, so whatever the resource does simply does not happen for that visitor.
+
+The consequence depends on what it is. An advertising pixel not firing means missing revenue data. A conversion tag not firing means the conversion is not recorded. And when something essential to the page has ended up on a blocked host, the page itself breaks for a share of visitors that is large in some audiences and small in others.
+
+## What squirrel checks
+
+The rule is site-wide and reads a result the cloud blocklist service produced before the rules ran, matched server-side against the full EasyList rules. It emits one check per finding, all named `blocked-links`:
+
+- Skipped when no result is available. Message: `Ad-blocker link check skipped`, with a readable skip reason.
+- Pass when nothing matched. Message: `No links or resources match EasyList ad-blocking rules`.
+- Warn once per match, up to `maxMatchesToReport`. Message: `Blocked by ad blockers: ads-twitter.com — X/Twitter ad pixel — https://static.ads-twitter.com/uwt.js`, naming the vendor where the domain is recognised and falling back to the bare hostname where it is not, with a note of the page it appeared on. Severity warning, weight 2.
+
+The three blocking rules share one blocklist check per audit.
+
+## How to fix it
+
+Move anything the page needs off a blocked host. For measurement, a first-party or server-side collector survives blocking; for advertising, the finding is a description of your audience rather than a defect.
+
+Check what each match actually is before acting. The report names the vendor for the domains it recognises, which is usually enough to tell an ad pixel from something the page depends on.
 
 | | |
 |---|---|
@@ -15,23 +33,17 @@ Checks for links and resources pointing to blocked tracking domains (matched ser
 | **Severity** | warning |
 | **Weight** | 2/10 |
 
-## Solution
-
-Links to tracking domains (analytics, pixels, etc.) will be blocked by users with adblockers like uBlock Origin or AdBlock. If these are essential resources, they won't load. If they're analytics, you may get incomplete data from users with adblockers. Consider using first-party analytics or privacy-respecting alternatives.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `maxMatchesToReport` | unknown | `undefined` | Maximum blocked links to report in detail |
+| `maxMatchesToReport` | number | `10` | Maximum blocked links to report in detail |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."adblock/blocked-links"]
-maxMatchesToReport = 20
+[rule_options."adblock/blocked-links"]
+maxMatchesToReport = 25
 ```
 
 ## Enable / disable
@@ -57,3 +69,29 @@ disable = ["adblock/*"]
 enable = ["adblock/blocked-links"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [adblock/privacy-blocked](/rules/adblock/privacy-blocked): the tracker half, matched against EasyPrivacy.
+- [adblock/element-hiding](/rules/adblock/element-hiding): elements hidden by cosmetic filters rather than blocked.
+- [security/third-party-cookies](/rules/security/third-party-cookies): the same hosts seen from the privacy side.
+- [analytics/gtm-present](/rules/analytics/gtm-present): the measurement that may be blocked.
+
+Blocking findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Blocking section of the report. Each blocked resource is listed with what it is and where it appeared. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Blocking section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/adblock/element-hiding.mdx
+++ b/docs/rules/adblock/element-hiding.mdx
@@ -1,11 +1,35 @@
 ---
-title: "Adblock Element Hiding"
-description: "Checks for elements that would be hidden by common adblockers"
+title: "Adblock cosmetic filters: classes that get hidden"
+description: "A block named .ad-container is hidden for anyone running an ad blocker, whatever is in it. squirrel matches your selectors against EasyList."
 ---
 
 <Note>**Cloud rule** - requires login (`squirrel auth login`). All three [adblock rules](/rules/adblock) share a single blocklist check per audit, **included in the audit base charge**. Skipped when not logged in. See [Cloud rules](/cloud/rules).</Note>
 
-Checks for elements that would be hidden by common adblockers (matched server-side against the full EasyList cosmetic rules)
+## What a cosmetic filter is
+
+EasyList is the filter list most ad blockers use. Alongside network rules that stop requests, it carries cosmetic rules: CSS selectors the blocker hides on every page, so an element with a class like `ad-wrapper` or `sponsored-box` disappears whether or not it holds an advert.
+
+That is the trap. A blocker cannot read your intent, only your class names, so a legitimate block called `.banner` or a `#sponsors` section thanking supporters is hidden from a large share of visitors. The fix is naming, not markup.
+
+## What squirrel checks
+
+The rule is site-wide and reads a result the cloud blocklist service produced before the rules ran, matching the site's selectors against the full EasyList cosmetic rules server-side. It emits a single check named `adblock-elements`:
+
+- Skipped when no result is available. Message: `Adblock element-hiding check skipped`, with a readable skip reason.
+- Pass when nothing matched. Message: `No elements match common adblock filters`.
+- Warn otherwise. Message: `4 selector(s) on the site match adblock element-hiding rules`, listing up to `maxMatchesToReport` of them. Severity warning, weight 3.
+
+The three blocking rules share one blocklist check per audit, so enabling them all costs the same as enabling one.
+
+## How to fix it
+
+```html
+<section class="partner-list">…</section>
+```
+
+Rename the classes and ids that match. `partner-list` and `promo-panel` carry the same meaning to you and do not match a filter written to catch advertising.
+
+Where the element really is an advert, the finding is accurate and the choice is yours. What is worth fixing is the case where a blocker hides content you meant everyone to see.
 
 | | |
 |---|---|
@@ -15,24 +39,17 @@ Checks for elements that would be hidden by common adblockers (matched server-si
 | **Severity** | warning |
 | **Weight** | 3/10 |
 
-## Solution
-
-Elements matching adblock filter rules may be hidden for users with adblockers. This can affect ad revenue or hide legitimate content if element names/classes match ad patterns. Consider renaming CSS classes that unintentionally match ad-blocking patterns (like .ad-*, .banner, .sponsor).
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `maxMatchesToReport` | unknown | `undefined` | Maximum matching elements to report in detail |
-| `lists` | unknown | `undefined` | Filter lists to check against |
+| `maxMatchesToReport` | number | `10` | Maximum matching selectors to report in detail |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."adblock/element-hiding"]
-maxMatchesToReport = 20
+[rule_options."adblock/element-hiding"]
+maxMatchesToReport = 25
 ```
 
 ## Enable / disable
@@ -58,3 +75,29 @@ disable = ["adblock/*"]
 enable = ["adblock/element-hiding"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [adblock/blocked-links](/rules/adblock/blocked-links): requests the same lists block outright.
+- [adblock/privacy-blocked](/rules/adblock/privacy-blocked): the tracker half, matched against EasyPrivacy.
+- [content/hidden-text](/rules/content/hidden-text): content hidden by your own CSS rather than by a blocker.
+- [analytics/gtm-present](/rules/analytics/gtm-present): the measurement that may be blocked with it.
+
+Blocking findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Blocking section of the report. Each matching selector is listed, up to the configured maximum. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Blocking section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/adblock/element-hiding.mdx
+++ b/docs/rules/adblock/element-hiding.mdx
@@ -7,9 +7,9 @@ description: "A block named .ad-container is hidden for anyone running an ad blo
 
 ## What a cosmetic filter is
 
-EasyList is the filter list most ad blockers use. Alongside network rules that stop requests, it carries cosmetic rules: CSS selectors the blocker hides on every page, so an element with a class like `ad-wrapper` or `sponsored-box` disappears whether or not it holds an advert.
+EasyList is the filter list most ad blockers use. Alongside network rules that stop requests, it carries cosmetic rules: CSS selectors the blocker hides. Some are global and some apply only on named domains, and they match ids, attributes and selector structure as well as classes.
 
-That is the trap. A blocker cannot read your intent, only your class names, so a legitimate block called `.banner` or a `#sponsors` section thanking supporters is hidden from a large share of visitors. The fix is naming, not markup.
+That is the trap. A blocker cannot read your intent, only your markup, so a legitimate block called `.banner` or a `#sponsors` section thanking supporters can be hidden from a large share of visitors.
 
 ## What squirrel checks
 
@@ -27,7 +27,7 @@ The three blocking rules share one blocklist check per audit, so enabling them a
 <section class="partner-list">…</section>
 ```
 
-Rename the classes and ids that match. `partner-list` and `promo-panel` carry the same meaning to you and do not match a filter written to catch advertising.
+Rename whatever the filter matched, and check the result against a blocker rather than assuming. A name like `partner-list` carries the same meaning to you, but the fix is that the new markup stops matching the applicable rules, which can key on an id or an attribute as easily as a class.
 
 Where the element really is an advert, the finding is accurate and the choice is yours. What is worth fixing is the case where a blocker hides content you meant everyone to see.
 
@@ -87,6 +87,7 @@ Blocking findings ship in every audit next to the SEO, performance and agent exp
 
 ## References
 
+- [CSS selectors, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_selectors)
 - [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
 
 ## Check your site

--- a/docs/rules/adblock/index.mdx
+++ b/docs/rules/adblock/index.mdx
@@ -9,6 +9,8 @@ The **Blocking** category covers content, links, and trackers that ad blockers a
 
 <Note>Rule IDs and config filters keep the `adblock/` prefix (e.g. `adblock/*`) - only the report category was renamed to Blocking.</Note>
 
+The three rules answer one question from three angles: what does a visitor running a blocker not get? A resource on an EasyList domain is never requested, a tracker on EasyPrivacy is blocked in several browsers by default, and an element whose class matches a cosmetic filter is hidden whatever is in it. All three share a single blocklist check per audit.
+
 ## Ad blocking
 
 <CardGroup cols={2}>
@@ -34,3 +36,5 @@ The **Blocking** category covers content, links, and trackers that ad blockers a
 [rules]
 disable = ["adblock/*"]
 ```
+
+Every audit reports Blocking findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/adblock/index.mdx
+++ b/docs/rules/adblock/index.mdx
@@ -14,19 +14,19 @@ The three rules answer one question from three angles: what does a visitor runni
 ## Ad blocking
 
 <CardGroup cols={2}>
-  <Card title="Adblock Element Hiding" icon="triangle-exclamation" href="/rules/adblock/element-hiding">
-    Checks for elements that would be hidden by common adblockers
+  <Card title="Adblock cosmetic filters: classes that get hidden" icon="triangle-exclamation" href="/rules/adblock/element-hiding">
+    A block named .ad-container is hidden for anyone running an ad blocker, whatever is in it. squirrel matches your selectors against EasyList.
   </Card>
-  <Card title="Blocked Tracking Links" icon="circle-info" href="/rules/adblock/blocked-links">
-    Checks for links and resources pointing to blocked tracking domains
+  <Card title="Requests ad blockers stop: links and resources on EasyList" icon="circle-info" href="/rules/adblock/blocked-links">
+    A resource on an EasyList domain never loads for a visitor running a blocker. squirrel reports each one with what it is.
   </Card>
 </CardGroup>
 
 ## Privacy blocking
 
 <CardGroup cols={2}>
-  <Card title="Privacy Filter Matches" icon="circle-info" href="/rules/adblock/privacy-blocked">
-    Checks for trackers and analytics that EasyPrivacy would block
+  <Card title="EasyPrivacy matches: analytics that silently does not run" icon="circle-info" href="/rules/adblock/privacy-blocked">
+    Privacy filters block trackers by default in several browsers, so your analytics quietly under-counts. squirrel reports which resources they block.
   </Card>
 </CardGroup>
 

--- a/docs/rules/adblock/privacy-blocked.mdx
+++ b/docs/rules/adblock/privacy-blocked.mdx
@@ -7,7 +7,7 @@ description: "Privacy filters block trackers by default in several browsers, so 
 
 EasyPrivacy is the tracker list, separate from the advertising one. Blocking it is not a niche setting: uBlock Origin uses it by default, Brave blocks equivalent hosts, and Firefox's strict mode blocks a comparable set.
 
-The effect on measurement is silent. Nothing errors and nothing appears in the report; the page simply does not load the tracker for those visitors, and they do not appear in the numbers. That skews the data most where your audience is most technical, which is often the audience you most want to understand.
+The effect on measurement is silent. Nothing errors and nothing appears in the report; the page does not load the tracker for those visitors, and they do not appear in the numbers. That skews the data most where your audience is most technical, which is often the audience you most want to understand.
 
 ## What squirrel checks
 

--- a/docs/rules/adblock/privacy-blocked.mdx
+++ b/docs/rules/adblock/privacy-blocked.mdx
@@ -7,7 +7,7 @@ description: "Privacy filters block trackers by default in several browsers, so 
 
 EasyPrivacy is the tracker list, separate from the advertising one. Blocking it is not a niche setting: uBlock Origin uses it by default, Brave blocks equivalent hosts, and Firefox's strict mode blocks a comparable set.
 
-The effect on measurement is silent. Nothing errors and nothing appears in the report; the page does not load the tracker for those visitors, and they do not appear in the numbers. That skews the data most where your audience is most technical, which is often the audience you most want to understand.
+The effect on your measurement is silent, even though the browser is not. A blocked script can raise an error event and show up in developer tools, but nothing reaches the analytics dashboard, so those visitors are absent from the numbers with no gap to notice. That skews the data most where your audience is most technical, which is often the audience you most want to understand.
 
 ## What squirrel checks
 
@@ -21,7 +21,7 @@ The three blocking rules share one blocklist check per audit.
 
 ## How to fix it
 
-Move measurement first-party or server-side, so it is a request to your own domain rather than to a host on the list. Privacy-focused analytics products are built for this and are usually a smaller change than proxying an existing tool.
+Move measurement first-party or server-side, so it is a request to your own domain rather than to a host on the list. That may reduce blocking rather than end it: filters can match a first-party endpoint, and forwarding server-side cannot recover an event whose browser request was blocked. Privacy-focused analytics products are built for this and are usually a smaller change than proxying an existing tool.
 
 Whatever you do, treat the numbers you already have as an undercount rather than as the truth.
 

--- a/docs/rules/adblock/privacy-blocked.mdx
+++ b/docs/rules/adblock/privacy-blocked.mdx
@@ -1,11 +1,29 @@
 ---
-title: "Privacy Filter Matches"
-description: "Checks for trackers and analytics that privacy filter lists (EasyPrivacy) would block"
+title: "EasyPrivacy matches: analytics that silently does not run"
+description: "Privacy filters block trackers by default in several browsers, so your analytics quietly under-counts. squirrel reports which resources they block."
 ---
 
-<Note>**Cloud rule** - requires login (`squirrel auth login`). All three [adblock rules](/rules/adblock) share a single blocklist check per audit, **included in the audit base charge**. Skipped when not logged in. See [Cloud rules](/cloud/rules).</Note>
+## What privacy filtering blocks
 
-Checks for trackers and analytics that privacy filter lists (EasyPrivacy) would block.
+EasyPrivacy is the tracker list, separate from the advertising one. Blocking it is not a niche setting: uBlock Origin uses it by default, Brave blocks equivalent hosts, and Firefox's strict mode blocks a comparable set.
+
+The effect on measurement is silent. Nothing errors and nothing appears in the report; the page simply does not load the tracker for those visitors, and they do not appear in the numbers. That skews the data most where your audience is most technical, which is often the audience you most want to understand.
+
+## What squirrel checks
+
+The rule is site-wide and reads a result the cloud blocklist service produced before the rules ran, matched server-side against the full EasyPrivacy rules. It emits a single check named `privacy-blocked`:
+
+- Skipped when no result is available. Message: `Privacy filter check skipped`, with a readable skip reason.
+- Pass when nothing matched. Message: `No resources match EasyPrivacy tracking filters`.
+- Warn otherwise. Message: `6 resource(s) would be blocked by privacy filters (EasyPrivacy)`, listing up to `maxMatchesToReport` of them. Severity warning, weight 2.
+
+The three blocking rules share one blocklist check per audit.
+
+## How to fix it
+
+Move measurement first-party or server-side, so it is a request to your own domain rather than to a host on the list. Privacy-focused analytics products are built for this and are usually a smaller change than proxying an existing tool.
+
+Whatever you do, treat the numbers you already have as an undercount rather than as the truth.
 
 | | |
 |---|---|
@@ -14,15 +32,19 @@ Checks for trackers and analytics that privacy filter lists (EasyPrivacy) would 
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 2/10 |
-| **Default** | Enabled |
 
-## What it checks
+## Options
 
-The site's scripts, pixels, and request URLs are matched server-side against the full **EasyPrivacy** filter list - the list used by privacy-focused browsers and extensions (uBlock Origin, Brave, Firefox strict mode). Matches are reported with the specific filter rule that would block them.
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `maxMatchesToReport` | number | `10` | Maximum privacy-blocked matches to report in detail |
 
-## Solution
+### Configuration example
 
-Analytics, session replay, and tracking pixels on matched domains will silently fail for visitors using privacy tooling, skewing your measurement data. Consider first-party or privacy-respecting analytics so measurement survives tracker blocking.
+```toml squirrel.toml
+[rule_options."adblock/privacy-blocked"]
+maxMatchesToReport = 25
+```
 
 ## Enable / disable
 
@@ -39,3 +61,38 @@ disable = ["adblock/privacy-blocked"]
 [rules]
 disable = ["adblock/*"]
 ```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["adblock/privacy-blocked"]
+disable = ["*"]
+```
+
+## Related rules
+
+- [analytics/gtm-present](/rules/analytics/gtm-present): the platforms this rule finds blocked.
+- [adblock/blocked-links](/rules/adblock/blocked-links): the advertising half, matched against EasyList.
+- [security/third-party-cookies](/rules/security/third-party-cookies): the same hosts seen from the privacy side.
+- [legal/cookie-consent](/rules/legal/cookie-consent): the consent gate those trackers also need.
+
+Blocking findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
+- [Privacy on the web, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Blocking section of the report. Each blocked tracker is listed, up to the configured maximum. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Blocking section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/analytics/consent-mode.mdx
+++ b/docs/rules/analytics/consent-mode.mdx
@@ -73,7 +73,7 @@ disable = ["*"]
 
 - [legal/cookie-consent](/rules/legal/cookie-consent): the banner that produces the consent signal.
 - [analytics/gtm-present](/rules/analytics/gtm-present): which Google tags are on the page.
-- [security/third-party-cookies](/rules/security/third-party-cookies): the storage the consent parameters govern.
+- [security/third-party-cookies](/rules/security/third-party-cookies): third-party resources that may set cookies.
 - [legal/privacy-policy](/rules/legal/privacy-policy): the policy the same processing has to be described in.
 
 Analytics findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/analytics/consent-mode.mdx
+++ b/docs/rules/analytics/consent-mode.mdx
@@ -1,9 +1,41 @@
 ---
-title: "Consent Mode"
-description: "Checks for Google Consent Mode v2 implementation"
+title: "Google Consent Mode v2: the four consent parameters"
+description: "Google Ads in the EEA requires Consent Mode v2. squirrel checks for the consent call and for the two parameters v2 added."
 ---
 
-Checks for Google Consent Mode v2 implementation
+## What Consent Mode is
+
+Consent Mode is Google's mechanism for telling its tags what a visitor has consented to. You set defaults before the tags load, then update them when the visitor answers the banner. Tags adjust their behaviour rather than being blocked outright, which is what lets modelling fill the gap.
+
+Version 2 added two parameters to the original two. `ad_storage` and `analytics_storage` cover cookies; `ad_user_data` and `ad_personalization` cover sending user data to Google for advertising and using it for personalisation. Google has required v2 for EEA traffic to its advertising products since March 2024.
+
+## What squirrel checks
+
+The rule runs on every crawled page and matches the raw HTML against patterns. It first checks whether the page carries Google tags at all, by looking for `googletagmanager.com`, `gtag`, `google-analytics`, `googlesyndication` or `googleadservices`. It emits a single check named `consent-mode`:
+
+- Skipped when no Google tags were found. Message: `No Google tags detected (consent mode not applicable)`.
+- Pass when a consent signal and a v2 signal are both present. Message: `Google Consent Mode v2 detected`.
+- Info when a consent signal is present without a v2 signal. Message: `Consent Mode detected (may need v2 upgrade)`, with `Add ad_user_data and ad_personalization for v2` as the value.
+- Info when no consent signal is present. Message: `Google Consent Mode not detected`, with `Required for EU Google Ads compliance` as the value.
+
+A consent signal is any of a `gtag('consent'` call, a `consent: 'default'` pair, or the literal strings `ad_storage`, `analytics_storage`, `ad_user_data` or `ad_personalization`. A v2 signal is `ad_user_data` or `ad_personalization`. All of it is a substring match on the page HTML, so consent mode configured inside a tag manager container rather than inline is not detected. Severity info, weight 4.
+
+## How to fix it
+
+```html
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    ad_storage: 'denied', analytics_storage: 'denied',
+    ad_user_data: 'denied', ad_personalization: 'denied'
+  });
+</script>
+```
+
+Set the defaults before any Google tag loads, then call `gtag('consent', 'update', …)` with the visitor's answer. Deny by default for an EEA audience.
+
+Most consent platforms do this for you. What they cannot do is run before your tags, so the ordering in the page is still yours to get right.
 
 | | |
 |---|---|
@@ -12,10 +44,6 @@ Checks for Google Consent Mode v2 implementation
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 4/10 |
-
-## Solution
-
-Google Consent Mode v2 is required for Google Ads in the EU/EEA (March 2024). It allows Google tags to adjust behavior based on user consent. Implement with `gtag('consent', 'default', {...})` before loading Google tags. Set ad_storage, analytics_storage, ad_user_data, and ad_personalization. Update on user consent.
 
 ## Enable / disable
 
@@ -40,3 +68,30 @@ disable = ["analytics/*"]
 enable = ["analytics/consent-mode"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [legal/cookie-consent](/rules/legal/cookie-consent): the banner that produces the consent signal.
+- [analytics/gtm-present](/rules/analytics/gtm-present): which Google tags are on the page.
+- [security/third-party-cookies](/rules/security/third-party-cookies): the storage the consent parameters govern.
+- [legal/privacy-policy](/rules/legal/privacy-policy): the policy the same processing has to be described in.
+
+Analytics findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Consent Mode, Google tag platform](https://developers.google.com/tag-platform/security/guides/consent)
+- [Google Tag Manager developer guide](https://developers.google.com/tag-platform/tag-manager)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Analytics section of the report. Each page is reported with whether a consent signal and a v2 signal were found. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Analytics section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/analytics/consent-mode.mdx
+++ b/docs/rules/analytics/consent-mode.mdx
@@ -5,7 +5,7 @@ description: "Google Ads in the EEA requires Consent Mode v2. squirrel checks fo
 
 ## What Consent Mode is
 
-Consent Mode is Google's mechanism for telling its tags what a visitor has consented to. You set defaults before the tags load, then update them when the visitor answers the banner. Tags adjust their behaviour rather than being blocked outright, which is what lets modelling fill the gap.
+Consent Mode is Google's mechanism for telling its tags what a visitor has consented to. You set defaults before the tags load, then update them when the visitor answers the banner. In advanced mode the tags load and adjust their behaviour, sending cookieless pings that let modelling fill the gap; in basic mode they do not load at all until consent is granted.
 
 Version 2 added two parameters to the original two. `ad_storage` and `analytics_storage` cover cookies; `ad_user_data` and `ad_personalization` cover sending user data to Google for advertising and using it for personalisation. Google has required v2 for EEA traffic to its advertising products since March 2024.
 
@@ -18,7 +18,7 @@ The rule runs on every crawled page and matches the raw HTML against patterns. I
 - Info when a consent signal is present without a v2 signal. Message: `Consent Mode detected (may need v2 upgrade)`, with `Add ad_user_data and ad_personalization for v2` as the value.
 - Info when no consent signal is present. Message: `Google Consent Mode not detected`, with `Required for EU Google Ads compliance` as the value.
 
-A consent signal is any of a `gtag('consent'` call, a `consent: 'default'` pair, or the literal strings `ad_storage`, `analytics_storage`, `ad_user_data` or `ad_personalization`. A v2 signal is `ad_user_data` or `ad_personalization`. All of it is a substring match on the page HTML, so consent mode configured inside a tag manager container rather than inline is not detected. Severity info, weight 4.
+A consent signal is any of a `gtag('consent'` call, a `consent: 'default'` pair, or the literal strings `ad_storage`, `analytics_storage`, `ad_user_data` or `ad_personalization`. A v2 signal is `ad_user_data` or `ad_personalization`. The consent patterns are case-insensitive regular expressions that tolerate whitespace inside the call. The Google-tag and v2 tests are case-sensitive substring matches, so an uppercase `AD_USER_DATA` satisfies the consent test and not the v2 one. Either way it reads the page HTML, so consent mode configured inside a tag manager container rather than inline is not detected. Severity info, weight 4.
 
 ## How to fix it
 
@@ -35,7 +35,7 @@ A consent signal is any of a `gtag('consent'` call, a `consent: 'default'` pair,
 
 Set the defaults before any Google tag loads, then call `gtag('consent', 'update', …)` with the visitor's answer. Deny by default for an EEA audience.
 
-Most consent platforms do this for you. What they cannot do is run before your tags, so the ordering in the page is still yours to get right.
+Most consent platforms do this for you, and a tag manager can run the platform on its consent initialization trigger so it fires before the other tags. Getting that ordering right is the part that is still yours.
 
 | | |
 |---|---|
@@ -81,6 +81,7 @@ Analytics findings ship in every audit next to the SEO, performance and agent ex
 ## References
 
 - [Consent Mode, Google tag platform](https://developers.google.com/tag-platform/security/guides/consent)
+- [Consent Mode concepts, Google tag platform](https://developers.google.com/tag-platform/security/concepts/consent-mode)
 - [Google Tag Manager developer guide](https://developers.google.com/tag-platform/tag-manager)
 
 ## Check your site

--- a/docs/rules/analytics/gtm-present.mdx
+++ b/docs/rules/analytics/gtm-present.mdx
@@ -60,7 +60,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [analytics/consent-mode](/rules/analytics/consent-mode): whether the Google tags respect a consent signal.
+- [analytics/consent-mode](/rules/analytics/consent-mode): whether Google Consent Mode markers appear in the markup.
 - [security/third-party-cookies](/rules/security/third-party-cookies): the same vendors seen from the privacy side.
 - [adblock/privacy-blocked](/rules/adblock/privacy-blocked): which of them privacy filters already block.
 - [legal/cookie-consent](/rules/legal/cookie-consent): the banner that should gate them.

--- a/docs/rules/analytics/gtm-present.mdx
+++ b/docs/rules/analytics/gtm-present.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Analytics Tracking"
-description: "Checks for Google Tag Manager or analytics implementation"
+title: "Analytics tracking: which platforms a page loads"
+description: "squirrel inventories the analytics on each page, from Google Tag Manager and GA4 to Plausible, Matomo, Segment and session-replay tools."
 ---
 
-Checks for Google Tag Manager or analytics implementation
+## What this inventory is for
+
+Analytics tells you what happens on a site after someone arrives, which is the half a crawl cannot see. Any of them will do the job: a tag manager, a direct measurement tag, or a privacy-focused alternative that stores less.
+
+The reason to inventory them is that they accumulate. A site often ends up carrying three overlapping tools nobody removed, each adding a third-party request and each needing to be named in a privacy policy and gated behind consent.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It matches the raw HTML against three substring tests and reads every `script[src]` for nine more. It emits a single check named `gtm-present`:
+
+- Pass when any platform is detected. Message: `2 analytics platform(s) detected`, listing the deduplicated names.
+- Info when none is. Message: `No analytics tracking detected`, with `Consider adding analytics to measure performance` as the value.
+
+From the HTML it detects `GTM` from `googletagmanager.com` or `gtm.js`, `GA4` from `gtag/js` or `googletagmanager.com/gtag`, and `UA (legacy)` from `analytics.js` or `ga.js`. From script sources it detects Plausible, Fathom, Matomo including its former name Piwik, Segment, Mixpanel, Amplitude, Heap, Hotjar and Microsoft Clarity, each by a substring of the URL.
+
+A tool loaded through a tag manager rather than as its own script tag is not detected separately. Severity info, weight 3.
+
+## How to fix it
+
+Nothing to fix when the list is what you expect. When it is longer than you expect, remove the tools nobody reads, since each one costs a request and an entry in your privacy policy.
+
+When nothing is detected, check whether measurement is loaded through a tag manager or injected after render, which this rule cannot see.
 
 | | |
 |---|---|
@@ -12,10 +33,6 @@ Checks for Google Tag Manager or analytics implementation
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Analytics tracking helps understand user behavior and measure SEO success. Use Google Tag Manager (GTM) to manage all tags centrally. GTM should be in the `<head>` with a noscript fallback in `<body>`. Alternatives: Google Analytics 4 directly, Plausible, Fathom, or Matomo. Ensure tracking complies with privacy laws.
 
 ## Enable / disable
 
@@ -40,3 +57,30 @@ disable = ["analytics/*"]
 enable = ["analytics/gtm-present"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [analytics/consent-mode](/rules/analytics/consent-mode): whether the Google tags respect a consent signal.
+- [security/third-party-cookies](/rules/security/third-party-cookies): the same vendors seen from the privacy side.
+- [adblock/privacy-blocked](/rules/adblock/privacy-blocked): which of them privacy filters already block.
+- [legal/cookie-consent](/rules/legal/cookie-consent): the banner that should gate them.
+
+Analytics findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Google Tag Manager developer guide](https://developers.google.com/tag-platform/tag-manager)
+- [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Analytics section of the report. Each page is reported with the analytics platforms detected on it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Analytics section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/analytics/gtm-present.mdx
+++ b/docs/rules/analytics/gtm-present.mdx
@@ -5,9 +5,9 @@ description: "squirrel inventories the analytics on each page, from Google Tag M
 
 ## What this inventory is for
 
-Analytics tells you what happens on a site after someone arrives, which is the half a crawl cannot see. Any of them will do the job: a tag manager, a direct measurement tag, or a privacy-focused alternative that stores less.
+Analytics tells you what happens on a site after someone arrives, which is the half a crawl cannot see. A measurement tag or a privacy-focused alternative does that job; a tag manager does not measure anything itself, it deploys the tags that do.
 
-The reason to inventory them is that they accumulate. A site often ends up carrying three overlapping tools nobody removed, each adding a third-party request and each needing to be named in a privacy policy and gated behind consent.
+The reason to inventory them is that they accumulate. A site often ends up carrying three overlapping tools nobody removed. What each one costs depends on how it is implemented: a third-party script is a request to someone else's host, a self-hosted or cookieless tool need not be, and whether consent is required turns on what is stored and where the visitor is.
 
 ## What squirrel checks
 

--- a/docs/rules/analytics/index.mdx
+++ b/docs/rules/analytics/index.mdx
@@ -8,11 +8,11 @@ Analytics rules read what a page loads for measurement and whether it respects c
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Analytics Tracking" icon="circle-info" href="/rules/analytics/gtm-present">
-    Checks for Google Tag Manager or analytics implementation
+  <Card title="Analytics tracking: which platforms a page loads" icon="circle-info" href="/rules/analytics/gtm-present">
+    squirrel inventories the analytics on each page, from Google Tag Manager and GA4 to Plausible, Matomo, Segment and session-replay tools.
   </Card>
-  <Card title="Consent Mode" icon="circle-info" href="/rules/analytics/consent-mode">
-    Checks for Google Consent Mode v2 implementation
+  <Card title="Google Consent Mode v2: the four consent parameters" icon="circle-info" href="/rules/analytics/consent-mode">
+    Google Ads in the EEA requires Consent Mode v2. squirrel checks for the consent call and for the two parameters v2 added.
   </Card>
 </CardGroup>
 

--- a/docs/rules/analytics/index.mdx
+++ b/docs/rules/analytics/index.mdx
@@ -3,7 +3,7 @@ title: "Analytics"
 description: "Tracking and measurement implementation"
 ---
 
-Tracking and measurement implementation
+Analytics rules read what a page loads for measurement and whether it respects consent. One inventories the platforms present, from tag managers to privacy-focused alternatives. The other checks for Google Consent Mode v2, which Google requires for advertising traffic from the EEA. Both are informational: what you measure with is your decision, and this category reports it rather than judging it.
 
 ## Rules
 
@@ -22,3 +22,5 @@ Tracking and measurement implementation
 [rules]
 disable = ["analytics/*"]
 ```
+
+Every audit reports Analytics findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/content/article-links.mdx
+++ b/docs/rules/content/article-links.mdx
@@ -1,9 +1,29 @@
 ---
-title: "Article Link Density"
-description: "Articles should have appropriate internal and external links based on length"
+title: "Article link density: how many links an article should carry"
+description: "An article that cites nothing and links nowhere is a dead end. squirrel scales the minimum with the article's length."
 ---
 
-Articles should have appropriate internal and external links based on length
+## What link density means for an article
+
+An article carries two kinds of link. Internal links connect it to the rest of the site, which is how a reader continues and how the site says what belongs together. External links cite the sources the argument rests on.
+
+The right number scales with length. A 500-word post that links out twice is well connected; a 3000-word guide that does the same is not. This rule sets a floor by length band rather than a target, so it only fires when an article is clearly under-linked.
+
+## What squirrel checks
+
+The rule runs on every crawled page, and only on pages the parser classified as an article or that carry Article structured data. It picks thresholds from the word count and emits two checks:
+
+- `article-links` reports info when the page is not an article. Message: `Not an article page`. No further checks run.
+- `internal-links` warns below the minimum. Message: `long article has 1 internal links (min 3)`, with the count and the threshold. It passes otherwise with `4 internal links`.
+- `external-links` warns below the minimum. Message: `medium article has 0 external links (min 2)`. It passes otherwise with `3 external links`.
+
+The bands are short below `short_max_words`, 800 by default; medium up to `long_min_words`, 1500 by default; and long above that. The defaults are 1 internal and 1 external for short, 2 and 2 for medium, and 3 internal and 2 external for long. Severity warning, weight 4.
+
+## How to fix it
+
+Link to the pages on your site that the article assumes or extends, from the sentences where they come up rather than from a list at the end. Cite the sources you actually used.
+
+A reference page or a changelog that legitimately links nowhere is best excluded by disabling the rule for that section rather than by adding links to satisfy it.
 
 | | |
 |---|---|
@@ -13,37 +33,25 @@ Articles should have appropriate internal and external links based on length
 | **Severity** | warning |
 | **Weight** | 4/10 |
 
-## Solution
-
-Add relevant internal links to other pages on your site and cite authoritative external sources. Short articles (under 800 words) need at least 1 of each, medium (800-1500) need 2 of each, long (over 1500) need 3 internal and 2 external.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `short_max_words` | unknown | `undefined` |  |
-| `long_min_words` | unknown | `undefined` |  |
-| `short_min_internal` | unknown | `undefined` |  |
-| `medium_min_internal` | unknown | `undefined` |  |
-| `long_min_internal` | unknown | `undefined` |  |
-| `short_min_external` | unknown | `undefined` |  |
-| `medium_min_external` | unknown | `undefined` |  |
-| `long_min_external` | unknown | `undefined` |  |
+| `short_max_words` | number | `800` | Upper word count for the short band |
+| `long_min_words` | number | `1500` | Word count at which the long band starts |
+| `short_min_internal` | number | `1` | Minimum internal links for a short article |
+| `medium_min_internal` | number | `2` | Minimum internal links for a medium article |
+| `long_min_internal` | number | `3` | Minimum internal links for a long article |
+| `short_min_external` | number | `1` | Minimum external links for a short article |
+| `medium_min_external` | number | `2` | Minimum external links for a medium article |
+| `long_min_external` | number | `2` | Minimum external links for a long article |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."content/article-links"]
-short_max_words = undefined
-long_min_words = undefined
-short_min_internal = undefined
-medium_min_internal = undefined
-long_min_internal = undefined
-short_min_external = undefined
-medium_min_external = undefined
-long_min_external = undefined
+[rule_options."content/article-links"]
+long_min_internal = 5
+long_min_external = 3
 ```
 
 ## Enable / disable
@@ -69,3 +77,30 @@ disable = ["content/*"]
 enable = ["content/article-links"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/no-contextual-inbound](/rules/links/no-contextual-inbound): whether other articles link back to this one.
+- [links/dead-end-pages](/rules/links/dead-end-pages): pages with no outgoing internal links at all.
+- [eeat/citations](/rules/eeat/citations): the external links read as a trust signal.
+- [links/anchor-text](/rules/links/anchor-text): what those links say.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each article is reported with its internal and external link counts. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/article-links.mdx
+++ b/docs/rules/content/article-links.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Article link density: how many links an article should carry"
+title: "Article link density: how many links an article needs"
 description: "An article that cites nothing and links nowhere is a dead end. squirrel scales the minimum with the article's length."
 ---
 

--- a/docs/rules/content/article-links.mdx
+++ b/docs/rules/content/article-links.mdx
@@ -17,7 +17,7 @@ The rule runs on every crawled page, and only on pages the parser classified as 
 - `internal-links` warns below the minimum. Message: `long article has 1 internal links (min 3)`, with the count and the threshold. It passes otherwise with `4 internal links`.
 - `external-links` warns below the minimum. Message: `medium article has 0 external links (min 2)`. It passes otherwise with `3 external links`.
 
-The bands are short below `short_max_words`, 800 by default; medium up to `long_min_words`, 1500 by default; and long above that. The defaults are 1 internal and 1 external for short, 2 and 2 for medium, and 3 internal and 2 external for long. Severity warning, weight 4.
+The bands are short below `short_max_words`, 800 by default; medium from there up to but not including `long_min_words`, 1500 by default; and long from 1500 up. The defaults are 1 internal and 1 external for short, 2 and 2 for medium, and 3 internal and 2 external for long. Severity warning, weight 4.
 
 ## How to fix it
 

--- a/docs/rules/content/author-info.mdx
+++ b/docs/rules/content/author-info.mdx
@@ -66,7 +66,7 @@ disable = ["*"]
 ## Related rules
 
 - [eeat/author-byline](/rules/eeat/author-byline): the same signal judged as a trust requirement.
-- [eeat/author-expertise](/rules/eeat/author-expertise): whether the bio establishes any.
+- [eeat/author-expertise](/rules/eeat/author-expertise): author pages and Person schema as expertise indicators.
 - [schema/article](/rules/schema/article): the structured data the author node belongs in.
 - [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the topics where this matters most.
 

--- a/docs/rules/content/author-info.mdx
+++ b/docs/rules/content/author-info.mdx
@@ -16,7 +16,7 @@ The rule runs on every crawled page and emits one check per signal it finds, plu
 - `author-schema` passes when a JSON-LD block contains `"author"`. Message: `Author schema markup present`, with the author name when one can be pulled out of the text.
 - `author-links` passes when the page has any `a[rel="author"]`. Message: `2 author link(s) found`, with the first link's text.
 - `og-author` passes when `article:author` is present. Message: `Open Graph author meta present`, with its content.
-- `visible-author` reports info when an element whose class contains `author` or `byline` exists but no schema and no author link do. Message: `Author element found but no structured data`, with `Consider adding author schema markup` as the value.
+- `visible-author` reports info when the page matches `[class*="author"], [class*="byline"], [rel="author"]` but has no author schema and no author link. The `rel` half of that selector matches any element, not only anchors. Message: `Author element found but no structured data`, with `Consider adding author schema markup` as the value.
 - `author-info` reports info when none of the four were found. Message: `No author information detected`, with `Consider adding author attribution for E-E-A-T` as the value.
 
 The schema test is a substring match over the script text rather than a parse, and the name is extracted with a regular expression, so a deeply nested author object may be detected without a name. Severity info, weight 3.

--- a/docs/rules/content/author-info.mdx
+++ b/docs/rules/content/author-info.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Author Info"
-description: "Checks for author markup and attribution"
+title: "Author attribution: schema, rel=author and visible bylines"
+description: "Who wrote a page is part of how a reader decides whether to trust it. squirrel inventories the author markup a page carries."
 ---
 
-Checks for author markup and attribution
+## What author attribution is
+
+Author attribution is naming who wrote a page and making that machine-readable. It can appear as a `Person` in the page's structured data, as a link with `rel="author"`, as the Open Graph `article:author` meta tag, or as a visible byline in the markup.
+
+It matters most where the reader is deciding whether to trust the content. Google's guidance on helpful content asks who wrote this and what makes them qualified, and for topics touching health, finance or safety, that question carries more weight than anywhere else.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits one check per signal it finds, plus a fallback:
+
+- `author-schema` passes when a JSON-LD block contains `"author"`. Message: `Author schema markup present`, with the author name when one can be pulled out of the text.
+- `author-links` passes when the page has any `a[rel="author"]`. Message: `2 author link(s) found`, with the first link's text.
+- `og-author` passes when `article:author` is present. Message: `Open Graph author meta present`, with its content.
+- `visible-author` reports info when an element whose class contains `author` or `byline` exists but no schema and no author link do. Message: `Author element found but no structured data`, with `Consider adding author schema markup` as the value.
+- `author-info` reports info when none of the four were found. Message: `No author information detected`, with `Consider adding author attribution for E-E-A-T` as the value.
+
+The schema test is a substring match over the script text rather than a parse, and the name is extracted with a regular expression, so a deeply nested author object may be detected without a name. Severity info, weight 3.
+
+## How to fix it
+
+```html
+<a rel="author" href="/authors/jane-diaz">Jane Diaz</a>
+```
+
+Show the author's name where a reader will see it, link it to a bio page that says what they know about the subject, and mirror the same name in a `Person` node in the page's structured data.
+
+A byline with no link and no bio is weaker than none at all on a topic where expertise matters, because it raises the question without answering it.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for author markup and attribution
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Author information supports E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness). Use Person schema to mark up authors with name, url, and credentials. Link to author bio pages. Display author names visibly on content. For YMYL topics (health, finance), include author qualifications. Consider using rel='author' links.
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["content/*"]
 enable = ["content/author-info"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/author-byline](/rules/eeat/author-byline): the same signal judged as a trust requirement.
+- [eeat/author-expertise](/rules/eeat/author-expertise): whether the bio establishes any.
+- [schema/article](/rules/schema/article): the structured data the author node belongs in.
+- [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the topics where this matters most.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Article structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/article)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is listed with the author signals it carries. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/broken-html.mdx
+++ b/docs/rules/content/broken-html.mdx
@@ -1,9 +1,38 @@
 ---
-title: "Broken HTML"
-description: "Checks for malformed HTML structure"
+title: "Malformed HTML: missing doctype, nested links and deprecated tags"
+description: "Browsers recover from bad markup silently and other parsers may not. squirrel checks document structure, nesting and deprecated elements."
 ---
 
-Checks for malformed HTML structure
+## What malformed HTML means here
+
+Browsers are required to recover from broken markup, so a page with structural errors usually looks correct. Anything else reading the page, a crawler, a reader-mode extractor, an assistive technology, may recover differently or not at all.
+
+The errors worth checking are the ones with consequences. A missing doctype puts the browser in quirks mode, where layout follows rules from the 1990s. Nested interactive elements, a link inside a link or a button inside a link, have no defined behaviour and produce a confusing accessibility tree. Deprecated presentational elements still render and have had CSS equivalents for two decades.
+
+## What squirrel checks
+
+The rule runs on every crawled page against the raw HTML and the parsed document. It emits a single check named `broken-html`:
+
+- Pass when nothing was found. Message: `HTML structure appears valid`.
+- Warn or info otherwise. Message: `3 HTML issue(s) found`, with each issue listed by a slug and a readable label.
+
+The issues detected are: `missing-doctype` when the trimmed HTML does not start with `<!doctype`; `missing-html`, `missing-head` and `missing-body` when the parsed document has no such element; `nested-links` labelled `2 nested <a> tag(s)`; `button-in-link` for a button inside a link or the reverse; `nested-forms`; and one `deprecated-<tag>` for the first of `center`, `font`, `marquee`, `blink` or `strike` that appears, reported once regardless of how many deprecated elements the page has.
+
+The status is warn when any of the four structural issues fired, and info otherwise. Severity for the rule is warning, weight 4.
+
+## How to fix it
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>…</head>
+  <body>…</body>
+</html>
+```
+
+Start every document with the doctype. For nested interactive elements, pick one: a card that is a link should be one anchor, and a button inside it should be a sibling rather than a child.
+
+Replace deprecated presentational tags with CSS. `<center>` is `text-align: center`, `<font>` is a font declaration, `<strike>` is `<s>` or `<del>` depending on what you mean.
 
 | | |
 |---|---|
@@ -12,10 +41,6 @@ Checks for malformed HTML structure
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Valid HTML helps search engines parse and understand your content. Common issues: unclosed tags, nested elements incorrectly, invalid attributes. Use an HTML validator to find issues. Modern browsers are forgiving, but search engine parsers may not be. Clean HTML also improves accessibility and maintainability.
 
 ## Enable / disable
 
@@ -40,3 +65,30 @@ disable = ["content/*"]
 enable = ["content/broken-html"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/meta-in-body](/rules/content/meta-in-body): meta tags displaced by a structural error.
+- [a11y/empty-heading](/rules/a11y/empty-heading): the accessibility view of an empty heading.
+- [core/doctype](/rules/core/doctype): the doctype checked on its own.
+- [content/unrendered-markup](/rules/content/unrendered-markup): markup that reached the reader as text.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The head element, HTML Standard](https://html.spec.whatwg.org/multipage/semantics.html#the-head-element)
+- [The anchor element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is listed with the structural issues found. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/broken-html.mdx
+++ b/docs/rules/content/broken-html.mdx
@@ -7,7 +7,7 @@ description: "Browsers recover from bad markup silently and other parsers may no
 
 Browsers are required to recover from broken markup, so a page with structural errors usually looks correct. Anything else reading the page, a crawler, a reader-mode extractor, an assistive technology, may recover differently or not at all.
 
-The errors worth checking are the ones with consequences. A missing doctype puts the browser in quirks mode, where layout follows rules from the 1990s. Nested interactive elements, a link inside a link or a button inside a link, have no defined behaviour and produce a confusing accessibility tree. Deprecated presentational elements still render and have had CSS equivalents for two decades.
+The errors worth checking are the ones with consequences. A missing doctype puts the browser in quirks mode, where layout follows rules from the 1990s. Nested interactive elements, a link inside a link or a button inside a link, are nonconforming. The parser has defined recovery for them, so the page renders, but what a click or a screen reader does with the result is not what the markup suggests. Deprecated presentational elements still render and have had CSS equivalents for two decades.
 
 ## What squirrel checks
 
@@ -78,7 +78,7 @@ Content findings ship in every audit next to the SEO, performance and agent expe
 ## References
 
 - [The head element, HTML Standard](https://html.spec.whatwg.org/multipage/semantics.html#the-head-element)
-- [The anchor element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
+- [Parsing HTML documents, HTML Standard](https://html.spec.whatwg.org/multipage/parsing.html)
 
 ## Check your site
 

--- a/docs/rules/content/broken-html.mdx
+++ b/docs/rules/content/broken-html.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Malformed HTML: missing doctype, nested links and deprecated tags"
+title: "Malformed HTML: doctype, nesting and deprecated tags"
 description: "Browsers recover from bad markup silently and other parsers may not. squirrel checks document structure, nesting and deprecated elements."
 ---
 

--- a/docs/rules/content/date-agreement.mdx
+++ b/docs/rules/content/date-agreement.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Date Agreement"
-description: "Checks the visible date, schema dates and URL/title year agree"
+title: "Visible date disagrees with schema: which date is wrong"
+description: "A page states its date in several places and presence checks pass as soon as one exists. squirrel compares the byline, the schema and the URL year."
 ---
 
-Checks the visible date, schema dates and URL/title year agree
+## What date agreement is
+
+A dated page usually carries its date more than once: a visible byline, `datePublished` and `dateModified` in schema, a year in the URL or the title, the sitemap `lastmod`, the `Last-Modified` header. Readers see one of those and crawlers read another.
+
+When they disagree, at least one is wrong, and a presence check cannot tell you which, because it passes as soon as any single signal exists. The usual cause is a template printing a build-time or hardcoded value while the schema prints the CMS field, or the other way round.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It reads the visible byline date, the schema dates on the node that describes this document, and any year in the URL or title. Only a node of a document type counts, so a sitewide `Organization` or `SoftwareApplication` node cannot supply the date. It emits up to four checks:
+
+- `schema-date-source` reports info when the only schema date sits on a non-document node. Message: `The only schema date on this page is datePublished 2019-04-02 on a SoftwareApplication node, which describes that entity rather than this page — the visible date 12 March 2026 has nothing to be checked against. Add datePublished/dateModified to an Article or WebPage node.`
+- `byline-vs-schema-date` warns when the visible date and the nearest schema date are more than `tolerance_days` apart. Message: `The visible date reads 12 March 2026 but the Article schema says datePublished 2026-01-04 — 67 day(s) apart, so readers and crawlers are being told different things`. It passes otherwise with `Visible date 12 March 2026 agrees with the Article schema dates`.
+- `visible-date-missing` warns when an article-type node carries a date and the page shows the reader none. Message: `This Article states datePublished 2026-03-12 in its schema but shows the reader no date at all`.
+- `url-title-year` warns when a year in the URL or title is not one of the schema years. Message: `The title says 2024 but the Article schema dates are from 2026`. It passes otherwise with `The title year 2024 matches the Article schema dates`.
+
+The visible-date-missing branch only fires when the page prints no date at all, so a page showing a date this rule declined to parse is not accused. Severity warning, weight 4. The rule is skipped on soft 404 pages, whose dates describe nothing.
+
+## How to fix it
+
+Drive every date on the page from one content timestamp. When the byline and the schema disagree, find which one renders from the wrong field, and check that the schema date is attached to the node describing the page rather than to a sitewide entity.
+
+If the schema carries dates the reader never sees, render the date in the article header. Google asks for a visible date on dated content, and a date only crawlers can see is not one.
 
 | | |
 |---|---|
@@ -13,82 +34,17 @@ Checks the visible date, schema dates and URL/title year agree
 | **Severity** | warning |
 | **Weight** | 4/10 |
 
-## What it checks
-
-A page states its date up to five times: the visible byline, schema.org
-`datePublished` / `dateModified`, a year in the URL or the title, the sitemap `lastmod`, and the
-`Last-Modified` header. [Content Freshness](/rules/content/freshness) passes as soon as **any** of
-them exists and [Content Dates](/rules/eeat/content-dates) reports how many pages carry them, so a
-page whose signals contradict each other passes both. The disagreement is the defect, and this rule
-is the only one that looks for it. (The sitemap side of the same question is
-[Sitemap Lastmod Drift](/rules/crawl/sitemap-lastmod-drift); this rule stays on the page.)
-
-Four page-side signals are extracted and reported on every finding:
-
-| Signal | Read from |
-|--------|-----------|
-| Visible date | The date the reader sees: a rendered `<time>`, byline/entry-meta markup, or a short date-only line at the top of main content |
-| Schema document date | `datePublished` / `dateModified` on a node that describes the DOCUMENT (`Article`, `BlogPosting`, `NewsArticle`, `WebPage`, `FAQPage`, ...), `@graph` included |
-| URL / title year | A four-digit year in the URL path, else in the `<title>` |
-| `Last-Modified` | The HTTP response header |
-
-| Check | Fires when |
-|-------|-----------|
-| `byline-vs-schema-date` | The visible date and the schema document date are more than `tolerance_days` apart. Both values are named in the finding |
-| `visible-date-missing` | An `Article`-family node states dates the page never renders — a date only crawlers can see |
-| `url-title-year` | The year in the URL, else in the title, is not the year of either schema document date |
-| `schema-date-source` | Informational: the page shows a date, but its only schema date sits on a node that does not describe the page |
-
-Every visible date is measured against the **closest** schema date and the best pairing decides, so
-a page showing "Published 6 January · Updated 10 February" is telling the truth about both and stays
-quiet. A page-level node (`WebPage`, `CollectionPage`) alongside several visible dates is an index
-or an archive — those dates belong to the entries it lists, so nothing is compared.
-
-`visible-date-missing` fires only when main content prints no date-shaped string **anywhere**. A
-date this rule declined to read as a byline is still a date on the reader's screen, and "this page
-shows no date" has to be literally true to be worth saying.
-
-`Last-Modified` is reported alongside the others but never raises a warning on its own: origins
-stamp it at deploy time far more often than at content-change time, so a disagreement there is not
-evidence of a defect.
-
-### What it deliberately does not report
-
-Both of these are false positives that a naive version of this check produced in bulk, so they are
-guarded rather than tuned:
-
-- **A date on a node that does not describe the page.** A sitewide `SoftwareApplication`, `Product`
-  or `Organization` node carries its own `datePublished` — the release date of that entity, not the
-  publication date of the post it happens to sit beside. Taking the first `datePublished` in the
-  document attributes one placeholder date to every page on the site. Only document-describing
-  `@type`s can raise a disagreement; a date from anywhere else is reported with its node type noted
-  (`schema-date-source`) and never compared.
-- **A date-shaped string that is not a byline.** A byline is a position, not a pattern: running
-  prose ("INP replaced FID on March 12, 2024") and outbound citations
-  (`<a href="https://web.dev/...">March 12, 2024</a>`) are date-shaped and are not this page's
-  publication date. A candidate must sit near the top of main content **and** look like byline
-  markup — a `<time>` element, `byline`/`entry-meta`-style markup, or a short line that says nothing
-  beyond the date. An anchor's own text never counts.
-
-A `WebPage` node carrying dates is not required to render them: WordPress SEO plugins emit one on
-every page of a site, contact form included, so demanding a visible date there would warn on
-everything.
-
-## Solution
-
-A page states its date more than once - the visible byline, schema.org datePublished/dateModified, a year in the URL or title, the sitemap lastmod, the Last-Modified header - and readers and crawlers do not all read the same one. When they disagree, at least one is wrong, and presence checks cannot tell you which: they pass as soon as any single signal exists. Drive every date on the page from ONE content timestamp. If the visible byline disagrees with the schema, fix whichever renders from the wrong field (a common cause is the template printing a build-time or hardcoded value while the schema prints the CMS field). If the schema carries dates the reader never sees, render the date in the article header - Google asks for a visible date on dated content, and a date only crawlers can see is not one. Check the schema date is attached to the node describing the page (Article/BlogPosting/WebPage): a datePublished on a sitewide SoftwareApplication or Organization node is that entity's own date and says nothing about this page.
-
 ## Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `tolerance_days` | number | `1` | Days the visible byline date may differ from the schema document date before warning |
 
-### Configuration Example
+### Configuration example
 
 ```toml squirrel.toml
 [rule_options."content/date-agreement"]
-tolerance_days = 1
+tolerance_days = 3
 ```
 
 ## Enable / disable
@@ -114,3 +70,30 @@ disable = ["content/*"]
 enable = ["content/date-agreement"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-lastmod-drift](/rules/crawl/sitemap-lastmod-drift): the sitemap date compared against the same page dates.
+- [content/freshness](/rules/content/freshness): whether the page publishes any date signal at all.
+- [content/stale-copyright](/rules/content/stale-copyright): the footer year, a different date claim.
+- [eeat/content-dates](/rules/eeat/content-dates): dates as a trust signal rather than a consistency one.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Article structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/article)
+- [The time element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each disagreement is reported with both dates and the gap between them. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/date-agreement.mdx
+++ b/docs/rules/content/date-agreement.mdx
@@ -7,22 +7,22 @@ description: "A page states its date in several places and presence checks pass 
 
 A dated page usually carries its date more than once: a visible byline, `datePublished` and `dateModified` in schema, a year in the URL or the title, the sitemap `lastmod`, the `Last-Modified` header. Readers see one of those and crawlers read another.
 
-When they disagree, at least one is wrong, and a presence check cannot tell you which, because it passes as soon as any single signal exists. The usual cause is a template printing a build-time or hardcoded value while the schema prints the CMS field, or the other way round.
+Different dates are not automatically a contradiction: a publication date and a modification date describe different events and should differ. What should agree is the visible and the machine-readable version of the same event. When those disagree, one of them is wrong, and a presence check cannot tell you which, because it passes as soon as any single signal exists. The usual cause is a template printing a build-time or hardcoded value while the schema prints the CMS field, or the other way round.
 
 ## What squirrel checks
 
-The rule runs on every crawled page. It reads the visible byline date, the schema dates on the node that describes this document, and any year in the URL or title. Only a node of a document type counts, so a sitewide `Organization` or `SoftwareApplication` node cannot supply the date. It emits up to four checks:
+The rule runs on every crawled page. It reads the visible byline date, the schema dates on the node that describes this document, and any year in the URL or title. Only a node of a document type counts, so a sitewide `Organization` or `SoftwareApplication` node cannot supply the date. Four check names exist and at most two appear in one result, since the schema-source branch returns immediately and the byline and missing-date branches are mutually exclusive:
 
 - `schema-date-source` reports info when the only schema date sits on a non-document node. Message: `The only schema date on this page is datePublished 2019-04-02 on a SoftwareApplication node, which describes that entity rather than this page — the visible date 12 March 2026 has nothing to be checked against. Add datePublished/dateModified to an Article or WebPage node.`
-- `byline-vs-schema-date` warns when the visible date and the nearest schema date are more than `tolerance_days` apart. Message: `The visible date reads 12 March 2026 but the Article schema says datePublished 2026-01-04 — 67 day(s) apart, so readers and crawlers are being told different things`. It passes otherwise with `Visible date 12 March 2026 agrees with the Article schema dates`.
+- `byline-vs-schema-date` compares every visible date against every schema date and takes the closest pairing, so one visible date that matches prevents a warning. It is skipped for a non-article document node with several visible dates. It warns when that closest pair is more than `tolerance_days` apart. Message: `The visible date reads 12 March 2026 but the Article schema says datePublished 2026-01-04 — 67 day(s) apart, so readers and crawlers are being told different things`. It passes otherwise with `Visible date 12 March 2026 agrees with the Article schema dates`.
 - `visible-date-missing` warns when an article-type node carries a date and the page shows the reader none. Message: `This Article states datePublished 2026-03-12 in its schema but shows the reader no date at all`.
-- `url-title-year` warns when a year in the URL or title is not one of the schema years. Message: `The title says 2024 but the Article schema dates are from 2026`. It passes otherwise with `The title year 2024 matches the Article schema dates`.
+- `url-title-year` takes the first eligible year in the URL path, and looks at the title only when the path has none. It warns when that year is not one of the schema years. Message: `The title says 2024 but the Article schema dates are from 2026`. It passes otherwise with `The title year 2024 matches the Article schema dates`.
 
-The visible-date-missing branch only fires when the page prints no date at all, so a page showing a date this rule declined to parse is not accused. Severity warning, weight 4. The rule is skipped on soft 404 pages, whose dates describe nothing.
+The visible-date-missing branch is suppressed by any recognisable date in the selected content root, using the same date matcher, so it can still fire on a page printing a date in a format the matcher does not support. Severity warning, weight 4. The rule is skipped on soft 404 pages, whose dates describe nothing.
 
 ## How to fix it
 
-Drive every date on the page from one content timestamp. When the byline and the schema disagree, find which one renders from the wrong field, and check that the schema date is attached to the node describing the page rather than to a sitewide entity.
+Render the visible date and the schema date for the same event from the same field. When the byline and the schema disagree, find which one renders from the wrong field, and check that the schema date is attached to the node describing the page rather than to a sitewide entity. Keep the publication and modification dates as separate values: they are meant to differ.
 
 If the schema carries dates the reader never sees, render the date in the article header. Google asks for a visible date on dated content, and a date only crawlers can see is not one.
 

--- a/docs/rules/content/dev-leakage.mdx
+++ b/docs/rules/content/dev-leakage.mdx
@@ -76,7 +76,7 @@ Content findings ship in every audit next to the SEO, performance and agent expe
 
 ## References
 
-- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [RFC 1918: Address allocation for private internets](https://datatracker.ietf.org/doc/html/rfc1918)
 - [Why HTTPS matters, web.dev](https://web.dev/articles/why-https-matters)
 
 ## Check your site

--- a/docs/rules/content/dev-leakage.mdx
+++ b/docs/rules/content/dev-leakage.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Development Host Leakage"
-description: "Detects localhost, private, staging and preview hosts on a production page"
+title: "localhost in production: development hosts left in the markup"
+description: "A link or image pointing at localhost or a preview deployment is broken for every visitor. squirrel classifies the host and says whether it is yours."
 ---
 
-Detects localhost, private, staging and preview hosts on a production page
+## What development host leakage is
+
+A development host in production markup is a URL that was correct on someone's machine and is not correct on the live site. It reaches production through a hard-coded template value, a CMS field authored while working locally, or a base-URL environment variable that never got a production value.
+
+The consequence depends on where it sits. In an `href` or a `src` it is a broken reference a visitor can hit right now. In body copy it is a mention rather than a break. A preview deployment URL is a third case: it usually resolves, so nothing looks broken, but it points visitors and crawlers at a copy of the site nobody is maintaining.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits a single check named `dev-leakage`:
+
+- Skipped when there is no parsed document. Message: `No document available`.
+- Skipped when the page URL cannot be parsed. Message: `Page URL could not be parsed`.
+- Skipped when the audited origin is itself a development host. Message: `Audited origin is itself a non-production host (localhost:3000), so its own URLs are not leakage`.
+- Pass when nothing was found. Message: `No development, private or preview hosts referenced`.
+- Warn or fail otherwise. Message: `3 development host reference(s) on a production page (localhost, preview-host): example http://localhost:3000/api`.
+
+Five kinds are classified: `localhost` for a loopback host, `private-ip` for a private address range, `preview-host` for a deployment-preview domain, `dev-subdomain` for a development subdomain of the audited site, and `insecure-self-link` for an `http://` link back to your own host. Each hit also records whether it came from an attribute or from body copy, and whether the host is unmistakably this site's own.
+
+The status is fail when a live `href` or `src` points at a host that is clearly this site's own development artifact, since that is a reference a visitor can follow into nothing. An `insecure-self-link` is treated as soft and warns instead, as does any mention in copy and any preview host that could belong to someone else. Severity for the rule is warning, weight 6. The rule is skipped on soft 404 pages.
+
+## How to fix it
+
+```html
+<a href="/api/docs">API documentation</a>
+```
+
+Replace the origin with a relative path where the target is on this site. That makes the reference correct in every environment at once, which is the actual fix; changing one absolute URL to the production one leaves the same bug in the next environment.
+
+Point a staging or preview link at the production equivalent, and check whether that staging site is publicly indexable while you are there. Make an `http://` self-link relative or `https://`, since the redirect it costs every visitor is avoidable.
 
 | | |
 |---|---|
@@ -12,54 +40,6 @@ Detects localhost, private, staging and preview hosts on a production page
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## Solution
-
-A URL that was correct in development shipped to production. Find where it is stored, not just the page it appears on: a link or image pointing at localhost, a private address, or a preview deployment is usually a hard-coded value in a template, a CMS field written while working locally, or a base-URL environment variable that never got a production value, so the same URL is on every page that renders that component. Replace the origin with a relative path where the target is on this site, which is what makes the link correct in every environment at once. For a staging or preview host, point the link at the production equivalent and check whether the staging site is publicly indexable while you are there. For an `http://` link back to your own site, make it relative or `https://`, since the redirect it currently costs every visitor is avoidable.
-
-## What it checks
-
-Five kinds, in every `href` and `src` on the page and in the copy a visitor reads. The head is included: a `<link rel="canonical">` at localhost de-indexes the page and a stylesheet or script at localhost breaks it outright, so those are the highest-impact findings the rule has.
-
-| Kind | Example | Meaning |
-|---|---|---|
-| `localhost` | `http://localhost:3000/api` | a dev server address shipped to production |
-| `private-ip` | `http://192.168.1.10/logo.png` | an address only reachable inside one network |
-| `dev-subdomain` | `https://staging.example.com/pricing` | a non-production tier of this site's own domain |
-| `preview-host` | `https://example-git-main.vercel.app/` | an ephemeral deployment that will stop resolving |
-| `insecure-self-link` | `http://example.com/pricing` | this site's own URL, spelled without TLS |
-
-`localhost` covers the whole `127.0.0.0/8` block, the IPv6 loopback `[::1]`, the unspecified address `0.0.0.0`, and any `*.localhost` name. `private-ip` covers the three RFC 1918 blocks: `10.0.0.0/8`, `172.16.0.0/12` and `192.168.0.0/16`. Preview hosts are `vercel.app`, `netlify.app`, `pages.dev`, `ngrok.io`, `ngrok.app`, `ngrok-free.app` and `trycloudflare.com`.
-
-**Severity depends on whether the reference is live.** A dev host in an `href` or `src` is something a visitor can click or a browser will try to load, and it fails. A dev host that only appears in copy is embarrassing rather than broken, and it warns.
-
-## What is excluded
-
-The rule is mostly a list of ways to tell a leaked URL apart from a URL a page is talking about on purpose.
-
-- **Code samples.** `<code>`, `<pre>`, `<samp>` and `<kbd>` subtrees, `<template>` content, and the container classes syntax highlighters and in-page editors use (`hljs`, `shiki`, `prism`, `code-block`, `cm-editor`, `monaco-editor`, any `language-*`) are all dropped before the copy is read. A getting-started page printing `http://localhost:5173` in a code block stays clean. A live `<a href>` is still judged wherever it sits, including inside a `<pre>`, because a clickable link is clickable regardless of its surroundings.
-- **A bare `localhost` in a sentence.** "The app also runs on localhost during development" is a sentence people write. A scheme, a port or a path is required before a bare `localhost` counts, so `localhost:5173` and `http://localhost` do. A qualified name like `api.acme.localhost` has no second reading and counts on its own.
-- **A bare address in `10.0.0.0/8`.** Four dotted numbers starting at 10 is also how enterprise software spells a version, so `Contoso Server 10.0.0.1` is not reported. With a scheme, a port or a path it is unmistakably a host and is. The `192.168.*`, `172.16-31.*` and `127.*` blocks have no such reading and count bare.
-- **A bare platform name.** "We deploy to pages.dev" names a platform. `abc123.pages.dev` names a deployment, so at least one leading label is required.
-- **Non-production audits.** If the audited origin is itself a localhost, private, preview or `staging.`/`dev.`/`test.` host, the rule skips the page rather than passing it. Auditing a preview deploy would otherwise report every internal link on it as leakage. Both the seed URL and the URL the page finally resolved to are checked, so a page that redirected onto a preview host skips too. A tier word only counts when it really is a tier: `dev.to`, `test.com` and `staging.com` are registrable domains in their own right, and sites hosted on them are audited normally.
-
-## Subdomain matching
-
-`staging.`, `dev.` and `test.` are matched against the audited site's **registrable domain**, resolved through the Public Suffix List, not by a string suffix test. Two things follow.
-
-`notdev.example.com`, `webdev.example.com` and `development.example.com` are not reported, because the leftmost label has to be exactly `staging`, `dev` or `test`. Somebody else's `dev.other.com` is not reported either, because its registrable domain is not this site's. Multi-label public suffixes resolve correctly, so `dev.example.co.uk` is a dev tier of `example.co.uk` rather than of `co.uk`.
-
-## Preview hosts that are not yours
-
-Plenty of production sites live on `vercel.app` and `pages.dev`, and a page may legitimately link to somebody else's project there. A preview host whose leftmost label carries this site's own name (`example-git-main.vercel.app` for `example.com`) is treated as this site's own deployment and fails. One that does not is still reported, because linking production content at an ephemeral platform host is worth knowing about, but it only warns.
-
-The name has to be a whole hyphen-separated segment of the label, never a substring. Vercel, Netlify and Cloudflare all build the label out of hyphen-joined parts, so a project's own name is always a segment; a substring test would instead read `sandbox-demo.vercel.app` as `box.com`'s own deployment and fail a link its owner cannot do anything about.
-
-## Related rules
-
-[links/https-downgrade](/rules/links/https-downgrade) counts every `http://` anchor on an HTTPS page, including links to other people's sites, and owns the transport-security story. This rule looks at the same attribute from a different angle and deliberately stays narrower: it reports an `http://` URL only when it points back at **your own** registrable domain, where the fix is a template or a config value rather than a decision about whether to link somewhere at all. That kind never escalates this rule past `warn` and never decides its status by itself, so an HTTPS page whose only finding is a self-referential `http://` link gets one warning here and one from `links/https-downgrade`, describing the same href as two different problems: an avoidable redirect, and a baked-in absolute URL.
-
-[links/invalid-links](/rules/links/invalid-links) reports URLs that do not parse. There is no overlap: `http://localhost:3000/api` is a perfectly well-formed URL, so it never appears there, and a value this rule cannot parse is skipped rather than reported, so a malformed href is never counted twice. Broken-link rules would catch a dev host only when it happens to be unreachable from the crawler, which is the wrong signal at the wrong time: `staging.example.com` usually resolves, and `abc123.vercel.app` resolves right up until the deployment is garbage-collected.
 
 ## Enable / disable
 
@@ -84,3 +64,30 @@ disable = ["content/*"]
 enable = ["content/dev-leakage"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/leaked-secrets](/rules/security/leaked-secrets): credentials that shipped the same way.
+- [content/placeholder-text](/rules/content/placeholder-text): other values that reached production unfinished.
+- [links/https-downgrade](/rules/links/https-downgrade): the `http://` links this rule also reports.
+- [links/broken-links](/rules/links/broken-links): internal links that resolve to an error.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Why HTTPS matters, web.dev](https://web.dev/articles/why-https-matters)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is listed with the host kinds found and an example URL. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/dev-leakage.mdx
+++ b/docs/rules/content/dev-leakage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "localhost in production: development hosts left in the markup"
+title: "localhost in production: dev hosts left in the markup"
 description: "A link or image pointing at localhost or a preview deployment is broken for every visitor. squirrel classifies the host and says whether it is yours."
 ---
 

--- a/docs/rules/content/duplicate-description.mdx
+++ b/docs/rules/content/duplicate-description.mdx
@@ -1,9 +1,29 @@
 ---
-title: "Duplicate Description"
-description: "Checks for duplicate meta descriptions across the site"
+title: "Duplicate meta descriptions across pages"
+description: "One description reused across a section describes none of those pages well. squirrel groups every crawled page by its meta description."
 ---
 
-Checks for duplicate meta descriptions across the site
+## What a meta description does
+
+The meta description is a suggestion for the snippet under a search result. Search engines often write their own instead, taking text from the page that matches the query, so a description is an opportunity rather than a guarantee.
+
+When several pages share one, none of them gets a snippet that describes it. It is the same failure as a duplicate title but with a lower cost, since the search engine can substitute page text. A description reused across a whole section usually means a template default nobody filled in.
+
+## What squirrel checks
+
+The rule is site-wide. It groups crawled pages by their meta description, trimmed and lowercased, and reports any description held by more than one page. Pages with no description are skipped. It emits a single check named `duplicate-description`:
+
+- Skipped below two pages. Message: `Insufficient pages to check for duplicates`.
+- Warn when duplicates exist. Message: `3 duplicate description(s) found across 9 pages`. Each item is the description, labelled `"The best products for every occa..." (4 pages)`, with the URLs that share it. Severity warning, weight 5.
+- Pass otherwise. Message: `All pages have unique meta descriptions`.
+
+Comparison is exact after trimming and lowercasing.
+
+## How to fix it
+
+Write a description per page that summarises that page. Where a section has too many pages for that to be practical, generating one from the page's own content beats reusing a template string.
+
+For a page with nothing unique to say, omitting the description entirely is better than duplicating one. The search engine will take text from the page.
 
 | | |
 |---|---|
@@ -12,10 +32,6 @@ Checks for duplicate meta descriptions across the site
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Each page should have a unique meta description that summarizes its specific content. Duplicate descriptions reduce click-through rates and provide poor user experience in search results. Write unique, compelling descriptions for each page. For pages without unique content (like paginated results), consider using no description rather than a duplicate.
 
 ## Enable / disable
 
@@ -40,3 +56,29 @@ disable = ["content/*"]
 enable = ["content/duplicate-description"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/duplicate-title](/rules/content/duplicate-title): the same problem in the title, which matters more.
+- [core/meta-description](/rules/core/meta-description): the per-page description checks.
+- [core/nosnippet](/rules/core/nosnippet): directives that suppress the snippet entirely.
+- [crawl/pagination](/rules/crawl/pagination): the paginated pages that most often share one.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Control your snippets in search results, Google Search Central](https://developers.google.com/search/docs/appearance/snippet)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each duplicated description is listed with the pages that share it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/duplicate-title.mdx
+++ b/docs/rules/content/duplicate-title.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Duplicate Title"
-description: "Checks for duplicate title tags across the site"
+title: "Duplicate title tags: the same title on several pages"
+description: "Two pages with the same title compete with each other in search and look identical in results. squirrel groups every crawled page by its title."
 ---
 
-Checks for duplicate title tags across the site
+## What a duplicate title is
+
+The `<title>` is the page's name: it is the search result heading, the browser tab label and the default text when someone shares the link. Two pages sharing one is two pages claiming to be the same thing.
+
+The usual causes are templated and mechanical: a category page and its first paginated page, a product available in several variants, a listing filtered by a parameter, or a template that falls back to the site name when the page has no title of its own.
+
+## What squirrel checks
+
+The rule is site-wide. It groups crawled pages by their title, trimmed and lowercased, and reports any title held by more than one page. Pages with no title are skipped. It emits a single check named `duplicate-title`:
+
+- Skipped below two pages. Message: `Insufficient pages to check for duplicates`.
+- Warn when duplicates exist. Message: `4 duplicate title(s) found across 11 pages`. Each item is the title, labelled `"Product listing page for..." (3 pages)`, with the URLs that share it. Severity warning, weight 6.
+- Pass otherwise. Message: `All pages have unique titles`.
+
+Comparison is exact after trimming and lowercasing, so two titles differing only by punctuation are counted as distinct.
+
+## How to fix it
+
+```html
+<title>Running shoes, page 2 | Acme</title>
+```
+
+Give each page a title that describes what is on it. For paginated series, add the page number. For variants, add the distinguishing attribute. For a filtered listing that should not be its own page, canonicalize it to the unfiltered version.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Checks for duplicate title tags across the site
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## Solution
-
-Each page should have a unique title tag that accurately describes its content. Duplicate titles confuse search engines about which page to rank and make your pages less distinguishable in search results. Use unique, descriptive titles that include relevant keywords. For similar pages (e.g., pagination), add differentiating elements like page numbers or category names.
 
 ## Enable / disable
 
@@ -40,3 +58,30 @@ disable = ["content/*"]
 enable = ["content/duplicate-title"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/duplicate-description](/rules/content/duplicate-description): the same problem in the meta description.
+- [core/title-unique](/rules/core/title-unique): the per-page view of title uniqueness.
+- [content/title-pattern-outlier](/rules/content/title-pattern-outlier): titles that diverge from the site template.
+- [crawl/pagination](/rules/crawl/pagination): the paginated pages that most often share a title.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Influencing your title links in search results, Google Search Central](https://developers.google.com/search/docs/appearance/title-link)
+- [Consolidate duplicate URLs, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each duplicated title is listed with the pages that share it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/freshness.mdx
+++ b/docs/rules/content/freshness.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Content Freshness"
-description: "Checks for last-modified and published date signals"
+title: "Freshness signals: the dates a page publishes about itself"
+description: "squirrel inventories the date signals on a page: the Last-Modified header, schema dates, time elements and Open Graph article dates."
 ---
 
-Checks for last-modified and published date signals
+## What a freshness signal is
+
+A freshness signal is anything on a page that says when its content was published or last changed. There are four common carriers: the `Last-Modified` response header, `datePublished` and `dateModified` in structured data, a `<time datetime>` element in the markup, and the Open Graph `article:published_time` and `article:modified_time` meta tags.
+
+None of them is required, and a page with none is not broken. They matter on content whose age changes its usefulness, where a visible date helps a reader decide whether to trust what they are reading.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits one check per signal it finds, plus a fallback:
+
+- `http-last-modified` passes when the response carries a `Last-Modified` header. Message: `Last-Modified header present`, with the header value.
+- `schema-dates` passes when any JSON-LD block contains the text `datePublished` or `dateModified`. Message: `Date schema markup present`.
+- `time-elements` passes when the page has any `time[datetime]`. Message: `3 <time> element(s) found`, with the first `datetime` value.
+- `og-article-dates` passes when either `article:published_time` or `article:modified_time` is present. Message: `Open Graph article dates present`.
+- `freshness` reports info when none of those were found. Message: `No freshness signals detected`, with `Consider adding date schema or Last-Modified header` as the value.
+
+The schema test is a substring match over the script text rather than a parse, so it does not check that the date belongs to the node describing the page. `content/date-agreement` is the rule that does. Severity info, weight 3.
+
+## How to fix it
+
+```html
+<time datetime="2026-03-12">12 March 2026</time>
+```
+
+Publish the date in the markup and in the structured data, both from the same content timestamp. A `<time datetime>` element is the piece that is visible to the reader as well as machine-readable.
+
+Update `dateModified` when you make a substantive change, and leave it alone when you do not. A date that moves on every deploy is not a freshness signal.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for last-modified and published date signals
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Date signals help search engines understand content freshness. Use Article schema with datePublished and dateModified. Show visible publication dates on content. Update dates when making significant changes. For evergreen content, periodic updates with new dateModified signal relevance. The Last-Modified HTTP header also helps crawlers.
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["content/*"]
 enable = ["content/freshness"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/date-agreement](/rules/content/date-agreement): whether those signals agree with each other.
+- [crawl/sitemap-lastmod-drift](/rules/crawl/sitemap-lastmod-drift): the sitemap date compared against them.
+- [eeat/content-dates](/rules/eeat/content-dates): dates read as a trust signal.
+- [content/stale-copyright](/rules/content/stale-copyright): the footer year, a different claim entirely.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Article structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/article)
+- [Last-Modified, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Last-Modified)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is listed with the date signals it carries. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/heading-hierarchy.mdx
+++ b/docs/rules/content/heading-hierarchy.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Heading Hierarchy"
-description: "Validates heading structure and hierarchy"
+title: "Skipped heading levels: h1 to h3 and other outline problems"
+description: "Headings are the page's outline, and a skipped level breaks it for anyone navigating by structure. squirrel checks order, emptiness, length and repeats."
 ---
 
-Validates heading structure and hierarchy
+## What heading hierarchy is
+
+Headings from `h1` to `h6` describe the document's structure. Screen reader users navigate by them, jumping from heading to heading rather than reading linearly, and search engines use them to understand how a page is organised.
+
+The order carries the meaning. `h1` to `h2` to `h3` says each section is inside the last; `h1` straight to `h3` says a level is missing, and the reader is left to guess what. The common cause is choosing a heading level for how it looks rather than for where it sits, which is what CSS is for.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reads the heading analysis the parser produced. It emits up to four checks:
+
+- `heading-hierarchy` warns when a level was skipped. Message: `Skipped heading levels detected`, listing each skip. Severity warning, weight 5.
+- `heading-hierarchy` passes when nothing was skipped and the page has headings. Message: `Heading hierarchy is valid`.
+- `empty-headings` warns when a heading has no text. Message: `2 empty heading(s) found`.
+- `long-headings` reports info for headings over 70 characters. Message: `3 heading(s) over 70 characters`, each item naming the level with the first 50 characters of its text.
+- `duplicate-headings` reports info for repeated heading text. Message: `4 duplicate heading(s)`, listing the repeated text.
+
+A page with no headings at all emits nothing from the first check, since the pass branch requires at least one heading.
+
+## How to fix it
+
+```html
+<h1>URL structure</h1>
+<h2>Word separators</h2>
+<h3>Hyphens versus underscores</h3>
+```
+
+Pick the level from the position in the outline and style it with CSS. Reading only the headings should give a sensible summary of the page.
+
+An empty heading is usually a styling wrapper or a decorative element that ended up as an `h2`. Use a `div` and a class instead.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Validates heading structure and hierarchy
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Proper heading structure (H1 → H2 → H3) helps users and search engines understand your content organization. Skipping levels (H1 → H3) creates confusion. Use headings in sequential order without skipping levels. Each section should use the next heading level down. Think of headings as an outline: they should make sense when read alone. Avoid empty headings or using headings purely for styling.
 
 ## Enable / disable
 
@@ -40,3 +64,30 @@ disable = ["content/*"]
 enable = ["content/heading-hierarchy"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [core/h1](/rules/core/h1): whether the page has exactly one top-level heading.
+- [a11y/heading-order](/rules/a11y/heading-order): the accessibility check over the same structure.
+- [content/word-count](/rules/content/word-count): how much content sits under those headings.
+- [images/figure-figcaption](/rules/images/figure-figcaption): the other structural markup on a content page.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The heading elements, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
+- [Understanding headings and labels, WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is listed with its skipped levels, empty headings and repeats. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/hidden-text.mdx
+++ b/docs/rules/content/hidden-text.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Hidden Text & Links"
-description: "Detects text and links hidden from users but left visible to search engines"
+title: "Hidden text and links: what Google's spam policy covers"
+description: "Text a crawler reads and a visitor cannot see is a spam policy violation. squirrel finds it while exempting screen-reader and collapsed-UI patterns."
 ---
 
-Detects text and links hidden from users but left visible to search engines
+## What hidden text is
+
+Hidden text is content present in the markup and invisible on screen. Google's spam policies treat text or links visible to crawlers but hidden from visitors as deceptive, and pages doing it can lose rankings or be removed from search.
+
+Most hiding is legitimate. The screen-reader-only pattern deliberately hides text visually while leaving it available to assistive technology. A collapsed accordion, a closed dialog and an inactive tab panel are all hidden until the user opens them. What is not legitimate is a block of keywords or links behind `display: none`, a zero font size, an off-screen offset or same-on-same colour, put there for a crawler.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits a single check named `hidden-text`:
+
+- Skipped when there is no `<body>`. Message: `No body content to analyze`.
+- Pass when nothing qualified. Message: `No hidden text or links detected`.
+- Warn when hidden elements were found. Message: `3 hidden element(s) containing 240 characters of text`.
+- Fail when the hidden links reach `min_hidden_links`. Message: `3 hidden element(s) containing 14 link(s) and 240 characters of text`.
+
+Each item names the element's selector and the techniques that hid it, and carries the character count, link count and a markup snippet. Hidden links are the stronger spam signal, which is why they alone escalate the finding to a failure.
+
+An element is exempt before any technique is considered when it carries a known screen-reader-only class such as `sr-only`, `visually-hidden` or `screen-reader-text`, or one you add through `a11y_classes`, and when it is marked as intentionally hidden UI through `aria-hidden`, the `hidden` attribute, or a role such as `tabpanel` or `dialog`. An element must hold at least `min_hidden_chars` characters to be reported. Severity for the rule is warning, weight 6.
+
+## How to fix it
+
+```html
+<span class="sr-only">Opens in a new window</span>
+```
+
+Delete the hidden block, or make it genuinely visible. For text meant only for screen readers, use the standard visually-hidden pattern, a clipped one-pixel box or a class named `sr-only` or `visually-hidden`, so it is recognisable as an accessibility affordance rather than as hiding.
+
+For UI that starts collapsed, mark the hidden state explicitly with `aria-hidden`, the `hidden` attribute, or a role such as `tabpanel` or `dialog`. That is what makes the state read as intentional.
 
 | | |
 |---|---|
@@ -13,73 +40,23 @@ Detects text and links hidden from users but left visible to search engines
 | **Severity** | warning (escalates to a failure when hidden links are involved) |
 | **Weight** | 6/10 |
 
-## Solution
-
-Google's spam policies treat text or links that are visible to crawlers but hidden from visitors as deceptive, and pages doing it can lose rankings or be removed from search entirely. Delete the hidden block, or make it genuinely visible to users.
-
-If the content is only meant for screen readers, use the standard visually-hidden pattern: a 1x1 clipped box, or a class named `sr-only` / `visually-hidden`, so it is recognisable as an accessibility affordance. If it is interactive UI that starts collapsed, mark it up as such with `aria-hidden`, the `hidden` attribute, or a role like `tabpanel` or `dialog`, so its hidden state reads as intentional.
-
-Never place keywords or links behind `display:none`, `opacity:0`, a zero font size, an off-screen offset, or same-on-same colour in order to reach a crawler.
-
-## What it checks
-
-squirrelscan reads the page's markup, not a rendered layout: there is no browser here to resolve the full CSS cascade. The rule therefore works from what is directly readable, and it is tuned for precision, so it would rather miss a spam page than accuse an honest one.
-
-**Where styles come from**
-
-- Inline `style` attributes on elements that carry text or links.
-- `<style>` blocks, but only rules whose selector is a bare class (`.promo`) or a bare id (`#promo`). Descendant, compound, pseudo and attribute selectors are skipped, because resolving them correctly needs a cascade.
-- Rules inside `@media`, `@supports`, `@layer` and `@keyframes` are never applied. `@media print { .no-print { display: none } }` hides nothing on screen, and honouring it would manufacture findings. They are not forgotten either: any class or id a conditional block mentions is treated as unresolvable, so the desktop copy of a responsive footer is left alone rather than reported.
-- External stylesheets are not fetched.
-
-**Techniques reported**
-
-| Technique | Example |
-|---|---|
-| `display:none` | `<div style="display:none">` |
-| `visibility:hidden` | `.promo { visibility: hidden }` |
-| `opacity:0` | `<span style="opacity:0">` |
-| Zero font size | `<p style="font-size:0">` |
-| Off-screen text indent | `text-indent: -9999px` |
-| Off-screen positioning | `position:absolute; left:-9999px` |
-| Off-screen margin | `margin-left: -9999px` |
-| Zero-size clipping | `height:0; overflow:hidden` |
-| Colour on colour | `color:#fff` painted on a `#fff` background, or `color:transparent` |
-
-An element is only reported when the hidden content is substantial: at least `min_hidden_chars` characters of text, or at least `min_hidden_links` links. Only the outermost hidden element is reported, so one hidden block produces one finding rather than one per descendant.
-
-The finding is a **warning** for hidden text and escalates to a **failure** once the page carries `min_hidden_links` hidden links or more, since hidden links are the stronger spam signal.
-
-## What it does not flag
-
-The rule deliberately stays quiet on every common, legitimate reason content is hidden.
-
-- **Screen-reader-only text.** The `clip` / `clip-path` idiom, a 1x1 off-screen box, and the usual class names: `sr-only`, `visually-hidden`, `visuallyhidden`, `screen-reader-text`, `skip-link` and friends.
-- **Interactive UI that starts collapsed.** Tab panels, accordions, dropdowns, modals, off-canvas navigation, carousels, toasts and cookie or consent banners, recognised through `role`, `aria-*`, `<dialog>` / `<details>` / `<nav>`, toggle attributes such as `data-bs-toggle`, and class names containing those words. A hidden element nested inside such a container is covered too.
-- **The `hidden` attribute and `aria-hidden="true"`.** These are the platform's own toggle and decoration markers and read as an explicit statement of intent, so they exempt an element rather than incriminate it.
-- **Elements whose class is also targeted by a selector the rule cannot resolve.** If `.drawer` is hidden by a simple rule but `.drawer.open` appears elsewhere in the stylesheet, the element is script-driven and is left alone.
-- **Idioms that look like hiding but are not.** `opacity:0` with a transition (a fade-in), `opacity:0` beside a displacing `transform` (the resting state of an entrance animation), `max-height:0` with a transition (a collapsing accordion), `text-indent:-9999px` with a background image (image replacement), `font-size:0` used only to close inline-block gaps, `color:transparent` with `background-clip:text` (gradient text), and invalid unitless offsets such as `left:-9999`, which no browser applies. A transition declared on a compound selector counts too, so `.card { opacity: 0 }` paired with `.card.in-view { transition: opacity .4s }` reads as a scroll reveal.
-- **Viewport and print variants.** Class names such as `nomobile`, `desktop-only` and `noprint` mark content shown in a medium the rule cannot evaluate.
-- **Elements the page's own JavaScript addresses.** When an inline script names an element by id or class, its hidden state is script-controlled: a form's success message, a tab, a footer revealed after hydration. This applies only to `display:none`, `visibility:hidden` and `opacity:0`, which every toggle library writes. Off-screen offsets, zero font sizes, zero-size clipping and colour-on-colour have no legitimate scripted use and are still reported.
-- **The `main` and `body` landmarks.** A hidden `<main>` is a page-load transition or a hydration shell waiting to be revealed, and the script that reveals it usually lives in an external bundle the rule cannot read. Concealment presupposes a visible page to conceal something on, so an element that *is* the page is not a hiding place. As above, this covers only `display:none`, `visibility:hidden` and `opacity:0`; an off-screen `<main>` is still reported. Wrapper `div`s doing the same fade are not exempt.
-- **Small amounts of hidden text** with no keyword or link payload.
-- **Light text over unknown backdrops.** Colour matching only fires when both the text colour and the paint behind it are resolvable. Positioned overlays, elements with a `text-shadow`, and anything sitting on a background image or gradient are left alone.
-
 ## Options
 
 | Option | Type | Default | Description |
-|---|---|---|---|
-| `min_hidden_chars` | number | `50` | Characters of hidden text on one element before it is reported |
-| `min_hidden_links` | number | `10` | Hidden links before the finding escalates from a warning to a failure |
+|--------|------|---------|-------------|
+| `min_hidden_chars` | integer, 1 or more | `50` | Characters of hidden text on one element before it is reported |
+| `min_hidden_links` | integer, 1 or more | `10` | Hidden links before the finding escalates from a warning to a failure |
 | `offscreen_px_threshold` | number | `-999` | Offsets at or below this many pixels count as pushed off-screen |
-| `a11y_classes` | string[] | `[]` | Extra screen-reader-only class names to treat as legitimate |
-| `safe_classes` | string[] | `[]` | Extra class names to exempt from hidden-text reporting |
+| `a11y_classes` | array of strings | `[]` | Extra screen-reader-only class names to treat as legitimate |
+| `safe_classes` | array of strings | `[]` | Extra class names to exempt from hidden-text reporting |
+
+### Configuration example
 
 ```toml squirrel.toml
-[rules.options."content/hidden-text"]
-min_hidden_chars = 120
-a11y_classes = ["acme-offscreen"]
-safe_classes = ["legacy-print-block"]
+[rule_options."content/hidden-text"]
+min_hidden_chars = 100
+a11y_classes = ["u-hide-visually"]
+safe_classes = ["mega-menu-panel"]
 ```
 
 ## Enable / disable
@@ -105,3 +82,30 @@ disable = ["content/*"]
 enable = ["content/hidden-text"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [integrity/cloaking](/rules/integrity/cloaking): serving different content to a crawler than to a visitor.
+- [content/keyword-stuffing](/rules/content/keyword-stuffing): the visible version of the same intent.
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): focusable elements hidden from assistive technology.
+- [integrity/seo-doorway](/rules/integrity/seo-doorway): injected pages carrying the same kind of block.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Spam policies for Google web search](https://developers.google.com/search/docs/essentials/spam-policies)
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Every hidden element is listed with its selector, the technique used and a snippet. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -8,71 +8,71 @@ Content rules read the words a visitor actually sees. Some of them catch pipelin
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Article Link Density" icon="triangle-exclamation" href="/rules/content/article-links">
-    Articles should have appropriate internal and external links based on length
+  <Card title="Article link density: how many links an article needs" icon="triangle-exclamation" href="/rules/content/article-links">
+    An article that cites nothing and links nowhere is a dead end. squirrel scales the minimum with the article's length.
   </Card>
-  <Card title="Author Info" icon="circle-info" href="/rules/content/author-info">
-    Checks for author markup and attribution
+  <Card title="Author attribution: schema, rel=author and visible bylines" icon="circle-info" href="/rules/content/author-info">
+    Who wrote a page is part of how a reader decides whether to trust it. squirrel inventories the author markup a page carries.
   </Card>
-  <Card title="Broken HTML" icon="triangle-exclamation" href="/rules/content/broken-html">
-    Checks for malformed HTML structure
+  <Card title="Malformed HTML: doctype, nesting and deprecated tags" icon="triangle-exclamation" href="/rules/content/broken-html">
+    Browsers recover from bad markup silently and other parsers may not. squirrel checks document structure, nesting and deprecated elements.
   </Card>
-  <Card title="Content Freshness" icon="circle-info" href="/rules/content/freshness">
-    Checks for last-modified and published date signals
+  <Card title="Freshness signals: the dates a page publishes about itself" icon="circle-info" href="/rules/content/freshness">
+    squirrel inventories the date signals on a page: the Last-Modified header, schema dates, time elements and Open Graph article dates.
   </Card>
-  <Card title="Content Quality" icon="circle-info" href="/rules/content/quality">
-    LLM-based content quality analysis for SEO
+  <Card title="LLM content quality score: what it measures" icon="circle-info" href="/rules/content/quality">
+    An optional language-model read of the page copy, scored 0 to 100 with written feedback. Off by default and needs an OpenRouter key.
   </Card>
-  <Card title="Date Agreement" icon="triangle-exclamation" href="/rules/content/date-agreement">
-    Checks the visible date, schema dates and URL/title year agree
+  <Card title="Visible date disagrees with schema: which date is wrong" icon="triangle-exclamation" href="/rules/content/date-agreement">
+    A page states its date in several places and presence checks pass as soon as one exists. squirrel compares the byline, the schema and the URL year.
   </Card>
-  <Card title="Development Host Leakage" icon="triangle-exclamation" href="/rules/content/dev-leakage">
-    Detects localhost, private, staging and preview hosts on a production page
+  <Card title="localhost in production: dev hosts left in the markup" icon="triangle-exclamation" href="/rules/content/dev-leakage">
+    A link or image pointing at localhost or a preview deployment is broken for every visitor. squirrel classifies the host and says whether it is yours.
   </Card>
-  <Card title="Duplicate Description" icon="triangle-exclamation" href="/rules/content/duplicate-description">
-    Checks for duplicate meta descriptions across the site
+  <Card title="Duplicate meta descriptions across pages" icon="triangle-exclamation" href="/rules/content/duplicate-description">
+    One description reused across a section describes none of those pages well. squirrel groups every crawled page by its meta description.
   </Card>
-  <Card title="Duplicate Title" icon="triangle-exclamation" href="/rules/content/duplicate-title">
-    Checks for duplicate title tags across the site
+  <Card title="Duplicate title tags: the same title on several pages" icon="triangle-exclamation" href="/rules/content/duplicate-title">
+    Two pages with the same title compete with each other in search and look identical in results. squirrel groups every crawled page by its title.
   </Card>
-  <Card title="Encoding Corruption" icon="triangle-exclamation" href="/rules/content/mojibake">
-    Detects mojibake and replacement characters in visible text
+  <Card title="Mojibake: â€™ and other encoding corruption in page text" icon="triangle-exclamation" href="/rules/content/mojibake">
+    Strange character sequences in your copy mean the bytes and the declared encoding disagree. squirrel finds them and names which of the two is wrong.
   </Card>
-  <Card title="Heading Hierarchy" icon="triangle-exclamation" href="/rules/content/heading-hierarchy">
-    Validates heading structure and hierarchy
+  <Card title="Skipped heading levels: h1 to h3 and other outline problems" icon="triangle-exclamation" href="/rules/content/heading-hierarchy">
+    Headings are the page's outline, and a skipped level breaks it for anyone navigating by structure. squirrel checks order, emptiness, length and repeats.
   </Card>
-  <Card title="Hidden Text and Links" icon="triangle-exclamation" href="/rules/content/hidden-text">
-    Detects text and links hidden from users but left visible to search engines
+  <Card title="Hidden text and links: what Google's spam policy covers" icon="triangle-exclamation" href="/rules/content/hidden-text">
+    Text a crawler reads and a visitor cannot see is a spam policy violation. squirrel finds it while exempting screen-reader and collapsed-UI patterns.
   </Card>
-  <Card title="Keyword Stuffing" icon="triangle-exclamation" href="/rules/content/keyword-stuffing">
-    Detects excessive keyword repetition in content
+  <Card title="Keyword stuffing: measuring density around your CTAs" icon="triangle-exclamation" href="/rules/content/keyword-stuffing">
+    Repeating a term unnaturally is a spam policy violation. squirrel measures density while discounting repeated call-to-action labels.
   </Card>
-  <Card title="Meta Tags in Body" icon="circle-exclamation" href="/rules/content/meta-in-body">
-    Detects meta tags incorrectly placed in document body
+  <Card title="Meta tags in the body: why they are silently ignored" icon="circle-exclamation" href="/rules/content/meta-in-body">
+    A meta description or robots tag inside body is not read by anything. squirrel finds every meta element that ended up outside the head.
   </Card>
-  <Card title="MIME Type Validation" icon="triangle-exclamation" href="/rules/content/mime-type">
-    Detects Content-Type header mismatches with file extensions
+  <Card title="Wrong Content-Type: header and extension disagree" icon="triangle-exclamation" href="/rules/content/mime-type">
+    A stylesheet served as text/html is refused by the browser under nosniff. squirrel compares the response type against the URL extension.
   </Card>
-  <Card title="Placeholder Text" icon="triangle-exclamation" href="/rules/content/placeholder-text">
-    Detects template leftovers and filler copy that shipped to production
+  <Card title="Lorem ipsum in production: placeholders and leftovers" icon="triangle-exclamation" href="/rules/content/placeholder-text">
+    Filler copy, unrendered template syntax and a visible undefined all mean something shipped unfinished. squirrel names the family and shows a sample.
   </Card>
-  <Card title="Reading Level" icon="circle-info" href="/rules/content/reading-level">
-    Analyzes content readability using Flesch-Kincaid
+  <Card title="Flesch reading ease: measuring how hard a page is to read" icon="circle-info" href="/rules/content/reading-level">
+    squirrel computes a Flesch reading ease score and a Flesch-Kincaid grade level from the page text, and reports both without judging them.
   </Card>
-  <Card title="Stale Copyright Year" icon="circle-info" href="/rules/content/stale-copyright">
-    Checks the footer copyright year against the current year
+  <Card title="Footer copyright year behind the current year" icon="circle-info" href="/rules/content/stale-copyright">
+    An old year in the footer is the cheapest signal that a site is abandoned. squirrel reads the footer only, so dated body copy is left alone.
   </Card>
-  <Card title="Thin Content vs Site Norm" icon="triangle-exclamation" href="/rules/content/thin-vs-site-norm">
-    Finds pages far shorter than the site's own norm for their page type
+  <Card title="Thin against your own site: outliers by page type" icon="triangle-exclamation" href="/rules/content/thin-vs-site-norm">
+    A 200 word product page is normal and a 200 word article is not. squirrel compares each page against the median for its own page type.
   </Card>
-  <Card title="Title Template Consistency" icon="triangle-exclamation" href="/rules/content/title-pattern-outlier">
-    Finds pages whose title breaks the template the rest of the site follows
+  <Card title="Inconsistent page titles: pages breaking the template" icon="triangle-exclamation" href="/rules/content/title-pattern-outlier">
+    Most sites title pages the same way and then ship a pocket that does not. squirrel infers your template and reports the pages that break it.
   </Card>
-  <Card title="Unrendered Markup" icon="triangle-exclamation" href="/rules/content/unrendered-markup">
-    Detects literal markdown or escaped HTML leaking into rendered copy
+  <Card title="Literal **bold** on the page: markdown that never rendered" icon="triangle-exclamation" href="/rules/content/unrendered-markup">
+    Visible asterisks, bracket links or escaped tags mean a value printed as text instead of markup. squirrel reads the prose and names the mistake.
   </Card>
-  <Card title="Word Count" icon="triangle-exclamation" href="/rules/content/word-count">
-    Checks content length for thin content issues
+  <Card title="Thin content: the 300 word floor and what to do below it" icon="triangle-exclamation" href="/rules/content/word-count">
+    A page under a few hundred words rarely answers the question it ranks for. squirrel counts the words and reports against two thresholds.
   </Card>
 </CardGroup>
 

--- a/docs/rules/content/index.mdx
+++ b/docs/rules/content/index.mdx
@@ -3,7 +3,7 @@ title: "Content"
 description: "Text quality, readability, and content structure"
 ---
 
-Text quality, readability, and content structure
+Content rules read the words a visitor actually sees. Some of them catch pipeline failures that reach the reader as text: mojibake, literal markdown, lorem ipsum, a development URL, a visible undefined. Others measure the writing itself, its length, its readability and its keyword density. A third group compares pages against each other, finding duplicate titles, thin outliers and titles that break the site's own template.
 
 ## Rules
 
@@ -82,3 +82,5 @@ Text quality, readability, and content structure
 [rules]
 disable = ["content/*"]
 ```
+
+Every audit reports Content findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/content/keyword-stuffing.mdx
+++ b/docs/rules/content/keyword-stuffing.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Keyword stuffing: measuring density without counting your CTAs"
+title: "Keyword stuffing: measuring density around your CTAs"
 description: "Repeating a term unnaturally is a spam policy violation. squirrel measures density while discounting repeated call-to-action labels."
 ---
 

--- a/docs/rules/content/keyword-stuffing.mdx
+++ b/docs/rules/content/keyword-stuffing.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Keyword Stuffing"
-description: "Detects excessive keyword repetition in content"
+title: "Keyword stuffing: measuring density without counting your CTAs"
+description: "Repeating a term unnaturally is a spam policy violation. squirrel measures density while discounting repeated call-to-action labels."
 ---
 
-Detects excessive keyword repetition in content
+## What keyword stuffing is
+
+Keyword stuffing is repeating a word or phrase far beyond what the writing needs, in order to signal relevance to a search engine. Google's spam policies name it explicitly, and it has not worked for a long time.
+
+Measuring it naively produces false positives. A product listing with fifty "Add to cart" buttons repeats those words fifty times without saying anything, and a page about socks will legitimately use the word "socks" a lot. So density alone is not the test.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the body text with scripts, styles and noscript excluded, matching words of three or more letters. It emits a single check named `keyword-stuffing`:
+
+- Skipped when there is no `<body>`. Message: `No body content to analyze`.
+- Info below 100 words. Message: `Content too short for keyword density analysis`.
+- Warn when any word crosses both thresholds. Message: `2 word(s) may be overused`, each item labelled `"widget" (4.7%)` with its count and density. Severity warning, weight 5.
+- Pass otherwise. Message: `No keyword stuffing detected`.
+
+A word is flagged when its density is above `density_threshold`, 3% by default, and its count is above `min_occurrences`, 5 by default. Two subtractions come first. A list of roughly fifty function words and generic verbs is excluded outright, covering articles, pronouns, auxiliaries and words like `get` and `here` that read as high density on any page. Then generic call-to-action labels on `<a>` and `<button>` elements are counted, and their words are subtracted from both the word's own count and the denominator, so a page of "Learn more" buttons is measured on its prose. Nested controls are counted once, from the outermost element.
+
+## How to fix it
+
+Rewrite the passage. Use synonyms and related terms where the exact phrase is not needed, and write the sentence you would write if nobody were counting.
+
+Add your brand name or a genuinely repeated product term to `whitelist` rather than editing around it. A page about one product will name that product often, and that is not stuffing.
 
 | | |
 |---|---|
@@ -13,27 +34,20 @@ Detects excessive keyword repetition in content
 | **Severity** | warning |
 | **Weight** | 5/10 |
 
-## Solution
-
-Keyword stuffing is repeating words unnaturally to manipulate rankings. Search engines penalize this practice. Write naturally for users first. Use keywords where they fit naturally. Aim for 1-2% keyword density at most. Use synonyms and related terms instead of repeating the exact same phrase. Focus on providing value, not gaming algorithms.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `density_threshold` | unknown | `undefined` | Keyword density percentage threshold |
-| `min_occurrences` | unknown | `undefined` | Minimum word occurrences to flag |
-| `whitelist` | unknown | `undefined` | Words to ignore (e.g., brand name) |
+| `density_threshold` | number | `3` | Keyword density percentage threshold |
+| `min_occurrences` | number | `5` | Minimum word occurrences to flag |
+| `whitelist` | array of strings | `[]` | Words to ignore (for example a brand name) |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."content/keyword-stuffing"]
-density_threshold = undefined
-min_occurrences = undefined
-whitelist = undefined
+[rule_options."content/keyword-stuffing"]
+density_threshold = 4
+whitelist = ["acme", "squirrelscan"]
 ```
 
 ## Enable / disable
@@ -59,3 +73,30 @@ disable = ["content/*"]
 enable = ["content/keyword-stuffing"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/hidden-text](/rules/content/hidden-text): keywords hidden from readers rather than repeated at them.
+- [integrity/seo-doorway](/rules/integrity/seo-doorway): injected pages built entirely out of this pattern.
+- [content/quality](/rules/content/quality): an LLM read of whether the writing is any good.
+- [content/reading-level](/rules/content/reading-level): the other readability measurement over the same text.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Keyword stuffing, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#keyword-stuffing)
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each overused word is listed with its count and density. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/meta-in-body.mdx
+++ b/docs/rules/content/meta-in-body.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Meta Tags in Body"
-description: "Detects meta tags incorrectly placed in document body"
+title: "Meta tags in the body: why they are silently ignored"
+description: "A meta description or robots tag inside body is not read by anything. squirrel finds every meta element that ended up outside the head."
 ---
 
-Detects meta tags incorrectly placed in document body
+## What a meta tag in the body is
+
+`<meta>` elements belong in `<head>`. A meta element in the body is parsed as content, not as metadata, so browsers and search engines ignore it. The page looks fine and the tag does nothing.
+
+It usually means the head was closed earlier than intended, or that a component injecting head content rendered in place instead. A malformed tag before it, or content emitted before `<head>` was finished, can also cause the parser to open the body early and put everything after it in the wrong place.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the selector `body meta`. It emits a single check named `meta-in-body`:
+
+- Pass when there are none. Message: `All meta tags correctly placed in <head>`.
+- Fail otherwise. Message: `Found 3 meta tags in <body>`, or `Found 1 meta tag in <body>` for one. Each item is identified by its `name`, its `property`, or `unknown`, labelled with its content truncated to 50 characters. Severity error, weight 8.
+
+The selector reads the parsed DOM, so it reflects where the browser's own parser placed the element, not where it appeared in the source. A meta element written inside the head but pushed into the body by a parse error is reported here, which is the correct result: that is where it ends up.
+
+## How to fix it
+
+```html
+<head>
+  <meta name="description" content="…" />
+</head>
+```
+
+Move the tag into the head. When a whole group of tags is in the body, look for what closed the head early: an unclosed tag, a stray character, or a component rendering head content into the page.
+
+A framework's head component has to hoist its output into the document head. Rendering it inline produces exactly this finding.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Detects meta tags incorrectly placed in document body
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Move all meta tags from `<body>` to `<head>`. Meta tags in the body are ignored by browsers and search engines. Common offenders: meta description, viewport, robots, and Open Graph tags. This is often caused by incorrect HTML structure or dynamic rendering issues.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["content/*"]
 enable = ["content/meta-in-body"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/broken-html](/rules/content/broken-html): the structural problems that cause an early body.
+- [core/meta-description](/rules/core/meta-description): the description that is being ignored.
+- [core/robots-meta](/rules/core/robots-meta): the robots directive that is being ignored.
+- [core/og-tags](/rules/core/og-tags): Open Graph tags with the same placement requirement.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The meta element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta)
+- [The head element, HTML Standard](https://html.spec.whatwg.org/multipage/semantics.html#the-head-element)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Every misplaced meta tag is listed by name with its content. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/mime-type.mdx
+++ b/docs/rules/content/mime-type.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Wrong Content-Type: when the header and the extension disagree"
+title: "Wrong Content-Type: header and extension disagree"
 description: "A stylesheet served as text/html is refused by the browser under nosniff. squirrel compares the response type against the URL extension."
 ---
 

--- a/docs/rules/content/mime-type.mdx
+++ b/docs/rules/content/mime-type.mdx
@@ -1,9 +1,36 @@
 ---
-title: "MIME Type Validation"
-description: "Detects Content-Type header mismatches with file extensions"
+title: "Wrong Content-Type: when the header and the extension disagree"
+description: "A stylesheet served as text/html is refused by the browser under nosniff. squirrel compares the response type against the URL extension."
 ---
 
-Detects Content-Type header mismatches with file extensions
+## What a MIME type mismatch is
+
+The `Content-Type` response header tells the client what a file is. The extension in the URL is a convention, not a declaration: the header is what the browser acts on.
+
+When they disagree, the header wins and things break in ways that look unrelated. A stylesheet served as `text/html` is refused outright when `X-Content-Type-Options: nosniff` is set, and a script served as `text/plain` will not execute. Without `nosniff` the browser may sniff its way to the right answer, which hides the misconfiguration until the day you add the header.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It takes the lowercased extension from the end of the URL path and compares the response `Content-Type`, with any charset parameter removed, against the types expected for that extension. It emits a single check named `mime-type`:
+
+- Skipped when the URL has no extension. Message: `No file extension detected`.
+- Info when the extension is not in the map. Message: `Unknown extension .xyz, skipping validation`.
+- Fail when there is no `Content-Type` header. Message: `Missing Content-Type header for .css file`, with the expected type.
+- Fail when the type does not match. Message: `Incorrect MIME type for .css file`, with the value found and the accepted types.
+- Pass otherwise. Message: `Correct MIME type for .css`, with the value.
+
+The map covers scripts, stylesheets, images, fonts, and the document types `.pdf`, `.json`, `.xml`, `.html` and `.htm`, each with the one or two types that are acceptable for it. Severity warning, weight 5.
+
+## How to fix it
+
+```nginx
+include mime.types;
+default_type application/octet-stream;
+```
+
+Fix it in the server configuration rather than per file. Both Apache and nginx ship a mime types map; the usual cause is a custom handler or a framework route that sets a default type for everything it serves.
+
+Serving a static file through an application route is where this most often goes wrong. Set the type explicitly there.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Detects Content-Type header mismatches with file extensions
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Incorrect MIME types break resource loading and waste crawl budget. Common issues include .js files served as text/html, images without image/* type, CSS without text/css. Fix server configuration to serve correct Content-Type headers. For Apache use .htaccess, for nginx use mime.types config.
 
 ## Enable / disable
 
@@ -40,3 +63,30 @@ disable = ["content/*"]
 enable = ["content/mime-type"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/x-content-type](/rules/security/x-content-type): the nosniff header that turns a mismatch into a refusal.
+- [core/charset](/rules/core/charset): the charset parameter on the same header.
+- [content/mojibake](/rules/content/mojibake): what a wrong charset does to the text.
+- [crawl/pdf-size](/rules/crawl/pdf-size): the PDFs this rule also validates the type of.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Content-Type, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type)
+- [X-Content-Type-Options, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each mismatch is reported with the type sent and the type expected. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/mojibake.mdx
+++ b/docs/rules/content/mojibake.mdx
@@ -20,7 +20,7 @@ The rule runs on every crawled page over the prose in `<body>`, excluding `<scri
 
 The status is fail when the replacement character was found, since that is not arguable, and warn for the other two families. The cause named in the message depends on the page's declared charset: no `<meta charset>` at all means the browser guessed; a correct `utf-8` means the source bytes are already double-encoded; any other value means the declaration is wrong and the source may be too.
 
-Eighteen byte sequences are matched, each a real UTF-8 lead byte rendered as its latin1 character, so legitimate French, German and Spanish copy stays clean. The alternation is ordered longest first, because `â€` is a prefix of five of the others and counting them independently would double-count every long one.
+Eighteen byte sequences are matched, each a real UTF-8 lead byte rendered as its latin1 character, so legitimate French, German and Spanish copy stays clean. They are matched as one alternation ordered longest first, so a longer sequence is consumed whole rather than partly matched by a shorter entry.
 
 ## How to fix it
 

--- a/docs/rules/content/mojibake.mdx
+++ b/docs/rules/content/mojibake.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Encoding Corruption"
-description: "Detects mojibake and replacement characters in visible text"
+title: "Mojibake: â€™ and other encoding corruption in page text"
+description: "Strange character sequences in your copy mean the bytes and the declared encoding disagree. squirrel finds them and names which of the two is wrong."
 ---
 
-Detects mojibake and replacement characters in visible text
+## What mojibake is
+
+Mojibake is text that was encoded one way and decoded another. The most common form on the web is UTF-8 bytes read as latin1 or cp1252, which turns a right single quote into `â€™`, an em dash into `â€”` and an accented `é` into `Ã©`.
+
+Two other shapes appear alongside it. The replacement character, U+FFFD, is what a decoder writes when it gave up on a byte sequence entirely, so it is unambiguous corruption. A literal `&amp;nbsp;` on screen means the source said `&amp;amp;nbsp;`, an entity that was encoded one time too many, usually during an import.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the prose in `<body>`, excluding `<script>`, `<style>`, `<noscript>` and the code-like elements `<code>`, `<pre>`, `<samp>` and `<kbd>`. Attributes and raw HTML are not read, since a reader never sees them. It emits a single check named `encoding-corruption`:
+
+- Skipped when there is no parsed document. Message: `No document available`.
+- Skipped when there is no `<body>`. Message: `No body element to read visible text from`.
+- Pass when nothing matched. Message: `No encoding corruption in visible text`.
+- Warn or fail otherwise. Message: `14 encoding corruption occurrence(s) in visible text (utf8-as-latin1): charset is correctly utf-8, so the source itself is double-encoded: re-import the content from its original source`.
+
+The status is fail when the replacement character was found, since that is not arguable, and warn for the other two families. The cause named in the message depends on the page's declared charset: no `<meta charset>` at all means the browser guessed; a correct `utf-8` means the source bytes are already double-encoded; any other value means the declaration is wrong and the source may be too.
+
+Eighteen byte sequences are matched, each a real UTF-8 lead byte rendered as its latin1 character, so legitimate French, German and Spanish copy stays clean. The alternation is ordered longest first, because `â€` is a prefix of five of the others and counting them independently would double-count every long one.
+
+## How to fix it
+
+```html
+<meta charset="utf-8" />
+```
+
+Fix the declaration first: `<meta charset="utf-8">` as the first thing in the head, and `Content-Type: text/html; charset=utf-8` on the response. If the declaration is already correct, the stored content is corrupt and the fix is upstream.
+
+Re-import from the original source rather than replacing the visible symptoms. The same corruption is usually in fields you cannot see from the page: meta descriptions, alt text, structured data.
 
 | | |
 |---|---|
@@ -12,41 +39,6 @@ Detects mojibake and replacement characters in visible text
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Mojibake means the bytes and the declared encoding disagree. Fix the declaration first: serve `<meta charset="utf-8">` as the first thing in the head, and send `Content-Type: text/html; charset=utf-8`. If the declaration is already utf-8, the source itself was double-encoded, usually by a CMS migration that read utf-8 bytes as latin1 and re-encoded them. Re-import the affected content from the original source rather than search-and-replacing the visible symptoms, because the same corruption is usually present in fields you cannot see, such as meta descriptions and alt text.
-
-## What it checks
-
-Three families of corruption, in visible text only:
-
-| Kind | Example | Meaning |
-|---|---|---|
-| `utf8-as-latin1` | `Itâ€™s`, `cafÃ©` | utf-8 bytes decoded as latin1 or cp1252 |
-| `replacement-char` | `caf�` | the decoder gave up on those bytes |
-| `double-encoded-entity` | visible `&amp;nbsp;` | the source said `&amp;amp;nbsp;` |
-
-The check reads prose, never raw HTML, so an encoded sequence in an attribute is not reported. Two kinds of markup are excluded:
-
-- `<script>`, `<style>` and `<noscript>`, because a visitor never reads them.
-- `<code>`, `<pre>`, `<samp>` and `<kbd>`, because a visitor reads them as a quoted literal. A changelog entry or docs page that quotes `â€™` inside a code span is documenting the corruption, not suffering from it.
-
-A page with no body is skipped rather than passed.
-
-**Severity depends on certainty.** The replacement character is unambiguous corruption and fails. The other families warn.
-
-## Cause attribution
-
-The finding cross-checks `<meta charset>` so the message names the actual fix rather than just reporting odd characters:
-
-- **No charset declared**: the browser guessed. Add `<meta charset="utf-8">`.
-- **Charset is utf-8**: the declaration is right, so the source is double-encoded. Re-import the content.
-- **Charset is something else**: correct the declaration, then re-check whether the source is also double-encoded.
-
-## False positives
-
-Correctly-decoded accented text is not corruption. Copy such as `Un café à Paris`, `Grüße aus Köln`, `jalapeño`, `25°` or curly quotes stays clean, because the rule matches multi-character *sequences* that only arise from a bad decode, not individual accented letters.
 
 ## Enable / disable
 
@@ -71,3 +63,30 @@ disable = ["content/*"]
 enable = ["content/mojibake"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/unrendered-markup](/rules/content/unrendered-markup): literal markdown or escaped HTML reaching the reader.
+- [content/placeholder-text](/rules/content/placeholder-text): template leftovers in the same body copy.
+- [core/charset](/rules/core/charset): whether the page declares an encoding at all.
+- [content/mime-type](/rules/content/mime-type): the header that carries the same charset parameter.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Character encoding, MDN glossary](https://developer.mozilla.org/en-US/docs/Glossary/Character_encoding)
+- [Specifying the document's character encoding, HTML Standard](https://html.spec.whatwg.org/multipage/semantics.html#charset)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is listed with the corruption families found, a sample and a count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/placeholder-text.mdx
+++ b/docs/rules/content/placeholder-text.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Placeholder Text"
-description: "Detects template leftovers and filler copy that shipped to production"
+title: "Lorem ipsum in production: placeholder and template leftovers"
+description: "Filler copy, unrendered template syntax and a visible undefined all mean something shipped unfinished. squirrel names the family and shows a sample."
 ---
 
-Detects template leftovers and filler copy that shipped to production
+## What placeholder text is
+
+Placeholder text is anything on a live page that was never meant to be read: lorem ipsum, a theme's demo copy, a template expression that never evaluated, a JavaScript value that was concatenated into a sentence, a TODO note.
+
+Each family points at a different break in the publishing pipeline. Filler copy means the page was published before the copy was written. Unrendered template syntax means the engine never ran over that string. A visible `undefined` or `[object Object]` means the code printed a value it did not have. All of them are visible to readers and to search engines exactly as written.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the prose in `<body>`, excluding scripts, styles and code-like elements. It emits a single check named `placeholder-content`:
+
+- Skipped when there is no parsed document. Message: `No document available`.
+- Skipped when there is no `<body>`. Message: `No body element to read visible text from`.
+- Pass when nothing matched. Message: `No placeholder or template leftovers in visible text`.
+- Warn or fail otherwise. Message: `3 placeholder occurrence(s) in visible text: lorem ipsum filler (Lorem ipsum dolor sit amet, consectetur…)`, naming each family with a truncated sample. Each family is listed as an item with its own count and samples.
+
+Six families are detected, reported under these labels: `lorem ipsum filler`, `theme boilerplate`, `unrendered template syntax`, `stringified object in copy`, `JavaScript value in copy` and `source-comment marker`. The status is fail when lorem ipsum, unrendered template syntax or a stringified object was found, because none of those has an innocent reading, and warn for the other three. Severity for the rule is warning, weight 6. The rule is skipped on soft 404 pages.
+
+## How to fix it
+
+Replace the copy, and add the affected fields to whatever check gates publishing. A theme's demo text usually survives because nobody knows which fields still hold it.
+
+For unrendered template syntax, render server-side or delete the stale copy. For a visible `undefined` or `NaN`, guard the field at the point of render rather than hiding it in CSS. For a TODO marker, finish it or remove it.
 
 | | |
 |---|---|
@@ -12,66 +33,6 @@ Detects template leftovers and filler copy that shipped to production
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## Solution
-
-Each family points at a different break in the publishing pipeline. Lorem ipsum and theme boilerplate mean a page was published before its copy was written: replace the text, and add the affected fields to whatever check gates publishing. Unrendered template syntax means the templating engine never ran over that string, usually because the value was interpolated into an already-escaped fragment or the template was served as static HTML: render it server-side, or delete the stale copy. A visible `undefined`, `NaN`, `null` or `[object Object]` means the value was missing and the code concatenated it into the copy anyway: guard the field at the point of render rather than in CSS. `TODO` and `FIXME` markers mean a draft shipped: finish or remove the note, since search engines and readers see it exactly as written.
-
-## What it checks
-
-Five families, in visible text only:
-
-| Kind | Example | Meaning |
-|---|---|---|
-| `lorem-ipsum` | `Lorem ipsum dolor sit amet` | latin filler was never replaced |
-| `boilerplate-copy` | `Your Company Name`, `Insert text here` | theme or page-builder filler |
-| `unrendered-template` | `{{ user.name }}`, `{% for x in y %}`, `<%= title %>`, `${total}`, `[[slug]]` | the template engine never ran |
-| `stringified-object` | `[object Object]` | an object was concatenated into a string |
-| `js-artifact` | `Rating: NaN`, a table cell reading `undefined` | a missing value was rendered anyway |
-| `todo-marker` | `TODO: write this`, `FIXME(alice)` | a draft note shipped |
-
-**Severity depends on certainty.** Lorem ipsum, unrendered template syntax and `[object Object]` are machine-generated and nothing legitimate produces them, so they fail. The rest warn, including the bare words `undefined`, `null` and `NaN`: an API reference whose defaults column reads `null` is ordinary, and telling it apart from a value that failed to render is not possible from the text alone.
-
-## What is not visible text
-
-The check reads rendered prose, never raw HTML, so a framework attribute such as `v-bind:title="{{ x }}"` is not reported. Four kinds of markup are excluded:
-
-- `<script>`, `<style>` and `<noscript>`, because a visitor never reads them.
-- `<code>`, `<pre>`, `<samp>` and `<kbd>`, because a visitor reads them as a quoted literal. This page is the proof: every example above is inside a code span, and this page passes its own rule.
-- `<template>`, because its content is inert markup for JavaScript to clone. Without this exclusion every Vue, Alpine, Handlebars and htmx page would report its own component templates.
-- Containers belonging to an in-page code editor or syntax highlighter, matched by class: `hljs`, `shiki`, `prism`, `torchlight`, `codeblock`, `code-block`, and anything starting `language-`, `cm-` or `monaco-`. CodeMirror and Monaco build their view from plain divs and spans with no `<pre>` or `<code>` anywhere, so a tag-only test reads a Liquid tutorial as a page full of unrendered Liquid.
-
-Text is read with a line break at every block boundary, so a value alone in a table cell or list item is seen as a value alone on its line. A page with no body is skipped rather than passed, and a [soft 404](/rules/crawl/soft-404) is skipped so one broken error template cannot spray warnings across a crawl.
-
-## False positives
-
-Each family is deliberately narrower than its name suggests, because every one of them is also a legitimate thing to write.
-
-**Lorem ipsum** needs corroboration: three distinct marker words, or the opening phrase `dolor sit amet`. The `Lorem ipsum` bigram alone is never enough at any position, so a page that mentions the filler, the way Jinja's documentation describes its `lipsum()` helper, stays clean. Words that are real in other languages, including `dolor`, `sit`, `amet`, `elit` and `sed`, are not markers at all, so Spanish and Latin copy stays clean.
-
-**Boilerplate copy** matches whole-word phrases, never single words and never substrings. `Request a sample of our placeholder API`, `we resample textures` and the headings `Placeholder Text` and `Example text` are all ordinary and stay clean.
-
-**JavaScript artifacts** match only the JavaScript spellings, case-sensitively, as standalone words. `NULL` in SQL prose, a sentence beginning `Undefined`, and identifiers such as `nullable` or `non-null` never match. Beyond that, the word has to sit where a **value** sits, not where a noun sits. It is reported only when it is alone on its line, which is what `<h1>{title}</h1>` renders as when the title is missing, or when a label such as `:` or `>` introduces it. A comma does not count as a label, and neither does a pipe: both read as prose far more often than as a list. All of these stay clean:
-
-```text
-This triggers undefined behaviour in C++.
-The function returns undefined when the key is missing.
-We reject the null hypothesis.
-Comparison with NaN
-If an operand is a quiet NaN, there is no exception.
-Accepts a string, null, or undefined.
-The parameter accepts string | null | undefined
-TypeError: null/undefined has no properties
-Reject the [null] hypothesis.
-```
-
-The cost of that strictness is deliberate: `Posted by undefined` at the end of a line is the same shape as `Comparison with NaN`, so the ambiguous shape is left alone.
-
-**Comment markers** match `TODO` and `FIXME` in annotation form: followed by `:` or `(`, preceded by a comment sigil such as `//`, or introducing a lowercase sentence on the same line. A bare standalone `TODO` is left alone, because it is the name of a column on every task board ever shipped. `XXX` is narrower still and needs the comment sigil, because `Super Bowl XXX: the box score` and `Rated XXX (explicit)` fit annotation form exactly. Redacted digits such as `555-XXX-XXXX` and `$XXX,XXX` are not markers either.
-
-## Known limit
-
-A page whose SUBJECT is one of these values is reported, as a warning. A JavaScript language reference that lists `null`, `undefined` and `NaN` as navigation entries, an API reference whose defaults column reads `null`, or an article whose visible heading is the bare word all look exactly like a page whose values failed to render, and no amount of reading the text can tell them apart. That is why this family warns rather than fails. Disable the rule for those pages.
 
 ## Enable / disable
 
@@ -96,3 +57,29 @@ disable = ["content/*"]
 enable = ["content/placeholder-text"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/unrendered-markup](/rules/content/unrendered-markup): markup that reached the reader as literal text.
+- [content/dev-leakage](/rules/content/dev-leakage): development hosts in the same production copy.
+- [content/mojibake](/rules/content/mojibake): encoding corruption in the same body text.
+- [content/word-count](/rules/content/word-count): pages that are short because the copy was never written.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is listed with the placeholder families found and a sample of each. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/placeholder-text.mdx
+++ b/docs/rules/content/placeholder-text.mdx
@@ -7,7 +7,7 @@ description: "Filler copy, unrendered template syntax and a visible undefined al
 
 Placeholder text is anything on a live page that was never meant to be read: lorem ipsum, a theme's demo copy, a template expression that never evaluated, a JavaScript value that was concatenated into a sentence, a TODO note.
 
-Each family points at a different break in the publishing pipeline. Filler copy means the page was published before the copy was written. Unrendered template syntax means the engine never ran over that string. A visible `undefined` or `[object Object]` means the code printed a value it did not have. All of them are visible to readers and to search engines exactly as written.
+Each family points at a different break in the publishing pipeline. Filler copy means the page was published before the copy was written. Unrendered template syntax means the engine never ran over that string. A visible `undefined` means the code printed a value it did not have; a visible `[object Object]` means it printed one it did have and coerced an object to a string on the way. All of them are visible to readers and to search engines exactly as written.
 
 ## What squirrel checks
 
@@ -16,7 +16,7 @@ The rule runs on every crawled page over the prose in `<body>`, excluding script
 - Skipped when there is no parsed document. Message: `No document available`.
 - Skipped when there is no `<body>`. Message: `No body element to read visible text from`.
 - Pass when nothing matched. Message: `No placeholder or template leftovers in visible text`.
-- Warn or fail otherwise. Message: `3 placeholder occurrence(s) in visible text: lorem ipsum filler (Lorem ipsum dolor sit amet, consectetur…)`, naming each family with a truncated sample. Each family is listed as an item with its own count and samples.
+- Warn or fail otherwise. Message: `3 placeholder occurrence(s) in visible text: lorem ipsum filler (lorem)`, naming each family with the marker token that matched rather than a passage excerpt. Each family is listed as an item with its own count and samples.
 
 Six families are detected, reported under these labels: `lorem ipsum filler`, `theme boilerplate`, `unrendered template syntax`, `stringified object in copy`, `JavaScript value in copy` and `source-comment marker`. The status is fail when lorem ipsum, unrendered template syntax or a stringified object was found, because none of those has an innocent reading, and warn for the other three. Severity for the rule is warning, weight 6. The rule is skipped on soft 404 pages.
 

--- a/docs/rules/content/placeholder-text.mdx
+++ b/docs/rules/content/placeholder-text.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Lorem ipsum in production: placeholder and template leftovers"
+title: "Lorem ipsum in production: placeholders and leftovers"
 description: "Filler copy, unrendered template syntax and a visible undefined all mean something shipped unfinished. squirrel names the family and shows a sample."
 ---
 

--- a/docs/rules/content/quality.mdx
+++ b/docs/rules/content/quality.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Content Quality"
-description: "LLM-based content quality analysis for SEO"
+title: "LLM content quality score: what it measures and when it runs"
+description: "An optional language-model read of the page copy, scored 0 to 100 with written feedback. Off by default and needs an OpenRouter key."
 ---
 
-LLM-based content quality analysis for SEO
+<Note>
+This rule requires `OPENROUTER_API_KEY` environment variable to be set.
+</Note>
+
+## What the quality score is
+
+This rule sends the page's visible text to a language model and asks it to score the content out of 100 on clarity and readability, depth of information, structure, value to the reader, grammar and spelling, and originality. It returns the score and two or three sentences of feedback.
+
+It is a second opinion rather than a measurement. The score is a model's judgement of prose, so it is useful for finding the pages on a large site that most need a human read, and not useful as a target to optimise. The rule is disabled by default for that reason, and because it costs an API call per page.
+
+## What squirrel checks
+
+The rule runs on every crawled page when it is enabled and a key is available. It extracts the visible text, excluding scripts, styles, nav, footer and header, and sends the first 3000 characters. It emits a single check named `content-quality`:
+
+- Skipped when no API key is configured. Message: `Content quality analysis skipped`, with the reason `OPENROUTER_API_KEY not set`.
+- Skipped when the page has no text. Message: `No content to analyze`.
+- Fail when the model call itself failed. Message: `LLM analysis failed: <error>`.
+- Pass at a score of 70 or above. Message: `Content quality score: 84/100`.
+- Warn from 40 to 69. Message: `Content quality needs improvement: 52/100`.
+- Fail below 40. Message: `Poor content quality: 31/100`.
+
+The model's feedback is carried as the check value, truncated to 200 characters. Severity for the rule is info and the weight is 3, and it is disabled by default.
+
+## How to fix it
+
+Read the feedback and the page together. The score on its own does not tell you what to change, and a model's opinion of prose is worth exactly as much as your agreement with the reasons it gives.
+
+Enable this on a section you suspect rather than site-wide. It costs one model call per page.
 
 | | |
 |---|---|
@@ -14,43 +41,7 @@ LLM-based content quality analysis for SEO
 | **Weight** | 3/10 |
 | **Default** | Disabled |
 
-<Note>
-This rule requires `OPENROUTER_API_KEY` environment variable to be set.
-</Note>
-
-## How it works
-
-This rule uses an LLM to analyze page content and provide a quality score (0-100) based on:
-
-- Clarity and readability
-- Depth of information
-- Structure and organization
-- Engagement and value to readers
-- Grammar and spelling
-- Originality and uniqueness
-
-## Scoring
-
-| Score | Status | Meaning |
-|-------|--------|---------|
-| 70-100 | Pass | Good content quality |
-| 40-69 | Warning | Content needs improvement |
-| 0-39 | Fail | Poor content quality |
-
-## Solution
-
-Content quality affects both user engagement and search rankings. High-quality content is clear, well-structured, informative, and free of errors. Review flagged pages for clarity and depth. Ensure content provides genuine value to readers. Check for grammar and spelling errors. Break up long paragraphs, use subheadings, and include relevant examples. Consider whether the content fully answers user questions.
-
 ## Enable / disable
-
-### Enable this rule
-
-This rule is disabled by default. To enable:
-
-```toml squirrel.toml
-[rules]
-enable = ["content/quality"]
-```
 
 ### Disable this rule
 
@@ -65,3 +56,37 @@ disable = ["content/quality"]
 [rules]
 disable = ["content/*"]
 ```
+
+### Enable only this rule
+
+```toml squirrel.toml
+[rules]
+enable = ["content/quality"]
+disable = ["*"]
+```
+
+## Related rules
+
+- [content/word-count](/rules/content/word-count): length, which the score is not a substitute for.
+- [content/reading-level](/rules/content/reading-level): a formula-based readability measurement.
+- [content/thin-vs-site-norm](/rules/content/thin-vs-site-norm): length judged against your own site.
+- [eeat/authority-signals](/rules/eeat/authority-signals): the trust signals a reader weighs alongside the writing.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each scored page is reported with its score and the model's written feedback. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/quality.mdx
+++ b/docs/rules/content/quality.mdx
@@ -1,5 +1,5 @@
 ---
-title: "LLM content quality score: what it measures and when it runs"
+title: "LLM content quality score: what it measures"
 description: "An optional language-model read of the page copy, scored 0 to 100 with written feedback. Off by default and needs an OpenRouter key."
 ---
 

--- a/docs/rules/content/reading-level.mdx
+++ b/docs/rules/content/reading-level.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Reading Level"
-description: "Analyzes content readability using Flesch-Kincaid"
+title: "Flesch reading ease: measuring how hard a page is to read"
+description: "squirrel computes a Flesch reading ease score and a Flesch-Kincaid grade level from the page text, and reports both without judging them."
 ---
 
-Analyzes content readability using Flesch-Kincaid
+## What the Flesch scores are
+
+Flesch Reading Ease and Flesch-Kincaid Grade Level are two formulas over the same two inputs: average sentence length and average syllables per word. Reading ease runs from 0 to 100, higher being easier; grade level maps the same numbers onto a US school year.
+
+They measure sentence and word length, not clarity. A page of short sentences made of jargon scores well, and a precise technical explanation scores badly for being precise. That is why this rule reports the numbers as information and never fails: the right score depends entirely on who the page is for.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the body text with scripts, styles and noscript excluded. It splits sentences on `.`, `!` and `?`, takes words as runs of letters, and estimates syllables with a vowel-group heuristic. It emits up to two checks:
+
+- Skipped when there is no `<body>`. Message: `No body content to analyze`.
+- Info when the text has fewer than 5 sentences or fewer than 100 words. Message: `Content too short for readability analysis`.
+- `reading-level` reports info with the result. Message: `Readability: Moderate (Grade 9.4)`, with `Flesch score: 58/100` as the value. The label is `Easy` at 70 or above, `Moderate` from 50, `Difficult` from 30, and `Very Difficult` below that.
+- `sentence-length` reports info when the average sentence exceeds 25 words. Message: `Average sentence length is high`, with `28 words/sentence` as the value.
+
+Severity info, weight 3. The syllable count is an approximation, so treat the grade level as a rough band rather than a measurement.
+
+## How to fix it
+
+Shorten the sentences that are long because they contain three ideas, and leave the ones that are long because the idea is long. Break up paragraphs, and use headings and lists where the content is genuinely a list.
+
+Technical content for expert readers scoring as Difficult is not a problem. Compare the score against the audience, not against a target.
 
 | | |
 |---|---|
@@ -12,10 +33,6 @@ Analyzes content readability using Flesch-Kincaid
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Content should match your target audience's reading level. For general audiences, aim for 6th-8th grade level (60-70 Flesch score). Use shorter sentences and simpler words. Break up long paragraphs. Use bullet points and headings. Technical content may have lower readability scores, which is acceptable for expert audiences.
 
 ## Enable / disable
 
@@ -40,3 +57,29 @@ disable = ["content/*"]
 enable = ["content/reading-level"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/word-count](/rules/content/word-count): how much text there is to read.
+- [content/quality](/rules/content/quality): an LLM read of the same content.
+- [content/keyword-stuffing](/rules/content/keyword-stuffing): repetition measured over the same text.
+- [content/heading-hierarchy](/rules/content/heading-hierarchy): the structure that makes long content navigable.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is reported with its reading ease score and grade level. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/reading-level.mdx
+++ b/docs/rules/content/reading-level.mdx
@@ -5,7 +5,7 @@ description: "squirrel computes a Flesch reading ease score and a Flesch-Kincaid
 
 ## What the Flesch scores are
 
-Flesch Reading Ease and Flesch-Kincaid Grade Level are two formulas over the same two inputs: average sentence length and average syllables per word. Reading ease runs from 0 to 100, higher being easier; grade level maps the same numbers onto a US school year.
+Flesch Reading Ease and Flesch-Kincaid Grade Level are two formulas over the same two inputs: average sentence length and average syllables per word. The reading ease formula can produce values outside 0 to 100; squirrel clamps and rounds the reported score into that range, higher being easier. Grade level maps the same inputs onto a US school year.
 
 They measure sentence and word length, not clarity. A page of short sentences made of jargon scores well, and a precise technical explanation scores badly for being precise. That is why this rule reports the numbers as information and never fails: the right score depends entirely on who the page is for.
 
@@ -69,7 +69,7 @@ Content findings ship in every audit next to the SEO, performance and agent expe
 
 ## References
 
-- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Readable, WCAG 2.2](https://www.w3.org/TR/WCAG22/#readable)
 
 ## Check your site
 

--- a/docs/rules/content/stale-copyright.mdx
+++ b/docs/rules/content/stale-copyright.mdx
@@ -7,7 +7,7 @@ description: "An old year in the footer is the cheapest signal that a site is ab
 
 The copyright line in a site footer is one of the few dates every visitor sees on every page. When it is a year or two behind, it reads as nobody has touched this site since then, whatever the content says.
 
-It has no legal consequence and no direct ranking effect. It is a trust signal, and it costs nothing to fix, which is why the rule exists and why its weight is low.
+It is read as a maintenance signal, which is not what a copyright notice formally is: the conventional US notice carries the year of first publication, not the year the site was last touched. That is why the rule warns rather than fails, and why its weight is low.
 
 ## What squirrel checks
 
@@ -28,7 +28,7 @@ A notice is recognised from `©`, `(c)`, the `&copy;` entity or the word `copyri
 
 Render the year from the server or the build step rather than hardcoding it, or use a range whose end year updates.
 
-If the date is a deliberate legal assertion tied to a fixed publication, move it out of the site chrome and into the page body, so it reads as a statement about that content rather than about the site.
+If the year is an accurate publication date rather than a maintenance signal, leave it as it is. Moving it out of the site chrome and into the page body makes it read as a statement about that content rather than about the site, which is what it is.
 
 | | |
 |---|---|

--- a/docs/rules/content/stale-copyright.mdx
+++ b/docs/rules/content/stale-copyright.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Stale Copyright Year"
-description: "Checks the footer copyright year against the current year"
+title: "Footer copyright year behind the current year"
+description: "An old year in the footer is the cheapest signal that a site is abandoned. squirrel reads the footer only, so dated body copy is left alone."
 ---
 
-Checks the footer copyright year against the current year
+## What a stale copyright year is
+
+The copyright line in a site footer is one of the few dates every visitor sees on every page. When it is a year or two behind, it reads as nobody has touched this site since then, whatever the content says.
+
+It has no legal consequence and no direct ranking effect. It is a trust signal, and it costs nothing to fix, which is why the rule exists and why its weight is low.
+
+## What squirrel checks
+
+The rule runs on every crawled page over site-chrome regions only: `footer`, `[role=contentinfo]`, `.footer`, `#footer`, `.site-footer`, `.page-footer` and `#colophon`. Body copy is not read, so an archived post quoting an old copyright notice is not reported. It emits a single check named `footer-copyright-year`:
+
+- Skipped when no footer region was found. Message: `No footer or site-chrome region found on this page`.
+- Skipped when the footer has no copyright year. Message: `No copyright year in the footer`.
+- Warn when the year is behind the current one. Message: `Footer copyright year is 2024, behind the current year 2026`, with both as the value and expected value. Severity warning, weight 2.
+- Pass otherwise. Message: `Footer copyright year is 2026`.
+
+A notice is recognised from `©`, `(c)`, the `&copy;` entity or the word `copyright`, followed within thirty non-digit characters by a year, optionally a range. A range is judged on its end year, so `2019-2026` is current in 2026. A footer with several notices is judged on the newest. Years outside 1990 to 2999 are ignored as version numbers or identifiers. A year ahead of the current one passes, since sites legitimately roll over early.
+
+## How to fix it
+
+```html
+<p>&copy; 2019&ndash;{new Date().getFullYear()} Acme</p>
+```
+
+Render the year from the server or the build step rather than hardcoding it, or use a range whose end year updates.
+
+If the date is a deliberate legal assertion tied to a fixed publication, move it out of the site chrome and into the page body, so it reads as a statement about that content rather than about the site.
 
 | | |
 |---|---|
@@ -13,31 +38,18 @@ Checks the footer copyright year against the current year
 | **Severity** | warning |
 | **Weight** | 2/10 |
 
-## Solution
-
-A footer copyright year behind the current year is the most common "this site is abandoned" signal a visitor sees, and it costs nothing to fix. Render the year dynamically from the server or build step rather than hardcoding it, or use a range whose end year updates ("2019-2026"). If the date is a deliberate legal assertion tied to a fixed publication, move it out of site chrome and into the page body so it reads as a statement about that content rather than about the site.
-
-## What it checks
-
-Reads `©`, `(c)`, `&copy;` or the word "Copyright" followed by a year or a year range, and compares the **latest** year found against the current year.
-
-- **Ranges are judged on the end year.** In 2026, `© 2019-2026` is clean and `© 2019-2025` warns.
-- **A year ahead of now is not a finding.** Sites legitimately roll the year over early.
-- **Only site chrome is inspected**: `<footer>`, `[role=contentinfo]`, `.footer`, `#footer`, `.site-footer`, `.page-footer` and `#colophon`. A historical year in body copy is correct as written, and an archived post is supposed to say 2019, so neither is reported.
-- Pages with no footer, or a footer with no copyright notice, are **skipped** rather than passed.
-
 ## Options
 
 | Option | Type | Default | Description |
-|---|---|---|---|
-| `current_year` | number | current UTC year | Year to compare the footer against |
+|--------|------|---------|-------------|
+| `current_year` | integer, 1970 to 9999 | the current UTC year | Year to compare the footer against |
+
+### Configuration example
 
 ```toml squirrel.toml
-[rules.options."content/stale-copyright"]
+[rule_options."content/stale-copyright"]
 current_year = 2026
 ```
-
-Setting `current_year` pins the comparison, which is useful when auditing an archived snapshot of a site as of a particular year.
 
 ## Enable / disable
 
@@ -62,3 +74,29 @@ disable = ["content/*"]
 enable = ["content/stale-copyright"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/freshness](/rules/content/freshness): whether the content itself carries a date.
+- [content/date-agreement](/rules/content/date-agreement): dates on the page that disagree with each other.
+- [eeat/trust-signals](/rules/eeat/trust-signals): the other footer signals a reader checks.
+- [legal/privacy-policy](/rules/legal/privacy-policy): the other thing that lives in the footer.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is reported with the footer year it carries. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/stale-copyright.mdx
+++ b/docs/rules/content/stale-copyright.mdx
@@ -77,7 +77,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [content/freshness](/rules/content/freshness): whether the content itself carries a date.
+- [content/freshness](/rules/content/freshness): which date signals the page publishes about itself.
 - [content/date-agreement](/rules/content/date-agreement): dates on the page that disagree with each other.
 - [eeat/trust-signals](/rules/eeat/trust-signals): the other footer signals a reader checks.
 - [legal/privacy-policy](/rules/legal/privacy-policy): the other thing that lives in the footer.

--- a/docs/rules/content/thin-vs-site-norm.mdx
+++ b/docs/rules/content/thin-vs-site-norm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Thin against your own site: word-count outliers by page type"
+title: "Thin against your own site: outliers by page type"
 description: "A 200 word product page is normal and a 200 word article is not. squirrel compares each page against the median for its own page type."
 ---
 

--- a/docs/rules/content/thin-vs-site-norm.mdx
+++ b/docs/rules/content/thin-vs-site-norm.mdx
@@ -17,11 +17,13 @@ The rule is site-wide. It groups crawled pages by page type, then computes the m
 - Skipped below the site floor of 10 crawled pages. Message: `Only 6 page(s) crawled; 10 needed to establish a site norm`.
 - Skipped when no page type qualifies. Message: `No page type has 8+ comparable pages with a clear word-count norm`.
 - Pass when no page is an outlier. Message: `All 210 comparable page(s) sit within their page type's word-count norm (median words: article 1840, product 320)`.
-- Warn when outliers exist, and fail when they cover 20% or more of the judged pages. Message: `7 of 210 page(s) are far shorter than the norm for their page type (median words: article 1840)`. Each item reads `240 words vs the article norm of 1840 (13%)`, with up to ten listed.
+- Warn when outliers exist, and fail when they cover 20% or more of the judged pages. Message: `7 of 210 page(s) are far shorter than the norm for their page type (median words: article 1840)`. Each item reads `340 words vs the article norm of 1840 (18%)`, with up to ten listed.
 
-Four guards apply in order. The site needs 10 crawled pages. A page type needs 8. At least 70% of a group must sit within half its median for that median to count as a norm. And a flagged page must be both under half the group median and more than three robust standard deviations below it, so neither a tight nor a wide distribution can fire on its own.
+Four guards apply in order. The site needs 10 crawled pages. A page type needs 8. At least 70% of a group must sit within half its median for that median to count as a norm. And a flagged page must be both under half the group median and more than three deviations below it, where a deviation is the larger of 1.4826 times the median absolute deviation and a tenth of the median, so neither a tight nor a wide distribution can fire on its own.
 
-Pages below 300 words are never considered here, because `content/word-count` owns them. Severity warning, weight 3.
+Only pages that returned a 2xx status and carry a known page type are sampled.
+
+Pages below 300 words are never reported here, because `content/word-count` owns them, but they do still count toward their group's size, median, deviation and agreement, and toward the judged-page total in the message. Severity warning, weight 3.
 
 ## How to fix it
 

--- a/docs/rules/content/thin-vs-site-norm.mdx
+++ b/docs/rules/content/thin-vs-site-norm.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Thin Content vs Site Norm"
-description: "Finds pages far shorter than the site's own norm for their page type"
+title: "Thin against your own site: word-count outliers by page type"
+description: "A 200 word product page is normal and a 200 word article is not. squirrel compares each page against the median for its own page type."
 ---
 
-Finds pages far shorter than the site's own norm for their page type
+## What a site-relative thin page is
+
+An absolute word-count threshold is wrong on most sites. Product pages, documentation pages and long-form articles all have different natural lengths, and one number cannot judge them together.
+
+Your own site already sets the expectation. If your articles median 1800 words, a 300-word article is an outlier against its siblings whatever an absolute floor says. This rule groups pages by type and reports only the low outliers within a group.
+
+## What squirrel checks
+
+The rule is site-wide. It groups crawled pages by page type, then computes the median and the median absolute deviation of the word count in each group. It emits a single check named `thin-vs-site-norm`:
+
+- Skipped when there are no pages. Message: `No pages available for analysis`.
+- Skipped below the site floor of 10 crawled pages. Message: `Only 6 page(s) crawled; 10 needed to establish a site norm`.
+- Skipped when no page type qualifies. Message: `No page type has 8+ comparable pages with a clear word-count norm`.
+- Pass when no page is an outlier. Message: `All 210 comparable page(s) sit within their page type's word-count norm (median words: article 1840, product 320)`.
+- Warn when outliers exist, and fail when they cover 20% or more of the judged pages. Message: `7 of 210 page(s) are far shorter than the norm for their page type (median words: article 1840)`. Each item reads `240 words vs the article norm of 1840 (13%)`, with up to ten listed.
+
+Four guards apply in order. The site needs 10 crawled pages. A page type needs 8. At least 70% of a group must sit within half its median for that median to count as a norm. And a flagged page must be both under half the group median and more than three robust standard deviations below it, so neither a tight nor a wide distribution can fire on its own.
+
+Pages below 300 words are never considered here, because `content/word-count` owns them. Severity warning, weight 3.
+
+## How to fix it
+
+Expand the page to the depth its siblings have, consolidate it into a fuller page, or `noindex` it if it exists only for navigation.
+
+A deliberate stub or a landing page that is short on purpose will be reported. The finding is that it does not match what the rest of its page type promises, which is worth confirming rather than padding.
 
 | | |
 |---|---|
@@ -12,40 +36,6 @@ Finds pages far shorter than the site's own norm for their page type
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 3/10 |
-
-## How it works
-
-There is no universal "enough words" number, so this rule never uses one. It groups
-the crawled pages by page type (article, product, category, docs, and so on),
-computes the median and MAD (median absolute deviation) of the word count within
-each group, and flags only the pages that sit far below their own group.
-
-A 200-word product page on a site whose products all run to 200 words is normal. A
-200-word article on a site whose articles median 1,800 words is not, and that is the
-only case this rule reports.
-
-It stays quiet unless it has grounds to speak:
-
-- Fewer than 10 crawled pages: no site norm exists, so the rule is skipped.
-- Fewer than 8 pages of a given page type: that type is dropped, not guessed at.
-- A page type whose word counts do not cluster (under 70% of its pages within 50%
-  of the median): the type is legitimately varied, so nothing in it is a deviant.
-- Pages under 300 words: those belong to [Word Count](/rules/content/word-count),
-  which stays absolute-only. The two rules never both flag the same page.
-
-A flagged page must be both under half its group's median and more than three
-robust deviations below it, so template-uniform pages with small natural variation
-are never reported.
-
-## Solution
-
-These pages are much shorter than the other pages of the same type on your own site,
-which is a stronger thin-content signal than any absolute word count: your articles
-set the expectation for what an article on this site looks like. Either expand each
-page to the depth its siblings have, consolidate it into a fuller page, or noindex it
-if it exists only for navigation. If a page is deliberately short (a stub, a redirect
-landing page), that is fine: the point is that it does not match what the rest of its
-page type promises.
 
 ## Enable / disable
 
@@ -70,3 +60,29 @@ disable = ["content/*"]
 enable = ["content/thin-vs-site-norm"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/word-count](/rules/content/word-count): the absolute floor this rule defers to.
+- [content/title-pattern-outlier](/rules/content/title-pattern-outlier): the same outlier approach applied to titles.
+- [url/slug-convention](/rules/url/slug-convention): the same approach applied to URL conventions.
+- [content/duplicate-title](/rules/content/duplicate-title): pages that are similar in a different way.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each outlier is listed with its word count and its page type's median. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/title-pattern-outlier.mdx
+++ b/docs/rules/content/title-pattern-outlier.mdx
@@ -11,16 +11,16 @@ Per-page rules cannot see when that breaks. `core/meta-title` checks that a titl
 
 ## What squirrel checks
 
-The rule is site-wide. It splits each title on `|`, `::`, `»`, `>`, ` - ` and `: `, infers the brand affix that most titles carry at the same end, then infers the separator that sits next to it. It emits a single check named `title-pattern-outlier`:
+The rule is site-wide. It splits each title on a separator set: `|`, `::` and `»` with optional surrounding whitespace; `-`, `–`, `—`, `·` and `>` with whitespace required on both sides; `>>`; and `:` followed by whitespace. It infers the brand affix that most titles carry at the same end, then infers the separator that sits next to it. Only pages that returned a 2xx status with a parseable URL are sampled. It emits a single check named `title-pattern-outlier`:
 
 - Skipped when there are no pages. Message: `No pages available for analysis`.
 - Skipped below 10 crawled pages. Message: `Only 6 page(s) crawled; 10 needed to establish a title template`.
 - Skipped below 10 titled pages. Message: `Only 7 page(s) have a title; 10 needed to establish a title template`.
 - Skipped when no brand affix reaches 70% agreement. Message: `No title template reaches 70% agreement across the crawled titles`.
-- Pass when nothing deviates. Message: `All 240 titled page(s) follow the site's own title template (brand "Acme" as suffix, separator "|")`.
-- Warn when deviations exist, and fail at or above 20% of titled pages. Message: `9 of 240 titled page(s) break the site's own title template (brand "Acme" as suffix, separator "|")`.
+- Pass when nothing deviates. Message: `All 240 titled page(s) follow the site's own title template (brand "Acme" last 100%, separator "|" 100%)`.
+- Warn when deviations exist, and fail at or above 20% of titled pages. Message: `9 of 240 titled page(s) break the site's own title template (brand "Acme" last 96%, separator "|" 100%)`.
 
-Deviations are grouped into four classes, reported most meaningful first. Each item is labelled in full: `3 of 240 page(s) have a title that is only the brand "Acme"`; `4 of 240 page(s) never mention "Acme", which 96% of titles carry`; `1 of 240 page(s) put "Acme" at the start but the norm is at the end`; `1 of 210 page(s) separate "Acme" with "-" but the norm is "|"`. Up to ten groups are listed with up to ten example URLs each.
+Deviations are grouped into four classes and ordered by group size, with the class order breaking ties. Each item is labelled in full: `3 of 240 page(s) have a title that is only the brand "Acme"`; `4 of 240 page(s) never mention "Acme", which 96% of titles carry`; `1 of 240 page(s) put "Acme" first but the norm is last`; `1 of 210 page(s) separate "Acme" with "-" but the norm is "|"`. Up to ten groups are listed with up to ten example URLs each. The separator norm needs its own sample of at least 10 votes and its own 70% agreement before a separator deviation is reported at all.
 
 Two guards keep it honest. On a multi-section site the brand candidate must appear in at least two sections, so a section label such as `Blog` cannot be mistaken for the brand in a lopsided crawl. And the homepage is exempt, since `Acme - tools for X` is a normal home title. A page with no title never votes and is never a deviant, because `core/meta-title` owns that case. Severity warning, weight 3.
 

--- a/docs/rules/content/title-pattern-outlier.mdx
+++ b/docs/rules/content/title-pattern-outlier.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Title Template Consistency"
-description: "Finds pages whose title breaks the template the rest of the site follows"
+title: "Inconsistent page titles: pages that break your title template"
+description: "Most sites title pages the same way and then ship a pocket that does not. squirrel infers your template and reports the pages that break it."
 ---
 
-Finds pages whose title breaks the template the rest of the site follows
+## What a title template is
+
+Most sites title their pages from one layout: a page name, a separator, and the brand. `URL structure | Acme` on every page, and the brand always at the same end with the same separator.
+
+Per-page rules cannot see when that breaks. `core/meta-title` checks that a title exists and is a reasonable length, which a title with the brand missing or at the wrong end passes. The inconsistency is invisible on any single page and obvious across the corpus, so the template is inferred from the site itself and only the minority form is reported.
+
+## What squirrel checks
+
+The rule is site-wide. It splits each title on `|`, `::`, `»`, `>`, ` - ` and `: `, infers the brand affix that most titles carry at the same end, then infers the separator that sits next to it. It emits a single check named `title-pattern-outlier`:
+
+- Skipped when there are no pages. Message: `No pages available for analysis`.
+- Skipped below 10 crawled pages. Message: `Only 6 page(s) crawled; 10 needed to establish a title template`.
+- Skipped below 10 titled pages. Message: `Only 7 page(s) have a title; 10 needed to establish a title template`.
+- Skipped when no brand affix reaches 70% agreement. Message: `No title template reaches 70% agreement across the crawled titles`.
+- Pass when nothing deviates. Message: `All 240 titled page(s) follow the site's own title template (brand "Acme" as suffix, separator "|")`.
+- Warn when deviations exist, and fail at or above 20% of titled pages. Message: `9 of 240 titled page(s) break the site's own title template (brand "Acme" as suffix, separator "|")`.
+
+Deviations are grouped into four classes, reported most meaningful first. Each item is labelled in full: `3 of 240 page(s) have a title that is only the brand "Acme"`; `4 of 240 page(s) never mention "Acme", which 96% of titles carry`; `1 of 240 page(s) put "Acme" at the start but the norm is at the end`; `1 of 210 page(s) separate "Acme" with "-" but the norm is "|"`. Up to ten groups are listed with up to ten example URLs each.
+
+Two guards keep it honest. On a multi-section site the brand candidate must appear in at least two sections, so a section label such as `Blog` cannot be mistaken for the brand in a lopsided crawl. And the homepage is exempt, since `Acme - tools for X` is a normal home title. A page with no title never votes and is never a deviant, because `core/meta-title` owns that case. Severity warning, weight 3.
+
+## How to fix it
+
+Fix the template at its source, in the layout or the CMS field that builds the title, rather than page by page. Keep the brand on the same side with the same separator everywhere.
+
+A page that deliberately differs, a campaign landing page for instance, will be reported. The finding is that a handful of pages are the exception, which is worth confirming.
 
 | | |
 |---|---|
@@ -12,55 +37,6 @@ Finds pages whose title breaks the template the rest of the site follows
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 3/10 |
-
-## How it works
-
-Most sites title their pages with one template: a page name, a separator, and the
-brand. No per-page check can see that template, because it only exists across the
-corpus. This rule infers it from your own crawled titles and reports the pages that
-break it.
-
-It works out two things from the titles themselves:
-
-- the **brand affix**: the segment most titles carry at the same end, first or last
-- the **separator** that sits next to that brand (`|`, `::`, `»`, `>`, ` - `, `: `)
-
-Then it reports four kinds of deviation:
-
-| Deviation | What it means |
-|---|---|
-| Missing brand | The title never mentions the brand the rest of the site carries |
-| Inverted order | The brand is at the opposite end from the norm |
-| Different separator | The brand is separated by something other than the modal separator |
-| Brand only | The title is nothing but the brand, so the page has no name of its own |
-
-Each page is reported once, for its most meaningful deviation.
-
-It stays quiet unless it has grounds to speak:
-
-- Fewer than 10 crawled pages, or fewer than 10 pages with a title: there is no
-  template to infer, so the rule is skipped.
-- No brand affix reaching 70% agreement: the site's titles genuinely follow no
-  single template, so nothing in it is a deviant.
-- On a site with more than one section, a candidate brand only ever seen inside one
-  section is treated as a section label, not the brand.
-- The homepage is exempt: "Acme - tools for X" is a normal home title and a normal
-  departure from the template every other page follows.
-- Pages with no title at all belong to [Meta Title](/rules/core/meta-title), which
-  stays per-page. The two rules never both flag the same page.
-
-Pages generated from the same template sit inside the norm by construction, so a
-large templated site is clean here unless a pocket of pages genuinely drifted.
-
-## Solution
-
-Most of your pages title themselves the same way - a page name, a separator, and your
-brand - and these pages do not. Inconsistent titles cost you brand recall in the
-search results and make templated pages look hand-edited or broken. Fix the template
-at its source (the layout or CMS field that builds the title) rather than page by
-page, keeping the brand on the same side with the same separator everywhere. A page
-that deliberately differs, like the homepage or a campaign landing page, is fine: the
-point is that a handful of pages should not be the exception.
 
 ## Enable / disable
 
@@ -85,3 +61,29 @@ disable = ["content/*"]
 enable = ["content/title-pattern-outlier"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [core/meta-title](/rules/core/meta-title): the per-page title checks this rule defers to.
+- [content/duplicate-title](/rules/content/duplicate-title): titles that repeat rather than diverge.
+- [content/thin-vs-site-norm](/rules/content/thin-vs-site-norm): the same outlier approach applied to length.
+- [url/slug-convention](/rules/url/slug-convention): the same approach applied to URL conventions.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Influencing your title links in search results, Google Search Central](https://developers.google.com/search/docs/appearance/title-link)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each deviation class is listed with its page count and example URLs. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/title-pattern-outlier.mdx
+++ b/docs/rules/content/title-pattern-outlier.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Inconsistent page titles: pages that break your title template"
+title: "Inconsistent page titles: pages breaking the template"
 description: "Most sites title pages the same way and then ship a pocket that does not. squirrel infers your template and reports the pages that break it."
 ---
 

--- a/docs/rules/content/unrendered-markup.mdx
+++ b/docs/rules/content/unrendered-markup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Literal **bold** on the page: markdown that never rendered"
-description: "Visible asterisks, bracket links or escaped tags mean a value was printed as text instead of markup. squirrel reads the prose and names which mistake it is."
+description: "Visible asterisks, bracket links or escaped tags mean a value printed as text instead of markup. squirrel reads the prose and names the mistake."
 ---
 
 ## What unrendered markup is

--- a/docs/rules/content/unrendered-markup.mdx
+++ b/docs/rules/content/unrendered-markup.mdx
@@ -7,7 +7,7 @@ description: "Visible asterisks, bracket links or escaped tags mean a value was 
 
 Unrendered markup is authored markup that reached the reader as literal text. Three different mistakes produce it, and they have different fixes.
 
-Literal markdown, `**bold**` or `[text](url)` on screen, means a field stored as markdown was printed without a markdown-to-HTML pass. Visible `<p>` or `<a href` means the opposite: HTML was escaped twice, usually by escaping a value that the templating engine had already escaped. A visible `&amp;nbsp;` means the entity itself was encoded a second time on the way in.
+Literal markdown, `**bold**` or `[text](url)` on screen, means a field stored as markdown was printed without a markdown-to-HTML pass. A visible `<p>` or `<a href` means HTML was escaped when it was meant to be rendered, which is one escape rather than two: the source said `&lt;p&gt;`. A visible `&amp;nbsp;` means the entity itself was encoded a second time on the way in.
 
 ## What squirrel checks
 
@@ -26,7 +26,7 @@ The status is fail when an escaped tag or a double-encoded entity was found, sin
 
 Find the field rather than the page. A CMS storing markdown and a template printing it raw produces the same literal text everywhere that field appears, so fixing one page leaves the rest broken.
 
-For escaped HTML, remove the manual escape rather than marking the value safe: the templating engine already escaped it. For a double-encoded entity, re-import the affected content.
+For escaped HTML, trace the rendering path before changing anything. The value is being escaped somewhere it was meant to be rendered as markup, and the fix is to render it through a sanitising HTML path rather than to switch autoescaping off. For a double-encoded entity, re-import the affected content.
 
 If the markup is meant to be on display, put it in `<code>` or `<pre>`, which this rule skips.
 
@@ -73,7 +73,8 @@ Content findings ship in every audit next to the SEO, performance and agent expe
 
 ## References
 
-- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Character reference, MDN glossary](https://developer.mozilla.org/en-US/docs/Glossary/Character_reference)
+- [HTML Sanitizer API, MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API)
 
 ## Check your site
 

--- a/docs/rules/content/unrendered-markup.mdx
+++ b/docs/rules/content/unrendered-markup.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Unrendered Markup"
-description: "Detects literal markdown or escaped HTML leaking into rendered copy"
+title: "Literal **bold** on the page: markdown that never rendered"
+description: "Visible asterisks, bracket links or escaped tags mean a value was printed as text instead of markup. squirrel reads the prose and names which mistake it is."
 ---
 
-Detects literal markdown or escaped HTML leaking into rendered copy
+## What unrendered markup is
+
+Unrendered markup is authored markup that reached the reader as literal text. Three different mistakes produce it, and they have different fixes.
+
+Literal markdown, `**bold**` or `[text](url)` on screen, means a field stored as markdown was printed without a markdown-to-HTML pass. Visible `<p>` or `<a href` means the opposite: HTML was escaped twice, usually by escaping a value that the templating engine had already escaped. A visible `&amp;nbsp;` means the entity itself was encoded a second time on the way in.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the prose in `<body>`, excluding scripts, styles and the code-like elements `<code>`, `<pre>`, `<samp>` and `<kbd>`, so a page deliberately quoting markup is not reported. It emits a single check named `unrendered-markup`:
+
+- Skipped when there is no parsed document. Message: `No document available`.
+- Skipped when there is no `<body>`. Message: `No body element to read visible text from`.
+- Pass when nothing matched. Message: `No unrendered markup in visible text`.
+- Warn or fail otherwise. Message: `4 unrendered markup occurrence(s) in visible text (markdown-emphasis, markdown-link): example **bold**`.
+
+Seven families are detected: `markdown-emphasis`, `markdown-link`, `markdown-heading`, `markdown-code-fence`, `markdown-inline-code`, `escaped-html-tag` and `double-encoded-entity`. Inline code is corroborating only: it appears in the details when something else fires and never accuses on its own, and it is excluded from the count and the example in the message.
+
+The status is fail when an escaped tag or a double-encoded entity was found, since nothing renders those on purpose outside a code block, or when three or more literal markdown occurrences were found. One stray asterisk pair is a typo; three is a template that never ran its markdown pass. Severity for the rule is warning, weight 5. The rule is skipped on soft 404 pages.
+
+## How to fix it
+
+Find the field rather than the page. A CMS storing markdown and a template printing it raw produces the same literal text everywhere that field appears, so fixing one page leaves the rest broken.
+
+For escaped HTML, remove the manual escape rather than marking the value safe: the templating engine already escaped it. For a double-encoded entity, re-import the affected content.
+
+If the markup is meant to be on display, put it in `<code>` or `<pre>`, which this rule skips.
 
 | | |
 |---|---|
@@ -12,62 +37,6 @@ Detects literal markdown or escaped HTML leaking into rendered copy
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Something rendered a value as plain text that was authored as markup. Find the field, not the page: a CMS that stores markdown and a template that prints it without a markdown-to-HTML pass produces literal `**bold**` and `[text](url)` everywhere that field appears, and fixing one page leaves the rest broken. Visible `<p>` or `<a href` means the opposite mistake: HTML was escaped twice, usually by escaping a value that a templating engine (Jinja, Twig, Blade, JSX) had already escaped, so remove the manual escape rather than marking the value safe. Visible `&nbsp;` or `&amp;` means the entity itself was encoded a second time on the way in, which is normally an import or a rich-text editor round-trip, so re-import the affected content. If the markup is meant to be on display, put it in `<code>` or `<pre>`, which this rule skips.
-
-## What it checks
-
-Seven kinds, in three families, in visible text only:
-
-| Kind | Example on screen | Meaning |
-|---|---|---|
-| `markdown-emphasis` | `**unlimited audits**` | a markdown field printed as plain text |
-| `markdown-link` | `[our docs](https://example.com/d)` | the same, for links and images |
-| `markdown-heading` | a line starting `## ` | the same, for headings |
-| `markdown-code-fence` | a line of three backticks | the same, for fenced code |
-| `markdown-inline-code` | `` `squirrel audit` `` | corroborating only, see below |
-| `escaped-html-tag` | `<p>Prices exclude tax.</p>` | HTML escaped twice |
-| `double-encoded-entity` | `&nbsp;`, `&amp;` | an entity encoded a second time |
-
-The check reads the text a visitor sees, decoded, never the raw HTML. That matters for the HTML families: the page source says `&lt;p&gt;`, and the browser paints `<p>`, so the rule looks for the painted form.
-
-**Severity depends on certainty.** Visible tags and entities fail, because nothing outside a code block renders them on purpose. Literal markdown warns at one or two occurrences and fails at three or more, where it stops looking like a typo and starts looking like a template that never ran its markdown pass.
-
-## What is excluded
-
-Displaying markup is not the same as leaking it, and this rule is mostly a list of ways to tell the two apart.
-
-- `<script>`, `<style>`, `<noscript>` and `<template>`, because a visitor never reads them.
-- `<code>`, `<pre>`, `<samp>`, `<kbd>` and `<textarea>`, because a visitor reads them as a quoted literal. A tutorial showing `**bold**` in a code span is doing its job, and an editor pre-filled with a post's markdown source is not a defect.
-- Any element a syntax highlighter marks as its own: the whole class tokens `highlight`, `hljs`, `shiki`, `chroma`, `codehilite`, `code-block`, `preformatted` and their siblings, any `language-*` or `lang-*` class, and the `data-language` family of attributes. Whole tokens, so a `highlight-box` callout is still judged as prose.
-
-Five more limits keep the rule quiet on pages that talk about markup rather than mangle it.
-
-- **Underscore emphasis must contain a space.** `__init__` and `__main__` are flanked exactly like bold and appear in ordinary prose, so `__bold__` on its own is not reported. `**bold**` still is.
-- **A markdown link needs a URL-shaped target.** `array[i](arg)` and `[see note] (below)` are not links.
-- **A single `#` needs a capitalised word after it.** `#` is also the number sign, so `# of seats` in a table header is not a heading, and neither is the URL fragment MDN prints under a specification link. `##` and deeper have no second reading and are taken as written, so `## my-package` still counts.
-- **Escaped tags must be lowercase.** `<Article>` and `<Header>` are component names a page is showing on purpose. Markup that leaked from a template came from HTML a server emitted, which is lowercase.
-- **At least one escaped tag must carry a true closing form or a recognised attribute with a value.** A page that writes `<pre>` or `<meta name>` in a sentence is documenting an element. A leak brings `</p>` or `class="row"` with it. A self-closing `<br/>` is not a closing form, `</path/to/file>` is a path rather than a closing tag, and `c=1` is not an attribute, so `if a<b then c=1>0` stays clean.
-
-## False positives
-
-Two classes are known and deliberate.
-
-Prose full of identifiers stays clean: `CLOUDFLARE_API_TOKEN`, `some_file_name.ts`, `max_pages`, `width * height` and `2 * 3` are none of them emphasis, because both emphasis forms require CommonMark-style flanking.
-
-Backticks alone never trip the rule. They are the one markdown character people put on a page on purpose and often, in a prompt written to be copied into an agent, a chat transcript, or a changelog. Inline code spans are reported in the detail once another family has fired, and never before.
-
-Text is read block by block, so a match is never assembled out of two elements that each hold half of it. A heading ending in `*` followed by a link starting with `*` is two stray asterisks, not emphasis.
-
-The residual case is a page whose subject is HTML source, displayed in a container the rule cannot recognise. A tutorial that shows `<p>This is a paragraph.</p>` inside a plain `<div>` with a bespoke class is indistinguishable from a page that leaked it. Wrap such examples in `<pre>` or `<code>`, which is also what makes them selectable and copyable for readers.
-
-## Related rules
-
-[content/mojibake](/rules/content/mojibake) covers the neighbouring problem: bytes decoded with the wrong encoding. The two sit one encoding level apart on entities. Mojibake reports a visible `&amp;nbsp;`, meaning the source was encoded three times; this rule reports a visible `&nbsp;`, meaning twice.
-
-They do overlap on triple-encoded text, and deliberately so. A page showing `&amp;nbsp;` trips mojibake on the whole sequence and this rule on the `&amp;` inside it, and both findings are true: the entity was encoded once too many, and a reader is looking at raw markup. Expect one finding from each rule on such a page.
 
 ## Enable / disable
 
@@ -92,3 +61,29 @@ disable = ["content/*"]
 enable = ["content/unrendered-markup"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/mojibake](/rules/content/mojibake): the encoding half of the same class of problem.
+- [content/placeholder-text](/rules/content/placeholder-text): template syntax that never rendered at all.
+- [content/broken-html](/rules/content/broken-html): structural problems in the same markup.
+- [content/dev-leakage](/rules/content/dev-leakage): development values that reached production copy.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is listed with the markup families found and an example. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/word-count.mdx
+++ b/docs/rules/content/word-count.mdx
@@ -1,9 +1,29 @@
 ---
-title: "Word Count"
-description: "Checks content length for thin content issues"
+title: "Thin content: the 300 word floor and what to do below it"
+description: "A page under a few hundred words rarely answers the question it ranks for. squirrel counts the words and reports against two thresholds."
 ---
 
-Checks content length for thin content issues
+## What thin content is
+
+Thin content is a page with too little substance to be worth returning as a search result. Word count is a proxy for it rather than the thing itself: a 200-word page that answers a question completely is fine, and a 2000-word page that says nothing is not.
+
+The count is still useful as a floor. Below a few hundred words a page usually is not answering anything, and a site with many of them dilutes its own crawl budget. Google's guidance is about helpfulness rather than length, so treat the number as a prompt to look at the page.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reads the word count the parser computed. It emits a single check named `word-count`:
+
+- Warn below `min_words`, 300 by default. Message: `Thin content: 140 words (min 300)`, with the count as the value and the threshold as the expected value. Severity warning, weight 4.
+- Info below `warn_threshold`, 500 by default. Message: `Content could be longer: 420 words`.
+- Pass otherwise. Message: `Good content length: 1240 words`.
+
+The 300-word floor is also a precedence boundary. `content/thin-vs-site-norm` compares a page against the median for its page type, and it never considers a page below this floor, so the two rules cannot both raise a finding on the same page.
+
+## How to fix it
+
+Expand the page to answer the question it exists for, consolidate it into a fuller page and redirect, or `noindex` it if it exists only for navigation.
+
+A category or listing page is short by design. Those are worth excluding rather than padding.
 
 | | |
 |---|---|
@@ -13,25 +33,19 @@ Checks content length for thin content issues
 | **Severity** | warning |
 | **Weight** | 4/10 |
 
-## Solution
-
-Pages with thin content (under 300 words) often struggle to rank well and are actively deindexed by Google since the June 2025 core update. Add more valuable, relevant content to thin pages, aiming for at least 500 words for standard pages and 1000+ for in-depth articles. If a page can't be fleshed out, voluntarily noindex it or consolidate it into a more comprehensive resource. Trimming thin pages from your index is better than leaving low-value content for Google to penalize.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `min_words` | unknown | `undefined` | Minimum word count |
-| `warn_threshold` | unknown | `undefined` | Word count for optimal content |
+| `min_words` | number | `300` | Minimum word count |
+| `warn_threshold` | number | `500` | Word count for optimal content |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."content/word-count"]
-min_words = undefined
-warn_threshold = undefined
+[rule_options."content/word-count"]
+min_words = 150
+warn_threshold = 400
 ```
 
 ## Enable / disable
@@ -57,3 +71,29 @@ disable = ["content/*"]
 enable = ["content/word-count"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/thin-vs-site-norm](/rules/content/thin-vs-site-norm): the same question asked against your own site's median.
+- [content/quality](/rules/content/quality): an LLM read of whether the words are worth anything.
+- [content/reading-level](/rules/content/reading-level): how hard the words are to read.
+- [crawl/indexability](/rules/crawl/indexability): noindexing a page that cannot be made worthwhile.
+
+Content findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Content section of the report. Each page is reported with its word count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Content section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/content/word-count.mdx
+++ b/docs/rules/content/word-count.mdx
@@ -17,7 +17,7 @@ The rule runs on every crawled page and reads the word count the parser computed
 - Info below `warn_threshold`, 500 by default. Message: `Content could be longer: 420 words`.
 - Pass otherwise. Message: `Good content length: 1240 words`.
 
-The 300-word floor is also a precedence boundary. `content/thin-vs-site-norm` compares a page against the median for its page type, and it never considers a page below this floor, so the two rules cannot both raise a finding on the same page.
+The 300-word floor is also a precedence boundary. `content/thin-vs-site-norm` never reports a page below 300 words, so at the default `min_words` the two rules cannot both raise a finding on one page. That boundary is the fixed constant, not the configured option, so raising `min_words` above 300 opens a band where both can fire.
 
 ## How to fix it
 

--- a/docs/rules/crawl/all-noindex-pages.mdx
+++ b/docs/rules/crawl/all-noindex-pages.mdx
@@ -1,9 +1,35 @@
 ---
-title: "All Non-Indexed Pages"
-description: "Lists all pages blocked from indexing for user audit"
+title: "All non-indexed pages: the full blocked list for review"
+description: "One list of every page a search engine will not index, with the reason. squirrel can raise severity for URL patterns that must never be blocked."
 ---
 
-Lists all pages blocked from indexing for user audit
+## What this list is for
+
+Individual `noindex` directives are easy to justify one at a time and hard to audit in aggregate. A staging directive that survived a deploy, a robots.txt rule that is broader than intended, or a CMS default applied to a whole post type all look normal on the page and only become visible when you list every blocked URL together.
+
+This rule is that list. It is informational by default, and it becomes a real finding only for URL patterns you nominate as ones that must stay indexable.
+
+## What squirrel checks
+
+The rule is site-wide. For each crawled page it runs the shared indexability test over the parsed head, the response headers, the URL and robots.txt, collecting a reason list such as `meta:noindex`, `header:noindex` or `robots.txt:disallowed`. Every non-indexable page is bucketed by the patterns you configured:
+
+- `critical-noindex` fails for pages matching `errorOnPatterns`. Message: `2 critical page(s) blocked from indexing (match error patterns)`, listing up to five as path plus reasons.
+- `important-noindex` warns for pages matching `warnOnPatterns`. Message: `4 important page(s) blocked from indexing (match warning patterns)`, listing up to five.
+- `all-noindex` reports info for everything else that is blocked. Message: `18 page(s) blocked from indexing`, listing up to ten.
+- `all-noindex` passes when every page is indexable. Message: `All pages are indexable`.
+- `all-noindex` is skipped when there are no pages. Message: `No pages to check`.
+
+Both pattern lists are empty by default, so an unconfigured run only ever produces the info bucket. Severity for the rule is info, weight 2.
+
+## How to fix it
+
+```toml squirrel.toml
+[rule_options."crawl/all-noindex-pages"]
+errorOnPatterns = ["/products/", "/blog/"]
+warnOnPatterns = ["/guides/"]
+```
+
+Nominate the sections that must stay indexable, then treat any failure as a release blocker. For the pages themselves, remove the directive the reason names: `meta:noindex` is in the head, `header:noindex` is in the response, `robots.txt:disallowed` is a crawl rule rather than an index rule.
 
 | | |
 |---|---|
@@ -13,9 +39,20 @@ Lists all pages blocked from indexing for user audit
 | **Severity** | info |
 | **Weight** | 2/10 |
 
-## Solution
+## Options
 
-Review this list to ensure all non-indexed pages are intentionally blocked. Common unintentional blocks: staging directives left in production, overly broad robots.txt rules, CMS defaults. Remove noindex from pages that should be indexed.
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `warnOnPatterns` | array of strings | `[]` | URL patterns that should trigger warning severity if noindex (for example `/blog/`, `/products/`) |
+| `errorOnPatterns` | array of strings | `[]` | URL patterns that should trigger error severity if noindex (for example `/landing-pages/`) |
+
+### Configuration example
+
+```toml squirrel.toml
+[rule_options."crawl/all-noindex-pages"]
+warnOnPatterns = ["/blog/"]
+errorOnPatterns = ["/products/"]
+```
 
 ## Enable / disable
 
@@ -40,3 +77,30 @@ disable = ["crawl/*"]
 enable = ["crawl/all-noindex-pages"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/indexability](/rules/crawl/indexability): the per-page version, with the directive named.
+- [crawl/indexability-conflicts](/rules/crawl/indexability-conflicts): robots.txt allowing what the page then noindexes, and the reverse.
+- [crawl/noindex-in-sitemap](/rules/crawl/noindex-in-sitemap): blocked pages you are still submitting in a sitemap.
+- [crawl/robots-txt](/rules/crawl/robots-txt): the file that produces the `robots.txt:disallowed` reason.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Robots meta tag and X-Robots-Tag, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
+- [Introduction to robots.txt, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots/intro)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every blocked page is listed by path with the reason it is blocked. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/all-noindex-pages.mdx
+++ b/docs/rules/crawl/all-noindex-pages.mdx
@@ -19,7 +19,7 @@ The rule is site-wide. For each crawled page it runs the shared indexability tes
 - `all-noindex` passes when every page is indexable. Message: `All pages are indexable`.
 - `all-noindex` is skipped when there are no pages. Message: `No pages to check`.
 
-Both pattern lists are empty by default, so an unconfigured run only ever produces the info bucket. Severity for the rule is info, weight 2.
+Both pattern lists are empty by default, so an unconfigured run produces the info bucket when anything is blocked, a pass when nothing is, and a skip when there are no pages. Severity for the rule is info, weight 2.
 
 ## How to fix it
 

--- a/docs/rules/crawl/canonical-chain.mdx
+++ b/docs/rules/crawl/canonical-chain.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Canonical Chain"
-description: "Checks for redirect chains on canonical URLs"
+title: "Canonical URL resolves through a redirect: how to spot it"
+description: "A canonical that redirects sends search engines on an extra hop before they reach the real URL. squirrel checks the tag against the page's own redirect chain."
 ---
 
-Checks for redirect chains on canonical URLs
+## What a canonical chain is
+
+A `<link rel="canonical">` names the URL you want a page indexed under. It should be the address that serves the content directly, with no redirect in between.
+
+When the canonical points at a URL that redirects, the crawler has to follow a hop before it reaches the page, and the signal is weaker than a direct one. The common causes are a canonical built from a stored URL that has since moved, a canonical using the wrong scheme or host variant, and a canonical that points at the requested URL on a page that redirected on the way in.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It reads the first `link[rel="canonical"]` in the document and resolves it against the page URL. It can emit several checks:
+
+- `page-redirect-chain` warns when the page itself redirected before serving content. Message: `Page redirects before content is served`, with the hops listed.
+- `canonical-chain` is skipped when there is no canonical tag. Message: `No canonical tag found`.
+- `canonical-chain` warns when the canonical href cannot be parsed. Message: `Invalid canonical URL`.
+- `canonical-protocol` warns when the page is HTTPS and the canonical is HTTP. Message: `Canonical points to HTTP instead of HTTPS`.
+- `canonical-chain` warns when the canonical URL matches one of the redirect-looking patterns `/?...redirect`, `/go/`, `/out/`, `/link/` or `/r/`. Message: `Canonical URL may be a redirect`. It passes otherwise with `Canonical URL appears direct`.
+- `canonical-target` reports info when the canonical names a different URL from the page, ignoring a trailing slash difference. Message: `Page canonicalizes to different URL`.
+- `canonical-redirects` warns when the canonical names the exact URL that was requested and that request redirected. Message: `Canonical URL resolves through a redirect chain`, with the hops listed.
+
+The last check compares request targets, not normalised forms, so `/page`, `/page/` and `/page?x=1` are treated as distinct. Only the one that was actually fetched carries the chain. Severity warning, weight 5.
+
+## How to fix it
+
+```html
+<link rel="canonical" href="https://example.com/pricing" />
+```
+
+Point the canonical at the final URL: the scheme, host and path that answer 200 directly. Generate it from the resolved route rather than from a stored string, so it moves when the route does.
+
+A cross-page canonical, where one page deliberately points at another, is reported as info rather than a defect. That is a normal deduplication choice.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks for redirect chains on canonical URLs
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Canonical URLs should point directly to the final destination, not through redirects. Redirect chains waste crawl budget and dilute link equity. If your canonical URL redirects, update it to point to the final URL. Check that canonical URLs use the preferred protocol (https) and www/non-www version. Self-referencing canonicals should match the page URL exactly.
 
 ## Enable / disable
 
@@ -40,3 +64,30 @@ disable = ["crawl/*"]
 enable = ["crawl/canonical-chain"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/redirect-chain](/rules/crawl/redirect-chain): multi-hop chains anywhere on the site.
+- [crawl/pagination](/rules/crawl/pagination): paginated pages canonicalizing to page 1.
+- [crawl/indexability-conflicts](/rules/crawl/indexability-conflicts): directives that disagree about the same URL.
+- [url/trailing-slash](/rules/url/trailing-slash): the slash difference this check normalises away.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Consolidate duplicate URLs, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+- [How Google canonicalization works](https://developers.google.com/search/docs/crawling-indexing/canonicalization)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Each canonical is reported with its target and any redirect hops behind it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/canonical-chain.mdx
+++ b/docs/rules/crawl/canonical-chain.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Canonical URL resolves through a redirect: how to spot it"
-description: "A canonical that redirects sends search engines on an extra hop before they reach the real URL. squirrel checks the tag against the page's own redirect chain."
+description: "A canonical that redirects sends search engines on an extra hop before the real URL. squirrel checks the tag against the page's own redirect chain."
 ---
 
 ## What a canonical chain is

--- a/docs/rules/crawl/html-size.mdx
+++ b/docs/rules/crawl/html-size.mdx
@@ -1,9 +1,35 @@
 ---
-title: "HTML Size"
-description: "Checks HTML document size against Googlebot crawl limits"
+title: "HTML document size: when a page is too big to crawl fully"
+description: "A very large HTML document risks being read only in part. squirrel measures the response body and warns at 1MB, failing at 2MB by default."
 ---
 
-Checks HTML document size against Googlebot crawl limits
+## What the HTML size limit is
+
+Crawlers do not read an unlimited amount of markup. Google documents that Googlebot fetches up to 15 MB of an HTML or text-based file and its resources, and anything past that point is not considered. Other crawlers publish lower limits or none at all.
+
+Long before any limit, size costs time. A document that carries an entire product catalogue inline, or a framework payload serialised into the page, is slower to transfer and slower to parse, and pushes the content that matters further from the top of the file.
+
+squirrel's thresholds are stricter than Google's documented figure. The default warning is 1 MB and the default failure is 2 MB, which is closer to what a page should need than to what a crawler will tolerate.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It measures the UTF-8 byte length of the response HTML and emits a single check named `html-size`:
+
+- Fail at or above `error_bytes`, 2 MB by default. Message: `HTML is 2.4MB — exceeds Googlebot 2MB limit, content will be truncated`, with the byte count as the value and the threshold as the expected value. Severity error, weight 5.
+- Warn at or above `warn_bytes`, 1 MB by default. Message: `HTML is 1180KB — approaching Googlebot 2MB limit`.
+- Pass otherwise. Message: `HTML size OK: 84KB`.
+
+The failure message names a 2 MB Googlebot limit, which is the rule's own default threshold rather than the 15 MB figure Google publishes. Both thresholds are configurable.
+
+## How to fix it
+
+```html
+<script id="__DATA__" type="application/json" src="/data/catalogue.json"></script>
+```
+
+Move large inline blobs out of the document: serialised state, base64 images, inline SVG sprites and inline CSS are the usual culprits. Paginate or lazy-load long lists rather than rendering ten thousand rows.
+
+Keep the title, meta description, headings and main body near the top of the file. If anything is ever cut, it should be the parts that do not describe the page.
 
 | | |
 |---|---|
@@ -13,25 +39,19 @@ Checks HTML document size against Googlebot crawl limits
 | **Severity** | error |
 | **Weight** | 5/10 |
 
-## Solution
-
-Googlebot truncates HTML documents at 2MB: content beyond that limit is silently ignored during indexing. Move inline styles and scripts to external files, defer non-critical content, lazy-load below-the-fold sections, and remove unnecessary markup. Keep critical SEO content (title, meta, headings, main body) near the top of the document so it's indexed even if truncation occurs.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `warn_bytes` | unknown | `undefined` | Byte size to trigger warning |
-| `error_bytes` | unknown | `undefined` | Byte size to trigger error (Googlebot truncation limit) |
+| `warn_bytes` | number | `1048576` | Byte size to trigger warning |
+| `error_bytes` | number | `2097152` | Byte size to trigger error (Googlebot truncation limit) |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."crawl/html-size"]
-warn_bytes = undefined
-error_bytes = undefined
+[rule_options."crawl/html-size"]
+warn_bytes = 512000
+error_bytes = 1048576
 ```
 
 ## Enable / disable
@@ -57,3 +77,30 @@ disable = ["crawl/*"]
 enable = ["crawl/html-size"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/pdf-size](/rules/crawl/pdf-size): the same measurement applied to linked PDF documents.
+- [content/word-count](/rules/content/word-count): how much of that markup is actually text.
+- [crawl/soft-404](/rules/crawl/soft-404): pages whose body is an error shell rather than content.
+- [performance/dom-size](/rules/performance/dom-size): the parsed cost of the same document.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Googlebot, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/googlebot)
+- [Managing crawl budget for large sites, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/large-site-managing-crawl-budget)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every oversized page is listed with its exact byte count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/html-size.mdx
+++ b/docs/rules/crawl/html-size.mdx
@@ -83,7 +83,7 @@ disable = ["*"]
 - [crawl/pdf-size](/rules/crawl/pdf-size): the same measurement applied to linked PDF documents.
 - [content/word-count](/rules/content/word-count): how much of that markup is actually text.
 - [crawl/soft-404](/rules/crawl/soft-404): pages whose body is an error shell rather than content.
-- [performance/dom-size](/rules/performance/dom-size): the parsed cost of the same document.
+- [performance/dom-size](/rules/perf/dom-size): the parsed cost of the same document.
 
 Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
 

--- a/docs/rules/crawl/html-size.mdx
+++ b/docs/rules/crawl/html-size.mdx
@@ -83,7 +83,7 @@ disable = ["*"]
 - [crawl/pdf-size](/rules/crawl/pdf-size): the same measurement applied to linked PDF documents.
 - [content/word-count](/rules/content/word-count): how much of that markup is actually text.
 - [crawl/soft-404](/rules/crawl/soft-404): pages whose body is an error shell rather than content.
-- [performance/dom-size](/rules/perf/dom-size): the parsed cost of the same document.
+- [perf/dom-size](/rules/perf/dom-size): the parsed cost of the same document.
 
 Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
 

--- a/docs/rules/crawl/html-size.mdx
+++ b/docs/rules/crawl/html-size.mdx
@@ -5,11 +5,11 @@ description: "A very large HTML document risks being read only in part. squirrel
 
 ## What the HTML size limit is
 
-Crawlers do not read an unlimited amount of markup. Google documents that Googlebot fetches up to 15 MB of an HTML or text-based file and its resources, and anything past that point is not considered. Other crawlers publish lower limits or none at all.
+Crawlers do not read an unlimited amount of markup. Google documents that Googlebot fetches up to 2 MB from any individual URL other than a PDF, response headers included, and stops there. The bytes past the cutoff are not fetched, not rendered and not indexed. Referenced resources such as stylesheets and scripts have their own separate per-URL counter and do not consume the document's allowance.
 
-Long before any limit, size costs time. A document that carries an entire product catalogue inline, or a framework payload serialised into the page, is slower to transfer and slower to parse, and pushes the content that matters further from the top of the file.
+Most pages are nowhere near it. A page gets there through inline base64 images, large blocks of inline CSS or JavaScript, or a serialised framework payload, and what falls off the end is whatever came last in the file.
 
-squirrel's thresholds are stricter than Google's documented figure. The default warning is 1 MB and the default failure is 2 MB, which is closer to what a page should need than to what a crawler will tolerate.
+squirrel's default failure threshold is that same 2 MB, with a warning at 1 MB so a page is flagged before it starts losing content.
 
 ## What squirrel checks
 
@@ -19,15 +19,15 @@ The rule runs on every crawled page. It measures the UTF-8 byte length of the re
 - Warn at or above `warn_bytes`, 1 MB by default. Message: `HTML is 1180KB — approaching Googlebot 2MB limit`.
 - Pass otherwise. Message: `HTML size OK: 84KB`.
 
-The failure message names a 2 MB Googlebot limit, which is the rule's own default threshold rather than the 15 MB figure Google publishes. Both thresholds are configurable.
+Both thresholds are configurable. The default failure threshold matches the 2 MB per-URL limit Google documents for Googlebot.
 
 ## How to fix it
 
-```html
-<script id="__DATA__" type="application/json" src="/data/catalogue.json"></script>
+```js
+const catalogue = await fetch("/data/catalogue.json").then((r) => r.json());
 ```
 
-Move large inline blobs out of the document: serialised state, base64 images, inline SVG sprites and inline CSS are the usual culprits. Paginate or lazy-load long lists rather than rendering ten thousand rows.
+Move large inline blobs out of the document and fetch them instead. A `<script type="application/json">` block only holds inline data, so an external file has to be requested rather than referenced with `src`. Serialised state, base64 images, inline SVG sprites and inline CSS are the usual culprits. Paginate or lazy-load long lists rather than rendering ten thousand rows.
 
 Keep the title, meta description, headings and main body near the top of the file. If anything is ever cut, it should be the parts that do not describe the page.
 
@@ -89,7 +89,7 @@ Crawlability findings ship in every audit next to the SEO, performance and agent
 
 ## References
 
-- [Googlebot, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/googlebot)
+- [Inside Googlebot: crawling, fetching and the bytes we process, Google Search Central](https://developers.google.com/search/blog/2026/03/crawler-blog-post)
 - [Managing crawl budget for large sites, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/large-site-managing-crawl-budget)
 
 ## Check your site

--- a/docs/rules/crawl/index.mdx
+++ b/docs/rules/crawl/index.mdx
@@ -8,65 +8,65 @@ Crawlability rules cover the layer before ranking: whether a search engine can r
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="4XX Pages in Sitemap" icon="triangle-exclamation" href="/rules/crawl/sitemap-4xx">
-    Checks for sitemap URLs returning 4XX status codes
+  <Card title="4XX pages in sitemap: dead URLs you are still submitting" icon="triangle-exclamation" href="/rules/crawl/sitemap-4xx">
+    A sitemap entry that returns 404 wastes a crawl and teaches search engines to trust the file less. squirrel reports the status of every checked entry.
   </Card>
-  <Card title="All Non-Indexed Pages" icon="circle-info" href="/rules/crawl/all-noindex-pages">
-    Lists all pages blocked from indexing for user audit
+  <Card title="All non-indexed pages: the full blocked list for review" icon="circle-info" href="/rules/crawl/all-noindex-pages">
+    One list of every page a search engine will not index, with the reason. squirrel can raise severity for URL patterns that must never be blocked.
   </Card>
-  <Card title="Canonical Chain" icon="triangle-exclamation" href="/rules/crawl/canonical-chain">
-    Checks for redirect chains on canonical URLs
+  <Card title="Canonical URL resolves through a redirect: how to spot it" icon="triangle-exclamation" href="/rules/crawl/canonical-chain">
+    A canonical that redirects sends search engines on an extra hop before the real URL. squirrel checks the tag against the page's own redirect chain.
   </Card>
-  <Card title="HTML Size" icon="triangle-exclamation" href="/rules/crawl/html-size">
-    Checks HTML document size against Googlebot crawl limits
+  <Card title="HTML document size: when a page is too big to crawl fully" icon="triangle-exclamation" href="/rules/crawl/html-size">
+    A very large HTML document risks being read only in part. squirrel measures the response body and warns at 1MB, failing at 2MB by default.
   </Card>
-  <Card title="Indexability Check" icon="circle-info" href="/rules/crawl/indexability">
-    Identifies pages blocked from search engine indexing
+  <Card title="Page is blocked from indexing: finding the directive" icon="circle-info" href="/rules/crawl/indexability">
+    A page can be excluded from search by a robots meta tag or an X-Robots-Tag header. squirrel reports which one, per page.
   </Card>
-  <Card title="Indexability Conflicts" icon="triangle-exclamation" href="/rules/crawl/indexability-conflicts">
-    Detects conflicting signals between robots.txt and meta/headers
+  <Card title="robots.txt vs noindex: the two conflicts explained" icon="triangle-exclamation" href="/rules/crawl/indexability-conflicts">
+    A page blocked in robots.txt can never be read for its noindex tag. squirrel compares the crawl rules against the page directives, both ways.
   </Card>
-  <Card title="Noindex in Sitemap" icon="triangle-exclamation" href="/rules/crawl/noindex-in-sitemap">
-    Checks for noindexed pages listed in sitemap
+  <Card title="Noindexed page in sitemap: why it is a contradiction" icon="triangle-exclamation" href="/rules/crawl/noindex-in-sitemap">
+    A sitemap says crawl this, noindex says do not index it. squirrel cross-references every crawled page's robots meta against your sitemap URLs.
   </Card>
-  <Card title="Pagination" icon="circle-info" href="/rules/crawl/pagination">
-    Checks that paginated pages have proper canonicals
+  <Card title="Pagination canonicals: why page 2 is not page 1" icon="circle-info" href="/rules/crawl/pagination">
+    Canonicalizing every paginated page to page 1 hides the rest of the sequence. squirrel detects paginated URLs and checks where their canonical points.
   </Card>
-  <Card title="PDF Size" icon="triangle-exclamation" href="/rules/crawl/pdf-size">
-    Checks linked PDF sizes against a 60MB default truncation threshold
+  <Card title="PDF size: large linked documents and what gets indexed" icon="triangle-exclamation" href="/rules/crawl/pdf-size">
+    A very large PDF may only be read in part by a crawler. squirrel measures every internal PDF the crawl fetched and reports the outliers.
   </Card>
-  <Card title="Redirect Chains" icon="triangle-exclamation" href="/rules/crawl/redirect-chain">
-    Detects multi-hop redirect chains that waste crawl budget
+  <Card title="Redirect chains: when one hop turns into three" icon="triangle-exclamation" href="/rules/crawl/redirect-chain">
+    Each redirect hop costs latency and crawl budget, and search engines stop following after a few. squirrel counts the hops on every crawled URL.
   </Card>
-  <Card title="Robots Meta Conflict" icon="triangle-exclamation" href="/rules/crawl/robots-meta-conflict">
-    Detects conflicts between robots meta tags and robots.txt
+  <Card title="Redundant noindex: a blocked page nobody reads it on" icon="triangle-exclamation" href="/rules/crawl/robots-meta-conflict">
+    A page disallowed in robots.txt is never fetched, so its noindex is never seen. squirrel lists the pages carrying both.
   </Card>
-  <Card title="Robots.txt" icon="circle-exclamation" href="/rules/crawl/robots-txt">
-    Checks if robots.txt exists and is properly configured
+  <Card title="robots.txt: what to put in it and how squirrel checks it" icon="circle-exclamation" href="/rules/crawl/robots-txt">
+    A missing robots.txt, a Disallow: / left in production, or a syntax error changes what gets crawled. squirrel checks existence, syntax and rules.
   </Card>
-  <Card title="Schema + Noindex Conflict" icon="circle-exclamation" href="/rules/crawl/schema-noindex-conflict">
-    Detects pages with rich result schema that are blocked from indexing
+  <Card title="Rich result schema on a noindexed page: wasted markup" icon="circle-exclamation" href="/rules/crawl/schema-noindex-conflict">
+    Structured data on a page search engines cannot index will never produce a rich result. squirrel finds pages carrying both.
   </Card>
-  <Card title="Sitemap Coverage" icon="triangle-exclamation" href="/rules/crawl/sitemap-coverage">
-    Checks for indexable pages that are not in the sitemap
+  <Card title="Indexable pages missing from the sitemap: measuring the gap" icon="triangle-exclamation" href="/rules/crawl/sitemap-coverage">
+    A page you want indexed that is in no sitemap depends entirely on link discovery. squirrel diffs the crawl against the sitemap in both directions.
   </Card>
-  <Card title="Sitemap Domain" icon="circle-exclamation" href="/rules/crawl/sitemap-domain">
-    Checks that all sitemap URLs belong to the expected domain
+  <Card title="Cross-domain sitemap URL: why search engines ignore it" icon="circle-exclamation" href="/rules/crawl/sitemap-domain">
+    A sitemap can only vouch for URLs on its own host. squirrel compares every sitemap entry's hostname against your base URL.
   </Card>
-  <Card title="Sitemap Exists" icon="circle-exclamation" href="/rules/crawl/sitemap-exists">
-    Checks if XML sitemap exists and is referenced in robots.txt
+  <Card title="No XML sitemap found: where squirrel looks and what to add" icon="circle-exclamation" href="/rules/crawl/sitemap-exists">
+    Without a sitemap, discovery depends entirely on internal links. squirrel checks the common locations and robots.txt, and counts the URLs it found.
   </Card>
-  <Card title="Sitemap Lastmod Churn" icon="triangle-exclamation" href="/rules/crawl/sitemap-lastmod-churn">
-    Detects build-stamped lastmod values that carry no real freshness signal
+  <Card title="Sitemap lastmod stamped at build time: how to detect it" icon="triangle-exclamation" href="/rules/crawl/sitemap-lastmod-churn">
+    If every lastmod carries the same date, the field records your deploy, not your content. squirrel counts distinct days across the sitemap.
   </Card>
-  <Card title="Sitemap Lastmod Drift" icon="triangle-exclamation" href="/rules/crawl/sitemap-lastmod-drift">
-    Checks that sitemap lastmod matches the page's own dateModified
+  <Card title="Sitemap lastmod disagrees with the page's dateModified" icon="triangle-exclamation" href="/rules/crawl/sitemap-lastmod-drift">
+    When lastmod and the page's own dateModified disagree, one of them is wrong. squirrel compares them per URL and separates the two directions.
   </Card>
-  <Card title="Sitemap Valid" icon="circle-exclamation" href="/rules/crawl/sitemap-valid">
-    Validates sitemap structure and URL limits
+  <Card title="Sitemap validation: XML errors and the 50,000 entry limit" icon="circle-exclamation" href="/rules/crawl/sitemap-valid">
+    A sitemap that fails to parse or exceeds the protocol limits is ignored past the break. squirrel reports errors per file and checks entry counts.
   </Card>
-  <Card title="Soft 404" icon="triangle-exclamation" href="/rules/crawl/soft-404">
-    Detects pages that serve 404/error content with an HTTP 200 status
+  <Card title="Soft 404: error content served with an HTTP 200 status" icon="triangle-exclamation" href="/rules/crawl/soft-404">
+    A not-found page that answers 200 gets crawled and can be indexed as thin content. squirrel detects the error shell and re-checks it before reporting.
   </Card>
 </CardGroup>
 

--- a/docs/rules/crawl/index.mdx
+++ b/docs/rules/crawl/index.mdx
@@ -3,7 +3,7 @@ title: "Crawlability"
 description: "Robots.txt, sitemaps, and crawl directives"
 ---
 
-Robots.txt, sitemaps, and crawl directives
+Crawlability rules cover the layer before ranking: whether a search engine can reach a page, is permitted to index it, and is being told the truth about it. They read robots.txt, every discovered sitemap, the robots directives in each page's head and headers, and the redirect chains the crawl recorded. Most findings here are configuration mismatches rather than content problems, which makes them cheap to fix and easy to ship by accident.
 
 ## Rules
 
@@ -33,7 +33,7 @@ Robots.txt, sitemaps, and crawl directives
     Checks that paginated pages have proper canonicals
   </Card>
   <Card title="PDF Size" icon="triangle-exclamation" href="/rules/crawl/pdf-size">
-    Checks linked PDF sizes against Googlebot 64MB truncation limit
+    Checks linked PDF sizes against a 60MB default truncation threshold
   </Card>
   <Card title="Redirect Chains" icon="triangle-exclamation" href="/rules/crawl/redirect-chain">
     Detects multi-hop redirect chains that waste crawl budget
@@ -76,3 +76,5 @@ Robots.txt, sitemaps, and crawl directives
 [rules]
 disable = ["crawl/*"]
 ```
+
+Every audit reports Crawlability findings next to the performance, security and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.

--- a/docs/rules/crawl/indexability-conflicts.mdx
+++ b/docs/rules/crawl/indexability-conflicts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "robots.txt vs noindex: the two conflicts and which one matters"
+title: "robots.txt vs noindex: the two conflicts explained"
 description: "A page blocked in robots.txt can never be read for its noindex tag. squirrel compares the crawl rules against the page directives, both ways."
 ---
 

--- a/docs/rules/crawl/indexability-conflicts.mdx
+++ b/docs/rules/crawl/indexability-conflicts.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Indexability Conflicts"
-description: "Detects conflicting signals between robots.txt and meta/headers"
+title: "robots.txt vs noindex: the two conflicts and which one matters"
+description: "A page blocked in robots.txt can never be read for its noindex tag. squirrel compares the crawl rules against the page directives, both ways."
 ---
 
-Detects conflicting signals between robots.txt and meta/headers
+## What an indexability conflict is
+
+robots.txt controls crawling and a robots meta tag controls indexing. They are different mechanisms applied at different moments, and combining them wrongly produces two distinct situations.
+
+The first is a page robots.txt allows that then carries `noindex`. That works: the crawler fetches the page, reads the directive and drops it. Two mechanisms are declaring the same intent, which is confusing but harmless. The second is a page robots.txt blocks that also carries `noindex`. That does not work as intended, because the crawler never fetches the page and so never sees the tag. The URL can still be indexed from links elsewhere with no description.
+
+## What squirrel checks
+
+The rule is site-wide. For each crawled page it tests robots.txt against the URL and runs the shared indexability test over the page's head and headers, then sorts the disagreements into two buckets.
+
+- Skipped when there is no robots.txt or no pages. Message: `Insufficient data (no robots.txt or pages)`.
+- `robots-allow-but-noindex` warns for pages robots.txt allows that are not indexable by meta or header. Message: `6 page(s) allowed in robots.txt but have noindex`, with up to three paths in the value and a `+N more` suffix.
+- `robots-block-without-noindex` reports info for pages robots.txt blocks that are otherwise indexable. Message: `12 page(s) blocked by robots.txt (noindex meta not needed)`.
+- `conflicts` passes when neither bucket has an entry. Message: `No indexability conflicts detected`.
+
+Severity is warning and the weight is 4.
+
+## How to fix it
+
+```
+# robots.txt: let the crawler in so it can read the directive
+User-agent: *
+Allow: /private-preview/
+```
+
+To keep a page out of the index, let it be crawled and use `noindex`. To save crawl budget on pages nobody should fetch, use `Disallow` and drop the meta tag, accepting that a URL can still be listed without a description.
+
+Use one mechanism per page and pick it based on what you want: `noindex` removes a page from results, `Disallow` stops the fetch.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Detects conflicting signals between robots.txt and meta/headers
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Conflicting signals confuse search engines and indicate configuration errors. Type 1 conflict: robots.txt allows BUT meta/header has noindex (works but confusing - choose one method). Type 2 conflict: robots.txt disallows BUT page crawlable (search engines can't crawl to see noindex anyway - remove unnecessary noindex or allow in robots.txt).
 
 ## Enable / disable
 
@@ -40,3 +63,30 @@ disable = ["crawl/*"]
 enable = ["crawl/indexability-conflicts"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/robots-meta-conflict](/rules/crawl/robots-meta-conflict): the same blocked-plus-noindex case, reported on its own.
+- [crawl/all-noindex-pages](/rules/crawl/all-noindex-pages): the full list of blocked pages with their reasons.
+- [crawl/robots-txt](/rules/crawl/robots-txt): the syntax and rules of the file being compared.
+- [crawl/indexability](/rules/crawl/indexability): the per-page verdict for one URL.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Robots meta tag and X-Robots-Tag, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
+- [Introduction to robots.txt, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots/intro)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Each conflicting page is listed by path, split by which conflict it is. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/indexability-conflicts.mdx
+++ b/docs/rules/crawl/indexability-conflicts.mdx
@@ -7,7 +7,9 @@ description: "A page blocked in robots.txt can never be read for its noindex tag
 
 robots.txt controls crawling and a robots meta tag controls indexing. They are different mechanisms applied at different moments, and combining them wrongly produces two distinct situations.
 
-The first is a page robots.txt allows that then carries `noindex`. That works: the crawler fetches the page, reads the directive and drops it. Two mechanisms are declaring the same intent, which is confusing but harmless. The second is a page robots.txt blocks that also carries `noindex`. That does not work as intended, because the crawler never fetches the page and so never sees the tag. The URL can still be indexed from links elsewhere with no description.
+The first is a page robots.txt allows that then carries `noindex`. That is the combination that works, and it is how you keep a page out of the index: the crawler has to fetch the page to read the directive. It is reported here so you can confirm the exclusion was deliberate.
+
+The second is a page robots.txt blocks that carries no `noindex` at all. The crawler never fetches it, so nothing on the page can influence indexing either way, and the URL can still be listed from links elsewhere with no description. Adding a `noindex` to such a page would not help, which is the point of the informational status.
 
 ## What squirrel checks
 
@@ -28,9 +30,9 @@ User-agent: *
 Allow: /private-preview/
 ```
 
-To keep a page out of the index, let it be crawled and use `noindex`. To save crawl budget on pages nobody should fetch, use `Disallow` and drop the meta tag, accepting that a URL can still be listed without a description.
+When you are relying on `noindex`, allow the crawl. The directive only works if the page is fetched, so a `Disallow` on the same path defeats it.
 
-Use one mechanism per page and pick it based on what you want: `noindex` removes a page from results, `Disallow` stops the fetch.
+When the goal is saving crawl budget on pages nobody should fetch, `Disallow` alone is the right tool, and the URL can still be listed without a description. Pick based on which of the two you want: `noindex` removes a page from results, `Disallow` stops the fetch.
 
 | | |
 |---|---|

--- a/docs/rules/crawl/indexability.mdx
+++ b/docs/rules/crawl/indexability.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Indexability Check"
-description: "Identifies pages blocked from search engine indexing"
+title: "Page is blocked from indexing: finding the directive"
+description: "A page can be excluded from search by a robots meta tag or an X-Robots-Tag header. squirrel reports which one, per page."
 ---
 
-Identifies pages blocked from search engine indexing
+## What indexability is
+
+Indexability is whether a search engine is permitted to keep a page in its index once it has fetched it. Two mechanisms say no: a `<meta name="robots" content="noindex">` tag in the head, and an `X-Robots-Tag: noindex` response header. Either one is enough.
+
+Being non-indexable is often correct. Thank-you pages, faceted filter combinations, internal search results and staging routes are all better left out. The problem is a directive nobody meant to ship, which is why this rule reports the state and the source rather than treating it as a defect.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits a single check named `indexability`, using the shared indexability test over the parsed head and the response headers.
+
+- Skipped when the page could not be parsed. Message: `Page could not be parsed`.
+- Info when the page is not indexable. Message: `Page is blocked from indexing via robots meta tag`, or `via X-Robots-Tag header`, or `via unknown` when neither string contains `noindex`. The value is `not indexable`.
+- Pass when it is indexable. Message: `Page is indexable`, value `indexable`.
+
+The source is decided by looking for `noindex` in the lowercased `robots` meta first, then in the lowercased `x-robots-tag` header. Severity is info and the weight is 2, so this rule describes rather than penalises.
+
+## How to fix it
+
+```html
+<meta name="robots" content="index, follow" />
+```
+
+Remove the `noindex` from whichever source the report names. A header set at the CDN or reverse proxy is easy to miss because it does not appear in the page source, so check the response headers when the report says `X-Robots-Tag`.
+
+Leave the directive in place when the page is genuinely not meant for search. The info status exists for that case.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Identifies pages blocked from search engine indexing
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## Solution
-
-If this page should be indexed by search engines, remove 'noindex' from robots meta tag or X-Robots-Tag header. If the page is intentionally blocked (e.g., admin pages, thank-you pages), this is expected behavior.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["crawl/*"]
 enable = ["crawl/indexability"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/all-noindex-pages](/rules/crawl/all-noindex-pages): the same question rolled up across the whole site, with severity patterns.
+- [crawl/noindex-in-sitemap](/rules/crawl/noindex-in-sitemap): noindexed pages you are still submitting in a sitemap.
+- [crawl/indexability-conflicts](/rules/crawl/indexability-conflicts): robots.txt and the page directives disagreeing.
+- [crawl/schema-noindex-conflict](/rules/crawl/schema-noindex-conflict): rich-result markup on a page that will never be indexed.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Robots meta tag and X-Robots-Tag, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
+- [Block search indexing with noindex, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/block-indexing)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every blocked page is listed with the directive that blocked it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/indexability.mdx
+++ b/docs/rules/crawl/indexability.mdx
@@ -14,7 +14,7 @@ Being non-indexable is often correct. Thank-you pages, faceted filter combinatio
 The rule runs on every crawled page and emits a single check named `indexability`, using the shared indexability test over the parsed head and the response headers.
 
 - Skipped when the page could not be parsed. Message: `Page could not be parsed`.
-- Info when the page is not indexable. Message: `Page is blocked from indexing via robots meta tag`, or `via X-Robots-Tag header`, or `via unknown` when neither string contains `noindex`. The value is `not indexable`.
+- Info when the page is not indexable. Message: `Page is blocked from indexing via robots meta tag` or `via X-Robots-Tag header`. The value is `not indexable`. A third wording, `via unknown`, exists in the code but is unreachable: a page is only non-indexable here when one of those two strings contains `noindex`.
 - Pass when it is indexable. Message: `Page is indexable`, value `indexable`.
 
 The source is decided by looking for `noindex` in the lowercased `robots` meta first, then in the lowercased `x-robots-tag` header. Severity is info and the weight is 2, so this rule describes rather than penalises.

--- a/docs/rules/crawl/noindex-in-sitemap.mdx
+++ b/docs/rules/crawl/noindex-in-sitemap.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Noindex in Sitemap"
-description: "Checks for noindexed pages listed in sitemap"
+title: "Noindexed page in sitemap: why it is a contradiction"
+description: "A sitemap says crawl this, noindex says do not index it. squirrel cross-references every crawled page's robots meta against your sitemap URLs."
 ---
 
-Checks for noindexed pages listed in sitemap
+## What a noindex in a sitemap means
+
+A sitemap is a list of URLs you are asking search engines to crawl and consider for indexing. A `noindex` robots directive on a page tells them to drop it from the index once they have crawled it. Listing a noindexed URL in the sitemap asks for both at once.
+
+Nothing breaks, and the `noindex` wins. What it costs is crawl budget and clarity: the crawler spends a fetch on a page it will then discard, and in Search Console the URL is reported as excluded by noindex while your sitemap keeps submitting it. The usual cause is a sitemap generator that enumerates routes without reading the robots directives the pages render.
+
+## What squirrel checks
+
+The rule is site-wide. It collects every `<loc>` from every discovered sitemap, then walks the crawled pages looking for a `noindex` token in the `robots` meta tag, matched against the sitemap URLs as-is.
+
+- Skipped when no sitemap was discovered or no page data is available. Message: `Sitemap or page data not available`.
+- Warn when at least one noindexed page appears in a sitemap. Message: `3 noindexed page(s) found in sitemap`, with each URL listed. Severity warning, weight 5.
+- Pass otherwise. Message: `No noindexed pages in sitemap`.
+
+The `robots` meta value is lowercased and split on commas before the `noindex` token is looked for, so `noindex, follow` matches. Only the meta tag is read here: an `X-Robots-Tag` response header carrying `noindex` is not part of this comparison, and `crawl/all-noindex-pages` covers that case.
+
+## How to fix it
+
+```xml
+<!-- drop the noindexed URL from sitemap.xml -->
+<url>
+  <loc>https://example.com/thank-you</loc>
+</url>
+```
+
+Fix it in the generator rather than the file. Most frameworks expose the same route metadata the page uses to render its robots tag, so the sitemap builder can filter on it. If the page should be indexed, remove the `noindex` instead.
+
+A staging `noindex` left in a production template produces this finding across the whole site. Check one page's rendered head before editing the sitemap.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks for noindexed pages listed in sitemap
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Pages with noindex meta tags should not be in your sitemap. Sitemaps tell search engines which pages to index, while noindex tells them not to. Having both sends mixed signals. Remove noindexed pages from your sitemap, or remove the noindex directive if you want them indexed. Use a sitemap generator that respects robots directives.
 
 ## Enable / disable
 
@@ -40,3 +63,30 @@ disable = ["crawl/*"]
 enable = ["crawl/noindex-in-sitemap"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/indexability](/rules/crawl/indexability): whether an individual page is indexable at all, and why not.
+- [crawl/all-noindex-pages](/rules/crawl/all-noindex-pages): the full list of blocked pages, including header-based noindex.
+- [crawl/sitemap-coverage](/rules/crawl/sitemap-coverage): the opposite gap, indexable pages missing from the sitemap.
+- [crawl/robots-meta-conflict](/rules/crawl/robots-meta-conflict): noindex on a page robots.txt already blocks, so nobody reads it.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Block search indexing with noindex, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/block-indexing)
+- [Build and submit a sitemap, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every noindexed sitemap URL is listed with its address. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/pagination.mdx
+++ b/docs/rules/crawl/pagination.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Pagination"
-description: "Checks that paginated pages have proper canonicals"
+title: "Pagination canonicals: why page 2 should not canonicalize to page 1"
+description: "Canonicalizing every paginated page to page 1 hides the rest of the sequence. squirrel detects paginated URLs and checks where their canonical points."
 ---
 
-Checks that paginated pages have proper canonicals
+## What pagination canonicals are
+
+A paginated listing splits one set of items across several URLs. Each of those URLs holds different items, so each is a distinct page rather than a duplicate of the first.
+
+Pointing every page's canonical at page 1 tells search engines the rest do not exist as separate documents, which is how items that only appear on page 4 stop being discovered. The correct arrangement is a self-referencing canonical on each page. The `rel="next"` and `rel="prev"` link relations describe the sequence; Google stopped using them as an indexing signal in 2019, and they remain valid HTML that other clients may read.
+
+## What squirrel checks
+
+The rule runs on every crawled page. A page counts as paginated when its URL carries a `page`, `p`, `pg`, `offset` or `start` query parameter, or when its path ends in `/page/<number>`. It also looks for `link[rel="next"]` and `link[rel="prev"]` in the head.
+
+- Skipped when the page is neither paginated nor carrying pagination links. Message: `Page does not appear to be paginated`.
+- `pagination-canonical` warns when a paginated page has a canonical that is not itself paginated. Message: `Paginated page canonicalizes to non-paginated URL`, with the value `Page 3 → https://example.com/blog`. It passes otherwise with `Paginated page has appropriate canonical`. This check only runs when a canonical tag is present.
+- `pagination-links` reports info when `rel="next"` or `rel="prev"` is present. Message: `Pagination links present`, with `prev, next` as the value.
+- `pagination-links` reports info when the page is paginated with neither link. Message: `No rel=next/prev links (optional)`.
+
+Severity is info and the weight is 4, so this rule surfaces the pattern rather than penalising it.
+
+## How to fix it
+
+```html
+<link rel="canonical" href="https://example.com/blog?page=3" />
+<link rel="prev" href="https://example.com/blog?page=2" />
+<link rel="next" href="https://example.com/blog?page=4" />
+```
+
+Give each paginated URL a canonical that points at itself. Make sure the items on each page are reachable by a crawler without JavaScript, and consider a view-all page as the canonical target only when it genuinely lists everything.
+
+A filtered listing whose parameters happen to include `p` or `start` is treated as paginated by the URL test. Disable the rule for those routes if the canonical is deliberate.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks that paginated pages have proper canonicals
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 4/10 |
-
-## Solution
-
-Paginated pages should NOT all canonicalize to page 1. Each page should have a self-referencing canonical. Use rel='next' and rel='prev' links to indicate pagination sequence (though Google no longer uses these for indexing, they help users). Consider view-all pages or infinite scroll as alternatives. Ensure each paginated page has unique, valuable content.
 
 ## Enable / disable
 
@@ -40,3 +63,30 @@ disable = ["crawl/*"]
 enable = ["crawl/pagination"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): canonical tags that resolve through a redirect.
+- [links/dead-end-pages](/rules/links/dead-end-pages): listing pages that lead nowhere further.
+- [crawl/sitemap-coverage](/rules/crawl/sitemap-coverage): whether the paginated URLs are in the sitemap at all.
+- [content/duplicate-title](/rules/content/duplicate-title): paginated pages sharing one title.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Pagination and incremental page loading, Google Search Central](https://developers.google.com/search/docs/specialty/ecommerce/pagination-and-incremental-page-loading)
+- [Consolidate duplicate URLs, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every paginated page is listed with where its canonical points. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/pagination.mdx
+++ b/docs/rules/crawl/pagination.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Pagination canonicals: why page 2 should not canonicalize to page 1"
+title: "Pagination canonicals: why page 2 is not page 1"
 description: "Canonicalizing every paginated page to page 1 hides the rest of the sequence. squirrel detects paginated URLs and checks where their canonical points."
 ---
 

--- a/docs/rules/crawl/pdf-size.mdx
+++ b/docs/rules/crawl/pdf-size.mdx
@@ -1,9 +1,35 @@
 ---
-title: "PDF Size"
-description: "Checks linked PDF sizes against Googlebot 60MB truncation limit"
+title: "PDF size: large linked documents and what gets indexed"
+description: "A very large PDF may only be read in part by a crawler. squirrel measures every internal PDF the crawl fetched and reports the outliers."
 ---
 
-Checks linked PDF sizes against Googlebot 60MB truncation limit
+## What the PDF size question is
+
+Search engines index PDFs as documents in their own right, extracting text, title and links. Like HTML, a PDF is read up to a limit rather than in full, and content past that point does not contribute to what the document ranks for.
+
+Google publishes a 15 MB fetch limit for HTML and text-based files and does not publish a separate figure for PDFs. squirrel's thresholds, 30 MB for a warning and 60 MB for a failure, are its own defaults and are configurable. Either way, a 60 MB PDF is a slow download for a human as well as a crawler, and is usually a scanned document that could be compressed or split.
+
+## What squirrel checks
+
+The rule is site-wide and reads PDF sizes the crawl fetched ahead of time. When no size data is present it first looks for internal PDF links, meaning links ending in `.pdf` whose origin matches the site base URL.
+
+- Skipped when no pages were crawled. Message: `No pages crawled`.
+- Pass when there is no size data and no internal PDF link exists. Message: `No internal PDF links found`.
+- Skipped when internal PDF links exist but no sizes were fetched. Message: `PDF size data not available`.
+- `pdf-size` fails at or above `error_bytes`, 60 MB by default. Message: `2 PDF(s) exceed Googlebot 60MB limit`, each listed with its size in megabytes. Severity error, weight 4.
+- `pdf-size-warn` warns at or above `warn_bytes`, 30 MB by default. Message: `3 PDF(s) exceed 30MB — approaching Googlebot 60MB limit`.
+- `pdf-size` passes when every measured PDF is under the warning threshold. Message: `14 PDF(s) checked — all under 30MB`.
+- `pdf-size-errors` reports info for PDFs whose size could not be fetched. Message: `Could not check 2 PDF(s)`.
+
+The messages name a 60 MB Googlebot limit, which is the rule's own default threshold rather than a figure Google publishes.
+
+## How to fix it
+
+```
+X-Robots-Tag: noindex
+```
+
+Compress the images inside the document, split a long report into chapters, or serve an HTML version and keep the PDF as a download. Where a PDF does not need to appear in search at all, send `X-Robots-Tag: noindex` on its response, which works for non-HTML files that cannot carry a meta tag.
 
 | | |
 |---|---|
@@ -13,27 +39,19 @@ Checks linked PDF sizes against Googlebot 60MB truncation limit
 | **Severity** | error |
 | **Weight** | 4/10 |
 
-## Solution
-
-Googlebot truncates PDFs at 60MB: content beyond that limit is ignored during indexing. Split large documents into smaller parts, compress images within PDFs, or add a noindex X-Robots-Tag header if the PDF doesn't need to appear in search results.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `warn_bytes` | number | `31457280` (30MB) | Byte size to trigger warning |
-| `error_bytes` | number | `62914560` (60MB) | Byte size to trigger error (Googlebot truncation limit) |
-| `max_pdfs_to_check` | number | `50` | Maximum number of PDF links to check |
+| `warn_bytes` | number | `31457280` | Byte size to trigger warning |
+| `error_bytes` | number | `62914560` | Byte size to trigger error (Googlebot truncation limit) |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."crawl/pdf-size"]
-warn_bytes = 31457280
-error_bytes = 62914560
-max_pdfs_to_check = 50
+[rule_options."crawl/pdf-size"]
+warn_bytes = 10485760
+error_bytes = 26214400
 ```
 
 ## Enable / disable
@@ -59,3 +77,30 @@ disable = ["crawl/*"]
 enable = ["crawl/pdf-size"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/html-size](/rules/crawl/html-size): the same measurement applied to HTML documents.
+- [crawl/indexability](/rules/crawl/indexability): the `X-Robots-Tag` header this rule's fix uses.
+- [links/broken-links](/rules/links/broken-links): PDF links that no longer resolve.
+- [content/mime-type](/rules/content/mime-type): documents served with the wrong content type.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Googlebot, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/googlebot)
+- [Robots meta tag and X-Robots-Tag, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every measured PDF over the threshold is listed with its size. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/pdf-size.mdx
+++ b/docs/rules/crawl/pdf-size.mdx
@@ -7,13 +7,13 @@ description: "A very large PDF may only be read in part by a crawler. squirrel m
 
 Search engines index PDFs as documents in their own right, extracting text, title and links. Like HTML, a PDF is read up to a limit rather than in full, and content past that point does not contribute to what the document ranks for.
 
-Google publishes a 15 MB fetch limit for HTML and text-based files and does not publish a separate figure for PDFs. squirrel's thresholds, 30 MB for a warning and 60 MB for a failure, are its own defaults and are configurable. Either way, a 60 MB PDF is a slow download for a human as well as a crawler, and is usually a scanned document that could be compressed or split.
+Google documents a 64 MB fetch limit for PDFs, against 2 MB for any other individual URL. squirrel's thresholds sit just under it: 30 MB for a warning and 60 MB for a failure, both configurable. Either way, a 60 MB PDF is a slow download for a person as well as a crawler, and is usually a scanned document that could be compressed or split.
 
 ## What squirrel checks
 
 The rule is site-wide and reads PDF sizes the crawl fetched ahead of time. When no size data is present it first looks for internal PDF links, meaning links ending in `.pdf` whose origin matches the site base URL.
 
-- Skipped when no pages were crawled. Message: `No pages crawled`.
+- Skipped when no PDF sizes were fetched and no pages were crawled. Message: `No pages crawled`. A non-empty size list is processed regardless of the page count.
 - Pass when there is no size data and no internal PDF link exists. Message: `No internal PDF links found`.
 - Skipped when internal PDF links exist but no sizes were fetched. Message: `PDF size data not available`.
 - `pdf-size` fails at or above `error_bytes`, 60 MB by default. Message: `2 PDF(s) exceed Googlebot 60MB limit`, each listed with its size in megabytes. Severity error, weight 4.
@@ -21,7 +21,7 @@ The rule is site-wide and reads PDF sizes the crawl fetched ahead of time. When 
 - `pdf-size` passes when every measured PDF is under the warning threshold. Message: `14 PDF(s) checked — all under 30MB`.
 - `pdf-size-errors` reports info for PDFs whose size could not be fetched. Message: `Could not check 2 PDF(s)`.
 
-The messages name a 60 MB Googlebot limit, which is the rule's own default threshold rather than a figure Google publishes.
+The messages name a 60 MB Googlebot limit. That is the rule's own default threshold; the figure Google documents is 64 MB.
 
 ## How to fix it
 
@@ -89,7 +89,7 @@ Crawlability findings ship in every audit next to the SEO, performance and agent
 
 ## References
 
-- [Googlebot, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/googlebot)
+- [Inside Googlebot: crawling, fetching and the bytes we process, Google Search Central](https://developers.google.com/search/blog/2026/03/crawler-blog-post)
 - [Robots meta tag and X-Robots-Tag, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
 
 ## Check your site

--- a/docs/rules/crawl/redirect-chain.mdx
+++ b/docs/rules/crawl/redirect-chain.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Redirect Chains"
-description: "Detects multi-hop redirect chains that waste crawl budget"
+title: "Redirect chains: when one hop turns into three"
+description: "Each redirect hop costs latency and crawl budget, and search engines stop following after a few. squirrel counts the hops on every crawled URL."
 ---
 
-Detects multi-hop redirect chains that waste crawl budget
+## What a redirect chain is
+
+A redirect chain is more than one redirect between the requested URL and the page that answers. `http://example.com` to `https://example.com` to `https://www.example.com` to `https://www.example.com/` is three hops for one request.
+
+Chains accumulate rather than being designed. Each migration adds a layer: a protocol switch, a host consolidation, a slash convention, a site restructure. The cost is a round trip per hop for every visitor who takes the old URL, and a crawler that may give up before the end. The fix is to collapse the rules so each source URL points at the final destination in one step.
+
+## What squirrel checks
+
+The rule is site-wide and reads the redirect chain the crawler recorded for each page. It emits up to two kinds of check:
+
+- Skipped when no pages are available. Message: `No pages available for redirect chain analysis`.
+- `entry-url-redirect`, one per finding, when the site's base URL itself redirected. It warns above `maxHops` with `Entry URL has 3-hop redirect chain`, and reports info at or below it with `Entry URL redirects (1 hop)`. The entry URL is reported even for a single hop, because the address people type should answer directly.
+- `redirect-chain` warns for other pages whose chain exceeds `maxHops`. Message: `4 page(s) have redirect chains >2 hops`, listing each URL with its hop count and the chain rendered as `/old (301) → /new (301) → /final (200)`.
+- `redirect-chain` passes when neither fired. Message: `No redirect chains exceed 2 hops`.
+
+The default `maxHops` is 2. Severity warning, weight 5.
+
+## How to fix it
+
+```nginx
+# one rule, one hop: scheme, host and slash resolved together
+server {
+  listen 80;
+  server_name example.com www.example.com;
+  return 301 https://www.example.com$request_uri;
+}
+```
+
+Collapse the rules so each source URL reaches its destination in one hop. Then update internal links, canonical tags and the sitemap to the final URLs, so no ordinary navigation takes a redirect at all.
 
 | | |
 |---|---|
@@ -13,23 +41,17 @@ Detects multi-hop redirect chains that waste crawl budget
 | **Severity** | warning |
 | **Weight** | 5/10 |
 
-## Solution
-
-Each redirect hop adds latency and consumes crawl budget. Search engines may stop following after 5+ hops. Consolidate redirect chains to a single hop by updating the source URL to point directly to the final destination. Common causes: HTTP→HTTPS→www→trailing slash combinations, or legacy domain migrations.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `maxHops` | unknown | `undefined` | Flag redirect chains exceeding this many hops |
+| `maxHops` | integer, 1 or more | `2` | Flag redirect chains exceeding this many hops |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."crawl/redirect-chain"]
-maxHops = undefined
+[rule_options."crawl/redirect-chain"]
+maxHops = 1
 ```
 
 ## Enable / disable
@@ -55,3 +77,30 @@ disable = ["crawl/*"]
 enable = ["crawl/redirect-chain"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): a canonical tag that points into one of these chains.
+- [links/redirect-chains](/rules/links/redirect-chains): internal links that walk a chain on every click.
+- [security/http-to-https](/rules/security/http-to-https): the HTTP to HTTPS hop that usually starts one.
+- [url/trailing-slash](/rules/url/trailing-slash): the slash convention that usually adds the last one.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [301 redirects and Google Search](https://developers.google.com/search/docs/crawling-indexing/301-redirects)
+- [Managing crawl budget for large sites, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/large-site-managing-crawl-budget)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every chain is listed with its hop count and the full path it takes. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/redirect-chain.mdx
+++ b/docs/rules/crawl/redirect-chain.mdx
@@ -5,7 +5,7 @@ description: "Each redirect hop costs latency and crawl budget, and search engin
 
 ## What a redirect chain is
 
-A redirect chain is more than one redirect between the requested URL and the page that answers. `http://example.com` to `https://example.com` to `https://www.example.com` to `https://www.example.com/` is three hops for one request.
+A redirect chain is more than one redirect between the requested URL and the page that answers. `http://example.com/page` to `https://example.com/page` to `https://www.example.com/page` to `https://www.example.com/page/` is three redirects for one request.
 
 Chains accumulate rather than being designed. Each migration adds a layer: a protocol switch, a host consolidation, a slash convention, a site restructure. The cost is a round trip per hop for every visitor who takes the old URL, and a crawler that may give up before the end. The fix is to collapse the rules so each source URL points at the final destination in one step.
 
@@ -18,12 +18,12 @@ The rule is site-wide and reads the redirect chain the crawler recorded for each
 - `redirect-chain` warns for other pages whose chain exceeds `maxHops`. Message: `4 page(s) have redirect chains >2 hops`, listing each URL with its hop count and the chain rendered as `/old (301) → /new (301) → /final (200)`.
 - `redirect-chain` passes when neither fired. Message: `No redirect chains exceed 2 hops`.
 
-The default `maxHops` is 2. Severity warning, weight 5.
+The default `maxHops` is 2. The count is the number of entries in the recorded chain, and that includes the final non-redirect response, so `/old (301) → /new (301) → /final (200)` counts as three hops rather than two redirects. Severity warning, weight 5.
 
 ## How to fix it
 
 ```nginx
-# one rule, one hop: scheme, host and slash resolved together
+# scheme and host in a single hop
 server {
   listen 80;
   server_name example.com www.example.com;
@@ -31,7 +31,7 @@ server {
 }
 ```
 
-Collapse the rules so each source URL reaches its destination in one hop. Then update internal links, canonical tags and the sitemap to the final URLs, so no ordinary navigation takes a redirect at all.
+Collapse the rules so each source URL reaches its destination in one hop. `$request_uri` carries the original path and query through unchanged, so a slash convention needs its own routing rule rather than falling out of this one. Then update internal links, canonical tags and the sitemap to the final URLs, so no ordinary navigation takes a redirect at all.
 
 | | |
 |---|---|

--- a/docs/rules/crawl/robots-meta-conflict.mdx
+++ b/docs/rules/crawl/robots-meta-conflict.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Redundant noindex: a blocked page nobody can read the tag on"
+title: "Redundant noindex: a blocked page nobody reads it on"
 description: "A page disallowed in robots.txt is never fetched, so its noindex is never seen. squirrel lists the pages carrying both."
 ---
 

--- a/docs/rules/crawl/robots-meta-conflict.mdx
+++ b/docs/rules/crawl/robots-meta-conflict.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Robots Meta Conflict"
-description: "Detects conflicts between robots meta tags and robots.txt"
+title: "Redundant noindex: a blocked page nobody can read the tag on"
+description: "A page disallowed in robots.txt is never fetched, so its noindex is never seen. squirrel lists the pages carrying both."
 ---
 
-Detects conflicts between robots meta tags and robots.txt
+## What a redundant noindex is
+
+When robots.txt disallows a path, a compliant crawler does not request it. Any directive in that page's HTML, including `noindex`, is therefore never read.
+
+The combination is common because both look like ways to keep a page out of search. They are not interchangeable. `Disallow` prevents the fetch; `noindex` removes the page from the index after a fetch. Applying both means the second has no effect, and the URL can still appear in results as a bare link discovered elsewhere.
+
+## What squirrel checks
+
+The rule is site-wide. For each crawled page it takes the URL path and tests it against the `*` user-agent group in robots.txt, matching a `Disallow` whose path is `/` or which the page path starts with. It then looks for a `noindex` token in the `robots` meta tag.
+
+- Skipped when there is no robots.txt or no pages. Message: `Insufficient data to check for conflicts`.
+- `redundant-noindex` reports info for pages that are both blocked and carry `noindex`. Message: `4 page(s) blocked in robots.txt also have noindex`, with `noindex won't be seen if page is blocked from crawling` as the value.
+- `robots-conflict` passes. Message: `No robots meta/robots.txt conflicts detected`.
+
+The `robots-conflict` check always passes in the current implementation: its warn branch is never reached, so the only finding this rule produces is the informational one. Severity for the rule is warning, weight 5.
+
+The path test only reads the `*` group, so a `Disallow` written for a named user-agent such as `Googlebot` is not considered here.
+
+## How to fix it
+
+```
+# robots.txt: remove the Disallow so the noindex is readable
+User-agent: *
+Allow: /archive/
+```
+
+Pick one. If the goal is keeping the page out of results, allow the crawl and keep `noindex`. If the goal is saving crawl budget on a section nobody should fetch, keep the `Disallow` and drop the meta tag.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Detects conflicts between robots meta tags and robots.txt
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Robots.txt and robots meta tags should work together, not conflict. If robots.txt blocks a URL, search engines won't see the meta robots tag at all. Common conflicts: blocking a page in robots.txt while trying to noindex it (unnecessary), or allowing in robots.txt but noindexing (works but confusing). For noindex, let the page be crawled so the directive is seen. For blocked pages, robots.txt alone is sufficient.
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["crawl/*"]
 enable = ["crawl/robots-meta-conflict"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/indexability-conflicts](/rules/crawl/indexability-conflicts): the same comparison, plus the allowed-but-noindexed case.
+- [crawl/robots-txt](/rules/crawl/robots-txt): the file this rule reads its rules from.
+- [crawl/all-noindex-pages](/rules/crawl/all-noindex-pages): every blocked page with the reason it is blocked.
+- [crawl/noindex-in-sitemap](/rules/crawl/noindex-in-sitemap): noindexed pages you are still submitting.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Robots meta tag and X-Robots-Tag, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
+- [How Google interprets the robots.txt specification](https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Each page carrying both directives is counted and named. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/robots-txt.mdx
+++ b/docs/rules/crawl/robots-txt.mdx
@@ -1,9 +1,39 @@
 ---
-title: "Robots.txt"
-description: "Checks if robots.txt exists and is properly configured"
+title: "robots.txt: what to put in it and how squirrel checks it"
+description: "A missing robots.txt, a Disallow: / left in production, or a syntax error changes what gets crawled. squirrel checks existence, syntax and rules."
 ---
 
-Checks if robots.txt exists and is properly configured
+## What robots.txt is
+
+`robots.txt` is a plain text file at the root of a host that tells automated clients which paths they may request. It is defined by RFC 9309 and consists of `User-agent` groups, each with `Allow` and `Disallow` rules, plus optional `Sitemap` lines that can appear anywhere in the file.
+
+It controls crawling, not indexing. A URL blocked in robots.txt can still be indexed from links elsewhere, because the crawler never fetches it and so never sees a `noindex`. It is also advisory: it constrains well-behaved crawlers and does nothing about anything else.
+
+## What squirrel checks
+
+The rule is site-wide and reads the robots.txt the crawl fetched. It emits up to five checks:
+
+- `robots-txt-exists` reports info when no robots.txt data is available at all. Message: `robots.txt data not available`.
+- `robots-txt-exists` reports info when the probe recorded an error, so absence was never established. Message: `robots.txt could not be checked`, with `The request did not complete, so this is unknown, not missing` as the value.
+- `robots-txt-exists` fails when the file is confirmed absent. Message: `No robots.txt found`, with `Search engines will crawl all accessible pages` as the value. Severity error, weight 8.
+- `robots-txt-exists` passes when the file exists. Message: `robots.txt exists`, with the file URL.
+- `robots-txt-syntax` warns when the parser recorded errors. Message: `2 syntax error(s) in robots.txt`, listing each. It passes otherwise with `robots.txt syntax is valid`.
+- `robots-txt-disallow` fails when the `*` group has `Disallow: /` and no `Allow` rule. Message: `robots.txt blocks all crawling`, with `Disallow: / with no Allow rules`. It reports info when there is a `Disallow: /` alongside `Allow` exceptions, and passes otherwise with `robots.txt does not block all crawling`.
+- `robots-txt-sitemap` passes when at least one `Sitemap` line is present, listing the URLs. Otherwise it reports info with `No sitemap referenced in robots.txt`.
+- `robots-txt-size` warns when the file exceeds 500 KB. Message: `robots.txt is very large`, with the size and Google's 500 KB limit as the value.
+
+## How to fix it
+
+```
+User-agent: *
+Allow: /
+
+Sitemap: https://example.com/sitemap.xml
+```
+
+Serve it from the host root with a `text/plain` content type. Keep `Disallow` for paths that genuinely waste crawl budget, such as faceted search and session URLs, and use `noindex` rather than `Disallow` when the goal is keeping a page out of results.
+
+Do not block the CSS, JavaScript or image paths a renderer needs. A page rendered without its stylesheet can be judged as broken or as having hidden text.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks if robots.txt exists and is properly configured
 | **Scope** | Site-wide |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-robots.txt tells search engines which pages to crawl. Place it at the root of your domain (example.com/robots.txt). Include your sitemap URL. Avoid blocking important resources (CSS, JS, images) that search engines need to render pages. Never use 'Disallow: /' unless you want to block all crawling. Use Google Search Console to test your robots.txt.
 
 ## Enable / disable
 
@@ -40,3 +66,31 @@ disable = ["crawl/*"]
 enable = ["crawl/robots-txt"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-exists](/rules/crawl/sitemap-exists): the sitemap the `Sitemap` line should point at.
+- [crawl/indexability-conflicts](/rules/crawl/indexability-conflicts): pages where robots.txt and the page directives disagree.
+- [crawl/robots-meta-conflict](/rules/crawl/robots-meta-conflict): noindex on a page robots.txt already blocks, so nobody reads it.
+- [ax/ai-crawlers](/rules/ax/ai-crawlers): the same file read for AI crawler user-agents.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Introduction to robots.txt, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/robots/intro)
+- [How Google interprets the robots.txt specification](https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt)
+- [RFC 9309: Robots Exclusion Protocol](https://datatracker.ietf.org/doc/html/rfc9309)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. The file is reported with its syntax errors, its blocking rules and its sitemap references. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/schema-noindex-conflict.mdx
+++ b/docs/rules/crawl/schema-noindex-conflict.mdx
@@ -17,7 +17,7 @@ The rule is site-wide. For each crawled page it extracts the rich-result types f
 - Fail when at least one page has rich-result schema and is not indexable. Message: `3 page(s) have rich schema but are blocked from indexing`. The value lists up to five as the path, the schema types found, and the reasons it is blocked, such as `meta:noindex` or `robots.txt:disallowed`.
 - Pass otherwise. Message: `No schema+noindex conflicts`.
 
-Severity error, weight 8. Only schema types that can produce a rich result count; generic `WebPage` or `Organization` markup does not trigger the rule.
+Severity error, weight 8. The types that count come from a fixed list: `Article`, `NewsArticle`, `BlogPosting`, `Product`, `Review`, `Recipe`, `Event`, `FAQPage`, `HowTo`, `LocalBusiness`, `Organization`, `Person`, `VideoObject`, `BreadcrumbList`, `WebSite` and `SearchAction`. A plain `WebPage` node does not trigger the rule. The list is squirrel's own and is not tied to what Google currently supports: `HowTo` is on it although its Google rich result was retired.
 
 ## How to fix it
 

--- a/docs/rules/crawl/schema-noindex-conflict.mdx
+++ b/docs/rules/crawl/schema-noindex-conflict.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Schema + Noindex Conflict"
-description: "Detects pages with rich result schema that are blocked from indexing"
+title: "Rich result schema on a noindexed page: wasted markup"
+description: "Structured data on a page search engines cannot index will never produce a rich result. squirrel finds pages carrying both."
 ---
 
-Detects pages with rich result schema that are blocked from indexing
+## What the conflict is
+
+Rich results are the enhanced listings search engines build from structured data: review stars, recipe times, event dates, product prices. They appear in search results, which means the page has to be in the index for them to exist at all.
+
+Markup on a page that is blocked from indexing produces nothing. It is not harmful, but it is effort spent on a page that will never show it, and it usually means one of the two decisions was made without knowing about the other: a template that emits schema for every post type, applied to a post type someone later set to `noindex`.
+
+## What squirrel checks
+
+The rule is site-wide. For each crawled page it extracts the rich-result types from the page's structured data, skips pages with none, then runs the shared indexability test over the head, headers, URL and robots.txt. It emits a single check named `schema-noindex`:
+
+- Skipped when there are no pages. Message: `No pages to check`.
+- Fail when at least one page has rich-result schema and is not indexable. Message: `3 page(s) have rich schema but are blocked from indexing`. The value lists up to five as the path, the schema types found, and the reasons it is blocked, such as `meta:noindex` or `robots.txt:disallowed`.
+- Pass otherwise. Message: `No schema+noindex conflicts`.
+
+Severity error, weight 8. Only schema types that can produce a rich result count; generic `WebPage` or `Organization` markup does not trigger the rule.
+
+## How to fix it
+
+```html
+<meta name="robots" content="index, follow" />
+```
+
+Decide which of the two is wrong. If the page should rank with a rich result, remove the directive the report names. If it should stay out of the index, remove the structured data from that template so the markup stops being generated.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Detects pages with rich result schema that are blocked from indexing
 | **Scope** | Site-wide |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Pages with rich result schemas (Article, Product, Recipe, Event, etc.) should be indexed so search engines can display rich results. Having schema markup on noindexed pages wastes effort and prevents rich results from appearing. Remove noindex directive or remove schema markup if page shouldn't be indexed.
 
 ## Enable / disable
 
@@ -40,3 +58,30 @@ disable = ["crawl/*"]
 enable = ["crawl/schema-noindex-conflict"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/indexability](/rules/crawl/indexability): the per-page verdict and which directive produced it.
+- [crawl/all-noindex-pages](/rules/crawl/all-noindex-pages): every blocked page, with the same reason strings.
+- [schema/json-ld-valid](/rules/schema/json-ld-valid): whether the markup itself parses and validates.
+- [schema/article](/rules/schema/article): one of the rich-result types this rule counts.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Search gallery of rich results, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/search-gallery)
+- [Block search indexing with noindex, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/block-indexing)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Each page is listed with its schema types and the reason it is blocked. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/sitemap-4xx.mdx
+++ b/docs/rules/crawl/sitemap-4xx.mdx
@@ -1,9 +1,31 @@
 ---
-title: "4XX Pages in Sitemap"
-description: "Checks for sitemap URLs returning 4XX status codes"
+title: "4XX pages in sitemap: dead URLs you are still submitting"
+description: "A sitemap entry that returns 404 wastes a crawl and teaches search engines to trust the file less. squirrel reports the status of every checked entry."
 ---
 
-Checks for sitemap URLs returning 4XX status codes
+## What a 4XX sitemap entry is
+
+A sitemap lists URLs you are asking a crawler to fetch. An entry that answers with a 4XX status is a request you asked for and cannot serve: 404 for a page that no longer exists, 403 for one behind auth, 410 for one deliberately removed.
+
+Each one costs a fetch that could have gone to a real page, and a sitemap with many of them is a weaker signal overall. The usual causes are a generator reading a stale cache, a content deletion that never propagated to the sitemap, and URLs built from data that has since changed.
+
+## What squirrel checks
+
+The rule is site-wide and reads the status codes the crawl recorded for sitemap URLs. It emits up to two checks:
+
+- Skipped when no sitemap was discovered. Message: `No sitemap to compare`.
+- `sitemap-4xx` passes when no sitemap URL statuses were collected. Message: `No sitemap URL checks available`.
+- `sitemap-4xx` warns when entries returned a status from 400 to 499. Message: `9 sitemap URL(s) return 4XX`, with each URL listed alongside its status and any fetch error. Severity warning, weight 6.
+- `sitemap-4xx` passes otherwise. Message: `No 4XX pages found in sitemap URLs checked`.
+- `sitemap-rate-limited` reports info for entries the host throttled. Message: `5 sitemap URL(s) rate-limited - status unverifiable`.
+
+Rate-limit responses are separated deliberately. A 429, a 430 or a 503 carrying `Retry-After` sits inside or near the 4XX band but says the host throttled the audit, not that the URL is dead, so those entries are excluded from the warn list and reported on their own.
+
+## How to fix it
+
+Remove the dead entries and regenerate from live data. Where a URL moved, redirect it and list the destination instead: a sitemap should hold final URLs, not redirects.
+
+A rate-limited run leaves entries unverified rather than failing them. Re-run with a lower concurrency if you need a definite answer for those URLs.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Checks for sitemap URLs returning 4XX status codes
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## Solution
-
-Sitemaps should only list URLs that return 200 and are intended for indexing. Remove 4XX URLs from the sitemap or fix them by restoring the content or redirecting to a valid page. Keep sitemap entries clean to avoid wasting crawl budget.
 
 ## Enable / disable
 
@@ -40,3 +58,30 @@ disable = ["crawl/*"]
 enable = ["crawl/sitemap-4xx"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-coverage](/rules/crawl/sitemap-coverage): the reverse gap, pages missing from the sitemap.
+- [crawl/sitemap-valid](/rules/crawl/sitemap-valid): structural problems in the same files.
+- [links/broken-links](/rules/links/broken-links): internal links that point at the same dead URLs.
+- [crawl/soft-404](/rules/crawl/soft-404): pages that return 200 while showing an error, which this check cannot see.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Build and submit a sitemap, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [HTTP status codes and Google Search](https://developers.google.com/search/docs/crawling-indexing/http-network-errors)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every failing entry is listed with the status code it returned. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/sitemap-coverage.mdx
+++ b/docs/rules/crawl/sitemap-coverage.mdx
@@ -7,7 +7,7 @@ description: "A page you want indexed that is in no sitemap depends entirely on 
 
 Coverage is the overlap between the pages a crawl reaches and the URLs a sitemap lists. Two gaps are possible and they mean different things.
 
-A crawled, indexable page that is not in the sitemap relies on internal links to be found. That is usually fine for a well-linked page and a real problem for one buried several levels deep. A sitemap URL the crawl never reached is the reverse: either the page is orphaned from the site's own navigation, or the crawl simply stopped before reaching it.
+A crawled, indexable page that is not in the sitemap relies on internal links to be found. That is usually fine for a well-linked page and a real problem for one buried several levels deep. A sitemap URL the crawl never reached is the reverse: either the page is orphaned from the site's own navigation, or the crawl stopped before reaching it.
 
 ## What squirrel checks
 

--- a/docs/rules/crawl/sitemap-coverage.mdx
+++ b/docs/rules/crawl/sitemap-coverage.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Sitemap Coverage"
-description: "Checks for indexable pages that are not in the sitemap"
+title: "Indexable pages missing from the sitemap: measuring the gap"
+description: "A page you want indexed that is in no sitemap depends entirely on link discovery. squirrel diffs the crawl against the sitemap in both directions."
 ---
 
-Checks for indexable pages that are not in the sitemap
+## What sitemap coverage is
+
+Coverage is the overlap between the pages a crawl reaches and the URLs a sitemap lists. Two gaps are possible and they mean different things.
+
+A crawled, indexable page that is not in the sitemap relies on internal links to be found. That is usually fine for a well-linked page and a real problem for one buried several levels deep. A sitemap URL the crawl never reached is the reverse: either the page is orphaned from the site's own navigation, or the crawl simply stopped before reaching it.
+
+## What squirrel checks
+
+The rule is site-wide. It uses the sitemap processor's precomputed missing and orphan lists, and falls back to computing the missing list itself when that is empty. The fallback skips pages whose status is not 200 and pages carrying a `noindex` in the `robots` meta, then checks both the page URL and its final URL against the normalised sitemap URLs.
+
+- Skipped when no sitemap was discovered. Message: `No sitemap to compare`.
+- Skipped when no pages were crawled. Message: `No pages to compare`.
+- `sitemap-coverage` warns when indexable pages are missing. Message: `23 indexable page(s) not in sitemap (18%)`, where the percentage is of all crawled pages. It passes otherwise with `All indexable pages are in sitemap`. Severity warning, weight 5.
+- `sitemap-orphans` warns for sitemap URLs the crawl did not reach. Message: `31 sitemap URL(s) were not crawled`.
+- `sitemap-orphans` reports info instead when the crawl hit its page cap and the sitemap holds more URLs than that cap. Message: `31 sitemap URL(s) not audited this run (crawl capped at 25 pages)`.
+
+The capped case matters because a shallow crawl profile against a large sitemap would otherwise report a crawl-budget artefact as a coverage defect.
+
+## How to fix it
+
+Generate the sitemap from the same route data the site renders from, filtered to indexable pages that return 200, and regenerate it on deploy.
+
+For sitemap URLs the crawl could not reach, check whether anything on the site links to them. A page that exists only in the sitemap is discoverable but not navigable, which is a different problem from a missing sitemap entry.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Checks for indexable pages that are not in the sitemap
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Your sitemap should include all pages you want search engines to index. Pages that are crawlable and indexable (no noindex, not blocked by robots.txt) should generally be in your sitemap. Missing pages may not be discovered or indexed efficiently. Use a sitemap generator that automatically includes all indexable pages, or manually add important pages.
 
 ## Enable / disable
 
@@ -40,3 +58,30 @@ disable = ["crawl/*"]
 enable = ["crawl/sitemap-coverage"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-exists](/rules/crawl/sitemap-exists): whether there is a sitemap to compare against.
+- [crawl/noindex-in-sitemap](/rules/crawl/noindex-in-sitemap): the reverse mistake, submitting pages you have blocked.
+- [links/orphan-pages](/rules/links/orphan-pages): pages with too few inbound internal links to be found.
+- [crawl/sitemap-4xx](/rules/crawl/sitemap-4xx): listed URLs that resolve to an error.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Build and submit a sitemap, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [Sitemaps overview, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Both gaps are listed by URL, with the missing-page share as a percentage. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/sitemap-domain.mdx
+++ b/docs/rules/crawl/sitemap-domain.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Sitemap Domain"
-description: "Checks that all sitemap URLs belong to the expected domain"
+title: "Cross-domain sitemap URL: why search engines ignore it"
+description: "A sitemap can only vouch for URLs on its own host. squirrel compares every sitemap entry's hostname against your base URL."
 ---
 
-Checks that all sitemap URLs belong to the expected domain
+## What cross-submission means
+
+A sitemap speaks for the host that serves it. A search engine will not accept a `<loc>` pointing at a different domain from a sitemap at `example.com/sitemap.xml`, because anyone could then submit URLs on someone else's behalf.
+
+The `www` and bare forms of the same registrable name are treated as the same site here, since one is normally a redirect to the other. Anything further away is either a configuration mistake, usually a generator with the wrong base URL, or a leftover from a domain migration.
+
+## What squirrel checks
+
+The rule is site-wide. It takes the hostname of the site's base URL, then compares it against the hostname of every `<loc>` in every discovered sitemap, lowercased.
+
+- Skipped when no sitemap was discovered. Message: `No sitemap to validate`.
+- Skipped when the base URL has no parseable hostname. Message: `Could not determine expected domain`.
+- Fail when any entry's hostname differs. Message: `14 URL(s) point to different domain(s)`, listing each URL with the host it resolved to. Severity error, weight 8.
+- Pass otherwise. Message: `All sitemap URLs match site domain`.
+
+A hostname matches when it equals the expected host, equals `www.` plus the expected host, or when `www.` plus itself equals the expected host. Entries whose `<loc>` has no parseable hostname are skipped rather than flagged.
+
+## How to fix it
+
+```xml
+<url><loc>https://example.com/pricing</loc></url>
+```
+
+Set the generator's base URL to the canonical host and regenerate. Where a second domain genuinely has pages of its own, give it its own sitemap served from that host.
+
+A site that has just moved domains will produce this finding until the sitemap is regenerated. Fix the sitemap, not the redirects.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that all sitemap URLs belong to the expected domain
 | **Scope** | Site-wide |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-All URLs in your sitemap should point to pages on your own domain. Cross-domain URLs in sitemaps are a configuration error - search engines will ignore URLs that don't match the sitemap's domain. Remove external URLs from your sitemap or fix the domain in URLs if they're incorrectly formatted.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["crawl/*"]
 enable = ["crawl/sitemap-domain"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-valid](/rules/crawl/sitemap-valid): the structural checks over the same files.
+- [crawl/sitemap-4xx](/rules/crawl/sitemap-4xx): entries that resolve to an error rather than to another host.
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): canonical tags pointing somewhere other than the page itself.
+- [links/https-downgrade](/rules/links/https-downgrade): internal references that keep the wrong scheme.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Build and submit a sitemap, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [Sitemaps overview, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every cross-domain entry is listed with the host it points at. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/sitemap-domain.mdx
+++ b/docs/rules/crawl/sitemap-domain.mdx
@@ -5,9 +5,9 @@ description: "A sitemap can only vouch for URLs on its own host. squirrel compar
 
 ## What cross-submission means
 
-A sitemap speaks for the host that serves it. A search engine will not accept a `<loc>` pointing at a different domain from a sitemap at `example.com/sitemap.xml`, because anyone could then submit URLs on someone else's behalf.
+A sitemap normally speaks for the host that serves it, so a `<loc>` on another domain is usually a generator with the wrong base URL or a leftover from a migration.
 
-The `www` and bare forms of the same registrable name are treated as the same site here, since one is normally a redirect to the other. Anything further away is either a configuration mistake, usually a generator with the wrong base URL, or a leftover from a domain migration.
+Cross-submission is not forbidden. Google accepts URLs for another host when you have verified ownership of both, or when the other host's robots.txt names the sitemap. This rule does not know about either arrangement: it compares hostnames only, treating the `www` and bare forms of one registrable name as the same site. A deliberate, authorised cross-submission will therefore be flagged.
 
 ## What squirrel checks
 
@@ -26,9 +26,9 @@ A hostname matches when it equals the expected host, equals `www.` plus the expe
 <url><loc>https://example.com/pricing</loc></url>
 ```
 
-Set the generator's base URL to the canonical host and regenerate. Where a second domain genuinely has pages of its own, give it its own sitemap served from that host.
+Set the generator's base URL to the canonical host and regenerate. A site that has just moved domains will produce this finding until the sitemap is rebuilt; fix the sitemap, not the redirects.
 
-A site that has just moved domains will produce this finding until the sitemap is regenerated. Fix the sitemap, not the redirects.
+If the cross-domain entries are intentional, verify both hosts in Search Console or reference the sitemap from the other host's robots.txt, and disable this rule for that site.
 
 | | |
 |---|---|
@@ -73,7 +73,7 @@ Crawlability findings ship in every audit next to the SEO, performance and agent
 
 ## References
 
-- [Build and submit a sitemap, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [Sitemaps FAQs, including cross-submission, Google Search Central](https://developers.google.com/search/blog/2008/01/sitemaps-faqs)
 - [Sitemaps overview, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview)
 
 ## Check your site

--- a/docs/rules/crawl/sitemap-exists.mdx
+++ b/docs/rules/crawl/sitemap-exists.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Sitemap Exists"
-description: "Checks if XML sitemap exists and is referenced in robots.txt"
+title: "No XML sitemap found: where squirrel looks and what to add"
+description: "Without a sitemap, discovery depends entirely on internal links. squirrel checks the common locations and robots.txt, and counts the URLs it found."
 ---
 
-Checks if XML sitemap exists and is referenced in robots.txt
+## What an XML sitemap is
+
+An XML sitemap is a file listing the URLs on a site that you want search engines to know about, each in a `<loc>` element with optional `<lastmod>`. It supplements link discovery rather than replacing it: a URL in a sitemap is a suggestion to crawl, not an instruction to index.
+
+It matters most where link discovery is weak. New sites with few inbound links, large archives where old pages are many clicks deep, and sections reachable only through search or filters all benefit. A single sitemap file holds at most 50,000 URLs and 50 MB uncompressed; beyond that you use a sitemap index that points at several files.
+
+## What squirrel checks
+
+The rule is site-wide and reads what sitemap discovery found. It emits up to three checks:
+
+- `sitemap-exists` reports info when no sitemap data is available. Message: `Sitemap data not available`.
+- `sitemap-exists` reports info when discovery was truncated before every candidate location was tried, so nothing was established. Message: `Sitemap discovery did not complete, so no sitemap check was made`, with `Not all candidate locations were reached` as the value.
+- `sitemap-exists` fails when discovery finished and found nothing. Message: `No XML sitemap found`, with `Checked common locations and robots.txt` as the value. Severity error, weight 10, the highest in the Crawlability category.
+- `sitemap-exists` passes when sitemaps were found. Message: `2 sitemap(s) found`, listing each with its URL count.
+- `sitemap-in-robots` runs only when robots.txt exists. It passes when a `Sitemap` line was one of the discovery sources, and otherwise reports info with `Sitemap not referenced in robots.txt`.
+- `sitemap-urls` reports info with the total. Message: `Sitemap contains 412 URL(s)`.
+
+## How to fix it
+
+```
+Sitemap: https://example.com/sitemap.xml
+```
+
+Generate the sitemap from the same source of truth your routes come from, serve it at a stable URL, and add the `Sitemap` line to robots.txt so discovery does not depend on guessing filenames.
+
+List only canonical, indexable URLs that return 200. A sitemap full of redirects and noindexed pages is worse than a smaller accurate one.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks if XML sitemap exists and is referenced in robots.txt
 | **Scope** | Site-wide |
 | **Severity** | error |
 | **Weight** | 10/10 |
-
-## Solution
-
-XML sitemaps help search engines discover and index your pages. Create a sitemap.xml at your domain root listing all important pages. Reference it in robots.txt with 'Sitemap: https://yoursite.com/sitemap.xml'. Submit it to Google Search Console and Bing Webmaster Tools. Keep it under 50MB and 50,000 URLs per file; use a sitemap index for larger sites.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["crawl/*"]
 enable = ["crawl/sitemap-exists"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-valid](/rules/crawl/sitemap-valid): whether the sitemap that exists parses and respects the protocol limits.
+- [crawl/sitemap-coverage](/rules/crawl/sitemap-coverage): indexable pages the sitemap leaves out.
+- [crawl/sitemap-4xx](/rules/crawl/sitemap-4xx): sitemap URLs that no longer resolve.
+- [crawl/robots-txt](/rules/crawl/robots-txt): the file that should carry the `Sitemap` line.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Build and submit a sitemap, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [Sitemaps overview, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Each discovered sitemap is listed with its URL count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/sitemap-exists.mdx
+++ b/docs/rules/crawl/sitemap-exists.mdx
@@ -14,7 +14,7 @@ It matters most where link discovery is weak. New sites with few inbound links, 
 The rule is site-wide and reads what sitemap discovery found. It emits up to three checks:
 
 - `sitemap-exists` reports info when no sitemap data is available. Message: `Sitemap data not available`.
-- `sitemap-exists` reports info when discovery was truncated before every candidate location was tried, so nothing was established. Message: `Sitemap discovery did not complete, so no sitemap check was made`, with `Not all candidate locations were reached` as the value.
+- `sitemap-exists` reports info when discovery was truncated before every candidate location was tried and found nothing at all, so nothing was established. Message: `Sitemap discovery did not complete, so no sitemap check was made`, with `Not all candidate locations were reached` as the value. A truncated walk that did find a sitemap reports the pass below instead.
 - `sitemap-exists` fails when discovery finished and found nothing. Message: `No XML sitemap found`, with `Checked common locations and robots.txt` as the value. Severity error, weight 10, the highest in the Crawlability category.
 - `sitemap-exists` passes when sitemaps were found. Message: `2 sitemap(s) found`, listing each with its URL count.
 - `sitemap-in-robots` runs only when robots.txt exists. It passes when a `Sitemap` line was one of the discovery sources, and otherwise reports info with `Sitemap not referenced in robots.txt`.

--- a/docs/rules/crawl/sitemap-lastmod-churn.mdx
+++ b/docs/rules/crawl/sitemap-lastmod-churn.mdx
@@ -5,9 +5,9 @@ description: "If every lastmod carries the same date, the field records your dep
 
 ## What lastmod churn is
 
-`<lastmod>` is meant to record when a page's content last changed, so a crawler can prioritise what has actually moved. It only works if the values differ from one another.
+`<lastmod>` records when a page's content last changed, so a crawler can prioritise what has actually moved. Its usefulness depends on the values being derived from the content rather than from the pipeline that publishes it.
 
-A sitemap where every URL carries today's date is recording the build, not the content. The generator stamps the current time on every entry each time it runs. The field then carries no information, and a search engine that notices has no reason to trust it on that site again.
+When several hundred URLs all carry the same date, that is what a build-time stamp looks like: the generator writing the current time onto every entry each run. It is not proof, since a site really can republish everything on one day, and this is why the rule reports rather than fails. But a `lastmod` that moves on every deploy tells a crawler nothing it can act on.
 
 ## What squirrel checks
 

--- a/docs/rules/crawl/sitemap-lastmod-churn.mdx
+++ b/docs/rules/crawl/sitemap-lastmod-churn.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Sitemap Lastmod Churn"
-description: "Checks that sitemap lastmod values aren't all stamped with the same build date"
+title: "Sitemap lastmod stamped at build time: how to detect it"
+description: "If every lastmod carries the same date, the field records your deploy, not your content. squirrel counts distinct days across the sitemap."
 ---
 
-Checks that sitemap lastmod values aren't all stamped with the same build date
+## What lastmod churn is
+
+`<lastmod>` is meant to record when a page's content last changed, so a crawler can prioritise what has actually moved. It only works if the values differ from one another.
+
+A sitemap where every URL carries today's date is recording the build, not the content. The generator stamps the current time on every entry each time it runs. The field then carries no information, and a search engine that notices has no reason to trust it on that site again.
+
+## What squirrel checks
+
+The rule is site-wide. It walks every `<lastmod>` in every discovered sitemap, parses each into a calendar day, and counts distinct days. Google News sitemaps are excluded from the sample and counted separately.
+
+- Skipped when no sitemap was discovered. Message: `No sitemap to validate`.
+- Skipped when fewer than 20 non-news URLs carry a parseable `lastmod`. Message: `Only 8 sitemap URL(s) carry a lastmod; sitemap is too small to judge lastmod churn`.
+- Skipped with different wording when every `lastmod` came from a news sitemap. Message: `Only news-sitemap URLs carry a lastmod (140); news sitemaps hold ~48 hours of articles by design, so their lastmod values are excluded from this check`.
+- Warn when the values collapse onto two distinct days or fewer. Message: `412 sitemap URL(s) with lastmod collapse onto 1 distinct day(s): 2026-09-08 (from https://example.com/sitemap.xml)`, with each date listed as an item carrying its count. Severity warning, weight 4.
+- Pass otherwise. Message: `412 sitemap URL(s) with lastmod spread across 96 distinct days`.
+
+A Google News sitemap holds roughly 48 hours of articles by specification, so its `lastmod` values always cluster. Pooling them in would accuse every news publisher of build-stamping, which is why they are set aside.
+
+## How to fix it
+
+```xml
+<url>
+  <loc>https://example.com/blog/post</loc>
+  <lastmod>2026-03-14T09:12:00Z</lastmod>
+</url>
+```
+
+Drive `lastmod` from the content's own modification timestamp, whether that comes from the CMS field or from version control, and leave it alone when a deploy does not change the page. Omitting the element entirely is better than stamping it: an absent `lastmod` says nothing, and a wrong one says something false.
 
 | | |
 |---|---|
@@ -12,18 +39,6 @@ Checks that sitemap lastmod values aren't all stamped with the same build date
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-If every URL in your sitemap carries the same (or nearly the same) lastmod date, the field is being stamped at build/deploy time rather than reflecting real content changes. This makes lastmod useless as a freshness signal - search engines may learn to ignore it entirely. Update lastmod only when a page's content actually changes, driven by your CMS or version control history, not by the deploy pipeline. Google News sitemaps are excluded from this check: they hold only about 48 hours of articles by design, so their lastmod values are supposed to cluster.
-
-## What this rule does not count
-
-**Google News sitemaps are excluded.** A news sitemap (one declaring the `xmlns:news` namespace) carries roughly the last 48 hours of articles by specification, so its `lastmod` values always fall on one or two days. Counting them would flag every publisher that has one. Detection is by namespace, not filename, so a news sitemap served from any path is recognised.
-
-If the only `lastmod` values found on your site come from a news sitemap, the check reports as skipped and says so, rather than reporting a problem you do not have.
-
-The check needs at least 20 URLs carrying a `lastmod` (news-sitemap URLs excluded) before it will judge anything. Below that it skips, because a handful of pages legitimately updated in the same week is indistinguishable from a build stamp.
 
 ## Enable / disable
 
@@ -48,3 +63,30 @@ disable = ["crawl/*"]
 enable = ["crawl/sitemap-lastmod-churn"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-lastmod-drift](/rules/crawl/sitemap-lastmod-drift): lastmod that disagrees with the page's own dateModified.
+- [content/freshness](/rules/content/freshness): how old the content itself is.
+- [content/date-agreement](/rules/content/date-agreement): the dates a page shows in its markup and its text.
+- [crawl/sitemap-valid](/rules/crawl/sitemap-valid): structural problems in the same file.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Best practices for setting the lastmod element, Google Search Central](https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping)
+- [Build and submit a sitemap, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. The distinct dates are listed with how many URLs carry each one. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/sitemap-lastmod-churn.mdx
+++ b/docs/rules/crawl/sitemap-lastmod-churn.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 ## Related rules
 
 - [crawl/sitemap-lastmod-drift](/rules/crawl/sitemap-lastmod-drift): lastmod that disagrees with the page's own dateModified.
-- [content/freshness](/rules/content/freshness): how old the content itself is.
+- [content/freshness](/rules/content/freshness): which date signals the page publishes about itself.
 - [content/date-agreement](/rules/content/date-agreement): the dates a page shows in its markup and its text.
 - [crawl/sitemap-valid](/rules/crawl/sitemap-valid): structural problems in the same file.
 

--- a/docs/rules/crawl/sitemap-lastmod-drift.mdx
+++ b/docs/rules/crawl/sitemap-lastmod-drift.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Sitemap Lastmod Drift"
-description: "Checks that sitemap lastmod matches the page's own dateModified"
+title: "Sitemap lastmod disagrees with the page's dateModified"
+description: "When lastmod and the page's own dateModified disagree, one of them is wrong. squirrel compares them per URL and separates the two directions."
 ---
 
-Checks that sitemap lastmod matches the page's own dateModified
+## What lastmod drift is
+
+A page usually carries its own modification date twice: once in the sitemap as `<lastmod>`, and once on the page as schema `dateModified` or a visible updated date. Both are supposed to describe the same event.
+
+When they disagree, the sitemap generator and the page renderer are reading different fields. A `lastmod` older than the page's own date tells crawlers not to bother with a page that has in fact changed, and usually means a stale cached sitemap or a generator resolving `publishedAt` where the page renders `updatedAt`. A `lastmod` newer than the page's date usually means it is stamped at deploy time.
+
+## What squirrel checks
+
+The rule is site-wide. For each crawled page it looks up the sitemap `lastmod` by normalised URL, then resolves the page's own date from the first of three sources that yields a usable value: the `dateModified` of the JSON-LD node describing this document, the `dateModified` markup the parser lifted from the page, or the visible published date. Pages with no `lastmod` or no page-side date are skipped rather than reported.
+
+- Skipped when no sitemap was discovered. Message: `No sitemap to compare`.
+- Skipped when no pages were crawled. Message: `No pages to compare`.
+- Skipped when no URL had both values. Message: `No sitemap URL carries both a lastmod and a page-side date signal`.
+- `sitemap-lastmod-behind-page` warns when the page's own date is newer than `lastmod` by more than `behind_days`, 7 by default. Message: `12 page(s) have a sitemap lastmod older than the page's own dateModified by more than 7 day(s)`.
+- `sitemap-lastmod-ahead-of-page` warns when `lastmod` is newer than the page's date by more than `ahead_days`, 30 by default. Message: `40 page(s) have a sitemap lastmod newer than the page's own dateModified by more than 30 day(s)`.
+- `sitemap-lastmod-drift` passes when neither fired. Message: `220 sitemap URL(s) carry a lastmod consistent with the page's own dateModified`.
+
+Each item reads `lastmod 2026-01-04 vs dateModified 2026-03-14 (69 day(s))` and records which of the three sources the page date came from. The day count is truncated rather than rounded, so a 7.5 day gap reports as 7 and does not warn. Findings are capped at 50 items, with the real total in the details. Severity warning, weight 4.
+
+An Article-family JSON-LD node wins over any other document node wherever it sits in the graph, so a sitewide `WebSite` node emitted first by an SEO plugin cannot supply the date.
+
+## How to fix it
+
+Drive both values from the same content-modification timestamp. Check the field precedence on each side: a generator reading `publishedAt ?? updatedAt` while the page renders `updatedAt ?? publishedAt` passes every presence check and still disagrees on every post that was ever edited.
 
 | | |
 |---|---|
@@ -13,67 +36,19 @@ Checks that sitemap lastmod matches the page's own dateModified
 | **Severity** | warning |
 | **Weight** | 4/10 |
 
-## What it checks
-
-For every crawled page that appears in a sitemap with a `lastmod`, the rule compares that
-`lastmod` against the page's own strongest date signal: schema.org `dateModified`, else the
-`dateModified`-equivalent markup (`[itemprop="dateModified"]` meta / `<time>`), else the visible
-published date. Pages with no date signal at all are skipped: that is
-[Content Freshness](/rules/content/freshness) territory, not drift.
-
-### Which JSON-LD node the date comes from
-
-Only the node that describes the **document** is read: an `Article`, `BlogPosting`,
-`NewsArticle` or similar, else a page-level node such as `WebPage`, `FAQPage` or `Recipe`. A
-sitewide `WebSite`, `Organization`, `Product` or `SoftwareApplication` node carries its own
-`dateModified` that has nothing to do with when this page changed, and Yoast and Rank Math emit
-one *first* in `@graph`, ahead of the article. Those nodes are ignored, and an article node is
-preferred over a page-level one wherever the two sit, so moving a sitewide node around the
-`@graph` cannot change the verdict.
-
-Types may be written bare (`Article`), as a full IRI (`https://schema.org/Article`) or against
-the `schema:` prefix, and a node may claim several at once (`["WebPage", "BlogPosting"]` counts
-as the article). The date itself may be a plain string, a `{"@value": "..."}` wrapper, or a
-list of either, in which case the first entry that parses as a date is used.
-
-If no document-describing node carries a usable `dateModified`, the rule falls through to the
-page's own markup and visible date rather than borrowing the sitewide one. The same scoping is
-applied by [Date Agreement](/rules/content/date-agreement).
-
-The two directions are reported as separate checks, because they point at different code:
-
-| Check | Fires when | Usual cause |
-|-------|-----------|-------------|
-| `sitemap-lastmod-behind-page` | `lastmod` is older than the page's `dateModified` by more than 7 days | Stale cached sitemap, or a generator resolving `publishedAt ?? updatedAt` while the page renders `updatedAt ?? publishedAt` |
-| `sitemap-lastmod-ahead-of-page` | `lastmod` is newer than the page's `dateModified` by more than 30 days | `lastmod` stamped at build/deploy time instead of on content change |
-
-Each finding reports both dates and the gap in days. The gap is counted in whole elapsed days,
-so a difference has to reach the next whole day past the threshold before it warns: with the
-default `behind_days = 7`, a 7.5-day gap passes and an 8-day gap warns. Same-day and
-within-threshold differences never warn.
-
-Lastmod being *older* than the page's own `dateModified` is the more clearly wrong of the two:
-it tells crawlers not to bother re-fetching a page that has in fact changed.
-
-## Solution
-
-A sitemap lastmod that disagrees with the page's own dateModified points at the sitemap generator, not the content. Lastmod OLDER than the page's dateModified tells crawlers not to bother with a page that has in fact changed - usually a stale cached sitemap, or a generator resolving `publishedAt ?? updatedAt` while the page renders `updatedAt ?? publishedAt` (a precedence inversion; both fields are present, so presence checks pass). Lastmod NEWER than the page's dateModified usually means lastmod is stamped at build/deploy time. Drive both values from the same content-modification timestamp.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `ahead_days` | number | `30` | Days a sitemap lastmod may run ahead of the page's own dateModified before warning |
 | `behind_days` | number | `7` | Days a sitemap lastmod may lag the page's own dateModified before warning |
 
-### Configuration Example
+### Configuration example
 
 ```toml squirrel.toml
-[rules."crawl/sitemap-lastmod-drift"]
-ahead_days = 30
-behind_days = 7
+[rule_options."crawl/sitemap-lastmod-drift"]
+ahead_days = 14
+behind_days = 3
 ```
 
 ## Enable / disable
@@ -99,3 +74,30 @@ disable = ["crawl/*"]
 enable = ["crawl/sitemap-lastmod-drift"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-lastmod-churn](/rules/crawl/sitemap-lastmod-churn): every lastmod carrying the same build date.
+- [content/date-agreement](/rules/content/date-agreement): the dates a single page shows in its own markup and text.
+- [content/freshness](/rules/content/freshness): how old the content is, independent of what it claims.
+- [eeat/content-dates](/rules/eeat/content-dates): whether the page publishes a date at all.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Best practices for setting the lastmod element, Google Search Central](https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping)
+- [dateModified, Schema.org](https://schema.org/dateModified)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Each mismatched URL is listed with both dates and the gap in days. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/sitemap-lastmod-drift.mdx
+++ b/docs/rules/crawl/sitemap-lastmod-drift.mdx
@@ -79,7 +79,7 @@ disable = ["*"]
 
 - [crawl/sitemap-lastmod-churn](/rules/crawl/sitemap-lastmod-churn): every lastmod carrying the same build date.
 - [content/date-agreement](/rules/content/date-agreement): the dates a single page shows in its own markup and text.
-- [content/freshness](/rules/content/freshness): how old the content is, independent of what it claims.
+- [content/freshness](/rules/content/freshness): which date signals the page publishes about itself.
 - [eeat/content-dates](/rules/eeat/content-dates): whether the page publishes a date at all.
 
 Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.

--- a/docs/rules/crawl/sitemap-valid.mdx
+++ b/docs/rules/crawl/sitemap-valid.mdx
@@ -1,9 +1,39 @@
 ---
-title: "Sitemap Valid"
-description: "Validates sitemap structure and URL limits"
+title: "Sitemap validation: XML errors and the 50,000 entry limit"
+description: "A sitemap that fails to parse or exceeds the protocol limits is ignored past the break. squirrel reports errors per file and checks entry counts."
 ---
 
-Validates sitemap structure and URL limits
+## What sitemap validity means
+
+A valid sitemap is well-formed XML in UTF-8, using the sitemap protocol namespace, with each URL in a `<loc>` element. A sitemap index uses a different root element and lists child sitemap files instead of URLs.
+
+The protocol caps a single file at 50,000 entries and 50 MB uncompressed. Those two limits apply separately to the two file types: a URL set is capped at 50,000 URLs, and an index is capped at 50,000 child sitemaps. Sites past either limit shard into several files behind an index.
+
+## What squirrel checks
+
+The rule is site-wide. It emits up to five checks:
+
+- `sitemap-fetch-failed` fails when a sitemap named in robots.txt could not be fetched, excluding ones the walk never requested. Message: `1 sitemap(s) from robots.txt failed to fetch`, listing each URL with its error.
+- `sitemap-valid` reports info when discovery was truncated with nothing found. Message: `Sitemap discovery did not complete, so no sitemap was validated`.
+- `sitemap-valid` is skipped when there is simply no sitemap. Message: `No sitemap to validate`.
+- `sitemap-syntax` fails when any discovered sitemap recorded parse errors. Message: `3 error(s) in 1 sitemap(s)`, listing each sitemap with its first error. It passes otherwise with `Sitemap XML syntax is valid`.
+- `sitemap-size` warns when a URL set holds more than 50,000 URLs, or an index holds more than 50,000 child sitemaps. Message: `1 sitemap(s) exceed the 50,000-entry protocol limit`. It passes otherwise with `All sitemaps within URL limits`.
+- `sitemap-orphans` reports info for sitemap URLs the crawl did not reach. Message: `12 URL(s) in sitemap not found during crawl`.
+- `sitemap-missing` reports info for crawled pages the sitemap does not list. Message: `7 crawled page(s) not in sitemap`.
+
+The URL count stored on a top-level index is the aggregated total across its children, which is why an index is measured against its child count rather than that total. Severity error, weight 8.
+
+## How to fix it
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap-posts-1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap-posts-2.xml</loc></sitemap>
+</sitemapindex>
+```
+
+Shard past 50,000 entries behind an index. For parse errors, look for unescaped ampersands and raw angle brackets in URLs, which is what hand-built or string-concatenated sitemaps usually get wrong.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Validates sitemap structure and URL limits
 | **Scope** | Site-wide |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Sitemaps must follow the sitemap protocol: use UTF-8 encoding, proper XML structure, and valid URLs. Each sitemap file can contain max 50,000 URLs and be max 50MB uncompressed. For larger sites, use a sitemap index file. All URLs should return 200 status codes. Use lastmod dates to indicate content freshness. Compress with gzip for faster loading.
 
 ## Enable / disable
 
@@ -40,3 +66,30 @@ disable = ["crawl/*"]
 enable = ["crawl/sitemap-valid"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/sitemap-exists](/rules/crawl/sitemap-exists): whether a sitemap was found at all.
+- [crawl/sitemap-domain](/rules/crawl/sitemap-domain): sitemap URLs pointing at a host that is not yours.
+- [crawl/sitemap-coverage](/rules/crawl/sitemap-coverage): the gap between what you crawl and what the sitemap lists.
+- [crawl/sitemap-lastmod-churn](/rules/crawl/sitemap-lastmod-churn): whether the `lastmod` values in it mean anything.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [Build and submit a sitemap, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [Sitemaps overview, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Each sitemap is listed with its parse errors and entry count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/crawl/sitemap-valid.mdx
+++ b/docs/rules/crawl/sitemap-valid.mdx
@@ -15,7 +15,7 @@ The rule is site-wide. It emits up to five checks:
 
 - `sitemap-fetch-failed` fails when a sitemap named in robots.txt could not be fetched, excluding ones the walk never requested. Message: `1 sitemap(s) from robots.txt failed to fetch`, listing each URL with its error.
 - `sitemap-valid` reports info when discovery was truncated with nothing found. Message: `Sitemap discovery did not complete, so no sitemap was validated`.
-- `sitemap-valid` is skipped when there is simply no sitemap. Message: `No sitemap to validate`.
+- `sitemap-valid` is skipped when no sitemap was found. Message: `No sitemap to validate`.
 
 Both of those branches only run when there was no reportable robots.txt fetch failure. When a sitemap named in robots.txt failed to fetch and discovery found nothing, the fetch failure is the only check returned.
 

--- a/docs/rules/crawl/sitemap-valid.mdx
+++ b/docs/rules/crawl/sitemap-valid.mdx
@@ -16,6 +16,9 @@ The rule is site-wide. It emits up to five checks:
 - `sitemap-fetch-failed` fails when a sitemap named in robots.txt could not be fetched, excluding ones the walk never requested. Message: `1 sitemap(s) from robots.txt failed to fetch`, listing each URL with its error.
 - `sitemap-valid` reports info when discovery was truncated with nothing found. Message: `Sitemap discovery did not complete, so no sitemap was validated`.
 - `sitemap-valid` is skipped when there is simply no sitemap. Message: `No sitemap to validate`.
+
+Both of those branches only run when there was no reportable robots.txt fetch failure. When a sitemap named in robots.txt failed to fetch and discovery found nothing, the fetch failure is the only check returned.
+
 - `sitemap-syntax` fails when any discovered sitemap recorded parse errors. Message: `3 error(s) in 1 sitemap(s)`, listing each sitemap with its first error. It passes otherwise with `Sitemap XML syntax is valid`.
 - `sitemap-size` warns when a URL set holds more than 50,000 URLs, or an index holds more than 50,000 child sitemaps. Message: `1 sitemap(s) exceed the 50,000-entry protocol limit`. It passes otherwise with `All sitemaps within URL limits`.
 - `sitemap-orphans` reports info for sitemap URLs the crawl did not reach. Message: `12 URL(s) in sitemap not found during crawl`.

--- a/docs/rules/crawl/soft-404.mdx
+++ b/docs/rules/crawl/soft-404.mdx
@@ -1,9 +1,43 @@
 ---
-title: "Soft 404"
-description: "Detects pages that serve 404/error content with an HTTP 200 status"
+title: "Soft 404: error content served with an HTTP 200 status"
+description: "A not-found page that answers 200 gets crawled and can be indexed as thin content. squirrel detects the error shell and re-checks it before reporting."
 ---
 
-Detects pages that serve 404/error content with an HTTP 200 status
+## What a soft 404 is
+
+A soft 404 is a page that tells a human the content is missing while telling a machine that everything is fine. The body says "page not found" and the response status is 200 rather than 404 or 410.
+
+Crawlers have no reason to stop requesting a URL that answers 200, so soft 404s consume crawl budget indefinitely and can be indexed as thin or duplicate content. Search engines try to detect them heuristically, which means you lose control of whether the URL is dropped and when. Single-page applications produce them easily, because the shell renders successfully and only the client-side route resolves to nothing.
+
+## What squirrel checks
+
+The signal itself is computed during parsing from the status code and the page content. The rule surfaces it and emits a single check named `soft-404`:
+
+- Pass when the page is not a soft 404. Message: `Page does not serve 404 content with a success status`.
+- Warn when it is, with the wording chosen by an end-of-crawl confirmation re-fetch. Severity warning, weight 5.
+
+Every warn message ends with the same sentence: `This check reads the server's HTML response and can differ from what a browser shows.` The part before it depends on the confirmation verdict:
+
+- Confirmed: `Page serves 404 content with HTTP 200.`
+- Intermittent, meaning the re-fetch returned real content: `Page intermittently serves 404 error content with HTTP 200.`
+- Unconfirmed: `Page serves 404 content with HTTP 200 (based on a single crawl observation).`
+- Unconfirmed after a rendered observation: `Page serves 404 content with HTTP 200 (based on the rendered crawl observation; cannot verify without JS rendering).`
+
+The value is the status code as `HTTP 200`, and each detection signal is listed as an item with its own detail. The intermittent case matters on sites where a CDN or incremental regeneration occasionally serves the error shell for a real page.
+
+## How to fix it
+
+```js
+export async function loader({ params }) {
+  const post = await getPost(params.slug);
+  if (!post) throw new Response("Not Found", { status: 404 });
+  return post;
+}
+```
+
+Return the real status from the server. For a client-rendered app, that means the server route has to know the resource is missing, which usually means resolving it during server rendering rather than after hydration.
+
+If the URL is valid and the finding is wrong, the page is emitting error-shell markup: a title or heading saying not found, or an error template that renders alongside the content.
 
 | | |
 |---|---|
@@ -12,31 +46,6 @@ Detects pages that serve 404/error content with an HTTP 200 status
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-A soft 404 is a URL that shows "not found" or error content but returns a success (2xx) status instead of a real 404 or 410. squirrelscan flags a page only when it shows at least two independent signals, with at least one strong content signal: a framework error-shell marker (for example `<html id="__next_error__">`), a "page not found" title or heading, plus supporting signals such as a robots `noindex` directive or near-empty content. A regular article that merely mentions "404" is never flagged.
-
-Soft 404s waste crawl budget and can be indexed as thin or duplicate content. They also cause downstream content, legal, and agent-experience rules to skip the page (with a visible `soft-404` skip reason), so one broken template can't spray per-page warnings.
-
-## Confirmation before warning
-
-Some sites intermittently serve an error shell (HTTP 200 with `noindex`) for real, existing pages because of transient CDN or incremental-static-regeneration behaviour. To avoid a confusing false positive, squirrelscan does not warn from a single observation: when a page trips the soft-404 signals during the crawl, it re-fetches that page once at the end of the crawl and re-runs detection.
-
-- The error shell reproduces: the standard soft 404 warning is reported.
-- The re-fetch returns real content: a distinct finding, "page intermittently serves 404 error content with HTTP 200", is reported instead. This is still a problem because crawlers can hit the poisoned variant and the `noindex` on it can deindex a real page, even though your browser may show the page normally.
-- The re-fetch is not possible (offline, a network error, or the confirmation budget is exhausted): the finding is reported but annotated as based on a single crawl observation.
-
-Every variant notes that the check reads the server's raw HTML response, which can differ from what a browser renders.
-
-The confirmation pass is on by default, is bounded to the flagged pages only, and stays polite: same-host re-fetches are sequential and honor the crawl's per-host delay, with an overall time budget. On rate-limited or staging hosts you can turn it off, in which case flagged pages are reported as unconfirmed rather than re-fetched:
-
-```toml squirrel.toml
-[integrity.soft404_confirm]
-enabled = false
-```
-
-## Solution
-
-Return a proper 404 (or 410 for permanently removed URLs) for missing pages, or restore the real content if the URL should resolve. If the URL is valid, remove the error-shell markup and the "page not found" title/heading so the page reads as a real page.
 
 ## Enable / disable
 
@@ -61,3 +70,30 @@ disable = ["crawl/*"]
 enable = ["crawl/soft-404"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/indexability](/rules/crawl/indexability): whether the same page is also blocked from indexing.
+- [links/broken-links](/rules/links/broken-links): internal links pointing at pages that fail outright.
+- [crawl/sitemap-4xx](/rules/crawl/sitemap-4xx): sitemap entries returning a real 4XX status.
+- [content/word-count](/rules/content/word-count): the thin-content side of the same page.
+
+Crawlability findings ship in every audit next to the SEO, performance and agent experience rules. See [The Screaming Frog alternative for agents](https://squirrelscan.com/learn/screaming-frog-alternative) for how an agent works through a report.
+
+## References
+
+- [HTTP status codes and Google Search](https://developers.google.com/search/docs/crawling-indexing/http-network-errors)
+- [Managing crawl budget for large sites, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/large-site-managing-crawl-budget)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Crawlability section of the report. Every soft 404 is listed with the signals that identified it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Crawlability section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/about-page.mdx
+++ b/docs/rules/eeat/about-page.mdx
@@ -74,7 +74,7 @@ E-E-A-T findings ship in every audit next to the SEO, performance and agent expe
 
 ## Check your site
 
-Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The About page is reported with its URL and word count. Local audits are free.
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The About page is reported with its URL when it passes, or its word count when the content is thin. Local audits are free.
 
 <CardGroup cols={2}>
   <Card title="Install squirrel" icon="terminal" href="/quickstart">

--- a/docs/rules/eeat/about-page.mdx
+++ b/docs/rules/eeat/about-page.mdx
@@ -1,9 +1,30 @@
 ---
-title: "About Page"
-description: "Checks for an about/company page with content"
+title: "About page: what it establishes and how squirrel finds it"
+description: "An About page is where a reader decides whether you are a real organisation. squirrel finds it by URL or schema and checks it has content."
 ---
 
-Checks for an about/company page with content
+## What an About page is for
+
+An About page answers who is behind this site. For a reader deciding whether to trust what they are reading, it is often the second page they open, and for Google's helpful-content guidance it is where the who and the why of a site are supposed to be answerable.
+
+A page that exists and says three sentences does not do that job. What makes it work is specifics: who runs the organisation, what they have done, how long they have been doing it, and how to reach them.
+
+## What squirrel checks
+
+The rule is site-wide. It looks for an About page in two ways: a URL path matching one of the multilingual about patterns, or a page whose structured data declares the `AboutPage` type. The first match wins. It emits a single check named `about-page`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when the page is found and has 200 words or more. Message: `About page exists with substantial content`, with the URL as the value. Severity warning, weight 5.
+- Info when it is found with fewer than 200 words. Message: `About page exists but has limited content`, with `84 words - consider expanding` as the value.
+- Warn when no About page was found. Message: `No About page found`, with `Create /about or /about-us page` as the value.
+
+The schema fallback exists so a localised path the URL patterns do not recognise is still found.
+
+## How to fix it
+
+Write the page for someone who has never heard of you: who runs this, what you do, what you have done before, where you are. Link it from the main navigation or the footer so it is reachable from every page.
+
+The word threshold is a proxy for that. Padding the page to 200 words does not make it convincing.
 
 | | |
 |---|---|
@@ -12,10 +33,6 @@ Checks for an about/company page with content
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-An About page establishes credibility and trust. Include company history, mission, team overview, and credentials. Link from main navigation or footer. For E-E-A-T, explain your expertise and why visitors should trust you. Include contact information and physical location if applicable.
 
 ## Enable / disable
 
@@ -40,3 +57,30 @@ disable = ["eeat/*"]
 enable = ["eeat/about-page"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/contact-page](/rules/eeat/contact-page): the other page a reader opens to check you are real.
+- [eeat/physical-address](/rules/eeat/physical-address): the address that usually lives on both.
+- [eeat/author-expertise](/rules/eeat/author-expertise): who wrote the content, as opposed to who runs the site.
+- [eeat/trust-signals](/rules/eeat/trust-signals): the reviews and certifications a reader looks for next.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [AboutPage, Schema.org](https://schema.org/AboutPage)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The About page is reported with its URL and word count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/affiliate-disclosure.mdx
+++ b/docs/rules/eeat/affiliate-disclosure.mdx
@@ -1,9 +1,38 @@
 ---
-title: "Affiliate Disclosure"
-description: "Checks for affiliate and sponsored content disclosures"
+title: "Affiliate disclosure: detecting affiliate links without one"
+description: "Undisclosed affiliate links are a regulatory problem and a trust problem. squirrel detects affiliate link patterns and looks for a disclosure page."
 ---
 
-Checks for affiliate and sponsored content disclosures
+## What affiliate disclosure is
+
+An affiliate link earns the publisher a commission when the reader buys. Disclosure is telling the reader that before they click, and in the United States the Federal Trade Commission requires it for any material connection between the endorser and the seller. Other jurisdictions have equivalent rules.
+
+Where it goes matters as much as whether it exists. A line in the footer is not where someone reads before clicking a product link; the disclosure belongs near the links it covers, at the top of the page or beside them.
+
+## What squirrel checks
+
+The rule is site-wide. It looks for a disclosure page by URL and, separately, counts pages carrying links that match affiliate patterns. It emits up to two checks:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- `affiliate-links` reports info when affiliate links were found. Message: `12 page(s) appear to have affiliate links`.
+- `affiliate-disclosure` passes when links were found and a disclosure page exists. Message: `Affiliate disclosure page found`, with the URL.
+- `affiliate-disclosure` warns when links were found and no page exists. Message: `Affiliate links detected but no disclosure page found`, with `Create /affiliate-disclosure page (FTC requirement)` as the value.
+- `affiliate-disclosure` passes when no links were found but a page exists. Message: `Disclosure page exists`.
+- `affiliate-disclosure` reports info when neither was found. Message: `No affiliate links or disclosure page detected`.
+
+The disclosure page is matched on `/disclosure`, `/affiliate-disclosure`, `/advertising-disclosure`, `/sponsored-disclosure` or `/ftc-disclosure`. Affiliate links are matched on an Amazon URL carrying `tag=`, on `shareasale.com`, `go.redirectingat.com`, `awin1.com` or `commission-junction`, or on any URL containing `?ref=` or `?affiliate=`. That last pair is broad: an internal referral parameter will match it. Severity info, weight 4.
+
+The rule only runs when the audit classified the site as a blog or a news site. A classification below medium confidence, or an audit with no site metadata at all, runs it anyway.
+
+## How to fix it
+
+```html
+<p class="disclosure">We earn a commission from purchases made through the links below.</p>
+```
+
+Put the sentence at the top of the page, above the links it covers, and keep a dedicated disclosure page linked from the footer for the detail. Use plain language rather than a legal formula.
+
+A `?ref=` parameter on an internal link will be counted as affiliate. Check what was matched before concluding you have a disclosure gap.
 
 | | |
 |---|---|
@@ -12,10 +41,6 @@ Checks for affiliate and sponsored content disclosures
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 4/10 |
-
-## Solution
-
-FTC requires clear disclosure of affiliate relationships and sponsored content. Disclose at the top of pages with affiliate links, not just in footer. Use clear language: 'We earn commissions from purchases' or 'This post is sponsored.' Create a dedicated disclosure page and link to it. Failure to disclose can result in penalties.
 
 ## Enable / disable
 
@@ -40,3 +65,30 @@ disable = ["eeat/*"]
 enable = ["eeat/affiliate-disclosure"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/disclaimers](/rules/eeat/disclaimers): the non-commercial version of the same obligation.
+- [links/external-links](/rules/links/external-links): the outbound links this rule is reading.
+- [security/new-tab](/rules/security/new-tab): the rel attributes those links should carry.
+- [eeat/trust-signals](/rules/eeat/trust-signals): the other things a reader weighs on a review page.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Qualify your outbound links, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with its affiliate link count and whether a disclosure page exists. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/affiliate-disclosure.mdx
+++ b/docs/rules/eeat/affiliate-disclosure.mdx
@@ -20,7 +20,7 @@ The rule is site-wide. It looks for a disclosure page by URL and, separately, co
 - `affiliate-disclosure` passes when no links were found but a page exists. Message: `Disclosure page exists`.
 - `affiliate-disclosure` reports info when neither was found. Message: `No affiliate links or disclosure page detected`.
 
-The disclosure page is matched on `/disclosure`, `/affiliate-disclosure`, `/advertising-disclosure`, `/sponsored-disclosure` or `/ftc-disclosure`. Affiliate links are matched on an Amazon URL carrying `tag=`, on `shareasale.com`, `go.redirectingat.com`, `awin1.com` or `commission-junction`, or on any URL containing `?ref=` or `?affiliate=`. That last pair is broad: an internal referral parameter will match it. Severity info, weight 4.
+The disclosure page is matched on `/disclosure`, `/affiliate-disclosure`, `/advertising-disclosure`, `/sponsored-disclosure` or `/ftc-disclosure`. Affiliate links are matched against seven patterns applied to the whole URL string, not to the hostname: `amazon.<tld>/` followed later by `tag=`, `shareasale.com`, `go.redirectingat.com`, `awin1.com`, `commission-junction`, `?ref=` and `?affiliate=`. The Amazon pattern needs the tag to come after a path segment, so a bare `amazon.co.uk/?tag=…` does not match, and the last two are broad enough that an internal referral parameter will. Severity info, weight 4.
 
 The rule only runs when the audit classified the site as a blog or a news site. A classification below medium confidence, or an audit with no site metadata at all, runs it anyway.
 
@@ -82,7 +82,7 @@ E-E-A-T findings ship in every audit next to the SEO, performance and agent expe
 
 ## Check your site
 
-Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with its affiliate link count and whether a disclosure page exists. Local audits are free.
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with how many pages carry a matching affiliate link and whether a disclosure page exists. Local audits are free.
 
 <CardGroup cols={2}>
   <Card title="Install squirrel" icon="terminal" href="/quickstart">

--- a/docs/rules/eeat/author-byline.mdx
+++ b/docs/rules/eeat/author-byline.mdx
@@ -17,9 +17,9 @@ An author is found from the parser's extracted author, from any flattened JSON-L
 
 - Skipped when no pages were crawled. Message: `No pages available for analysis`.
 - Info when no content pages were detected. Message: `No content pages detected for author analysis`.
-- Pass at 80% coverage or above. Message: `92% of content pages have author attribution`, with `46/50 pages` as the value. Severity warning, weight 5.
-- Info from 50%. Message: `64% of content pages have author attribution`, with `Consider adding authors to more content` as the value.
-- Warn below 50%. Message: `Only 20% of content pages have author attribution`, or `No content pages have author attribution` when none do.
+- Pass when the coverage percentage, rounded to a whole number, is 80 or above. Message: `92% of content pages have author attribution`, with `46/50 pages` as the value. Severity warning, weight 5.
+- Info from 50. Message: `64% of content pages have author attribution`, with `Consider adding authors to more content` as the value.
+- Warn below 50. Message: `Only 20% of content pages have author attribution`, or `No content pages have author attribution` when none do.
 
 The rule only runs when the audit classified the site as a blog, a news site, a healthcare provider, an education site or a nonprofit. A classification below medium confidence, or an audit with no site metadata at all, runs the rule anyway.
 

--- a/docs/rules/eeat/author-byline.mdx
+++ b/docs/rules/eeat/author-byline.mdx
@@ -68,7 +68,7 @@ disable = ["*"]
 ## Related rules
 
 - [content/author-info](/rules/content/author-info): the per-page inventory of the same markup.
-- [eeat/author-expertise](/rules/eeat/author-expertise): whether the author has a bio establishing any.
+- [eeat/author-expertise](/rules/eeat/author-expertise): author pages and Person schema as expertise indicators.
 - [eeat/authority-signals](/rules/eeat/authority-signals): the cloud assessment of attribution in context.
 - [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the topics where attribution matters most.
 

--- a/docs/rules/eeat/author-byline.mdx
+++ b/docs/rules/eeat/author-byline.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Author Bylines"
-description: "Checks for visible author names on content pages"
+title: "Author bylines on content pages: what share carry one"
+description: "Content published by nobody in particular is harder to trust. squirrel measures what share of your content pages attribute an author."
 ---
 
-Checks for visible author names on content pages
+## What an author byline is
+
+A byline names who wrote a page. It can be structured data, a `rel="author"` link, or visible markup in the page's entry header, and it is the first half of the experience and expertise part of E-E-A-T.
+
+It matters most where the reader is being asked to act on what they read. Google's guidance asks whether content presents information in a way that makes you want to trust it, and an unattributed article on a topic where expertise matters answers that badly.
+
+## What squirrel checks
+
+The rule is site-wide. It counts content pages and how many of them attribute an author. A page counts as content when its path matches `/blog`, `/article`, `/post`, `/news`, `/guide`, `/how-to` or `/review`, when its schema declares `Article`, `BlogPosting` or `NewsArticle`, or when the parser found visible byline markup. On a crawl of five pages or fewer, every page is counted as content.
+
+An author is found from the parser's extracted author, from any flattened JSON-LD node carrying an `author` property, or from visible byline markup such as an hCard or a `rel="author"` link. It emits a single check named `author-byline`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Info when no content pages were detected. Message: `No content pages detected for author analysis`.
+- Pass at 80% coverage or above. Message: `92% of content pages have author attribution`, with `46/50 pages` as the value. Severity warning, weight 5.
+- Info from 50%. Message: `64% of content pages have author attribution`, with `Consider adding authors to more content` as the value.
+- Warn below 50%. Message: `Only 20% of content pages have author attribution`, or `No content pages have author attribution` when none do.
+
+The rule only runs when the audit classified the site as a blog, a news site, a healthcare provider, an education site or a nonprofit. A classification below medium confidence, or an audit with no site metadata at all, runs the rule anyway.
+
+## How to fix it
+
+```html
+<a rel="author" href="/authors/jane-diaz">Jane Diaz</a>
+```
+
+Show the name where the reader sees it, link it to a bio, and mirror it in the page's `Article` schema as a `Person`. Put it in the article template so it applies to everything published through it.
+
+An organisation byline is legitimate for institutional content. A named person with a bio is stronger where the claim rests on individual expertise.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks for visible author names on content pages
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Author bylines demonstrate experience and accountability. Show author names prominently on articles, blog posts, and expert content. Include author credentials where relevant. Link author names to bio pages. For YMYL content (health, finance), author transparency is especially important for Google's E-E-A-T assessment.
 
 ## Enable / disable
 
@@ -40,3 +64,30 @@ disable = ["eeat/*"]
 enable = ["eeat/author-byline"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/author-info](/rules/content/author-info): the per-page inventory of the same markup.
+- [eeat/author-expertise](/rules/eeat/author-expertise): whether the author has a bio establishing any.
+- [eeat/authority-signals](/rules/eeat/authority-signals): the cloud assessment of attribution in context.
+- [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the topics where attribution matters most.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Article structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/article)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with the share of content pages that attribute an author. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/author-expertise.mdx
+++ b/docs/rules/eeat/author-expertise.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Author Expertise"
-description: "Checks for author credentials and expertise indicators"
+title: "Author expertise: bio pages and Person schema"
+description: "A name is attribution; a bio is expertise. squirrel looks for author pages and Person structured data across the crawl."
 ---
 
-Checks for author credentials and expertise indicators
+## What an expertise signal is
+
+A byline says who wrote something. An expertise signal says why they were the person to write it: a bio page with credentials, a professional profile, a `Person` node in the structured data linking the two.
+
+Google's guidance asks about the degree of expertise behind content and about who is responsible for it. On health, finance and legal topics, that is the difference between a name and a qualification. This rule looks for the infrastructure that carries it rather than judging the credentials themselves.
+
+## What squirrel checks
+
+The rule is site-wide. It counts pages whose path matches `/author/`, `/authors`, `/team`, `/contributors` or `/about-the-author`, and separately checks whether any crawled page declares the `Person` schema type. It emits a single check named `author-expertise`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when either signal is present. Message: `Author expertise signals found`, listing what was found as `4 author page(s)` and `Person schema`.
+- Info when neither is. Message: `Limited author expertise signals`, with `Consider adding author pages with credentials` as the value.
+
+The check is structural. It does not read the bio pages or look for credentials in them, so a `/team` page with four names and no detail passes. Severity info, weight 4.
+
+The rule only runs when the audit classified the site as a blog, a news site, a healthcare provider, an education site or a nonprofit. A classification below medium confidence, or an audit with no site metadata at all, runs the rule anyway.
+
+## How to fix it
+
+```html
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Person","name":"Jane Diaz","jobTitle":"Registered Dietitian","url":"https://example.com/authors/jane-diaz"}
+</script>
+```
+
+Give each regular author a page that says what they know and how they know it: qualifications, relevant experience, where else they publish. Mark it up as a `Person` and link the byline to it.
+
+For content where a reviewer signs off, such as medical writing, name the reviewer and their credentials as well as the writer.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks for author credentials and expertise indicators
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 4/10 |
-
-## Solution
-
-Author expertise is key for E-E-A-T, especially for YMYL content. Include: professional credentials (MD, JD, CPA), work experience, education, relevant certifications, and author bio pages. Link authors to LinkedIn or professional profiles. For health content, show medical reviewer credentials.
 
 ## Enable / disable
 
@@ -40,3 +64,30 @@ disable = ["eeat/*"]
 enable = ["eeat/author-expertise"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/author-byline](/rules/eeat/author-byline): whether the content is attributed at all.
+- [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the topics where credentials matter most.
+- [eeat/disclaimers](/rules/eeat/disclaimers): what those pages need alongside the credentials.
+- [content/author-info](/rules/content/author-info): the per-page markup inventory.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Person, Schema.org](https://schema.org/Person)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with the author pages and Person schema found. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/authority-signals.mdx
+++ b/docs/rules/eeat/authority-signals.mdx
@@ -1,11 +1,31 @@
 ---
-title: "Authority Signals"
-description: "AI assessment of per-page authority signals: authorship, citations, and outbound references"
+title: "Authority signals: an AI read of authorship and citations"
+description: "Pattern matching sees markup; this rule reads the page. The cloud service reports whether it is attributed and what its claims rest on."
 ---
 
 <Note>**Cloud rule** - requires login (`squirrel auth login`); the analysis is **included in the audit base charge**. Skipped when not logged in. See [Cloud rules](/cloud/rules).</Note>
 
-AI assessment of per-page authority signals: authorship, citations, and outbound references.
+## What an authority signal is
+
+Authority, in the sense Google's guidance uses, is whether a page shows who stands behind what it says and what those claims rest on. In practice that is authorship and sourcing.
+
+Markup rules can only see the shapes those take: a `Person` node, a `rel="author"` link, an outbound link to a domain on a list. This rule reads the page instead, so it can recognise a byline that is plain text and tell a citation from a footer link to a partner site.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reads a result the cloud service produced before the rules ran. It emits a single check named `authority-signals`:
+
+- Skipped when no result is available for the page, whether because the feature was not prefetched or the service skipped it. Message: `Authority signal analysis skipped`, with a readable skip reason.
+- Warn when the page has no author attribution and zero citations. Message: `No author attribution or citations detected on this page`. When the page has outbound links, the details add `4 outbound link(s) present but none read as citations.` Severity warning, weight 3.
+- Pass otherwise. Message: `Authority signals: author attributed, 6 citation(s), 14 outbound reference(s)`, or `no author` in place of the first part. Any specific signals the service identified are listed as items.
+
+The rule is skipped on soft 404 pages, so a broken template cannot warn about a missing author on every URL.
+
+## How to fix it
+
+Add a visible byline with credentials where they are relevant, cite sources for factual claims in the sentences that make them, and link out to the references the argument rests on.
+
+The warn condition needs both halves to be missing. A page with an author and no citations passes, as does a page with citations and no named author.
 
 | | |
 |---|---|
@@ -16,16 +36,6 @@ AI assessment of per-page authority signals: authorship, citations, and outbound
 | **Weight** | 3/10 |
 | **Default** | Enabled |
 
-## What it checks
-
-The cloud service reads each page and reports whether an author is attributed, how many claims are backed by citations, and how many outbound references the page makes. A page with **no author attribution and zero citations** warns; otherwise the rule passes and lists the detected signals.
-
-Unlike the pattern-based [`eeat/author-byline`](/rules/eeat/author-byline) and [`eeat/citations`](/rules/eeat/citations) rules, this is a semantic assessment - it understands attribution and sourcing in context rather than matching markup patterns.
-
-## Solution
-
-Pages that demonstrate who wrote them and what their claims rest on earn more trust from readers, search engines, and AI assistants. Add a visible author byline (with credentials where relevant), cite sources for factual claims, and link out to authoritative references.
-
 ## Enable / disable
 
 ### Disable this rule
@@ -34,3 +44,29 @@ Pages that demonstrate who wrote them and what their claims rest on earn more tr
 [rules]
 disable = ["eeat/authority-signals"]
 ```
+
+## Related rules
+
+- [eeat/author-byline](/rules/eeat/author-byline): the pattern-based version of the attribution half.
+- [eeat/citations](/rules/eeat/citations): the pattern-based version of the sourcing half.
+- [content/author-info](/rules/content/author-info): the per-page markup inventory.
+- [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the topics where both halves matter most.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. Each page is reported with its author, citation and outbound reference counts. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/citations.mdx
+++ b/docs/rules/eeat/citations.mdx
@@ -17,7 +17,7 @@ The rule is site-wide. It walks the external links on every crawled page and cou
 - Pass when any authoritative link was found. Message: `24 authoritative citation(s) found`, with `Across 9 page(s)` as the value.
 - Info when none was. Message: `No authoritative citations detected`, with `Consider citing .gov, .edu, or industry sources` as the value.
 
-The list has fifteen entries: `gov`, `edu`, `who.int`, `cdc.gov`, `nih.gov`, `fda.gov`, `mayo.clinic`, `webmd`, `healthline`, `wikipedia.org`, `reuters.com`, `bbc.com`, `nytimes.com`, `wsj.com`. Matching is a substring test on the hostname, so `gov` and `edu` catch any `.gov` or `.edu` domain and also anything else containing those letters in its hostname. The list is US and English-centric, and a site citing national statistics offices or journals outside it will report zero. Severity info, weight 3.
+The list has fourteen entries: `gov`, `edu`, `who.int`, `cdc.gov`, `nih.gov`, `fda.gov`, `mayo.clinic`, `webmd`, `healthline`, `wikipedia.org`, `reuters.com`, `bbc.com`, `nytimes.com`, `wsj.com`. Matching is a substring test on the hostname, so `gov` and `edu` catch any `.gov` or `.edu` domain and also anything else containing those letters in its hostname. The list is US and English-centric, and a site citing national statistics offices or journals outside it will report zero. Severity info, weight 3.
 
 The rule only runs when the audit classified the site as a blog, a news site, a healthcare provider, an education site or a nonprofit. A classification below medium confidence, or an audit with no site metadata at all, runs the rule anyway.
 

--- a/docs/rules/eeat/citations.mdx
+++ b/docs/rules/eeat/citations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Authoritative citations: linking to sources that can be checked"
+title: "Authoritative citations: sources a reader can check"
 description: "A factual claim with a source a reader can follow is stronger than one without. squirrel counts outbound links to a list of authoritative domains."
 ---
 

--- a/docs/rules/eeat/citations.mdx
+++ b/docs/rules/eeat/citations.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Citations"
-description: "Checks for citations to authoritative external sources"
+title: "Authoritative citations: linking to sources that can be checked"
+description: "A factual claim with a source a reader can follow is stronger than one without. squirrel counts outbound links to a list of authoritative domains."
 ---
 
-Checks for citations to authoritative external sources
+## What a citation is here
+
+A citation is an outbound link to the source a claim rests on. It lets a reader verify the claim without taking your word for it, and it is one of the few outward signals that content was researched rather than assembled.
+
+Which sources count depends on the topic. For health content that is health authorities and peer-reviewed research; for anything statistical it is the body that published the numbers. This rule uses a fixed list as a proxy rather than judging relevance, so treat a low count as a prompt rather than a verdict.
+
+## What squirrel checks
+
+The rule is site-wide. It walks the external links on every crawled page and counts those whose hostname matches one of its authoritative domains. It emits a single check named `citations`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when any authoritative link was found. Message: `24 authoritative citation(s) found`, with `Across 9 page(s)` as the value.
+- Info when none was. Message: `No authoritative citations detected`, with `Consider citing .gov, .edu, or industry sources` as the value.
+
+The list has fifteen entries: `gov`, `edu`, `who.int`, `cdc.gov`, `nih.gov`, `fda.gov`, `mayo.clinic`, `webmd`, `healthline`, `wikipedia.org`, `reuters.com`, `bbc.com`, `nytimes.com`, `wsj.com`. Matching is a substring test on the hostname, so `gov` and `edu` catch any `.gov` or `.edu` domain and also anything else containing those letters in its hostname. The list is US and English-centric, and a site citing national statistics offices or journals outside it will report zero. Severity info, weight 3.
+
+The rule only runs when the audit classified the site as a blog, a news site, a healthcare provider, an education site or a nonprofit. A classification below medium confidence, or an audit with no site metadata at all, runs the rule anyway.
+
+## How to fix it
+
+Link the claim to its source, in the sentence where the claim is made rather than in a list at the end. Prefer the primary source over an article about it.
+
+A zero here on a site that cites journals or a national statistics office is a limitation of the list, not a finding. Check the outbound links yourself before acting on it.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Checks for citations to authoritative external sources
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Citing authoritative sources builds credibility and supports E-E-A-T. Link to: government sites (.gov), educational institutions (.edu), peer-reviewed research, industry authorities. For health: cite NIH, CDC, WHO, medical journals. Include a sources/references section. Don't cite low-quality or unverified sources.
 
 ## Enable / disable
 
@@ -40,3 +58,29 @@ disable = ["eeat/*"]
 enable = ["eeat/citations"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/article-links](/rules/content/article-links): the external link minimum by article length.
+- [eeat/authority-signals](/rules/eeat/authority-signals): the cloud assessment of what reads as a citation.
+- [links/broken-external-links](/rules/links/broken-external-links): whether those sources still resolve.
+- [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the topics where sourcing matters most.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with its authoritative citation count and the pages carrying them. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/contact-page.mdx
+++ b/docs/rules/eeat/contact-page.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Contact Page"
-description: "Checks for contact page with multiple contact methods"
+title: "Contact page: finding it and counting the contact methods"
+description: "A site with no reachable human is a site a reader has no reason to trust. squirrel finds the contact page and counts its email and phone links."
 ---
 
-Checks for contact page with multiple contact methods
+## What a contact page is for
+
+A contact page is the answer to how do I reach these people. It carries at minimum a way to get in touch, and usually several: an email address, a phone number, a form, a postal address.
+
+More than one method matters because they fail differently. A form is easy to build and impossible to verify from outside; a `mailto:` address and a `tel:` number are things a reader can check and use immediately.
+
+## What squirrel checks
+
+The rule is site-wide. It finds the contact page by a URL path matching one of the multilingual contact patterns, or by a page whose structured data declares the `ContactPage` type. It emits up to two checks:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- `contact-page` warns when none is found. Message: `No Contact page found`, with `Create /contact page` as the value. No further checks run. Severity warning, weight 5.
+- `contact-page` passes when one is found. Message: `Contact page exists`, with the URL as the value.
+- `contact-methods` passes when the page carries both a `mailto:` and a `tel:` link. Message: `Contact page has multiple contact methods`, listing them.
+- `contact-methods` reports info when it carries exactly one. Message: `Contact page has limited contact methods`, with `Consider adding email, phone, and address` as the value.
+
+Only `mailto:` and `tel:` links count as methods. A contact form is not detected, so a page with a form and no direct address emits no methods check at all. The `ContactPoint` schema type is deliberately not used as a fallback, because it is usually an Organization property present on every page rather than a marker of this page.
+
+## How to fix it
+
+```html
+<a href="mailto:hello@example.com">hello@example.com</a>
+<a href="tel:+61292223333">(02) 9222 3333</a>
+```
+
+Publish a real address and a real number as links, not as images or as text a reader has to retype. Keep the contact link in the footer so it is reachable from anywhere.
+
+A form is fine as an addition. It is weak on its own, because there is no way for a reader to tell whether anyone reads it.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks for contact page with multiple contact methods
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-A contact page with multiple contact methods builds trust. Include: email address or contact form, phone number (if applicable), physical address, and social media links. Make contact information easy to find from any page. For local businesses, include business hours. Response time expectations are also helpful.
 
 ## Enable / disable
 
@@ -40,3 +63,30 @@ disable = ["eeat/*"]
 enable = ["eeat/contact-page"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/tel-mailto](/rules/links/tel-mailto): whether those links are well formed and match their text.
+- [eeat/physical-address](/rules/eeat/physical-address): the address that belongs on the same page.
+- [eeat/about-page](/rules/eeat/about-page): the other page a reader checks.
+- [security/form-captcha](/rules/security/form-captcha): protecting the contact form from spam.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [ContactPage, Schema.org](https://schema.org/ContactPage)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The contact page is reported with its URL and the methods found on it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/content-dates.mdx
+++ b/docs/rules/eeat/content-dates.mdx
@@ -1,9 +1,38 @@
 ---
-title: "Content Dates"
-description: "Checks for published and modified dates on content"
+title: "datePublished and dateModified coverage across content pages"
+description: "Undated content leaves a reader guessing whether it is current. squirrel measures how much of your content carries each date."
 ---
 
-Checks for published and modified dates on content
+## What content dates do
+
+A published date tells a reader when something was written; a modified date tells them whether it has been kept up. Both can come from `Article` structured data or from visible markup in the entry header.
+
+They matter where age changes the answer. On a tutorial for a tool that ships every month, a 2019 date is the most useful thing on the page. On a page about something that has not changed in a century, it is noise, which is why this rule is gated to content-publishing sites.
+
+## What squirrel checks
+
+The rule is site-wide. It counts content pages and how many carry each date. A page counts as content when its schema declares `Article`, `BlogPosting` or `NewsArticle`, or when the parser found a visible published date or a visible author. On a crawl of five pages or fewer, every page counts.
+
+Dates are read from any flattened JSON-LD node carrying `datePublished` or `dateModified`, falling back to visible entry-meta `<time>` markup. It emits up to two checks:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Info when no article content was detected. Message: `No article content detected for date analysis`.
+- `date-published` passes at 80% coverage or above. Message: `95% of content has datePublished`. It warns below that, with `Only 40% of content has datePublished` or `No content pages have datePublished`, and `Add dates to Article schema` as the value. Severity warning, weight 4.
+- `date-modified` passes at 50% or above. Message: `70% of content has dateModified`. It reports info below that, with `20% of content has dateModified` and `Add dateModified to show freshness` as the value.
+
+Flattening the JSON-LD matters here: a top-level-only read misses every date on a site whose SEO plugin emits an `@graph`.
+
+The rule only runs when the audit classified the site as a blog, a news site, a healthcare provider or an education site. A classification below medium confidence, or an audit with no site metadata at all, runs the rule anyway.
+
+## How to fix it
+
+```html
+<time datetime="2026-03-12" class="entry-date published">12 March 2026</time>
+```
+
+Render the date in the article header and put the same value in the `Article` schema. One content timestamp should drive both.
+
+Move `dateModified` when the content actually changes. A date that updates on every deploy tells a reader nothing and tells a crawler something false.
 
 | | |
 |---|---|
@@ -12,10 +41,6 @@ Checks for published and modified dates on content
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Visible dates show content freshness and help users assess relevance. Include datePublished and dateModified in Article schema. Show human-readable dates on pages. Update dateModified when making significant changes. Fresh content signals ongoing maintenance and expertise. Stale dates may hurt rankings for time-sensitive topics.
 
 ## Enable / disable
 
@@ -40,3 +65,30 @@ disable = ["eeat/*"]
 enable = ["eeat/content-dates"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/date-agreement](/rules/content/date-agreement): whether the dates on a page agree with each other.
+- [content/freshness](/rules/content/freshness): the same signals inventoried per page.
+- [crawl/sitemap-lastmod-drift](/rules/crawl/sitemap-lastmod-drift): the sitemap date compared against them.
+- [eeat/author-byline](/rules/eeat/author-byline): the other half of a complete byline.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Article structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/article)
+- [The time element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with the share of content carrying each date. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/content-dates.mdx
+++ b/docs/rules/eeat/content-dates.mdx
@@ -5,7 +5,7 @@ description: "Undated content leaves a reader guessing whether it is current. sq
 
 ## What content dates do
 
-A published date tells a reader when something was written; a modified date tells them whether it has been kept up. Both can come from `Article` structured data or from visible markup in the entry header.
+A published date tells a reader when something was published, which is not always when it was written; a modified date tells them whether it has been kept up. Both can come from `Article` structured data or from visible markup in the entry header.
 
 They matter where age changes the answer. On a tutorial for a tool that ships every month, a 2019 date is the most useful thing on the page. On a page about something that has not changed in a century, it is noise, which is why this rule is gated to content-publishing sites.
 
@@ -17,8 +17,8 @@ Dates are read from any flattened JSON-LD node carrying `datePublished` or `date
 
 - Skipped when no pages were crawled. Message: `No pages available for analysis`.
 - Info when no article content was detected. Message: `No article content detected for date analysis`.
-- `date-published` passes at 80% coverage or above. Message: `95% of content has datePublished`. It warns below that, with `Only 40% of content has datePublished` or `No content pages have datePublished`, and `Add dates to Article schema` as the value. Severity warning, weight 4.
-- `date-modified` passes at 50% or above. Message: `70% of content has dateModified`. It reports info below that, with `20% of content has dateModified` and `Add dateModified to show freshness` as the value.
+- `date-published` passes when the coverage percentage, rounded to a whole number, is 80 or above. Message: `95% of content has datePublished`. It warns below that, with `Only 40% of content has datePublished` or `No content pages have datePublished`, and `Add dates to Article schema` as the value. Severity warning, weight 4.
+- `date-modified` passes when its rounded percentage is 50 or above. Message: `70% of content has dateModified`. It reports info below that, with `20% of content has dateModified` and `Add dateModified to show freshness` as the value.
 
 Flattening the JSON-LD matters here: a top-level-only read misses every date on a site whose SEO plugin emits an `@graph`.
 

--- a/docs/rules/eeat/content-dates.mdx
+++ b/docs/rules/eeat/content-dates.mdx
@@ -1,5 +1,5 @@
 ---
-title: "datePublished and dateModified coverage across content pages"
+title: "datePublished and dateModified across content pages"
 description: "Undated content leaves a reader guessing whether it is current. squirrel measures how much of your content carries each date."
 ---
 

--- a/docs/rules/eeat/disclaimers.mdx
+++ b/docs/rules/eeat/disclaimers.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Disclaimers"
-description: "Checks for appropriate disclaimers on sensitive content"
+title: "Disclaimers on YMYL content: what to say and where"
+description: "Health, finance and legal content needs to say what it is not. squirrel looks for a dedicated disclaimer page by its URL."
 ---
 
-Checks for appropriate disclaimers on sensitive content
+## What a disclaimer does
+
+A disclaimer states the limits of what content is. On health writing that is this is not medical advice; on finance, not financial advice; on legal writing, not legal advice. Each one points the reader at the professional they should actually be asking.
+
+It is both a legal position and a trust signal. A page that is clear about what it is not is easier to trust about what it is, and the absence of one on content that reads like advice is itself a signal.
+
+## What squirrel checks
+
+The rule is site-wide. It matches each crawled page's URL path against five patterns and takes the first hit. It emits a single check named `disclaimer-page`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when a page matches. Message: `Disclaimer page found`, with the URL as the value.
+- Info when none does. Message: `No dedicated disclaimer page found`, with `Consider adding if you have YMYL or affiliate content` as the value.
+
+The patterns are `/disclaimer`, `/legal-disclaimer`, `/medical-disclaimer`, `/affiliate-disclosure` and `/advertising-disclosure`, each anchored to the end of the path. The rule looks for a dedicated page only: a disclaimer rendered inline at the top of an article is not detected. Severity info, weight 4.
+
+The rule only runs when the audit classified the site as YMYL. A classification below medium confidence, or an audit with no site metadata at all, runs it anyway.
+
+## How to fix it
+
+Publish a disclaimer page and link it from the footer, then put the relevant sentence at the top of the articles it applies to. Fine print at the bottom of a long page is not where a reader looks before acting.
+
+Say what the content is not and who to ask instead. "This article is general information and is not medical advice. Speak to your doctor about your own situation." is the whole pattern.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Checks for appropriate disclaimers on sensitive content
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 4/10 |
-
-## Solution
-
-Disclaimers protect you legally and build trust. Health content: 'This is not medical advice. Consult a healthcare professional.' Finance: 'Not financial advice. Consult a financial advisor.' Legal: 'Not legal advice. Consult an attorney.' Affiliate: 'We may earn commissions.' Make disclaimers visible, not hidden in fine print.
 
 ## Enable / disable
 
@@ -40,3 +58,29 @@ disable = ["eeat/*"]
 enable = ["eeat/disclaimers"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the classification that turns this rule on.
+- [eeat/affiliate-disclosure](/rules/eeat/affiliate-disclosure): the commercial version of the same obligation.
+- [eeat/author-expertise](/rules/eeat/author-expertise): the credentials the disclaimer sits alongside.
+- [legal/terms-of-service](/rules/legal/terms-of-service): the broader legal page in the footer.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The disclaimer page is reported with its URL when one is found. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/disclaimers.mdx
+++ b/docs/rules/eeat/disclaimers.mdx
@@ -11,7 +11,7 @@ It is both a legal position and a trust signal. A page that is clear about what 
 
 ## What squirrel checks
 
-The rule is site-wide. It matches each crawled page's URL path against five patterns and takes the first hit. It emits a single check named `disclaimer-page`:
+The rule is site-wide. It matches each crawled page's URL path against five patterns and takes the first hit. It emits one check, named `disclaimers` for the skip and `disclaimer-page` for the other two:
 
 - Skipped when no pages were crawled. Message: `No pages available for analysis`.
 - Pass when a page matches. Message: `Disclaimer page found`, with the URL as the value.

--- a/docs/rules/eeat/editorial-policy.mdx
+++ b/docs/rules/eeat/editorial-policy.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Editorial Policy"
-description: "Checks for editorial and content policy pages"
+title: "Editorial policy: publishing how the content gets made"
+description: "A stated editorial process is a claim a reader can hold you to. squirrel looks for policy pages by their multilingual URL patterns."
 ---
 
-Checks for editorial and content policy pages
+## What an editorial policy is
+
+An editorial policy describes how content on a site is produced: who writes it, who reviews it, how facts are checked, what happens when something is wrong, and who has a say in what gets published.
+
+It is standard at news organisations and increasingly common on any site publishing at scale. Its value is that it is checkable: a correction policy means a reader can see whether corrections actually appear.
+
+## What squirrel checks
+
+The rule is site-wide. It matches each crawled page's URL path against the multilingual editorial policy patterns and collects every match. It emits a single check named `editorial-policy`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when at least one page matches. Message: `2 policy page(s) found`, listing each path.
+- Info when none does. Message: `No editorial/content policy pages found`, with `Consider adding for content-heavy sites` as the value.
+
+The match is on the URL path only, so a policy published on an unusual slug or inside the About page is not found. Severity info, weight 3.
+
+The rule only runs when the audit classified the site as a news site, a blog, a healthcare provider or an education site. A classification below medium confidence, or an audit with no site metadata at all, runs it anyway.
+
+## How to fix it
+
+Publish a page covering how content is created and reviewed, how facts are checked, how corrections are handled, and how editorial decisions stay independent of commercial ones. Link it from the footer or the About page.
+
+Write what you actually do. A policy describing a review process nobody follows is worse than none.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Checks for editorial and content policy pages
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Editorial policies demonstrate content quality standards and professionalism. Include: how content is created/reviewed, fact-checking process, correction policy, and editorial independence. For news sites, this is essential. For content sites, it builds trust and supports E-E-A-T. Link from footer or about page.
 
 ## Enable / disable
 
@@ -40,3 +58,29 @@ disable = ["eeat/*"]
 enable = ["eeat/editorial-policy"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/about-page](/rules/eeat/about-page): the page this one usually sits beside.
+- [eeat/author-expertise](/rules/eeat/author-expertise): who the policy says is qualified to write.
+- [eeat/ymyl-detection](/rules/eeat/ymyl-detection): the topics where a review process matters most.
+- [eeat/trust-signals](/rules/eeat/trust-signals): the other claims a reader can check.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. Each policy page found is listed by path. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/index.mdx
+++ b/docs/rules/eeat/index.mdx
@@ -3,7 +3,7 @@ title: "E-E-A-T"
 description: "Experience, expertise, authority, trust signals"
 ---
 
-Experience, expertise, authority, trust signals
+E-E-A-T rules look for the evidence a reader uses to decide whether to believe a site: who runs it, who wrote the page, what the claims rest on, and how to reach a human. Most of them check for a page or a piece of structured data rather than judging its quality, so a pass means the signal exists and not that it is convincing. Several are gated on the audit's own site classification, since author credentials matter on a medical site and mean nothing on a landing page.
 
 ## Rules
 
@@ -61,3 +61,5 @@ Experience, expertise, authority, trust signals
 [rules]
 disable = ["eeat/*"]
 ```
+
+Every audit reports E-E-A-T findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/eeat/index.mdx
+++ b/docs/rules/eeat/index.mdx
@@ -8,50 +8,50 @@ E-E-A-T rules look for the evidence a reader uses to decide whether to believe a
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="About Page" icon="triangle-exclamation" href="/rules/eeat/about-page">
-    Checks for an about/company page with content
+  <Card title="About page: what it establishes and how squirrel finds it" icon="triangle-exclamation" href="/rules/eeat/about-page">
+    An About page is where a reader decides whether you are a real organisation. squirrel finds it by URL or schema and checks it has content.
   </Card>
-  <Card title="Affiliate Disclosure" icon="circle-info" href="/rules/eeat/affiliate-disclosure">
-    Checks for affiliate and sponsored content disclosures
+  <Card title="Affiliate disclosure: detecting affiliate links without one" icon="circle-info" href="/rules/eeat/affiliate-disclosure">
+    Undisclosed affiliate links are a regulatory problem and a trust problem. squirrel detects affiliate link patterns and looks for a disclosure page.
   </Card>
-  <Card title="Author Bylines" icon="triangle-exclamation" href="/rules/eeat/author-byline">
-    Checks for visible author names on content pages
+  <Card title="Author bylines on content pages: what share carry one" icon="triangle-exclamation" href="/rules/eeat/author-byline">
+    Content published by nobody in particular is harder to trust. squirrel measures what share of your content pages attribute an author.
   </Card>
-  <Card title="Author Expertise" icon="circle-info" href="/rules/eeat/author-expertise">
-    Checks for author credentials and expertise indicators
+  <Card title="Author expertise: bio pages and Person schema" icon="circle-info" href="/rules/eeat/author-expertise">
+    A name is attribution; a bio is expertise. squirrel looks for author pages and Person structured data across the crawl.
   </Card>
-  <Card title="Authority Signals" icon="triangle-exclamation" href="/rules/eeat/authority-signals">
-    AI assessment of authorship, citations, and outbound references (cloud)
+  <Card title="Authority signals: an AI read of authorship and citations" icon="triangle-exclamation" href="/rules/eeat/authority-signals">
+    Pattern matching sees markup; this rule reads the page. The cloud service reports whether it is attributed and what its claims rest on.
   </Card>
-  <Card title="Citations" icon="circle-info" href="/rules/eeat/citations">
-    Checks for citations to authoritative external sources
+  <Card title="Authoritative citations: sources a reader can check" icon="circle-info" href="/rules/eeat/citations">
+    A factual claim with a source a reader can follow is stronger than one without. squirrel counts outbound links to a list of authoritative domains.
   </Card>
-  <Card title="Contact Page" icon="triangle-exclamation" href="/rules/eeat/contact-page">
-    Checks for contact page with multiple contact methods
+  <Card title="Contact page: finding it and counting the contact methods" icon="triangle-exclamation" href="/rules/eeat/contact-page">
+    A site with no reachable human is a site a reader has no reason to trust. squirrel finds the contact page and counts its email and phone links.
   </Card>
-  <Card title="Content Dates" icon="triangle-exclamation" href="/rules/eeat/content-dates">
-    Checks for published and modified dates on content
+  <Card title="datePublished and dateModified across content pages" icon="triangle-exclamation" href="/rules/eeat/content-dates">
+    Undated content leaves a reader guessing whether it is current. squirrel measures how much of your content carries each date.
   </Card>
-  <Card title="Disclaimers" icon="circle-info" href="/rules/eeat/disclaimers">
-    Checks for appropriate disclaimers on sensitive content
+  <Card title="Disclaimers on YMYL content: what to say and where" icon="circle-info" href="/rules/eeat/disclaimers">
+    Health, finance and legal content needs to say what it is not. squirrel looks for a dedicated disclaimer page by its URL.
   </Card>
-  <Card title="Editorial Policy" icon="circle-info" href="/rules/eeat/editorial-policy">
-    Checks for editorial and content policy pages
+  <Card title="Editorial policy: publishing how the content gets made" icon="circle-info" href="/rules/eeat/editorial-policy">
+    A stated editorial process is a claim a reader can hold you to. squirrel looks for policy pages by their multilingual URL patterns.
   </Card>
-  <Card title="Physical Address" icon="circle-info" href="/rules/eeat/physical-address">
-    Checks for visible physical address information
+  <Card title="Physical address: PostalAddress and LocalBusiness schema" icon="circle-info" href="/rules/eeat/physical-address">
+    A real address is a trust signal a visitor can verify. squirrel looks for address structured data across the crawl.
   </Card>
-  <Card title="Privacy Policy" icon="triangle-exclamation" href="/rules/eeat/privacy-policy">
-    Checks for privacy policy page linked from footer
+  <Card title="Privacy policy: the page and how widely it is linked" icon="triangle-exclamation" href="/rules/eeat/privacy-policy">
+    A privacy policy nobody can find does not do its job. squirrel finds the page and measures what share of your pages link to it.
   </Card>
-  <Card title="Terms of Service" icon="circle-info" href="/rules/eeat/terms-of-service">
-    Checks for terms of service page
+  <Card title="Terms of service page: when a site needs one" icon="circle-info" href="/rules/eeat/terms-of-service">
+    Terms of service set the rules for using a site or a service. squirrel looks for the page by its multilingual URL patterns.
   </Card>
-  <Card title="Trust Signals" icon="circle-info" href="/rules/eeat/trust-signals">
-    Checks for trust badges, certifications, and social proof
+  <Card title="Trust signals: reviews, testimonials and social proof" icon="circle-info" href="/rules/eeat/trust-signals">
+    Reviews and testimonials are what a hesitant visitor looks for. squirrel checks for review schema and testimonial pages across the crawl.
   </Card>
-  <Card title="YMYL Detection" icon="circle-info" href="/rules/eeat/ymyl-detection">
-    Detects Your Money Your Life (YMYL) content
+  <Card title="YMYL content: what it is and how squirrel detects it" icon="circle-info" href="/rules/eeat/ymyl-detection">
+    Health, finance and legal content is held to a higher standard. squirrel classifies the crawl by keyword and reports which categories it found.
   </Card>
 </CardGroup>
 

--- a/docs/rules/eeat/physical-address.mdx
+++ b/docs/rules/eeat/physical-address.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Physical Address"
-description: "Checks for visible physical address information"
+title: "Physical address: PostalAddress and LocalBusiness schema"
+description: "A real address is a trust signal a visitor can verify. squirrel looks for address structured data across the crawl."
 ---
 
-Checks for visible physical address information
+## What the address signal is
+
+A publicly listed address tells a visitor there is a place and an entity behind the site. For a business with premises it is also what feeds local search results and map listings, where the address is the thing being matched.
+
+Structured data is what makes it machine-readable. `PostalAddress` describes the address itself, and it is normally attached to a `LocalBusiness` or `Organization` node that says whose address it is.
+
+## What squirrel checks
+
+The rule is site-wide. It walks the crawled pages looking for two things in the structured data: the `PostalAddress` type anywhere, and any of `LocalBusiness`, `Organization`, `Restaurant` or `Store`. It emits a single check named `physical-address`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when either was found. Message: `Address schema markup found`, with `LocalBusiness/Organization` or `PostalAddress` as the value.
+- Info when neither was. Message: `No address schema markup detected`, with `Add PostalAddress schema if applicable` as the value.
+
+The check reads structured data only. An address printed in the footer as plain text is not detected, and an `Organization` node with no address at all passes, since the type alone satisfies the second test. Severity info, weight 3.
+
+The rule only runs when the audit classified the site as a local business. A classification below medium confidence, or an audit with no site metadata at all, runs it anyway.
+
+## How to fix it
+
+```json
+{"@context":"https://schema.org","@type":"LocalBusiness","name":"Acme","address":{"@type":"PostalAddress","streetAddress":"12 Example St","addressLocality":"Sydney","addressRegion":"NSW","postalCode":"2000","addressCountry":"AU"}}
+```
+
+Publish the address in the footer or on the contact page and mark it up as a `PostalAddress` on the node that owns it. Keep the name, address and phone identical to what your directory and map listings say.
+
+An online-only business can list a registered office. The point is that something is verifiable.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for visible physical address information
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-A physical address builds trust and is essential for local businesses. Include in: footer, contact page, about page. Use PostalAddress schema markup. For local SEO, ensure NAP (Name, Address, Phone) consistency across the site and external listings. Virtual businesses can use registered office addresses.
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["eeat/*"]
 enable = ["eeat/physical-address"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [schema/local-business](/rules/schema/local-business): the full local business markup this address belongs to.
+- [local/nap-consistency](/rules/local/nap-consistency): whether the same details appear consistently across the site.
+- [eeat/contact-page](/rules/eeat/contact-page): the page the address usually sits on.
+- [links/tel-mailto](/rules/links/tel-mailto): the phone number that goes with it.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Local business structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/local-business)
+- [PostalAddress, Schema.org](https://schema.org/PostalAddress)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with the address schema types found. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/physical-address.mdx
+++ b/docs/rules/eeat/physical-address.mdx
@@ -11,7 +11,7 @@ Structured data is what makes it machine-readable. `PostalAddress` describes the
 
 ## What squirrel checks
 
-The rule is site-wide. It walks the crawled pages looking for two things in the structured data: the `PostalAddress` type anywhere, and any of `LocalBusiness`, `Organization`, `Restaurant` or `Store`. It emits a single check named `physical-address`:
+The rule is site-wide. It walks the crawled pages looking for two things in the list of schema types the parser collected: `PostalAddress`, and any of `LocalBusiness`, `Organization`, `Restaurant` or `Store`. That list covers top-level and `@graph` nodes, so a `PostalAddress` nested as an `address` property does not satisfy the first test on its own. It emits a single check named `physical-address`:
 
 - Skipped when no pages were crawled. Message: `No pages available for analysis`.
 - Pass when either was found. Message: `Address schema markup found`, with `LocalBusiness/Organization` or `PostalAddress` as the value.

--- a/docs/rules/eeat/privacy-policy.mdx
+++ b/docs/rules/eeat/privacy-policy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Privacy policy: finding the page and how widely it is linked"
+title: "Privacy policy: the page and how widely it is linked"
 description: "A privacy policy nobody can find does not do its job. squirrel finds the page and measures what share of your pages link to it."
 ---
 

--- a/docs/rules/eeat/privacy-policy.mdx
+++ b/docs/rules/eeat/privacy-policy.mdx
@@ -16,8 +16,8 @@ The rule is site-wide. It finds the privacy page by a known multilingual slug, o
 - Skipped when no pages were crawled. Message: `No pages available for analysis`.
 - `privacy-policy` warns when no page is found. Message: `No Privacy Policy page found`, with `Create /privacy-policy page` as the value. No further checks run. Severity warning, weight 5.
 - `privacy-policy` passes when one is found. Message: `Privacy Policy page exists`, with the URL as the value.
-- `privacy-linked` passes at 80% coverage or above. Message: `Privacy policy linked from 94% of pages`.
-- `privacy-linked` reports info from 50%. Message: `Privacy policy linked from 62% of pages`, with `Consider adding to all page footers` as the value.
+- `privacy-linked` passes when the coverage percentage, rounded to a whole number, is 80 or above. Message: `Privacy policy linked from 94% of pages`.
+- `privacy-linked` reports info from 50. Message: `Privacy policy linked from 62% of pages`, with `Consider adding to all page footers` as the value.
 - `privacy-linked` warns below 50%. Message: `Privacy policy only linked from 12% of pages`, with `Add privacy link to footer on all pages` as the value.
 
 Coverage is measured by matching the link href against the known privacy slugs, not by anchor text. `legal/privacy-policy` is the rule that also reads anchor text.
@@ -30,7 +30,7 @@ Coverage is measured by matching the link href against the known privacy slugs, 
 
 Put the link in the footer component so every page inherits it. Cover what you collect, why, who you share it with, how long you keep it, and how someone exercises their rights.
 
-Update it when the practices change, not on a schedule. A policy that describes vendors you stopped using is worse than useless.
+Update it when the practices change, and check what periodic requirement applies to you: a business covered by the CCPA has to refresh the specified disclosures at least every twelve months. A policy that describes vendors you stopped using is worse than useless.
 
 | | |
 |---|---|

--- a/docs/rules/eeat/privacy-policy.mdx
+++ b/docs/rules/eeat/privacy-policy.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Privacy Policy"
-description: "Checks for privacy policy page linked from footer"
+title: "Privacy policy: finding the page and how widely it is linked"
+description: "A privacy policy nobody can find does not do its job. squirrel finds the page and measures what share of your pages link to it."
 ---
 
-Checks for privacy policy page linked from footer
+## What a privacy policy is
+
+A privacy policy states what data a site collects, why, who it goes to and what a visitor can do about it. Several jurisdictions require one, including the GDPR in the EU and the CCPA in California, and analytics or advertising vendors usually require one in their terms as well.
+
+Being reachable is part of the requirement. The convention is a footer link on every page, which is why this rule measures link coverage rather than just existence.
+
+## What squirrel checks
+
+The rule is site-wide. It finds the privacy page by a known multilingual slug, or by a crawled page whose title or `h1` reads as a privacy policy, which catches unusual slugs and redirects. There is no standard schema type for a privacy page, so there is no schema fallback. It emits up to two checks:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- `privacy-policy` warns when no page is found. Message: `No Privacy Policy page found`, with `Create /privacy-policy page` as the value. No further checks run. Severity warning, weight 5.
+- `privacy-policy` passes when one is found. Message: `Privacy Policy page exists`, with the URL as the value.
+- `privacy-linked` passes at 80% coverage or above. Message: `Privacy policy linked from 94% of pages`.
+- `privacy-linked` reports info from 50%. Message: `Privacy policy linked from 62% of pages`, with `Consider adding to all page footers` as the value.
+- `privacy-linked` warns below 50%. Message: `Privacy policy only linked from 12% of pages`, with `Add privacy link to footer on all pages` as the value.
+
+Coverage is measured by matching the link href against the known privacy slugs, not by anchor text. `legal/privacy-policy` is the rule that also reads anchor text.
+
+## How to fix it
+
+```html
+<a href="/privacy-policy">Privacy policy</a>
+```
+
+Put the link in the footer component so every page inherits it. Cover what you collect, why, who you share it with, how long you keep it, and how someone exercises their rights.
+
+Update it when the practices change, not on a schedule. A policy that describes vendors you stopped using is worse than useless.
 
 | | |
 |---|---|
@@ -12,14 +39,6 @@ Checks for privacy policy page linked from footer
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-A privacy policy is required by law in many jurisdictions (GDPR, CCPA) and signals trustworthiness. Link it from your footer on every page. Cover: what data you collect, how you use it, third-party sharing, user rights, and contact for privacy concerns. Keep it updated when practices change.
-
-## Detection
-
-A crawled page is credited as your privacy policy when its URL matches a known privacy slug (`/privacy`, `/privacy-policy`, `/legal/privacy`, and localized variants) or when its title or h1 reads "Privacy Policy" / "Privacy Notice" (a dated qualifier like "(Updated July 2026)" is fine), so a page with an unusual slug is still recognized.
 
 ## Enable / disable
 
@@ -44,3 +63,29 @@ disable = ["eeat/*"]
 enable = ["eeat/privacy-policy"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [legal/privacy-policy](/rules/legal/privacy-policy): the compliance view, which also reads anchor text.
+- [legal/cookie-consent](/rules/legal/cookie-consent): whether the site asks before setting cookies.
+- [eeat/terms-of-service](/rules/eeat/terms-of-service): the other legal page in the footer.
+- [security/third-party-cookies](/rules/security/third-party-cookies): the vendors the policy has to name.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The privacy page is reported with its URL and the share of pages that link to it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/privacy-policy.mdx
+++ b/docs/rules/eeat/privacy-policy.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 ## Related rules
 
 - [legal/privacy-policy](/rules/legal/privacy-policy): the compliance view, which also reads anchor text.
-- [legal/cookie-consent](/rules/legal/cookie-consent): whether the site asks before setting cookies.
+- [legal/cookie-consent](/rules/legal/cookie-consent): whether a cookie consent mechanism is present.
 - [eeat/terms-of-service](/rules/eeat/terms-of-service): the other legal page in the footer.
 - [security/third-party-cookies](/rules/security/third-party-cookies): the vendors the policy has to name.
 

--- a/docs/rules/eeat/terms-of-service.mdx
+++ b/docs/rules/eeat/terms-of-service.mdx
@@ -1,9 +1,29 @@
 ---
-title: "Terms of Service"
-description: "Checks for terms of service page"
+title: "Terms of service page: when a site needs one"
+description: "Terms of service set the rules for using a site or a service. squirrel looks for the page by its multilingual URL patterns."
 ---
 
-Checks for terms of service page
+## What terms of service are
+
+Terms of service are the contract between a site and the people using it: what they may do, what you owe them, who owns what, and how disputes are handled.
+
+They matter most where there is a transaction or an account: online stores, subscription software, membership sites, anything with user-generated content. A site that publishes articles and sells nothing can reasonably not have them, which is why this rule reports at info severity rather than as a defect.
+
+## What squirrel checks
+
+The rule is site-wide. It matches each crawled page's URL path against the multilingual terms patterns, and takes the first match. It emits a single check named `terms-of-service`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when a page matches. Message: `Terms of Service page found`, with the URL as the value.
+- Info when none does. Message: `No Terms of Service page found`, with `Consider adding for e-commerce/SaaS sites` as the value.
+
+The match is on the URL path only. There is no title fallback and no schema fallback, so a terms page on an unusual slug is not found. Severity info, weight 3.
+
+## How to fix it
+
+Write terms covering what a user may and may not do, who owns the content on both sides, what you disclaim, and how disputes are resolved. Link them from the footer next to the privacy policy.
+
+Keep them current when the practices change, and note the last revision date so a reader can tell.
 
 | | |
 |---|---|
@@ -12,10 +32,6 @@ Checks for terms of service page
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Terms of Service (ToS) define the rules for using your site/service. Essential for: e-commerce, SaaS, membership sites. Include: user responsibilities, intellectual property, disclaimers, dispute resolution. Link from footer. Keep updated when practices change. For simple content sites, may be optional but still recommended.
 
 ## Enable / disable
 
@@ -40,3 +56,29 @@ disable = ["eeat/*"]
 enable = ["eeat/terms-of-service"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [legal/terms-of-service](/rules/legal/terms-of-service): the compliance view of the same page.
+- [eeat/privacy-policy](/rules/eeat/privacy-policy): the other legal page, which is more often required.
+- [eeat/disclaimers](/rules/eeat/disclaimers): the disclaimers that sit alongside them on YMYL sites.
+- [eeat/about-page](/rules/eeat/about-page): the page a reader reads before either of these.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The terms page is reported with its URL when one is found. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/trust-signals.mdx
+++ b/docs/rules/eeat/trust-signals.mdx
@@ -27,6 +27,8 @@ Both tests are coarse. Security and payment badges are not detected, certificati
 
 Publish real reviews with names and dates, and mark up the aggregate rating so it is machine-readable. Put the strongest proof where the decision happens: the product page, the pricing page, the checkout.
 
+Note that this example alone will not satisfy the rule. The parser collects top-level and `@graph` node types, so an `AggregateRating` nested inside a `Product` is recorded as `Product`. Detection needs a `Review` or `AggregateRating` node of its own, or a URL matching the testimonial patterns.
+
 Do not mark up ratings you cannot back with visible reviews on the page. Google's review snippet guidelines require the rating to be about the page's own subject and visible to the reader.
 
 | | |

--- a/docs/rules/eeat/trust-signals.mdx
+++ b/docs/rules/eeat/trust-signals.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Trust Signals"
-description: "Checks for trust badges, certifications, and social proof"
+title: "Trust signals: reviews, testimonials and social proof"
+description: "Reviews and testimonials are what a hesitant visitor looks for. squirrel checks for review schema and testimonial pages across the crawl."
 ---
 
-Checks for trust badges, certifications, and social proof
+## What a trust signal is
+
+A trust signal is evidence from somewhere other than your own marketing copy: customer reviews, testimonials, certifications, membership of a professional body, awards.
+
+They work by being checkable. A rating with reviews behind it, or a named customer who can be looked up, carries weight that a claim about quality does not. Marked up as structured data, an aggregate rating can also appear in search results.
+
+## What squirrel checks
+
+The rule is site-wide. It looks for two signals: any page whose structured data declares `Review` or `AggregateRating`, and any page whose URL path matches `testimonial`, `review` or `customer-stories`. It emits a single check named `trust-signals`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when either was found. Message: `2 trust signal(s) detected`, listing them as `Review/Rating schema` and `Testimonials section`.
+- Info when neither was. Message: `Limited trust signals detected`, with `Consider adding reviews, testimonials, or certifications` as the value.
+
+Both tests are coarse. Security and payment badges are not detected, certifications are not detected, and testimonials rendered on a page whose URL says nothing about them are not detected either. A pass means these two markers were present, not that the site is well trusted. Severity info, weight 3.
+
+## How to fix it
+
+```json
+{"@context":"https://schema.org","@type":"Product","name":"Widget","aggregateRating":{"@type":"AggregateRating","ratingValue":"4.6","reviewCount":"128"}}
+```
+
+Publish real reviews with names and dates, and mark up the aggregate rating so it is machine-readable. Put the strongest proof where the decision happens: the product page, the pricing page, the checkout.
+
+Do not mark up ratings you cannot back with visible reviews on the page. Google's review snippet guidelines require the rating to be about the page's own subject and visible to the reader.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for trust badges, certifications, and social proof
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Trust signals help visitors feel confident. Include: security badges (Norton, McAfee), payment badges (Visa, PayPal), certifications (BBB, industry-specific), customer reviews/testimonials, and social proof (customer count, awards). Place trust signals prominently on homepage, checkout, and contact pages.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["eeat/*"]
 enable = ["eeat/trust-signals"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [schema/review](/rules/schema/review): the review markup and its requirements.
+- [schema/rating-scope](/rules/schema/rating-scope): whether the rating is attached to the right thing.
+- [eeat/about-page](/rules/eeat/about-page): the page that carries the rest of the case.
+- [eeat/citations](/rules/eeat/citations): evidence of a different kind.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Review snippet structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/review-snippet)
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with the trust signals detected. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/eeat/ymyl-detection.mdx
+++ b/docs/rules/eeat/ymyl-detection.mdx
@@ -13,14 +13,14 @@ This rule does not judge the content. It reports which YMYL categories appear on
 
 ## What squirrel checks
 
-The rule is site-wide. It scans each page's text and URL path for keywords in three groups and counts the pages matching each. It emits up to two checks:
+The rule is site-wide. It searches each page's title, meta description and URL pathname for keywords in three groups, case-insensitively, and counts the pages matching each. The body copy is not searched. It emits up to two checks:
 
 - Skipped when no pages were crawled. Message: `No pages available for analysis`.
 - `ymyl-content` reports info when any category matched. Message: `YMYL content detected - apply higher E-E-A-T standards`, listing what was found as `Health (14 pages)`, `Finance (3 pages)` and `Legal (1 pages)`.
 - `ymyl-requirements` reports info alongside it. Message: `YMYL content should have expert authors, disclaimers, and citations`.
 - `ymyl-detection` passes when nothing matched. Message: `No obvious YMYL content detected`.
 
-The three keyword groups cover health terms such as `symptoms`, `treatment`, `medication` and `surgery`; finance terms such as `investment`, `mortgage`, `tax` and `crypto`; and legal terms such as `lawyer`, `lawsuit` and `custody`. A keyword anywhere in the page text or the path is a match, so an unrelated page mentioning `insurance` in a sentence is counted. Read the counts as a prompt, not a classification. Severity info, weight 5.
+The three keyword groups cover health terms such as `symptoms`, `treatment`, `medication` and `surgery`; finance terms such as `investment`, `mortgage`, `tax` and `crypto`; and legal terms such as `lawyer`, `lawsuit` and `custody`. A keyword anywhere in the title, the description or the path is a match, so a page titled around an unrelated use of `credit` is counted. Read the counts as a prompt, not a classification. Severity info, weight 5.
 
 Several other E-E-A-T rules are gated on the audit's own site classification, which is a separate mechanism from this rule's keyword scan.
 

--- a/docs/rules/eeat/ymyl-detection.mdx
+++ b/docs/rules/eeat/ymyl-detection.mdx
@@ -1,9 +1,34 @@
 ---
-title: "YMYL Detection"
-description: "Detects Your Money Your Life (YMYL) content"
+title: "YMYL content: what it is and how squirrel detects it"
+description: "Health, finance and legal content is held to a higher standard. squirrel classifies the crawl by keyword and reports which categories it found."
 ---
 
-Detects Your Money Your Life (YMYL) content
+## What YMYL means
+
+YMYL stands for Your Money or Your Life. It is the label Google's quality rater guidelines use for topics where bad information can cause real harm: medical advice, financial decisions, legal matters, safety, civic information.
+
+Content in those areas is judged more strictly on expertise and trustworthiness than content that is merely wrong about a film. The practical consequence is that attribution, credentials, sourcing and disclaimers stop being nice-to-have.
+
+This rule does not judge the content. It reports which YMYL categories appear on the site, so you know which standard applies.
+
+## What squirrel checks
+
+The rule is site-wide. It scans each page's text and URL path for keywords in three groups and counts the pages matching each. It emits up to two checks:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- `ymyl-content` reports info when any category matched. Message: `YMYL content detected - apply higher E-E-A-T standards`, listing what was found as `Health (14 pages)`, `Finance (3 pages)` and `Legal (1 pages)`.
+- `ymyl-requirements` reports info alongside it. Message: `YMYL content should have expert authors, disclaimers, and citations`.
+- `ymyl-detection` passes when nothing matched. Message: `No obvious YMYL content detected`.
+
+The three keyword groups cover health terms such as `symptoms`, `treatment`, `medication` and `surgery`; finance terms such as `investment`, `mortgage`, `tax` and `crypto`; and legal terms such as `lawyer`, `lawsuit` and `custody`. A keyword anywhere in the page text or the path is a match, so an unrelated page mentioning `insurance` in a sentence is counted. Read the counts as a prompt, not a classification. Severity info, weight 5.
+
+Several other E-E-A-T rules are gated on the audit's own site classification, which is a separate mechanism from this rule's keyword scan.
+
+## How to fix it
+
+Where the categories are right, apply the stricter standard to those sections: named authors with relevant credentials, a disclaimer that says what the content is not, sources a reader can check, and a visible review date.
+
+Where they are wrong, the keyword scan caught an incidental mention. Nothing needs fixing.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Detects Your Money Your Life (YMYL) content
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 5/10 |
-
-## Solution
-
-YMYL content (health, finance, legal, safety) is held to higher E-E-A-T standards by Google. If detected: ensure expert authors with credentials, add disclaimers ('not medical advice'), cite authoritative sources, show content review dates, and include professional credentials. YMYL errors can significantly impact rankings.
 
 ## Enable / disable
 
@@ -40,3 +61,29 @@ disable = ["eeat/*"]
 enable = ["eeat/ymyl-detection"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/disclaimers](/rules/eeat/disclaimers): the disclaimers YMYL content needs.
+- [eeat/author-expertise](/rules/eeat/author-expertise): the credentials that carry the most weight here.
+- [eeat/citations](/rules/eeat/citations): sourcing for claims a reader may act on.
+- [eeat/editorial-policy](/rules/eeat/editorial-policy): how the content is reviewed before it ships.
+
+E-E-A-T findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the E-E-A-T section of the report. The site is reported with the YMYL categories found and their page counts. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the E-E-A-T section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/gaps/content.mdx
+++ b/docs/rules/gaps/content.mdx
@@ -18,7 +18,7 @@ The rule is site-wide and reads a result the cloud content-gaps service produced
 - `content-gaps` is skipped when no result is available, because the rule was not enabled or the service skipped it. Message: `Content gap analysis skipped`, with a readable skip reason.
 - `content-gaps` passes when the service found none. Message: `No content gaps found`.
 - `content-gaps` reports info with the count. Message: `6 content gap topics found`, or `1 content gap topic found` for one.
-- `content-gaps-high-volume` warns when any cluster has at least 500 combined monthly searches. Message: `2 high-volume content gap topics (≥500 combined searches/mo) — significant uncovered demand`.
+- `content-gaps-high-volume` warns when more than 20 clusters each have at least 500 combined monthly searches. Message: `21 high-volume content gap topics (≥500 combined searches/mo) — significant uncovered demand`.
 
 Severity for the rule is info and the weight is 1. It is disabled by default and costs 25 credits per audit when enabled.
 

--- a/docs/rules/gaps/content.mdx
+++ b/docs/rules/gaps/content.mdx
@@ -1,11 +1,32 @@
 ---
-title: "Content Gaps"
-description: "Finds topic clusters with search demand that lack dedicated coverage"
+title: "Content gaps: topic clusters your site does not cover"
+description: "A content gap is a cluster of related searches next to what you already rank for. squirrel groups the demand and reports the uncovered clusters."
 ---
 
 <Note>**Cloud rule, opt-in** - requires login (`squirrel auth login`), costs **25 credits per audit**, and is **disabled by default**. See [Cloud rules](/cloud/rules).</Note>
 
-Finds topic clusters with search demand around the site's existing content that lack dedicated coverage.
+## What a content gap is
+
+A content gap is a topic cluster with search demand that sits next to your existing content and has no page of its own. Where a keyword gap is one term, a cluster is a group of related questions that one good page could answer together.
+
+Adjacency is what makes them worth doing first. A cluster next to something you already rank for benefits from the topical standing you have, so a new page there starts from a better position than one on an unrelated subject.
+
+## What squirrel checks
+
+The rule is site-wide and reads a result the cloud content-gaps service produced before the rules ran. It emits up to two checks:
+
+- `content-gaps` is skipped when no result is available, because the rule was not enabled or the service skipped it. Message: `Content gap analysis skipped`, with a readable skip reason.
+- `content-gaps` passes when the service found none. Message: `No content gaps found`.
+- `content-gaps` reports info with the count. Message: `6 content gap topics found`, or `1 content gap topic found` for one.
+- `content-gaps-high-volume` warns when any cluster has at least 500 combined monthly searches. Message: `2 high-volume content gap topics (≥500 combined searches/mo) — significant uncovered demand`.
+
+Severity for the rule is info and the weight is 1. It is disabled by default and costs 25 credits per audit when enabled.
+
+## How to fix it
+
+Plan a page per cluster rather than per keyword, starting with the highest combined volume. A guide, a comparison or a genuine FAQ usually covers a cluster better than several thin pages splitting it.
+
+Link the new page from the existing content it sits next to. That is what connects it to the standing that made the cluster worth writing.
 
 | | |
 |---|---|
@@ -16,20 +37,21 @@ Finds topic clusters with search demand around the site's existing content that 
 | **Weight** | 1/10 |
 | **Default** | Disabled (opt-in) |
 
-## What it checks
-
-Using live search data, the rule maps topic clusters adjacent to what your site already covers and reports clusters with combined search volume that have no dedicated page on your site.
-
-## Solution
-
-Each gap is a topic cluster with combined search volume the site doesn't cover directly. Plan content (guides, comparisons, FAQs) around the highest-volume clusters first - they're adjacent to what you already rank for, so new pages benefit from existing topical authority.
-
 ## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `country` | string | `US` | ISO country for search data |
+| `language` | string | `en` | Language code for search data |
+| `competitors` | array of strings | none | Competitor domains to compare against, up to 5 |
+
+### Configuration example
 
 ```toml squirrel.toml
 [rule_options."gaps/content"]
-country = "US"        # ISO country for search data (default US)
-language = "en"       # language code for search data (default en)
+country = "AU"
+language = "en"
+competitors = ["competitor.com", "other.example"]
 ```
 
 ## Enable / disable
@@ -40,3 +62,30 @@ This rule is opt-in - enable it explicitly:
 [rules]
 enable = ["gaps/content"]
 ```
+
+## Related rules
+
+- [gaps/keywords](/rules/gaps/keywords): individual terms rather than clusters.
+- [content/article-links](/rules/content/article-links): linking a new page into the site.
+- [content/thin-vs-site-norm](/rules/content/thin-vs-site-norm): existing pages that under-cover their topic.
+- [links/orphan-pages](/rules/links/orphan-pages): making sure the new pages are reachable.
+
+Gap Analysis findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [SEO starter guide, Google Search Central](https://developers.google.com/search/docs/fundamentals/seo-starter-guide)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Gap Analysis section of the report. Each gap cluster is listed with its combined search volume. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Gap Analysis section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/gaps/index.mdx
+++ b/docs/rules/gaps/index.mdx
@@ -5,7 +5,7 @@ description: "Keyword and content gap analysis backed by live search data"
 
 <Note>**Cloud rules, opt-in** - these rules require login (`squirrel auth login`), cost **25 credits each per audit**, and are **disabled by default** so a routine audit never spends them by surprise. See [Cloud rules](/cloud/rules).</Note>
 
-Gap analysis compares your site against live search demand data: what people search for, what competitors rank for, and which of those topics your site doesn't cover.
+Gap analysis compares your site against live search demand data: what people search for, what competitors rank for, and which of those topics your site doesn't cover. Both rules read a result the cloud service produced before the rules ran, report at info severity with a weight of 1, and flag anything above 500 monthly searches as high volume. They are research output rather than defects, which is why they barely move a score.
 
 ## Rules
 
@@ -37,3 +37,5 @@ country = "US"                       # ISO country for search data
 language = "en"                      # language code for search data
 competitors = ["competitor.com"]     # up to 5 competitor domains
 ```
+
+Every audit reports Gap Analysis findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/gaps/index.mdx
+++ b/docs/rules/gaps/index.mdx
@@ -10,11 +10,11 @@ Gap analysis compares your site against live search demand data: what people sea
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Keyword Gaps" icon="circle-info" href="/rules/gaps/keywords">
-    Keywords competitors rank for (or seed-keyword opportunities) that this site doesn't rank for
+  <Card title="Keyword gaps: terms competitors rank for and you do not" icon="circle-info" href="/rules/gaps/keywords">
+    A keyword gap is demand your competitors capture and you do not. squirrel compares your ranking footprint against theirs using live search data.
   </Card>
-  <Card title="Content Gaps" icon="circle-info" href="/rules/gaps/content">
-    Topic clusters with search demand around your existing content that lack dedicated coverage
+  <Card title="Content gaps: topic clusters your site does not cover" icon="circle-info" href="/rules/gaps/content">
+    A content gap is a cluster of related searches next to what you already rank for. squirrel groups the demand and reports the uncovered clusters.
   </Card>
 </CardGroup>
 

--- a/docs/rules/gaps/keywords.mdx
+++ b/docs/rules/gaps/keywords.mdx
@@ -1,11 +1,32 @@
 ---
-title: "Keyword Gaps"
-description: "Finds keywords competitors rank for that this site doesn't rank for"
+title: "Keyword gaps: terms competitors rank for and you do not"
+description: "A keyword gap is demand your competitors capture and you do not. squirrel compares your ranking footprint against theirs using live search data."
 ---
 
 <Note>**Cloud rule, opt-in** - requires login (`squirrel auth login`), costs **25 credits per audit**, and is **disabled by default**. See [Cloud rules](/cloud/rules).</Note>
 
-Finds keywords competitors rank for (or seed-keyword opportunities) that this site doesn't rank for.
+## What a keyword gap is
+
+A keyword gap is a search term with real volume where competitors appear and you do not. It is a different question from how well your existing pages rank: it asks what you have not written about at all.
+
+The comparison needs competitors, either named by you or inferred, and live search data for volume. Without both, a keyword list is a guess. What comes back is demand, not a plan: a term with volume is only worth pursuing when it matches what your site is actually for.
+
+## What squirrel checks
+
+The rule is site-wide and reads a result the cloud keyword-gaps service produced before the rules ran. It emits up to two checks:
+
+- `keyword-gaps` is skipped when no result is available, because the rule was not enabled or the service skipped it. Message: `Keyword gap analysis skipped`, with a readable skip reason.
+- `keyword-gaps` passes when the service found none. Message: `No keyword gaps found`.
+- `keyword-gaps` reports info with the count. Message: `18 keyword gaps found`, or `1 keyword gap found` for one.
+- `keyword-gaps-high-volume` warns when any gap has at least 500 monthly searches. Message: `4 high-volume keyword gaps (≥500 searches/mo) — significant untapped search demand`.
+
+Severity for the rule is info and the weight is 1, so it never moves a score much: it is a research output rather than a defect. It is disabled by default and costs 25 credits per audit when enabled.
+
+## How to fix it
+
+Work through the high-volume gaps that match your site's intent and build a page per keyword cluster. A dedicated page generally outranks one that mentions the topic in passing.
+
+Name your real competitors in the `competitors` option. Without them the analysis falls back on seed keywords from your own content, which is a weaker comparison.
 
 | | |
 |---|---|
@@ -16,21 +37,21 @@ Finds keywords competitors rank for (or seed-keyword opportunities) that this si
 | **Weight** | 1/10 |
 | **Default** | Disabled (opt-in) |
 
-## What it checks
-
-Using live search data, the rule compares your site's ranking footprint against competitor domains (or seed keywords derived from your content) and reports keywords with real search volume where competitors rank and you don't.
-
-## Solution
-
-Review the listed gap keywords and prioritize the high-volume ones that match your site's intent. Create or expand pages targeting them - a dedicated page per keyword cluster generally outranks a page that mentions the topic in passing. Configure competitor domains via the `competitors` option to sharpen the analysis.
-
 ## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `country` | string | `US` | ISO country for search data |
+| `language` | string | `en` | Language code for search data |
+| `competitors` | array of strings | none | Competitor domains to compare against, up to 5 |
+
+### Configuration example
 
 ```toml squirrel.toml
 [rule_options."gaps/keywords"]
-country = "US"                       # ISO country for search data (default US)
-language = "en"                      # language code for search data (default en)
-competitors = ["competitor.com"]     # up to 5 competitor domains
+country = "AU"
+language = "en"
+competitors = ["competitor.com", "other.example"]
 ```
 
 ## Enable / disable
@@ -41,3 +62,30 @@ This rule is opt-in - enable it explicitly:
 [rules]
 enable = ["gaps/keywords"]
 ```
+
+## Related rules
+
+- [gaps/content](/rules/gaps/content): topic clusters rather than individual keywords.
+- [content/word-count](/rules/content/word-count): whether the pages you have say enough.
+- [content/thin-vs-site-norm](/rules/content/thin-vs-site-norm): which existing pages are thinner than their siblings.
+- [links/no-contextual-inbound](/rules/links/no-contextual-inbound): whether new pages will be linked into the site.
+
+Gap Analysis findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [SEO starter guide, Google Search Central](https://developers.google.com/search/docs/fundamentals/seo-starter-guide)
+- [Creating helpful, reliable content, Google Search Central](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Gap Analysis section of the report. Each gap keyword is listed with its search volume. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Gap Analysis section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/gaps/keywords.mdx
+++ b/docs/rules/gaps/keywords.mdx
@@ -7,7 +7,7 @@ description: "A keyword gap is demand your competitors capture and you do not. s
 
 ## What a keyword gap is
 
-A keyword gap is a search term with real volume where competitors appear and you do not. It is a different question from how well your existing pages rank: it asks what you have not written about at all.
+A keyword gap is a search term with real volume where competitors appear and you do not. It is a different question from how well your existing pages rank. A gap can mean you have nothing on the topic, or that what you have does not rank, and the fix differs: a new page in the first case, an expanded one in the second.
 
 The comparison needs competitors, either named by you or inferred, and live search data for volume. Without both, a keyword list is a guess. What comes back is demand, not a plan: a term with volume is only worth pursuing when it matches what your site is actually for.
 
@@ -18,7 +18,7 @@ The rule is site-wide and reads a result the cloud keyword-gaps service produced
 - `keyword-gaps` is skipped when no result is available, because the rule was not enabled or the service skipped it. Message: `Keyword gap analysis skipped`, with a readable skip reason.
 - `keyword-gaps` passes when the service found none. Message: `No keyword gaps found`.
 - `keyword-gaps` reports info with the count. Message: `18 keyword gaps found`, or `1 keyword gap found` for one.
-- `keyword-gaps-high-volume` warns when any gap has at least 500 monthly searches. Message: `4 high-volume keyword gaps (≥500 searches/mo) — significant untapped search demand`.
+- `keyword-gaps-high-volume` warns when more than 20 gaps each have at least 500 monthly searches. Message: `21 high-volume keyword gaps (≥500 searches/mo) — significant untapped search demand`.
 
 Severity for the rule is info and the weight is 1, so it never moves a score much: it is a research output rather than a defect. It is disabled by default and costs 25 credits per audit when enabled.
 

--- a/docs/rules/i18n/hreflang.mdx
+++ b/docs/rules/i18n/hreflang.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Hreflang Tags"
-description: "Checks for hreflang link elements"
+title: "hreflang: x-default and the self-referencing tag"
+description: "hreflang tells search engines which language version to show. squirrel checks for x-default and a self-reference on any page that has them."
 ---
 
-Checks for hreflang link elements
+## What hreflang is
+
+`<link rel="alternate" hreflang="…">` tells a search engine that a page has versions for other languages or regions, and where they are. Without it, the versions compete as near-duplicates and the wrong one is shown.
+
+Two rules make a set work. Every page in the set lists every version including itself, so the set is confirmed from every direction. And `x-default` names the version to show a visitor whose language matches none of the others, usually a language selector or the primary version.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `link[rel="alternate"][hreflang]`. It emits up to three checks:
+
+- Info when the page has no hreflang tags. Message: `No hreflang tags found (not required for single-language sites)`. No further checks run.
+- `hreflang-xdefault` warns when no tag has `hreflang="x-default"`. Message: `No x-default hreflang found`.
+- `hreflang-self` warns when no tag's resolved href equals the page URL exactly. Message: `No self-referencing hreflang found`.
+- `hreflang` passes, listing the language codes found. Message: `4 hreflang tag(s) found`.
+
+The final pass check is always emitted alongside any warnings, so a page can report both a missing `x-default` and a count of its tags. The self-reference comparison is on the fully resolved URL, so a self-tag that differs by a trailing slash or a query string does not count. Language codes are not validated, and the return links from the other versions cannot be checked from this page. Severity info, weight 3.
+
+## How to fix it
+
+```html
+<link rel="alternate" hreflang="en-au" href="https://example.com/au/pricing" />
+<link rel="alternate" hreflang="en-gb" href="https://example.com/uk/pricing" />
+<link rel="alternate" hreflang="x-default" href="https://example.com/pricing" />
+```
+
+Generate the full set from one source of truth so every version lists every other, including itself, with URLs matching the canonical form exactly.
+
+Keep `hreflang` and the canonical tag consistent: each version should be canonical to itself, not to the primary language.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks for hreflang link elements
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Hreflang tags tell search engines about language and regional variations of pages, preventing duplicate content issues and ensuring users see the right version. Add hreflang link tags for each language/region version of a page. Include x-default for the fallback. Every page referenced should link back to all variants (bidirectional). Use correct ISO language and country codes.
 
 ## Enable / disable
 
@@ -40,3 +63,30 @@ disable = ["i18n/*"]
 enable = ["i18n/hreflang"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [i18n/lang-attribute](/rules/i18n/lang-attribute): the language of this page, as opposed to its alternates.
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): the canonical tag each version needs.
+- [content/duplicate-title](/rules/content/duplicate-title): what language versions look like without hreflang.
+- [crawl/sitemap-coverage](/rules/crawl/sitemap-coverage): whether every version is in the sitemap.
+
+Internationalization findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Localized versions of your pages, Google Search Central](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [Declaring language in HTML, W3C Internationalization](https://www.w3.org/International/questions/qa-html-language-declarations)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Internationalization section of the report. Each page is reported with its hreflang codes and any missing x-default or self-reference. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Internationalization section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/i18n/index.mdx
+++ b/docs/rules/i18n/index.mdx
@@ -3,7 +3,7 @@ title: "Internationalization"
 description: "Language declarations and multi-region support"
 ---
 
-Language declarations and multi-region support
+Internationalization rules cover two declarations. The `lang` attribute on the `html` element says what language this page is in, which a screen reader uses to pick a voice. The hreflang tags say which other language or region versions exist, which is what stops them competing with each other in search. Both are cheap to get right and quietly wrong on a lot of sites.
 
 ## Rules
 
@@ -22,3 +22,5 @@ Language declarations and multi-region support
 [rules]
 disable = ["i18n/*"]
 ```
+
+Every audit reports Internationalization findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/i18n/index.mdx
+++ b/docs/rules/i18n/index.mdx
@@ -8,11 +8,11 @@ Internationalization rules cover two declarations. The `lang` attribute on the `
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Hreflang Tags" icon="circle-info" href="/rules/i18n/hreflang">
-    Checks for hreflang link elements
+  <Card title="hreflang: x-default and the self-referencing tag" icon="circle-info" href="/rules/i18n/hreflang">
+    hreflang tells search engines which language version to show. squirrel checks for x-default and a self-reference on any page that has them.
   </Card>
-  <Card title="Lang Attribute" icon="triangle-exclamation" href="/rules/i18n/lang-attribute">
-    Checks for lang attribute on html element
+  <Card title="lang attribute on <html>: declaring the page's language" icon="triangle-exclamation" href="/rules/i18n/lang-attribute">
+    Without a lang attribute a screen reader guesses which voice to use and may read the page in the wrong language. squirrel checks it and its format.
   </Card>
 </CardGroup>
 

--- a/docs/rules/i18n/lang-attribute.mdx
+++ b/docs/rules/i18n/lang-attribute.mdx
@@ -5,7 +5,7 @@ description: "Without a lang attribute a screen reader guesses which voice to us
 
 ## What the lang attribute is
 
-`<html lang="en">` declares the natural language of a page's content. A screen reader uses it to pick a pronunciation model, a browser uses it for hyphenation and for offering translation, and a search engine uses it as one signal about who the page is for.
+`<html lang="en">` declares the natural language of a page's content. A screen reader uses it to pick a pronunciation model, and a browser uses it for hyphenation and for offering translation. Google is explicit that it ignores code-level language declarations and works out the language from the visible content instead, so treat this as an accessibility and browser-behaviour attribute rather than a ranking one.
 
 The value is a BCP 47 language tag: a two or three letter language subtag, optionally followed by a region, as in `en`, `es` or `en-AU`. Use a region subtag only when the regional variant matters; `en` is more useful than `en-US` on a page that is not specifically American.
 
@@ -76,6 +76,7 @@ Internationalization findings ship in every audit next to the SEO, performance a
 
 - [The lang global attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang)
 - [Declaring language in HTML, W3C Internationalization](https://www.w3.org/International/questions/qa-html-language-declarations)
+- [Managing multi-regional and multilingual sites, Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites)
 
 ## Check your site
 

--- a/docs/rules/i18n/lang-attribute.mdx
+++ b/docs/rules/i18n/lang-attribute.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Lang Attribute"
-description: "Checks for lang attribute on html element"
+title: "lang attribute on <html>: declaring the page's language"
+description: "Without a lang attribute a screen reader guesses which voice to use and may read the page in the wrong language. squirrel checks it and its format."
 ---
 
-Checks for lang attribute on html element
+## What the lang attribute is
+
+`<html lang="en">` declares the natural language of a page's content. A screen reader uses it to pick a pronunciation model, a browser uses it for hyphenation and for offering translation, and a search engine uses it as one signal about who the page is for.
+
+The value is a BCP 47 language tag: a two or three letter language subtag, optionally followed by a region, as in `en`, `es` or `en-AU`. Use a region subtag only when the regional variant matters; `en` is more useful than `en-US` on a page that is not specifically American.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reads the `lang` attribute on the `<html>` element. It emits a single check named `lang-attribute`:
+
+- Warn when the attribute is absent or empty. Message: `Missing lang attribute on <html> element`. Severity warning, weight 4.
+- Info when the value does not match `^[a-z]{2}(-[A-Z]{2})?$`. Message: `Lang attribute format: en_US`, with the value.
+- Pass when it does. Message: `Lang attribute present: en-AU`, with the value.
+
+The format test is narrower than BCP 47 allows. It accepts only a lowercase two-letter language with an optional uppercase two-letter region, so valid tags such as `pt-BR` pass while `zh-Hant`, `en-GB-oxendict` and three-letter language subtags are reported as an unexpected format rather than as an error. The informational status reflects that.
+
+Only the `<html>` element is checked. A `lang` on a section of the page in another language is not read here.
+
+## How to fix it
+
+```html
+<html lang="en-AU">
+```
+
+Set it in the base layout, from the same value the site uses to pick its content language. On a multilingual site, render the tag per locale rather than hardcoding one.
+
+Mark passages in another language with their own `lang` on the element that contains them, so a screen reader switches voice for them.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for lang attribute on html element
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-The lang attribute on the html element declares the page's language, helping browsers, screen readers, and search engines process content correctly. Add lang="xx" to your html tag using a valid ISO 639-1 code (e.g., "en", "es", "fr"). For regional variants, use lang="en-US" or "en-GB". This improves accessibility and helps search engines serve your content to the right audience.
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["i18n/*"]
 enable = ["i18n/lang-attribute"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [i18n/hreflang](/rules/i18n/hreflang): the tags that connect this page to its other language versions.
+- [a11y/html-lang-valid](/rules/a11y/html-lang-valid): the accessibility check over the same attribute.
+- [core/charset](/rules/core/charset): the other declaration in the same part of the document.
+- [content/mojibake](/rules/content/mojibake): what a wrong encoding does to non-English text.
+
+Internationalization findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The lang global attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang)
+- [Declaring language in HTML, W3C Internationalization](https://www.w3.org/International/questions/qa-html-language-declarations)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Internationalization section of the report. Each page is reported with the lang value it declares. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Internationalization section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/alt-text.mdx
+++ b/docs/rules/images/alt-text.mdx
@@ -5,7 +5,7 @@ description: "An image with no alt attribute has no name for a screen reader. An
 
 ## What the alt attribute is
 
-`alt` is the text alternative for an image: what a screen reader announces, and what a browser shows when the image does not load. Every `<img>` is required to have one.
+`alt` is the text alternative for an image: what a screen reader announces, and what a browser shows when the image does not load. This rule expects one on every `<img>`. The HTML specification allows a few narrow exceptions, for cases where no alternative text is available and none can be produced, and they do not apply to a normal page.
 
 The two valid states are a description and an empty string. `alt="Chart showing revenue by quarter"` names an image that carries information. `alt=""` marks an image as decorative and tells assistive technology to skip it, which is the correct markup for a divider, a background flourish or an icon whose meaning is already in the adjacent text. Omitting the attribute is the failure, because it leaves the software to guess, and most screen readers fall back to reading the filename.
 

--- a/docs/rules/images/alt-text.mdx
+++ b/docs/rules/images/alt-text.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Image Alt Text"
-description: "Checks that every image carries an alt attribute, counting an empty alt as a decorative marker"
+title: "Missing alt attribute: what an empty alt means"
+description: "An image with no alt attribute has no name for a screen reader. An empty alt is the correct way to say decorative, and squirrel accepts it."
 ---
 
-Checks that every image carries an alt attribute, counting an empty alt as a decorative marker
+## What the alt attribute is
+
+`alt` is the text alternative for an image: what a screen reader announces, and what a browser shows when the image does not load. Every `<img>` is required to have one.
+
+The two valid states are a description and an empty string. `alt="Chart showing revenue by quarter"` names an image that carries information. `alt=""` marks an image as decorative and tells assistive technology to skip it, which is the correct markup for a divider, a background flourish or an icon whose meaning is already in the adjacent text. Omitting the attribute is the failure, because it leaves the software to guess, and most screen readers fall back to reading the filename.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the images the parser extracted. It emits a single check named `alt-text` or `alt-text-missing`:
+
+- `alt-text` passes when the page has no images. Message: `No images on page`, with a value of 0.
+- `alt-text-missing` fails when any image has no `alt` attribute at all. Message: `3 image(s) missing alt text`, listing each image source. Severity warning, weight 5. No further checks run.
+- `alt-text` passes when every image has a non-empty alt. Message: `All 12 image(s) have alt text`.
+- `alt-text` passes when every image is marked decorative. Message: `All 12 image(s) marked decorative (alt="")`.
+- `alt-text` passes on a mix. Message: `9/12 image(s) have alt text, 3 marked decorative (alt="")`.
+
+A whitespace-only alt counts as decorative, since it is a sloppy spelling of the same thing. There is no check on the quality or length of the text: this rule only asks whether the attribute is there.
+
+## How to fix it
+
+```html
+<img src="/revenue.png" alt="Revenue by quarter, rising from Q1 to Q4" />
+<img src="/divider.svg" alt="" />
+```
+
+Describe what the image conveys in context, not what it depicts in general. Skip "image of" and "photo of", which screen readers already announce. Keep it under about 125 characters.
+
+For an icon inside a labelled button, the empty alt is right: the button carries the name and the icon should not be announced twice.
 
 | | |
 |---|---|
@@ -12,28 +39,6 @@ Checks that every image carries an alt attribute, counting an empty alt as a dec
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Alt text describes images for screen readers and displays when images fail to load. It is essential for accessibility and helps with image search SEO. Add descriptive alt text to every image that carries information, keeping it concise (under 125 characters) and free of keyword stuffing. An image that is purely decorative should carry an empty alt attribute (alt="") instead: that is the correct markup for "skip me" and this rule accepts it. Only an image with no alt attribute at all is reported here.
-
-## What counts as missing
-
-| Markup | Reported |
-|---|---|
-| `<img src="photo.jpg" alt="A red barn">` | No |
-| `<img src="divider.svg" alt="">` | No, this is a decorative image |
-| `<img src="photo.jpg">` | Yes, the alt attribute is absent |
-
-A decorative image is one that carries no information the surrounding text does
-not already give: a spacer, a background flourish, or an icon sitting beside a
-label that already names it. Giving such an image invented alt text makes the
-page worse for screen reader users, which is why `alt=""` is the right answer
-and why this rule accepts it.
-
-If an `alt=""` image is the only content of a link, the link itself has no
-accessible name. That is a real defect, and [`a11y/link-text`](/rules/a11y/link-text)
-reports it.
 
 ## Enable / disable
 
@@ -58,3 +63,31 @@ disable = ["images/*"]
 enable = ["images/alt-text"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/image-redundant-alt](/rules/a11y/image-redundant-alt): alt text that repeats the adjacent link or caption.
+- [links/anchor-text](/rules/links/anchor-text): image-only links whose alt is the link's name.
+- [images/figure-figcaption](/rules/images/figure-figcaption): captions, which are visible text rather than an alternative.
+- [images/filename-quality](/rules/images/filename-quality): the filename a screen reader falls back to.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [The img element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
+- [Decorative images, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/images/decorative/)
+- [Google Images best practices](https://developers.google.com/search/docs/appearance/google-images)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Every image with no alt attribute is listed by source. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/aspect-mismatch.mdx
+++ b/docs/rules/images/aspect-mismatch.mdx
@@ -77,7 +77,7 @@ disable = ["*"]
 
 - [images/dimensions](/rules/images/dimensions): the attributes this rule compares against.
 - [images/responsive-size](/rules/images/responsive-size): images displayed much smaller than the file served.
-- [performance/cls-hints](/rules/performance/cls-hints): the layout shift the same attributes prevent.
+- [performance/cls-hints](/rules/perf/cls-hints): the layout shift the same attributes prevent.
 - [images/srcset](/rules/images/srcset): serving a file that matches the rendered box.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/images/aspect-mismatch.mdx
+++ b/docs/rules/images/aspect-mismatch.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Image Aspect Ratio Mismatch"
-description: "Flags images whose width/height attributes conflict with their CSS box aspect ratio"
+title: "Image aspect ratio mismatch: attributes versus the CSS box"
+description: "When width and height describe one ratio and CSS forces another, the image stretches. squirrel compares the two and allows for object-fit."
 ---
 
-Flags images whose `width`/`height` attributes declare a different aspect ratio than their CSS box, which stretches or squishes the image.
+## What an aspect ratio mismatch is
+
+An `<img>` can have its ratio declared twice: once by the `width` and `height` attributes, and once by CSS, either through an explicit `aspect-ratio` or through a fixed width and height in pixels. When those two disagree, the browser fills the CSS box and the image is stretched or squashed.
+
+`object-fit` is the escape hatch. `cover`, `contain`, `scale-down` and `none` all reshape the image inside the box rather than distorting it, so a mismatch under one of those is a deliberate crop rather than a bug.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `img[style]`, so an image with no inline style is not examined. It needs integer `width` and `height` attributes and an inline style that fixes a ratio, either an `aspect-ratio` declaration or both `width` and `height` in `px`.
+
+- Warn when the two ratios differ by more than `tolerance`, as a fraction of the attribute ratio. Message: `2 image(s) with conflicting attribute vs CSS aspect ratio (distortion risk)`, each item labelled `/photo.jpg (1200x800 attr vs 1.00:1 CSS)` with a markup snippet. Up to ten items are listed. Severity warning, weight 4.
+- Pass otherwise. Message: `No conflicting image aspect ratios detected`.
+
+An image is skipped when its inline style sets `object-fit` to `cover`, `contain`, `scale-down` or `none`, or when its `class` attribute contains one of `object-cover`, `object-contain`, `object-scale-down` or `object-none`. External stylesheets cannot be read, so a utility class is the only signal available for class-based `object-fit`.
+
+## How to fix it
+
+```html
+<img src="/photo.jpg" width="1200" height="800" alt="…" style="width:600px;height:400px" />
+```
+
+Make the two agree, or set only the width in CSS and let the height follow. Where the crop is deliberate, add `object-fit: cover` so the image fills the box without distortion.
+
+An image styled through an external stylesheet cannot be checked, because the rule only reads inline styles.
 
 | | |
 |---|---|
@@ -13,32 +36,17 @@ Flags images whose `width`/`height` attributes declare a different aspect ratio 
 | **Severity** | warning |
 | **Weight** | 4/10 |
 
-## What it detects
+## Options
 
-The rule compares two aspect ratios that are both declared in the HTML:
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `tolerance` | number | `0.05` | Allowed fractional difference between the two aspect ratios |
 
-- The ratio from the `width`/`height` **attributes** (e.g. `1200x1500` = 4:5).
-- The ratio fixed by the **inline CSS**: either an explicit `width` and `height` in `px`, or an `aspect-ratio` property (e.g. `1000x750` / `aspect-ratio: 4/3` = 4:3).
-
-When the two differ by more than the tolerance (default 5%) and no `object-fit: cover/contain/scale-down/none` compensates, the image renders distorted. Images without both attribute dimensions, with only relative CSS units (`%`, `vw`), or with `height: auto` (the recommended responsive pattern) are not flagged.
-
-<Info>
-This rule catches aspect conflicts that are **declared statically** in the markup. Detecting a mismatch between an image file's *intrinsic* dimensions and its display slot (wasted cropped bytes) would require the natural image dimensions, which the audit does not decode, so that case is out of scope.
-</Info>
-
-## Solution
-
-When an image's `width`/`height` attributes describe one aspect ratio but CSS forces a different one, the image is stretched or squished. Set the `width`/`height` attributes to the image's true aspect ratio, and let CSS size it with `height: auto` (or a matching ratio). If cropping is intended, add `object-fit: cover` so the image fills the box without distortion.
-
-## Configuration
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `tolerance` | `0.05` | Allowed fractional difference between the attribute and CSS aspect ratios before flagging. |
+### Configuration example
 
 ```toml squirrel.toml
-[rules."images/aspect-mismatch"]
-tolerance = 0.1
+[rule_options."images/aspect-mismatch"]
+tolerance = 0.02
 ```
 
 ## Enable / disable
@@ -64,3 +72,30 @@ disable = ["images/*"]
 enable = ["images/aspect-mismatch"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/dimensions](/rules/images/dimensions): the attributes this rule compares against.
+- [images/responsive-size](/rules/images/responsive-size): images displayed much smaller than the file served.
+- [performance/cls-hints](/rules/performance/cls-hints): the layout shift the same attributes prevent.
+- [images/srcset](/rules/images/srcset): serving a file that matches the rendered box.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [object-fit, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)
+- [aspect-ratio, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Each mismatch is listed with both ratios and a markup snippet. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/aspect-mismatch.mdx
+++ b/docs/rules/images/aspect-mismatch.mdx
@@ -5,9 +5,9 @@ description: "When width and height describe one ratio and CSS forces another, t
 
 ## What an aspect ratio mismatch is
 
-An `<img>` can have its ratio declared twice: once by the `width` and `height` attributes, and once by CSS, either through an explicit `aspect-ratio` or through a fixed width and height in pixels. When those two disagree, the browser fills the CSS box and the image is stretched or squashed.
+An `<img>` can have its ratio declared twice: once by the `width` and `height` attributes, and once by CSS, either through an explicit `aspect-ratio` or through a fixed width and height in pixels. A disagreement is a distortion risk rather than a certainty: with a fixed width and height the image is stretched to fill the box, while `aspect-ratio` has no effect when both dimensions are already definite.
 
-`object-fit` is the escape hatch. `cover`, `contain`, `scale-down` and `none` all reshape the image inside the box rather than distorting it, so a mismatch under one of those is a deliberate crop rather than a bug.
+`object-fit` is the escape hatch. `cover`, `contain`, `scale-down` and `none` all preserve the image's natural proportions inside the box, whether by cropping, by leaving space around it, or by not resizing it at all. A mismatch under any of those is deliberate rather than a bug.
 
 ## What squirrel checks
 
@@ -24,7 +24,7 @@ An image is skipped when its inline style sets `object-fit` to `cover`, `contain
 <img src="/photo.jpg" width="1200" height="800" alt="…" style="width:600px;height:400px" />
 ```
 
-Make the two agree, or set only the width in CSS and let the height follow. Where the crop is deliberate, add `object-fit: cover` so the image fills the box without distortion.
+Make the two agree, or set the width in CSS with `height: auto` so the height follows the ratio. A CSS width alone does not do it while a `height` attribute is still in play. Where the crop is deliberate, add `object-fit: cover` so the image fills the box without distortion.
 
 An image styled through an external stylesheet cannot be checked, because the rule only reads inline styles.
 

--- a/docs/rules/images/aspect-mismatch.mdx
+++ b/docs/rules/images/aspect-mismatch.mdx
@@ -77,7 +77,7 @@ disable = ["*"]
 
 - [images/dimensions](/rules/images/dimensions): the attributes this rule compares against.
 - [images/responsive-size](/rules/images/responsive-size): images displayed much smaller than the file served.
-- [performance/cls-hints](/rules/perf/cls-hints): the layout shift the same attributes prevent.
+- [perf/cls-hints](/rules/perf/cls-hints): the layout shift the same attributes prevent.
 - [images/srcset](/rules/images/srcset): serving a file that matches the rendered box.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/images/aspect-mismatch.mdx
+++ b/docs/rules/images/aspect-mismatch.mdx
@@ -76,7 +76,7 @@ disable = ["*"]
 ## Related rules
 
 - [images/dimensions](/rules/images/dimensions): the attributes this rule compares against.
-- [images/responsive-size](/rules/images/responsive-size): images displayed much smaller than the file served.
+- [images/responsive-size](/rules/images/responsive-size): thumbnail-sized images with no srcset or picture markup.
 - [perf/cls-hints](/rules/perf/cls-hints): the layout shift the same attributes prevent.
 - [images/srcset](/rules/images/srcset): serving a file that matches the rendered box.
 

--- a/docs/rules/images/broken-images.mdx
+++ b/docs/rules/images/broken-images.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Broken Images"
-description: "Checks for images returning 404 errors"
+title: "Broken images: empty and placeholder src attributes"
+description: "An img with an empty or placeholder src renders as a broken icon. squirrel collects image sources across the crawl and flags the malformed ones."
 ---
 
-Checks for images returning 404 errors
+## What this rule detects
+
+A broken image is one whose `src` does not resolve to a file, so the browser shows its broken-image placeholder. The usual causes are a template variable that rendered empty, a path that moved, and a `src="#"` placeholder that was never filled in.
+
+This rule catches the malformed sources rather than the missing files. It reads the markup and reports sources that are empty, a bare `#`, or an error data URI. An image URL that looks correct but returns 404 is not detected here, which is why the pass message says "no obviously broken images" rather than none.
+
+## What squirrel checks
+
+The rule is site-wide. It walks the images of every crawled page, deduplicating by source, and emits a single check named `broken-images`:
+
+- Skipped when there is no site data. Message: `Site data not available`.
+- Fail when any source is empty, is exactly `#`, or starts with `data:error`. Message: `2 potentially broken image(s) found`, each listed by source or as `(empty)`, with the page it appeared on. Severity error, weight 6.
+- Pass otherwise. Message: `No obviously broken images detected`.
+
+No HTTP request is made for image URLs, so a well-formed URL that 404s passes this rule. `images/image-file-size` reports on the images the crawl did fetch.
+
+## How to fix it
+
+```html
+{photo?.url ? <img src={photo.url} alt={photo.alt} /> : null}
+```
+
+Guard the render on the source being present rather than emitting an `<img>` with an empty `src`. An empty `src` is worse than no element: some browsers re-request the current page for it.
+
+Replace `src="#"` placeholders with the real path or remove the element.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for images returning 404 errors
 | **Scope** | Site-wide |
 | **Severity** | error |
 | **Weight** | 6/10 |
-
-## Solution
-
-Broken images hurt user experience and can indicate neglected content. Fix 404 images by: updating the src URL, restoring the missing file, or removing the img element. Use automated monitoring to detect broken images. Consider implementing fallback images with onerror handlers.
 
 ## Enable / disable
 
@@ -40,3 +60,29 @@ disable = ["images/*"]
 enable = ["images/broken-images"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/image-file-size](/rules/images/image-file-size): the images the crawl actually fetched and weighed.
+- [links/broken-links](/rules/links/broken-links): the same idea for anchor targets.
+- [images/alt-text](/rules/images/alt-text): the alt text a broken image falls back to showing.
+- [security/mixed-content](/rules/security/mixed-content): images blocked because they load over HTTP.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [The img element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Every malformed image source is listed with the page it appeared on. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/dimensions.mdx
+++ b/docs/rules/images/dimensions.mdx
@@ -7,7 +7,7 @@ description: "An image with no width and height reserves no space, so the page j
 
 The `width` and `height` attributes on an `<img>` give the browser the image's aspect ratio before the file arrives. It can then reserve the right amount of space and lay the page out once, instead of reflowing everything below the image when it loads.
 
-That reflow is Cumulative Layout Shift, one of the Core Web Vitals. The attributes are not a sizing instruction: CSS still controls the rendered size, and `height: auto` alongside a percentage width keeps the image responsive while the ratio does its job.
+That reflow is Cumulative Layout Shift, one of the Core Web Vitals. The attributes are a rendered-size hint as well as a ratio, and CSS overrides them: `height: auto` alongside a percentage width keeps the image responsive while the ratio does its job.
 
 ## What squirrel checks
 

--- a/docs/rules/images/dimensions.mdx
+++ b/docs/rules/images/dimensions.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Image Dimensions"
-description: "Checks for width/height attributes (prevents CLS)"
+title: "Image width and height attributes: preventing layout shift"
+description: "An image with no width and height reserves no space, so the page jumps when it loads. squirrel checks both attributes on every image."
 ---
 
-Checks for width/height attributes (prevents CLS)
+## What width and height do
+
+The `width` and `height` attributes on an `<img>` give the browser the image's aspect ratio before the file arrives. It can then reserve the right amount of space and lay the page out once, instead of reflowing everything below the image when it loads.
+
+That reflow is Cumulative Layout Shift, one of the Core Web Vitals. The attributes are not a sizing instruction: CSS still controls the rendered size, and `height: auto` alongside a percentage width keeps the image responsive while the ratio does its job.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the images the parser extracted. It emits a single check named `image-dimensions`:
+
+- Pass when the page has no images. Message: `No images on page`, with a value of 0.
+- Warn when any image is missing `width` or `height`, or has either set to a falsy value. Message: `5 image(s) missing width/height (causes CLS)`, with the count as the value and each image listed with a markup snippet. Severity warning, weight 4.
+- Pass otherwise. Message: `All 12 image(s) have dimensions`, with the count as the value.
+
+Both attributes are required for a finding to pass; one on its own does not give a ratio.
+
+## How to fix it
+
+```html
+<img src="/photo.jpg" width="1200" height="800" alt="…" style="width:100%;height:auto" />
+```
+
+Use the image's intrinsic pixel dimensions in the attributes and let CSS size it. `height: auto` is what keeps the rendered image proportional while the attributes supply the ratio.
+
+For an image whose dimensions are unknown at render time, set `aspect-ratio` in CSS on the container instead. That reserves the space the same way.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for width/height attributes (prevents CLS)
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Specifying width and height attributes prevents Cumulative Layout Shift (CLS) by reserving space before images load. Add width and height attributes to img tags matching the image's intrinsic dimensions. Use CSS for responsive sizing if needed. For responsive images, the aspect ratio from width/height prevents layout shifts even when CSS overrides the actual size.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["images/*"]
 enable = ["images/dimensions"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/aspect-mismatch](/rules/images/aspect-mismatch): dimensions that disagree with the CSS box, which distorts the image.
+- [performance/cls-hints](/rules/performance/cls-hints): the other sources of layout shift on the page.
+- [images/offscreen-lazy](/rules/images/offscreen-lazy): lazy images, which shift the layout hardest without dimensions.
+- [images/srcset](/rules/images/srcset): serving the right file for the reserved space.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Optimize Cumulative Layout Shift, web.dev](https://web.dev/articles/optimize-cls)
+- [The img element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Every image missing a dimension is listed with a markup snippet. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/dimensions.mdx
+++ b/docs/rules/images/dimensions.mdx
@@ -64,7 +64,7 @@ disable = ["*"]
 ## Related rules
 
 - [images/aspect-mismatch](/rules/images/aspect-mismatch): dimensions that disagree with the CSS box, which distorts the image.
-- [performance/cls-hints](/rules/perf/cls-hints): the other sources of layout shift on the page.
+- [perf/cls-hints](/rules/perf/cls-hints): the other sources of layout shift on the page.
 - [images/offscreen-lazy](/rules/images/offscreen-lazy): lazy images, which shift the layout hardest without dimensions.
 - [images/srcset](/rules/images/srcset): serving the right file for the reserved space.
 

--- a/docs/rules/images/dimensions.mdx
+++ b/docs/rules/images/dimensions.mdx
@@ -64,7 +64,7 @@ disable = ["*"]
 ## Related rules
 
 - [images/aspect-mismatch](/rules/images/aspect-mismatch): dimensions that disagree with the CSS box, which distorts the image.
-- [performance/cls-hints](/rules/performance/cls-hints): the other sources of layout shift on the page.
+- [performance/cls-hints](/rules/perf/cls-hints): the other sources of layout shift on the page.
 - [images/offscreen-lazy](/rules/images/offscreen-lazy): lazy images, which shift the layout hardest without dimensions.
 - [images/srcset](/rules/images/srcset): serving the right file for the reserved space.
 

--- a/docs/rules/images/figure-figcaption.mdx
+++ b/docs/rules/images/figure-figcaption.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Figure Captions"
-description: "Checks for proper use of figure and figcaption elements"
+title: "figure and figcaption: captions that are properly associated"
+description: "A caption in a plain div is text near an image; a figcaption is the image's caption. squirrel checks figures for captions and notes standalone images."
 ---
 
-Checks for proper use of figure and figcaption elements
+## What figure and figcaption are
+
+`<figure>` groups a piece of content with its caption, and `<figcaption>` is that caption. The association is explicit in the markup, so assistive technology can announce the caption as belonging to the image rather than as unrelated text that happens to follow it.
+
+A caption is not a substitute for `alt`. The caption is visible to everyone and describes the image's role in the argument; the `alt` is the text alternative for people who cannot see it. An image can reasonably have both, or a caption and an empty `alt` when the caption already says everything.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It counts `<figure>` elements and, separately, images that are not inside one, using the selector `img:not(figure img)`. It emits up to two checks:
+
+- Skipped when the page has neither figures nor standalone images. Message: `No images or figures found`.
+- `figure-figcaption` reports info when any figure has no `<figcaption>`, or one whose text is empty. Message: `2/5 figure(s) missing figcaption`, with `Add descriptive captions to figures` as the value.
+- `figure-figcaption` passes when every figure has a caption. Message: `All 5 figure(s) have captions`.
+- `figure-usage` reports info when the page has standalone images and no figures at all. Message: `8 image(s) not using figure/figcaption`, with `Consider using <figure> for images that need captions` as the value.
+
+Severity info, weight 2. A `<figure>` is valid without a caption in the HTML specification, so the informational status is deliberate: this rule suggests rather than requires.
+
+## How to fix it
+
+```html
+<figure>
+  <img src="/chart.png" width="800" height="500" alt="Revenue rising each quarter" />
+  <figcaption>Quarterly revenue, 2024 to 2026. Source: internal reporting.</figcaption>
+</figure>
+```
+
+Use a figure when the image has a caption a reader should see. Leave a purely decorative or inline image as a bare `<img>`; wrapping everything in figures adds markup without adding meaning.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for proper use of figure and figcaption elements
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## Solution
-
-Use `<figure>` and `<figcaption>` for images with captions. This provides semantic meaning and accessibility benefits. Screen readers announce figcaption as the image caption. Good for SEO as captions often contain keywords. Example: `<figure>``<img src='...' alt='...'>``<figcaption>`Description`</figcaption>``</figure>`.
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["images/*"]
 enable = ["images/figure-figcaption"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/alt-text](/rules/images/alt-text): the text alternative, which a caption does not replace.
+- [content/heading-hierarchy](/rules/content/heading-hierarchy): the other structural markup on the same page.
+- [images/dimensions](/rules/images/dimensions): the attributes that belong on the img inside.
+- [images/filename-quality](/rules/images/filename-quality): the filename, another descriptive signal.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [The figure element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/figure)
+- [Google Images best practices](https://developers.google.com/search/docs/appearance/google-images)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Each page is reported with its figure count and how many carry a caption. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/figure-figcaption.mdx
+++ b/docs/rules/images/figure-figcaption.mdx
@@ -1,5 +1,5 @@
 ---
-title: "figure and figcaption: captions that are properly associated"
+title: "figure and figcaption: captions that are associated"
 description: "A caption in a plain div is text near an image; a figcaption is the image's caption. squirrel checks figures for captions and notes standalone images."
 ---
 

--- a/docs/rules/images/figure-figcaption.mdx
+++ b/docs/rules/images/figure-figcaption.mdx
@@ -11,7 +11,7 @@ A caption is not a substitute for `alt`. The caption is visible to everyone and 
 
 ## What squirrel checks
 
-The rule runs on every crawled page. It counts `<figure>` elements and, separately, images that are not inside one, using the selector `img:not(figure img)`. It emits up to two checks:
+The rule runs on every crawled page. It counts `<figure>` elements and, separately, images that are not inside one, using the selector `img:not(figure img)`. It emits at most one check, since the caption branches need figures and the usage branch needs none:
 
 - Skipped when the page has neither figures nor standalone images. Message: `No images or figures found`.
 - `figure-figcaption` reports info when any figure has no `<figcaption>`, or one whose text is empty. Message: `2/5 figure(s) missing figcaption`, with `Add descriptive captions to figures` as the value.

--- a/docs/rules/images/filename-quality.mdx
+++ b/docs/rules/images/filename-quality.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Image Filename Quality"
-description: "Checks for descriptive image filenames"
+title: "IMG_1234.jpg: image filenames that describe nothing"
+description: "A filename straight off a camera or a hash tells nobody what the picture is. squirrel matches image filenames against a list of generic patterns."
 ---
 
-Checks for descriptive image filenames
+## What an image filename does
+
+The filename is one of the few pieces of text attached to an image file itself, and Google's image guidance names it alongside the `alt` text and the surrounding copy as a signal about what an image shows.
+
+It also matters when the alternatives fail. A screen reader with no `alt` to read often falls back to the filename, and a downloaded image keeps its name in the user's folder. `red-running-shoes.jpg` is useful in both cases; `IMG_20231015.jpg` is not.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `img[src]`, taking the last path segment with any query string removed. `data:` sources and `.svg` files are skipped. The filename without its extension is matched against thirteen patterns.
+
+- Skipped when the page has no images. Message: `No images found`.
+- Pass when at least one filename is descriptive and none are poor. Message: `All 12 image(s) have descriptive filenames`.
+- Info when any filename matches a poor pattern. Message: `4 image(s) with non-descriptive filenames`, listing up to three examples.
+
+The patterns catch camera and device names such as `IMG_001`, `DSC1234`, `DCIM001` and `P20231015`, generic names such as `image1`, `photo1`, `pic1`, `screenshot`, `screen-shot` and `untitled`, and machine identifiers: a name that is eight or more leading digits, a 32-character hexadecimal hash, or a 36-character UUID. Severity info, weight 2.
+
+## How to fix it
+
+```
+/images/red-running-shoes-side-view.jpg
+```
+
+Rename on upload, deriving the name from the title or the alt text: lowercase, hyphens between words, no more than a few words. Most CMSes can do this automatically.
+
+A hashed filename from a build pipeline is deliberate cache-busting and will be reported here. Keep the descriptive part in front of the hash where the tooling allows it, or accept the finding.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for descriptive image filenames
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## Solution
-
-Use descriptive, keyword-rich filenames for images instead of generic names like IMG_001.jpg or DSC1234.png. Good: 'red-running-shoes-nike.jpg'. Bad: 'IMG_20231015.jpg'. Filenames contribute to image SEO and help search engines understand image content. Use hyphens to separate words.
 
 ## Enable / disable
 
@@ -40,3 +60,29 @@ disable = ["images/*"]
 enable = ["images/filename-quality"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/alt-text](/rules/images/alt-text): the text alternative that matters more than the filename.
+- [url/slug-keywords](/rules/url/slug-keywords): the same question asked of page URLs.
+- [images/figure-figcaption](/rules/images/figure-figcaption): the visible caption, a third descriptive signal.
+- [images/broken-images](/rules/images/broken-images): sources that are malformed rather than uninformative.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Google Images best practices](https://developers.google.com/search/docs/appearance/google-images)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Up to three example filenames are listed for each page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/filename-quality.mdx
+++ b/docs/rules/images/filename-quality.mdx
@@ -17,7 +17,7 @@ The rule runs on every crawled page over every `img[src]`, taking the last path 
 - Pass when at least one filename is descriptive and none are poor. Message: `All 12 image(s) have descriptive filenames`.
 - Info when any filename matches a poor pattern. Message: `4 image(s) with non-descriptive filenames`, listing up to three examples.
 
-The patterns catch camera and device names such as `IMG_001`, `DSC1234`, `DCIM001` and `P20231015`, generic names such as `image1`, `photo1`, `pic1`, `screenshot`, `screen-shot` and `untitled`, and machine identifiers: a name that is eight or more leading digits, a 32-character hexadecimal hash, or a 36-character UUID. Severity info, weight 2.
+The patterns catch camera and device names such as `IMG_001`, `DSC1234`, `DCIM001` and `P20231015`, generic names such as `image1`, `photo1`, `pic1`, `screenshot`, `screen-shot` and `untitled`, and machine identifiers: a name starting with eight or more digits, one starting with 32 or more hexadecimal characters, or one starting with 36 or more hexadecimal characters and hyphens. The last two are prefix tests rather than exact hash or UUID validation. Severity info, weight 2.
 
 ## How to fix it
 
@@ -27,7 +27,7 @@ The patterns catch camera and device names such as `IMG_001`, `DSC1234`, `DCIM00
 
 Rename on upload, deriving the name from the title or the alt text: lowercase, hyphens between words, no more than a few words. Most CMSes can do this automatically.
 
-A hashed filename from a build pipeline is deliberate cache-busting and will be reported here. Keep the descriptive part in front of the hash where the tooling allows it, or accept the finding.
+A long content hash at the start of a filename matches the machine-identifier patterns. A short one such as `a1b2c3d4.jpg` does not, and neither does a name that leads with words and carries the hash after them, which is the shape worth keeping anyway.
 
 | | |
 |---|---|

--- a/docs/rules/images/image-file-size.mdx
+++ b/docs/rules/images/image-file-size.mdx
@@ -82,7 +82,7 @@ disable = ["*"]
 - [images/modern-format](/rules/images/modern-format): the format change that usually fixes the size.
 - [images/srcset](/rules/images/srcset): serving a smaller file to smaller screens.
 - [images/responsive-size](/rules/images/responsive-size): images displayed far smaller than the file served.
-- [performance/total-byte-weight](/rules/performance/total-byte-weight): how much of the page total these images are.
+- [performance/total-byte-weight](/rules/perf/total-byte-weight): how much of the page total these images are.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/images/image-file-size.mdx
+++ b/docs/rules/images/image-file-size.mdx
@@ -82,7 +82,7 @@ disable = ["*"]
 - [images/modern-format](/rules/images/modern-format): the format change that usually fixes the size.
 - [images/srcset](/rules/images/srcset): serving a smaller file to smaller screens.
 - [images/responsive-size](/rules/images/responsive-size): images displayed far smaller than the file served.
-- [performance/total-byte-weight](/rules/perf/total-byte-weight): how much of the page total these images are.
+- [perf/total-byte-weight](/rules/perf/total-byte-weight): how much of the page total these images are.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/images/image-file-size.mdx
+++ b/docs/rules/images/image-file-size.mdx
@@ -13,7 +13,7 @@ Weight shows up directly in Largest Contentful Paint, because the LCP element is
 
 The rule is site-wide and reads the image sizes the crawl fetched. It emits up to two checks:
 
-- Pass when no image files were measured. Message: `No image files detected`.
+- Pass when the crawl recorded no image resources at all. Message: `No image files detected`. A recorded resource whose size could not be read falls through to the pass below instead.
 - `image-file-size` fails for files above `error_bytes`, 1 MB by default. Message: `2 image(s) exceed 1.0 MB`, each listed with its URL, size, status and content type, and the pages it appears on. Severity error, weight 7.
 - `image-file-size-warn` warns for files above `warn_bytes` and at or below the error threshold. Message: `9 image(s) exceed 200.0 KB`.
 - `image-file-size` passes when neither fired. Message: `All image files are within size limits`.

--- a/docs/rules/images/image-file-size.mdx
+++ b/docs/rules/images/image-file-size.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Image File Size Too Large"
-description: "Checks for image files that exceed recommended size limits"
+title: "Oversized image files: the 200KB and 1MB thresholds"
+description: "One unoptimised photo can outweigh every other asset on the page. squirrel measures the images the crawl fetched and reports the heavy ones."
 ---
 
-Checks for image files that exceed recommended size limits
+## What an oversized image is
+
+Images are usually the largest thing a page downloads. A camera JPEG straight out of a phone is several megabytes; the same picture, resized to the width it is displayed at and encoded as WebP, is often under 100 KB with no visible difference.
+
+Weight shows up directly in Largest Contentful Paint, because the LCP element is an image on most content pages, and it costs the visitor real bandwidth. squirrel's default thresholds are 200 KB for a warning and 1 MB for a failure.
+
+## What squirrel checks
+
+The rule is site-wide and reads the image sizes the crawl fetched. It emits up to two checks:
+
+- Pass when no image files were measured. Message: `No image files detected`.
+- `image-file-size` fails for files above `error_bytes`, 1 MB by default. Message: `2 image(s) exceed 1.0 MB`, each listed with its URL, size, status and content type, and the pages it appears on. Severity error, weight 7.
+- `image-file-size-warn` warns for files above `warn_bytes` and at or below the error threshold. Message: `9 image(s) exceed 200.0 KB`.
+- `image-file-size` passes when neither fired. Message: `All image files are within size limits`.
+
+Only images the crawl actually fetched are measured, so an image loaded by script after render does not appear.
+
+## How to fix it
+
+```bash
+cwebp -q 80 photo.jpg -o photo.webp
+```
+
+Resize to the largest dimension the image is displayed at, then encode as WebP or AVIF at a quality around 75 to 85. An image CDN does both on request, which is usually less work than a build step.
+
+Serving several sizes with `srcset` is what stops a phone downloading the desktop file. Compression alone does not fix that.
 
 | | |
 |---|---|
@@ -13,25 +38,19 @@ Checks for image files that exceed recommended size limits
 | **Severity** | error |
 | **Weight** | 7/10 |
 
-## Solution
-
-Large images slow down page loads and impact Core Web Vitals. Compress oversized images, use modern formats (WebP/AVIF), and resize images to the display dimensions. Consider responsive images with srcset to serve smaller files on mobile.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `warn_bytes` | number | `204800` (200KB) | Byte size to trigger warning |
-| `error_bytes` | number | `1048576` (1MB) | Byte size to trigger error |
+| `warn_bytes` | number | `204800` | Byte size to trigger warning |
+| `error_bytes` | number | `1048576` | Byte size to trigger error |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."images/image-file-size"]
-warn_bytes = 204800
-error_bytes = 1048576
+[rule_options."images/image-file-size"]
+warn_bytes = 102400
+error_bytes = 512000
 ```
 
 ## Enable / disable
@@ -57,3 +76,30 @@ disable = ["images/*"]
 enable = ["images/image-file-size"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/modern-format](/rules/images/modern-format): the format change that usually fixes the size.
+- [images/srcset](/rules/images/srcset): serving a smaller file to smaller screens.
+- [images/responsive-size](/rules/images/responsive-size): images displayed far smaller than the file served.
+- [performance/total-byte-weight](/rules/performance/total-byte-weight): how much of the page total these images are.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Use WebP images, web.dev](https://web.dev/articles/serve-images-webp)
+- [Optimize Largest Contentful Paint, web.dev](https://web.dev/articles/optimize-lcp)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Every oversized image is listed with its size and the pages it appears on. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/image-file-size.mdx
+++ b/docs/rules/images/image-file-size.mdx
@@ -81,7 +81,7 @@ disable = ["*"]
 
 - [images/modern-format](/rules/images/modern-format): the format change that usually fixes the size.
 - [images/srcset](/rules/images/srcset): serving a smaller file to smaller screens.
-- [images/responsive-size](/rules/images/responsive-size): images displayed far smaller than the file served.
+- [images/responsive-size](/rules/images/responsive-size): thumbnail-sized images with no srcset or picture markup.
 - [perf/total-byte-weight](/rules/perf/total-byte-weight): how much of the page total these images are.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/images/index.mdx
+++ b/docs/rules/images/index.mdx
@@ -3,7 +3,7 @@ title: "Images"
 description: "Image optimization and accessibility"
 ---
 
-Image optimization and accessibility
+Images rules cover the two things images most often break: page weight and layout. Weight is file size, format and whether the right size is served to the right screen; layout is the width and height attributes that reserve space before an image arrives. The category also carries the markup checks, alt attributes, picture fallbacks and figure captions, that decide whether an image means anything to a reader who cannot see it.
 
 ## Rules
 
@@ -61,3 +61,5 @@ Image optimization and accessibility
 [rules]
 disable = ["images/*"]
 ```
+
+Every audit reports Images findings next to the SEO, security and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/images/index.mdx
+++ b/docs/rules/images/index.mdx
@@ -8,50 +8,50 @@ Images rules cover the two things images most often break: page weight and layou
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Broken Images" icon="circle-exclamation" href="/rules/images/broken-images">
-    Checks for images returning 404 errors
+  <Card title="Broken images: empty and placeholder src attributes" icon="circle-exclamation" href="/rules/images/broken-images">
+    An img with an empty or placeholder src renders as a broken icon. squirrel collects image sources across the crawl and flags the malformed ones.
   </Card>
-  <Card title="Figure Captions" icon="circle-info" href="/rules/images/figure-figcaption">
-    Checks for proper use of figure and figcaption elements
+  <Card title="figure and figcaption: captions that are associated" icon="circle-info" href="/rules/images/figure-figcaption">
+    A caption in a plain div is text near an image; a figcaption is the image's caption. squirrel checks figures for captions and notes standalone images.
   </Card>
-  <Card title="Image Alt Text" icon="triangle-exclamation" href="/rules/images/alt-text">
-    Validates image alt attributes
+  <Card title="Missing alt attribute: what an empty alt means" icon="triangle-exclamation" href="/rules/images/alt-text">
+    An image with no alt attribute has no name for a screen reader. An empty alt is the correct way to say decorative, and squirrel accepts it.
   </Card>
-  <Card title="Image Dimensions" icon="triangle-exclamation" href="/rules/images/dimensions">
-    Checks for width/height attributes (prevents CLS)
+  <Card title="Image width and height attributes: preventing layout shift" icon="triangle-exclamation" href="/rules/images/dimensions">
+    An image with no width and height reserves no space, so the page jumps when it loads. squirrel checks both attributes on every image.
   </Card>
-  <Card title="Image Aspect Ratio Mismatch" icon="triangle-exclamation" href="/rules/images/aspect-mismatch">
-    Flags images whose width/height attributes conflict with their CSS box aspect ratio
+  <Card title="Image aspect ratio mismatch: attributes versus the CSS box" icon="triangle-exclamation" href="/rules/images/aspect-mismatch">
+    When width and height describe one ratio and CSS forces another, the image stretches. squirrel compares the two and allows for object-fit.
   </Card>
-  <Card title="Image File Size Too Large" icon="circle-exclamation" href="/rules/images/image-file-size">
-    Checks for image files that exceed recommended size limits
+  <Card title="Oversized image files: the 200KB and 1MB thresholds" icon="circle-exclamation" href="/rules/images/image-file-size">
+    One unoptimised photo can outweigh every other asset on the page. squirrel measures the images the crawl fetched and reports the heavy ones.
   </Card>
-  <Card title="Image Filename Quality" icon="circle-info" href="/rules/images/filename-quality">
-    Checks for descriptive image filenames
+  <Card title="IMG_1234.jpg: image filenames that describe nothing" icon="circle-info" href="/rules/images/filename-quality">
+    A filename straight off a camera or a hash tells nobody what the picture is. squirrel matches image filenames against a list of generic patterns.
   </Card>
-  <Card title="Image Optimization" icon="circle-info" href="/rules/images/optimized">
-    Checks for image optimization indicators
+  <Card title="Image optimization signals: CDNs and modern formats" icon="circle-info" href="/rules/images/optimized">
+    squirrel reads image URLs for the marks of an optimization pipeline: a known image CDN, a modern format, or a format parameter in the query.
   </Card>
-  <Card title="Inline SVG Size" icon="circle-info" href="/rules/images/svg-inline">
-    Checks for large inline SVGs bloating HTML
+  <Card title="Large inline SVG: when to move it to an external file" icon="circle-info" href="/rules/images/svg-inline">
+    Inline SVG cannot be cached separately from the HTML, so a big one is paid for on every page view. squirrel measures inline SVG size per page.
   </Card>
-  <Card title="Lazy Loading" icon="circle-info" href="/rules/images/lazy-loading">
-    Checks for lazy loading on below-fold images
+  <Card title="Lazy loading: how much of the page defers its load" icon="circle-info" href="/rules/images/lazy-loading">
+    A page-wide count of images and iframes using loading=lazy. squirrel reports the mix rather than judging individual images.
   </Card>
-  <Card title="Modern Image Formats" icon="circle-info" href="/rules/images/modern-format">
-    Checks for modern image formats like WebP or AVIF
+  <Card title="WebP and AVIF: converting from JPEG and PNG" icon="circle-info" href="/rules/images/modern-format">
+    WebP and AVIF encode the same picture in far fewer bytes than JPEG or PNG. squirrel counts modern and legacy formats per page.
   </Card>
-  <Card title="Offscreen Image Lazy Loading" icon="triangle-exclamation" href="/rules/images/offscreen-lazy">
-    Checks if offscreen images use lazy loading
+  <Card title="loading=lazy: which images need it and which must not" icon="triangle-exclamation" href="/rules/images/offscreen-lazy">
+    Images below the fold that load eagerly compete with the ones the visitor can see. squirrel treats the first few images as above the fold.
   </Card>
-  <Card title="Picture Element Validation" icon="circle-exclamation" href="/rules/images/picture-element">
-    Validates `<picture>` elements have required `<img>` fallback
+  <Card title="<picture> without an <img>: the fallback that is required" icon="circle-exclamation" href="/rules/images/picture-element">
+    A picture element with no img child renders nothing at all. squirrel checks every picture on the page for its required fallback.
   </Card>
-  <Card title="Responsive Image Size" icon="triangle-exclamation" href="/rules/images/responsive-size">
-    Checks if images are sized appropriately for their display size
+  <Card title="Thumbnails without srcset: small images serving large files" icon="triangle-exclamation" href="/rules/images/responsive-size">
+    A 60 by 60 avatar that loads a 2000 pixel photo wastes almost all of it. squirrel flags small declared sizes with no responsive variants.
   </Card>
-  <Card title="Responsive Images" icon="circle-info" href="/rules/images/srcset">
-    Checks for responsive images with srcset attribute
+  <Card title="srcset: serving the right image size for the screen" icon="circle-info" href="/rules/images/srcset">
+    Without srcset every visitor downloads the same file, sized for the largest screen. squirrel counts responsive images against fixed-size ones.
   </Card>
 </CardGroup>
 

--- a/docs/rules/images/lazy-loading.mdx
+++ b/docs/rules/images/lazy-loading.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Lazy loading: how many elements on the page defer their load"
+title: "Lazy loading: how much of the page defers its load"
 description: "A page-wide count of images and iframes using loading=lazy. squirrel reports the mix rather than judging individual images."
 ---
 
@@ -64,8 +64,8 @@ disable = ["*"]
 ## Related rules
 
 - [images/offscreen-lazy](/rules/images/offscreen-lazy): the per-image decision about which ones should be lazy.
-- [performance/lazy-above-fold](/rules/performance/lazy-above-fold): images lazy-loaded that should not be.
-- [performance/render-blocking](/rules/performance/render-blocking): the other resources delaying the first render.
+- [performance/lazy-above-fold](/rules/perf/lazy-above-fold): images lazy-loaded that should not be.
+- [performance/render-blocking](/rules/perf/render-blocking): the other resources delaying the first render.
 - [images/image-file-size](/rules/images/image-file-size): the weight deferring is meant to postpone.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/images/lazy-loading.mdx
+++ b/docs/rules/images/lazy-loading.mdx
@@ -15,7 +15,7 @@ The rule runs on every crawled page. It counts every `<img>` by its `loading` at
 
 - Skipped when the page has no images. Message: `No images found`. Iframes are not considered in this branch.
 - `lazy-loading` passes when any image or iframe is lazy. Message: `9 element(s) use lazy loading`, counting both kinds together.
-- `lazy-loading-missing` reports info alongside that pass, when some images have no `loading` attribute at all. Message: `4 image(s) without loading attribute`, with `Consider adding loading='lazy' for below-fold images` as the value.
+- `lazy-loading-missing` reports info alongside that pass, counting every image whose `loading` value is neither exactly `lazy` nor exactly `eager`. That includes an absent attribute, an empty one, a misspelling and a different capitalisation. Message: `4 image(s) without loading attribute`, with `Consider adding loading='lazy' for below-fold images` as the value.
 - `lazy-loading` reports info when nothing is lazy and the page has more than three images. Message: `12 images without lazy loading`, with `Add loading='lazy' to below-fold images` as the value.
 - `lazy-loading` reports info when nothing is lazy and there are three images or fewer. Message: `2 image(s) found, no lazy loading detected`.
 

--- a/docs/rules/images/lazy-loading.mdx
+++ b/docs/rules/images/lazy-loading.mdx
@@ -64,8 +64,8 @@ disable = ["*"]
 ## Related rules
 
 - [images/offscreen-lazy](/rules/images/offscreen-lazy): the per-image decision about which ones should be lazy.
-- [performance/lazy-above-fold](/rules/perf/lazy-above-fold): images lazy-loaded that should not be.
-- [performance/render-blocking](/rules/perf/render-blocking): the other resources delaying the first render.
+- [perf/lazy-above-fold](/rules/perf/lazy-above-fold): images lazy-loaded that should not be.
+- [perf/render-blocking](/rules/perf/render-blocking): the other resources delaying the first render.
 - [images/image-file-size](/rules/images/image-file-size): the weight deferring is meant to postpone.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/images/lazy-loading.mdx
+++ b/docs/rules/images/lazy-loading.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Lazy Loading"
-description: "Checks for lazy loading on below-fold images"
+title: "Lazy loading: how many elements on the page defer their load"
+description: "A page-wide count of images and iframes using loading=lazy. squirrel reports the mix rather than judging individual images."
 ---
 
-Checks for lazy loading on below-fold images
+## What this count measures
+
+This rule counts how much of a page defers loading, across both images and iframes. It is a summary, not a per-image verdict: `images/offscreen-lazy` is the rule that decides whether a particular image should have the attribute.
+
+Iframes are the part worth noticing. An embedded video or map is a whole document with its own scripts, and `loading="lazy"` on the `<iframe>` keeps all of it out of the initial load until the visitor scrolls near it.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It counts every `<img>` by its `loading` attribute and every `<iframe>` with `loading="lazy"`. It emits up to two checks:
+
+- Skipped when the page has no images. Message: `No images found`. Iframes are not considered in this branch.
+- `lazy-loading` passes when any image or iframe is lazy. Message: `9 element(s) use lazy loading`, counting both kinds together.
+- `lazy-loading-missing` reports info alongside that pass, when some images have no `loading` attribute at all. Message: `4 image(s) without loading attribute`, with `Consider adding loading='lazy' for below-fold images` as the value.
+- `lazy-loading` reports info when nothing is lazy and the page has more than three images. Message: `12 images without lazy loading`, with `Add loading='lazy' to below-fold images` as the value.
+- `lazy-loading` reports info when nothing is lazy and there are three images or fewer. Message: `2 image(s) found, no lazy loading detected`.
+
+Severity info, weight 3. Images explicitly marked `eager` are counted as neither lazy nor missing.
+
+## How to fix it
+
+```html
+<iframe src="https://www.youtube.com/embed/…" loading="lazy" title="…"></iframe>
+```
+
+Add `loading="lazy"` to embeds and to images the visitor has to scroll to. Leave the first screen alone, and see `images/offscreen-lazy` for which images those are.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for lazy loading on below-fold images
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Use loading='lazy' on images below the fold to defer loading until needed. This improves initial page load and saves bandwidth. Native lazy loading is supported by all modern browsers. Don't lazy load above-fold images (especially LCP candidates). Consider loading='eager' for critical images.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["images/*"]
 enable = ["images/lazy-loading"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/offscreen-lazy](/rules/images/offscreen-lazy): the per-image decision about which ones should be lazy.
+- [performance/lazy-above-fold](/rules/performance/lazy-above-fold): images lazy-loaded that should not be.
+- [performance/render-blocking](/rules/performance/render-blocking): the other resources delaying the first render.
+- [images/image-file-size](/rules/images/image-file-size): the weight deferring is meant to postpone.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Browser-level image lazy loading, web.dev](https://web.dev/articles/browser-level-image-lazy-loading)
+- [The img element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Each page is reported with its lazy and non-lazy element counts. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/modern-format.mdx
+++ b/docs/rules/images/modern-format.mdx
@@ -11,14 +11,14 @@ The saving is large enough to be worth the conversion on its own. For a typical 
 
 ## What squirrel checks
 
-The rule runs on every crawled page. It reads the `src` of every `img[src]` and the `srcset` and `type` of every `source[srcset]`, all lowercased, and classifies by substring. It emits a single check named `modern-format`:
+The rule runs on every crawled page. It reads the `src` of every `img[src]` and the `srcset` and `type` of every `source[srcset]`, all lowercased, and classifies by substring. It emits at most one check named `modern-format`, and none at all when images are present but neither count is above zero, which an SVG-only page produces:
 
 - Skipped when the page has no images. Message: `No images found`.
 - Pass when modern formats are present and no legacy ones are. Message: `All 8 image(s) use modern formats`.
 - Info on a mix. Message: `8 modern format(s), 4 legacy format(s)`, with `Consider converting remaining images to WebP/AVIF` as the value.
 - Info when only legacy formats are present. Message: `12 image(s) using legacy formats (JPEG/PNG)`, with `Consider using WebP or AVIF for better compression` as the value.
 
-Modern means the URL contains `.webp` or `.avif`, or a `<source>` whose `type` contains `webp` or `avif`. Legacy means `.jpg`, `.jpeg`, `.png` or `.gif`. The test is a substring match anywhere in the URL, so a query parameter naming a format is enough. An image served as WebP through content negotiation, with a `.jpg` URL, is counted as legacy. Severity info, weight 3.
+Modern means the URL contains `.webp` or `.avif`, or a `<source>` whose `type` contains `webp` or `avif`. Legacy means `.jpg`, `.jpeg`, `.png` or `.gif`. The match includes the leading dot, so `?format=webp` does not count and `?format=.webp` does. Legacy extensions are only counted on `<img src>`, never on a `<source srcset>`. An image served as WebP through content negotiation, with a `.jpg` URL, is counted as legacy. Severity info, weight 3.
 
 ## How to fix it
 

--- a/docs/rules/images/modern-format.mdx
+++ b/docs/rules/images/modern-format.mdx
@@ -1,9 +1,38 @@
 ---
-title: "Modern Image Formats"
-description: "Checks for modern image formats like WebP or AVIF"
+title: "WebP and AVIF: converting from JPEG and PNG"
+description: "WebP and AVIF encode the same picture in far fewer bytes than JPEG or PNG. squirrel counts modern and legacy formats per page."
 ---
 
-Checks for modern image formats like WebP or AVIF
+## What the modern image formats are
+
+WebP and AVIF are image formats designed to replace JPEG, PNG and GIF. WebP is supported in every current browser. AVIF compresses harder still and has slightly narrower support, which is what `<picture>` with multiple `<source>` elements is for.
+
+The saving is large enough to be worth the conversion on its own. For a typical photograph, WebP produces a file well under the JPEG equivalent at matching visual quality, and AVIF smaller again. Neither changes anything about how the image is marked up.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It reads the `src` of every `img[src]` and the `srcset` and `type` of every `source[srcset]`, all lowercased, and classifies by substring. It emits a single check named `modern-format`:
+
+- Skipped when the page has no images. Message: `No images found`.
+- Pass when modern formats are present and no legacy ones are. Message: `All 8 image(s) use modern formats`.
+- Info on a mix. Message: `8 modern format(s), 4 legacy format(s)`, with `Consider converting remaining images to WebP/AVIF` as the value.
+- Info when only legacy formats are present. Message: `12 image(s) using legacy formats (JPEG/PNG)`, with `Consider using WebP or AVIF for better compression` as the value.
+
+Modern means the URL contains `.webp` or `.avif`, or a `<source>` whose `type` contains `webp` or `avif`. Legacy means `.jpg`, `.jpeg`, `.png` or `.gif`. The test is a substring match anywhere in the URL, so a query parameter naming a format is enough. An image served as WebP through content negotiation, with a `.jpg` URL, is counted as legacy. Severity info, weight 3.
+
+## How to fix it
+
+```html
+<picture>
+  <source srcset="/photo.avif" type="image/avif" />
+  <source srcset="/photo.webp" type="image/webp" />
+  <img src="/photo.jpg" width="800" height="533" alt="…" />
+</picture>
+```
+
+Convert at build time with `sharp` or `cwebp`, or let an image CDN negotiate the format per request. The `<picture>` form is what gives you AVIF with a WebP and JPEG fallback in one element.
+
+SVG needs no conversion. It is already the right format for anything vector.
 
 | | |
 |---|---|
@@ -12,10 +41,6 @@ Checks for modern image formats like WebP or AVIF
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Modern formats (WebP, AVIF) offer 25-50% better compression than JPEG/PNG with similar quality. Use `<picture>` with WebP/AVIF sources and fallbacks. Most browsers support WebP (97%+). AVIF offers even better compression but lower support (~92%). Convert images with tools like cwebp, squoosh, or sharp.
 
 ## Enable / disable
 
@@ -40,3 +65,30 @@ disable = ["images/*"]
 enable = ["images/modern-format"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/optimized](/rules/images/optimized): the wider optimisation view, including image CDNs.
+- [images/image-file-size](/rules/images/image-file-size): the byte counts the conversion reduces.
+- [images/picture-element](/rules/images/picture-element): the markup that carries multiple formats.
+- [images/srcset](/rules/images/srcset): serving several sizes alongside several formats.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Use WebP images, web.dev](https://web.dev/articles/serve-images-webp)
+- [The picture element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/picture)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Each page is reported with its modern and legacy format counts. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/offscreen-lazy.mdx
+++ b/docs/rules/images/offscreen-lazy.mdx
@@ -15,10 +15,10 @@ The rule runs on every crawled page. It takes every `img[src]` in document order
 
 - Info when the page has no images. Message: `No images found`.
 - Pass when there are no images past the fold count. Message: `Few images on page - lazy loading not critical`.
-- `offscreen-images-not-lazy` warns for below-fold images with no `loading` attribute. Message: `7 below-fold image(s) without lazy loading`, listing up to ten filenames. Severity warning, weight 5.
+- `offscreen-images-not-lazy` warns for below-fold images whose `loading` value is neither exactly `lazy` nor exactly `eager`, which covers an absent attribute, an empty one and any misspelling. Message: `7 below-fold image(s) without lazy loading`, listing up to ten filenames. Severity warning, weight 5.
 - `lazy-loading-used` passes when any below-fold image is lazy. Message: `12 image(s) use lazy loading`.
 - `eager-below-fold` reports info for below-fold images explicitly set to `eager`. Message: `2 below-fold image(s) explicitly set to eager`, noted as possibly intentional.
-- `offscreen-lazy` reports info when nothing below the fold has a `loading` attribute either way. Message: `No lazy loading configured - consider adding loading='lazy'`.
+- `offscreen-lazy` reports info when nothing was flagged and nothing was lazy, which happens when every examined image is `eager` or every one was skipped as a data URI. Message: `No lazy loading configured - consider adding loading='lazy'`.
 
 Document order is a proxy for position, not a measurement. An image that appears late in the markup but is positioned at the top of the viewport by CSS is treated as below the fold.
 

--- a/docs/rules/images/offscreen-lazy.mdx
+++ b/docs/rules/images/offscreen-lazy.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Offscreen Image Lazy Loading"
-description: "Checks if offscreen images use lazy loading"
+title: "loading=lazy: which images need it and which must not have it"
+description: "Images below the fold that load eagerly compete with the ones the visitor can see. squirrel treats the first few images as above the fold."
 ---
 
-Checks if offscreen images use lazy loading
+## What loading="lazy" does
+
+`loading="lazy"` on an `<img>` tells the browser to defer the request until the image is near the viewport. It is native, needs no JavaScript, and is supported in every current browser.
+
+It is the wrong attribute for anything visible on arrival. Lazy-loading the largest visible image delays the request that Largest Contentful Paint is measured on, so a page can get slower by adding it. The rule of thumb is lazy below the fold, `eager` or nothing above it.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It takes every `img[src]` in document order, treats the first `above_fold_count` of them as above the fold, and examines the rest. Images with a `data:` source are skipped.
+
+- Info when the page has no images. Message: `No images found`.
+- Pass when there are no images past the fold count. Message: `Few images on page - lazy loading not critical`.
+- `offscreen-images-not-lazy` warns for below-fold images with no `loading` attribute. Message: `7 below-fold image(s) without lazy loading`, listing up to ten filenames. Severity warning, weight 5.
+- `lazy-loading-used` passes when any below-fold image is lazy. Message: `12 image(s) use lazy loading`.
+- `eager-below-fold` reports info for below-fold images explicitly set to `eager`. Message: `2 below-fold image(s) explicitly set to eager`, noted as possibly intentional.
+- `offscreen-lazy` reports info when nothing below the fold has a `loading` attribute either way. Message: `No lazy loading configured - consider adding loading='lazy'`.
+
+Document order is a proxy for position, not a measurement. An image that appears late in the markup but is positioned at the top of the viewport by CSS is treated as below the fold.
+
+## How to fix it
+
+```html
+<img src="/hero.jpg" width="1200" height="600" alt="…" fetchpriority="high" />
+<img src="/gallery-1.jpg" width="600" height="400" alt="…" loading="lazy" />
+```
+
+Leave the hero image alone, or mark it `fetchpriority="high"`, and add `loading="lazy"` to everything the visitor has to scroll to. A component that renders a list of images can apply it to every item after the first row.
+
+Raise `above_fold_count` for a page whose first screen genuinely shows more images than the default three.
 
 | | |
 |---|---|
@@ -13,23 +41,17 @@ Checks if offscreen images use lazy loading
 | **Severity** | warning |
 | **Weight** | 5/10 |
 
-## Solution
-
-Add loading='lazy' to images below the fold to defer loading until needed. This reduces initial page load time and saves bandwidth. Exception: Don't lazy-load LCP image or above-the-fold content. Use loading='eager' for critical images.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `above_fold_count` | unknown | `undefined` | Number of images considered above the fold |
+| `above_fold_count` | number | `3` | Number of images considered above the fold |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."images/offscreen-lazy"]
-above_fold_count = undefined
+[rule_options."images/offscreen-lazy"]
+above_fold_count = 6
 ```
 
 ## Enable / disable
@@ -55,3 +77,30 @@ disable = ["images/*"]
 enable = ["images/offscreen-lazy"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/lazy-loading](/rules/images/lazy-loading): the page-wide count of lazy elements, including iframes.
+- [performance/lazy-above-fold](/rules/performance/lazy-above-fold): the opposite mistake, lazy-loading the LCP image.
+- [performance/lcp-fetchpriority](/rules/performance/lcp-fetchpriority): marking the image that should load first.
+- [images/dimensions](/rules/images/dimensions): the width and height that stop lazy images shifting the layout.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Browser-level image lazy loading, web.dev](https://web.dev/articles/browser-level-image-lazy-loading)
+- [Optimize Largest Contentful Paint, web.dev](https://web.dev/articles/optimize-lcp)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Every below-fold image without the attribute is listed by filename. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/offscreen-lazy.mdx
+++ b/docs/rules/images/offscreen-lazy.mdx
@@ -81,8 +81,8 @@ disable = ["*"]
 ## Related rules
 
 - [images/lazy-loading](/rules/images/lazy-loading): the page-wide count of lazy elements, including iframes.
-- [performance/lazy-above-fold](/rules/perf/lazy-above-fold): the opposite mistake, lazy-loading the LCP image.
-- [performance/lcp-fetchpriority](/rules/perf/lcp-fetchpriority): marking the image that should load first.
+- [perf/lazy-above-fold](/rules/perf/lazy-above-fold): the opposite mistake, lazy-loading the LCP image.
+- [perf/lcp-fetchpriority](/rules/perf/lcp-fetchpriority): marking the image that should load first.
 - [images/dimensions](/rules/images/dimensions): the width and height that stop lazy images shifting the layout.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/images/offscreen-lazy.mdx
+++ b/docs/rules/images/offscreen-lazy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "loading=lazy: which images need it and which must not have it"
+title: "loading=lazy: which images need it and which must not"
 description: "Images below the fold that load eagerly compete with the ones the visitor can see. squirrel treats the first few images as above the fold."
 ---
 
@@ -81,8 +81,8 @@ disable = ["*"]
 ## Related rules
 
 - [images/lazy-loading](/rules/images/lazy-loading): the page-wide count of lazy elements, including iframes.
-- [performance/lazy-above-fold](/rules/performance/lazy-above-fold): the opposite mistake, lazy-loading the LCP image.
-- [performance/lcp-fetchpriority](/rules/performance/lcp-fetchpriority): marking the image that should load first.
+- [performance/lazy-above-fold](/rules/perf/lazy-above-fold): the opposite mistake, lazy-loading the LCP image.
+- [performance/lcp-fetchpriority](/rules/perf/lcp-fetchpriority): marking the image that should load first.
 - [images/dimensions](/rules/images/dimensions): the width and height that stop lazy images shifting the layout.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/images/optimized.mdx
+++ b/docs/rules/images/optimized.mdx
@@ -11,7 +11,7 @@ This rule reads those marks off the URLs. It is inference rather than measuremen
 
 ## What squirrel checks
 
-The rule runs on every crawled page over every `img[src]`, skipping `data:` sources. It emits up to five checks:
+The rule runs on every crawled page over every `img[src]`, skipping `data:` sources. Six check names are possible and at most four appear in one result, since the optimization warning requires both the CDN and the modern-format counts to be zero:
 
 - `image-optimization` reports info when the page has no images. Message: `No images found`.
 - `image-cdn` passes when any image comes from a known image CDN. Message: `14 image(s) served from image CDN`.

--- a/docs/rules/images/optimized.mdx
+++ b/docs/rules/images/optimized.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Image optimization signals: CDNs, formats and what they imply"
+title: "Image optimization signals: CDNs and modern formats"
 description: "squirrel reads image URLs for the marks of an optimization pipeline: a known image CDN, a modern format, or a format parameter in the query."
 ---
 

--- a/docs/rules/images/optimized.mdx
+++ b/docs/rules/images/optimized.mdx
@@ -69,7 +69,7 @@ disable = ["*"]
 - [images/modern-format](/rules/images/modern-format): the format count on its own.
 - [images/image-file-size](/rules/images/image-file-size): the measured weight, which is the real test.
 - [images/srcset](/rules/images/srcset): serving several sizes as well as several formats.
-- [images/responsive-size](/rules/images/responsive-size): thumbnails that are still loading full-size files.
+- [images/responsive-size](/rules/images/responsive-size): thumbnail-sized images that may need responsive variants.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/images/optimized.mdx
+++ b/docs/rules/images/optimized.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Image Optimization"
-description: "Checks for image optimization indicators"
+title: "Image optimization signals: CDNs, formats and what they imply"
+description: "squirrel reads image URLs for the marks of an optimization pipeline: a known image CDN, a modern format, or a format parameter in the query."
 ---
 
-Checks for image optimization indicators
+## What the optimization signals are
+
+There are two common ways an image ends up small enough. Either it was converted and resized as part of the build, which shows up as a `.webp` or `.avif` extension, or it goes through an image CDN that transforms on request, which shows up as a recognisable hostname and often a format parameter in the query string.
+
+This rule reads those marks off the URLs. It is inference rather than measurement: `images/image-file-size` is the rule that actually weighs the files. What this one adds is a view of whether a pipeline exists at all.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `img[src]`, skipping `data:` sources. It emits up to five checks:
+
+- `image-optimization` reports info when the page has no images. Message: `No images found`.
+- `image-cdn` passes when any image comes from a known image CDN. Message: `14 image(s) served from image CDN`.
+- `modern-image-formats` passes when any image is in a modern format. Message: `14 image(s) use modern formats`.
+- `legacy-image-formats` reports info for legacy-format images that are not on a CDN. Message: `6 image(s) could use WebP/AVIF`, listing up to ten filenames.
+- `picture-elements` passes when the page has any `<picture>`. Message: `2 <picture> element(s) for responsive images`.
+- `image-optimization-needed` warns when there is no CDN, no modern format, and more than three legacy images. Message: `Images may not be optimized - consider using an image CDN`.
+
+Modern means a `.webp` or `.avif` extension, or a URL containing `format=webp`, `fm=webp`, `f_webp` or `format=avif`. SVG and ICO are counted as modern, since neither needs converting. Legacy means `.jpg`, `.jpeg`, `.png` or `.gif`. The CDN list covers around twenty hostnames including Cloudinary, imgix, ImageKit, Shopify, Sanity, Contentful and Cloudflare Images, matched as a substring of the hostname. Severity info, weight 4.
+
+## How to fix it
+
+```html
+<img src="https://res.cloudinary.com/demo/image/upload/f_auto,q_auto,w_800/photo.jpg" alt="…" />
+```
+
+Either convert during the build and reference the modern file, or put an image CDN in front and let it negotiate format and size per request. `f_auto` and its equivalents pick AVIF or WebP based on what the browser accepts.
+
+An image served as WebP through content negotiation, on a `.jpg` URL, is counted as legacy here because the rule can only read the URL.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks for image optimization indicators
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 4/10 |
-
-## Solution
-
-Optimize images to reduce file sizes without visible quality loss. Use tools like Squoosh, ImageOptim, or TinyPNG. Consider using an image CDN (Cloudinary, Imgix, Cloudflare Images) for automatic optimization and responsive delivery. Modern formats (WebP, AVIF) offer 25-50% better compression.
 
 ## Enable / disable
 
@@ -40,3 +63,30 @@ disable = ["images/*"]
 enable = ["images/optimized"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/modern-format](/rules/images/modern-format): the format count on its own.
+- [images/image-file-size](/rules/images/image-file-size): the measured weight, which is the real test.
+- [images/srcset](/rules/images/srcset): serving several sizes as well as several formats.
+- [images/responsive-size](/rules/images/responsive-size): thumbnails that are still loading full-size files.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Use WebP images, web.dev](https://web.dev/articles/serve-images-webp)
+- [Google Images best practices](https://developers.google.com/search/docs/appearance/google-images)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Each page is reported with its CDN, modern-format and legacy-format counts. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/picture-element.mdx
+++ b/docs/rules/images/picture-element.mdx
@@ -29,7 +29,7 @@ This is a structural check. It does not look at whether the `<source>` candidate
 </picture>
 ```
 
-Put the `<img>` last, after every `<source>`, and give it the widest-support format. The `alt`, `width` and `height` belong on the `<img>`, not on the sources.
+Put the `<img>` last, after every `<source>`, and give it the widest-support format. The `alt` belongs on the `<img>`. `width` and `height` can go on a `<source>` as well, which is how a source with a different aspect ratio reserves the right space.
 
 | | |
 |---|---|

--- a/docs/rules/images/picture-element.mdx
+++ b/docs/rules/images/picture-element.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Picture Element Validation"
-description: "Validates <picture> elements have required <img> fallback"
+title: "<picture> without an <img>: the fallback that is required"
+description: "A picture element with no img child renders nothing at all. squirrel checks every picture on the page for its required fallback."
 ---
 
-Validates `<picture>` elements have required `<img>` fallback
+## What the img inside a picture is for
+
+`<picture>` is a wrapper that lets the browser choose between `<source>` candidates by media query or MIME type. It does not render anything itself. The `<img>` inside it is the element that actually displays, and the HTML specification requires it.
+
+Without one, a browser that matches a `<source>` still has nothing to draw, and one that matches none has no fallback. The `<img>` is also where `alt`, `width` and `height` live, so leaving it out costs the accessible name and the layout reservation at the same time.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `<picture>` element. It emits a single check named `picture-element`:
+
+- Skipped when the page has no `<picture>` elements. Message: `No <picture> elements found`.
+- Pass when every one contains an `<img>`. Message: `All 4 <picture> element(s) have <img> fallback`.
+- Fail otherwise. Message: `1 of 4 <picture> element(s) missing <img> fallback`, identifying each by the `srcset` of its first `<source>`, or `unknown source` when it has none. Severity error, weight 6.
+
+This is a structural check. It does not look at whether the `<source>` candidates are valid or whether their types are correct.
+
+## How to fix it
+
+```html
+<picture>
+  <source srcset="/photo.avif" type="image/avif" />
+  <source srcset="/photo.webp" type="image/webp" />
+  <img src="/photo.jpg" width="800" height="533" alt="…" />
+</picture>
+```
+
+Put the `<img>` last, after every `<source>`, and give it the widest-support format. The `alt`, `width` and `height` belong on the `<img>`, not on the sources.
 
 | | |
 |---|---|
@@ -12,23 +38,6 @@ Validates `<picture>` elements have required `<img>` fallback
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 6/10 |
-
-## Solution
-
-Every `<picture>` element MUST contain an `<img>` child element as fallback.
-
-Correct structure:
-`<picture>`
-  `<source srcset="image.webp" type="image/webp">`
-  `<source srcset="image.jpg" type="image/jpeg">`
-  `<img src="image.jpg" alt="Description">`
-`</picture>`
-
-The `<img>` provides fallback for:
-- Browsers without `<picture>` support
-- Screen readers
-- Search engine crawlers
-- Failed srcset loading
 
 ## Enable / disable
 
@@ -53,3 +62,30 @@ disable = ["images/*"]
 enable = ["images/picture-element"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/srcset](/rules/images/srcset): the simpler responsive form, when you only need sizes.
+- [images/modern-format](/rules/images/modern-format): the format sources this element usually carries.
+- [images/alt-text](/rules/images/alt-text): the alt that lives on the img inside.
+- [images/dimensions](/rules/images/dimensions): the width and height that also belong on that img.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [The picture element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/picture)
+- [The picture element, HTML Standard](https://html.spec.whatwg.org/multipage/images.html#the-picture-element)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Every picture element missing its fallback is listed by its first source. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/responsive-size.mdx
+++ b/docs/rules/images/responsive-size.mdx
@@ -17,7 +17,7 @@ The rule runs on every crawled page over every `img[src]` that has both `width` 
 - Info when the page has no images. Message: `No images found on page`.
 - `images-possibly-oversized` warns for images whose declared width and height are both at or below `max_thumbnail_dimension`, and which have no `srcset` and no `<picture>` ancestor. Message: `6 small image(s) may be serving oversized files`, listing up to ten as `avatar.jpg (64x64, no srcset)`. Severity warning, weight 5.
 - `responsive-size` passes when images with dimensions were examined and none qualified. Message: `Image sizes appear appropriate`.
-- `responsive-size` reports info when no image carried explicit dimensions. Message: `No images with explicit dimensions to check`.
+- `responsive-size` reports info when no image yielded two dimensions that parse as non-zero integers. An absent attribute reaches this branch, and so does `width="0"` or `height="invalid"`. Message: `No images with explicit dimensions to check`.
 
 SVG and ICO files and `data:` sources are skipped. The rule does not fetch the images, so it cannot tell whether the file really is oversized: a small declared size with no responsive variants is the signal.
 
@@ -30,7 +30,7 @@ SVG and ICO files and `data:` sources are skipped. The rule does not fetch the i
 
 Generate a thumbnail variant and reference it, or hand the resize to an image CDN with a width parameter. Two candidates are enough for a fixed-size thumbnail: one for standard displays and one for high-density ones.
 
-An SVG or a small icon does not need this and is already excluded.
+The exclusions are a lowercase `.svg` or `.ico` filename and a `data:` source. A small PNG or WebP icon is not excluded and will be reported.
 
 | | |
 |---|---|

--- a/docs/rules/images/responsive-size.mdx
+++ b/docs/rules/images/responsive-size.mdx
@@ -82,7 +82,7 @@ disable = ["*"]
 - [images/srcset](/rules/images/srcset): the responsive markup this rule looks for.
 - [images/image-file-size](/rules/images/image-file-size): the measured weight of the files being served.
 - [images/dimensions](/rules/images/dimensions): the width and height attributes this rule reads.
-- [images/optimized](/rules/images/optimized): whether an image CDN is already resizing on request.
+- [images/optimized](/rules/images/optimized): image CDN hosts and other optimization markers in the URLs.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/images/responsive-size.mdx
+++ b/docs/rules/images/responsive-size.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Responsive Image Size"
-description: "Checks if images are sized appropriately for their display size"
+title: "Thumbnails without srcset: small images serving large files"
+description: "A 60 by 60 avatar that loads a 2000 pixel photo wastes almost all of it. squirrel flags small declared sizes with no responsive variants."
 ---
 
-Checks if images are sized appropriately for their display size
+## What the size mismatch is
+
+An image is served at one size and displayed at another. When the displayed size is much smaller, most of the downloaded bytes are discarded by the resize.
+
+The clearest case is a thumbnail: an avatar, a product grid tile, a logo in a list. Those are rendered at a hundred pixels or less, and if the same file is also used as a full-size image elsewhere, every thumbnail on the page pays for it. `srcset` or `<picture>` is what lets the browser take a smaller file instead.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `img[src]` that has both `width` and `height` attributes as parseable non-zero numbers. Images without those attributes are not examined.
+
+- Skipped when there is no parsed document. Message: `No document available`.
+- Info when the page has no images. Message: `No images found on page`.
+- `images-possibly-oversized` warns for images whose declared width and height are both at or below `max_thumbnail_dimension`, and which have no `srcset` and no `<picture>` ancestor. Message: `6 small image(s) may be serving oversized files`, listing up to ten as `avatar.jpg (64x64, no srcset)`. Severity warning, weight 5.
+- `responsive-size` passes when images with dimensions were examined and none qualified. Message: `Image sizes appear appropriate`.
+- `responsive-size` reports info when no image carried explicit dimensions. Message: `No images with explicit dimensions to check`.
+
+SVG and ICO files and `data:` sources are skipped. The rule does not fetch the images, so it cannot tell whether the file really is oversized: a small declared size with no responsive variants is the signal.
+
+## How to fix it
+
+```html
+<img src="/avatar-64.jpg" srcset="/avatar-64.jpg 64w, /avatar-128.jpg 128w"
+     sizes="64px" width="64" height="64" alt="…" />
+```
+
+Generate a thumbnail variant and reference it, or hand the resize to an image CDN with a width parameter. Two candidates are enough for a fixed-size thumbnail: one for standard displays and one for high-density ones.
+
+An SVG or a small icon does not need this and is already excluded.
 
 | | |
 |---|---|
@@ -13,23 +40,17 @@ Checks if images are sized appropriately for their display size
 | **Severity** | warning |
 | **Weight** | 5/10 |
 
-## Solution
-
-Serve images at appropriate sizes for their display dimensions. Oversized images waste bandwidth and slow page load. Undersized images look blurry on high-DPI displays. Use srcset to serve different sizes for different screens. For responsive images, serve 1x, 2x, and optionally 3x versions. Image CDNs can automatically resize images on-the-fly.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `max_thumbnail_dimension` | unknown | `undefined` | Max dimension to consider as thumbnail |
+| `max_thumbnail_dimension` | number | `100` | Max dimension to consider as thumbnail |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."images/responsive-size"]
-max_thumbnail_dimension = undefined
+[rule_options."images/responsive-size"]
+max_thumbnail_dimension = 200
 ```
 
 ## Enable / disable
@@ -55,3 +76,30 @@ disable = ["images/*"]
 enable = ["images/responsive-size"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/srcset](/rules/images/srcset): the responsive markup this rule looks for.
+- [images/image-file-size](/rules/images/image-file-size): the measured weight of the files being served.
+- [images/dimensions](/rules/images/dimensions): the width and height attributes this rule reads.
+- [images/optimized](/rules/images/optimized): whether an image CDN is already resizing on request.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Responsive images, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images)
+- [Optimize Largest Contentful Paint, web.dev](https://web.dev/articles/optimize-lcp)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Every small image without responsive variants is listed with its declared size. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/srcset.mdx
+++ b/docs/rules/images/srcset.mdx
@@ -5,9 +5,9 @@ description: "Without srcset every visitor downloads the same file, sized for th
 
 ## What srcset is
 
-`srcset` lists several versions of the same image with their widths, and `sizes` tells the browser how wide the image will be rendered. The browser picks a file before it downloads anything, taking screen density into account.
+`srcset` lists several versions of the same image. In its width form each candidate carries a `w` descriptor and `sizes` tells the browser how wide the image will be rendered; in its density form each carries `1x` or `2x` and no `sizes` is used. Either way the browser picks one file before it downloads anything.
 
-Without it there is one file for everyone. A hero sized for a 2560-pixel display is downloaded in full by a phone that will render it 390 pixels wide, which is most of the wasted bytes on a typical page. `<picture>` solves a related but different problem: choosing between formats, or between differently cropped images at different breakpoints.
+Without it there is one file for everyone. A hero sized for a 2560-pixel display is downloaded in full by a phone that will render it 390 pixels wide, which is most of the wasted bytes on a typical page. In a width-descriptor set, `sizes` matters as much as the candidates: with no `sizes` the browser assumes the image fills the viewport. `<picture>` solves a related but different problem: choosing between formats, or between differently cropped images at different breakpoints.
 
 ## What squirrel checks
 
@@ -31,7 +31,7 @@ Severity info, weight 3. The responsive count adds the `srcset` images and the `
 />
 ```
 
-Generate the variants at build time or through an image CDN. `sizes` matters as much as `srcset`: without it the browser assumes the image is the full viewport width and picks a file that is too large.
+Generate the variants at build time or through an image CDN. For a fixed-size image, the density form is shorter: `srcset="/logo.png 1x, /logo@2x.png 2x"` and no `sizes` at all.
 
 Icons, logos and anything rendered at a fixed small size do not need this.
 

--- a/docs/rules/images/srcset.mdx
+++ b/docs/rules/images/srcset.mdx
@@ -1,9 +1,39 @@
 ---
-title: "Responsive Images"
-description: "Checks for responsive images with srcset attribute"
+title: "srcset: serving the right image size for the screen"
+description: "Without srcset every visitor downloads the same file, sized for the largest screen. squirrel counts responsive images against fixed-size ones."
 ---
 
-Checks for responsive images with srcset attribute
+## What srcset is
+
+`srcset` lists several versions of the same image with their widths, and `sizes` tells the browser how wide the image will be rendered. The browser picks a file before it downloads anything, taking screen density into account.
+
+Without it there is one file for everyone. A hero sized for a 2560-pixel display is downloaded in full by a phone that will render it 390 pixels wide, which is most of the wasted bytes on a typical page. `<picture>` solves a related but different problem: choosing between formats, or between differently cropped images at different breakpoints.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It counts every `img[src]` with and without a `srcset` attribute, and separately counts `<picture>` elements. It emits a single check named `srcset`:
+
+- Skipped when the page has no images. Message: `No images found`.
+- Pass when responsive images exist and none are fixed-size. Message: `All 8 image(s) are responsive`.
+- Info when both exist. Message: `8 responsive, 4 fixed-size image(s)`, with `Consider adding srcset for remaining images` as the value.
+- Info when none are responsive. Message: `12 image(s) without responsive srcset`, with `Add srcset for multiple image sizes` as the value.
+
+Severity info, weight 3. The responsive count adds the `srcset` images and the `<picture>` elements together, so an `<img srcset>` inside a `<picture>` contributes to both halves of that sum.
+
+## How to fix it
+
+```html
+<img
+  src="/photo-800.jpg"
+  srcset="/photo-400.jpg 400w, /photo-800.jpg 800w, /photo-1600.jpg 1600w"
+  sizes="(max-width: 640px) 100vw, 50vw"
+  width="800" height="533" alt="…"
+/>
+```
+
+Generate the variants at build time or through an image CDN. `sizes` matters as much as `srcset`: without it the browser assumes the image is the full viewport width and picks a file that is too large.
+
+Icons, logos and anything rendered at a fixed small size do not need this.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks for responsive images with srcset attribute
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Use srcset and sizes attributes to serve appropriately sized images for each viewport. This reduces bandwidth on mobile and improves LCP. Example: srcset='img-320.jpg 320w, img-640.jpg 640w, img-1280.jpg 1280w' sizes='(max-width: 640px) 100vw, 50vw'. Use `<picture>` element for art direction.
 
 ## Enable / disable
 
@@ -40,3 +66,30 @@ disable = ["images/*"]
 enable = ["images/srcset"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/picture-element](/rules/images/picture-element): the picture markup this rule also counts.
+- [images/responsive-size](/rules/images/responsive-size): small images with no responsive variants.
+- [images/image-file-size](/rules/images/image-file-size): the file weight srcset is there to reduce.
+- [images/modern-format](/rules/images/modern-format): the other half of the same optimisation.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Responsive images, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images)
+- [The img element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Each page is reported with its responsive and fixed-size image counts. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/images/svg-inline.mdx
+++ b/docs/rules/images/svg-inline.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 - [crawl/html-size](/rules/crawl/html-size): the document size these SVGs contribute to.
 - [images/modern-format](/rules/images/modern-format): formats for raster images, which SVG is exempt from.
 - [a11y/aria-labels](/rules/a11y/aria-labels): the accessible name an interactive SVG needs.
-- [performance/dom-size](/rules/perf/dom-size): the node count a large inline SVG adds.
+- [perf/dom-size](/rules/perf/dom-size): the node count a large inline SVG adds.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/images/svg-inline.mdx
+++ b/docs/rules/images/svg-inline.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 - [crawl/html-size](/rules/crawl/html-size): the document size these SVGs contribute to.
 - [images/modern-format](/rules/images/modern-format): formats for raster images, which SVG is exempt from.
 - [a11y/aria-labels](/rules/a11y/aria-labels): the accessible name an interactive SVG needs.
-- [performance/dom-size](/rules/performance/dom-size): the node count a large inline SVG adds.
+- [performance/dom-size](/rules/perf/dom-size): the node count a large inline SVG adds.
 
 Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/images/svg-inline.mdx
+++ b/docs/rules/images/svg-inline.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Inline SVG Size"
-description: "Checks for large inline SVGs bloating HTML"
+title: "Large inline SVG: when to move it to an external file"
+description: "Inline SVG cannot be cached separately from the HTML, so a big one is paid for on every page view. squirrel measures inline SVG size per page."
 ---
 
-Checks for large inline SVGs bloating HTML
+## What inline SVG costs
+
+An inline `<svg>` is part of the HTML document. That is exactly what you want for a small icon: no extra request, and the fill colour can be styled from CSS. It is the wrong shape for anything large, because the markup is re-downloaded with every page and cannot be cached on its own.
+
+An illustration exported from a design tool is often tens of kilobytes of path data. Referenced with `<img src="illustration.svg">` it is cached once and reused; inlined, it is added to every HTML response that carries it.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `<svg>` element in the document, measuring the length of each element's serialised markup. It emits a single check named `svg-inline`:
+
+- Info when the page has no inline SVG. Message: `No inline SVGs found`.
+- Warn when any single SVG exceeds 4000 characters. Message: `2 large inline SVG(s) (>4KB each)`, with `Total inline SVG size: 31.4KB. Consider external files` as the value. Severity info, weight 3.
+- Info when no single SVG is large but the total exceeds 10000 characters. Message: `24 inline SVG(s) totaling 14.2KB`, with `Consider using SVG sprites or external files` as the value.
+- Pass otherwise. Message: `9 inline SVG(s), 3.1KB total`.
+
+Sizes are character counts of the markup rather than transferred bytes, and they are measured before compression, which typically shrinks SVG considerably. The rule's own severity is info, so even the warn branch does not fail an audit.
+
+## How to fix it
+
+```html
+<img src="/illustration.svg" width="600" height="400" alt="" />
+```
+
+Move large graphics to an external file and reference them. Keep small icons inline where you need to style them from CSS, or collect them into one sprite sheet referenced with `<use>`.
+
+Run the files through SVGO first. Design-tool exports usually carry metadata, unused definitions and far more decimal places than any renderer needs.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks for large inline SVGs bloating HTML
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Large inline SVGs increase HTML size and block rendering. Move SVGs >4KB to external files and reference with `<img>` or CSS background. Inline small, critical SVGs (icons, logos) only. Use SVGO to optimize. Consider SVG sprites for icon sets. Inline SVGs can't be cached separately from HTML.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["images/*"]
 enable = ["images/svg-inline"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/html-size](/rules/crawl/html-size): the document size these SVGs contribute to.
+- [images/modern-format](/rules/images/modern-format): formats for raster images, which SVG is exempt from.
+- [a11y/aria-labels](/rules/a11y/aria-labels): the accessible name an interactive SVG needs.
+- [performance/dom-size](/rules/performance/dom-size): the node count a large inline SVG adds.
+
+Images findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [SVG, MDN](https://developer.mozilla.org/en-US/docs/Web/SVG)
+- [The img element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Images section of the report. Each page is reported with its inline SVG count and total size. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Images section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/brand-impersonation.mdx
+++ b/docs/rules/integrity/brand-impersonation.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Brand Impersonation"
-description: "Detects pages impersonating a third-party brand's login or booking surface"
+title: "Brand impersonation: a sign-in page that is not the brand's"
+description: "A 'Sign in with Google' control pointing at a host that is not Google is a phishing pattern. squirrel checks where credential controls actually go."
 ---
 
-Detects pages impersonating a third-party brand's login or booking surface (Calendly, Google/Microsoft login, ClickFunnels, Kajabi, DocuSign) where credentials are sent off-brand.
+## What brand impersonation is
+
+Brand impersonation, in this context, is a page on your own site that presents another company's sign-in or booking surface while sending the credentials somewhere that company does not own. It is the shape of an injected phishing kit: the attacker uses your domain's reputation to make the fake login look trustworthy.
+
+A legitimate integration always targets the provider's own host, `accounts.google.com` for Google or `calendly.com` for Calendly. Merely naming a brand is not impersonation, and neither is your own app's generic sign-in form. The defect is the mismatch between what the control says and where it points.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits at most one check named `brand-impersonation`. It fires only when all of the following hold on the same page: the page has a credential affordance, meaning an `input[type="password"]` or sign-in copy in the title or body text; the text matches a brand's lexicon; the text also matches one of that brand's action cues; and a credential control whose own label names that brand points at a host that is neither the brand's legitimate host nor the site's own registrable domain.
+
+- Info when this is the only integrity signal on the page. Message: `Possible Calendly brand impersonation (single signal — review)`.
+- Fail when at least two distinct integrity signals fire on the page. Message: `Likely phishing kit impersonating Calendly (3 corroborating integrity signals)`.
+
+Six brands are covered: Google, Microsoft, Calendly, DocuSign, ClickFunnels and Kajabi, each with its own lexicon, action cues and legitimate hosts. The credential surface is deliberately narrow: form actions on forms that contain a password field, and links whose own text matches `sign in`, `log in`, `login`, `continue with` or `verify`. A footer link to an unrelated third party is not read as a credential destination. Sibling subdomains count as the site's own surface, resolved through the Public Suffix List, so a link from `www.acme.com` to `app.acme.com` is spared.
+
+The four page-level integrity rules share one detector module and each computes the full signal set for its own page. Escalation to fail requires two distinct signals from `brand-impersonation`, `obfuscated-script`, `fake-auth-overlay` and `seo-doorway`.
+
+## How to fix it
+
+```html
+<a href="https://accounts.google.com/o/oauth2/v2/auth?client_id=...">Sign in with Google</a>
+```
+
+Point the control at the provider's own host. If you did not build the page, treat the site as compromised: remove the page, look for recently modified files and unexpected CMS entries, rotate credentials and read the server access logs.
+
+An OAuth flow proxied through your own authentication service is not flagged, because the destination shares your registrable domain. A flow proxied through a separate vendor domain will be flagged as a single signal, which is info rather than a failure.
 
 | | |
 |---|---|
@@ -12,16 +37,6 @@ Detects pages impersonating a third-party brand's login or booking surface (Cale
 | **Scope** | Page |
 | **Severity** | warning |
 | **Weight** | 8/10 |
-
-## How it works
-
-The rule fires only when a page combines a brand's lexicon **and** an action cue (sign in, book a call) **and** a credential affordance (a password field or login control) whose target is **not** that brand's legitimate host and **not** your own origin. A bare mention (e.g. "we integrate with Calendly") never fires, and a real "Sign in with Google" button pointing at `accounts.google.com` is spared.
-
-A lone brand-impersonation signal is reported as **info**. It escalates to a **failure** only when at least one other compromise signal corroborates on the same page (for example an obfuscated script or a full-viewport auth overlay): the classic phishing-kit shape.
-
-## Solution
-
-A page presenting a third-party brand's sign-in or booking surface whose credential target is NOT that brand's legitimate host is a classic phishing-kit pattern. If you did not create this page, your site is likely compromised: look for recently added files, unexpected pages not in your CMS, and injected PHP/JS. Remove the page, rotate credentials, and review server access logs. A legitimate integration must link to the brand's real domain (e.g. accounts.google.com, calendly.com).
 
 ## Enable / disable
 
@@ -46,3 +61,30 @@ disable = ["integrity/*"]
 enable = ["integrity/brand-impersonation"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [integrity/fake-auth-overlay](/rules/integrity/fake-auth-overlay): the iframe version of the same credential grab.
+- [integrity/obfuscated-script](/rules/integrity/obfuscated-script): the second signal that turns this finding into a failure.
+- [integrity/orphan-page](/rules/integrity/orphan-page): whether the page is linked from anywhere on your site.
+- [integrity/kit-signature](/rules/integrity/kit-signature): threat-intel signatures for the same kits, when the intel feature is on.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Social engineering (phishing and deceptive sites), Google Search Central](https://developers.google.com/search/docs/monitor-debug/security/social-engineering)
+- [Hacked content, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#hacked-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Each impersonation is listed by page with the brand and the off-brand host it targets. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/cloaking.mdx
+++ b/docs/rules/integrity/cloaking.mdx
@@ -32,7 +32,7 @@ When the probe is off, the rule emits nothing. It never reports a path it did no
 
 ## Enable the probe
 
-The probe is off by default and bounded by a hard page cap, so it never multiplies crawl cost.
+The probe is off by default. It adds two requests per selected path, or three when query variation is on, and the page cap is what bounds that extra work.
 
 ```toml squirrel.toml
 [integrity.cloaking_probe]
@@ -49,7 +49,7 @@ query_variation = true    # also probe an appended query token (token-gating)
 curl -A 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' https://example.com/path
 ```
 
-Fetch the URL yourself with a Googlebot user-agent to see what the crawler sees. Then look for server-side rules that branch on user-agent or query string, and audit recently modified files and plugins.
+Fetch the URL yourself with a Googlebot user-agent to see how the server responds to that string. A server can also identify Googlebot by reverse DNS on the request IP, so a spoofed user-agent shows you the user-agent branch and not necessarily what Google receives. Then look for server-side rules that branch on user-agent or query string, and audit recently modified files and plugins.
 
 Paywalls and A/B tests can produce a similarity divergence without being cloaking. Confirm what the Googlebot response actually contains before treating a finding as a compromise.
 

--- a/docs/rules/integrity/cloaking.mdx
+++ b/docs/rules/integrity/cloaking.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Cloaking: serving Googlebot different content than a visitor"
+title: "Cloaking: showing Googlebot a different page"
 description: "An injected payload can hide from you by branching on user-agent or a query token. squirrel re-fetches suspicious paths and compares the responses."
 ---
 

--- a/docs/rules/integrity/cloaking.mdx
+++ b/docs/rules/integrity/cloaking.mdx
@@ -1,9 +1,26 @@
 ---
-title: "Cloaking / UA-Gated Content"
-description: "Detects pages that serve different content to Googlebot than to a normal visitor"
+title: "Cloaking: serving Googlebot different content than a visitor"
+description: "An injected payload can hide from you by branching on user-agent or a query token. squirrel re-fetches suspicious paths and compares the responses."
 ---
 
-Detects pages that serve materially different content to a **Googlebot** user-agent than to a normal visitor (UA cloaking), or that change their response when a URL query token is added (token-gating). Both are classic ways an injected SEO-spam or phishing payload hides from the site owner while still ranking: you see a clean page, the search engine (or a tokened link) sees the payload.
+## What cloaking is
+
+Cloaking is serving materially different content to a search engine crawler than to a person. Google's spam policies treat it as a violation on its own, but on a site that did not choose to do it, cloaking is usually a symptom: an injected payload branches on the user-agent so the owner sees a clean page while the crawler indexes the spam.
+
+Token-gating is the same idea keyed on the URL instead. The page returns nothing interesting until a query parameter the attacker distributes is appended, which keeps the payload out of ordinary crawls. Legitimate personalisation by geography or device is not cloaking as long as the indexable content stays the same.
+
+## What squirrel checks
+
+The rule reads the results of an opt-in differential probe that runs after the crawl and before the rules. The probe picks a small, capped set of suspicious paths, meaning pages that are orphaned, with no inbound internal links and absent from the sitemap, or recently modified according to sitemap `lastmod`. It re-fetches each one with the default user-agent, again with a Googlebot user-agent, and optionally once more with an appended query token, then compares HTTP status and visible-text similarity.
+
+The rule emits these checks:
+
+- `cloaking` passes when the probe ran but found no suspicious paths to test. Message: `No suspicious paths to probe for cloaking`.
+- `cloaking` fails for paths where the Googlebot response diverges. Message: `2 page(s) serve different content to googlebot than to a normal visitor — likely cloaking`. The reported value describes up to five of them, either as `/path: googlebot got 200, normal visitor got 404 (UA-gated response)` or as `/path: googlebot content only 12% similar to the normal-visitor page`.
+- `cloaking-token-gated` warns for paths whose response changes when a query token is appended, excluding any already reported as UA cloaking. Message: `1 page(s) change their response when a query token is appended — possible token-gated content`.
+- `cloaking` passes when paths were probed and neither pattern appeared. Message: `Probed 8 suspicious path(s) — no UA cloaking or token-gating detected`.
+
+When the probe is off, the rule emits nothing. It never reports a path it did not probe as clean. Severity error, weight 7.
 
 | | |
 |---|---|
@@ -13,22 +30,9 @@ Detects pages that serve materially different content to a **Googlebot** user-ag
 | **Severity** | error |
 | **Weight** | 7/10 |
 
-## How it works
-
-This rule reads the results of an **opt-in differential probe**. After the crawl, squirrelscan picks a small, capped set of **suspicious** paths, pages that are *orphaned* (no inbound internal links and absent from the sitemap) or *recently modified* (sitemap `lastmod` within a recent window), and re-fetches each one:
-
-1. with the **default** (normal-visitor) user-agent: the baseline,
-2. with a **Googlebot** user-agent, and
-3. optionally once more with an appended query token.
-
-It then compares the responses by HTTP status and visible-text similarity:
-
-- **UA cloaking** (→ failure): the Googlebot response materially diverges from the baseline: for example, the normal visitor gets a `403`/`404` while Googlebot gets a `200`, or the visible text barely overlaps.
-- **Token-gating** (→ warning): the response changes materially when a query token is appended, suggesting content gated behind a URL parameter.
-
-The probe is **off by default** and **bounded** (capped page count) so it never multiplies crawl cost. When it is off, this rule does nothing: it never reports "clean" for paths it never probed.
-
 ## Enable the probe
+
+The probe is off by default and bounded by a hard page cap, so it never multiplies crawl cost.
 
 ```toml squirrel.toml
 [integrity.cloaking_probe]
@@ -39,9 +43,15 @@ query_variation = true    # also probe an appended query token (token-gating)
 # googlebot_user_agent = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 ```
 
-## Solution
+## How to fix it
 
-A page that shows search engines (or tokened links) different content than it shows you is cloaking: almost always an injected payload or a deceptive doorway, and a likely compromise. Fetch the URL yourself with a Googlebot user-agent (e.g. `curl -A 'Googlebot' <url>`) to see the hidden content, then audit recently modified files/plugins and any server-side rules that branch on user-agent or query string. Legitimate UA/geo personalization should never change the core indexable content.
+```bash
+curl -A 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' https://example.com/path
+```
+
+Fetch the URL yourself with a Googlebot user-agent to see what the crawler sees. Then look for server-side rules that branch on user-agent or query string, and audit recently modified files and plugins.
+
+Paywalls and A/B tests can produce a similarity divergence without being cloaking. Confirm what the Googlebot response actually contains before treating a finding as a compromise.
 
 ## Enable / disable
 
@@ -58,3 +68,30 @@ disable = ["integrity/cloaking"]
 [rules]
 disable = ["integrity/*"]
 ```
+
+## Related rules
+
+- [integrity/orphan-page](/rules/integrity/orphan-page): the hidden pages the probe selects from.
+- [integrity/known-malicious-url](/rules/integrity/known-malicious-url): reputation feeds that may already have seen the hidden payload.
+- [integrity/seo-doorway](/rules/integrity/seo-doorway): what cloaked pages usually turn out to contain.
+- [crawl/soft-404](/rules/crawl/soft-404): pages that return 200 while showing an error, a different status mismatch.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Cloaking, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#cloaking)
+- [Hacked content, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#hacked-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Each probed path is listed with the two status codes and the similarity score. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/fake-auth-overlay.mdx
+++ b/docs/rules/integrity/fake-auth-overlay.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Fake Authentication Overlay"
-description: "Detects full-viewport credential overlays and off-brand sign-in controls"
+title: "Fake authentication overlay: full-screen iframe login prompts"
+description: "A fixed, full-viewport, high z-index iframe with an auth identifier is a credential-harvesting overlay. squirrel measures the geometry and the intent."
 ---
 
-Detects full-viewport fixed high-z-index iframe overlays or sign-in controls that send credentials to an off-brand host: a credential-harvesting overlay pattern.
+## What a fake authentication overlay is
+
+A credential-harvesting overlay is an iframe injected into a real page, positioned to cover the whole viewport, that renders a login form the attacker controls. The address bar still shows your domain, so nothing about the page warns the visitor. The injected `#google-auth` iframe is the pattern this rule was written against.
+
+The geometry is what gives it away: `position: fixed`, a very high `z-index`, width and height at 100% of the viewport, and pinned to the top left corner. Legitimate full-page app shells share that geometry, which is why geometry alone is not enough to call it an attack.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits at most one check named `fake-auth-overlay`. It examines every `<iframe>` with an inline `style` attribute and requires all four geometry conditions: `position` is `fixed` or `absolute`; `z-index` is at least 1000; width contains `100%` or `100vw` and height contains `100%` or `100vh`; and `top` or `left` is `0` or `0px`.
+
+A frame with that geometry fires only when it also carries auth intent, meaning either its `id`, `class` or `src` matches `auth`, `login`, `signin`, `sign-in`, `oauth`, `verify` or `credential`, or it loads from a host that is not the site's own while the page separately shows auth copy or a password field.
+
+- Info when this is the only integrity signal on the page. Message: `Suspicious authentication overlay (single signal — review)`.
+- Fail when at least two distinct integrity signals fire on the page. Message: `Likely credential-harvesting overlay (3 corroborating integrity signals)`.
+
+The reported value names the z-index, the frame id and the source URL. The "Sign in with brand" link pattern is deliberately left to `integrity/brand-impersonation`, so one off-brand sign-in link cannot count as two signals and satisfy the escalation gate on its own.
+
+## How to fix it
+
+```html
+<!-- remove the injected overlay -->
+<iframe id="google-auth" style="position:fixed;top:0;left:0;width:100%;height:100%;z-index:99999"></iframe>
+```
+
+Find the template or plugin that emits the markup and delete it, then look for the loader that injected it. Treat the site as compromised: audit recently modified files, rotate credentials and read the access logs.
+
+A cookie banner or a support widget in a fixed iframe does not match, because it does not fill the viewport. A legitimate full-page portal iframe on your own origin does not match either, unless its id or class contains one of the auth words.
 
 | | |
 |---|---|
@@ -12,19 +38,6 @@ Detects full-viewport fixed high-z-index iframe overlays or sign-in controls tha
 | **Scope** | Page |
 | **Severity** | warning |
 | **Weight** | 8/10 |
-
-## How it works
-
-Two patterns trip this rule:
-
-1. A **full-viewport, fixed, high-z-index iframe** pinned to a corner (the injected `#google-auth` overlay from the real incident). A normal fixed cookie banner won't match: it lacks the viewport-filling dimensions.
-2. A **"Sign in with &lt;brand&gt;" control** whose link target is neither the brand's real host nor your own origin (i.e. where the credentials would actually go).
-
-A lone overlay signal is reported as **info**. It escalates to a **failure** only when another compromise signal corroborates on the same page.
-
-## Solution
-
-A full-viewport, fixed, high-z-index iframe that covers the page, or a 'Sign in with Google/Microsoft' control whose target is not the brand's real domain, is a credential-harvesting overlay. If you did not build it, your site is likely compromised: remove the overlay markup/script, audit recently modified files, and rotate credentials. Legitimate sign-in always targets the provider's own host (accounts.google.com, login.microsoftonline.com).
 
 ## Enable / disable
 
@@ -49,3 +62,30 @@ disable = ["integrity/*"]
 enable = ["integrity/fake-auth-overlay"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [integrity/brand-impersonation](/rules/integrity/brand-impersonation): the link version of the same credential grab.
+- [integrity/obfuscated-script](/rules/integrity/obfuscated-script): the script that usually injects the overlay.
+- [security/x-frame-options](/rules/security/x-frame-options): stopping other sites from framing you, the mirror problem.
+- [integrity/template-discontinuity](/rules/integrity/template-discontinuity): whether the page carrying the overlay belongs to your theme at all.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The iframe element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe)
+- [Social engineering (phishing and deceptive sites), Google Search Central](https://developers.google.com/search/docs/monitor-debug/security/social-engineering)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Each overlay is listed by page with its z-index, id and source. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/fake-auth-overlay.mdx
+++ b/docs/rules/integrity/fake-auth-overlay.mdx
@@ -13,7 +13,7 @@ The geometry is what gives it away: `position: fixed`, a very high `z-index`, wi
 
 The rule runs on every crawled page and emits at most one check named `fake-auth-overlay`. It examines every `<iframe>` with an inline `style` attribute and requires all four geometry conditions: `position` is `fixed` or `absolute`; `z-index` is at least 1000; width contains `100%` or `100vw` and height contains `100%` or `100vh`; and `top` or `left` is `0` or `0px`.
 
-A frame with that geometry fires only when it also carries auth intent, meaning either its `id`, `class` or `src` matches `auth`, `login`, `signin`, `sign-in`, `oauth`, `verify` or `credential`, or it loads from a host that is not the site's own while the page separately shows auth copy or a password field.
+A frame with that geometry fires only when it also carries auth intent. That means either its `id` or `class` matches `auth`, `login`, `signin`, `sign-in`, `oauth`, `verify` or `credential`, or its `src` matches the same list without `credential`, or it loads from a host that is not the site's own while the page separately shows auth copy or a password field.
 
 - Info when this is the only integrity signal on the page. Message: `Suspicious authentication overlay (single signal — review)`.
 - Fail when at least two distinct integrity signals fire on the page. Message: `Likely credential-harvesting overlay (3 corroborating integrity signals)`.
@@ -29,7 +29,7 @@ The reported value names the z-index, the frame id and the source URL. The "Sign
 
 Find the template or plugin that emits the markup and delete it, then look for the loader that injected it. Treat the site as compromised: audit recently modified files, rotate credentials and read the access logs.
 
-A cookie banner or a support widget in a fixed iframe does not match, because it does not fill the viewport. A legitimate full-page portal iframe on your own origin does not match either, unless its id or class contains one of the auth words.
+A cookie banner or a support widget in a fixed iframe does not match, because it does not fill the viewport. A legitimate full-page portal iframe on your own origin matches only if an auth word appears in its id, its class or its `src`, which a path like `/login` will do.
 
 | | |
 |---|---|

--- a/docs/rules/integrity/fake-auth-overlay.mdx
+++ b/docs/rules/integrity/fake-auth-overlay.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Fake authentication overlay: full-screen iframe login prompts"
+title: "Fake authentication overlay: full-screen login iframes"
 description: "A fixed, full-viewport, high z-index iframe with an auth identifier is a credential-harvesting overlay. squirrel measures the geometry and the intent."
 ---
 

--- a/docs/rules/integrity/index.mdx
+++ b/docs/rules/integrity/index.mdx
@@ -14,32 +14,32 @@ These rules run **locally and free**, no login required.
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Template Discontinuity" icon="triangle-exclamation" href="/rules/integrity/template-discontinuity">
-    Detects pages whose markup diverges hard from the site's common template
+  <Card title="Template discontinuity: a page that is not on your theme" icon="triangle-exclamation" href="/rules/integrity/template-discontinuity">
+    An injected standalone page loads none of your site's CSS, hosts or chrome. squirrel fingerprints every page and scores it against the site baseline.
   </Card>
-  <Card title="Hidden Orphan Page" icon="triangle-exclamation" href="/rules/integrity/orphan-page">
-    Detects crawled pages absent from every sitemap AND linked from nowhere
+  <Card title="Hidden orphan page: reachable but linked from nowhere" icon="triangle-exclamation" href="/rules/integrity/orphan-page">
+    An injected page hides by being in no sitemap and linked from no page. squirrel finds crawled pages with zero inbound links and no sitemap entry.
   </Card>
-  <Card title="Brand Impersonation" icon="triangle-exclamation" href="/rules/integrity/brand-impersonation">
-    Detects pages impersonating a third-party brand's login or booking surface
+  <Card title="Brand impersonation: a sign-in page that is not the brand's" icon="triangle-exclamation" href="/rules/integrity/brand-impersonation">
+    A 'Sign in with Google' control pointing at a host that is not Google is a phishing pattern. squirrel checks where credential controls actually go.
   </Card>
-  <Card title="Obfuscated Inline Script" icon="triangle-exclamation" href="/rules/integrity/obfuscated-script">
-    Detects large inline scripts with high entropy and obfuscation markers
+  <Card title="Obfuscated inline script: spotting an injected payload" icon="triangle-exclamation" href="/rules/integrity/obfuscated-script">
+    A large inline script with high entropy and eval or anti-tamper markers is rarely something a site ships on purpose. squirrel measures all three.
   </Card>
-  <Card title="Fake Authentication Overlay" icon="triangle-exclamation" href="/rules/integrity/fake-auth-overlay">
-    Detects full-viewport credential overlays and off-brand sign-in controls
+  <Card title="Fake authentication overlay: full-screen login iframes" icon="triangle-exclamation" href="/rules/integrity/fake-auth-overlay">
+    A fixed, full-viewport, high z-index iframe with an auth identifier is a credential-harvesting overlay. squirrel measures the geometry and the intent.
   </Card>
-  <Card title="SEO Doorway Page" icon="triangle-exclamation" href="/rules/integrity/seo-doorway">
-    Detects injected off-topic, keyword-stuffed affiliate doorway posts
+  <Card title="Doorway page: injected affiliate spam on a legitimate site" icon="triangle-exclamation" href="/rules/integrity/seo-doorway">
+    An off-topic, keyword-stuffed affiliate post is how a compromise monetises your domain's authority. squirrel checks the title, the density and the body.
   </Card>
-  <Card title="Cloaking / UA-Gated Content" icon="triangle-exclamation" href="/rules/integrity/cloaking">
-    Detects pages serving different content to Googlebot than to a normal visitor
+  <Card title="Cloaking: showing Googlebot a different page" icon="triangle-exclamation" href="/rules/integrity/cloaking">
+    An injected payload can hide from you by branching on user-agent or a query token. squirrel re-fetches suspicious paths and compares the responses.
   </Card>
-  <Card title="Kit Signature" icon="triangle-exclamation" href="/rules/integrity/kit-signature">
-    Matches a page against threat-intel signatures of known phishing and malware kits
+  <Card title="Kit signature: matching a page against known phishing kits" icon="triangle-exclamation" href="/rules/integrity/kit-signature">
+    A phishing kit reuses the same markup and strings on every site it lands on. squirrel matches each page against bundled kit signatures.
   </Card>
-  <Card title="Known Malicious URL" icon="triangle-exclamation" href="/rules/integrity/known-malicious-url">
-    Cross-references site URLs and outbound links against threat-intel feeds
+  <Card title="Known malicious URL: checking against threat feeds" icon="triangle-exclamation" href="/rules/integrity/known-malicious-url">
+    A page can be listed by Safe Browsing before you notice anything wrong. squirrel checks your URLs and outbound links against reputation feeds.
   </Card>
 </CardGroup>
 

--- a/docs/rules/integrity/index.mdx
+++ b/docs/rules/integrity/index.mdx
@@ -3,9 +3,7 @@ title: "Site Integrity"
 description: "Signs of compromise: injected pages, phishing kits, malware, SEO spam"
 ---
 
-Site Integrity rules answer a question SEO tools usually ignore: **is this site hacked?**
-
-A compromised page is, by construction, an anomaly: off-theme, hidden from your own navigation, impersonating a third-party brand, or carrying an obfuscated payload. squirrelscan already crawls every page's DOM, scripts, links, and sitemap, so it can spot these patterns for free, with no external calls.
+Site Integrity rules answer a question audit tools usually skip: is this site hacked? A compromised page is an anomaly by construction, off-theme, hidden from your own navigation, impersonating a brand, or carrying an obfuscated payload. squirrelscan already has every page's DOM, scripts, links and sitemap from the crawl, so it looks for those patterns without any extra request.
 
 ## Correlation gating (low false positives)
 
@@ -51,3 +49,5 @@ These rules run **locally and free**, no login required.
 [rules]
 disable = ["integrity/*"]
 ```
+
+Every audit reports Site Integrity findings next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/integrity/kit-signature.mdx
+++ b/docs/rules/integrity/kit-signature.mdx
@@ -1,9 +1,23 @@
 ---
-title: "Kit Signature"
-description: "Matches a page's HTML and JavaScript against threat-intel signatures of known phishing and malware kits"
+title: "Kit signature: matching a page against known phishing kits"
+description: "A phishing kit reuses the same markup and strings on every site it lands on. squirrel matches each page against bundled kit signatures."
 ---
 
-Matches a page's HTML and JavaScript against threat-intel signatures of known phishing and malware kits (for example the Calendly credential kit). A signature fires on the structural fingerprint of a kit, so it can catch an injected, token-gated standalone page that impersonates a brand's login or booking surface even when the softer heuristic integrity rules miss it.
+## What a kit signature is
+
+A phishing kit is a packaged set of files an attacker drops onto a compromised site: the cloned login page, the credential exfiltration script and a loader. Because the same kit is deployed on thousands of sites, it carries a recognisable structural fingerprint, a combination of brand strings, script tells and markup shapes that appear together.
+
+A signature encodes that combination. It is stricter than a heuristic, because it names the exact strings a specific kit ships, so it can catch an injected page that the softer integrity heuristics miss: a token-gated standalone document that shares nothing with the rest of the site.
+
+## What squirrel checks
+
+The rule is part of the opt-in threat-intel feature. When the feature is on, squirrelscan loads the bundled kit signatures before the audit rules run, then matches each crawled page. The match input is the page URL, its title, its HTML, its extracted text and the bodies of the external scripts attached to that page. Inline scripts are covered through the HTML.
+
+- Fail, once per matching signature. Message: `Matched kit signature "Calendly credential kit" (brand-lexicon, exfil-endpoint)`, naming the signature and every string that matched. The reported value is the signature id, and the details carry the signature's own severity and description. Severity error, weight 9.
+
+Signatures require several corroborating strings on the same page, so a match reports a failure directly rather than going through the two-signal correlation gate that the heuristic integrity rules use. When the threat-intel feature is off, the rule emits nothing at all: it never reports a page as clean for signatures it never ran.
+
+The signatures ship with squirrelscan and need no API key or network access, so the rule works on any opted-in audit from the CLI as well as in the cloud.
 
 | | |
 |---|---|
@@ -12,18 +26,6 @@ Matches a page's HTML and JavaScript against threat-intel signatures of known ph
 | **Scope** | Page |
 | **Severity** | error |
 | **Weight** | 9/10 |
-
-## How it works
-
-This rule is part of the opt-in **threat-intel** feature (`[intel]`). When the feature is on, squirrelscan loads a set of bundled kit signatures before the audit rules run, then matches each page against them using:
-
-- the page **URL** and **title**,
-- the page **HTML** and extracted **text**, and
-- the bodies of **inline and external scripts** attached to that page.
-
-Signatures are written to be high precision: each one requires several corroborating strings on the same page (a brand lexicon plus a kit tell), so a casual mention never trips it. Because the signature already demands multiple corroborating strings, a match reports a **failure** directly rather than going through the correlation gate the heuristic integrity rules use.
-
-The signatures ship with squirrelscan and need no API key or network access, so this rule works on every opted-in audit, both from the CLI and in the cloud. When the `[intel]` feature is off, `ctx.intel` is undefined and the rule does nothing: it never reports a page as clean for signatures it never ran.
 
 ## Enable the feature
 
@@ -34,9 +36,11 @@ Threat-intel is off by default. Turn it on to activate this rule:
 enabled = true            # off by default
 ```
 
-## Solution
+## How to fix it
 
-A page matching a known kit signature is a strong indicator that your site is compromised: an injected, often token-gated standalone page that impersonates a brand's login or booking surface to harvest credentials. Remove the page and any unexpected files, rotate credentials, audit server access logs, and review for a web shell or an injected loader. Signatures are high precision (they require multiple corroborating strings), so a match is not a casual false positive.
+Remove the matched page and every file that came with it. Treat the site as compromised: look for a web shell or an injected loader, audit recently modified files, rotate credentials and read the access logs. A signature match is not a casual false positive, because it needed several corroborating strings to fire.
+
+Read the matched strings in the report before acting. They name exactly what was found on the page, which is the fastest way to locate the file that emits it.
 
 ## Enable / disable
 
@@ -53,3 +57,30 @@ disable = ["integrity/kit-signature"]
 [rules]
 disable = ["integrity/*"]
 ```
+
+## Related rules
+
+- [integrity/known-malicious-url](/rules/integrity/known-malicious-url): the other half of the threat-intel feature, checking URLs against reputation feeds.
+- [integrity/brand-impersonation](/rules/integrity/brand-impersonation): the heuristic that catches kits with no signature yet.
+- [integrity/cloaking](/rules/integrity/cloaking): pages that hide the payload from your crawler entirely.
+- [integrity/orphan-page](/rules/integrity/orphan-page): how a standalone injected page usually shows up in a crawl.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Social engineering (phishing and deceptive sites), Google Search Central](https://developers.google.com/search/docs/monitor-debug/security/social-engineering)
+- [Hacked content, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#hacked-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Each match is listed by page with the signature name and the strings that matched. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/kit-signature.mdx
+++ b/docs/rules/integrity/kit-signature.mdx
@@ -13,7 +13,7 @@ A signature encodes that combination. It is stricter than a heuristic, because i
 
 The rule is part of the opt-in threat-intel feature. When the feature is on, squirrelscan loads the bundled kit signatures before the audit rules run, then matches each crawled page. The match input is the page URL, its title, its HTML, its extracted text and the bodies of the external scripts attached to that page. Inline scripts are covered through the HTML.
 
-- Fail, once per matching signature. Message: `Matched kit signature "Calendly credential kit" (brand-lexicon, exfil-endpoint)`, naming the signature and every string that matched. The reported value is the signature id, and the details carry the signature's own severity and description. Severity error, weight 9.
+- Fail, once per matching signature. Message: `Matched kit signature "Calendly phishing kit" (calendly_brand, google_auth_overlay)`, naming the signature and the identifiers of the patterns that matched, not the text found on the page. The reported value is the signature id, and the details carry the signature's own severity and description. Severity error, weight 9.
 
 Signatures require several corroborating strings on the same page, so a match reports a failure directly rather than going through the two-signal correlation gate that the heuristic integrity rules use. When the threat-intel feature is off, the rule emits nothing at all: it never reports a page as clean for signatures it never ran.
 
@@ -40,7 +40,7 @@ enabled = true            # off by default
 
 Remove the matched page and every file that came with it. Treat the site as compromised: look for a web shell or an injected loader, audit recently modified files, rotate credentials and read the access logs. A signature match is not a casual false positive, because it needed several corroborating strings to fire.
 
-Read the matched strings in the report before acting. They name exactly what was found on the page, which is the fastest way to locate the file that emits it.
+Read the matched pattern identifiers in the report before acting. They name which parts of the signature fired, such as a brand string in the title or an overlay id in the HTML, which narrows down where to look.
 
 ## Enable / disable
 

--- a/docs/rules/integrity/known-malicious-url.mdx
+++ b/docs/rules/integrity/known-malicious-url.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Known malicious URL: checking your site against threat feeds"
+title: "Known malicious URL: checking against threat feeds"
 description: "A page can be listed by Safe Browsing before you notice anything wrong. squirrel checks your URLs and outbound links against reputation feeds."
 ---
 

--- a/docs/rules/integrity/known-malicious-url.mdx
+++ b/docs/rules/integrity/known-malicious-url.mdx
@@ -5,7 +5,7 @@ description: "A page can be listed by Safe Browsing before you notice anything w
 
 ## What a threat-intel URL check is
 
-Reputation feeds are lists of URLs that security vendors have observed serving phishing or malware. Safe Browsing, URLhaus, ThreatFox, urlscan, VirusTotal, OpenPhish and PhishTank each publish or answer queries about them, and browsers use the same data to show interstitial warnings.
+Reputation feeds are lists of URLs that security vendors have observed serving phishing or malware. Safe Browsing, URLhaus, ThreatFox, urlscan, VirusTotal, OpenPhish and PhishTank each publish such lists or answer queries against them. Browsers show interstitial warnings from their own protection service, which for Chrome is Safe Browsing and for Edge is Microsoft Defender SmartScreen, so a listing in one feed does not mean every browser will warn.
 
 Checking your own URLs against those lists catches two things a crawler cannot. A page that only serves its payload to a specific referrer or token never renders the payload for your audit, but the feed may already have a sample of it. And an outbound link on your site may point at a host that was compromised after you linked to it.
 
@@ -13,8 +13,8 @@ Checking your own URLs against those lists catches two things a crawler cannot. 
 
 The rule is part of the opt-in threat-intel feature. All feed pulls and lookups happen before the rules run; the rule itself reads memoized verdicts. It collects candidates from the site base URL, every crawled page's URL and final URL, and every outbound external link, deduplicated by URL and tagged as `site` or `external-link`. It emits a check named `known-malicious-url`:
 
-- Fail, once per listed URL that belongs to the site. Message: `Site URL flagged as malicious by URLhaus, OpenPhish (phishing)`, naming the providers that listed it and any threat labels they attached.
-- Fail, once per listed outbound link. Message: `Outbound link to a known-malicious URL flagged by URLhaus (malware_download)`.
+- Fail, once per listed URL that belongs to the site. Message: `Site URL flagged as malicious by urlhaus, openphish (phishing)`, naming the provider ids that listed it and any threat labels they attached.
+- Fail, once per listed outbound link. Message: `Outbound link to a known-malicious URL flagged by urlhaus (malware_download)`.
 - Pass, once, when at least one provider was consulted and nothing matched. Message: `No site URLs or outbound links matched any threat-intel feed`.
 
 When no provider was consulted for any candidate, because the feature is off or nothing was prefetched, the rule emits nothing. Absence of data is never reported as a clean result. Severity error, weight 9.
@@ -29,15 +29,15 @@ When no provider was consulted for any candidate, because the feature is off or 
 
 ## Enable the feature
 
-Threat-intel is off by default. Turn it on and configure at least one provider so this rule has feeds to check against. URLhaus, ThreatFox, OpenPhish and PhishTank are keyless daily-pull feeds; Safe Browsing, urlscan and VirusTotal are API-keyed on-demand lookups.
+Threat-intel is off by default. Turn it on and configure at least one provider so this rule has feeds to check against. URLhaus, ThreatFox, OpenPhish and PhishTank are daily-pull feeds; Safe Browsing, urlscan and VirusTotal are on-demand lookups. URLhaus and ThreatFox both take an abuse.ch key, which squirrel sends as the `Auth-Key` header.
 
 ```toml squirrel.toml
 [intel]
 enabled = true            # off by default
 
-# Keyless daily-pull feeds: just switch them on.
+# Daily-pull feeds.
 [intel.providers.urlhaus]
-enabled = true
+api_key = "your-abuse-ch-key" # pragma: allowlist secret
 
 [intel.providers.openphish]
 enabled = true
@@ -52,7 +52,7 @@ api_key = "your-virustotal-key" # pragma: allowlist secret
 
 ## How to fix it
 
-A listed URL of your own means the page is serving a payload. Remove the content, rotate credentials, read the access logs, then request a review from the provider that listed it once the page is clean.
+A listing is a report of suspected malicious activity, not proof, and false positives happen. Open the URL and confirm before acting. Once you have confirmed it, remove the content, rotate credentials, read the access logs, then request a review from the provider that listed it.
 
 A listed outbound link points your visitors at a malicious host. Remove or replace it, and check whether you put it there. A link you did not add is itself a compromise signal.
 

--- a/docs/rules/integrity/known-malicious-url.mdx
+++ b/docs/rules/integrity/known-malicious-url.mdx
@@ -1,9 +1,23 @@
 ---
-title: "Known Malicious URL"
-description: "Cross-references the site's own URLs and outbound links against threat-intel feeds"
+title: "Known malicious URL: checking your site against threat feeds"
+description: "A page can be listed by Safe Browsing before you notice anything wrong. squirrel checks your URLs and outbound links against reputation feeds."
 ---
 
-Cross-references the site's own URLs (its domain and each page's final URL) and its outbound external links against threat-intel feeds and on-demand lookups. This catches token-gated or cloaked kits that never render for the crawler but are already listed by a reputation provider, and it flags outbound links that point visitors at a known-malicious host.
+## What a threat-intel URL check is
+
+Reputation feeds are lists of URLs that security vendors have observed serving phishing or malware. Safe Browsing, URLhaus, ThreatFox, urlscan, VirusTotal, OpenPhish and PhishTank each publish or answer queries about them, and browsers use the same data to show interstitial warnings.
+
+Checking your own URLs against those lists catches two things a crawler cannot. A page that only serves its payload to a specific referrer or token never renders the payload for your audit, but the feed may already have a sample of it. And an outbound link on your site may point at a host that was compromised after you linked to it.
+
+## What squirrel checks
+
+The rule is part of the opt-in threat-intel feature. All feed pulls and lookups happen before the rules run; the rule itself reads memoized verdicts. It collects candidates from the site base URL, every crawled page's URL and final URL, and every outbound external link, deduplicated by URL and tagged as `site` or `external-link`. It emits a check named `known-malicious-url`:
+
+- Fail, once per listed URL that belongs to the site. Message: `Site URL flagged as malicious by URLhaus, OpenPhish (phishing)`, naming the providers that listed it and any threat labels they attached.
+- Fail, once per listed outbound link. Message: `Outbound link to a known-malicious URL flagged by URLhaus (malware_download)`.
+- Pass, once, when at least one provider was consulted and nothing matched. Message: `No site URLs or outbound links matched any threat-intel feed`.
+
+When no provider was consulted for any candidate, because the feature is off or nothing was prefetched, the rule emits nothing. Absence of data is never reported as a clean result. Severity error, weight 9.
 
 | | |
 |---|---|
@@ -13,20 +27,9 @@ Cross-references the site's own URLs (its domain and each page's final URL) and 
 | **Severity** | error |
 | **Weight** | 9/10 |
 
-## How it works
-
-This rule is part of the opt-in **threat-intel** feature (`[intel]`). When the feature is on, squirrelscan gathers every candidate URL (the base domain, each crawled page's URL and final URL, and every outbound external link), then checks each one against the configured providers:
-
-- **Daily-pull feeds:** URLhaus, ThreatFox, OpenPhish, and PhishTank. These are pulled once per day into a cached blocklist.
-- **On-demand lookups:** Google Safe Browsing, urlscan, and VirusTotal. These are queried per URL and their results are memoized for the run.
-
-A flagged **site** URL means one of your own pages is serving (or hosting an injected) phishing or malware payload, a likely compromise. A flagged **outbound** link means the page links out to a known-malicious host.
-
-The rule reports honestly when data is incomplete: if no provider was consulted for a URL (the feature is off, or nothing was prefetched), it stays silent for that URL rather than implying it is clean. When at least one provider was consulted and nothing matched, it records a single reassuring pass for the report.
-
 ## Enable the feature
 
-Threat-intel is off by default. Turn it on and configure at least one provider so this rule has feeds to check against:
+Threat-intel is off by default. Turn it on and configure at least one provider so this rule has feeds to check against. URLhaus, ThreatFox, OpenPhish and PhishTank are keyless daily-pull feeds; Safe Browsing, urlscan and VirusTotal are API-keyed on-demand lookups.
 
 ```toml squirrel.toml
 [intel]
@@ -47,9 +50,11 @@ api_key = "your-safe-browsing-key" # pragma: allowlist secret
 api_key = "your-virustotal-key" # pragma: allowlist secret
 ```
 
-## Solution
+## How to fix it
 
-A site URL flagged by a threat feed means the page is serving (or is hosting an injected) phishing or malware payload, almost always a compromise. Remove the offending content, rotate credentials, and request a review from the listing provider once the page is clean. A flagged **outbound** link points your visitors at a malicious host: remove or replace the link, and check whether it was injected, which is a compromise signal in its own right.
+A listed URL of your own means the page is serving a payload. Remove the content, rotate credentials, read the access logs, then request a review from the provider that listed it once the page is clean.
+
+A listed outbound link points your visitors at a malicious host. Remove or replace it, and check whether you put it there. A link you did not add is itself a compromise signal.
 
 ## Enable / disable
 
@@ -66,3 +71,30 @@ disable = ["integrity/known-malicious-url"]
 [rules]
 disable = ["integrity/*"]
 ```
+
+## Related rules
+
+- [integrity/kit-signature](/rules/integrity/kit-signature): the other half of the threat-intel feature, matching page content rather than URLs.
+- [integrity/cloaking](/rules/integrity/cloaking): pages that hide the payload from your own crawl.
+- [links/broken-external-links](/rules/links/broken-external-links): outbound links that no longer resolve at all.
+- [security/new-tab](/rules/security/new-tab): the attributes those outbound links should carry.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Malware and unwanted software, Google Search Central](https://developers.google.com/search/docs/monitor-debug/security/malware)
+- [Social engineering (phishing and deceptive sites), Google Search Central](https://developers.google.com/search/docs/monitor-debug/security/social-engineering)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Each listed URL is named with the providers that flagged it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/obfuscated-script.mdx
+++ b/docs/rules/integrity/obfuscated-script.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Obfuscated inline script: how squirrel spots an injected payload"
+title: "Obfuscated inline script: spotting an injected payload"
 description: "A large inline script with high entropy and eval or anti-tamper markers is rarely something a site ships on purpose. squirrel measures all three."
 ---
 

--- a/docs/rules/integrity/obfuscated-script.mdx
+++ b/docs/rules/integrity/obfuscated-script.mdx
@@ -7,11 +7,11 @@ description: "A large inline script with high entropy and eval or anti-tamper ma
 
 An obfuscated script is JavaScript deliberately rewritten so a reader cannot follow it: identifiers replaced with hex names such as `_0x4a2b`, strings encoded and rebuilt with `String.fromCharCode` or `atob`, and the whole body wrapped in an `eval` or a packer. Injected payloads use it to hide what they do from anyone who views source.
 
-Minification is not obfuscation. A minified bundle is dense and has similar character entropy, but it does not call `eval`, does not rebuild its own strings at runtime, and does not carry anti-tamper strings. A large obfuscated blob shipped inline rather than as an external, source-mapped bundle is the combination worth looking at.
+Minification is a different goal. It shortens code without hiding intent, and a minified bundle is usually readable again once it is formatted. Minifiers do not forbid `eval` or runtime string rebuilding, so those markers are a signal rather than proof. What is worth looking at is the combination: a large, high-entropy blob shipped inline rather than as an external, source-mapped bundle.
 
 ## What squirrel checks
 
-The rule runs on every crawled page over every inline `<script>`, meaning any `<script>` with no `src`. A script is a hit only when all three conditions hold: it is at least 4096 bytes; its lowercased body contains at least one packer marker; and its Shannon entropy is at least 4.5 bits per character. When several scripts qualify, the largest is reported.
+The rule runs on every crawled page over every inline `<script>`. An inline script here means one whose `src` attribute is absent or empty. A script is a hit only when all three conditions hold: its text is at least 4096 characters long, counted as UTF-16 code units rather than encoded bytes; its lowercased body contains at least one packer marker; and its Shannon entropy is at least 4.5 bits per character. When several scripts qualify, the longest is reported.
 
 The packer markers are `eval(`, `function("return this")`, `function('return this')`, `atob(`, `unescape(`, `fromcharcode`, `the code has been tampered` and `_0x`.
 
@@ -20,7 +20,7 @@ It emits at most one check named `obfuscated-script`:
 - Info when this is the only integrity signal on the page. Message: `Suspicious 152.4KB obfuscated inline script (single signal — review)`.
 - Fail when at least two distinct integrity signals fire on the page. Message: `Likely injected payload: 152.4KB obfuscated inline script (3 corroborating integrity signals)`.
 
-The reported value carries the size in kilobytes, the entropy rounded to two decimals, and the list of markers that matched. External scripts are out of scope for this signal.
+The size in the message is that character count divided by 1024, so it tracks the text length rather than the transferred bytes. The reported value carries that size, the entropy rounded to two decimals, and the list of markers that matched. Scripts with a real `src` are out of scope for this signal.
 
 ## How to fix it
 

--- a/docs/rules/integrity/obfuscated-script.mdx
+++ b/docs/rules/integrity/obfuscated-script.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Obfuscated Inline Script"
-description: "Detects large inline scripts with high entropy and obfuscation markers"
+title: "Obfuscated inline script: how squirrel spots an injected payload"
+description: "A large inline script with high entropy and eval or anti-tamper markers is rarely something a site ships on purpose. squirrel measures all three."
 ---
 
-Detects large inline scripts with high entropy and obfuscation markers (eval, char-code arithmetic, anti-tamper strings) typical of injected payloads.
+## What an obfuscated inline script is
+
+An obfuscated script is JavaScript deliberately rewritten so a reader cannot follow it: identifiers replaced with hex names such as `_0x4a2b`, strings encoded and rebuilt with `String.fromCharCode` or `atob`, and the whole body wrapped in an `eval` or a packer. Injected payloads use it to hide what they do from anyone who views source.
+
+Minification is not obfuscation. A minified bundle is dense and has similar character entropy, but it does not call `eval`, does not rebuild its own strings at runtime, and does not carry anti-tamper strings. A large obfuscated blob shipped inline rather than as an external, source-mapped bundle is the combination worth looking at.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every inline `<script>`, meaning any `<script>` with no `src`. A script is a hit only when all three conditions hold: it is at least 4096 bytes; its lowercased body contains at least one packer marker; and its Shannon entropy is at least 4.5 bits per character. When several scripts qualify, the largest is reported.
+
+The packer markers are `eval(`, `function("return this")`, `function('return this')`, `atob(`, `unescape(`, `fromcharcode`, `the code has been tampered` and `_0x`.
+
+It emits at most one check named `obfuscated-script`:
+
+- Info when this is the only integrity signal on the page. Message: `Suspicious 152.4KB obfuscated inline script (single signal — review)`.
+- Fail when at least two distinct integrity signals fire on the page. Message: `Likely injected payload: 152.4KB obfuscated inline script (3 corroborating integrity signals)`.
+
+The reported value carries the size in kilobytes, the entropy rounded to two decimals, and the list of markers that matched. External scripts are out of scope for this signal.
+
+## How to fix it
+
+```html
+<!-- serve heavy JavaScript as an external, readable bundle -->
+<script src="/assets/app.4f2c1a.js" defer></script>
+```
+
+If you did not add the inline blob, find the file or plugin that emits it, remove it, then look for dropped files and a loader that re-injects it. Rotate credentials and read the access logs.
+
+A tag manager or consent platform that ships a large inline loader using `atob` can match. Confirm the vendor and the exact bytes before treating it as an injection, and disable the rule for that page if it is expected.
 
 | | |
 |---|---|
@@ -12,16 +40,6 @@ Detects large inline scripts with high entropy and obfuscation markers (eval, ch
 | **Scope** | Page |
 | **Severity** | warning |
 | **Weight** | 8/10 |
-
-## How it works
-
-The rule scores inline `<script>` elements on three axes at once: **length** (the injected kit in the real incident was a single ~152KB inline blob), **Shannon entropy** (packed/encoded payloads are near-random), and **obfuscation markers** (`eval(`, `atob(`, `String.fromCharCode`, hex-mangled `_0x` identifiers, anti-tamper strings). A normal minified bundle is dense but lacks the eval/anti-tamper cues, and a small snippet never trips regardless of markers, so the rule fires only when all three line up.
-
-A lone obfuscated script is reported as **info**. It escalates to a **failure** only when another compromise signal corroborates on the same page.
-
-## Solution
-
-A large, high-entropy inline script using eval/packers or anti-tamper strings is rarely something a legitimate site ships inline. If you did not add it, treat the page as compromised: identify the file serving it, remove the injected script, scan for dropped PHP/JS, and rotate credentials. Legitimate heavy JS should be served as an external, source-mapped bundle, not an obfuscated inline blob.
 
 ## Enable / disable
 
@@ -46,3 +64,30 @@ disable = ["integrity/*"]
 enable = ["integrity/obfuscated-script"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [integrity/fake-auth-overlay](/rules/integrity/fake-auth-overlay): what an injected script usually builds.
+- [integrity/brand-impersonation](/rules/integrity/brand-impersonation): the second signal that turns this into a failure.
+- [security/leaked-secrets](/rules/security/leaked-secrets): credentials the same script would find in the page.
+- [security/csp](/rules/security/csp): the policy that stops an injected inline script from running.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [eval(), MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval)
+- [Malware and unwanted software, Google Search Central](https://developers.google.com/search/docs/monitor-debug/security/malware)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Each script is listed by page with its size, entropy and matched markers. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/orphan-page.mdx
+++ b/docs/rules/integrity/orphan-page.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Hidden Orphan Page"
-description: "Detects crawled pages absent from every sitemap AND linked from nowhere"
+title: "Hidden orphan page: reachable but linked from nowhere"
+description: "An injected page hides by being in no sitemap and linked from no page. squirrel finds crawled pages with zero inbound links and no sitemap entry."
 ---
 
-Detects crawled pages that are absent from every sitemap **and** have no inbound internal links: a hidden page is a common injected-page signal.
+## What a hidden orphan page is
+
+A hidden page is one that answers a request but appears nowhere in the site's own structure: no internal link points at it and no sitemap lists it. It is live to anyone holding the URL and invisible to the owner browsing their own site.
+
+That is exactly how injected phishing and spam pages survive. A legitimate unlisted landing page has the same shape, which is why the rule separates the two by whether the page also carries other compromise signals. Note that this is a different question from `links/orphan-pages`, which counts pages with too few inbound links for discoverability.
+
+## What squirrel checks
+
+The rule is site-wide. It builds the set of sitemap URLs from every discovered sitemap, counts inbound internal links for every crawled page, then evaluates each page. The homepage is never flagged, and pages whose status code is outside 200 to 299 are ignored.
+
+A page is hidden when it has zero inbound internal links and, if the site has a sitemap at all, is absent from it. When the site has no sitemap, absence from it means nothing, so zero inbound links alone qualifies. Each hidden page is then correlated with the page-level integrity signals for that page.
+
+- Skipped when the crawl produced fewer pages than `minPages`. Message: `Need >=3 pages for hidden-page analysis`.
+- Pass when no page is hidden. Message: `No hidden pages (all crawled pages are linked or in a sitemap)`.
+- `orphan-page` fails for hidden pages that carry at least one page-level integrity signal. Message: `2 hidden page(s) carrying compromise signals — likely injected`, with up to five paths listed.
+- `orphan-page-review` reports info for hidden pages with no other signal. Message: `4 hidden page(s): in no sitemap and linked from nowhere (review)`.
+
+URLs are normalised before comparison on both sides. Severity is warning, weight 6.
+
+## How to fix it
+
+Open each listed page. If you created it, add it to the sitemap so it is at least visible to you, or link it from somewhere in the site. If you did not, treat the site as compromised: remove the page, audit recently modified files and read the access logs.
+
+A crawl that starts from a sitemap it cannot reach, or one that stops before it walks the whole site, produces hidden pages that are only artefacts of the crawl. Check the crawl coverage before acting on a long list.
 
 | | |
 |---|---|
@@ -13,25 +36,17 @@ Detects crawled pages that are absent from every sitemap **and** have no inbound
 | **Severity** | warning |
 | **Weight** | 6/10 |
 
-## How it differs from `links/orphan-pages`
-
-The SEO rule [`links/orphan-pages`](/rules/links) flags pages with *fewer than N* inbound internal links, a discoverability concern. This integrity rule is about *hidden* pages: zero inbound links **and** absent from the sitemap, which is exactly how injected phishing or spam pages stay invisible to the site owner while remaining live to anyone with the URL.
-
-A lone hidden page is reported as **info**. It escalates to a **failure** only when the hidden page also carries page-level compromise signals: the correlation gating that keeps false positives down.
-
-## Solution
-
-A reachable page that is in no sitemap and linked from nowhere on your site is invisible to you but live to anyone with the URL: exactly how injected phishing/spam pages hide. Confirm you created the page; if not, treat the site as compromised: remove it, audit recently modified files, and review server logs. Legitimate hidden pages (e.g. unlisted landing pages) should at least be in your sitemap if you want them found.
-
 ## Options
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `minPages` | `3` | Minimum crawled pages before hidden-page analysis runs |
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `minPages` | integer, 2 or more | `3` | Minimum crawled pages before hidden-page analysis runs |
+
+### Configuration example
 
 ```toml squirrel.toml
-[rules."integrity/orphan-page"]
-minPages = 3
+[rule_options."integrity/orphan-page"]
+minPages = 10
 ```
 
 ## Enable / disable
@@ -57,3 +72,30 @@ disable = ["integrity/*"]
 enable = ["integrity/orphan-page"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/orphan-pages](/rules/links/orphan-pages): the discoverability version, counting pages with too few inbound links.
+- [integrity/template-discontinuity](/rules/integrity/template-discontinuity): whether a hidden page even uses your theme.
+- [integrity/seo-doorway](/rules/integrity/seo-doorway): what injected hidden pages usually contain.
+- [crawl/sitemap-coverage](/rules/crawl/sitemap-coverage): the gap between what you crawl and what the sitemap lists.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Sitemaps overview, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview)
+- [Hacked content, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#hacked-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Every hidden page is listed by path, split by whether it carries other compromise signals. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/seo-doorway.mdx
+++ b/docs/rules/integrity/seo-doorway.mdx
@@ -1,9 +1,30 @@
 ---
-title: "SEO Doorway Page"
-description: "Detects injected off-topic, keyword-stuffed affiliate doorway posts"
+title: "Doorway page: injected affiliate spam on a legitimate site"
+description: "An off-topic, keyword-stuffed affiliate post is how a compromise monetises your domain's authority. squirrel checks the title, the density and the body."
 ---
 
-Detects injected off-topic, keyword-stuffed affiliate doorway posts that diverge from the rest of the site's content.
+## What a doorway page is
+
+A doorway page is content published to rank for a query and funnel the visitor somewhere else, with no value of its own. When it appears on a site that has nothing to do with the topic, it is usually injected: an attacker with write access publishes affiliate posts to borrow the domain's standing in search.
+
+Google's spam policies treat doorways as a violation, so leaving them up risks the whole site's rankings, not just the injected pages. The give-away is topical: a plumbing site that suddenly carries posts about sales funnels and passive income.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits at most one check named `seo-doorway`. A page is a hit only when the title contains at least one term from the doorway lexicon, at least two distinct lexicon terms appear across the title and body, and the body is either thin or keyword-stuffed.
+
+The lexicon is `clickfunnels`, `kajabi`, `affiliate`, `make money online`, `passive income`, `best funnel` and `sales funnel`. Thin means the parser marked the content as thin or the body is under 500 words. Stuffed means the most repeated lexicon term, weighted by its own word count, exceeds 3% of the body's words.
+
+- Info when this is the only integrity signal on the page. Message: `Possible SEO doorway / affiliate spam page (single signal — review)`.
+- Fail when at least two distinct integrity signals fire on the page. Message: `Likely injected SEO doorway page (3 corroborating integrity signals)`.
+
+The reported value names the matched title terms and says whether the body was thin, stuffed, or both, with the measured density.
+
+## How to fix it
+
+Delete the injected posts, then close the way in. Check for CMS accounts and plugins you did not add, look at what changed on disk around the publication date, and read the access logs. Request reprocessing in Search Console once the pages return 410 or 404.
+
+An affiliate site writing genuinely about funnels will match the lexicon. That page fires a single signal and stays at info, which is the intended behaviour rather than a defect.
 
 | | |
 |---|---|
@@ -12,16 +33,6 @@ Detects injected off-topic, keyword-stuffed affiliate doorway posts that diverge
 | **Scope** | Page |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## How it works
-
-The rule fires when a page's title carries doorway lexicon (affiliate funnel terms like ClickFunnels, Kajabi, "sales funnel", "make money online") **and** the body is either thin or keyword-stuffed with multiple distinct doorway terms. A single legitimate "affiliate disclosure" mention never fires: the rule needs real keyword stuffing, not one word.
-
-A lone doorway signal is reported as **info** (it could be legitimate affiliate content). It escalates to a **failure** only when another compromise signal corroborates: for example the post is also an off-template, hidden orphan page, the parasite-SEO shape from the real incident.
-
-## Solution
-
-Off-topic, thin, keyword-stuffed affiliate posts injected into a site are a parasite-SEO compromise: they hijack the domain's authority to rank spam. If you did not publish this content, treat the site as compromised: remove the injected posts, audit your CMS for unauthorized authors/plugins, and check server logs. Google penalizes doorway pages, so leaving them up risks ranking damage.
 
 ## Enable / disable
 
@@ -46,3 +57,30 @@ disable = ["integrity/*"]
 enable = ["integrity/seo-doorway"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [integrity/orphan-page](/rules/integrity/orphan-page): injected posts are usually linked from nowhere.
+- [integrity/template-discontinuity](/rules/integrity/template-discontinuity): whether they even use your theme.
+- [content/keyword-stuffing](/rules/content/keyword-stuffing): the same density measurement applied to your own content.
+- [eeat/affiliate-disclosure](/rules/eeat/affiliate-disclosure): what a legitimate affiliate page has to say.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Doorways, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#doorways)
+- [Hacked content, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#hacked-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Each doorway page is listed with the matched terms and the measured keyword density. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/integrity/seo-doorway.mdx
+++ b/docs/rules/integrity/seo-doorway.mdx
@@ -18,13 +18,13 @@ The lexicon is `clickfunnels`, `kajabi`, `affiliate`, `make money online`, `pass
 - Info when this is the only integrity signal on the page. Message: `Possible SEO doorway / affiliate spam page (single signal — review)`.
 - Fail when at least two distinct integrity signals fire on the page. Message: `Likely injected SEO doorway page (3 corroborating integrity signals)`.
 
-The reported value names the matched title terms and says whether the body was thin, stuffed, or both, with the measured density.
+The reported value names up to two matched title terms and says whether the body was thin, stuffed, or both. The measured density appears only when the page was stuffed; a thin-only finding says `thin body` and no percentage.
 
 ## How to fix it
 
 Delete the injected posts, then close the way in. Check for CMS accounts and plugins you did not add, look at what changed on disk around the publication date, and read the access logs. Request reprocessing in Search Console once the pages return 410 or 404.
 
-An affiliate site writing genuinely about funnels will match the lexicon. That page fires a single signal and stays at info, which is the intended behaviour rather than a defect.
+An affiliate site writing genuinely about funnels can satisfy every condition: a lexicon term in the title, two distinct terms overall, and a body under 500 words. That page fires a single signal and stays at info, which is the intended behaviour rather than a defect. It only becomes a failure if another integrity signal fires on the same page.
 
 | | |
 |---|---|

--- a/docs/rules/integrity/template-discontinuity.mdx
+++ b/docs/rules/integrity/template-discontinuity.mdx
@@ -5,13 +5,15 @@ description: "An injected standalone page loads none of your site's CSS, hosts o
 
 ## What template discontinuity is
 
-Every page a CMS renders shares a template: the same stylesheets, the same asset hosts, the same body classes, the same navigation and footer. A page an attacker drops in has none of that, because it was written to stand alone and to look like something else.
+Most pages a CMS renders share theme markers: the same stylesheets, the same asset hosts, overlapping body classes, a navigation element and a footer. It is not a rule. WordPress supports per-page templates and page-specific body classes, and injected content can also inherit the theme it was injected into. What the pattern catches is the standalone case, a page written to look like something else that loads none of the site's own assets.
 
 Measuring the gap turns "this page looks wrong" into a number. A page can legitimately be off-theme, a bare landing page or a hosted form, so a low score on its own is a review item rather than a verdict.
 
 ## What squirrel checks
 
-The rule is site-wide. It fingerprints each page on five theme markers: stylesheet hrefs, external asset hosts, body class tokens, declared CSS custom-property names, and whether the page has a `<nav>` and a `<footer>`. It builds a baseline from the dominant cluster, then scores each page's similarity as a weighted Jaccard average: stylesheets 0.35, asset hosts 0.25, body classes 0.15, CSS variables 0.1 and page chrome 0.15.
+The rule is site-wide. It fingerprints each page on five theme markers: stylesheet hrefs, asset hostnames from `link`, `script` and `img` references including same-origin ones, body class tokens, CSS custom-property names declared in `<style>` elements or in an inline `style` on `<html>` or `<body>`, and whether the page matches `nav, [role='navigation']` and `footer, [role='contentinfo']`.
+
+The baseline is not a cluster. Each marker is tallied across every fingerprint and kept when it appears on at least `max(2, ceil(n / 2))` pages. Similarity is then a weighted sum: Jaccard overlap for stylesheets at 0.35, asset hosts at 0.25, body classes at 0.15 and CSS variables at 0.1, plus a chrome term at 0.15 that is the average of two boolean matches on nav and footer.
 
 - Skipped when the crawl produced fewer pages than `minPages`. Message: `Need >=4 pages to establish a template baseline`.
 - Skipped when too few pages had a parseable document. Message: `Too few parseable pages for a template baseline`.
@@ -26,7 +28,7 @@ Severity is warning, weight 6.
 
 Open the listed pages and compare them with a normal page from the same site. If a page is yours, load the shared stylesheet and the site chrome on it, which also fixes the inconsistency a visitor would notice. If it is not, treat the site as compromised: remove it, audit recently modified files and read the access logs.
 
-A site built from several unrelated templates, or one where a marketing landing page deliberately ships its own CSS, produces review-only findings on every audit. Lower `similarityThreshold`, or disable the rule, if that is the design.
+A marketing landing page that deliberately ships its own CSS scores low and is reported for review. A site with no shared stylesheets or asset hosts at all produces a skip instead, because there is no baseline to measure against. Lower `similarityThreshold`, or disable the rule, when off-template pages are the design.
 
 | | |
 |---|---|

--- a/docs/rules/integrity/template-discontinuity.mdx
+++ b/docs/rules/integrity/template-discontinuity.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Template Discontinuity"
-description: "Detects pages whose markup diverges hard from the site's common template"
+title: "Template discontinuity: a page that is not on your theme"
+description: "An injected standalone page loads none of your site's CSS, hosts or chrome. squirrel fingerprints every page and scores it against the site baseline."
 ---
 
-Detects pages whose markup diverges hard from the site's common template: a standalone page with none of the site's theme is a classic injected-page signal.
+## What template discontinuity is
+
+Every page a CMS renders shares a template: the same stylesheets, the same asset hosts, the same body classes, the same navigation and footer. A page an attacker drops in has none of that, because it was written to stand alone and to look like something else.
+
+Measuring the gap turns "this page looks wrong" into a number. A page can legitimately be off-theme, a bare landing page or a hosted form, so a low score on its own is a review item rather than a verdict.
+
+## What squirrel checks
+
+The rule is site-wide. It fingerprints each page on five theme markers: stylesheet hrefs, external asset hosts, body class tokens, declared CSS custom-property names, and whether the page has a `<nav>` and a `<footer>`. It builds a baseline from the dominant cluster, then scores each page's similarity as a weighted Jaccard average: stylesheets 0.35, asset hosts 0.25, body classes 0.15, CSS variables 0.1 and page chrome 0.15.
+
+- Skipped when the crawl produced fewer pages than `minPages`. Message: `Need >=4 pages to establish a template baseline`.
+- Skipped when too few pages had a parseable document. Message: `Too few parseable pages for a template baseline`.
+- Skipped when the baseline has no shared stylesheets and no shared asset hosts, so there is no theme to diverge from. Message: `No shared template baseline detected across the site`.
+- Pass when every page scores at or above the threshold. Message: `All pages share the site's common template`.
+- `template-discontinuity` fails for below-threshold pages that also carry at least one page-level integrity signal. Message: `1 off-template page(s) carrying compromise signals — likely injected`, listing up to five as `/path (sim 0.04)`.
+- `template-discontinuity-review` reports info for below-threshold pages with no other signal. Message: `3 page(s) diverge from the site template (review)`.
+
+Severity is warning, weight 6.
+
+## How to fix it
+
+Open the listed pages and compare them with a normal page from the same site. If a page is yours, load the shared stylesheet and the site chrome on it, which also fixes the inconsistency a visitor would notice. If it is not, treat the site as compromised: remove it, audit recently modified files and read the access logs.
+
+A site built from several unrelated templates, or one where a marketing landing page deliberately ships its own CSS, produces review-only findings on every audit. Lower `similarityThreshold`, or disable the rule, if that is the design.
 
 | | |
 |---|---|
@@ -13,27 +36,19 @@ Detects pages whose markup diverges hard from the site's common template: a stan
 | **Severity** | warning |
 | **Weight** | 6/10 |
 
-## How it works
-
-The rule fingerprints every crawled page on stable theme markers: shared stylesheets, asset hosts, body classes, CSS custom properties, and the presence of a nav and footer. It then builds a baseline from the markers shared by the majority of pages (your theme). Pages whose similarity to that baseline falls below the threshold are reported.
-
-A lone off-theme page is reported as **info** (it might be a legitimate off-theme landing page). It escalates to a **failure** only when the divergent page also carries page-level compromise signals (brand impersonation, an obfuscated script, an auth overlay, or doorway content): the correlation gating that keeps false positives down.
-
-## Solution
-
-A page that shares almost none of your site's theme (no shared stylesheets, asset hosts, nav/footer, or CSS variables) may be an injected standalone page rather than something your CMS produced. Confirm the page is one you created; if not, treat the site as compromised: remove the page, audit recently modified files, and check server access logs. Legitimate off-theme landing pages should still load your shared assets.
-
 ## Options
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `minPages` | `4` | Minimum pages needed to establish a reliable baseline |
-| `similarityThreshold` | `0.2` | Pages below this similarity to the baseline are flagged |
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `minPages` | integer, 3 or more | `4` | Minimum pages needed to establish a reliable baseline |
+| `similarityThreshold` | number, 0 to 1 | `0.2` | Pages below this similarity to the baseline are flagged |
+
+### Configuration example
 
 ```toml squirrel.toml
-[rules."integrity/template-discontinuity"]
-minPages = 4
-similarityThreshold = 0.2
+[rule_options."integrity/template-discontinuity"]
+minPages = 10
+similarityThreshold = 0.1
 ```
 
 ## Enable / disable
@@ -59,3 +74,30 @@ disable = ["integrity/*"]
 enable = ["integrity/template-discontinuity"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [integrity/orphan-page](/rules/integrity/orphan-page): whether the off-template page is linked from anywhere.
+- [integrity/seo-doorway](/rules/integrity/seo-doorway): the content that usually sits on an off-template page.
+- [content/title-pattern-outlier](/rules/content/title-pattern-outlier): the same outlier idea applied to title formats.
+- [content/thin-vs-site-norm](/rules/content/thin-vs-site-norm): pages whose length diverges from the rest of the site.
+
+Site Integrity findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Hacked content, Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies#hacked-content)
+- [Malware and unwanted software, Google Search Central](https://developers.google.com/search/docs/monitor-debug/security/malware)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Site Integrity section of the report. Each outlier is listed by path with its similarity score. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Site Integrity section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/legal/cookie-consent.mdx
+++ b/docs/rules/legal/cookie-consent.mdx
@@ -11,7 +11,7 @@ What counts is behaviour rather than appearance. A banner that says cookies are 
 
 ## What squirrel checks
 
-The rule runs on every crawled page and looks for structural signals only, never for prose about cookies. It emits a single check named `cookie-consent`:
+The rule runs on every crawled page. It emits a single check named `cookie-consent`:
 
 - Pass when a consent mechanism is found. Message: `Cookie consent mechanism detected`.
 - Warn when none is found and the site metadata places the audience under the GDPR. Message: `No cookie consent mechanism detected — required for your EU/UK (GDPR) audience`.
@@ -19,7 +19,7 @@ The rule runs on every crawled page and looks for structural signals only, never
 
 Three kinds of signal count. A script or stylesheet URL matching one of about twenty consent platform patterns, covering Cookiebot, OneTrust, Usercentrics, CookieYes, iubenda, Didomi, Osano, Quantcast, Termly, TrustArc, Axeptio, Complianz, Klaro, Sourcepoint and others, plus Shopify's first-party privacy banner. A known platform banner container, matched by id or class such as `#onetrust-banner-sdk` or `#CybotCookiebotDialog`. Or an element whose id or class carries an unambiguous consent token such as `cookie-banner` or `cookie-consent`.
 
-Matching is against structural attributes only, script `src`, element `id` and `class`, so a blog post about cookies no longer registers as a consent mechanism. Severity info, weight 4. The rule is skipped on soft 404 pages, and it does not run for personal sites or portfolios.
+The third path is the one that reads text. A region is eligible when its id, class or role marks it as a cookie or consent widget or a dialog; it then qualifies either because its id or class carries an unambiguous consent token, or because the region mentions cookies, in its attributes or its own text, and contains a control whose label, `value` or `aria-label` reads as an accept or reject action. So a cookie dialog with an accept button passes without any consent-keyed class, while a blog post about cookies does not, because it has no such control. Severity info, weight 4. The rule is skipped on soft 404 pages, and it does not run for personal sites or portfolios.
 
 ## How to fix it
 

--- a/docs/rules/legal/cookie-consent.mdx
+++ b/docs/rules/legal/cookie-consent.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Cookie Consent"
-description: "Checks for cookie consent mechanism"
+title: "Cookie consent banner: detecting a consent mechanism"
+description: "Setting non-essential cookies without consent is unlawful for an EU audience. squirrel looks for a consent platform or a consent-keyed banner."
 ---
 
-Checks for cookie consent mechanism
+## What a consent mechanism is
+
+A cookie consent mechanism asks a visitor before non-essential cookies are set, records the answer, and holds the tracking until it has one. Under the EU ePrivacy rules and the GDPR, that ordering is the requirement: consent comes before the cookie, not after.
+
+What counts is behaviour rather than appearance. A banner that says cookies are in use while the analytics tag has already run is not a consent mechanism. Strictly necessary cookies, the ones without which the site cannot work, do not need consent.
+
+## What squirrel checks
+
+The rule runs on every crawled page and looks for structural signals only, never for prose about cookies. It emits a single check named `cookie-consent`:
+
+- Pass when a consent mechanism is found. Message: `Cookie consent mechanism detected`.
+- Warn when none is found and the site metadata places the audience under the GDPR. Message: `No cookie consent mechanism detected — required for your EU/UK (GDPR) audience`.
+- Info when none is found otherwise. Message: `No cookie consent mechanism detected`, with `Required for GDPR compliance if using cookies` as the value.
+
+Three kinds of signal count. A script or stylesheet URL matching one of about twenty consent platform patterns, covering Cookiebot, OneTrust, Usercentrics, CookieYes, iubenda, Didomi, Osano, Quantcast, Termly, TrustArc, Axeptio, Complianz, Klaro, Sourcepoint and others, plus Shopify's first-party privacy banner. A known platform banner container, matched by id or class such as `#onetrust-banner-sdk` or `#CybotCookiebotDialog`. Or an element whose id or class carries an unambiguous consent token such as `cookie-banner` or `cookie-consent`.
+
+Matching is against structural attributes only, script `src`, element `id` and `class`, so a blog post about cookies no longer registers as a consent mechanism. Severity info, weight 4. The rule is skipped on soft 404 pages, and it does not run for personal sites or portfolios.
+
+## How to fix it
+
+Install a consent platform, or build one that holds every non-essential tag until the visitor has answered. The technical half is the important half: the banner is easy and the gating is what makes it lawful.
+
+Do not pre-tick optional categories, make rejecting as easy as accepting, and store the answer so the question is not asked again.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Checks for cookie consent mechanism
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 4/10 |
-
-## Solution
-
-Cookie consent is required under GDPR and ePrivacy regulations for EU users. Implement a consent banner that: allows users to accept/reject non-essential cookies, doesn't pre-check optional cookies, stores consent preferences, and blocks tracking cookies until consent. Use tools like CookieYes, OneTrust, or Cookiebot.
 
 ## Enable / disable
 
@@ -40,3 +58,30 @@ disable = ["legal/*"]
 enable = ["legal/cookie-consent"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [analytics/consent-mode](/rules/analytics/consent-mode): whether Google tags are wired to that consent signal.
+- [security/third-party-cookies](/rules/security/third-party-cookies): the vendors the banner has to gate.
+- [security/cookie-flags](/rules/security/cookie-flags): the flags on the cookies your own server sets.
+- [legal/privacy-policy](/rules/legal/privacy-policy): the policy the banner links to.
+
+Legal Compliance findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Using HTTP cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies)
+- [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Legal Compliance section of the report. Each page is reported with whether a consent mechanism was detected. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Legal Compliance section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/legal/cookie-consent.mdx
+++ b/docs/rules/legal/cookie-consent.mdx
@@ -61,7 +61,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [analytics/consent-mode](/rules/analytics/consent-mode): whether Google tags are wired to that consent signal.
+- [analytics/consent-mode](/rules/analytics/consent-mode): whether Google Consent Mode markers appear in the markup.
 - [security/third-party-cookies](/rules/security/third-party-cookies): the vendors the banner has to gate.
 - [security/cookie-flags](/rules/security/cookie-flags): the flags on the cookies your own server sets.
 - [legal/privacy-policy](/rules/legal/privacy-policy): the policy the banner links to.

--- a/docs/rules/legal/index.mdx
+++ b/docs/rules/legal/index.mdx
@@ -3,7 +3,7 @@ title: "Legal Compliance"
 description: "Privacy policy and legal compliance signals"
 ---
 
-Privacy policy and legal compliance signals
+Legal Compliance rules check for the pages and mechanisms that privacy law and commercial practice expect: a consent gate before non-essential cookies, a privacy policy, terms of service, and a sub-processor disclosure for businesses that handle customer data. They confirm the thing exists and is reachable, not that its contents satisfy any particular regulator. Two of them escalate when the audit's site metadata places the audience under a stricter regime.
 
 ## Rules
 
@@ -28,3 +28,5 @@ Privacy policy and legal compliance signals
 [rules]
 disable = ["legal/*"]
 ```
+
+Every audit reports Legal Compliance findings next to the performance, security and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/legal/index.mdx
+++ b/docs/rules/legal/index.mdx
@@ -8,17 +8,17 @@ Legal Compliance rules check for the pages and mechanisms that privacy law and c
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Cookie Consent" icon="circle-info" href="/rules/legal/cookie-consent">
-    Checks for cookie consent mechanism
+  <Card title="Cookie consent banner: detecting a consent mechanism" icon="circle-info" href="/rules/legal/cookie-consent">
+    Setting non-essential cookies without consent is unlawful for an EU audience. squirrel looks for a consent platform or a consent-keyed banner.
   </Card>
-  <Card title="Privacy Policy" icon="triangle-exclamation" href="/rules/legal/privacy-policy">
-    Checks for privacy policy link presence
+  <Card title="Privacy policy link: finding one anywhere on the site" icon="triangle-exclamation" href="/rules/legal/privacy-policy">
+    A missing privacy policy is a legal exposure where the GDPR or CCPA applies. squirrel accepts a policy page or a link to one from any crawled page.
   </Card>
-  <Card title="Sub-processor Disclosure" icon="circle-info" href="/rules/legal/subprocessor-disclosure">
-    Checks for a sub-processor / data-processing (DPA) disclosure page or link
+  <Card title="Sub-processor disclosure: what a security review asks" icon="circle-info" href="/rules/legal/subprocessor-disclosure">
+    A processor has to name the sub-processors it engages. squirrel looks for a subprocessors page or a DPA link anywhere on the site.
   </Card>
-  <Card title="Terms of Service" icon="circle-info" href="/rules/legal/terms-of-service">
-    Checks for terms of service link presence
+  <Card title="Terms of service link: finding it in the page's links" icon="circle-info" href="/rules/legal/terms-of-service">
+    Terms of service belong in the footer of every page. squirrel checks each page's links by both href and anchor text, in five languages.
   </Card>
 </CardGroup>
 

--- a/docs/rules/legal/privacy-policy.mdx
+++ b/docs/rules/legal/privacy-policy.mdx
@@ -1,25 +1,42 @@
 ---
-title: "Privacy Policy"
-description: "Checks for privacy policy link presence"
+title: "Privacy policy link: finding one anywhere on the site"
+description: "A missing privacy policy is a legal exposure where the GDPR or CCPA applies. squirrel accepts a policy page or a link to one from any crawled page."
 ---
 
-Checks for privacy policy link presence
+## What this rule looks for
+
+A privacy policy explains what personal data a site collects, why, who receives it and what a visitor can do about it. The GDPR and the CCPA both require one for the audiences they cover, and most analytics and advertising vendors require one in their own terms.
+
+This rule asks the narrow question of whether the site has one at all, by page or by link. `eeat/privacy-policy` asks the related question of how widely it is linked.
+
+## What squirrel checks
+
+The rule is site-wide. It accepts a privacy policy in two ways: a crawled page that is one, found by a known multilingual slug or by a title or `h1` reading as a privacy policy, or a link to one from any crawled page. The link test reads both the href and the anchor text, which is what makes it wider than the `eeat` rule's href-only test. It emits a single check named `privacy-policy`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when either is found. Message: `Privacy policy link found`, with the URL as the value.
+- Fail when none is found and the site metadata places the site under a stricter privacy regime. Message: `No privacy policy link found across site — required under GDPR`, naming the regime, with `Add a privacy policy — legally required for your audience (GDPR)` as the value.
+- Warn when none is found otherwise. Message: `No privacy policy link found across site`, with `Add a link to your privacy policy` as the value.
+
+Severity for the rule is warning, weight 5. The escalation to a failure depends on site metadata; an offline run or one with no metadata warns instead.
+
+## How to fix it
+
+```html
+<a href="/privacy-policy">Privacy policy</a>
+```
+
+Publish the policy and link it from the footer component so every page carries it. Cover what you collect, why, who you share it with, how long you keep it and how someone exercises their rights.
+
+Keep it in step with the vendors you actually use. A policy naming an analytics tool you removed is inaccurate in both directions.
 
 | | |
 |---|---|
 | **Rule ID** | `legal/privacy-policy` |
 | **Category** | [Legal Compliance](/rules/legal) |
-| **Scope** | Per-page |
+| **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-A privacy policy is legally required in many jurisdictions (GDPR, CCPA). Link to your privacy policy from every page, typically in the footer. The policy should explain what data you collect, how it's used, and user rights. Consider using schema.org markup to identify the policy page.
-
-## Detection
-
-This rule credits a privacy policy when the crawl contains a page whose URL matches a known privacy slug (`/privacy`, `/privacy-policy`, `/legal/privacy`, and localized variants) or whose title or h1 reads "Privacy Policy" / "Privacy Notice", or when any page links to one. It shares this acceptance with the E-E-A-T privacy policy rule so both stay consistent.
 
 ## Enable / disable
 
@@ -44,3 +61,30 @@ disable = ["legal/*"]
 enable = ["legal/privacy-policy"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/privacy-policy](/rules/eeat/privacy-policy): the same page, measured for link coverage.
+- [legal/cookie-consent](/rules/legal/cookie-consent): the banner that should link to it.
+- [legal/terms-of-service](/rules/legal/terms-of-service): the other legal page in the footer.
+- [security/third-party-cookies](/rules/security/third-party-cookies): the vendors the policy has to name.
+
+Legal Compliance findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Privacy on the web, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy)
+- [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Legal Compliance section of the report. The site is reported with the privacy policy URL it found, or that it found none. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Legal Compliance section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/legal/subprocessor-disclosure.mdx
+++ b/docs/rules/legal/subprocessor-disclosure.mdx
@@ -68,7 +68,7 @@ Legal Compliance findings ship in every audit next to the SEO, performance and a
 
 ## References
 
-- [Privacy on the web, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy)
+- [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
 
 ## Check your site
 

--- a/docs/rules/legal/subprocessor-disclosure.mdx
+++ b/docs/rules/legal/subprocessor-disclosure.mdx
@@ -1,9 +1,29 @@
 ---
-title: "Sub-processor Disclosure"
-description: "Checks for a sub-processor / data-processing (DPA) disclosure page or link"
+title: "Sub-processor disclosure: the page a security review asks for"
+description: "A processor has to name the sub-processors it engages. squirrel looks for a subprocessors page or a DPA link anywhere on the site."
 ---
 
-Checks for a sub-processor / data-processing (DPA) disclosure page or link
+## What a sub-processor disclosure is
+
+When a business handles personal data on behalf of its customers, the vendors it passes that data to are sub-processors. Article 28 of the GDPR requires a processor to disclose them and to have a data processing agreement in place with the customer.
+
+In practice it is a page listing each third party that touches customer data, what it does and where it is, plus a DPA a customer can sign. For B2B software it is a standard item on a security review, and not having one delays deals.
+
+## What squirrel checks
+
+The rule is site-wide and looks in two places, in order. First a crawled page whose URL path matches one of the sub-processor path patterns. Then, if none matched, a link on any crawled page whose text or href reads as a sub-processor or DPA reference. The first hit wins in crawl order. It emits a single check named `subprocessor-disclosure`:
+
+- Skipped when no pages were crawled. Message: `No pages available for analysis`.
+- Pass when a disclosure is found. Message: `Sub-processor / data-processing disclosure found`, with the URL as the value.
+- Warn when none is found. Message: `No sub-processor / data-processing (DPA) disclosure found`, with `Publish a /subprocessors page + DPA (GDPR Art. 28)` as the value.
+
+Severity info, weight 3. The rule only runs when the audit classified the site as SaaS, a web app or corporate, and, when a business category is known, as software and technology, fintech, banking or IT services. A classification below medium confidence, or an audit with no site metadata, runs it anyway.
+
+## How to fix it
+
+Publish a `/subprocessors` page listing each third party that processes customer personal data, what it is used for and where it operates. Link a DPA from your legal or trust pages, and keep the list current when you change vendors.
+
+A stale list is worse than none in a security review, because it is checkable and the reviewer will check it.
 
 | | |
 |---|---|
@@ -12,14 +32,6 @@ Checks for a sub-processor / data-processing (DPA) disclosure page or link
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-<Note>This rule only runs for SaaS, web-app, and corporate sites (and software, fintech, banking, and IT-services businesses): the site types where the GDPR Art. 28 sub-processor duty applies. It is skipped for everyone else and when no site profile is available.</Note>
-
-## Solution
-
-Under GDPR Art. 28, processors must disclose the sub-processors they engage and offer a Data Processing Agreement (DPA). Publish a `/subprocessors` page listing each third party that handles customer personal data (purpose, location), keep it current, and link a DPA from your legal/trust pages. B2B SaaS and fintech buyers expect this during security review.
-
-The rule passes when it finds a dedicated sub-processor / data-processing / DPA page (by URL path) or a link to one (by href or anchor text) on any crawled page.
 
 ## Enable / disable
 
@@ -44,3 +56,29 @@ disable = ["legal/*"]
 enable = ["legal/subprocessor-disclosure"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [legal/privacy-policy](/rules/legal/privacy-policy): the policy that names the same vendors.
+- [legal/terms-of-service](/rules/legal/terms-of-service): the contract the DPA attaches to.
+- [security/third-party-cookies](/rules/security/third-party-cookies): the vendors visible from the page itself.
+- [eeat/trust-signals](/rules/eeat/trust-signals): the other things a buyer checks during review.
+
+Legal Compliance findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Privacy on the web, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Legal Compliance section of the report. The site is reported with the disclosure URL it found, or that it found none. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Legal Compliance section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/legal/subprocessor-disclosure.mdx
+++ b/docs/rules/legal/subprocessor-disclosure.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Sub-processor disclosure: the page a security review asks for"
+title: "Sub-processor disclosure: what a security review asks"
 description: "A processor has to name the sub-processors it engages. squirrel looks for a subprocessors page or a DPA link anywhere on the site."
 ---
 

--- a/docs/rules/legal/terms-of-service.mdx
+++ b/docs/rules/legal/terms-of-service.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Terms of Service"
-description: "Checks for terms of service link presence"
+title: "Terms of service link: finding it in the page's links"
+description: "Terms of service belong in the footer of every page. squirrel checks each page's links by both href and anchor text, in five languages."
 ---
 
-Checks for terms of service link presence
+## What this rule looks for
+
+Terms of service define what a visitor may do with a site or a service and what the operator owes them. They matter most where there is an account, a transaction or user-generated content, and they are optional on a site that publishes and sells nothing.
+
+This rule checks per page rather than per site, because the convention is a footer link that every page carries. A terms page that exists but is linked from nowhere is not doing its job.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `a[href]`, testing both the href and the link text. It emits a single check named `terms-of-service`:
+
+- Pass when a link matches. Message: `Terms of service link found`, with the href as the value.
+- Info when none does. Message: `No terms of service link found`, with `Consider adding terms of service for legal protection` as the value.
+
+The href is matched against nine patterns covering `terms-of-service`, `terms-of-use`, `terms-and-conditions`, `tos`, `/terms`, `/legal/terms`, and the German, French and Spanish equivalents `nutzungsbedingungen`, `agb`, `conditions générales` and `condiciones`. The text matches on `terms of service`, `terms of use`, `terms and conditions`, `terms & conditions`, or any text containing `terms` that is under 30 characters.
+
+That last text rule is loose: a link labelled "Search terms" would satisfy it. Severity info, weight 3. The rule is skipped on soft 404 pages, which have no footer.
+
+## How to fix it
+
+```html
+<a href="/terms">Terms of service</a>
+```
+
+Put the link in the footer component alongside the privacy policy. Label it plainly so both the href and the text are recognisable.
+
+Cover what a user may and may not do, who owns what, what you disclaim and how disputes are resolved. Note the last revision date so a reader can tell whether they have seen this version.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks for terms of service link presence
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Terms of Service (ToS) protect your business by defining user rights and limitations. Link to ToS from your footer on every page. Essential for: e-commerce sites, SaaS products, user-generated content platforms, and membership sites. Include sections on: usage rules, liability limits, dispute resolution, and termination.
 
 ## Enable / disable
 
@@ -40,3 +61,29 @@ disable = ["legal/*"]
 enable = ["legal/terms-of-service"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/terms-of-service](/rules/eeat/terms-of-service): the same page, found by URL rather than by link.
+- [legal/privacy-policy](/rules/legal/privacy-policy): the other legal page, which is more often required.
+- [legal/subprocessor-disclosure](/rules/legal/subprocessor-disclosure): what a B2B buyer asks for next.
+- [eeat/about-page](/rules/eeat/about-page): the page a reader reads before any of these.
+
+Legal Compliance findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Privacy on the web, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Legal Compliance section of the report. Each page is reported with the terms link it carries, or that it carries none. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Legal Compliance section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/legal/terms-of-service.mdx
+++ b/docs/rules/legal/terms-of-service.mdx
@@ -73,7 +73,7 @@ Legal Compliance findings ship in every audit next to the SEO, performance and a
 
 ## References
 
-- [Privacy on the web, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy)
+- [The anchor element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
 
 ## Check your site
 

--- a/docs/rules/links/anchor-text.mdx
+++ b/docs/rules/links/anchor-text.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Empty and generic anchor text: click here, read more, and icons"
+title: "Empty and generic anchor text: click here and icons"
 description: "A link with no text has no name, and click here describes nothing. squirrel groups links by destination and checks each group for a descriptive name."
 ---
 
@@ -9,7 +9,7 @@ Anchor text is the visible name of a link. It tells a reader where the link goes
 
 Two failures matter. A link with no accessible name at all, usually an icon or a wrapped image with no `alt` and no `aria-label`, is announced by a screen reader as "link" and nothing more. A link whose text is `click here` or `read more` has a name that describes nothing, which fails WCAG's link purpose criterion when the surrounding context does not supply it.
 
-Cards complicate the count. A card often links to the same destination three times, from the image, the headline and a "Read more". squirrel treats those as one group and asks whether any member is named, which is a heuristic rather than a rule of the platform: assistive technology names each link separately. The robust fix is one link wrapping the whole card, or a name on each.
+Cards complicate the count. A card often links to the same destination three times, from the image, the headline and a "Read more". squirrel treats those as one group and asks whether any member is named, which is a heuristic rather than a rule of the platform: assistive technology names each link separately. The reliable fix is one link wrapping the whole card, or a name on each.
 
 ## What squirrel checks
 

--- a/docs/rules/links/anchor-text.mdx
+++ b/docs/rules/links/anchor-text.mdx
@@ -7,9 +7,9 @@ description: "A link with no text has no name, and click here describes nothing.
 
 Anchor text is the visible name of a link. It tells a reader where the link goes before they take it, and it is one of the few signals a search engine has about the page on the other end.
 
-Two failures matter. A link with no text at all, usually an icon or a wrapped image with no `alt`, has no accessible name: a screen reader announces it as "link" and nothing more. A link whose text is `click here` or `read more` has a name that describes nothing, which fails WCAG's link purpose criterion when the surrounding context does not supply it.
+Two failures matter. A link with no accessible name at all, usually an icon or a wrapped image with no `alt` and no `aria-label`, is announced by a screen reader as "link" and nothing more. A link whose text is `click here` or `read more` has a name that describes nothing, which fails WCAG's link purpose criterion when the surrounding context does not supply it.
 
-Cards are the reason this needs care. A card often links to the same destination three times, from the image, the headline and a "Read more". Only one of those has to carry the name.
+Cards complicate the count. A card often links to the same destination three times, from the image, the headline and a "Read more". squirrel treats those as one group and asks whether any member is named, which is a heuristic rather than a rule of the platform: assistive technology names each link separately. The robust fix is one link wrapping the whole card, or a name on each.
 
 ## What squirrel checks
 
@@ -18,7 +18,7 @@ The rule runs on every crawled page. It takes every `a[href]`, skips fragment-on
 An accessible name comes from the link's text content, an `alt` on an image inside it, an `aria-label`, an `aria-labelledby` pointing at an element with text, a `title`, a `<title>` or `aria-label` on an `<svg>` inside it, or an `aria-label` on a descendant with `role="img"`. Generic means the trimmed lowercased text is exactly one of `click here`, `here`, `read more`, `learn more`, `more`, `link`, `this`, `this link`, `go` or `continue`.
 
 - `empty-anchor` warns for groups where no member has any accessible name. Message: `3 link(s) have empty anchor text`, each item carrying the destination and a markup snippet of the first link.
-- `generic-anchor` reports info for groups whose only names are generic. Message: `8 link(s) use generic anchor text`, listing the distinct phrases found.
+- `generic-anchor` reports info for groups where every named member has generic text. Message: `8 link(s) use generic anchor text`, listing the distinct phrases found. The generic test reads the link's trimmed, lowercased text content only, not its accessible name, so a `Read more` link with a descriptive `aria-label` is still reported, and an image-only link with `alt="click here"` is not.
 - `anchor-text` passes when neither fired. Message: `Link anchor text is descriptive`.
 
 Severity warning, weight 4.

--- a/docs/rules/links/anchor-text.mdx
+++ b/docs/rules/links/anchor-text.mdx
@@ -1,9 +1,40 @@
 ---
-title: "Anchor Text"
-description: "Checks for empty or generic anchor text"
+title: "Empty and generic anchor text: click here, read more, and icons"
+description: "A link with no text has no name, and click here describes nothing. squirrel groups links by destination and checks each group for a descriptive name."
 ---
 
-Checks for empty or generic anchor text
+## What anchor text does
+
+Anchor text is the visible name of a link. It tells a reader where the link goes before they take it, and it is one of the few signals a search engine has about the page on the other end.
+
+Two failures matter. A link with no text at all, usually an icon or a wrapped image with no `alt`, has no accessible name: a screen reader announces it as "link" and nothing more. A link whose text is `click here` or `read more` has a name that describes nothing, which fails WCAG's link purpose criterion when the surrounding context does not supply it.
+
+Cards are the reason this needs care. A card often links to the same destination three times, from the image, the headline and a "Read more". Only one of those has to carry the name.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It takes every `a[href]`, skips fragment-only links, resolves each href against the page URL, and groups links by resolved destination. A group passes when any member has an accessible name that is not generic.
+
+An accessible name comes from the link's text content, an `alt` on an image inside it, an `aria-label`, an `aria-labelledby` pointing at an element with text, a `title`, a `<title>` or `aria-label` on an `<svg>` inside it, or an `aria-label` on a descendant with `role="img"`. Generic means the trimmed lowercased text is exactly one of `click here`, `here`, `read more`, `learn more`, `more`, `link`, `this`, `this link`, `go` or `continue`.
+
+- `empty-anchor` warns for groups where no member has any accessible name. Message: `3 link(s) have empty anchor text`, each item carrying the destination and a markup snippet of the first link.
+- `generic-anchor` reports info for groups whose only names are generic. Message: `8 link(s) use generic anchor text`, listing the distinct phrases found.
+- `anchor-text` passes when neither fired. Message: `Link anchor text is descriptive`.
+
+Severity warning, weight 4.
+
+## How to fix it
+
+```html
+<a href="/guides/url-structure">
+  <img src="/thumb.png" alt="" />
+  <h3>How to structure URLs</h3>
+</a>
+```
+
+Let the headline carry the name and leave the decorative image with an empty `alt`, so the group has exactly one accessible name and no duplication. For a standalone icon link, put an `aria-label` on the anchor.
+
+Where "Read more" has to stay for the layout, give it a name that works out of context: `aria-label="Read more about URL structure"`.
 
 | | |
 |---|---|
@@ -12,23 +43,6 @@ Checks for empty or generic anchor text
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Descriptive anchor text helps users and search engines understand link destinations. Avoid generic text like 'click here' or 'read more'. Use natural language that describes the target page. For accessibility, anchor text should make sense out of context. Avoid overly long anchor text or keyword stuffing. When a card links to the same target more than once (e.g. an image link and a headline link), only one of those links needs descriptive text — the group is evaluated together, not link by link.
-
-## How this rule evaluates links
-
-This rule groups a page's outgoing links by resolved target URL before evaluating them, rather than scoring every `<a>` tag on its own. That matters for the common card pattern — an image link, a headline link, and a "Read more" link all pointing at the same destination — where the headline already names the target and the other two links are intentionally redundant.
-
-A target group is flagged as:
-
-- **`empty-anchor`** only when *no* link in the group carries any accessible name (text content, image `alt`, `aria-label`, `aria-labelledby`, `title`, or an accessible SVG name).
-- **`generic-anchor`** only when *every* link in the group uses generic text (e.g. "read more", "click here") and none carries a descriptive accessible name.
-
-A group with at least one descriptively-labeled link passes, even if its sibling links (an image wrapper, a "Read more" affordance) are empty or generic.
-
-Note this is narrower than it sounds: a genuinely empty single link, or a card where every link is empty or generic, is still reported. If you need to flag empty links in the tab order regardless of sibling context, that's an accessibility concern handled by the `a11y` category — this rule is an SEO check on whether the destination is described.
 
 ## Enable / disable
 
@@ -53,3 +67,30 @@ disable = ["links/*"]
 enable = ["links/anchor-text"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/link-text](/rules/a11y/link-text): the accessibility rule covering the same defect.
+- [images/alt-text](/rules/images/alt-text): the alt attribute that names an image-only link.
+- [links/internal-links](/rules/links/internal-links): how many internal links a page carries.
+- [links/no-contextual-inbound](/rules/links/no-contextual-inbound): whether those links sit in body copy or in chrome.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The anchor element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
+- [Understanding link purpose in context, WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every unnamed link is listed with its destination and a markup snippet. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/broken-external-links.mdx
+++ b/docs/rules/links/broken-external-links.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Broken External Links"
-description: "Detects external links returning 4xx/5xx errors or timeouts"
+title: "Broken external links: link rot on pages you cannot fix"
+description: "External links die without warning when the other site changes. squirrel checks each one and separates dead links from unverifiable ones."
 ---
 
-Detects external links returning 4xx/5xx errors or timeouts
+## What link rot is
+
+An external link points at a site you do not control, so it can break at any time and you will not be told. Studies of link rot put the half-life of a web citation in the low single-digit years.
+
+Not every failed check is a dead link. A 403 from a web application firewall means the site refused an automated request while serving humans normally. A 429, or a 503 carrying `Retry-After`, means the host was throttling the audit. Both are unverifiable rather than broken, and treating them as broken sends you chasing links that work.
+
+## What squirrel checks
+
+The rule is site-wide and reads the results of the external link check. It emits up to three checks:
+
+- `broken-external-links` passes when there are no external links at all. Message: `No external links found to check`.
+- `broken-external-links` warns when links failed. Message: `4 broken external link(s): 3 with 404, 1 failed`, grouped by status code with `failed` covering fetch errors. Each item reads `https://other.example/page (404)` or `(Error: timeout)`, with the pages that link to it. Severity warning, weight 5.
+- `broken-external-links` passes otherwise. Message: `All 128 external link(s) are working`.
+- `waf-blocked-external-links` reports info for links refused by a firewall. Message: `6 external link(s) blocked by WAF - status unverifiable`, naming the provider where it is known.
+- `rate-limited-external-links` reports info for throttled targets. Message: `2 external link(s) rate-limited - status unverifiable`.
+
+A link counts as broken when the fetch errored, or the status is 400 or above and it is neither a firewall-blocked 403 nor rate-limited.
+
+## How to fix it
+
+Replace the link with a working equivalent, point it at an archived copy, or remove it. For a reference that matters to the argument, host your own copy of the material rather than depending on someone else's uptime.
+
+Check the firewall-blocked and rate-limited lists by hand before touching them. Those links usually work in a browser.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Detects external links returning 4xx/5xx errors or timeouts
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Broken external links hurt user experience and credibility. Regularly audit external links using automated tools. Remove or replace broken links with working alternatives. Consider using archived versions (archive.org) if the original content is gone. For important resources, consider hosting your own copies of critical documentation or linking to more stable sources.
 
 ## Enable / disable
 
@@ -40,3 +58,30 @@ disable = ["links/*"]
 enable = ["links/broken-external-links"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/dead-links](/rules/links/dead-links): the cloud service that checks these links against a shared cache.
+- [links/broken-links](/rules/links/broken-links): the same check for links inside your own site.
+- [links/external-links](/rules/links/external-links): how many external links each page carries.
+- [security/new-tab](/rules/security/new-tab): the rel attributes those links should have.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+- [HTTP status codes and Google Search](https://developers.google.com/search/docs/crawling-indexing/http-network-errors)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every failing link is listed with its status and the pages that link to it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/broken-external-links.mdx
+++ b/docs/rules/links/broken-external-links.mdx
@@ -7,7 +7,7 @@ description: "External links die without warning when the other site changes. sq
 
 An external link points at a site you do not control, so it can break at any time and you will not be told. Studies of link rot put the half-life of a web citation in the low single-digit years.
 
-Not every failed check is a dead link. A 403 from a web application firewall means the site refused an automated request while serving humans normally. A 429, or a 503 carrying `Retry-After`, means the host was throttling the audit. Both are unverifiable rather than broken, and treating them as broken sends you chasing links that work.
+Not every failed check is a dead link. A 403 from a web application firewall means the automated request was refused; whether a person would reach the page is unverified either way. A 429, or a 503 carrying `Retry-After`, is treated as throttling, though a 503 can equally be scheduled maintenance. squirrel classifies both as unverifiable rather than broken, because reporting them as broken sends you chasing links that work.
 
 ## What squirrel checks
 

--- a/docs/rules/links/broken-links.mdx
+++ b/docs/rules/links/broken-links.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Broken Links"
-description: "Detects links returning 404 or 5xx errors"
+title: "Broken internal links: 404s inside your own site"
+description: "An internal link to a page that returns 404 or 500 is a dead end you control. squirrel cross-references every internal link against the crawl."
 ---
 
-Detects links returning 404 or 5xx errors
+## What a broken internal link is
+
+A broken internal link is an `<a href>` on your site pointing at a URL on your site that answers with an error. The visitor hits a 404, and a crawler spends a request learning the same thing.
+
+Internal links break quietly. A page is renamed, a section is restructured, a product is retired, and the links that pointed at it are left behind in body copy, in old posts and in hard-coded navigation. Nothing warns you, because the link still looks like a link.
+
+## What squirrel checks
+
+The rule is site-wide and compares link targets against pages the crawl actually fetched. It collects every internal link from every crawled page, normalises both sides, and looks up the recorded status code. Targets the crawl never visited are skipped rather than guessed at.
+
+- Skipped when there is no site data. Message: `Site data not available for broken link analysis`.
+- `broken-links` fails when a target returned 400 or above. Message: `7 broken internal link(s) (4xx/5xx)`. Each item reads `https://example.com/old-page (404)` and lists every page that links to it. Severity error, weight 7.
+- `broken-links` passes otherwise. Message: `No broken internal links detected`.
+- `rate-limited-links` reports info for targets that returned a rate-limit status. Message: `3 internal link(s) rate-limited - status unverifiable`.
+
+Normalisation strips the fragment and the trailing slash and lowercases the scheme and host, but not the path, so a case difference in the path is treated as a different URL. A throttled response means the host limited the crawl, not that the page is missing, so those are separated out before the 400 test.
+
+## How to fix it
+
+Update the link to the current URL, or redirect the old URL permanently and leave the link alone. Prefer fixing the link where you can: a redirect works but costs a hop on every click.
+
+Fix the source, not just the page. The report lists which pages carry each broken link, and a link repeated in a template needs one change rather than twenty.
 
 | | |
 |---|---|
@@ -12,10 +33,6 @@ Detects links returning 404 or 5xx errors
 | **Scope** | Site-wide |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Broken links hurt user experience and waste crawl budget. Regularly audit links using tools or crawlers. Fix or remove broken links. Set up 301 redirects for moved content. For external links, consider using nofollow and regularly verifying they still work. Implement custom 404 pages that help users find content.
 
 ## Enable / disable
 
@@ -40,3 +57,30 @@ disable = ["links/*"]
 enable = ["links/broken-links"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/broken-external-links](/rules/links/broken-external-links): the same check for links leaving your site.
+- [links/redirect-chains](/rules/links/redirect-chains): internal links that resolve, but through a redirect.
+- [crawl/soft-404](/rules/crawl/soft-404): pages that answer 200 while showing an error.
+- [crawl/sitemap-4xx](/rules/crawl/sitemap-4xx): dead URLs you are also submitting in a sitemap.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [HTTP status codes and Google Search](https://developers.google.com/search/docs/crawling-indexing/http-network-errors)
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every broken link is listed with its status code and the pages that link to it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/dead-end-pages.mdx
+++ b/docs/rules/links/dead-end-pages.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Dead-End Pages"
-description: "Pages with no outgoing internal links, potentially trapping users"
+title: "Dead-end page: no outgoing internal links to continue with"
+description: "A page with no onward links leaves the reader and the crawler with nowhere to go. squirrel counts outgoing internal links, excluding self-links."
 ---
 
-Pages with no outgoing internal links, potentially trapping users
+## What a dead-end page is
+
+A dead-end page has no internal links leading anywhere else. Whatever brought the reader here, nothing suggests what to read next, and a crawler that arrives finds no new URLs to follow.
+
+Some pages are meant to be terminal. A thank-you page after a form submission, a download confirmation, a success screen: those have done their job and the default exclusion list covers them. Everything else usually has related content it should be pointing at.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It counts internal links whose normalised URL differs from the page's own, so a self-link does not count. It emits a single check named `dead-end`:
+
+- Skipped when the page could not be parsed. Message: `Page could not be parsed`.
+- Skipped when the URL matches an exclusion pattern. Message: `Page excluded by pattern`.
+- Warn when the count is below `minLinks`, default 1. Message: `Page has no outgoing internal links (dead-end)`, with the count as the value. Severity warning, weight 3.
+- Pass otherwise. Message: `Page has outgoing internal links`, with the count as the value.
+
+The default exclusions are `/thank-you`, `/confirmation`, `/download`, `/success` and `/submitted`. Same-page anchor links are ignored unless `countAnchorLinks` is on, which is useful for a single-page app where the in-page navigation is the navigation.
+
+## How to fix it
+
+Add a related-content block, a breadcrumb back to the parent section, or links from the body copy to the pages this one references. One meaningful onward link is enough to clear the rule; three or four is better for a reader.
+
+For a single-page application whose whole navigation is fragment links, turn on `countAnchorLinks` rather than adding links that do not belong.
 
 | | |
 |---|---|
@@ -13,27 +34,21 @@ Pages with no outgoing internal links, potentially trapping users
 | **Severity** | warning |
 | **Weight** | 3/10 |
 
-## Solution
-
-Add navigation links or related content links to help users continue browsing. Internal links improve user experience and help search engines discover content.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `excludePatterns` | unknown | `undefined` |  |
-| `minLinks` | unknown | `undefined` |  |
-| `countAnchorLinks` | unknown | `undefined` | Count anchor links (#section) as valid internal links (useful for single-page apps) |
+| `excludePatterns` | array of strings | `["/thank-you", "/confirmation", "/download", "/success", "/submitted"]` | URL patterns that are allowed to be dead ends |
+| `minLinks` | number | `1` | Minimum outgoing internal links before the page is a dead end |
+| `countAnchorLinks` | boolean | `false` | Count anchor links (#section) as valid internal links (useful for single-page apps) |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."links/dead-end-pages"]
-excludePatterns = undefined
-minLinks = undefined
-countAnchorLinks = undefined
+[rule_options."links/dead-end-pages"]
+minLinks = 3
+countAnchorLinks = true
+excludePatterns = ["/thank-you", "/receipt"]
 ```
 
 ## Enable / disable
@@ -59,3 +74,29 @@ disable = ["links/*"]
 enable = ["links/dead-end-pages"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/internal-links](/rules/links/internal-links): the same count judged against a range rather than a floor.
+- [links/orphan-pages](/rules/links/orphan-pages): the inbound side of the same structure.
+- [links/anchor-text](/rules/links/anchor-text): what the onward links should say.
+- [content/article-links](/rules/content/article-links): whether the body copy links out at all.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every dead-end page is listed with its outgoing link count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/dead-links.mdx
+++ b/docs/rules/links/dead-links.mdx
@@ -7,7 +7,7 @@ description: "Checking every external link from your machine is slow and rude to
 
 ## What the cloud dead-links service is
 
-Verifying external links means one HTTP request per link. On a site with a few thousand outbound links, that is a slow phase for you and a burst of automated traffic for everyone you link to.
+Verifying external links means at least one HTTP request per link, and often more: the checker tries `HEAD`, falls back to `GET`, and follows redirects. On a site with a few thousand outbound links, that is a slow phase for you and a burst of automated traffic for everyone you link to.
 
 The cloud service moves that work behind a cache shared across every audit. A link any recent audit checked comes back immediately, working links stay cached for seven days and failures for 24 hours. This rule is the gate that turns it on: enabling it routes the audit's external-link phase through the service instead of fetching each link locally.
 
@@ -23,7 +23,7 @@ A link counts as dead on the same basis as `links/broken-external-links`: a fetc
 
 ## How to fix it
 
-Log in with `squirrel auth login` to use the service. If an audit's estimated dead-link spend exceeds your confirmation threshold you are prompted before the phase runs, and declining falls back to local per-link checking.
+Log in with `squirrel auth login` to use the service. Dead-link checking is included in the audit base charge, so it does not produce a separate spend prompt. Being logged out falls back to local per-link checking.
 
 The findings themselves are on `links/broken-external-links`. Fix them there.
 

--- a/docs/rules/links/dead-links.mdx
+++ b/docs/rules/links/dead-links.mdx
@@ -1,11 +1,31 @@
 ---
-title: "Dead Links (Cloud)"
-description: "Verifies external links through the cloud dead-links service with a shared global cache"
+title: "Cloud dead-link checking: the shared external link cache"
+description: "Checking every external link from your machine is slow and rude to the sites you link to. The cloud service checks against a shared cache instead."
 ---
 
 <Note>**Cloud rule** - requires login (`squirrel auth login`); **included in the audit base charge**. WAF-blocked links retried via a rendered fetch bill as rendered requests (2 credits per link). Skipped when not logged in (external links are then checked locally as usual). See [Cloud rules](/cloud/rules).</Note>
 
-Verifies external links through the cloud dead-links service, which shares a global link-check cache across all audits.
+## What the cloud dead-links service is
+
+Verifying external links means one HTTP request per link. On a site with a few thousand outbound links, that is a slow phase for you and a burst of automated traffic for everyone you link to.
+
+The cloud service moves that work behind a cache shared across every audit. A link any recent audit checked comes back immediately, working links stay cached for seven days and failures for 24 hours. This rule is the gate that turns it on: enabling it routes the audit's external-link phase through the service instead of fetching each link locally.
+
+## What squirrel checks
+
+The rule is a summary. The per-link findings belong to `links/broken-external-links`, and this check never re-scores them, which is why its status is always informational. It emits a single check named `dead-links`:
+
+- Skipped when external link checking did not run. Message: `No external link check data available`.
+- Info when the site has no external links. Message: `No external links found to verify`, with a value of 0.
+- Info otherwise, with one of two wordings: `Checked 128 external link(s); none are dead` or `Checked 128 external link(s); 4 dead`. When some targets were throttled, `; 2 rate-limited (status unverifiable)` is appended.
+
+A link counts as dead on the same basis as `links/broken-external-links`: a fetch error, or a status of 400 or above that is neither a firewall-blocked 403 nor a rate-limit response. Severity info, weight 1, the lowest of any rule in the Links category.
+
+## How to fix it
+
+Log in with `squirrel auth login` to use the service. If an audit's estimated dead-link spend exceeds your confirmation threshold you are prompted before the phase runs, and declining falls back to local per-link checking.
+
+The findings themselves are on `links/broken-external-links`. Fix them there.
 
 | | |
 |---|---|
@@ -15,16 +35,6 @@ Verifies external links through the cloud dead-links service, which shares a glo
 | **Severity** | info |
 | **Weight** | 1/10 |
 | **Default** | Enabled |
-
-## What it does
-
-This rule is the **enable gate** for cloud external-link checking. When it's enabled and you're logged in, the audit's external-link phase routes through the cloud service instead of fetching every link from your machine:
-
-- **Shared global cache** - links checked by any recent audit (yours or anyone's) return instantly from cache, so repeat audits are much faster and third-party sites aren't hammered.
-- **Fresh results** - working links are cached for 7 days, failures for 24 hours.
-- **Same report shape** - broken links found this way are detailed by [`links/broken-external-links`](/rules/links/broken-external-links), exactly as with local checking.
-
-If an audit's estimated dead-link spend exceeds your `confirm_threshold`, you're prompted before the phase runs. Declining (or being logged out) falls back to local per-link checking.
 
 ## Enable / disable
 
@@ -41,3 +51,29 @@ disable = ["links/dead-links"]
 [external_links]
 enabled = false
 ```
+
+## Related rules
+
+- [links/broken-external-links](/rules/links/broken-external-links): where the per-link findings are reported.
+- [links/external-links](/rules/links/external-links): how many external links each page carries.
+- [links/broken-links](/rules/links/broken-links): internal links, which are always checked locally.
+- [integrity/known-malicious-url](/rules/integrity/known-malicious-url): the reputation check over the same outbound links.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. The summary line reports how many external links were checked and how many are dead. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/external-links.mdx
+++ b/docs/rules/links/external-links.mdx
@@ -1,9 +1,28 @@
 ---
-title: "External Links"
-description: "Reports on external link count"
+title: "External link count: how many outbound links a page has"
+description: "External links are normal and this rule does not penalise them. squirrel counts them per page so you can see where they concentrate."
 ---
 
-Reports on external link count
+## What this count is for
+
+Outbound links are how a page cites its sources and points a reader at things worth reading. They are a normal part of good content, and there is no threshold at which they become a defect.
+
+The count is here because it is useful context next to the other link rules. A page with forty outbound links is a different kind of page from one with two, and it is usually the one worth checking for broken links, for `rel` attributes and for whether the links still say what you meant.
+
+## What squirrel checks
+
+The rule runs on every crawled page and counts links the parser marked as not internal. It emits a single check named `external-links`:
+
+- Info when there are none. Message: `No external links on page`, with a value of 0.
+- Pass otherwise. Message: `12 external link(s)`, with the count as the value.
+
+Severity info, weight 2. There is no failing outcome: the rule never warns and never fails regardless of the count.
+
+## How to fix it
+
+Nothing to fix. Use the count to decide where to look: pages with many outbound links are where `links/broken-external-links` and `security/new-tab` findings concentrate.
+
+Where an outbound link is paid, sponsored or user-generated, mark it with the matching `rel` value so it is qualified correctly.
 
 | | |
 |---|---|
@@ -12,10 +31,6 @@ Reports on external link count
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## Solution
-
-External links provide additional resources for users and signal content relevance to search engines. They're normal and healthy for most content pages. This check is informational: external links aren't inherently problematic. Ensure external links go to reputable sources and open in new tabs when appropriate. Use rel="nofollow" for untrusted or paid links. Avoid excessive external links that distract from your content.
 
 ## Enable / disable
 
@@ -40,3 +55,29 @@ disable = ["links/*"]
 enable = ["links/external-links"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/broken-external-links](/rules/links/broken-external-links): whether those destinations still resolve.
+- [security/new-tab](/rules/security/new-tab): the rel attributes on external links that open in a new tab.
+- [links/https-downgrade](/rules/links/https-downgrade): external links that drop back to HTTP.
+- [eeat/citations](/rules/eeat/citations): whether the page cites sources at all.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Qualify your outbound links, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Each page is reported with its external link count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/https-downgrade.mdx
+++ b/docs/rules/links/https-downgrade.mdx
@@ -1,9 +1,31 @@
 ---
-title: "HTTPS Downgrade"
-description: "Detects links from HTTPS pages to HTTP destinations"
+title: "Links from an HTTPS page to an http:// destination"
+description: "A link that drops the visitor to plain HTTP hands their next request to the network. squirrel flags every explicit http:// link on an HTTPS page."
 ---
 
-Detects links from HTTPS pages to HTTP destinations
+## What an HTTPS downgrade link is
+
+A downgrade link is an `<a href="http://...">` on a page that was itself served over HTTPS. Following it takes the visitor to an unencrypted connection, where the request and the response can be read and modified in transit.
+
+This is separate from mixed content. Mixed content is about subresources the page loads itself, which the browser blocks or upgrades. A navigation link is not blocked: the browser follows it, and the only signal the visitor gets is the address bar changing after the fact.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It emits a single check named `https-downgrade`:
+
+- Info when the page itself is not HTTPS, since there is nothing to downgrade from. Message: `Page is not HTTPS, downgrade check not applicable`.
+- Warn when any `a[href]` has an href that literally starts with `http://`. Message: `4 link(s) downgrade to HTTP`, with each href listed. Severity warning, weight 5.
+- Pass otherwise. Message: `No HTTPS to HTTP downgrades`.
+
+The test is on the raw attribute text, so protocol-relative hrefs such as `//example.org/page` are not flagged, and neither is a relative link. The check does not distinguish internal from external destinations.
+
+## How to fix it
+
+```html
+<a href="https://example.org/reference">Reference</a>
+```
+
+Change the scheme where the link is authored. For internal links this is always the right fix, since your own site serves HTTPS. For an external destination, check that the target actually supports HTTPS before rewriting, and reconsider linking there at all if it does not.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Detects links from HTTPS pages to HTTP destinations
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Links from HTTPS to HTTP pages create security warnings and break the trust chain. Users may see 'not secure' warnings. Update all links to use HTTPS. If the target site doesn't support HTTPS, consider if you really need to link there. For internal links, ensure your entire site uses HTTPS.
 
 ## Enable / disable
 
@@ -40,3 +58,30 @@ disable = ["links/*"]
 enable = ["links/https-downgrade"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/mixed-content](/rules/security/mixed-content): subresources loaded over HTTP, which browsers do block.
+- [security/https](/rules/security/https): whether the page itself is served over HTTPS.
+- [security/http-to-https](/rules/security/http-to-https): whether the HTTP forms of your own URLs redirect.
+- [links/external-links](/rules/links/external-links): the outbound links this rule reads.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Why HTTPS matters, web.dev](https://web.dev/articles/why-https-matters)
+- [Mixed content, MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every downgrading link is listed with its href. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/https-downgrade.mdx
+++ b/docs/rules/links/https-downgrade.mdx
@@ -5,9 +5,9 @@ description: "A link that drops the visitor to plain HTTP hands their next reque
 
 ## What an HTTPS downgrade link is
 
-A downgrade link is an `<a href="http://...">` on a page that was itself served over HTTPS. Following it takes the visitor to an unencrypted connection, where the request and the response can be read and modified in transit.
+A downgrade link is an `<a href="http://...">` on a page that was itself served over HTTPS. Unless something upgrades it first, following it takes the visitor to an unencrypted connection where the request and the response can be read and modified in transit. HSTS on the destination host, or a browser in HTTPS-only mode, will rewrite or block it, which is protection you do not control from your own markup.
 
-This is separate from mixed content. Mixed content is about subresources the page loads itself, which the browser blocks or upgrades. A navigation link is not blocked: the browser follows it, and the only signal the visitor gets is the address bar changing after the fact.
+This is separate from mixed content. Mixed content is about subresources the page loads itself, which the browser blocks or upgrades on its own. A navigation link gets no such treatment from the page: whether it is upgraded depends on the destination's policy and the visitor's browser settings.
 
 ## What squirrel checks
 

--- a/docs/rules/links/index.mdx
+++ b/docs/rules/links/index.mdx
@@ -8,50 +8,50 @@ Links rules read the link graph the crawl built. Half of them are health checks:
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Anchor Text" icon="triangle-exclamation" href="/rules/links/anchor-text">
-    Checks for empty or generic anchor text
+  <Card title="Empty and generic anchor text: click here and icons" icon="triangle-exclamation" href="/rules/links/anchor-text">
+    A link with no text has no name, and click here describes nothing. squirrel groups links by destination and checks each group for a descriptive name.
   </Card>
-  <Card title="Broken External Links" icon="triangle-exclamation" href="/rules/links/broken-external-links">
-    Detects external links returning 4xx/5xx errors or timeouts
+  <Card title="Broken external links: link rot on pages you cannot fix" icon="triangle-exclamation" href="/rules/links/broken-external-links">
+    External links die without warning when the other site changes. squirrel checks each one and separates dead links from unverifiable ones.
   </Card>
-  <Card title="Broken Links" icon="circle-exclamation" href="/rules/links/broken-links">
-    Detects links returning 404 or 5xx errors
+  <Card title="Broken internal links: 404s inside your own site" icon="circle-exclamation" href="/rules/links/broken-links">
+    An internal link to a page that returns 404 or 500 is a dead end you control. squirrel cross-references every internal link against the crawl.
   </Card>
-  <Card title="Dead Links (Cloud)" icon="circle-info" href="/rules/links/dead-links">
-    Verifies external links through the cloud service with a shared global cache
+  <Card title="Cloud dead-link checking: the shared external link cache" icon="circle-info" href="/rules/links/dead-links">
+    Checking every external link from your machine is slow and rude to the sites you link to. The cloud service checks against a shared cache instead.
   </Card>
-  <Card title="Dead-End Pages" icon="triangle-exclamation" href="/rules/links/dead-end-pages">
-    Pages with no outgoing internal links, potentially trapping users
+  <Card title="Dead-end page: no outgoing internal links to continue with" icon="triangle-exclamation" href="/rules/links/dead-end-pages">
+    A page with no onward links leaves the reader and the crawler with nowhere to go. squirrel counts outgoing internal links, excluding self-links.
   </Card>
-  <Card title="External Links" icon="circle-info" href="/rules/links/external-links">
-    Reports on external link count
+  <Card title="External link count: how many outbound links a page has" icon="circle-info" href="/rules/links/external-links">
+    External links are normal and this rule does not penalise them. squirrel counts them per page so you can see where they concentrate.
   </Card>
-  <Card title="HTTPS Downgrade" icon="triangle-exclamation" href="/rules/links/https-downgrade">
-    Detects links from HTTPS pages to HTTP destinations
+  <Card title="Links from an HTTPS page to an http:// destination" icon="triangle-exclamation" href="/rules/links/https-downgrade">
+    A link that drops the visitor to plain HTTP hands their next request to the network. squirrel flags every explicit http:// link on an HTTPS page.
   </Card>
-  <Card title="Internal Links" icon="triangle-exclamation" href="/rules/links/internal-links">
-    Validates internal link count
+  <Card title="Internal link count per page: too few and too many" icon="triangle-exclamation" href="/rules/links/internal-links">
+    A page with no internal links leads nowhere and a page with hundreds dilutes each one. squirrel counts internal links against a configurable range.
   </Card>
-  <Card title="Invalid Links" icon="triangle-exclamation" href="/rules/links/invalid-links">
-    Detects invalid link formats on the page
+  <Card title="Invalid links: hrefs that do not parse as a URL" icon="triangle-exclamation" href="/rules/links/invalid-links">
+    A malformed href is a link that goes nowhere, and javascript:void(0) is a button wearing a link costume. squirrel reports every href the parser rejected.
   </Card>
-  <Card title="No Contextual Inbound Links" icon="triangle-exclamation" href="/rules/links/no-contextual-inbound">
-    Detects pages whose only internal inbound links come from sitewide chrome (nav, header, footer, sidebar)
+  <Card title="Linked only from the nav and footer: no editorial links" icon="triangle-exclamation" href="/rules/links/no-contextual-inbound">
+    A footer link on every page looks like hundreds of inbound links and carries none of the signal. squirrel counts only links outside sitewide chrome.
   </Card>
-  <Card title="Nofollow Internal" icon="triangle-exclamation" href="/rules/links/nofollow-internal">
-    Flags internal links with rel=nofollow
+  <Card title="rel=nofollow on an internal link: usually a mistake" icon="triangle-exclamation" href="/rules/links/nofollow-internal">
+    Nofollow on your own links tells search engines to ignore your site's internal structure. squirrel flags every internal link carrying it.
   </Card>
-  <Card title="Orphan Pages" icon="triangle-exclamation" href="/rules/links/orphan-pages">
-    Detects pages with no internal links pointing to them
+  <Card title="Orphan pages: pages with too few inbound internal links" icon="triangle-exclamation" href="/rules/links/orphan-pages">
+    A page nothing links to is hard to discover and reads as unimportant. squirrel counts dofollow inbound internal links for every crawled page.
   </Card>
-  <Card title="Redirect Chains" icon="triangle-exclamation" href="/rules/links/redirect-chains">
-    Detects URLs that redirect and links pointing to redirects
+  <Card title="Links pointing at redirecting URLs: the hop on every click" icon="triangle-exclamation" href="/rules/links/redirect-chains">
+    An internal link to a URL that redirects costs a round trip every time anyone follows it. squirrel finds redirecting pages and who links to them.
   </Card>
-  <Card title="Tel & Mailto Links" icon="circle-info" href="/rules/links/tel-mailto">
-    Validates tel: and mailto: link formats
+  <Card title="tel: and mailto: links: format and href/text mismatches" icon="circle-info" href="/rules/links/tel-mailto">
+    A phone link whose href differs from the number on screen dials the wrong person. squirrel validates both formats and compares them with the visible text.
   </Card>
-  <Card title="Weak Internal Links" icon="triangle-exclamation" href="/rules/links/weak-internal-links">
-    Detects pages with only 1 dofollow internal link pointing to them
+  <Card title="Pages with only one internal link pointing to them" icon="triangle-exclamation" href="/rules/links/weak-internal-links">
+    One inbound link is enough to be found and not enough to look important. squirrel lists every page whose dofollow inbound count is exactly one.
   </Card>
 </CardGroup>
 

--- a/docs/rules/links/index.mdx
+++ b/docs/rules/links/index.mdx
@@ -3,7 +3,7 @@ title: "Links"
 description: "Internal and external link health and structure"
 ---
 
-Internal and external link health and structure
+Links rules read the link graph the crawl built. Half of them are health checks: internal and external targets that return an error, hrefs that do not parse, links that drop to plain HTTP, links that resolve only through a redirect. The other half describe structure: how many links point at a page, whether any of them sit in body copy rather than the footer, and whether the anchor text says what the destination is.
 
 ## Rules
 
@@ -61,3 +61,5 @@ Internal and external link health and structure
 [rules]
 disable = ["links/*"]
 ```
+
+Every audit reports Links findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/links/internal-links.mdx
+++ b/docs/rules/links/internal-links.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Internal Links"
-description: "Validates internal link count"
+title: "Internal link count per page: too few and too many"
+description: "A page with no internal links leads nowhere and a page with hundreds dilutes each one. squirrel counts internal links against a configurable range."
 ---
 
-Validates internal link count
+## What the internal link count measures
+
+This is a count of the internal links a page carries, judged against a floor and a ceiling. It is a shape check rather than a quality one: it says nothing about where the links go or what they say.
+
+The floor catches pages that lead nowhere. The ceiling catches the opposite, usually a page rendering an entire category tree or a mega-menu with several hundred entries, where any individual link is a small fraction of what the page is pointing at.
+
+## What squirrel checks
+
+The rule runs on every crawled page and counts links the parser marked as internal, including navigation and footer links. It emits a single check named `internal-links`:
+
+- Warn below `min_internal_links`, default 1. Message: `Too few internal links (0, min 1)`, with the count as the value and the threshold as the expected value.
+- Warn above `max_internal_links`, default 100. Message: `Too many internal links (240, max 100)`.
+- Pass otherwise. Message: `42 internal link(s)`, with the count as the value.
+
+Severity warning, weight 4. Every internal link on the page counts, so a large sitewide navigation pushes every page toward the ceiling. Raise the ceiling rather than removing navigation if that is the shape of the site.
+
+## How to fix it
+
+```toml squirrel.toml
+[rule_options."links/internal-links"]
+max_internal_links = 200
+```
+
+For the floor, add links to related content from the body copy. For the ceiling, decide whether the page really needs to expose the whole tree, or whether a hub page per section would serve a reader better.
+
+Set the ceiling to match the site. A documentation site with a full sidebar will exceed 100 on every page by design.
 
 | | |
 |---|---|
@@ -13,25 +38,19 @@ Validates internal link count
 | **Severity** | warning |
 | **Weight** | 4/10 |
 
-## Solution
-
-Internal links help users navigate your site and distribute page authority. Each page should have at least one internal link pointing to it (not counting navigation). Add contextual internal links from related content. Use descriptive anchor text that indicates what the linked page is about. Avoid orphan pages (no internal links) and ensure important pages receive more internal links. Review your site structure to create logical content clusters.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `min_internal_links` | unknown | `undefined` | Minimum internal links |
-| `max_internal_links` | unknown | `undefined` | Maximum internal links |
+| `min_internal_links` | number | `1` | Minimum internal links |
+| `max_internal_links` | number | `100` | Maximum internal links |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."links/internal-links"]
-min_internal_links = undefined
-max_internal_links = undefined
+[rule_options."links/internal-links"]
+min_internal_links = 3
+max_internal_links = 200
 ```
 
 ## Enable / disable
@@ -57,3 +76,29 @@ disable = ["links/*"]
 enable = ["links/internal-links"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/dead-end-pages](/rules/links/dead-end-pages): the floor, with exclusions for pages meant to be terminal.
+- [links/external-links](/rules/links/external-links): the same count for links leaving the site.
+- [links/orphan-pages](/rules/links/orphan-pages): the inbound side of the same structure.
+- [links/anchor-text](/rules/links/anchor-text): what those links say.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Each page is reported with its internal link count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/invalid-links.mdx
+++ b/docs/rules/links/invalid-links.mdx
@@ -5,16 +5,16 @@ description: "A malformed href is a link that goes nowhere, and javascript:void(
 
 ## What an invalid link is
 
-An invalid link is an `<a href>` whose value the parser could not turn into a URL. That covers malformed addresses, hrefs built from a template variable that resolved to nothing, and stray whitespace or markup inside the attribute.
+An invalid link is an `<a href>` whose value the parser could not turn into a URL, such as `http://[invalid` or an address with an unparseable host. It is a link that cannot go anywhere, usually produced by string concatenation or a template variable that resolved to something unexpected.
 
-The `javascript:void(0)` pattern belongs to the same family. It is an anchor used as a click target with the navigation deliberately disabled, which means keyboard and assistive-technology users get a link that announces itself as a link and does not go anywhere. A `<button>` is the element for that.
+Several things that look wrong are not reported here. An empty `href` and non-HTTP schemes are skipped by the extractor, surrounding whitespace is trimmed, and a space inside a path is encoded during parsing rather than rejected. A `javascript:void(0)` click target is a real accessibility problem and a real reason to use a `<button>`, but it is not what this rule counts.
 
 ## What squirrel checks
 
 The rule runs on every crawled page and reports the links the parser flagged with an error while extracting them. It emits a single check named `invalid-links`:
 
 - Pass when no link carries a parse error. Message: `No invalid link formats found`.
-- Warn otherwise. Message: `Found 3 invalid link(s)`, with each href listed alongside the parser's error string, or `Invalid format` when no error text was recorded. Severity warning, weight 2.
+- Warn otherwise. Message: `Found 3 invalid link(s)`, with each href listed alongside the parser's recorded error string. Severity warning, weight 2.
 
 The classification comes from the parser rather than from this rule, so what counts as invalid is whatever the link extractor could not resolve against the page URL.
 

--- a/docs/rules/links/invalid-links.mdx
+++ b/docs/rules/links/invalid-links.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Invalid Links"
-description: "Detects invalid link formats on the page"
+title: "Invalid links: hrefs that do not parse as a URL"
+description: "A malformed href is a link that goes nowhere, and javascript:void(0) is a button wearing a link costume. squirrel reports every href the parser rejected."
 ---
 
-Detects invalid link formats on the page
+## What an invalid link is
+
+An invalid link is an `<a href>` whose value the parser could not turn into a URL. That covers malformed addresses, hrefs built from a template variable that resolved to nothing, and stray whitespace or markup inside the attribute.
+
+The `javascript:void(0)` pattern belongs to the same family. It is an anchor used as a click target with the navigation deliberately disabled, which means keyboard and assistive-technology users get a link that announces itself as a link and does not go anywhere. A `<button>` is the element for that.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reports the links the parser flagged with an error while extracting them. It emits a single check named `invalid-links`:
+
+- Pass when no link carries a parse error. Message: `No invalid link formats found`.
+- Warn otherwise. Message: `Found 3 invalid link(s)`, with each href listed alongside the parser's error string, or `Invalid format` when no error text was recorded. Severity warning, weight 2.
+
+The classification comes from the parser rather than from this rule, so what counts as invalid is whatever the link extractor could not resolve against the page URL.
+
+## How to fix it
+
+```html
+<button type="button" onclick="openDialog()">Open</button>
+```
+
+Replace a click-target anchor with a button. For a genuinely malformed href, fix the template that produced it: an empty `href=""` usually means a variable that was not set, and a link with a stray space usually means the value came from unsanitised content.
 
 | | |
 |---|---|
@@ -12,10 +33,6 @@ Detects invalid link formats on the page
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 2/10 |
-
-## Solution
-
-Invalid links (malformed URLs, javascript: links, or broken references) harm user experience and can indicate code issues. Fix or remove invalid links. Replace javascript:void(0) with proper href values or button elements. Ensure all links have valid URL formats. Check for typos in URLs and verify links work correctly. Remove empty href attributes.
 
 ## Enable / disable
 
@@ -40,3 +57,30 @@ disable = ["links/*"]
 enable = ["links/invalid-links"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/broken-links](/rules/links/broken-links): links that parse correctly and lead to an error page.
+- [links/anchor-text](/rules/links/anchor-text): links with no accessible name.
+- [a11y/link-text](/rules/a11y/link-text): the accessibility view of the same markup.
+- [url/special-chars](/rules/url/special-chars): characters in a URL that need encoding.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The anchor element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
+- [RFC 3986: Uniform Resource Identifier](https://datatracker.ietf.org/doc/html/rfc3986)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every unparseable href is listed with the error it produced. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/no-contextual-inbound.mdx
+++ b/docs/rules/links/no-contextual-inbound.mdx
@@ -1,9 +1,31 @@
 ---
-title: "No Contextual Inbound Links"
-description: "Detects pages whose only internal inbound links come from sitewide chrome"
+title: "Linked only from the nav and footer: no contextual inbound links"
+description: "A footer link on every page looks like hundreds of inbound links and carries none of the signal. squirrel counts only links outside sitewide chrome."
 ---
 
-Detects pages whose only internal inbound links come from sitewide chrome (nav, header, footer, sidebar)
+## What a contextual inbound link is
+
+A contextual link sits inside the content: a sentence in an article, a description on a hub page, a related-reading list written for that page. A chrome link sits in the header, footer, navigation or a sidebar widget, and appears identically on every page of the site.
+
+Counting them together hides a real problem. A page reachable only through the footer has a large raw inbound count and no editorial support at all: nothing on the site says what the page is about or why it matters, only that it exists. This rule counts contextual links only.
+
+## What squirrel checks
+
+The rule is site-wide. For each crawled page it counts internal, resolvable, dofollow inbound links twice: all of them, and only those whose anchor sat outside a `nav`, `header`, `footer` or `aside` landmark. It emits a single check named `no-contextual-inbound`:
+
+- Skipped when there are too few pages. Message: `Insufficient pages for contextual inbound link analysis`.
+- Warn for pages with zero contextual inbound links. Message: `9 page(s) are linked only from sitewide chrome`. The value lists up to five paths with a `+N more` suffix, and every URL is listed as an item. Severity warning, weight 4.
+- Pass otherwise. Message: `All pages have at least one contextual inbound link`.
+
+A page is only considered when its raw inbound count is at or above `minInboundLinks`, default 2. Below that it is already reported by `links/orphan-pages`, and the two thresholds should be kept in sync when either is tuned. The homepage is skipped, since it is linked from every header by design.
+
+Crawls stored before the chrome flag existed report every link as contextual, so an old crawl passes rather than producing a site-wide false alarm.
+
+## How to fix it
+
+Link to the page from the body of the content it belongs with, using anchor text that describes it. A category page that introduces its members in prose, rather than only listing them, produces contextual links as a side effect.
+
+A whole site that links only through chrome will report every page. That is accurate rather than a false positive, and it usually means the content does not cross-reference itself.
 
 | | |
 |---|---|
@@ -13,57 +35,19 @@ Detects pages whose only internal inbound links come from sitewide chrome (nav, 
 | **Severity** | warning |
 | **Weight** | 4/10 |
 
-## What it checks
-
-Every internal link the crawl finds is recorded with whether its anchor sat inside site
-chrome - an ancestor `<nav>`, `<header>`, `<footer>` or `<aside>`. A link from any of those
-is repeated verbatim on every page of the site, so it carries no signal about what the
-target page is about or how important it is. A link from body copy does.
-
-This rule counts only the **contextual** (non-chrome) inbound links per page and warns when
-that count is zero.
-
-Chrome detection is deliberately strict: only those four landmark elements count. A wrapper
-named `class="post-nav"` is *not* treated as chrome, because misclassifying body copy would
-turn a genuinely well-linked page into a false warning.
-
-## Why the existing link rules miss this
-
-[Orphan Pages](/rules/links/orphan-pages) and [Weak Internal Links](/rules/links/weak-internal-links)
-both count **raw** inbound links, with no distinction by container. A page linked from the
-sitewide footer of a 200-page site has 200 inbound links and passes both - while receiving no
-editorial support at all.
-
-To keep the three rules from reporting the same page twice, this rule speaks only about the
-gap the other two cannot see: a page is flagged when it has **zero** contextual inbound links
-**and** a raw inbound count at or above the orphan threshold (`minInboundLinks`, default `2`).
-Below that threshold the page is already reported as an orphan.
-
-The homepage is always skipped - it is reached from every page's header and footer by design.
-
-## Solution
-
-These pages look well-linked but receive no editorial support: every link pointing at them is repeated on every page of the site, so it carries no signal about what the page is about or how important it is. Add links from the body copy of related articles, hub pages, or category descriptions using descriptive anchor text. Sitewide navigation links help discovery, but contextual links are what pass topical relevance and internal link equity.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `minInboundLinks` | number | `2` | Raw inbound-link threshold from links/orphan-pages; only pages at or above it are considered here (below it they are already reported as orphans) |
-| `excludePatterns` | array | `[]` | URL patterns to exclude from contextual inbound link detection |
+| `minInboundLinks` | integer, 0 or more | `2` | Raw inbound-link threshold from links/orphan-pages; only pages at or above it are considered here |
+| `excludePatterns` | array of strings | `[]` | URL patterns to exclude from contextual inbound link detection |
 
-Keep `minInboundLinks` in sync with the same option on
-[Orphan Pages](/rules/links/orphan-pages) - the two are the same threshold viewed from
-either side.
-
-### Configuration Example
+### Configuration example
 
 ```toml squirrel.toml
 [rule_options."links/no-contextual-inbound"]
 minInboundLinks = 2
-excludePatterns = ["/tags/", "/authors/"]
+excludePatterns = ["/lp/"]
 ```
 
 ## Enable / disable
@@ -89,3 +73,29 @@ disable = ["links/*"]
 enable = ["links/no-contextual-inbound"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/orphan-pages](/rules/links/orphan-pages): pages below the raw inbound threshold, which this rule leaves alone.
+- [links/weak-internal-links](/rules/links/weak-internal-links): pages with exactly one inbound link of any kind.
+- [links/anchor-text](/rules/links/anchor-text): what those contextual links should say.
+- [content/article-links](/rules/content/article-links): whether the body copy links out at all.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every chrome-only page is listed by path. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/no-contextual-inbound.mdx
+++ b/docs/rules/links/no-contextual-inbound.mdx
@@ -5,9 +5,9 @@ description: "A footer link on every page looks like hundreds of inbound links a
 
 ## What a contextual inbound link is
 
-A contextual link sits inside the content: a sentence in an article, a description on a hub page, a related-reading list written for that page. A chrome link sits in the header, footer, navigation or a sidebar widget, and appears identically on every page of the site.
+A contextual link sits inside the content: a sentence in an article, a description on a hub page, a related-reading list written for that page. A chrome link is one whose anchor has a `nav`, `header`, `footer` or `aside` ancestor. That is an element test rather than a repetition test, so an article's own `<header>` or a per-page `<aside>` counts as chrome too.
 
-Counting them together hides a real problem. A page reachable only through the footer has a large raw inbound count and no editorial support at all: nothing on the site says what the page is about or why it matters, only that it exists. This rule counts contextual links only.
+Counting the two together hides a real problem. A page reachable only through the footer has a large raw inbound count and no editorial support at all: nothing on the site says what the page is about or why it matters, only that it exists. This rule counts contextual links only.
 
 ## What squirrel checks
 
@@ -25,7 +25,7 @@ Crawls stored before the chrome flag existed report every link as contextual, so
 
 Link to the page from the body of the content it belongs with, using anchor text that describes it. A category page that introduces its members in prose, rather than only listing them, produces contextual links as a side effect.
 
-A whole site that links only through chrome will report every page. That is accurate rather than a false positive, and it usually means the content does not cross-reference itself.
+A whole site that links only through chrome reports every page that is not the homepage, is not excluded, and has at least `minInboundLinks` raw inbound links. That is accurate rather than a false positive, and it usually means the content does not cross-reference itself.
 
 | | |
 |---|---|

--- a/docs/rules/links/no-contextual-inbound.mdx
+++ b/docs/rules/links/no-contextual-inbound.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Linked only from the nav and footer: no contextual inbound links"
+title: "Linked only from the nav and footer: no editorial links"
 description: "A footer link on every page looks like hundreds of inbound links and carries none of the signal. squirrel counts only links outside sitewide chrome."
 ---
 

--- a/docs/rules/links/no-contextual-inbound.mdx
+++ b/docs/rules/links/no-contextual-inbound.mdx
@@ -77,7 +77,7 @@ disable = ["*"]
 ## Related rules
 
 - [links/orphan-pages](/rules/links/orphan-pages): pages below the raw inbound threshold, which this rule leaves alone.
-- [links/weak-internal-links](/rules/links/weak-internal-links): pages with exactly one inbound link of any kind.
+- [links/weak-internal-links](/rules/links/weak-internal-links): pages with exactly one dofollow internal inbound link.
 - [links/anchor-text](/rules/links/anchor-text): what those contextual links should say.
 - [content/article-links](/rules/content/article-links): whether the body copy links out at all.
 

--- a/docs/rules/links/nofollow-internal.mdx
+++ b/docs/rules/links/nofollow-internal.mdx
@@ -24,7 +24,7 @@ The hostname comparison is exact, so a link to a subdomain of the same site is t
 <a href="/pricing">Pricing</a>
 ```
 
-Remove the attribute. If the link points at something you genuinely do not want crawled, such as a faceted filter URL, the tool for that is robots.txt or `noindex` on the target, not nofollow on the link.
+Remove the attribute. If the link points at something you genuinely do not want crawled, such as a faceted filter URL, the tool is a robots.txt `Disallow`. If you want it crawled but not indexed, the tool is `noindex` on the target, which only works when the crawler is allowed to fetch it. Neither job belongs to nofollow on the link.
 
 Keep it for user-generated content, where `rel="ugc nofollow"` is the correct marking even on an internal profile link.
 

--- a/docs/rules/links/nofollow-internal.mdx
+++ b/docs/rules/links/nofollow-internal.mdx
@@ -1,5 +1,5 @@
 ---
-title: "rel=nofollow on an internal link: why it is usually a mistake"
+title: "rel=nofollow on an internal link: usually a mistake"
 description: "Nofollow on your own links tells search engines to ignore your site's internal structure. squirrel flags every internal link carrying it."
 ---
 

--- a/docs/rules/links/nofollow-internal.mdx
+++ b/docs/rules/links/nofollow-internal.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Nofollow Internal"
-description: "Flags internal links with rel=nofollow"
+title: "rel=nofollow on an internal link: why it is usually a mistake"
+description: "Nofollow on your own links tells search engines to ignore your site's internal structure. squirrel flags every internal link carrying it."
 ---
 
-Flags internal links with rel=nofollow
+## What nofollow does
+
+`rel="nofollow"` marks a link as one you do not vouch for. It was introduced for comment spam, and Google now treats it as a hint alongside `sponsored` and `ugc` rather than a strict instruction.
+
+On an external link it is a reasonable qualification. On an internal link it is a statement that you do not endorse your own page, which is almost never what the author meant. The pattern usually comes from an old technique called PageRank sculpting, which stopped working in 2009, or from a plugin applying it indiscriminately.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `a[href][rel]`. A link counts when its `rel`, lowercased, contains `nofollow` and its resolved hostname equals the page's hostname. It emits a single check named `nofollow-internal`:
+
+- Warn when any such link exists. Message: `3 internal link(s) have nofollow`, with each href listed. Severity warning, weight 5.
+- Pass otherwise. Message: `No internal links with nofollow`.
+
+The hostname comparison is exact, so a link to a subdomain of the same site is treated as external and is not flagged. Note that `links/orphan-pages` and the other inbound-count rules ignore nofollow links entirely, so a nofollowed internal link does not count toward a target page's inbound total.
+
+## How to fix it
+
+```html
+<a href="/pricing">Pricing</a>
+```
+
+Remove the attribute. If the link points at something you genuinely do not want crawled, such as a faceted filter URL, the tool for that is robots.txt or `noindex` on the target, not nofollow on the link.
+
+Keep it for user-generated content, where `rel="ugc nofollow"` is the correct marking even on an internal profile link.
 
 | | |
 |---|---|
@@ -12,10 +35,6 @@ Flags internal links with rel=nofollow
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Nofollow on internal links wastes PageRank and is generally bad practice. Internal links should flow link equity freely throughout your site. Remove nofollow from internal links unless you have a specific reason (e.g., user-generated content links). Use nofollow for external links you don't endorse.
 
 ## Enable / disable
 
@@ -40,3 +59,29 @@ disable = ["links/*"]
 enable = ["links/nofollow-internal"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/orphan-pages](/rules/links/orphan-pages): the inbound counts that skip nofollowed links.
+- [links/weak-internal-links](/rules/links/weak-internal-links): pages left with a single counted inbound link.
+- [crawl/robots-txt](/rules/crawl/robots-txt): the right tool for keeping a crawler off a URL.
+- [links/external-links](/rules/links/external-links): the links where nofollow does belong.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Qualify your outbound links, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every nofollowed internal link is listed with its href. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/orphan-pages.mdx
+++ b/docs/rules/links/orphan-pages.mdx
@@ -1,9 +1,29 @@
 ---
-title: "Orphan Pages"
-description: "Detects pages with no internal links pointing to them"
+title: "Orphan pages: pages with too few inbound internal links"
+description: "A page nothing links to is hard to discover and reads as unimportant. squirrel counts dofollow inbound internal links for every crawled page."
 ---
 
-Detects pages with no internal links pointing to them
+## What an orphan page is
+
+An orphan page is one that almost nothing on the site links to. Internal links are how a crawler moves between pages and how a site says which of its pages matter, so a page with no inbound links is both harder to find and weaker when it is found.
+
+Some pages are orphaned on purpose. A campaign landing page or a page reachable only from an email is a normal thing to have, and the exclusion list exists for those.
+
+## What squirrel checks
+
+The rule is site-wide. It counts inbound internal links for every crawled page, counting only links that are internal, resolvable and not `rel="nofollow"`. The homepage is never flagged, and neither is any URL matching an exclusion pattern.
+
+- Skipped when fewer than two pages were crawled. Message: `Insufficient pages for orphan analysis`.
+- Warn when any page has fewer inbound links than `minInboundLinks`. Message: `6 orphan page(s) with <2 incoming links`. The value lists up to five paths with a `+N more` suffix, and every URL is listed as an item. Severity warning, weight 5.
+- Pass otherwise. Message: `All pages have sufficient internal links pointing to them`.
+
+The default threshold is 2, so a page with exactly one inbound link is reported here and also, separately, by `links/weak-internal-links`. URLs are normalised on both sides before counting.
+
+## How to fix it
+
+Link to the page from somewhere that makes sense: a hub or category page, the body of a related article, or the navigation if it belongs there. Use anchor text that says what the page is.
+
+Sitemap membership is not a substitute. A sitemap makes a URL discoverable; internal links are what tell a search engine where the page sits in the site.
 
 | | |
 |---|---|
@@ -13,25 +33,19 @@ Detects pages with no internal links pointing to them
 | **Severity** | warning |
 | **Weight** | 5/10 |
 
-## Solution
-
-Orphan pages have no internal links and are hard for search engines to discover. They may not get indexed or rank well. Add internal links from relevant pages. Include in navigation or sidebar. Add to sitemap. Create contextual links from related content. If intentionally orphaned (e.g., landing pages), ensure they're accessible via sitemap.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `minInboundLinks` | unknown | `undefined` | Minimum inbound links required (pages below this are flagged) |
-| `excludePatterns` | unknown | `undefined` | URL patterns to exclude from orphan detection |
+| `minInboundLinks` | integer, 0 or more | `2` | Minimum inbound links required (pages below this are flagged) |
+| `excludePatterns` | array of strings | `[]` | URL patterns to exclude from orphan detection |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."links/orphan-pages"]
-minInboundLinks = undefined
-excludePatterns = undefined
+[rule_options."links/orphan-pages"]
+minInboundLinks = 1
+excludePatterns = ["/lp/", "/campaign/"]
 ```
 
 ## Enable / disable
@@ -57,3 +71,29 @@ disable = ["links/*"]
 enable = ["links/orphan-pages"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/weak-internal-links](/rules/links/weak-internal-links): pages with exactly one inbound link.
+- [links/no-contextual-inbound](/rules/links/no-contextual-inbound): pages linked only from the nav and footer.
+- [integrity/orphan-page](/rules/integrity/orphan-page): the compromise-signal version, hidden from sitemap and links both.
+- [crawl/sitemap-coverage](/rules/crawl/sitemap-coverage): whether these pages are at least in the sitemap.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every orphan is listed by path with its inbound link count threshold. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/redirect-chains.mdx
+++ b/docs/rules/links/redirect-chains.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Redirect Chains"
-description: "Detects URLs that redirect and links pointing to redirects"
+title: "Links pointing at redirecting URLs: the hop on every click"
+description: "An internal link to a URL that redirects costs a round trip every time anyone follows it. squirrel finds redirecting pages and who links to them."
 ---
 
-Detects URLs that redirect and links pointing to redirects
+## What linking to a redirect costs
+
+A redirect is fine as a safety net for old URLs arriving from elsewhere. It is waste when your own pages link to the redirecting URL instead of the destination, because every click and every crawl pays a round trip that a corrected link would remove.
+
+The pattern accumulates after any restructure. The redirect is set up, the content is moved, and the links in body copy and navigation still point at the old address. Nothing appears broken, so nothing prompts a fix.
+
+## What squirrel checks
+
+The rule is site-wide and works in two passes. First it finds crawled pages that redirected, using recorded redirect evidence rather than a URL comparison, so a page whose final URL differs only in normalisation is not counted. Then it walks every internal link on every page and matches it against those redirecting URLs.
+
+- Skipped when no pages are available. Message: `No pages available for redirect analysis`.
+- `redirect-pages` warns for the redirecting URLs themselves. Message: `5 page(s) redirect to another URL`, each item labelled with the full chain such as `/old (301) → /new (200)`.
+- `links-to-redirect` warns for the link targets. Message: `3 link target(s) point to redirecting URLs`, each item carrying the chain and every page that links to it.
+- `redirect-chains` passes when neither fired. Message: `No redirects detected`.
+
+Link matching is slash-sensitive. A page that links `/about/` is not blamed for `/about`'s redirect, because those are different hrefs and only one of them is the mistake.
+
+## How to fix it
+
+Rewrite the links to point at the final URL. The report lists which pages carry each one, so a link repeated in a template is a single change.
+
+Leave the redirect in place. It is still doing its job for links you do not control.
 
 | | |
 |---|---|
@@ -12,10 +33,6 @@ Detects URLs that redirect and links pointing to redirects
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Redirects add latency and waste crawl budget, especially when chained. Make sure every internal link hits the final destination directly, not the intermediate redirect, and consult the chain context emitted by this rule to trace multi-hop paths. Consolidate redirect rules, prefer 301s for permanent moves, and audit redirects regularly to remove legacy hops.
 
 ## Enable / disable
 
@@ -40,3 +57,30 @@ disable = ["links/*"]
 enable = ["links/redirect-chains"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/redirect-chain](/rules/crawl/redirect-chain): chains longer than a configured hop count, wherever they occur.
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): a canonical tag pointing into one of these chains.
+- [links/broken-links](/rules/links/broken-links): internal links whose target fails outright.
+- [url/trailing-slash](/rules/url/trailing-slash): the slash convention that produces many of these redirects.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [301 redirects and Google Search](https://developers.google.com/search/docs/crawling-indexing/301-redirects)
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Each redirecting target is listed with its chain and the pages that link to it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/redirect-chains.mdx
+++ b/docs/rules/links/redirect-chains.mdx
@@ -11,10 +11,10 @@ The pattern accumulates after any restructure. The redirect is set up, the conte
 
 ## What squirrel checks
 
-The rule is site-wide and works in two passes. First it finds crawled pages that redirected, using recorded redirect evidence rather than a URL comparison, so a page whose final URL differs only in normalisation is not counted. Then it walks every internal link on every page and matches it against those redirecting URLs.
+The rule is site-wide and works in two passes. First it finds crawled pages that redirected: either the request target changed, comparing path, trailing slash and query, or a redirect was actually observed in the recorded chain. Then it walks every internal link on every page and matches it against those redirecting URLs.
 
 - Skipped when no pages are available. Message: `No pages available for redirect analysis`.
-- `redirect-pages` warns for the redirecting URLs themselves. Message: `5 page(s) redirect to another URL`, each item labelled with the full chain such as `/old (301) → /new (200)`.
+- `redirect-pages` warns for the redirecting URLs themselves. Message: `5 page(s) redirect to another URL`. A multi-hop chain is labelled with full URLs and status codes, `https://example.com/old (301) → https://example.com/new (200)`. With no multi-hop chain the label falls back to `original → final` with no status codes.
 - `links-to-redirect` warns for the link targets. Message: `3 link target(s) point to redirecting URLs`, each item carrying the chain and every page that links to it.
 - `redirect-chains` passes when neither fired. Message: `No redirects detected`.
 

--- a/docs/rules/links/tel-mailto.mdx
+++ b/docs/rules/links/tel-mailto.mdx
@@ -5,21 +5,21 @@ description: "A phone link whose href differs from the number on screen dials th
 
 ## What tel: and mailto: links are
 
-`tel:` and `mailto:` are URI schemes that hand a phone number or an email address to the device's own application. RFC 3966 defines the phone form and recommends the global E.164 format, a leading `+` and digits with no punctuation, because a national number is ambiguous outside its country. RFC 6068 defines the mail form, including the `?subject=` and `?body=` parameters.
+`tel:` and `mailto:` are URI schemes that hand a phone number or an email address to the device's own application. RFC 3966 defines the phone form: it requires the global form, a leading `+` and the full number, whenever the number can be represented that way, permits the visual separators `-`, `.`, `(` and `)`, and requires a `phone-context` parameter for a local number. RFC 6068 defines the mail form, including the `?subject=` and `?body=` parameters.
 
 The failure that matters is a mismatch. When the href and the visible text carry different numbers or addresses, tapping the link contacts someone other than the person shown on screen. That is usually an edit applied to one and not the other.
 
 ## What squirrel checks
 
-The rule runs on every crawled page over every `a[href]` starting with `tel:` or `mailto:`. It emits up to five checks:
+The rule runs on every crawled page over every `a[href]` starting with `tel:` or `mailto:`. Five check names are possible and at most four appear in one result, since the last only fires when neither link type is present:
 
 - `tel-links` warns when a phone value has no digit or `+`, or is shorter than seven characters. Message: `1/4 tel: link(s) may be invalid`. It passes otherwise with `4 tel: link(s) found`.
-- `mailto-links` warns when an address is present but has no `@` or no dot. Message: `1/3 mailto: link(s) may be invalid`. It passes otherwise with `3 mailto: link(s) found`. An address-less share link such as `mailto:?subject=…` is not validated, since the recipient fills it in.
-- `tel-mismatch` warns when the link text contains three or more digits that do not match the href. Message: `2 tel link(s) have mismatched phone number in href vs display text`, each item labelled `href "+61414123456" ≠ text "0400 000 000"` with a markup snippet.
+- `mailto-links` warns when an address is present but has no `@` or no dot. Message: `1/3 mailto: link(s) may be invalid`. It passes otherwise with `3 mailto: link(s) found`. Format validation is skipped only for an empty recipient followed by a `?`, the `mailto:?subject=…` share pattern; a bare `mailto:` with nothing after it still warns.
+- `tel-mismatch` warns when the link text contains three or more consecutive digits that do not match the href. Message: `2 tel link(s) have mismatched phone number in href vs display text`, each item labelled `href "+61414123456" ≠ text "0400 000 000"` with a markup snippet.
 - `mailto-mismatch` warns when the link text looks like an email address and differs from the href, compared case-insensitively. Message: `1 mailto link(s) have mismatched email in href vs display text`.
 - `tel-mailto` reports info when the page has neither kind of link. Message: `No tel: or mailto: links found`.
 
-Numbers match on an exact digit comparison, on either digit string ending with the other, or on an E.164 href against national text with a leading trunk zero, so `+61414123456` and `0414 123 456` are not a mismatch. Severity for the rule is info, weight 2.
+Numbers match on an exact digit comparison, on either digit string ending with the other, or on a trunk-prefix comparison. That last one drops a single leading zero from either side and accepts the pair when the shared suffix is at least five digits and the other number carries exactly two or three extra leading digits, the length of a country calling code. It works in both directions and does not require a literal `+`, so `+61414123456` and `0414 123 456` are not a mismatch. Severity for the rule is info, weight 2.
 
 ## How to fix it
 

--- a/docs/rules/links/tel-mailto.mdx
+++ b/docs/rules/links/tel-mailto.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Tel & Mailto Links"
-description: "Validates tel: and mailto: link formats"
+title: "tel: and mailto: links: format and href/text mismatches"
+description: "A phone link whose href differs from the number on screen dials the wrong person. squirrel validates both formats and compares them with the visible text."
 ---
 
-Validates tel: and mailto: link formats
+## What tel: and mailto: links are
+
+`tel:` and `mailto:` are URI schemes that hand a phone number or an email address to the device's own application. RFC 3966 defines the phone form and recommends the global E.164 format, a leading `+` and digits with no punctuation, because a national number is ambiguous outside its country. RFC 6068 defines the mail form, including the `?subject=` and `?body=` parameters.
+
+The failure that matters is a mismatch. When the href and the visible text carry different numbers or addresses, tapping the link contacts someone other than the person shown on screen. That is usually an edit applied to one and not the other.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `a[href]` starting with `tel:` or `mailto:`. It emits up to five checks:
+
+- `tel-links` warns when a phone value has no digit or `+`, or is shorter than seven characters. Message: `1/4 tel: link(s) may be invalid`. It passes otherwise with `4 tel: link(s) found`.
+- `mailto-links` warns when an address is present but has no `@` or no dot. Message: `1/3 mailto: link(s) may be invalid`. It passes otherwise with `3 mailto: link(s) found`. An address-less share link such as `mailto:?subject=…` is not validated, since the recipient fills it in.
+- `tel-mismatch` warns when the link text contains three or more digits that do not match the href. Message: `2 tel link(s) have mismatched phone number in href vs display text`, each item labelled `href "+61414123456" ≠ text "0400 000 000"` with a markup snippet.
+- `mailto-mismatch` warns when the link text looks like an email address and differs from the href, compared case-insensitively. Message: `1 mailto link(s) have mismatched email in href vs display text`.
+- `tel-mailto` reports info when the page has neither kind of link. Message: `No tel: or mailto: links found`.
+
+Numbers match on an exact digit comparison, on either digit string ending with the other, or on an E.164 href against national text with a leading trunk zero, so `+61414123456` and `0414 123 456` are not a mismatch. Severity for the rule is info, weight 2.
+
+## How to fix it
+
+```html
+<a href="tel:+61292223333">(02) 9222 3333</a>
+<a href="mailto:sales@example.com">sales@example.com</a>
+```
+
+Put the E.164 form in the href and the locally readable form in the text. Generate both from one stored value so an edit cannot change only one of them.
+
+A share link with no recipient, `mailto:?subject=Look%20at%20this`, is valid and is deliberately not validated.
 
 | | |
 |---|---|
@@ -12,17 +39,6 @@ Validates tel: and mailto: link formats
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## What it detects
-
-- **Invalid tel: links**, phone numbers missing digits or too short
-- **Invalid mailto: links**, email addresses missing `@` or `.`
-- **Tel href/text mismatch**: the phone number in the `href` doesn't match the displayed text (e.g. `<a href="tel:+15551234567">+15559876543</a>`). Comparison is formatting-insensitive, allows omitted country codes, and treats an E.164 `href` (e.g. `+61414007351`) paired with national-format display text carrying a trunk prefix (e.g. `0414 007 351`) as the same number, which is the recommended markup pattern.
-- **Mailto href/text mismatch**: the email in the `href` doesn't match the displayed text (e.g. `<a href="mailto:sales@example.com">support@example.com</a>`). Comparison is case-insensitive and ignores query parameters.
-
-## Solution
-
-Tel links should use format: tel:+1234567890 (E.164 format preferred, no spaces/dashes). Mailto links should have valid email format: mailto:user@example.com. You can add subject and body parameters: mailto:user@example.com?subject=Hi&body=Hello. Invalid formats may not work on all devices. Ensure the displayed text matches the href: a mismatched phone number or email misleads users and may dial/email the wrong contact.
 
 ## Enable / disable
 
@@ -47,3 +63,30 @@ disable = ["links/*"]
 enable = ["links/tel-mailto"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [eeat/contact-page](/rules/eeat/contact-page): whether the site publishes contact details at all.
+- [eeat/physical-address](/rules/eeat/physical-address): the address that usually sits next to them.
+- [schema/local-business](/rules/schema/local-business): the structured data carrying the same phone number.
+- [links/invalid-links](/rules/links/invalid-links): hrefs that do not parse at all.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [RFC 3966: The tel URI for telephone numbers](https://datatracker.ietf.org/doc/html/rfc3966)
+- [RFC 6068: The mailto URI scheme](https://datatracker.ietf.org/doc/html/rfc6068)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every mismatch is listed with the href, the visible text and a markup snippet. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/weak-internal-links.mdx
+++ b/docs/rules/links/weak-internal-links.mdx
@@ -1,9 +1,29 @@
 ---
-title: "Weak Internal Links"
-description: "Detects pages with only 1 dofollow internal link pointing to them"
+title: "Pages with only one internal link pointing to them"
+description: "One inbound link is enough to be found and not enough to look important. squirrel lists every page whose dofollow inbound count is exactly one."
 ---
 
-Detects pages with only 1 dofollow internal link pointing to them
+## What weak internal linking is
+
+Internal links do two jobs: they let a crawler reach a page, and they distribute the site's own signals of importance. A page with a single inbound link clears the first bar and barely registers on the second.
+
+It is the band just above an orphan. Nothing is broken, and the page will be crawled, but it has no support from the rest of the site, which usually means it is not linked from any of the content it belongs with.
+
+## What squirrel checks
+
+The rule is site-wide and reads the same dofollow inbound counts as `links/orphan-pages`. The homepage is never flagged, and neither is any URL matching an exclusion pattern. It emits a single check named `weak-internal-links`:
+
+- Skipped when fewer than two pages were crawled. Message: `Insufficient pages for internal link analysis`.
+- Warn when any page has exactly one inbound internal link. Message: `12 page(s) have only 1 internal link`. Severity warning, weight 3.
+- Pass otherwise. Message: `All pages have sufficient internal link support`.
+
+The count of one is fixed and not configurable. With `links/orphan-pages` at its default threshold of 2, a page with one inbound link is reported by both rules.
+
+## How to fix it
+
+Add contextual links from the pages that share the topic, and from the hub or category page the content belongs to. Two or three links from related content are worth more than another entry in the footer.
+
+Which links count matters more than how many. See `links/no-contextual-inbound` for the difference between an editorial link and a sitewide one.
 
 | | |
 |---|---|
@@ -13,23 +33,17 @@ Detects pages with only 1 dofollow internal link pointing to them
 | **Severity** | warning |
 | **Weight** | 3/10 |
 
-## Solution
-
-Pages with only a single internal link have weak internal linking support and may struggle to rank. Search engines use internal links to understand page importance and distribute link equity. Add contextual links from related content, include in navigation or sidebar, or link from category/hub pages to strengthen internal link profiles.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `excludePatterns` | unknown | `undefined` | URL patterns to exclude from weak link detection |
+| `excludePatterns` | array of strings | `[]` | URL patterns to exclude from weak link detection |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."links/weak-internal-links"]
-excludePatterns = undefined
+[rule_options."links/weak-internal-links"]
+excludePatterns = ["/lp/", "/tag/"]
 ```
 
 ## Enable / disable
@@ -55,3 +69,29 @@ disable = ["links/*"]
 enable = ["links/weak-internal-links"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/orphan-pages](/rules/links/orphan-pages): pages below the inbound threshold entirely.
+- [links/no-contextual-inbound](/rules/links/no-contextual-inbound): whether the inbound links are editorial or chrome.
+- [links/anchor-text](/rules/links/anchor-text): what those links say about the page.
+- [links/dead-end-pages](/rules/links/dead-end-pages): the outbound side of the same structure.
+
+Links findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Make your links crawlable, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Links section of the report. Every page with a single inbound link is listed. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Links section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/links/weak-internal-links.mdx
+++ b/docs/rules/links/weak-internal-links.mdx
@@ -7,7 +7,7 @@ description: "One inbound link is enough to be found and not enough to look impo
 
 Internal links do two jobs: they let a crawler reach a page, and they distribute the site's own signals of importance. A page with a single inbound link clears the first bar and barely registers on the second.
 
-It is the band just above an orphan. Nothing is broken, and the page will be crawled, but it has no support from the rest of the site, which usually means it is not linked from any of the content it belongs with.
+It is the band just above an orphan. Nothing is broken, and the single link makes the page discoverable, though whether it is crawled still depends on access rules and the crawler's own scheduling. What it lacks is support from the rest of the site, which usually means it is not linked from any of the content it belongs with.
 
 ## What squirrel checks
 

--- a/docs/rules/mobile/font-size.mdx
+++ b/docs/rules/mobile/font-size.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Font Size"
-description: "Checks for readable font sizes on mobile"
+title: "Font size under 12px: text too small to read on a phone"
+description: "Body text below about 16px is hard to read on a phone without zooming. squirrel checks inline styles for sizes under 12px."
 ---
 
-Checks for readable font sizes on mobile
+## What the font size threshold is
+
+Text on a phone is read at arm's length on a screen a few inches wide. Around 16 CSS pixels is the common floor for body copy, which is also most browsers' default. Below about 12 pixels, text is small enough that a reader has to zoom to follow it.
+
+Relative units are what make this hold up. Sizing in `rem` means the text scales with the user's own browser setting, which is the setting people with low vision change first. A fixed pixel size ignores it.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every element with a `style` attribute. It reads a `font-size` declaration in `px` or `pt`, converting points to pixels by multiplying by 1.33. It emits a single check named `font-size`:
+
+- Warn when any inline font size resolves below 12 pixels. Message: `4 element(s) with font-size under 12px`, with `Ensure text is readable without zooming` as the value. Severity warning, weight 4.
+- Info otherwise. Message: `No extremely small inline font sizes detected`, with `Verify body text is at least 16px` as the value.
+
+Only inline styles are read. Font sizes set in an external stylesheet, which is where most of them live, are not visible to this rule, and neither are relative units such as `rem`, `em` or `%`. The pass wording says so: it reports that nothing small was found inline, not that the page is readable.
+
+## How to fix it
+
+```css
+body { font-size: 1rem; line-height: 1.5; }
+.small-print { font-size: 0.875rem; }
+```
+
+Set body copy in `rem` so it follows the reader's browser setting, and keep the smallest text on the page above about 0.75rem. Give it a line height of at least 1.5.
+
+Check the real sizes in a browser rather than relying on this rule alone. It only sees what is written in a `style` attribute.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for readable font sizes on mobile
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Body text should be at least 16px for readability without zooming. Smaller fonts strain eyes on mobile. Use relative units (rem, em) for scalability. Test on actual devices. Google's mobile-friendly test flags font sizes under 12px. Line height should be at least 1.5 for readability.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["mobile/*"]
 enable = ["mobile/font-size"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [mobile/viewport-zoom](/rules/mobile/viewport-zoom): whether a reader can zoom when text is too small.
+- [mobile/tap-targets](/rules/mobile/tap-targets): the same problem applied to things you touch.
+- [a11y/color-contrast](/rules/a11y/color-contrast): the other reason text is hard to read.
+- [mobile/horizontal-scroll](/rules/mobile/horizontal-scroll): layout that forces the reader to pan.
+
+Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Understanding resize text, WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
+- [Page experience, Google Search Central](https://developers.google.com/search/docs/appearance/page-experience)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Mobile section of the report. Each page is reported with its count of small inline font sizes. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Mobile section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/mobile/font-size.mdx
+++ b/docs/rules/mobile/font-size.mdx
@@ -7,13 +7,13 @@ description: "Body text below about 16px is hard to read on a phone without zoom
 
 Text on a phone is read at arm's length on a screen a few inches wide. Around 16 CSS pixels is the common floor for body copy, which is also most browsers' default. Below about 12 pixels, text is small enough that a reader has to zoom to follow it.
 
-Relative units are what make this hold up. Sizing in `rem` means the text scales with the user's own browser setting, which is the setting people with low vision change first. A fixed pixel size ignores it.
+Relative units are what make this hold up, if you let them. `rem` is relative to the root element's font size, so text follows the reader's browser setting only when that root size is left alone or set relatively. A fixed pixel size on `html`, or on the text itself, ignores the setting people with low vision change first.
 
 ## What squirrel checks
 
-The rule runs on every crawled page over every element with a `style` attribute. It reads a `font-size` declaration in `px` or `pt`, converting points to pixels by multiplying by 1.33. It emits a single check named `font-size`:
+The rule runs on every crawled page over every element with a `style` attribute. It matches `font-size:` followed by an integer and `px` or `pt`, converting points to pixels by multiplying by 1.33. The integer requirement means `font-size: 11.5px` is not read at all. It emits a single check named `font-size`:
 
-- Warn when any inline font size resolves below 12 pixels. Message: `4 element(s) with font-size under 12px`, with `Ensure text is readable without zooming` as the value. Severity warning, weight 4.
+- Warn when any matched inline font size resolves below 12 pixels. Message: `4 element(s) with font-size under 12px`, with `Ensure text is readable without zooming` as the value. Severity warning, weight 4.
 - Info otherwise. Message: `No extremely small inline font sizes detected`, with `Verify body text is at least 16px` as the value.
 
 Only inline styles are read. Font sizes set in an external stylesheet, which is where most of them live, are not visible to this rule, and neither are relative units such as `rem`, `em` or `%`. The pass wording says so: it reports that nothing small was found inline, not that the page is readable.
@@ -25,7 +25,7 @@ body { font-size: 1rem; line-height: 1.5; }
 .small-print { font-size: 0.875rem; }
 ```
 
-Set body copy in `rem` so it follows the reader's browser setting, and keep the smallest text on the page above about 0.75rem. Give it a line height of at least 1.5.
+Set body copy in `rem` and leave the root font size unset, so the text follows the reader's browser setting. Keep the smallest text on the page above about 0.75rem. Give it a line height of at least 1.5.
 
 Check the real sizes in a browser rather than relying on this rule alone. It only sees what is written in a `style` attribute.
 
@@ -73,6 +73,7 @@ Mobile findings ship in every audit next to the SEO, performance and agent exper
 ## References
 
 - [Understanding resize text, WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
+- [CSS length values, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/length)
 - [Page experience, Google Search Central](https://developers.google.com/search/docs/appearance/page-experience)
 
 ## Check your site

--- a/docs/rules/mobile/horizontal-scroll.mdx
+++ b/docs/rules/mobile/horizontal-scroll.mdx
@@ -5,7 +5,7 @@ description: "A page a phone can scroll sideways is a page that does not fit. sq
 
 ## What causes horizontal scroll
 
-Horizontal scrolling happens when something on the page is wider than the viewport. On a phone that means the reader has to pan to read a line, and text that runs off the edge is often simply not seen.
+Horizontal scrolling happens when something on the page is wider than the viewport. On a phone that means the reader has to pan to read a line, and text that runs off the edge is often not seen at all.
 
 Three things cause most of it. A fixed pixel width wider than a phone screen, which was a desktop measurement that survived. A table, which lays out to its content rather than to its container. And an iframe with a `width` attribute, most often an embedded video or map.
 

--- a/docs/rules/mobile/horizontal-scroll.mdx
+++ b/docs/rules/mobile/horizontal-scroll.mdx
@@ -13,7 +13,7 @@ Three things cause most of it. A fixed pixel width wider than a phone screen, wh
 
 The rule runs on every crawled page and collects three signals from the markup:
 
-- Elements with an inline `width` in pixels above 500.
+- Elements whose inline style declares a `width` as an integer number of pixels above 500. A fractional value such as `width: 500.5px` is not matched.
 - Every `table` on the page.
 - Every `iframe` carrying a `width` attribute.
 

--- a/docs/rules/mobile/horizontal-scroll.mdx
+++ b/docs/rules/mobile/horizontal-scroll.mdx
@@ -1,9 +1,39 @@
 ---
-title: "Horizontal Scroll"
-description: "Checks for elements that may cause horizontal scrolling"
+title: "Horizontal scroll on mobile: the usual causes"
+description: "A page a phone can scroll sideways is a page that does not fit. squirrel looks for fixed widths, tables and fixed-width iframes."
 ---
 
-Checks for elements that may cause horizontal scrolling
+## What causes horizontal scroll
+
+Horizontal scrolling happens when something on the page is wider than the viewport. On a phone that means the reader has to pan to read a line, and text that runs off the edge is often simply not seen.
+
+Three things cause most of it. A fixed pixel width wider than a phone screen, which was a desktop measurement that survived. A table, which lays out to its content rather than to its container. And an iframe with a `width` attribute, most often an embedded video or map.
+
+## What squirrel checks
+
+The rule runs on every crawled page and collects three signals from the markup:
+
+- Elements with an inline `width` in pixels above 500.
+- Every `table` on the page.
+- Every `iframe` carrying a `width` attribute.
+
+It emits a single check named `horizontal-scroll`:
+
+- Info when any signal was found. Message: `Elements may cause horizontal scroll on mobile`, listing what was found as `2 fixed-width element(s)`, `3 table(s) - ensure responsive` and `1 iframe(s) with fixed width`.
+- Pass when none was. Message: `No obvious horizontal scroll issues detected`.
+
+Nothing is rendered or measured, so these are candidates rather than confirmed overflow. Every table on the page is listed regardless of how wide it is, and a fixed width in an external stylesheet is not seen at all. Severity for the rule is warning, weight 5.
+
+## How to fix it
+
+```css
+img, video { max-width: 100%; height: auto; }
+.table-wrap { overflow-x: auto; }
+```
+
+Replace fixed widths with `max-width`, wrap tables in a container that scrolls on its own, and give embedded iframes a responsive aspect-ratio box instead of `width` and `height` attributes.
+
+Confirm in a browser at a narrow viewport. Comparing `document.documentElement.scrollWidth` with `clientWidth` finds the actual overflow.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks for elements that may cause horizontal scrolling
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Horizontal scrolling on mobile is a poor user experience and fails Google's mobile-friendly test. Common causes: fixed-width elements, images without max-width, wide tables. Use max-width: 100% on images, responsive tables, and avoid fixed pixel widths. Test on mobile devices.
 
 ## Enable / disable
 
@@ -40,3 +66,30 @@ disable = ["mobile/*"]
 enable = ["mobile/horizontal-scroll"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [mobile/viewport](/rules/mobile/viewport): the tag that makes the viewport the device width.
+- [images/dimensions](/rules/images/dimensions): image sizing, another overflow source.
+- [a11y/touch-targets](/rules/a11y/touch-targets): the other check that depends on a page fitting the screen.
+- [mobile/font-size](/rules/mobile/font-size): text that does not fit for a different reason.
+
+Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Understanding reflow, WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html)
+- [Page experience, Google Search Central](https://developers.google.com/search/docs/appearance/page-experience)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Mobile section of the report. Each page is listed with the elements that might overflow it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Mobile section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/mobile/index.mdx
+++ b/docs/rules/mobile/index.mdx
@@ -8,23 +8,23 @@ Mobile rules check whether a page works on a phone: the viewport tag that decide
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Font Size" icon="triangle-exclamation" href="/rules/mobile/font-size">
-    Checks for readable font sizes on mobile
+  <Card title="Font size under 12px: text too small to read on a phone" icon="triangle-exclamation" href="/rules/mobile/font-size">
+    Body text below about 16px is hard to read on a phone without zooming. squirrel checks inline styles for sizes under 12px.
   </Card>
-  <Card title="Horizontal Scroll" icon="triangle-exclamation" href="/rules/mobile/horizontal-scroll">
-    Checks for elements that may cause horizontal scrolling
+  <Card title="Horizontal scroll on mobile: the usual causes" icon="triangle-exclamation" href="/rules/mobile/horizontal-scroll">
+    A page a phone can scroll sideways is a page that does not fit. squirrel looks for fixed widths, tables and fixed-width iframes.
   </Card>
-  <Card title="Interstitials" icon="triangle-exclamation" href="/rules/mobile/interstitials">
-    Detects potentially intrusive mobile interstitials
+  <Card title="Intrusive interstitials: popups that cover mobile content" icon="triangle-exclamation" href="/rules/mobile/interstitials">
+    A popup covering the content a visitor came for is a ranking problem as well as a usability one. squirrel detects popup markup and libraries.
   </Card>
-  <Card title="Tap Targets" icon="triangle-exclamation" href="/rules/mobile/tap-targets">
-    Checks for properly sized touch targets
+  <Card title="Tap target size: the 44 by 44 pixel guideline" icon="triangle-exclamation" href="/rules/mobile/tap-targets">
+    A control smaller than a fingertip is a control people miss. squirrel counts interactive elements and flags small inline dimensions.
   </Card>
-  <Card title="Viewport Meta" icon="circle-exclamation" href="/rules/mobile/viewport">
-    Checks for proper viewport meta tag
+  <Card title="Missing viewport meta tag: what it does and what to set" icon="circle-exclamation" href="/rules/mobile/viewport">
+    Without a viewport meta tag a phone renders the page at desktop width and zooms out. squirrel checks the tag and its content properties.
   </Card>
-  <Card title="Viewport Zoom" icon="circle-exclamation" href="/rules/mobile/viewport-zoom">
-    Checks that viewport doesn't disable user zoom
+  <Card title="user-scalable=no: the viewport setting that blocks zoom" icon="circle-exclamation" href="/rules/mobile/viewport-zoom">
+    Disabling pinch zoom stops readers who need to magnify text. squirrel checks the viewport content for user-scalable and maximum-scale.
   </Card>
 </CardGroup>
 

--- a/docs/rules/mobile/index.mdx
+++ b/docs/rules/mobile/index.mdx
@@ -3,7 +3,7 @@ title: "Mobile"
 description: "Mobile-friendliness and responsive design"
 ---
 
-Mobile-friendliness and responsive design
+Mobile rules check whether a page works on a phone: the viewport tag that decides how it is laid out, whether zoom is still available, whether text and tap targets are large enough, and whether anything overflows the screen. Most of them read static markup, so they see inline styles and not the stylesheet, and several report a count as context rather than a measurement. Treat them as a list of things to look at in a narrow browser window.
 
 ## Rules
 
@@ -34,3 +34,5 @@ Mobile-friendliness and responsive design
 [rules]
 disable = ["mobile/*"]
 ```
+
+Every audit reports Mobile findings next to the performance, security and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.

--- a/docs/rules/mobile/interstitials.mdx
+++ b/docs/rules/mobile/interstitials.mdx
@@ -61,7 +61,7 @@ disable = ["*"]
 - [legal/cookie-consent](/rules/legal/cookie-consent): the consent banner that is exempt from this.
 - [integrity/fake-auth-overlay](/rules/integrity/fake-auth-overlay): overlays that are not yours at all.
 - [mobile/viewport](/rules/mobile/viewport): the tag that decides how the overlay is sized.
-- [performance/cls-hints](/rules/performance/cls-hints): the layout shift an overlay usually causes.
+- [performance/cls-hints](/rules/perf/cls-hints): the layout shift an overlay usually causes.
 
 Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/mobile/interstitials.mdx
+++ b/docs/rules/mobile/interstitials.mdx
@@ -16,7 +16,7 @@ The rule runs on every crawled page and looks for two things. Any `div` whose `c
 - Info when either was found. Message: `Popup/modal elements detected`, with `Ensure popups don't block content on mobile page load` as the value.
 - Pass when neither was. Message: `No intrusive interstitial patterns detected`.
 
-Nothing about timing, size or coverage is measured, and no distinction is made between an exempt consent banner and a full-screen email capture. A site using a modal for anything at all reports the informational finding. Severity for the rule is warning, weight 5.
+Nothing about timing, size or coverage is measured, and no distinction is made between an exempt consent banner and a full-screen email capture. Only a `div` whose class or id matches one of those four words, or one of the seven library strings in the HTML, triggers it. A native `<dialog>` with no matching class is not detected. Severity for the rule is warning, weight 5.
 
 ## How to fix it
 

--- a/docs/rules/mobile/interstitials.mdx
+++ b/docs/rules/mobile/interstitials.mdx
@@ -61,7 +61,7 @@ disable = ["*"]
 - [legal/cookie-consent](/rules/legal/cookie-consent): the consent banner that is exempt from this.
 - [integrity/fake-auth-overlay](/rules/integrity/fake-auth-overlay): overlays that are not yours at all.
 - [mobile/viewport](/rules/mobile/viewport): the tag that decides how the overlay is sized.
-- [perf/cls-hints](/rules/perf/cls-hints): the layout shift an overlay usually causes.
+- [perf/cls-hints](/rules/perf/cls-hints): images and iframes missing the dimensions that prevent shift.
 
 Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/mobile/interstitials.mdx
+++ b/docs/rules/mobile/interstitials.mdx
@@ -61,7 +61,7 @@ disable = ["*"]
 - [legal/cookie-consent](/rules/legal/cookie-consent): the consent banner that is exempt from this.
 - [integrity/fake-auth-overlay](/rules/integrity/fake-auth-overlay): overlays that are not yours at all.
 - [mobile/viewport](/rules/mobile/viewport): the tag that decides how the overlay is sized.
-- [performance/cls-hints](/rules/perf/cls-hints): the layout shift an overlay usually causes.
+- [perf/cls-hints](/rules/perf/cls-hints): the layout shift an overlay usually causes.
 
 Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 

--- a/docs/rules/mobile/interstitials.mdx
+++ b/docs/rules/mobile/interstitials.mdx
@@ -1,9 +1,28 @@
 ---
-title: "Interstitials"
-description: "Detects potentially intrusive mobile interstitials"
+title: "Intrusive interstitials: popups that cover mobile content"
+description: "A popup covering the content a visitor came for is a ranking problem as well as a usability one. squirrel detects popup markup and libraries."
 ---
 
-Detects potentially intrusive mobile interstitials
+## What an intrusive interstitial is
+
+An intrusive interstitial is an overlay that covers the main content on a mobile page, either immediately on arrival or before the content is reachable. Google announced in 2016 that pages doing this may rank lower, because a visitor arriving from search is shown a dialog instead of the page they chose.
+
+Some overlays are exempt. Cookie consent and age verification are required by law in places, and a login wall on genuinely gated content is not deceptive. The distinction is whether the overlay stands between a search visitor and the content the result promised.
+
+## What squirrel checks
+
+The rule runs on every crawled page and looks for two things. Any `div` whose `class` or `id` matches `popup`, `modal`, `overlay` or `interstitial`. And the raw HTML, lowercased, containing any of `popup.js`, `modal.js`, `mailchimp`, `sumo`, `optinmonster`, `hello-bar` or `leadpages`. It emits a single check named `interstitials`:
+
+- Info when either was found. Message: `Popup/modal elements detected`, with `Ensure popups don't block content on mobile page load` as the value.
+- Pass when neither was. Message: `No intrusive interstitial patterns detected`.
+
+Nothing about timing, size or coverage is measured, and no distinction is made between an exempt consent banner and a full-screen email capture. A site using a modal for anything at all reports the informational finding. Severity for the rule is warning, weight 5.
+
+## How to fix it
+
+Delay any promotional overlay until the reader has engaged with the page, or replace it with an inline banner that takes a reasonable amount of the screen. On mobile, an in-content form usually converts better than an overlay anyway.
+
+Keep consent and age gates as small as the law allows, and make sure the content behind them is what a search visitor was promised.
 
 | | |
 |---|---|
@@ -12,10 +31,6 @@ Detects potentially intrusive mobile interstitials
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Google penalizes intrusive interstitials that cover main content on mobile. Avoid: popups that cover the content immediately on page load, standalone interstitials before the main content, above-the-fold layouts that look like interstitials. Allowed: age verification, cookie consent (small), login walls for paywalled content.
 
 ## Enable / disable
 
@@ -40,3 +55,30 @@ disable = ["mobile/*"]
 enable = ["mobile/interstitials"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [legal/cookie-consent](/rules/legal/cookie-consent): the consent banner that is exempt from this.
+- [integrity/fake-auth-overlay](/rules/integrity/fake-auth-overlay): overlays that are not yours at all.
+- [mobile/viewport](/rules/mobile/viewport): the tag that decides how the overlay is sized.
+- [performance/cls-hints](/rules/performance/cls-hints): the layout shift an overlay usually causes.
+
+Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Helping users easily access content on mobile, Google Search Central](https://developers.google.com/search/blog/2016/08/helping-users-easily-access-content-on)
+- [Page experience, Google Search Central](https://developers.google.com/search/docs/appearance/page-experience)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Mobile section of the report. Each page is reported with whether popup markup or a popup library was detected. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Mobile section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/mobile/tap-targets.mdx
+++ b/docs/rules/mobile/tap-targets.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Tap Targets"
-description: "Checks for properly sized touch targets"
+title: "Tap target size: the 44 by 44 pixel guideline"
+description: "A control smaller than a fingertip is a control people miss. squirrel counts interactive elements and flags small inline dimensions."
 ---
 
-Checks for properly sized touch targets
+## What a tap target is
+
+A tap target is anything a finger has to hit: a link, a button, a form control, a checkbox. Unlike a cursor, a fingertip covers several millimetres and the contact point is not where the user is looking.
+
+The common guideline is around 44 by 44 CSS pixels with space between adjacent targets. WCAG 2.2 sets a minimum of 24 by 24 with exceptions for inline links and spacing. Padding is the usual way to reach it: the tappable area grows while the visible element stays the size the design wants.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It counts `button` and `[role="button"]` elements, `a[href]` links, and `input`, `select` and `textarea` controls. It then looks at the inline `style` on the buttons and links for a `font-size`, `height` or `width` in pixels below 30. It emits up to two checks:
+
+- `tap-targets` reports info when the page has any interactive element. Message: `84 interactive element(s) found`, with `Ensure tap targets are at least 44x44px` as the value.
+- `small-tap-targets` warns when any of those carries a small inline dimension. Message: `3 element(s) may have small tap targets`, with `Check inline styles for small dimensions` as the value. Severity warning, weight 5.
+
+Nothing is measured. Static markup carries no computed size, so the rule reports the count as context and uses inline styles as a weak proxy. A page whose sizes come from an external stylesheet produces the informational count and nothing else.
+
+## How to fix it
+
+```css
+.icon-button { padding: 12px; min-width: 44px; min-height: 44px; }
+```
+
+Give small controls padding rather than a larger icon, and keep at least 8 pixels between adjacent targets. Navigation links and icon-only buttons are where this usually goes wrong.
+
+Measure it in a browser. This rule tells you how many targets there are, not how big they render.
 
 | | |
 |---|---|
@@ -12,10 +35,6 @@ Checks for properly sized touch targets
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Touch targets (buttons, links) should be at least 44x44 CSS pixels with 8px spacing between them. This ensures users can tap accurately on mobile. Google's mobile-friendly test checks this. Use padding to increase tap area without changing visual size. Pay special attention to navigation links and form inputs.
 
 ## Enable / disable
 
@@ -40,3 +59,30 @@ disable = ["mobile/*"]
 enable = ["mobile/tap-targets"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/touch-targets](/rules/a11y/touch-targets): the WCAG target size check on rendered pages.
+- [mobile/font-size](/rules/mobile/font-size): text sized too small for the same reason.
+- [mobile/horizontal-scroll](/rules/mobile/horizontal-scroll): layout problems on the same screens.
+- [links/anchor-text](/rules/links/anchor-text): whether those targets are named at all.
+
+Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Understanding target size (minimum), WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)
+- [Page experience, Google Search Central](https://developers.google.com/search/docs/appearance/page-experience)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Mobile section of the report. Each page is reported with its interactive element count and any small inline dimensions. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Mobile section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/mobile/tap-targets.mdx
+++ b/docs/rules/mobile/tap-targets.mdx
@@ -62,7 +62,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/touch-targets](/rules/a11y/touch-targets): the WCAG target size check on rendered pages.
+- [a11y/touch-targets](/rules/a11y/touch-targets): inline sizing hints for potentially small touch targets.
 - [mobile/font-size](/rules/mobile/font-size): text sized too small for the same reason.
 - [mobile/horizontal-scroll](/rules/mobile/horizontal-scroll): layout problems on the same screens.
 - [links/anchor-text](/rules/links/anchor-text): whether those targets are named at all.

--- a/docs/rules/mobile/tap-targets.mdx
+++ b/docs/rules/mobile/tap-targets.mdx
@@ -11,12 +11,12 @@ The common guideline is around 44 by 44 CSS pixels with space between adjacent t
 
 ## What squirrel checks
 
-The rule runs on every crawled page. It counts `button` and `[role="button"]` elements, `a[href]` links, and `input`, `select` and `textarea` controls. It then looks at the inline `style` on the buttons and links for a `font-size`, `height` or `width` in pixels below 30. It emits up to two checks:
+The rule runs on every crawled page. It counts `button` and `[role="button"]` elements, `a[href]` links, and `input`, `select` and `textarea` controls. It then looks at the inline `style` on the buttons and links for a `font-size`, `height` or `width` declared as an integer number of pixels below 30. The patterns are case-sensitive and unanchored, so `min-width: 20px` matches the width test and a fractional `width: 20.5px` matches nothing. It emits up to two checks:
 
 - `tap-targets` reports info when the page has any interactive element. Message: `84 interactive element(s) found`, with `Ensure tap targets are at least 44x44px` as the value.
 - `small-tap-targets` warns when any of those carries a small inline dimension. Message: `3 element(s) may have small tap targets`, with `Check inline styles for small dimensions` as the value. Severity warning, weight 5.
 
-Nothing is measured. Static markup carries no computed size, so the rule reports the count as context and uses inline styles as a weak proxy. A page whose sizes come from an external stylesheet produces the informational count and nothing else.
+The counts are sums of selector matches with no deduplication, so an `<a href>` carrying `role="button"` is counted twice, in the small-target count as well when it qualifies. Nothing is measured either: static markup carries no computed size, so the rule reports the count as context and uses inline styles as a weak proxy. A page whose sizes come from an external stylesheet produces the informational count and nothing else.
 
 ## How to fix it
 

--- a/docs/rules/mobile/viewport-zoom.mdx
+++ b/docs/rules/mobile/viewport-zoom.mdx
@@ -1,9 +1,31 @@
 ---
-title: "Viewport Zoom"
-description: "Checks that viewport doesn't disable user zoom"
+title: "user-scalable=no: the viewport setting that blocks zoom"
+description: "Disabling pinch zoom stops readers who need to magnify text. squirrel checks the viewport content for user-scalable and maximum-scale."
 ---
 
-Checks that viewport doesn't disable user zoom
+## What disabling zoom does
+
+`user-scalable=no` and a low `maximum-scale` in the viewport meta tag ask the browser to prevent pinch zoom. The usual motivation is stopping iOS zooming in when a small form field is focused, which is a font-size problem being solved in the wrong place.
+
+The cost falls on people who need to magnify. WCAG success criterion 1.4.4 requires text to be resizable to 200% without loss of content or function, and blocking zoom fails it directly. Safari and recent Chrome ignore the request on that basis, but plenty of browsers still honour it.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reads `meta[name="viewport"]`. It emits a single check named `viewport-zoom`:
+
+- Skipped when there is no viewport tag. Message: `No viewport meta tag to check`.
+- Fail when the content contains `user-scalable=no`, `user-scalable=0`, or `maximum-scale=1` or `maximum-scale=1.0`. Message: `Viewport disables user zoom (accessibility issue)`, listing which of `user-scalable=no` and `maximum-scale=1` was found. Severity error, weight 7.
+- Pass otherwise. Message: `Viewport allows user zoom`.
+
+The `maximum-scale` test matches only the value 1, with optional decimal, so a `maximum-scale=2` is not flagged even though it also caps zoom below the WCAG threshold.
+
+## How to fix it
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+```
+
+Remove `user-scalable` and `maximum-scale` entirely. If the reason was iOS zooming into form fields, the fix is to set those fields to 16px or larger, which is what triggers the behaviour.
 
 | | |
 |---|---|
@@ -12,10 +34,6 @@ Checks that viewport doesn't disable user zoom
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Never disable user zoom with maximum-scale=1, user-scalable=no, or user-scalable=0. Users with visual impairments need to zoom. This is an accessibility violation (WCAG 1.4.4). It also harms usability for all users. Remove these properties from your viewport meta tag.
 
 ## Enable / disable
 
@@ -40,3 +58,30 @@ disable = ["mobile/*"]
 enable = ["mobile/viewport-zoom"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [mobile/viewport](/rules/mobile/viewport): the same tag, checked for the properties it should have.
+- [mobile/font-size](/rules/mobile/font-size): the small form fields that motivate disabling zoom.
+- [a11y/zoom-disabled](/rules/a11y/zoom-disabled): the accessibility rule covering the same defect.
+- [mobile/tap-targets](/rules/mobile/tap-targets): the other mobile accessibility measurement.
+
+Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Understanding resize text, WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
+- [Viewport meta element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Viewport_meta_element)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Mobile section of the report. Each page is reported with the zoom-blocking properties found. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Mobile section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/mobile/viewport.mdx
+++ b/docs/rules/mobile/viewport.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Viewport Meta"
-description: "Checks for proper viewport meta tag"
+title: "Missing viewport meta tag: what it does and what to set"
+description: "Without a viewport meta tag a phone renders the page at desktop width and zooms out. squirrel checks the tag and its content properties."
 ---
 
-Checks for proper viewport meta tag
+## What the viewport meta tag does
+
+`<meta name="viewport">` tells a mobile browser how wide to make the layout viewport. Without it, the browser assumes a desktop-width page, lays it out at around 980 pixels, and scales the result down to fit the screen, which is why an unstyled page looks like a shrunken desktop site.
+
+`width=device-width` sets the layout viewport to the device's own width, so CSS media queries measure what the user actually has. `initial-scale=1` sets the starting zoom so the two agree. Those two together are the whole tag for almost every site.
+
+## What squirrel checks
+
+The rule runs on every crawled page and looks for `meta[name="viewport"]`. It emits a single check named `viewport`, testing the `content` attribute by substring:
+
+- Fail when the tag is absent. Message: `Missing viewport meta tag`, with the recommended tag as the value. Severity error, weight 8.
+- Warn when `content` has no `width=` at all. Message: `Viewport missing width property`, with the content as the value.
+- Warn when it has a width that is not `width=device-width`. Message: `Viewport should use width=device-width`.
+- Info when it has `width=device-width` but no `initial-scale=`. Message: `Viewport missing initial-scale`.
+- Pass otherwise. Message: `Viewport meta tag is properly configured`.
+
+The checks are ordered, so only the first problem found is reported.
+
+## How to fix it
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+```
+
+Put it in the head of every page, usually in the base layout. Do not add `maximum-scale` or `user-scalable=no` alongside it: those disable zoom, which `mobile/viewport-zoom` reports separately.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for proper viewport meta tag
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-The viewport meta tag is essential for responsive design. Use: `<meta name='viewport' content='width=device-width, initial-scale=1'>`. This ensures proper scaling on mobile devices. Without it, mobile browsers render at desktop width and zoom out. Required for mobile-first indexing.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["mobile/*"]
 enable = ["mobile/viewport"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [mobile/viewport-zoom](/rules/mobile/viewport-zoom): the properties on the same tag that disable zoom.
+- [mobile/horizontal-scroll](/rules/mobile/horizontal-scroll): layout that overflows even with a correct viewport.
+- [content/meta-in-body](/rules/content/meta-in-body): a viewport tag that ended up outside the head.
+- [mobile/font-size](/rules/mobile/font-size): text sized for a desktop layout.
+
+Mobile findings ship in every audit next to the SEO, performance and agent experience rules. See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
+
+## References
+
+- [Viewport meta element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Viewport_meta_element)
+- [Page experience, Google Search Central](https://developers.google.com/search/docs/appearance/page-experience)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Mobile section of the report. Each page is reported with its viewport tag and what the content is missing. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Mobile section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/cookie-flags.mdx
+++ b/docs/rules/security/cookie-flags.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 ## Related rules
 
 - [security/third-party-cookies](/rules/security/third-party-cookies): cookies set by domains other than yours.
-- [legal/cookie-consent](/rules/legal/cookie-consent): whether the site asks before setting them.
+- [legal/cookie-consent](/rules/legal/cookie-consent): whether a cookie consent mechanism is present.
 - [security/https](/rules/security/https): the precondition for `Secure` to mean anything.
 - [security/csp](/rules/security/csp): the policy that limits the injected script `HttpOnly` protects against.
 

--- a/docs/rules/security/cookie-flags.mdx
+++ b/docs/rules/security/cookie-flags.mdx
@@ -17,7 +17,7 @@ The rule reads the `set-cookie` response header of each crawled page, splits it 
 - `cookie-samesite-none-insecure` fails when a cookie declares `SameSite=None` without `Secure`. Message: `1 cookie(s) set SameSite=None without Secure — modern browsers reject this combination`, with the cookie names listed.
 - `cookie-secure` warns when a cookie on an HTTPS page has no `Secure` attribute. Message: `2 cookie(s) missing the Secure flag`. The check is skipped on HTTP pages, where there is no secure connection to pin the cookie to.
 - `cookie-httponly` warns when a cookie has no `HttpOnly` attribute. Message: `2 cookie(s) missing the HttpOnly flag`.
-- `cookie-samesite` reports info when a cookie declares no `SameSite` at all. Message: `2 cookie(s) don't explicitly declare SameSite (browsers default to Lax)`.
+- `cookie-samesite` reports info when a cookie declares no `SameSite`, or declares it with an empty value such as `SameSite=`. Message: `2 cookie(s) don't explicitly declare SameSite (browsers default to Lax)`.
 - `cookie-flags` passes when cookies were set and none of the above fired. Message: `3 cookie(s) set with Secure, HttpOnly, and SameSite configured correctly`.
 
 Multiple cookies in one header value are split on newlines and on commas that are followed by a `name=` pair, so an `Expires` date containing a comma does not split a cookie in two. Only cookies your server sets in a response header are seen; cookies written by JavaScript are not.
@@ -30,7 +30,7 @@ Set-Cookie: session=abc123; Path=/; Secure; HttpOnly; SameSite=Lax
 
 Set the flags where the cookie is created, in the session middleware or the framework's cookie helper. Drop `HttpOnly` only for a cookie your own frontend genuinely reads, such as a CSRF token mirrored into the DOM. When you need `SameSite=None`, add `Secure` in the same change.
 
-An analytics or consent cookie written by a third-party script will show up without `HttpOnly` and cannot be changed from your side.
+Only cookies your server sets in a `Set-Cookie` response header are inspected. A cookie written by JavaScript, whether yours or a third party's, never reaches this rule.
 
 | | |
 |---|---|

--- a/docs/rules/security/cookie-flags.mdx
+++ b/docs/rules/security/cookie-flags.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Cookie Flags"
-description: "Checks Set-Cookie response headers for Secure, HttpOnly, and SameSite attributes"
+title: "Cookie flags: Secure, HttpOnly and SameSite on Set-Cookie"
+description: "SameSite=None without Secure is rejected outright, and a session cookie without HttpOnly is readable by any script. squirrel parses every Set-Cookie."
 ---
 
-Checks Set-Cookie response headers for Secure, HttpOnly, and SameSite attributes
+## What the cookie flags are
+
+`Set-Cookie` carries attributes that decide where a cookie may travel and who may read it. `Secure` stops the cookie being sent over plain HTTP. `HttpOnly` stops client-side JavaScript reading it, which closes the usual path from a cross-site scripting bug to a stolen session. `SameSite` decides whether the cookie rides along on requests started by other sites.
+
+Browsers now default an absent `SameSite` to `Lax`, so omitting it is weaker documentation rather than an open door. `SameSite=None` is the exception: it re-enables cross-site sending for cases like an embedded widget, and browsers reject the cookie entirely unless `Secure` is set alongside it.
+
+## What squirrel checks
+
+The rule reads the `set-cookie` response header of each crawled page, splits it into individual cookies, and emits these checks:
+
+- `cookie-flags` passes when the page sets no cookies at all. Message: `No cookies set on this page`.
+- `cookie-samesite-none-insecure` fails when a cookie declares `SameSite=None` without `Secure`. Message: `1 cookie(s) set SameSite=None without Secure — modern browsers reject this combination`, with the cookie names listed.
+- `cookie-secure` warns when a cookie on an HTTPS page has no `Secure` attribute. Message: `2 cookie(s) missing the Secure flag`. The check is skipped on HTTP pages, where there is no secure connection to pin the cookie to.
+- `cookie-httponly` warns when a cookie has no `HttpOnly` attribute. Message: `2 cookie(s) missing the HttpOnly flag`.
+- `cookie-samesite` reports info when a cookie declares no `SameSite` at all. Message: `2 cookie(s) don't explicitly declare SameSite (browsers default to Lax)`.
+- `cookie-flags` passes when cookies were set and none of the above fired. Message: `3 cookie(s) set with Secure, HttpOnly, and SameSite configured correctly`.
+
+Multiple cookies in one header value are split on newlines and on commas that are followed by a `name=` pair, so an `Expires` date containing a comma does not split a cookie in two. Only cookies your server sets in a response header are seen; cookies written by JavaScript are not.
+
+## How to fix it
+
+```
+Set-Cookie: session=abc123; Path=/; Secure; HttpOnly; SameSite=Lax
+```
+
+Set the flags where the cookie is created, in the session middleware or the framework's cookie helper. Drop `HttpOnly` only for a cookie your own frontend genuinely reads, such as a CSRF token mirrored into the DOM. When you need `SameSite=None`, add `Secure` in the same change.
+
+An analytics or consent cookie written by a third-party script will show up without `HttpOnly` and cannot be changed from your side.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks Set-Cookie response headers for Secure, HttpOnly, and SameSite attributes
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Cookies set by your server should carry the flags appropriate to their purpose. Secure stops a cookie from ever being sent over plain HTTP, so it can't be intercepted on a downgraded connection. HttpOnly stops client-side JavaScript from reading it, closing off a common XSS cookie-theft path — omit it only for cookies your own frontend genuinely needs to read. SameSite=Lax or SameSite=Strict blocks the cookie from being sent on cross-site requests, mitigating CSRF; if you need SameSite=None for a legitimate cross-site use case (e.g. an embedded widget), it must be paired with Secure or browsers will reject the cookie outright.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["security/*"]
 enable = ["security/cookie-flags"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/third-party-cookies](/rules/security/third-party-cookies): cookies set by domains other than yours.
+- [legal/cookie-consent](/rules/legal/cookie-consent): whether the site asks before setting them.
+- [security/https](/rules/security/https): the precondition for `Secure` to mean anything.
+- [security/csp](/rules/security/csp): the policy that limits the injected script `HttpOnly` protects against.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Set-Cookie, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie)
+- [Using HTTP cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies)
+- [Session management cheat sheet, OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every cookie missing a flag is listed by name and page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/csp.mdx
+++ b/docs/rules/security/csp.mdx
@@ -7,7 +7,7 @@ description: "A missing CSP, a report-only policy or an unsafe-inline script-src
 
 `Content-Security-Policy` is a response header that lists, per resource type, which origins a page is allowed to load from and whether inline code may run. The browser enforces it and blocks anything outside the policy. Its main job is to contain cross-site scripting: an injected `<script>` cannot execute if the policy has no matching source.
 
-A policy is only worth what its `script-src` says. `'unsafe-inline'` re-permits exactly the injected code CSP exists to stop, and a wildcard source lets any host serve executable code. `Content-Security-Policy-Report-Only` sends violation reports without blocking anything, which is the right way to develop a policy and the wrong way to ship one.
+A policy is only worth what its `script-src` says. `'unsafe-inline'` re-permits exactly the injected code CSP exists to stop, unless the same source list also carries a nonce or a hash, in which case browsers ignore it. A wildcard source lets any host serve executable code. `Content-Security-Policy-Report-Only` sends violation reports without blocking anything, which is the right way to develop a policy and the wrong way to ship one.
 
 ## What squirrel checks
 
@@ -23,7 +23,7 @@ The rule reads the response headers of the first crawled page and can emit sever
 - `csp-no-frame-ancestors` reports info when `frame-ancestors` is absent and no `X-Frame-Options` header is set either. Message: `CSP missing frame-ancestors directive`.
 - `csp-no-object-src` reports info when neither `object-src` nor `default-src` is declared. Message: `CSP missing object-src directive`.
 
-The effective script source is `script-src` when present, otherwise `default-src`. Severity is warning and the scope is site-wide.
+The effective script source is `script-src` when it is present and non-empty, otherwise `default-src`. Severity is warning and the scope is site-wide.
 
 ## How to fix it
 

--- a/docs/rules/security/csp.mdx
+++ b/docs/rules/security/csp.mdx
@@ -1,9 +1,39 @@
 ---
-title: "Content Security Policy"
-description: "Checks for Content-Security-Policy header and validates directives"
+title: "Content-Security-Policy: what to set and how to check it"
+description: "A missing CSP, a report-only policy or an unsafe-inline script-src leaves XSS unmitigated. squirrel parses the header and names each gap."
 ---
 
-Checks for Content-Security-Policy header and validates directives
+## What a Content Security Policy is
+
+`Content-Security-Policy` is a response header that lists, per resource type, which origins a page is allowed to load from and whether inline code may run. The browser enforces it and blocks anything outside the policy. Its main job is to contain cross-site scripting: an injected `<script>` cannot execute if the policy has no matching source.
+
+A policy is only worth what its `script-src` says. `'unsafe-inline'` re-permits exactly the injected code CSP exists to stop, and a wildcard source lets any host serve executable code. `Content-Security-Policy-Report-Only` sends violation reports without blocking anything, which is the right way to develop a policy and the wrong way to ship one.
+
+## What squirrel checks
+
+The rule reads the response headers of the first crawled page and can emit several checks:
+
+- `csp` skipped when the crawl produced no pages. Message: `No pages to check`.
+- `csp-missing` warns when neither `Content-Security-Policy` nor `Content-Security-Policy-Report-Only` is present. Message: `No Content-Security-Policy header`. No further checks run.
+- `csp-report-only` warns when only the report-only header is set. Message: `CSP in report-only mode (not enforced)`.
+- `csp-present` passes when the enforcing header is set. Message: `CSP header present and enforced`, with the first 100 characters of the policy as the value.
+- `csp-no-script-control` warns when the policy declares neither `script-src` nor `default-src`. Message: `CSP has no script-src or default-src directive`.
+- `csp-unsafe-scripts` warns when the effective script source contains `'unsafe-inline'` or `'unsafe-eval'`. Message: `CSP allows 'unsafe-inline' and 'unsafe-eval'`, naming whichever of the two it found.
+- `csp-wildcard` warns when that same source list contains `*`. Message: `CSP script-src allows wildcard (*)`.
+- `csp-no-frame-ancestors` reports info when `frame-ancestors` is absent and no `X-Frame-Options` header is set either. Message: `CSP missing frame-ancestors directive`.
+- `csp-no-object-src` reports info when neither `object-src` nor `default-src` is declared. Message: `CSP missing object-src directive`.
+
+The effective script source is `script-src` when present, otherwise `default-src`. Severity is warning and the scope is site-wide.
+
+## How to fix it
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-r4nd0m'; object-src 'none'; frame-ancestors 'self'
+```
+
+Set the header at the edge or in the application response, and generate a fresh nonce per response for the inline scripts you cannot remove. Develop the policy under `Content-Security-Policy-Report-Only` first, then move the same value to the enforcing header.
+
+A policy that legitimately allows a wildcard for images or fonts is not flagged. Only the script source list is checked for `*`, `'unsafe-inline'` and `'unsafe-eval'`.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks for Content-Security-Policy header and validates directives
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## Solution
-
-CSP prevents XSS attacks by restricting which resources can load. Start with a report-only policy to identify issues. Key directives: default-src 'self', script-src (avoid 'unsafe-inline'), img-src, style-src, frame-ancestors. Use nonces or hashes instead of 'unsafe-inline' for scripts. Test thoroughly as strict CSP can break functionality.
 
 ## Enable / disable
 
@@ -40,3 +66,31 @@ disable = ["security/*"]
 enable = ["security/csp"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/x-frame-options](/rules/security/x-frame-options): the older header that `frame-ancestors` replaces.
+- [security/sri](/rules/security/sri): per-file hashes for the third-party origins your policy allows.
+- [security/permissions-policy](/rules/security/permissions-policy): the companion header for device and browser features.
+- [security/leaked-secrets](/rules/security/leaked-secrets): what an attacker collects once a script does run.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Content-Security-Policy, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy)
+- [Content Security Policy Level 3, W3C](https://www.w3.org/TR/CSP3/)
+- [Mitigate cross-site scripting with a strict CSP, web.dev](https://web.dev/articles/strict-csp)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. The policy is parsed and each weak directive is named. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/form-captcha.mdx
+++ b/docs/rules/security/form-captcha.mdx
@@ -5,7 +5,7 @@ description: "A contact or newsletter form with no bot protection collects spam 
 
 ## What form CAPTCHA protection is
 
-A CAPTCHA is a challenge in front of a form submission that a script cannot answer cheaply. Modern implementations, including Cloudflare Turnstile, hCaptcha and reCAPTCHA v3, are usually invisible: they score the session in the background and only interrupt when the score is poor.
+A CAPTCHA is a challenge in front of a form submission that a script cannot answer cheaply. Modern implementations are usually invisible. reCAPTCHA v3 never interrupts the visitor at all: it returns a score and your server decides what to do with a low one. Cloudflare Turnstile and hCaptcha run a background check and show a challenge only when they need one.
 
 Any form that anyone on the internet can reach and that ends in an email or a database row is a target. Contact forms, comment boxes, newsletter signups and registration forms attract automated submissions within days of going live. A search box or a login form is a different problem: rate limiting and account lockout apply there, not a challenge on every keystroke.
 
@@ -20,7 +20,7 @@ The rule runs on every crawled page and emits a single check named `form-captcha
 
 A form is classified as excluded when it contains an `input[type="password"]` or when its `action`, `id`, `class` or `name` contains `search`, `login`, `signin`, `sign-in`, `admin`, `checkout` or `cart`. It is public when one of those attributes contains `contact`, `comment`, `feedback`, `newsletter`, `subscribe`, `register`, `signup`, `sign-up`, `inquiry`, `enquiry`, `request`, `support`, `message` or `email`, or when it holds a `<textarea>`, or an `input[type="email"]` with no password field. Anything else is unknown and is not checked.
 
-Protection is detected from the provider scripts, iframes and widget classes of reCAPTCHA, Turnstile, hCaptcha and Friendly Captcha, from their response fields such as `g-recaptcha-response`, from preload and modulepreload hints pointing at those scripts, from Shopify's `script#captcha-bootstrap` bootstrap, and from explicit-render containers whose id or class carries a provider token. FormShield is recognised from a `formshield.dev` script or a `data-fs-project-key` attribute and covers every public form on the page. A page-level signal only credits a public form when that form is the only public form on the page and no other form owns a widget of its own.
+Protection is detected from the provider scripts, iframes and widget classes of reCAPTCHA, Turnstile, hCaptcha and Friendly Captcha, from their response fields such as `g-recaptcha-response`, from preload and modulepreload hints pointing at those scripts, from Shopify's `script#captcha-bootstrap` bootstrap, and from explicit-render containers whose id or class carries a provider token. FormShield is recognised from a `script[src]` that either carries a `data-fs-project-key` attribute or points at `formshield.dev` or a subdomain of it with a path of `/js/formshield.js` or `/js/formshield.esm.js`, and it covers every public form on the page. A page-level signal only credits a public form when that form is the only public form on the page and no other form owns a widget of its own.
 
 ## How to fix it
 

--- a/docs/rules/security/form-captcha.mdx
+++ b/docs/rules/security/form-captcha.mdx
@@ -1,9 +1,41 @@
 ---
-title: "Form CAPTCHA"
-description: "Checks for CAPTCHA protection on public forms"
+title: "Public forms without CAPTCHA: what squirrel counts as public"
+description: "A contact or newsletter form with no bot protection collects spam within days. squirrel classifies forms and flags the unprotected public ones."
 ---
 
-Checks for CAPTCHA protection on public forms
+## What form CAPTCHA protection is
+
+A CAPTCHA is a challenge in front of a form submission that a script cannot answer cheaply. Modern implementations, including Cloudflare Turnstile, hCaptcha and reCAPTCHA v3, are usually invisible: they score the session in the background and only interrupt when the score is poor.
+
+Any form that anyone on the internet can reach and that ends in an email or a database row is a target. Contact forms, comment boxes, newsletter signups and registration forms attract automated submissions within days of going live. A search box or a login form is a different problem: rate limiting and account lockout apply there, not a challenge on every keystroke.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits a single check named `form-captcha`:
+
+- Info when the page contains no `<form>` at all. Message: `No forms on page`.
+- Info when no form on the page classifies as public. Message: `No public forms detected`.
+- Warn when at least one public form has no CAPTCHA signal. Message: `2 public form(s) without CAPTCHA`, with each form identified by its id, `name`, `action` or positional index. Severity warning.
+- Pass when every public form is covered. Message: `All 2 public form(s) have CAPTCHA`.
+
+A form is classified as excluded when it contains an `input[type="password"]` or when its `action`, `id`, `class` or `name` contains `search`, `login`, `signin`, `sign-in`, `admin`, `checkout` or `cart`. It is public when one of those attributes contains `contact`, `comment`, `feedback`, `newsletter`, `subscribe`, `register`, `signup`, `sign-up`, `inquiry`, `enquiry`, `request`, `support`, `message` or `email`, or when it holds a `<textarea>`, or an `input[type="email"]` with no password field. Anything else is unknown and is not checked.
+
+Protection is detected from the provider scripts, iframes and widget classes of reCAPTCHA, Turnstile, hCaptcha and Friendly Captcha, from their response fields such as `g-recaptcha-response`, from preload and modulepreload hints pointing at those scripts, from Shopify's `script#captcha-bootstrap` bootstrap, and from explicit-render containers whose id or class carries a provider token. FormShield is recognised from a `formshield.dev` script or a `data-fs-project-key` attribute and covers every public form on the page. A page-level signal only credits a public form when that form is the only public form on the page and no other form owns a widget of its own.
+
+## How to fix it
+
+```html
+<form action="/contact" method="post">
+  <textarea name="message"></textarea>
+  <div class="cf-turnstile" data-sitekey="0x4AAA..."></div>
+  <button type="submit">Send</button>
+</form>
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+```
+
+Put the widget inside the form it protects and verify the token server-side before accepting the submission. The client-side widget alone stops nothing.
+
+A form protected by something squirrel cannot see from the HTML, such as a server-side honeypot, a rate limiter or a challenge that only mounts after user interaction, still gets flagged. Disable the rule for that case rather than adding a widget you do not need.
 
 | | |
 |---|---|
@@ -12,14 +44,6 @@ Checks for CAPTCHA protection on public forms
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## What it detects
-
-Public-facing forms (contact, comment, newsletter, registration, etc.) with no detected CAPTCHA or bot-protection. Recognized providers: reCAPTCHA, Cloudflare Turnstile, hCaptcha, FriendlyCaptcha, and [FormShield](https://formshield.dev). FormShield protects an entire page invisibly via a single site-wide beacon script (no per-form widget), so its presence (the beacon script tag or its `data-fs-project-key` attribute) is treated as covering every public form on the page.
-
-## Solution
-
-Add CAPTCHA protection (reCAPTCHA, Cloudflare Turnstile, hCaptcha, FormShield, etc.) to public-facing forms to prevent spam and bot submissions. Contact forms, comment forms, newsletter signups, and registration forms are common targets for automated abuse. Modern solutions like Turnstile and FormShield offer invisible protection with minimal user friction.
 
 ## Enable / disable
 
@@ -44,3 +68,30 @@ disable = ["security/*"]
 enable = ["security/form-captcha"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/form-https](/rules/security/form-https): where the same forms submit to.
+- [a11y/form-labels](/rules/a11y/form-labels): whether those fields have accessible names.
+- [integrity/fake-auth-overlay](/rules/integrity/fake-auth-overlay): login prompts that were never yours.
+- [security/third-party-cookies](/rules/security/third-party-cookies): what the challenge provider loads alongside the widget.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Automated threats to web applications, OWASP](https://owasp.org/www-project-automated-threats-to-web-applications/)
+- [The form element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every unprotected public form is listed by page with its selector. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/form-captcha.mdx
+++ b/docs/rules/security/form-captcha.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Public forms without CAPTCHA: what squirrel counts as public"
+title: "Public forms without CAPTCHA: what counts as public"
 description: "A contact or newsletter form with no bot protection collects spam within days. squirrel classifies forms and flags the unprotected public ones."
 ---
 

--- a/docs/rules/security/form-https.mdx
+++ b/docs/rules/security/form-https.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Form HTTPS"
-description: "Checks that form actions use HTTPS"
+title: "Form action over HTTP: the insecure form submission warning"
+description: "A form on an HTTPS page that posts to http:// sends the data in the clear and browsers interstitial it. squirrel checks action and formaction."
 ---
 
-Checks that form actions use HTTPS
+## What an insecure form action is
+
+A form's `action` attribute is the URL the browser submits to. When that URL is `http://`, the field values travel unencrypted regardless of how the page itself was delivered. The padlock in the address bar describes the document, not the submission.
+
+The worst version is an HTTPS page with an HTTP action, because the user has every visual signal that the page is safe. Chrome and Firefox warn on it and may block the submission. A relative action such as `/subscribe` inherits the page's scheme and is safe on an HTTPS page, so only actions that carry their own scheme are worth checking. `formaction` on a submit button overrides the form's action and needs the same treatment.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits a single check named `form-https`. It collects every `<form action>` plus every `formaction` on a real submit control, meaning `button[formaction]` that is not `type="button"` or `type="reset"`, `input[type="submit"][formaction]` and `input[type="image"][formaction]`:
+
+- Fail when the page is HTTPS and at least one of those actions resolves to `http:`. Message: `2 form(s) on this HTTPS page submit to HTTP`, and each item is labelled `HTTPS page submits to <url> in the clear`. Severity error.
+- Warn when the page is not HTTPS and an action still resolves to `http:`. Message: `2 form(s) submit to HTTP`.
+- Pass when forms or submitters were found and none submit over HTTP. Message: `All forms use secure submission`.
+- Info when the page has no form actions at all. Message: `No forms detected`.
+
+Empty actions, fragment-only actions and the non-network schemes `javascript:`, `mailto:`, `tel:`, `sms:`, `data:`, `blob:` and `about:` are skipped. So are relative actions, because their scheme comes from the page and `security/https` already reports that. An action that fails to parse is still flagged when it literally begins with `http://`.
+
+## How to fix it
+
+```html
+<form action="https://example.com/subscribe" method="post">
+```
+
+Change the scheme at the source, or drop the origin entirely and use a relative action so the form follows the page. Check `formaction` on any submit button that overrides the form, since it is easy to miss in a template.
 
 | | |
 |---|---|
@@ -12,21 +35,6 @@ Checks that form actions use HTTPS
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 6/10 |
-
-## What it checks
-
-`form` `action` and submit-button `formaction` values are resolved against the page URL, so a relative or protocol-relative action inherits the page's scheme rather than being guessed at.
-
-| Outcome | When |
-|---|---|
-| `pass` | Every submission target resolves to HTTPS |
-| `warn` | A page already served over HTTP submits to `http://` |
-| `fail` | An HTTPS page submits to `http://`, downgrading the submission |
-| `info` | Nothing on the page submits anywhere |
-
-## Solution
-
-Forms should always submit to HTTPS URLs to protect user data in transit. Update form action attributes from http:// to https://, and check `formaction` on any submit button that overrides the form. A form on an HTTPS page that posts to http:// is the worst case: the padlock tells the user they are safe while the submission itself travels in the clear, and browsers block or interstitial it. Be especially careful with login forms, payment forms, and any forms collecting personal data. For relative URLs, ensure the page itself is on HTTPS.
 
 ## Enable / disable
 
@@ -51,3 +59,30 @@ disable = ["security/*"]
 enable = ["security/form-https"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/form-captcha](/rules/security/form-captcha): the same forms, checked for bot protection.
+- [security/https](/rules/security/https): the page scheme that a relative action inherits.
+- [security/mixed-content](/rules/security/mixed-content): subresources with the same downgrade problem.
+- [a11y/form-labels](/rules/a11y/form-labels): the accessibility pass over the same markup.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The form element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form)
+- [Mixed content, MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every insecure form action is listed by page with the form's selector and a markup snippet. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/form-https.mdx
+++ b/docs/rules/security/form-https.mdx
@@ -7,7 +7,7 @@ description: "A form on an HTTPS page that posts to http:// sends the data in th
 
 A form's `action` attribute is the URL the browser submits to. When that URL is `http://`, the field values travel unencrypted regardless of how the page itself was delivered. The padlock in the address bar describes the document, not the submission.
 
-The worst version is an HTTPS page with an HTTP action, because the user has every visual signal that the page is safe. Chrome and Firefox warn on it and may block the submission. A relative action such as `/subscribe` inherits the page's scheme and is safe on an HTTPS page, so only actions that carry their own scheme are worth checking. `formaction` on a submit button overrides the form's action and needs the same treatment.
+The worst version is an HTTPS page with an HTTP action, because the user has every visual signal that the page is safe. Chrome and Firefox warn on it and may block the submission. A relative action such as `/subscribe` resolves against the document base URL, which is the page URL unless a `<base href>` overrides it, so it is safe on an HTTPS page with no HTTP base. Only actions that carry their own scheme are checked. `formaction` on a submit button overrides the form's action and needs the same treatment.
 
 ## What squirrel checks
 
@@ -15,8 +15,8 @@ The rule runs on every crawled page and emits a single check named `form-https`.
 
 - Fail when the page is HTTPS and at least one of those actions resolves to `http:`. Message: `2 form(s) on this HTTPS page submit to HTTP`, and each item is labelled `HTTPS page submits to <url> in the clear`. Severity error.
 - Warn when the page is not HTTPS and an action still resolves to `http:`. Message: `2 form(s) submit to HTTP`.
-- Pass when forms or submitters were found and none submit over HTTP. Message: `All forms use secure submission`.
-- Info when the page has no form actions at all. Message: `No forms detected`.
+- Pass when at least one `action` or qualifying `formaction` was collected and none of them submit over HTTP. Message: `All forms use secure submission`.
+- Info when the page carries no `action` or `formaction` at all, even if it has `<form>` elements. Message: `No forms detected`.
 
 Empty actions, fragment-only actions and the non-network schemes `javascript:`, `mailto:`, `tel:`, `sms:`, `data:`, `blob:` and `about:` are skipped. So are relative actions, because their scheme comes from the page and `security/https` already reports that. An action that fails to parse is still flagged when it literally begins with `http://`.
 
@@ -26,7 +26,7 @@ Empty actions, fragment-only actions and the non-network schemes `javascript:`, 
 <form action="https://example.com/subscribe" method="post">
 ```
 
-Change the scheme at the source, or drop the origin entirely and use a relative action so the form follows the page. Check `formaction` on any submit button that overrides the form, since it is easy to miss in a template.
+Change the scheme at the source, or drop the origin entirely and use a relative action, which is safe as long as the document base URL is HTTPS. Check `formaction` on any submit button that overrides the form, since it is easy to miss in a template.
 
 | | |
 |---|---|

--- a/docs/rules/security/hsts.mdx
+++ b/docs/rules/security/hsts.mdx
@@ -1,9 +1,35 @@
 ---
-title: "HSTS Header"
-description: "Checks for HTTP Strict Transport Security header"
+title: "HSTS: what Strict-Transport-Security needs to be valid"
+description: "A missing or short Strict-Transport-Security header leaves the first request downgradeable. squirrel reads the header and checks max-age."
 ---
 
-Checks for HTTP Strict Transport Security header
+## What HSTS is
+
+HTTP Strict Transport Security is a response header, `Strict-Transport-Security`, that tells a browser to use HTTPS for this hostname for a stated number of seconds and to refuse a plain HTTP connection during that window. Once the browser has seen it, a user typing `example.com` never issues the HTTP request that a redirect would otherwise answer.
+
+The header only takes effect over HTTPS, and it is ignored on a plain HTTP response. `includeSubDomains` extends the policy to every subdomain, which will break any subdomain that is still HTTP-only. The first request before the header is ever seen is still downgradeable, which is what the preload list at hstspreload.org addresses.
+
+## What squirrel checks
+
+The rule reads the response headers of the first crawled page and emits a single check named `hsts`:
+
+- Skipped when the crawl produced no pages. Message: `No pages to check`.
+- Info when that page's URL is not HTTPS, since the header would be ignored. Message: `HSTS not applicable - site not served over HTTPS`.
+- Warn when the header is absent. Message: `Missing Strict-Transport-Security header`, with `Add: Strict-Transport-Security: max-age=31536000` as the value.
+- Warn when the header is present but contains no `max-age=<digits>` directive, which makes it inert. Message: `Malformed HSTS header — no valid max-age directive`.
+- Warn when `max-age=0`, which instructs browsers to drop the policy. Message: `HSTS disabled — max-age=0 tells browsers to stop enforcing HTTPS`.
+- Warn when `max-age` is below 15768000 seconds, six months. Message: `HSTS max-age too short (30 days)`, with the age rounded to whole days.
+- Pass otherwise. Message: `HSTS configured correctly`, with the raw header as the value.
+
+Severity is warning and the scope is site-wide, so the verdict comes from one page's headers rather than from every page.
+
+## How to fix it
+
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+```
+
+Set the header on the HTTPS origin, not on the HTTP redirect. Start with a short `max-age` while you confirm that every subdomain serves HTTPS, then raise it to a year. Adding `preload` is a separate, hard-to-reverse commitment: browsers ship the entry in their source, and removal takes months.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for HTTP Strict Transport Security header
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## Solution
-
-HSTS forces browsers to only connect via HTTPS, preventing downgrade attacks. Add the header: Strict-Transport-Security: max-age=31536000; includeSubDomains. Start with a short max-age (1 day) to test, then increase to 1 year. The includeSubDomains directive protects all subdomains. Consider preloading via hstspreload.org for maximum protection.
 
 ## Enable / disable
 
@@ -40,3 +62,31 @@ disable = ["security/*"]
 enable = ["security/hsts"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/https](/rules/security/https): whether the pages themselves are served over HTTPS in the first place.
+- [security/http-to-https](/rules/security/http-to-https): the redirect that HSTS eventually makes unnecessary.
+- [security/mixed-content](/rules/security/mixed-content): what breaks first when a subdomain is not ready for `includeSubDomains`.
+- [security/csp](/rules/security/csp): the other response header the same server block should be setting.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Strict-Transport-Security, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security)
+- [RFC 6797: HTTP Strict Transport Security](https://datatracker.ietf.org/doc/html/rfc6797)
+- [HTTP Strict Transport Security cheat sheet, OWASP](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. The Strict-Transport-Security header and its max-age are reported with the exact value your server sent. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/hsts.mdx
+++ b/docs/rules/security/hsts.mdx
@@ -29,7 +29,7 @@ Severity is warning and the scope is site-wide, so the verdict comes from one pa
 Strict-Transport-Security: max-age=31536000; includeSubDomains
 ```
 
-Set the header on the HTTPS origin, not on the HTTP redirect. Start with a short `max-age` while you confirm that every subdomain serves HTTPS, then raise it to a year. Adding `preload` is a separate, hard-to-reverse commitment: browsers ship the entry in their source, and removal takes months.
+Set the header on the HTTPS origin, not on the HTTP redirect. Start with a short `max-age` while you confirm that every subdomain serves HTTPS, then raise it to a year. The `preload` token is consent, not enrolment: the hostname joins the browser preload list only after you submit it at hstspreload.org and it is accepted. Getting an accepted entry removed again takes months, so treat submission as the hard-to-reverse step.
 
 | | |
 |---|---|

--- a/docs/rules/security/http-to-https.mdx
+++ b/docs/rules/security/http-to-https.mdx
@@ -19,7 +19,7 @@ The rule is site-wide and makes live network requests. It builds a sample of sam
 - Warn when at least one probed URL redirects to HTTPS. Message: `12 HTTP URL(s) redirect to HTTPS`, with each entry labelled `http://example.com/ → https://example.com/ (301)`.
 - Pass when none do. Message: `No HTTP to HTTPS redirects detected in sample`.
 
-Read the warn status as an inventory rather than a defect: it lists the HTTP URLs that are still reachable and redirecting. Probes run five at a time with a 100 ms stagger, each hop times out after 10 seconds, chains stop at 10 hops, and the whole probe is capped at 20 seconds of wall clock. When the budget runs out the rule reports on the subset it managed to probe. Redirect loops are skipped.
+Read the warn status as an inventory rather than a defect: it lists the HTTP URLs that are still reachable and redirecting. Probes run five at a time with a 100 ms stagger, each hop times out after 10 seconds and chains stop at 10 hops. A 20 second budget stops workers picking up new URLs, so the rule reports on the subset it started; probes already in flight are still awaited and can finish after the budget expires. Redirect loops are skipped.
 
 ## How to fix it
 

--- a/docs/rules/security/http-to-https.mdx
+++ b/docs/rules/security/http-to-https.mdx
@@ -1,9 +1,37 @@
 ---
-title: "HTTP to HTTPS Redirect"
-description: "Checks whether HTTP URLs redirect to HTTPS"
+title: "HTTP to HTTPS redirect: how squirrel probes for it"
+description: "squirrel requests the http:// version of a sample of your URLs and reports which ones redirect to HTTPS, with the status code of the first hop."
 ---
 
-Checks whether HTTP URLs redirect to HTTPS
+## What an HTTP to HTTPS redirect is
+
+An HTTP to HTTPS redirect is a response on port 80 that sends the client to the `https://` form of the same URL. It exists because links, bookmarks and typed addresses still arrive over plain HTTP, and without a redirect they either fail or serve a duplicate copy of the site on an insecure origin.
+
+Search engines treat `http://example.com/page` and `https://example.com/page` as separate URLs. A permanent redirect consolidates them and keeps the HTTPS version as the indexed one. HSTS eventually removes the need for the redirect in browsers that have already seen the header, but the redirect is what handles the first visit and every non-browser client.
+
+## What squirrel checks
+
+The rule is site-wide and makes live network requests. It builds a sample of same-hostname URLs starting with the base URL, adds crawled pages whose status code is under 400 until the sample limit is reached, rewrites each to `http://` and follows the redirect chain. It emits a single check named `http-to-https`:
+
+- Skipped when there is no base URL. Message: `No base URL available`.
+- Skipped when the base URL does not parse. Message: `Invalid base URL`.
+- Skipped when the base URL is not HTTPS. Message: `Base URL is not HTTPS`.
+- Warn when at least one probed URL redirects to HTTPS. Message: `12 HTTP URL(s) redirect to HTTPS`, with each entry labelled `http://example.com/ → https://example.com/ (301)`.
+- Pass when none do. Message: `No HTTP to HTTPS redirects detected in sample`.
+
+Read the warn status as an inventory rather than a defect: it lists the HTTP URLs that are still reachable and redirecting. Probes run five at a time with a 100 ms stagger, each hop times out after 10 seconds, chains stop at 10 hops, and the whole probe is capped at 20 seconds of wall clock. When the budget runs out the rule reports on the subset it managed to probe. Redirect loops are skipped.
+
+## How to fix it
+
+```nginx
+server {
+  listen 80;
+  server_name example.com www.example.com;
+  return 301 https://example.com$request_uri;
+}
+```
+
+Redirect in one hop, preserving the path and query string, and use 301 rather than 302 so the target is the canonical URL. Chaining HTTP to HTTPS to a canonical host costs a round trip on every first visit.
 
 | | |
 |---|---|
@@ -13,23 +41,17 @@ Checks whether HTTP URLs redirect to HTTPS
 | **Severity** | warning |
 | **Weight** | 3/10 |
 
-## Solution
-
-Ensure all HTTP URLs redirect to their HTTPS equivalents using permanent (301) redirects. This consolidates link equity and avoids mixed indexing. Configure your server to enforce HTTPS globally and verify that both the homepage and key internal URLs redirect correctly. WARNING: This rule makes external HTTP requests to probe redirect behavior.
-
 ## Options
-
-This rule supports the following configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `sampleLimit` | unknown | `undefined` | Maximum number of pages to probe for HTTP→HTTPS redirects |
+| `sampleLimit` | integer, 1 to 100 | `20` | Maximum number of pages to probe for HTTP to HTTPS redirects |
 
 ### Configuration example
 
 ```toml squirrel.toml
-[rules."security/http-to-https"]
-sampleLimit = undefined
+[rule_options."security/http-to-https"]
+sampleLimit = 40
 ```
 
 ## Enable / disable
@@ -55,3 +77,30 @@ disable = ["security/*"]
 enable = ["security/http-to-https"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/https](/rules/security/https): the pages themselves, checked without any network probe.
+- [security/hsts](/rules/security/hsts): the header that lets browsers skip the redirect entirely.
+- [crawl/redirect-chain](/rules/crawl/redirect-chain): multi-hop chains, including the ones this redirect can create.
+- [links/https-downgrade](/rules/links/https-downgrade): internal links that make the browser take the redirect on every click.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Redirections in HTTP, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Redirections)
+- [301 redirects and Google Search, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/301-redirects)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Each probed HTTP URL is listed with its destination and status code. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/https.mdx
+++ b/docs/rules/security/https.mdx
@@ -1,9 +1,35 @@
 ---
-title: "HTTPS"
-description: "Checks for HTTPS usage"
+title: "HTTPS: what it means when a page is not served over HTTPS"
+description: "A page delivered over plain HTTP can be read and rewritten in transit. squirrel flags every crawled URL whose protocol is not https."
 ---
 
-Checks for HTTPS usage
+## What HTTPS is
+
+HTTPS is HTTP carried inside a TLS connection. It encrypts the request and the response, and it proves to the browser that the server holding the certificate is the one that owns the hostname. Without it, anything between the user and the server can read the page and change it before it arrives.
+
+It is not optional infrastructure any more. Browsers mark plain HTTP pages as not secure, block most powerful web APIs on them, and Google treats HTTPS as a ranking signal. Certificates are free from Let's Encrypt and issued automatically by most hosts.
+
+## What squirrel checks
+
+The rule parses the URL of each crawled page and emits a single check named `https`:
+
+- Fail when the parsed protocol is anything other than `https:`. Report message: `Page not served over HTTPS`, with the page's actual protocol as the value and `https:` as the expected value. Severity error.
+- Pass when the protocol is `https:`. Message: `Page served over HTTPS`.
+- Fail when the URL cannot be parsed at all. Message: `Invalid URL format`, with the raw URL as the value.
+
+The check is per-page, so a site that has migrated but still links to a handful of `http://` URLs internally shows those pages individually rather than one site-wide verdict.
+
+## How to fix it
+
+```nginx
+server {
+  listen 80;
+  server_name example.com;
+  return 301 https://example.com$request_uri;
+}
+```
+
+Issue a certificate, serve the site on 443, then send a permanent redirect for every HTTP URL. After the switch, update internal links, canonical tags and the sitemap to the `https://` form, and re-audit for mixed content.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for HTTPS usage
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-HTTPS encrypts data between users and your server, protecting sensitive information. It's a ranking signal and required for many modern browser features. Migrate to HTTPS by obtaining an SSL certificate (free from Let's Encrypt). Update internal links to use https://. Set up 301 redirects from HTTP to HTTPS. Update your canonical URLs and sitemap. Check for mixed content warnings after migration.
 
 ## Enable / disable
 
@@ -40,3 +62,31 @@ disable = ["security/*"]
 enable = ["security/https"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/http-to-https](/rules/security/http-to-https): whether the HTTP versions of your URLs redirect to HTTPS at all.
+- [security/hsts](/rules/security/hsts): the header that stops the browser from trying HTTP again.
+- [security/mixed-content](/rules/security/mixed-content): HTTPS pages that still pull assets over HTTP.
+- [links/https-downgrade](/rules/links/https-downgrade): internal links that point back at `http://`.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [HTTPS, MDN glossary](https://developer.mozilla.org/en-US/docs/Glossary/HTTPS)
+- [Why HTTPS matters, web.dev](https://web.dev/articles/why-https-matters)
+- [Transport Layer Security, MDN implementation guide](https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/TLS)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every page that is not served over HTTPS is listed by page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/index.mdx
+++ b/docs/rules/security/index.mdx
@@ -4,10 +4,7 @@ description: "The Security score group: transport security, compromise signals, 
 icon: "shield-check"
 ---
 
-Security is one of the four score groups on every report. It spans four
-categories: transport and header hardening (this page), signs of compromise,
-legal compliance signals, and content blocked by ad blockers and privacy
-filters.
+Security is one of the four score groups on every report. This page covers transport and header hardening: HTTPS, response headers, cookie flags, form submission and secrets that reached the browser. Signs of compromise, legal compliance signals and content blocked by privacy filters are scored in the same group but documented in the categories below.
 
 ## Categories
 
@@ -84,3 +81,5 @@ HTTPS, headers, and safe link practices (16 rules).
 [rules]
 disable = ["security/*"]
 ```
+
+Every audit reports Security findings next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/security/index.mdx
+++ b/docs/rules/security/index.mdx
@@ -25,53 +25,53 @@ Security is one of the four score groups on every report. This page covers trans
 HTTPS, headers, and safe link practices (16 rules).
 
 <CardGroup cols={2}>
-  <Card title="Content Security Policy" icon="triangle-exclamation" href="/rules/security/csp">
-    Checks for Content-Security-Policy header and validates directives
+  <Card title="Content-Security-Policy: what to set and how to check it" icon="triangle-exclamation" href="/rules/security/csp">
+    A missing CSP, a report-only policy or an unsafe-inline script-src leaves XSS unmitigated. squirrel parses the header and names each gap.
   </Card>
-  <Card title="Cookie Flags" icon="triangle-exclamation" href="/rules/security/cookie-flags">
-    Checks Set-Cookie response headers for Secure, HttpOnly, and SameSite attributes
+  <Card title="Cookie flags: Secure, HttpOnly and SameSite on Set-Cookie" icon="triangle-exclamation" href="/rules/security/cookie-flags">
+    SameSite=None without Secure is rejected outright, and a session cookie without HttpOnly is readable by any script. squirrel parses every Set-Cookie.
   </Card>
-  <Card title="External Link Security" icon="triangle-exclamation" href="/rules/security/new-tab">
-    Checks external target=_blank links for noopener (security) and noreferrer (privacy)
+  <Card title="rel=noopener: external target=_blank links and tabnabbing" icon="triangle-exclamation" href="/rules/security/new-tab">
+    An external link with target=_blank and no rel gives the opened page a handle on yours. squirrel lists every one, per page.
   </Card>
-  <Card title="Form CAPTCHA" icon="triangle-exclamation" href="/rules/security/form-captcha">
-    Checks for CAPTCHA protection on public forms
+  <Card title="Public forms without CAPTCHA: what counts as public" icon="triangle-exclamation" href="/rules/security/form-captcha">
+    A contact or newsletter form with no bot protection collects spam within days. squirrel classifies forms and flags the unprotected public ones.
   </Card>
-  <Card title="Form HTTPS" icon="triangle-exclamation" href="/rules/security/form-https">
-    Checks that form actions use HTTPS
+  <Card title="Form action over HTTP: the insecure form submission warning" icon="triangle-exclamation" href="/rules/security/form-https">
+    A form on an HTTPS page that posts to http:// sends the data in the clear and browsers interstitial it. squirrel checks action and formaction.
   </Card>
-  <Card title="HSTS Header" icon="triangle-exclamation" href="/rules/security/hsts">
-    Checks for HTTP Strict Transport Security header
+  <Card title="HSTS: what Strict-Transport-Security needs to be valid" icon="triangle-exclamation" href="/rules/security/hsts">
+    A missing or short Strict-Transport-Security header leaves the first request downgradeable. squirrel reads the header and checks max-age.
   </Card>
-  <Card title="HTTP to HTTPS Redirect" icon="triangle-exclamation" href="/rules/security/http-to-https">
-    Checks whether HTTP URLs redirect to HTTPS
+  <Card title="HTTP to HTTPS redirect: how squirrel probes for it" icon="triangle-exclamation" href="/rules/security/http-to-https">
+    squirrel requests the http:// version of a sample of your URLs and reports which ones redirect to HTTPS, with the status code of the first hop.
   </Card>
-  <Card title="HTTPS" icon="circle-exclamation" href="/rules/security/https">
-    Checks for HTTPS usage
+  <Card title="HTTPS: what it means when a page is not served over HTTPS" icon="circle-exclamation" href="/rules/security/https">
+    A page delivered over plain HTTP can be read and rewritten in transit. squirrel flags every crawled URL whose protocol is not https.
   </Card>
-  <Card title="Leaked Environment Variables" icon="circle-exclamation" href="/rules/security/leaked-secrets">
-    Checks for exposed API keys, secrets, and credentials in HTML/JS
+  <Card title="Leaked API key in client-side code: how to find one" icon="circle-exclamation" href="/rules/security/leaked-secrets">
+    An API key shipped in HTML or a bundle can be read by anyone who views source. squirrel scans every page and script against 87 key patterns.
   </Card>
-  <Card title="Mixed Content" icon="circle-exclamation" href="/rules/security/mixed-content">
-    Checks for HTTP resources on HTTPS pages
+  <Card title="Mixed content: HTTP resources on an HTTPS page" icon="circle-exclamation" href="/rules/security/mixed-content">
+    An HTTPS page that loads a script or stylesheet over HTTP is not secure and browsers block it. squirrel lists every HTTP resource per page.
   </Card>
-  <Card title="Permissions-Policy" icon="circle-info" href="/rules/security/permissions-policy">
-    Checks for Permissions-Policy (Feature-Policy) header
+  <Card title="Permissions-Policy: what the header does and how to set it" icon="circle-info" href="/rules/security/permissions-policy">
+    Without a Permissions-Policy, embedded frames inherit access to camera, microphone and geolocation. squirrel reads the header once per site.
   </Card>
-  <Card title="Referrer-Policy" icon="circle-info" href="/rules/security/referrer-policy">
-    Checks for Referrer-Policy header
+  <Card title="Referrer-Policy: which value to send and what leaks" icon="circle-info" href="/rules/security/referrer-policy">
+    unsafe-url sends the full URL, query string included, to every site you link to. squirrel reads the header and flags the leaky values.
   </Card>
-  <Card title="Subresource Integrity" icon="triangle-exclamation" href="/rules/security/sri">
-    Checks that cross-origin scripts and stylesheets use Subresource Integrity (SRI)
+  <Card title="Subresource Integrity: which scripts need an integrity hash" icon="triangle-exclamation" href="/rules/security/sri">
+    Cross-origin scripts and stylesheets with no integrity hash can be swapped by a compromised CDN. squirrel lists every one, page by page.
   </Card>
-  <Card title="Third-Party Cookies" icon="circle-info" href="/rules/security/third-party-cookies">
-    Detects third-party resources that may set cookies
+  <Card title="Third-party cookies: which external domains a page loads" icon="circle-info" href="/rules/security/third-party-cookies">
+    Trackers and 1x1 pixels set cookies from domains you do not control. squirrel inventories the third-party scripts, iframes and pixels per page.
   </Card>
-  <Card title="X-Content-Type-Options" icon="circle-info" href="/rules/security/x-content-type">
-    Checks for MIME type sniffing protection
+  <Card title="X-Content-Type-Options: nosniff and why it matters" icon="circle-info" href="/rules/security/x-content-type">
+    Without nosniff a browser may execute an uploaded file as script because the bytes look like one. squirrel reads the header once per site.
   </Card>
-  <Card title="X-Frame-Options" icon="triangle-exclamation" href="/rules/security/x-frame-options">
-    Checks for clickjacking protection header
+  <Card title="X-Frame-Options: how to stop your pages being framed" icon="triangle-exclamation" href="/rules/security/x-frame-options">
+    With no X-Frame-Options and no frame-ancestors, any site can iframe your pages and overlay them. squirrel checks both headers together.
   </Card>
 </CardGroup>
 

--- a/docs/rules/security/leaked-secrets.mdx
+++ b/docs/rules/security/leaked-secrets.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Leaked Environment Variables"
-description: "Checks for exposed API keys, secrets, and credentials in HTML/JS"
+title: "Leaked API key in client-side code: how to find one"
+description: "An API key shipped in HTML or a bundle can be read by anyone who views source. squirrel scans every page and script against 87 key patterns."
 ---
 
-Checks for exposed API keys, secrets, and credentials in HTML/JS
+## What a leaked secret is
+
+A leaked secret is a credential that reaches the browser: an API key in a bundle, a database connection string in server-rendered HTML, a token in an inline script. Anything the browser can load, anyone can read, and automated scrapers do read it. A leaked key is used within hours of being published.
+
+Not every key in client-side code is a leak. Stripe publishable keys, Firebase and Google browser keys, OAuth client IDs, Supabase anon keys and Sentry DSNs are designed to ship publicly and are safe as long as their server-side restrictions are configured. The dangerous ones are secret keys, service-role keys, personal access tokens and anything with a database password in it.
+
+## What squirrel checks
+
+The rule scans the HTML of every crawled page, every inline `<script>`, and the content of external JavaScript files the crawl fetched. It matches against 87 patterns covering AI providers, cloud platforms, payment processors, databases, source hosts, messaging services and generic assignments such as `api_key = "..."`. Findings are deduplicated by value across the whole site, and each reported value is masked. It emits these checks:
+
+- `leaked-secrets-high` fails when a high-confidence pattern matched. Message: `2 high-confidence leaked secret(s) detected`. Each item reads as the pattern name plus the masked value, labelled `Found in inline-script (https://example.com/page)`. Severity error.
+- `leaked-secrets-medium` warns on medium-confidence matches, which are mostly the generic assignment patterns. Message: `4 potential secret(s) detected (verify manually)`.
+- `leaked-secrets-public` reports info for keys that are public by design. Message: `3 public client-side key(s) found (public by design — verify usage restrictions are configured)`. These never count as leaks.
+- `leaked-secrets` passes when no high- or medium-confidence match remains. Message: `No leaked API keys or secrets detected`.
+
+The location on each item is `html`, `inline-script` or `external-script`. Masking keeps the first six and last four characters when the value is longer than twelve, and the first four otherwise, so the report identifies the key without republishing it. Weight is 10, the highest of any rule in the Security category.
+
+## How to fix it
+
+```js
+// server route, not the client bundle
+const res = await fetch("https://api.example.com/v1/data", {
+  headers: { Authorization: `Bearer ${process.env.EXAMPLE_SECRET_KEY}` },
+});
+```
+
+Move the call behind an endpoint you control and read the key from an environment variable that the bundler never inlines. In a framework with a public-variable prefix, check that the leaked name does not carry it. Rotate the exposed credential before anything else: it has been public for as long as the page has.
+
+A medium-confidence hit on a variable named `apiKey` holding a placeholder is a false positive. Confirm the value before rotating.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks for exposed API keys, secrets, and credentials in HTML/JS
 | **Scope** | Site-wide |
 | **Severity** | error |
 | **Weight** | 10/10 |
-
-## Solution
-
-API keys and secrets exposed in client-side code can be harvested by attackers to access your services, incur charges, or steal data. Move sensitive credentials to server-side code and use environment variables that are NOT exposed to the browser. For frontend apps, use a backend proxy to make authenticated API calls. Rotate any exposed credentials immediately. Consider using secret scanning tools like Gitleaks or TruffleHog in your CI/CD pipeline to prevent future leaks.
 
 ## Enable / disable
 
@@ -40,3 +64,29 @@ disable = ["security/*"]
 enable = ["security/leaked-secrets"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/dev-leakage](/rules/content/dev-leakage): staging URLs, stack traces and debug output in the same responses.
+- [integrity/obfuscated-script](/rules/integrity/obfuscated-script): injected code that would use a key it finds.
+- [security/csp](/rules/security/csp): the policy that limits which scripts run at all.
+- [security/sri](/rules/security/sri): integrity hashes on the third-party bundles the scan reads.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Secrets management cheat sheet, OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every match is listed with its pattern name, masked value and the page or script it came from. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/mixed-content.mdx
+++ b/docs/rules/security/mixed-content.mdx
@@ -7,7 +7,7 @@ description: "An HTTPS page that loads a script or stylesheet over HTTP is not s
 
 Mixed content is an HTTPS page that pulls in a subresource over plain HTTP. The document arrives encrypted, the subresource does not, and anything in the network path can read or replace it. A tampered script has the same power as any other script on the page.
 
-Browsers treat the two halves differently. Active content, meaning scripts, stylesheets, frames and workers, is blocked outright. Passive content, meaning images, audio and video, is upgraded to HTTPS where possible and blocked when the upgrade fails. Either way the padlock is downgraded and the resource may not load, so mixed content shows up as a broken page before it shows up as a security report.
+Browsers treat the two halves differently. Active content, meaning scripts, stylesheets, frames and workers, is blocked outright. Passive content, meaning images, audio and video, is usually upgraded to HTTPS and blocked when the upgrade fails. Some requests are blocked rather than upgraded, including `srcset` and `<picture>` images and anything on an IP-literal host. What a visitor notices first is a missing asset, so mixed content tends to surface as a broken page before it surfaces as a security report.
 
 ## What squirrel checks
 

--- a/docs/rules/security/mixed-content.mdx
+++ b/docs/rules/security/mixed-content.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Mixed Content"
-description: "Checks for HTTP resources on HTTPS pages"
+title: "Mixed content: HTTP resources on an HTTPS page"
+description: "An HTTPS page that loads a script or stylesheet over HTTP is not secure and browsers block it. squirrel lists every HTTP resource per page."
 ---
 
-Checks for HTTP resources on HTTPS pages
+## What mixed content is
+
+Mixed content is an HTTPS page that pulls in a subresource over plain HTTP. The document arrives encrypted, the subresource does not, and anything in the network path can read or replace it. A tampered script has the same power as any other script on the page.
+
+Browsers treat the two halves differently. Active content, meaning scripts, stylesheets, frames and workers, is blocked outright. Passive content, meaning images, audio and video, is upgraded to HTTPS where possible and blocked when the upgrade fails. Either way the padlock is downgraded and the resource may not load, so mixed content shows up as a broken page before it shows up as a security report.
+
+## What squirrel checks
+
+The rule runs on every crawled page and emits a single check named `mixed-content`:
+
+- Info when the page URL does not start with `https://`, since the concept does not apply. Message: `Mixed content check not applicable - page not HTTPS`.
+- Fail when the HTML contains any element whose `src`, `href` or `data` attribute literally starts with `http://`. Message: `3 HTTP resource(s) on HTTPS page`, with each URL listed. Severity error.
+- Pass when none do. Message: `No mixed content detected`.
+
+The selectors are `img[src]`, `script[src]`, `link[href]`, `iframe[src]`, `video[src]`, `audio[src]`, `source[src]`, `embed[src]` and `object[data]`. The match is on the literal `http://` prefix in the markup, so protocol-relative URLs such as `//cdn.example.com/x.js` are not flagged, and neither are HTTP URLs that only appear in inline scripts or CSS.
+
+## How to fix it
+
+```html
+<script src="https://cdn.example.com/lib.js"></script>
+```
+
+Change the URL to `https://` at the source, in the template or the CMS field that produced it. For a large legacy corpus, `Content-Security-Policy: upgrade-insecure-requests` makes the browser rewrite the requests while you work through the markup, but it is a mitigation rather than the fix.
+
+A third-party host that has no HTTPS endpoint cannot be upgraded. Self-host the asset or drop it.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for HTTP resources on HTTPS pages
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Mixed content occurs when an HTTPS page loads resources over HTTP, breaking the security chain. Browsers may block these resources. Update all resource URLs to use HTTPS or protocol-relative URLs (//example.com). Check images, scripts, stylesheets, fonts, and iframes. Use Content-Security-Policy: upgrade-insecure-requests to automatically upgrade HTTP to HTTPS.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["security/*"]
 enable = ["security/mixed-content"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/https](/rules/security/https): whether the page itself is HTTPS before its subresources matter.
+- [links/https-downgrade](/rules/links/https-downgrade): navigation links, rather than subresources, that point at `http://`.
+- [security/sri](/rules/security/sri): integrity hashes for the cross-origin assets that remain.
+- [images/broken-images](/rules/images/broken-images): images that fail to load, which is how blocked mixed content usually surfaces.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Mixed content, MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)
+- [What is mixed content, web.dev](https://web.dev/articles/what-is-mixed-content)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every HTTP resource is listed by page with its URL. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/new-tab.mdx
+++ b/docs/rules/security/new-tab.mdx
@@ -1,9 +1,33 @@
 ---
-title: "External Link Security"
-description: "Checks external target=_blank links for noopener (security) and noreferrer (privacy)"
+title: "rel=noopener: external target=_blank links and tabnabbing"
+description: "An external link with target=_blank and no rel gives the opened page a handle on yours. squirrel lists every one, per page."
 ---
 
-Checks external target=_blank links for noopener (security) and noreferrer (privacy)
+## What rel="noopener" is
+
+`rel="noopener"` on a link tells the browser not to give the newly opened document a `window.opener` reference back to the page that opened it. Without it, the destination can call `window.opener.location = "..."` and silently replace the tab the user came from with a copy of your login page. That attack is called tabnabbing.
+
+`rel="noreferrer"` is the privacy half: it stops the `Referer` header and `window.opener` both, so the destination never learns which page sent the user. Browsers have applied `noopener` implicitly to `target="_blank"` since 2021, which makes the attribute a compatibility measure rather than the only defence. `noreferrer` has no such default.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `a[href][target="_blank"]` whose resolved hostname differs from the page hostname, and emits up to three checks:
+
+- `noopener` warns when at least one such link has a `rel` that does not contain `noopener`. Message: `4 external link(s) missing rel="noopener"`, with each href listed. It passes instead when every external `_blank` link has it, with message `4 external _blank link(s) have noopener`.
+- `noreferrer` reports info on the same basis for `noreferrer`. Message: `4 external link(s) missing rel="noreferrer"`. The pass message is `4 external _blank link(s) have noreferrer`.
+- `new-tab-security` reports info when the page has no external `_blank` links at all. Message: `No external target="_blank" links found`.
+
+The `rel` value is lowercased and matched as a substring, and hrefs that do not parse as URLs are skipped. Severity for the rule is warning.
+
+## How to fix it
+
+```html
+<a href="https://example.org/docs" target="_blank" rel="noopener noreferrer">Docs</a>
+```
+
+Add both tokens in the template or the component that renders external links, not link by link. If the site uses a Markdown renderer, most support a config option that adds the attributes to every external link.
+
+Dropping `noreferrer` is a legitimate choice when an affiliate or partner needs the referrer for attribution. Keep `noopener` in that case.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks external target=_blank links for noopener (security) and noreferrer (priv
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-External links with target="_blank" should include rel="noopener noreferrer". noopener prevents the opened page from accessing window.opener (tab-nabbing attacks). noreferrer prevents leaking the referrer URL to the destination site (privacy). Modern browsers default noopener for target="_blank", but explicit attributes ensure compatibility.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["security/*"]
 enable = ["security/new-tab"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/referrer-policy](/rules/security/referrer-policy): the site-wide version of what `noreferrer` does per link.
+- [links/external-links](/rules/links/external-links): how many external links a page carries and where they go.
+- [links/broken-external-links](/rules/links/broken-external-links): whether those destinations still resolve.
+- [integrity/known-malicious-url](/rules/integrity/known-malicious-url): outbound links to hosts that should not be there at all.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [rel=noopener, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noopener)
+- [Link type noopener, HTML Standard](https://html.spec.whatwg.org/multipage/links.html#link-type-noopener)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every external new-tab link missing the attribute is listed by page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/permissions-policy.mdx
+++ b/docs/rules/security/permissions-policy.mdx
@@ -7,7 +7,7 @@ description: "Without a Permissions-Policy, embedded frames inherit access to ca
 
 `Permissions-Policy` is a response header that lists which browser features the page and anything it embeds may use. Each entry names a feature and an allowlist of origins, so `camera=()` disables the camera entirely and `geolocation=(self)` limits it to your own origin.
 
-It matters most on pages that embed third-party frames, because an iframe otherwise inherits the permissions of the top-level document and can prompt the user in your name. The header was called `Feature-Policy` until 2020 and the old name still parses in some browsers, with a different syntax.
+It matters most on pages that embed third-party frames. A cross-origin frame gets no camera, microphone or geolocation access unless you delegate it, and the header is where you decide which features are available to delegate at all. The header was called `Feature-Policy` until 2020 and the old name still parses in some browsers, with a different syntax.
 
 ## What squirrel checks
 
@@ -26,7 +26,7 @@ The policy is not parsed and individual directives are not validated. Severity i
 Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
 ```
 
-Set it on HTML responses. Empty parentheses disable a feature for the document and every frame inside it. Name your own origin, as in `geolocation=(self)`, for the features the page genuinely uses, and add an embedded partner's origin explicitly when they need one.
+Set it on HTML responses. Empty parentheses disable a feature for the document and every frame inside it. Name your own origin, as in `geolocation=(self)`, for the features the page genuinely uses. Delegating a feature to an embedded partner takes two steps: list their origin in the header and add a matching `allow` attribute on the iframe.
 
 | | |
 |---|---|

--- a/docs/rules/security/permissions-policy.mdx
+++ b/docs/rules/security/permissions-policy.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Permissions-Policy"
-description: "Checks for Permissions-Policy (Feature-Policy) header"
+title: "Permissions-Policy: what the header does and how to set it"
+description: "Without a Permissions-Policy, embedded frames inherit access to camera, microphone and geolocation. squirrel reads the header once per site."
 ---
 
-Checks for Permissions-Policy (Feature-Policy) header
+## What Permissions-Policy is
+
+`Permissions-Policy` is a response header that lists which browser features the page and anything it embeds may use. Each entry names a feature and an allowlist of origins, so `camera=()` disables the camera entirely and `geolocation=(self)` limits it to your own origin.
+
+It matters most on pages that embed third-party frames, because an iframe otherwise inherits the permissions of the top-level document and can prompt the user in your name. The header was called `Feature-Policy` until 2020 and the old name still parses in some browsers, with a different syntax.
+
+## What squirrel checks
+
+The rule reads the response headers of the first crawled page and emits a single check named `permissions-policy`:
+
+- Skipped when the crawl produced no pages. Message: `No pages to check`.
+- Pass when a `Permissions-Policy` header is present, whatever it contains. Message: `Permissions-Policy header present`, with the first 100 characters of the policy as the value.
+- Info when only the legacy `Feature-Policy` header is present. Message: `Using deprecated Feature-Policy header`, with `Migrate to Permissions-Policy` as the value.
+- Info when neither header is present. Message: `No Permissions-Policy header`, with `Consider restricting browser features` as the value.
+
+The policy is not parsed and individual directives are not validated. Severity is info and the weight is 2, the lowest in the Security category.
+
+## How to fix it
+
+```
+Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
+```
+
+Set it on HTML responses. Empty parentheses disable a feature for the document and every frame inside it. Name your own origin, as in `geolocation=(self)`, for the features the page genuinely uses, and add an embedded partner's origin explicitly when they need one.
 
 | | |
 |---|---|
@@ -12,10 +35,6 @@ Checks for Permissions-Policy (Feature-Policy) header
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## Solution
-
-Permissions-Policy controls which browser features your site can use (camera, microphone, geolocation, etc.). This limits what embedded iframes can access. Example: Permissions-Policy: camera=(), microphone=(), geolocation=(). Empty parentheses disable the feature entirely. This is especially important if you embed third-party content.
 
 ## Enable / disable
 
@@ -40,3 +59,29 @@ disable = ["security/*"]
 enable = ["security/permissions-policy"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/csp](/rules/security/csp): which origins may load code, as opposed to which features that code may reach.
+- [security/x-frame-options](/rules/security/x-frame-options): who may embed you, the mirror of what you embed.
+- [security/third-party-cookies](/rules/security/third-party-cookies): an inventory of the frames and scripts a policy would apply to.
+- [security/referrer-policy](/rules/security/referrer-policy): the other privacy-facing response header.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Permissions-Policy, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. The header your server sent is reported once for the site. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/referrer-policy.mdx
+++ b/docs/rules/security/referrer-policy.mdx
@@ -29,7 +29,7 @@ Referrer-Policy: strict-origin-when-cross-origin
 
 Set it on the HTML responses at the edge. Use `no-referrer` for pages whose URLs carry tokens or personal data, and `same-origin` when no external site should learn where the user came from. Remove `unsafe-url` wherever it appears.
 
-Analytics tools that attribute traffic by referrer see less detail under a stricter policy. That is the trade the header exists to make, and origin-level attribution survives every value except `no-referrer`.
+Analytics tools that attribute traffic by referrer see less detail under a stricter policy. That is the trade the header exists to make. Origin-level attribution survives `strict-origin-when-cross-origin` and `strict-origin`, but not `no-referrer` or `same-origin`, and no policy sends a referrer from HTTPS to HTTP except the ones that leak more.
 
 | | |
 |---|---|

--- a/docs/rules/security/referrer-policy.mdx
+++ b/docs/rules/security/referrer-policy.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Referrer-Policy"
-description: "Checks for Referrer-Policy header"
+title: "Referrer-Policy: which value to send and what leaks"
+description: "unsafe-url sends the full URL, query string included, to every site you link to. squirrel reads the header and flags the leaky values."
 ---
 
-Checks for Referrer-Policy header
+## What Referrer-Policy is
+
+`Referrer-Policy` is a response header that controls how much of the current URL the browser puts in the `Referer` header of the next request. The choices run from `no-referrer`, which sends nothing, through origin-only values, to `unsafe-url`, which sends the full URL including path and query string on every request.
+
+Modern browsers default to `strict-origin-when-cross-origin`: the full URL on same-origin requests, the origin alone cross-origin, and nothing when moving from HTTPS to HTTP. That default is a reasonable policy, so the absence of the header is not itself a defect. Setting `unsafe-url` is, because password-reset tokens, search terms and session identifiers in URLs all travel to third parties.
+
+## What squirrel checks
+
+The rule reads the response headers of the first crawled page and emits a single check named `referrer-policy`:
+
+- Skipped when the crawl produced no pages. Message: `No pages to check`.
+- Info when the header is absent. Message: `No Referrer-Policy header (browser default applies)`, with `Modern browsers default to strict-origin-when-cross-origin` as the value.
+- Warn when the comma-separated value list includes `unsafe-url`. Message: `Referrer-Policy includes unsafe-url`, with `This leaks full URLs cross-origin` as the value.
+- Pass when the list includes any of `no-referrer`, `same-origin`, `strict-origin` or `strict-origin-when-cross-origin`. Message: `Referrer-Policy header present`, with the raw header value.
+- Info when the header is present with some other value, such as `origin` or `no-referrer-when-downgrade`. Message: `Referrer-Policy header present`, with the raw value.
+
+Values are lowercased and trimmed before comparison. Severity is info and the weight is 3.
+
+## How to fix it
+
+```
+Referrer-Policy: strict-origin-when-cross-origin
+```
+
+Set it on the HTML responses at the edge. Use `no-referrer` for pages whose URLs carry tokens or personal data, and `same-origin` when no external site should learn where the user came from. Remove `unsafe-url` wherever it appears.
+
+Analytics tools that attribute traffic by referrer see less detail under a stricter policy. That is the trade the header exists to make, and origin-level attribution survives every value except `no-referrer`.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for Referrer-Policy header
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Referrer-Policy controls what referrer information is sent with requests. Recommended: 'strict-origin-when-cross-origin' (default in modern browsers) sends origin only cross-site. 'no-referrer' for maximum privacy, 'same-origin' to only send referrer to same origin. Avoid 'unsafe-url' which leaks full URLs including paths.
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["security/*"]
 enable = ["security/referrer-policy"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/new-tab](/rules/security/new-tab): the per-link version of the same leak, `rel="noreferrer"`.
+- [security/permissions-policy](/rules/security/permissions-policy): the other privacy-facing response header.
+- [security/third-party-cookies](/rules/security/third-party-cookies): which external domains are receiving requests at all.
+- [security/x-content-type](/rules/security/x-content-type): the remaining one-line header in this group.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Referrer-Policy, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy)
+- [Referrer Policy, W3C](https://www.w3.org/TR/referrer-policy/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. The policy value your server sent is reported once for the site. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/sri.mdx
+++ b/docs/rules/security/sri.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Subresource Integrity"
-description: "Checks that cross-origin scripts and stylesheets use Subresource Integrity (SRI)"
+title: "Subresource Integrity: which scripts need an integrity hash"
+description: "Cross-origin scripts and stylesheets with no integrity hash can be swapped by a compromised CDN. squirrel lists every one, page by page."
 ---
 
-Checks that cross-origin scripts and stylesheets use Subresource Integrity (SRI)
+## What Subresource Integrity is
+
+Subresource Integrity (SRI) is an `integrity` attribute on a `<script>` or a `<link rel="stylesheet">` that carries a cryptographic hash of the file the page expects. The browser fetches the resource, hashes it, and refuses to run or apply it when the hash does not match. That closes the gap where a third-party host serves different bytes than the ones you reviewed.
+
+SRI only works on assets whose content never changes at a given URL. A versioned CDN build qualifies. A script that updates itself server-side does not, because the pinned hash goes stale on the vendor's next deploy and the embed stops loading. Same-origin resources do not need it: anyone who can change them can change the page that references them.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It looks at every `<script src>` and every `<link rel~="stylesheet" href>` whose URL resolves to a cross-origin `http:` or `https:` address, and emits a single check named `sri`:
+
+- Warn when one or more of those resources has no `integrity` attribute. Report message: `2 cross-origin resources without Subresource Integrity` (`resource`, singular, when there is one). Each URL is listed and labelled `script` or `stylesheet`. Severity warning.
+- Pass when every cross-origin resource carries `integrity`. Message: `All cross-origin scripts and stylesheets use Subresource Integrity`.
+- Info when the page loads no cross-origin scripts or stylesheets at all. Message: `No cross-origin scripts or stylesheets on this page — SRI not applicable`.
+
+Relative and protocol-relative URLs are resolved against the page URL before the origin comparison, so `//cdn.example.com/x.js` counts as cross-origin and `/local.js` does not. Eleven hostnames are exempt because their vendors document SRI as unsupported: `js.stripe.com`, `checkout.stripe.com`, `www.paypal.com`, `www.paypalobjects.com`, `www.google.com`, `www.gstatic.com`, `js.hcaptcha.com`, `www.googletagmanager.com`, `www.google-analytics.com`, `ssl.google-analytics.com` and `connect.facebook.net`.
+
+## How to fix it
+
+```html
+<script
+  src="https://cdn.example.com/lib@1.4.2/lib.min.js"
+  integrity="sha384-BASE64_HASH_OF_THE_FILE"
+  crossorigin="anonymous"
+></script>
+```
+
+The attribute goes on the tag that loads the resource. `crossorigin="anonymous"` is required alongside it, or the browser cannot read the response body to hash it. jsDelivr, cdnjs and unpkg publish the hash next to the file URL.
+
+A self-updating third-party script that is not on the exemption list still gets flagged. Pinning a hash there breaks the embed on the vendor's next release, so disable the rule instead of inventing an `integrity` value.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks that cross-origin scripts and stylesheets use Subresource Integrity (SRI)
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Cross-origin scripts and stylesheets can be tampered with in transit or at the source (a compromised CDN or third-party host), and the browser has no way to detect it without help. Add an integrity attribute with a sha256/sha384/sha512 hash of the expected file, plus crossorigin="anonymous": `<script src="..." integrity="sha384-..." crossorigin="anonymous"></script>`. Most CDNs (jsDelivr, cdnjs, unpkg) publish the hash alongside the URL. This only works for pinned/versioned assets — scripts that update themselves server-side (analytics, payment SDKs, CAPTCHAs) intentionally don't support it.
 
 ## Enable / disable
 
@@ -40,3 +64,30 @@ disable = ["security/*"]
 enable = ["security/sri"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/csp](/rules/security/csp): restricts which origins may serve scripts at all, one layer above per-file hashes.
+- [security/mixed-content](/rules/security/mixed-content): the same third-party assets pulled over plain HTTP.
+- [security/third-party-cookies](/rules/security/third-party-cookies): an inventory of the external domains a page loads from.
+- [integrity/obfuscated-script](/rules/integrity/obfuscated-script): scripts that are already on the page and are hiding what they do.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Subresource Integrity, MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+- [Subresource Integrity, W3C](https://www.w3.org/TR/SRI/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every cross-origin script and stylesheet without an integrity hash is listed by page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/sri.mdx
+++ b/docs/rules/security/sri.mdx
@@ -13,7 +13,7 @@ SRI only works on assets whose content never changes at a given URL. A versioned
 
 The rule runs on every crawled page. It looks at every `<script src>` and every `<link rel~="stylesheet" href>` whose URL resolves to a cross-origin `http:` or `https:` address, and emits a single check named `sri`:
 
-- Warn when one or more of those resources has no `integrity` attribute. Report message: `2 cross-origin resources without Subresource Integrity` (`resource`, singular, when there is one). Each URL is listed and labelled `script` or `stylesheet`. Severity warning.
+- Warn when one or more of those resources has a missing or empty `integrity` attribute. Report message: `2 cross-origin resources without Subresource Integrity` (`resource`, singular, when there is one). Each URL is listed and labelled `script` or `stylesheet`. Severity warning.
 - Pass when every cross-origin resource carries `integrity`. Message: `All cross-origin scripts and stylesheets use Subresource Integrity`.
 - Info when the page loads no cross-origin scripts or stylesheets at all. Message: `No cross-origin scripts or stylesheets on this page — SRI not applicable`.
 
@@ -29,7 +29,7 @@ Relative and protocol-relative URLs are resolved against the page URL before the
 ></script>
 ```
 
-The attribute goes on the tag that loads the resource. `crossorigin="anonymous"` is required alongside it, or the browser cannot read the response body to hash it. jsDelivr, cdnjs and unpkg publish the hash next to the file URL.
+The attribute goes on the tag that loads the resource. For a cross-origin classic script like this one, add `crossorigin="anonymous"` and make sure the host returns a permissive `Access-Control-Allow-Origin`, or the browser cannot read the body to hash it. Module scripts already fetch with CORS, and a same-origin resource needs no `crossorigin` attribute at all. jsDelivr, cdnjs and unpkg publish the hash next to the file URL.
 
 A self-updating third-party script that is not on the exemption list still gets flagged. Pinning a hash there breaks the embed on the vendor's next release, so disable the rule instead of inventing an `integrity` value.
 

--- a/docs/rules/security/third-party-cookies.mdx
+++ b/docs/rules/security/third-party-cookies.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Third-Party Cookies"
-description: "Detects third-party resources that may set cookies"
+title: "Third-party cookies: which external domains a page loads"
+description: "Trackers and 1x1 pixels set cookies from domains you do not control. squirrel inventories the third-party scripts, iframes and pixels per page."
 ---
 
-Detects third-party resources that may set cookies
+## What a third-party cookie is
+
+A third-party cookie is one set by a domain other than the one in the address bar, usually by a script, iframe or image the page loads from an external host. It is the mechanism behind cross-site advertising and session-replay analytics, because the same host sees the same identifier on every site that embeds it.
+
+Browsers have been closing it off. Safari and Firefox block third-party cookies by default, and Chrome has restricted them for a growing share of traffic. What survives is first-party measurement, server-side collection and consent-gated embeds. From a compliance angle, each of these domains is a processor you have to name in a privacy policy and, in most of Europe, ask permission for before it loads.
+
+## What squirrel checks
+
+The rule runs on every crawled page and inventories external hosts referenced in the HTML. It compares each resource hostname against the page hostname and emits up to three checks:
+
+- `tracking-domains` warns when a host matches its list of known tracking domains. Message: `3 known tracking domain(s) detected`, listing up to ten entries as `hostname (type)` where type is `script`, `iframe`, `pixel`, `image` or `script+iframe`.
+- `third-party-resources` reports info for the remaining external hosts. Message: `7 other third-party domain(s) found`, listing up to five.
+- `third-party-cookies` passes when neither list has an entry. Message: `No third-party tracking resources detected`.
+
+Scripts and iframes are collected from every `script[src]` and `iframe[src]`. Images are only collected when the host is a known tracker or when `width` and `height` are both `0` or `1`, which is the tracking-pixel shape. The tracking list covers roughly forty domains including `doubleclick.net`, `google-analytics.com`, `facebook.net`, `hotjar.com`, `segment.com`, `mixpanel.com`, `clarity.ms` and `sentry.io`, matched on the domain or any parent domain.
+
+No cookies are actually observed. The rule reads markup, so it reports domains that commonly set cookies rather than cookies that were set.
+
+## How to fix it
+
+```html
+<script type="text/plain" data-consent="analytics" src="https://cdn.example-analytics.com/a.js"></script>
+```
+
+Hold third-party tags behind a consent gate and only rewrite the `type` to `text/javascript` once the visitor has agreed. For measurement you control, a first-party or server-side collector removes the third-party host entirely.
+
+The info check is an inventory, not a defect. A CDN or font host appears there and needs no action beyond being named in the privacy policy where it applies.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Detects third-party resources that may set cookies
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Third-party cookies are being phased out by browsers. Review resources from external domains that may set cookies for tracking. Consider using first-party analytics solutions, server-side tracking, or privacy-focused alternatives. Ensure compliance with GDPR/CCPA by providing cookie consent and disclosing third-party services in your privacy policy.
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["security/*"]
 enable = ["security/third-party-cookies"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/cookie-flags](/rules/security/cookie-flags): the flags on the cookies your own server sets.
+- [legal/cookie-consent](/rules/legal/cookie-consent): whether a consent mechanism is present at all.
+- [analytics/consent-mode](/rules/analytics/consent-mode): whether Google tags are wired to that consent signal.
+- [adblock/privacy-blocked](/rules/adblock/privacy-blocked): which of these hosts privacy filters already block.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Third-party cookies, MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies)
+- [Set-Cookie, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Every third-party domain is listed by page with the resource type that pulled it in. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/third-party-cookies.mdx
+++ b/docs/rules/security/third-party-cookies.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 
 - [security/cookie-flags](/rules/security/cookie-flags): the flags on the cookies your own server sets.
 - [legal/cookie-consent](/rules/legal/cookie-consent): whether a consent mechanism is present at all.
-- [analytics/consent-mode](/rules/analytics/consent-mode): whether Google tags are wired to that consent signal.
+- [analytics/consent-mode](/rules/analytics/consent-mode): whether Google Consent Mode markers appear in the markup.
 - [adblock/privacy-blocked](/rules/adblock/privacy-blocked): which of these hosts privacy filters already block.
 
 Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/security/third-party-cookies.mdx
+++ b/docs/rules/security/third-party-cookies.mdx
@@ -7,17 +7,17 @@ description: "Trackers and 1x1 pixels set cookies from domains you do not contro
 
 A third-party cookie is one set by a domain other than the one in the address bar, usually by a script, iframe or image the page loads from an external host. It is the mechanism behind cross-site advertising and session-replay analytics, because the same host sees the same identifier on every site that embeds it.
 
-Browsers have been closing it off. Safari and Firefox block third-party cookies by default, and Chrome has restricted them for a growing share of traffic. What survives is first-party measurement, server-side collection and consent-gated embeds. From a compliance angle, each of these domains is a processor you have to name in a privacy policy and, in most of Europe, ask permission for before it loads.
+Browsers have been closing it off, in different ways. Safari blocks third-party cookies outright. Firefox partitions third-party storage per top-level site and blocks known tracking cookies. Chrome kept them behind a user choice rather than removing them. What works everywhere is first-party measurement, server-side collection and consent-gated embeds. Each external domain also has a role under privacy law, as controller or processor depending on what it does with the data, and most of them need consent before they load.
 
 ## What squirrel checks
 
 The rule runs on every crawled page and inventories external hosts referenced in the HTML. It compares each resource hostname against the page hostname and emits up to three checks:
 
-- `tracking-domains` warns when a host matches its list of known tracking domains. Message: `3 known tracking domain(s) detected`, listing up to ten entries as `hostname (type)` where type is `script`, `iframe`, `pixel`, `image` or `script+iframe`.
+- `tracking-domains` warns for hosts it treats as trackers, meaning a host on its known-tracker list or the host of a 0 by 0 or 1 by 1 image that it saw for the first time as that image. Message: `3 known tracking domain(s) detected`, listing up to ten entries as `hostname (type)` where type is `script`, `iframe`, `pixel`, `image` or `script+iframe`.
 - `third-party-resources` reports info for the remaining external hosts. Message: `7 other third-party domain(s) found`, listing up to five.
 - `third-party-cookies` passes when neither list has an entry. Message: `No third-party tracking resources detected`.
 
-Scripts and iframes are collected from every `script[src]` and `iframe[src]`. Images are only collected when the host is a known tracker or when `width` and `height` are both `0` or `1`, which is the tracking-pixel shape. The tracking list covers roughly forty domains including `doubleclick.net`, `google-analytics.com`, `facebook.net`, `hotjar.com`, `segment.com`, `mixpanel.com`, `clarity.ms` and `sentry.io`, matched on the domain or any parent domain.
+Scripts and iframes are collected from every `script[src]` and `iframe[src]`. Images are only collected when the host is a known tracker or when `width` and `height` are both `0` or `1`, which is the tracking-pixel shape. A host counts as external unless one hostname contains the other as a substring, and resource URLs that are relative or protocol-relative are skipped because the hostname is parsed without a base URL. The tracking list covers roughly forty domains including `doubleclick.net`, `google-analytics.com`, `facebook.net`, `hotjar.com`, `segment.com`, `mixpanel.com`, `clarity.ms` and `sentry.io`, matched on the domain or any parent domain.
 
 No cookies are actually observed. The rule reads markup, so it reports domains that commonly set cookies rather than cookies that were set.
 
@@ -27,7 +27,7 @@ No cookies are actually observed. The rule reads markup, so it reports domains t
 <script type="text/plain" data-consent="analytics" src="https://cdn.example-analytics.com/a.js"></script>
 ```
 
-Hold third-party tags behind a consent gate and only rewrite the `type` to `text/javascript` once the visitor has agreed. For measurement you control, a first-party or server-side collector removes the third-party host entirely.
+Hold third-party tags behind a consent gate. Changing the `type` on an existing element does not start it, so the consent manager has to create and insert a fresh `<script>` once the visitor has agreed, which is what the common ones do. For measurement you control, a first-party or server-side collector removes the third-party host entirely.
 
 The info check is an inventory, not a defect. A CDN or font host appears there and needs no action beyond being named in the privacy policy where it applies.
 

--- a/docs/rules/security/x-content-type.mdx
+++ b/docs/rules/security/x-content-type.mdx
@@ -1,9 +1,34 @@
 ---
-title: "X-Content-Type-Options"
-description: "Checks for MIME type sniffing protection"
+title: "X-Content-Type-Options: nosniff and why it matters"
+description: "Without nosniff a browser may execute an uploaded file as script because the bytes look like one. squirrel reads the header once per site."
 ---
 
-Checks for MIME type sniffing protection
+## What X-Content-Type-Options is
+
+`X-Content-Type-Options: nosniff` tells the browser to trust the `Content-Type` you sent and never guess a different type from the bytes. MIME sniffing exists because early servers were unreliable about content types, and it is still on by default.
+
+Sniffing turns a mislabelled upload into a script. A file served as `text/plain` that happens to start like JavaScript can be loaded in a `<script>` tag and executed under your origin. `nosniff` also makes the browser refuse a stylesheet or script whose declared type is wrong, which surfaces server misconfiguration instead of hiding it. The header has one valid value and no compatibility cost.
+
+## What squirrel checks
+
+The rule reads the response headers of the first crawled page and emits a single check named `x-content-type`:
+
+- Skipped when the crawl produced no pages. Message: `No pages to check`.
+- Pass when the header value, lowercased, is exactly `nosniff`. Message: `X-Content-Type-Options: nosniff is set`.
+- Warn when the header is present with any other value. Message: `X-Content-Type-Options has unexpected value`, with the value found and `nosniff` as expected.
+- Info when the header is absent. Message: `Missing X-Content-Type-Options header`, with `Add: X-Content-Type-Options: nosniff` as the value.
+
+Severity is info and the weight is 3, so a missing header nudges the Security score rather than dominating it.
+
+## How to fix it
+
+```
+X-Content-Type-Options: nosniff
+```
+
+Set it on every response, not only on HTML. The header matters most on the paths that serve user uploads and generated files, and it is easiest to add once at the edge or in a global middleware.
+
+The one thing to check after enabling it is that scripts and stylesheets go out with correct types. `nosniff` makes the browser reject a script served as `text/html`, which is a real bug it was previously hiding.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks for MIME type sniffing protection
 | **Scope** | Site-wide |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-X-Content-Type-Options: nosniff prevents browsers from MIME-sniffing responses, which could lead to security vulnerabilities. This is especially important for sites that allow file uploads or serve user-generated content. Simply add the header: X-Content-Type-Options: nosniff. This has no downside and improves security.
 
 ## Enable / disable
 
@@ -40,3 +61,29 @@ disable = ["security/*"]
 enable = ["security/x-content-type"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/x-frame-options](/rules/security/x-frame-options): the other single-value header to set in the same place.
+- [security/csp](/rules/security/csp): the policy that decides which scripts may run once the type is settled.
+- [content/mime-type](/rules/content/mime-type): pages whose declared content type is wrong to begin with.
+- [security/referrer-policy](/rules/security/referrer-policy): the remaining response header in this group.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [X-Content-Type-Options, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. The header is reported once for the site with the exact value your server sent. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/security/x-frame-options.mdx
+++ b/docs/rules/security/x-frame-options.mdx
@@ -1,9 +1,34 @@
 ---
-title: "X-Frame-Options"
-description: "Checks for clickjacking protection header"
+title: "X-Frame-Options: how to stop your pages being framed"
+description: "With no X-Frame-Options and no frame-ancestors, any site can iframe your pages and overlay them. squirrel checks both headers together."
 ---
 
-Checks for clickjacking protection header
+## What X-Frame-Options is
+
+`X-Frame-Options` is a response header that tells the browser whether the page may be loaded inside a `<frame>`, `<iframe>`, `<embed>` or `<object>`. `DENY` refuses all framing, `SAMEORIGIN` allows it only from the same origin. Without one, an attacker can load your page invisibly over their own and capture clicks meant for their interface, which is clickjacking.
+
+The header is superseded by the CSP `frame-ancestors` directive, which supports a source list rather than a single keyword and is the one modern browsers consult first. The `ALLOW-FROM` value never worked in Chrome and was removed from the others. Sending both headers is still common for older clients.
+
+## What squirrel checks
+
+The rule reads the response headers of the first crawled page and emits a single check named `x-frame-options`:
+
+- Skipped when the crawl produced no pages. Message: `No pages to check`.
+- Pass when `X-Frame-Options` is `DENY` or `SAMEORIGIN`, compared case-insensitively. Message: `X-Frame-Options header present`, with the raw value.
+- Warn when the value contains `ALLOW-FROM`. Message: `ALLOW-FROM is deprecated`, with `Use CSP frame-ancestors instead` as the value.
+- Pass when there is no `X-Frame-Options` header but the `Content-Security-Policy` header contains `frame-ancestors`. Message: `Clickjacking protection via CSP frame-ancestors`.
+- Warn when neither is present. Message: `No clickjacking protection`, with `Add X-Frame-Options: DENY or CSP frame-ancestors` as the value.
+
+An `X-Frame-Options` value that is neither of the two keywords nor contains `ALLOW-FROM` produces no check at all, so a typo shows up as a missing result rather than a warning.
+
+## How to fix it
+
+```
+Content-Security-Policy: frame-ancestors 'self'
+X-Frame-Options: SAMEORIGIN
+```
+
+Set both on every HTML response. Use `frame-ancestors 'none'` and `DENY` when nothing should ever frame the page. If a partner genuinely embeds you, list their origin in `frame-ancestors` rather than dropping the header, and keep `SAMEORIGIN` as the legacy fallback.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks for clickjacking protection header
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-X-Frame-Options prevents your site from being embedded in iframes, protecting against clickjacking attacks. Set: X-Frame-Options: DENY (no framing) or SAMEORIGIN (same origin only). For modern browsers, CSP frame-ancestors is preferred: Content-Security-Policy: frame-ancestors 'self'. Use both for maximum compatibility.
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["security/*"]
 enable = ["security/x-frame-options"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [security/csp](/rules/security/csp): where `frame-ancestors` lives and what else the policy should say.
+- [security/x-content-type](/rules/security/x-content-type): the other one-line response header worth setting at the same time.
+- [security/permissions-policy](/rules/security/permissions-policy): what an embedded frame is allowed to access.
+- [integrity/fake-auth-overlay](/rules/integrity/fake-auth-overlay): overlays served from your own pages rather than framed from outside.
+
+Security findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [X-Frame-Options, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options)
+- [CSP frame-ancestors, MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors)
+- [Clickjacking defence cheat sheet, OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Security section of the report. Framing protection is reported once for the site, with the header value your server sent. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Security section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/seo/index.mdx
+++ b/docs/rules/seo/index.mdx
@@ -4,13 +4,9 @@ description: "The SEO score group: crawling, indexing, content, markup, and acce
 icon: "search"
 ---
 
-SEO is one of the four score groups on every report. It covers everything that
-affects search visibility: whether crawlers can reach and index your pages, how
-your content and markup are structured, and how accessible the page is.
+SEO is one of the four score groups on every report. It covers everything that decides whether a page can be found and understood: whether a crawler can reach and index it, how its content and markup are structured, and how accessible it is to a reader who is not using a mouse and a screen.
 
-It's the broadest group, spanning 16 categories. Most rules run locally for
-free; a few [cloud rules](/cloud/rules) use AI analysis or live search data and
-are skipped when you're not logged in.
+It is the broadest group, spanning 16 categories. Most of its rules run locally and for free. A few [cloud rules](/cloud/rules) use AI analysis or live search data and are skipped when you are not logged in.
 
 ## Categories
 
@@ -79,3 +75,5 @@ disable = [
 ```
 
 See the [full rules reference](/rules) for the other score groups.
+
+Every audit reports SEO findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/social/asset-divergence.mdx
+++ b/docs/rules/social/asset-divergence.mdx
@@ -19,7 +19,7 @@ The rule is site-wide and judges three axes against the site's own most common v
 - Pass when nothing diverges. Message: `All 240 page(s) share the site's favicon, theme-color and default OG image (…)`.
 - Warn when pages diverge, and fail at or above 20% of judged pages. Message: `12 of 240 page(s) diverge from the site's own favicon (…)`. Each item reads `12 of 240 page(s) load favicon "/old-favicon.ico" but the site norm is "/favicon.svg"`, with up to ten groups and ten example URLs each.
 
-Three guards apply: 10 crawled pages, 10 pages declaring the asset before an axis is judged, and 70% agreement on its most common value. A page that declares nothing never votes and is never a deviant, since a missing favicon belongs to `core/favicon` and a missing share image to the Open Graph rules.
+Three guards apply: 10 crawled pages, 10 pages declaring the asset before an axis is judged, and 70% agreement on its most common value. Only pages that returned a 2xx status vote or are judged; a non-2xx page still counts toward the crawl-size floor. A page that declares nothing never votes and is never a deviant, since a missing favicon belongs to `core/favicon` and a missing share image to the Open Graph rules.
 
 The OG axis has two exemptions. Pages classified as article, product, recipe, event, profile or media never vote on it and are never judged by it, because a per-page share image is correct. And an `og:image` carried by exactly one page is dropped, since a fallback is shared by definition while a stale template brings a pocket of pages with it. Values are truncated at 200 characters when stored, so two long data URIs sharing a prefix compare equal and the divergence is missed rather than invented. Severity warning, weight 3.
 

--- a/docs/rules/social/asset-divergence.mdx
+++ b/docs/rules/social/asset-divergence.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Site Asset Consistency"
-description: "Finds pages whose favicon, theme-color or default OG image differs from the rest of the site"
+title: "Favicon and theme-color that differ across the site"
+description: "Site chrome comes from one layout, so a page carrying a different favicon is running a different template. squirrel finds the minority."
 ---
 
-Finds pages whose favicon, theme-color or default OG image differs from the rest of the site
+## What site asset divergence is
+
+The favicon, the `theme-color` and the fallback share image all come from one layout, so on a healthy site every page carries the same three. A page carrying a different one is not making a per-page decision, it is running a different template: a section that missed a redesign, a cached shell, a second layout nobody remembers owning.
+
+Nothing about that page looks wrong on its own, which is why no per-page rule can see it. What a visitor notices is a tab icon that changes as they move around, and link previews that degrade for some pages and not others.
+
+## What squirrel checks
+
+The rule is site-wide and judges three axes against the site's own most common value: the primary `<link rel="icon">` href resolved absolute, the `<meta name="theme-color">` content, and the default `og:image`. It emits a single check named `asset-divergence`:
+
+- Skipped when there are no pages. Message: `No pages available for analysis`.
+- Skipped below 10 crawled pages. Message: `Only 7 page(s) crawled; 10 needed to establish a site-asset norm`.
+- Skipped when no axis qualifies. Message: `No favicon, theme-color or default OG image is declared by 10 page(s) with 70% agreement`.
+- Pass when nothing diverges. Message: `All 240 page(s) share the site's favicon, theme-color and default OG image (…)`.
+- Warn when pages diverge, and fail at or above 20% of judged pages. Message: `12 of 240 page(s) diverge from the site's own favicon (…)`. Each item reads `12 of 240 page(s) load favicon "/old-favicon.ico" but the site norm is "/favicon.svg"`, with up to ten groups and ten example URLs each.
+
+Three guards apply: 10 crawled pages, 10 pages declaring the asset before an axis is judged, and 70% agreement on its most common value. A page that declares nothing never votes and is never a deviant, since a missing favicon belongs to `core/favicon` and a missing share image to the Open Graph rules.
+
+The OG axis has two exemptions. Pages classified as article, product, recipe, event, profile or media never vote on it and are never judged by it, because a per-page share image is correct. And an `og:image` carried by exactly one page is dropped, since a fallback is shared by definition while a stale template brings a pocket of pages with it. Values are truncated at 200 characters when stored, so two long data URIs sharing a prefix compare equal and the divergence is missed rather than invented. Severity warning, weight 3.
+
+## How to fix it
+
+Fix it where the assets are declared, in the shared head partial or the theme configuration, rather than page by page. The report names which pages carry the odd value, which is usually enough to identify the template.
+
+A deliberate per-page share image on an article or a product is not reported. What this rule compares is the fallback the rest of the site shares.
 
 | | |
 |---|---|
@@ -12,63 +36,6 @@ Finds pages whose favicon, theme-color or default OG image differs from the rest
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 3/10 |
-
-## How it works
-
-Your favicon, your `theme-color` and your fallback share image all come from one
-layout, so every page should carry the same three. When a pocket of pages carries
-different ones, those pages are usually running an older template: a section that
-missed a redesign, a cached shell, or a second layout nobody remembers owning.
-Nothing about such a page looks wrong on its own, which is why no per-page check
-can see it.
-
-Three axes are compared across the crawl:
-
-| Axis | What is read |
-|---|---|
-| Favicon | The first `<link rel="icon">` href, resolved to an absolute URL |
-| Theme color | `<meta name="theme-color">` content |
-| Default OG image | `og:image`, on the pages that should share one |
-
-Each axis is judged against your site's own modal value, and only the minority
-form is reported.
-
-### Per-page share images are not a finding
-
-Articles and products (plus recipes, events, profiles and media pages) **should**
-ship their own `og:image`. Those page types never vote on the OG axis and are
-never reported on it. Neither is any page whose `og:image` is used by that page
-alone, whatever its type: a fallback is by definition shared, so a one-off image
-is a per-page asset rather than a template running behind. What the rule compares
-there is the fallback the rest of the site shares. Favicon and theme-color have no
-such exemption: they are browser chrome, not content, and stay uniform even on an
-article.
-
-### It stays quiet unless it has grounds to speak
-
-- Fewer than 10 crawled pages: there is no norm to judge against, so the rule is
-  skipped.
-- Fewer than 10 pages declaring an asset: that axis is not judged at all.
-- No value reaching 70% agreement on any axis: your site genuinely varies its
-  chrome, so nothing in it is a deviant.
-- A page that declares nothing never votes and is never a deviant. A missing
-  favicon belongs to [Favicon](/rules/core/favicon) and a missing share image to
-  the Open Graph rules, so the two never both flag the same page.
-- Apple touch icons and mask icons legitimately differ from the tab icon and never
-  stand in for it. A light/dark `theme-color` pair is normal and reads as one
-  value.
-
-## Solution
-
-Your favicon, theme-color and fallback share image come from one layout, so every
-page should carry the same three. Pages that carry different ones are usually
-running an older template: a section that missed a redesign, a cached shell, or a
-second layout nobody remembers owning. The visible cost is inconsistent link
-previews and a tab icon that changes as visitors move around the site. Fix it
-where the assets are declared (the shared head partial or theme config) rather
-than page by page. Per-page share images on articles and products are correct and
-are not reported here: what this rule compares is the fallback the rest of the
-site shares.
 
 ## Enable / disable
 
@@ -93,3 +60,30 @@ disable = ["social/*"]
 enable = ["social/asset-divergence"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [core/favicon](/rules/core/favicon): whether a favicon is declared at all.
+- [core/og-tags](/rules/core/og-tags): the Open Graph tags this rule reads the fallback from.
+- [integrity/template-discontinuity](/rules/integrity/template-discontinuity): the same outlier idea applied to the whole template.
+- [content/title-pattern-outlier](/rules/content/title-pattern-outlier): the same idea applied to titles.
+
+Social Media findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [theme-color, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/theme-color)
+- [The Open Graph protocol](https://ogp.me/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Social Media section of the report. Each diverging group is listed with its value, the site norm and example URLs. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Social Media section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/social/index.mdx
+++ b/docs/rules/social/index.mdx
@@ -3,7 +3,7 @@ title: "Social Media"
 description: "Open Graph and social sharing metadata"
 ---
 
-Open Graph and social sharing metadata
+Social Media rules read the tags that decide what a shared link looks like: the Open Graph image and its declared size, the canonical identity in og:url, and the profile links that say which accounts are yours. One of them works across the corpus instead, finding pages whose favicon, theme-color or fallback share image says they are running an older template.
 
 ## Rules
 
@@ -31,3 +31,5 @@ Open Graph and social sharing metadata
 [rules]
 disable = ["social/*"]
 ```
+
+Every audit reports Social Media findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/social/index.mdx
+++ b/docs/rules/social/index.mdx
@@ -8,20 +8,20 @@ Social Media rules read the tags that decide what a shared link looks like: the 
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Site Asset Consistency" icon="triangle-exclamation" href="/rules/social/asset-divergence">
-    Finds pages whose favicon, theme-color or default OG image differs from the rest of the site
+  <Card title="Favicon and theme-color that differ across the site" icon="triangle-exclamation" href="/rules/social/asset-divergence">
+    Site chrome comes from one layout, so a page carrying a different favicon is running a different template. squirrel finds the minority.
   </Card>
-  <Card title="OG Image Size" icon="triangle-exclamation" href="/rules/social/og-image-size">
-    Checks og:image meets recommended size (1200x630)
+  <Card title="og:image size: the 1200 by 630 recommendation" icon="triangle-exclamation" href="/rules/social/og-image-size">
+    A share image below the recommended size is cropped or upscaled in the preview card. squirrel reads og:image and its declared dimensions.
   </Card>
-  <Card title="OG URL Match" icon="triangle-exclamation" href="/rules/social/og-url-match">
-    Checks that og:url matches canonical URL
+  <Card title="og:url versus canonical: why they should be the same URL" icon="triangle-exclamation" href="/rules/social/og-url-match">
+    When og:url and the canonical disagree, share counts split across two addresses. squirrel normalises both and compares them.
   </Card>
-  <Card title="Share Buttons" icon="circle-info" href="/rules/social/share-buttons">
-    Checks for social sharing buttons on content pages
+  <Card title="Social share buttons: detecting them on content pages" icon="circle-info" href="/rules/social/share-buttons">
+    Share buttons make it one click instead of three to pass a page on. squirrel looks for share markup, share libraries and platform share URLs.
   </Card>
-  <Card title="Social Profiles" icon="circle-info" href="/rules/social/social-profiles">
-    Checks for links to social media profiles
+  <Card title="Social profile links: which platforms a page links to" icon="circle-info" href="/rules/social/social-profiles">
+    Linking your official accounts confirms which ones are yours. squirrel detects profile links and cross-checks the accounts the audit knows about.
   </Card>
 </CardGroup>
 

--- a/docs/rules/social/og-image-size.mdx
+++ b/docs/rules/social/og-image-size.mdx
@@ -15,9 +15,9 @@ The rule runs on every crawled page and reads `meta[property="og:image"]` along 
 
 - `og-image-size` reports info when there is no `og:image`. Message: `No og:image tag found`. No further checks run.
 - `og-image-exists` passes when the tag is present. Message: `og:image is set`, with the first 60 characters of the URL.
-- `og-image-size` passes when both declared dimensions are at least 1200 and 630. Message: `og:image dimensions meet recommendations`, with `1200x630` as the value.
-- `og-image-size` warns when they are below that. Message: `og:image may be too small (600x315)`, with the recommendation as the value.
-- `og-image-size` reports info when the dimensions are not declared. Message: `og:image dimensions not specified`, with `Add og:image:width and og:image:height` as the value.
+- `og-image-size` passes when both declared dimensions parse as positive numbers and are at least 1200 and 630. Message: `og:image dimensions meet recommendations`, with `1200x630` as the value.
+- `og-image-size` warns when both parse as positive and at least one is below its recommendation. Message: `og:image may be too small (600x315)`, with the recommendation as the value.
+- `og-image-size` reports info in every other case. Message: `og:image dimensions not specified`, with `Add og:image:width and og:image:height` as the value. That covers an absent tag and also a present one whose value is zero, negative or unparseable.
 
 The image itself is never fetched, so the check reads the declared numbers rather than the real ones. A page declaring 1200 by 630 for a 400-pixel file passes. Severity warning, weight 4.
 

--- a/docs/rules/social/og-image-size.mdx
+++ b/docs/rules/social/og-image-size.mdx
@@ -1,9 +1,38 @@
 ---
-title: "OG Image Size"
-description: "Checks og:image meets recommended size (1200x630)"
+title: "og:image size: the 1200 by 630 recommendation"
+description: "A share image below the recommended size is cropped or upscaled in the preview card. squirrel reads og:image and its declared dimensions."
 ---
 
-Checks og:image meets recommended size (1200x630)
+## What og:image is
+
+`og:image` is the Open Graph property naming the picture a platform shows when someone shares the page. It is what turns a bare link into a card.
+
+Facebook's sharing guidance recommends at least 1200 by 630 pixels, a ratio of about 1.91 to 1, with a file under 8MB. Below that, a platform crops to its own ratio or upscales, and either result looks worse than the image you chose. `og:image:width` and `og:image:height` let the platform lay out the card before it has downloaded the file, which is why declaring them is worth doing.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reads `meta[property="og:image"]` along with the `og:image:width` and `og:image:height` properties. It emits up to two checks:
+
+- `og-image-size` reports info when there is no `og:image`. Message: `No og:image tag found`. No further checks run.
+- `og-image-exists` passes when the tag is present. Message: `og:image is set`, with the first 60 characters of the URL.
+- `og-image-size` passes when both declared dimensions are at least 1200 and 630. Message: `og:image dimensions meet recommendations`, with `1200x630` as the value.
+- `og-image-size` warns when they are below that. Message: `og:image may be too small (600x315)`, with the recommendation as the value.
+- `og-image-size` reports info when the dimensions are not declared. Message: `og:image dimensions not specified`, with `Add og:image:width and og:image:height` as the value.
+
+The image itself is never fetched, so the check reads the declared numbers rather than the real ones. A page declaring 1200 by 630 for a 400-pixel file passes. Severity warning, weight 4.
+
+## How to fix it
+
+```html
+<meta property="og:image" content="https://example.com/share.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="…" />
+```
+
+Generate a 1200 by 630 image per page or per template, and declare the dimensions alongside it. Use an absolute URL: several platforms will not resolve a relative one.
+
+Keep the important part of the image away from the edges. Different platforms crop to different ratios from the same file.
 
 | | |
 |---|---|
@@ -12,10 +41,6 @@ Checks og:image meets recommended size (1200x630)
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-og:image should be at least 1200x630 pixels for optimal display on Facebook and LinkedIn. Smaller images may appear cropped or low quality. Use 1.91:1 aspect ratio. Keep file size under 8MB. Test with Facebook Sharing Debugger. Consider creating dedicated social images for key pages.
 
 ## Enable / disable
 
@@ -40,3 +65,30 @@ disable = ["social/*"]
 enable = ["social/og-image-size"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [core/og-tags](/rules/core/og-tags): the rest of the Open Graph tags on the page.
+- [social/asset-divergence](/rules/social/asset-divergence): pages falling back to a different share image.
+- [core/twitter-cards](/rules/core/twitter-cards): the equivalent tags for X.
+- [images/image-file-size](/rules/images/image-file-size): the weight of the file being referenced.
+
+Social Media findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Sharing best practices, Meta for Developers](https://developers.facebook.com/docs/sharing/webmasters)
+- [The Open Graph protocol](https://ogp.me/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Social Media section of the report. Each page is reported with its og:image URL and declared dimensions. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Social Media section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/social/og-url-match.mdx
+++ b/docs/rules/social/og-url-match.mdx
@@ -7,7 +7,7 @@ description: "When og:url and the canonical disagree, share counts split across 
 
 `og:url` is the canonical address of the page as far as social platforms are concerned. It is what they use to deduplicate shares, so every share of the page accumulates against one identifier however the sharer arrived.
 
-The `<link rel="canonical">` tag does the same job for search engines. When the two disagree, usually over `www`, the scheme or a trailing slash, the page has two canonical identities and the share count splits between them.
+The `<link rel="canonical">` tag does the same job for search engines. When the two disagree, usually over `www`, the scheme or a trailing slash, the page is presenting two canonical identities. Whether that has actually split a share count depends on which URLs people shared, but it is the condition under which counts fragment.
 
 ## What squirrel checks
 
@@ -16,9 +16,9 @@ The rule runs on every crawled page and compares `meta[property="og:url"]` again
 - Info when there is no `og:url`. Message: `No og:url tag found`.
 - Info when there is no canonical to compare against. Message: `No canonical to compare og:url against`.
 - Pass when the normalised values are equal. Message: `og:url matches canonical URL`.
-- Warn otherwise. Message: `og:url does not match canonical URL`, with the og value as the value and the canonical as the expected value. Severity warning, weight 3.
+- Warn otherwise. Message: `og:url does not match canonical URL`, with `og: https://example.com/page` as the value and the raw canonical href as the expected value. Severity warning, weight 3.
 
-Normalisation only removes a trailing slash. Everything else, including a query string, a fragment and a case difference in the path, is compared as-is.
+Normalisation is whatever the URL parser does plus a trailing-slash strip. The parser resolves a relative value, lowercases the hostname, drops a default port and resolves dot segments; the extra step removes one trailing slash. A query string, a fragment and a case difference in the path all survive and are compared as-is.
 
 ## How to fix it
 

--- a/docs/rules/social/og-url-match.mdx
+++ b/docs/rules/social/og-url-match.mdx
@@ -1,9 +1,33 @@
 ---
-title: "OG URL Match"
-description: "Checks that og:url matches canonical URL"
+title: "og:url versus canonical: why they should be the same URL"
+description: "When og:url and the canonical disagree, share counts split across two addresses. squirrel normalises both and compares them."
 ---
 
-Checks that og:url matches canonical URL
+## What og:url is for
+
+`og:url` is the canonical address of the page as far as social platforms are concerned. It is what they use to deduplicate shares, so every share of the page accumulates against one identifier however the sharer arrived.
+
+The `<link rel="canonical">` tag does the same job for search engines. When the two disagree, usually over `www`, the scheme or a trailing slash, the page has two canonical identities and the share count splits between them.
+
+## What squirrel checks
+
+The rule runs on every crawled page and compares `meta[property="og:url"]` against `link[rel="canonical"]`. Both are resolved against the page URL and stripped of a trailing slash before comparison. It emits a single check named `og-url-match`:
+
+- Info when there is no `og:url`. Message: `No og:url tag found`.
+- Info when there is no canonical to compare against. Message: `No canonical to compare og:url against`.
+- Pass when the normalised values are equal. Message: `og:url matches canonical URL`.
+- Warn otherwise. Message: `og:url does not match canonical URL`, with the og value as the value and the canonical as the expected value. Severity warning, weight 3.
+
+Normalisation only removes a trailing slash. Everything else, including a query string, a fragment and a case difference in the path, is compared as-is.
+
+## How to fix it
+
+```html
+<link rel="canonical" href="https://example.com/guides/url-structure" />
+<meta property="og:url" content="https://example.com/guides/url-structure" />
+```
+
+Render both from the same value in the layout. That way a change to the canonical rule cannot leave `og:url` behind.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks that og:url matches canonical URL
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 3/10 |
-
-## Solution
-
-og:url should match your canonical URL. Mismatches can cause social share stats to be fragmented across different URLs. Use the same URL normalization (https, www, trailing slash) as your canonical tag. Facebook uses og:url for share counting and deduplication.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["social/*"]
 enable = ["social/og-url-match"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): the canonical tag checked on its own.
+- [core/og-tags](/rules/core/og-tags): the rest of the Open Graph tags.
+- [url/trailing-slash](/rules/url/trailing-slash): the difference that most often causes the mismatch.
+- [social/og-image-size](/rules/social/og-image-size): the share image on the same card.
+
+Social Media findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The Open Graph protocol](https://ogp.me/)
+- [Consolidate duplicate URLs, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Social Media section of the report. Each mismatch is reported with both URLs. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Social Media section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/social/share-buttons.mdx
+++ b/docs/rules/social/share-buttons.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Share Buttons"
-description: "Checks for social sharing buttons on content pages"
+title: "Social share buttons: detecting them on content pages"
+description: "Share buttons make it one click instead of three to pass a page on. squirrel looks for share markup, share libraries and platform share URLs."
 ---
 
-Checks for social sharing buttons on content pages
+## What a share button is
+
+A share button is a link or control that opens a platform's compose window prefilled with the page URL. It saves a reader copying the address and switching apps, which is most of the friction in sharing something.
+
+They earn their place on content people share: articles, guides, research. On a pricing page or a contact form they are decoration. Three or four platforms is usually the whole useful set, and every additional button is a third-party script.
+
+## What squirrel checks
+
+The rule runs on every crawled page and looks for two things. The lowercased page HTML matching one of four patterns: share plus facebook, share plus twitter, share plus linkedin, or the names `addthis`, `addtoany`, `shareaholic` and `sumo-share`. And links whose href contains `facebook.com/sharer`, `twitter.com/intent/tweet` or `linkedin.com/share`. It emits a single check named `share-buttons`:
+
+- Pass when either was found. Message: `Social share functionality detected`, with `3 share link(s)` as the value when share URLs were counted.
+- Info when neither was found and the page URL contains `/blog`, `/article`, `/post` or `/news`. Message: `No share buttons on content page`, with `Consider adding for better engagement` as the value.
+- Info otherwise. Message: `No social share buttons detected`.
+
+The HTML pattern test is loose: an article about sharing on Facebook can match it. Severity info, weight 2.
+
+## How to fix it
+
+```html
+<a href="https://x.com/intent/tweet?url=https%3A%2F%2Fexample.com%2Fpost">Share on X</a>
+```
+
+Plain links to each platform's share endpoint need no third-party script and work without JavaScript. Put them where a reader finishes reading rather than before they start.
+
+The `navigator.share` API is a better fit on mobile, since it offers the platforms the reader actually uses.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for social sharing buttons on content pages
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## Solution
-
-Social share buttons encourage content sharing and can drive traffic. Place them prominently on blog posts, articles, and shareable content. Include major platforms: Facebook, Twitter/X, LinkedIn. Consider sticky share bars for long content. Avoid too many buttons - 3-4 is optimal.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["social/*"]
 enable = ["social/share-buttons"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [social/social-profiles](/rules/social/social-profiles): links to your own accounts rather than share endpoints.
+- [core/og-tags](/rules/core/og-tags): the tags that decide what a share looks like.
+- [security/third-party-cookies](/rules/security/third-party-cookies): what a share widget loads alongside itself.
+- [performance/js-libraries](/rules/performance/js-libraries): the weight those widgets add.
+
+Social Media findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Sharing best practices, Meta for Developers](https://developers.facebook.com/docs/sharing/webmasters)
+- [The Open Graph protocol](https://ogp.me/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Social Media section of the report. Each page is reported with whether share functionality was detected. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Social Media section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/social/share-buttons.mdx
+++ b/docs/rules/social/share-buttons.mdx
@@ -7,7 +7,7 @@ description: "Share buttons make it one click instead of three to pass a page on
 
 A share button is a link or control that opens a platform's compose window prefilled with the page URL. It saves a reader copying the address and switching apps, which is most of the friction in sharing something.
 
-They earn their place on content people share: articles, guides, research. On a pricing page or a contact form they are decoration. Three or four platforms is usually the whole useful set, and every additional button is a third-party script.
+They earn their place on content people share: articles, guides, research. On a pricing page or a contact form they are decoration. Three or four platforms is usually the whole useful set. A share button can be a plain link, but the widget versions bring a third-party script each.
 
 ## What squirrel checks
 
@@ -22,10 +22,10 @@ The HTML pattern test is loose: an article about sharing on Facebook can match i
 ## How to fix it
 
 ```html
-<a href="https://x.com/intent/tweet?url=https%3A%2F%2Fexample.com%2Fpost">Share on X</a>
+<a href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fexample.com%2Fpost">Share on X</a>
 ```
 
-Plain links to each platform's share endpoint need no third-party script and work without JavaScript. Put them where a reader finishes reading rather than before they start.
+Plain links to each platform's share endpoint need no third-party script and work without JavaScript. Note that this rule recognises `twitter.com/intent/tweet` and not the `x.com` form, so a site using the newer host is not detected. Put them where a reader finishes reading rather than before they start.
 
 The `navigator.share` API is a better fit on mobile, since it offers the platforms the reader actually uses.
 

--- a/docs/rules/social/share-buttons.mdx
+++ b/docs/rules/social/share-buttons.mdx
@@ -66,7 +66,7 @@ disable = ["*"]
 - [social/social-profiles](/rules/social/social-profiles): links to your own accounts rather than share endpoints.
 - [core/og-tags](/rules/core/og-tags): the tags that decide what a share looks like.
 - [security/third-party-cookies](/rules/security/third-party-cookies): what a share widget loads alongside itself.
-- [performance/js-libraries](/rules/perf/js-libraries): the weight those widgets add.
+- [perf/js-libraries](/rules/perf/js-libraries): the weight those widgets add.
 
 Social Media findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
 

--- a/docs/rules/social/share-buttons.mdx
+++ b/docs/rules/social/share-buttons.mdx
@@ -66,7 +66,7 @@ disable = ["*"]
 - [social/social-profiles](/rules/social/social-profiles): links to your own accounts rather than share endpoints.
 - [core/og-tags](/rules/core/og-tags): the tags that decide what a share looks like.
 - [security/third-party-cookies](/rules/security/third-party-cookies): what a share widget loads alongside itself.
-- [perf/js-libraries](/rules/perf/js-libraries): the weight those widgets add.
+- [perf/js-libraries](/rules/perf/js-libraries): the JavaScript libraries those widgets pull in, and their known flaws.
 
 Social Media findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
 

--- a/docs/rules/social/share-buttons.mdx
+++ b/docs/rules/social/share-buttons.mdx
@@ -66,7 +66,7 @@ disable = ["*"]
 - [social/social-profiles](/rules/social/social-profiles): links to your own accounts rather than share endpoints.
 - [core/og-tags](/rules/core/og-tags): the tags that decide what a share looks like.
 - [security/third-party-cookies](/rules/security/third-party-cookies): what a share widget loads alongside itself.
-- [performance/js-libraries](/rules/performance/js-libraries): the weight those widgets add.
+- [performance/js-libraries](/rules/perf/js-libraries): the weight those widgets add.
 
 Social Media findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
 

--- a/docs/rules/social/social-profiles.mdx
+++ b/docs/rules/social/social-profiles.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Social Profiles"
-description: "Checks for links to social media profiles"
+title: "Social profile links: which platforms a page links to"
+description: "Linking your official accounts confirms which ones are yours. squirrel detects profile links and cross-checks the accounts the audit knows about."
 ---
 
-Checks for links to social media profiles
+## What a profile link does
+
+A link from your site to your social accounts is the simplest confirmation that those accounts are yours. Marked up as `sameAs` on an `Organization` node, it is also the machine-readable form, which is what feeds knowledge panels and entity matching.
+
+The reverse matters too. An account that exists and is linked from nowhere on the site cannot be verified as yours by anything reading the page, which is what the second half of this rule looks for.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `a[href]`, matching each href against seven platform patterns: Facebook, Twitter and X, Instagram, LinkedIn, YouTube, TikTok and Pinterest. It emits up to two checks:
+
+- `social-profiles` passes when any platform matched. Message: `3 social platform(s) linked`, listing the platform names.
+- `social-profiles` reports info when none did. Message: `No social media profile links found`, with `Consider adding to footer` as the value.
+- `social-profiles-missing` warns when the audit's site metadata knows about official accounts the page does not link. Message: `2 known social account(s) not linked on this page`, with `Link your official social profiles (Organization sameAs)` as the value and each missing account listed by URL and platform.
+
+The second check needs site metadata that identified official accounts. Without it, from an offline run or one where nothing was detected, it never fires. Severity for the rule is info, weight 2.
+
+The rule only runs when the audit classified the site as ecommerce, a marketplace, corporate, a small local business, an agency, SaaS, news, a blog, a nonprofit or media streaming. A classification below medium confidence, or an audit with no site metadata at all, runs it anyway.
+
+## How to fix it
+
+```json
+{"@context":"https://schema.org","@type":"Organization","name":"Acme","url":"https://example.com","sameAs":["https://www.linkedin.com/company/acme","https://x.com/acme"]}
+```
+
+Link the accounts from the footer and list them in `sameAs` on the `Organization` node. Keep the two lists in agreement: an account in `sameAs` that is not linked anywhere on the site is the case the second check reports.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for links to social media profiles
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## Solution
-
-Link to your social media profiles from your website. Include in footer or about page. Use Organization schema with sameAs property to list all official social profiles. This helps Google's Knowledge Panel and verifies your brand across platforms. Ensure links open in new tabs.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["social/*"]
 enable = ["social/social-profiles"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [schema/organization](/rules/schema/organization): the node that carries the sameAs list.
+- [social/share-buttons](/rules/social/share-buttons): links out to platforms rather than to your accounts.
+- [eeat/trust-signals](/rules/eeat/trust-signals): the other things a visitor checks.
+- [security/new-tab](/rules/security/new-tab): the rel attributes those outbound links should carry.
+
+Social Media findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [sameAs, Schema.org](https://schema.org/sameAs)
+- [Organization logo structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/logo)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Social Media section of the report. Each page is reported with the platforms it links and any known accounts it misses. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Social Media section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/social/social-profiles.mdx
+++ b/docs/rules/social/social-profiles.mdx
@@ -15,7 +15,7 @@ The rule runs on every crawled page over every `a[href]`, matching each href aga
 
 - `social-profiles` passes when any platform matched. Message: `3 social platform(s) linked`, listing the platform names.
 - `social-profiles` reports info when none did. Message: `No social media profile links found`, with `Consider adding to footer` as the value.
-- `social-profiles-missing` warns when the audit's site metadata knows about official accounts the page does not link. Message: `2 known social account(s) not linked on this page`, with `Link your official social profiles (Organization sameAs)` as the value and each missing account listed by URL and platform.
+- `social-profiles-missing` warns when the audit's site metadata knows about official accounts that this page's own links do not include. The comparison is against the page's anchor hrefs, not against the whole site and not against the page's `sameAs` list. Message: `2 known social account(s) not linked on this page`, with `Link your official social profiles (Organization sameAs)` as the value and each missing account listed by URL and platform.
 
 The second check needs site metadata that identified official accounts. Without it, from an offline run or one where nothing was detected, it never fires. Severity for the rule is info, weight 2.
 
@@ -27,7 +27,7 @@ The rule only runs when the audit classified the site as ecommerce, a marketplac
 {"@context":"https://schema.org","@type":"Organization","name":"Acme","url":"https://example.com","sameAs":["https://www.linkedin.com/company/acme","https://x.com/acme"]}
 ```
 
-Link the accounts from the footer and list them in `sameAs` on the `Organization` node. Keep the two lists in agreement: an account in `sameAs` that is not linked anywhere on the site is the case the second check reports.
+Link the accounts from the footer, which puts them on every page, and list them in `sameAs` on the `Organization` node. The second check compares the accounts the audit detected against the links on each page, so an account nobody links from this page is what it reports.
 
 | | |
 |---|---|

--- a/docs/rules/url/hyphens.mdx
+++ b/docs/rules/url/hyphens.mdx
@@ -27,7 +27,7 @@ https://example.com/blog/blue-running-shoes
 
 Change the slug at the source, in the CMS field or the route definition, then 301-redirect the old path so links and rankings follow.
 
-Renaming URLs is not free. On an established page, the redirect and the lost link equity can cost more than the separator is worth. Fix the convention going forward and migrate old URLs only when you are changing them anyway.
+Renaming URLs is not free. A correct permanent redirect does not throw away ranking signals, but a migration still costs implementation time and usually produces a period of ranking movement. Fix the convention going forward and migrate old URLs only when you are changing them anyway.
 
 | | |
 |---|---|

--- a/docs/rules/url/hyphens.mdx
+++ b/docs/rules/url/hyphens.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Underscores in URLs: why hyphens separate words and _ does not"
+title: "Underscores in URLs: why hyphens separate words"
 description: "Google reads blue-shoes as two words and blue_shoes as one. squirrel flags every crawled path containing an underscore."
 ---
 

--- a/docs/rules/url/hyphens.mdx
+++ b/docs/rules/url/hyphens.mdx
@@ -1,9 +1,33 @@
 ---
-title: "URL Hyphens"
-description: "Checks that URLs use hyphens, not underscores"
+title: "Underscores in URLs: why hyphens separate words and _ does not"
+description: "Google reads blue-shoes as two words and blue_shoes as one. squirrel flags every crawled path containing an underscore."
 ---
 
-Checks that URLs use hyphens, not underscores
+## What the hyphen convention is
+
+A URL path has no built-in idea of words. Search engines infer them from separators, and Google's URL structure guidance says to use hyphens rather than underscores, because a hyphen is read as a word break and an underscore is not.
+
+`blue-shoes` is therefore two tokens and `blue_shoes` is one. That matters where the slug carries the terms a page should be found for. It is a small effect on its own, and the reason to prefer hyphens is that it costs nothing and is what every other site does.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the URL path only. It emits a single check named `url-hyphens`:
+
+- Warn when the path contains an underscore. Message: `URL uses underscores (2) instead of hyphens`, with the path as the value. Severity warning, weight 4.
+- Pass when the path contains a hyphen and no underscore. Message: `URL uses hyphens for word separation`.
+- Info when the path contains neither. Message: `URL has no word separators`.
+
+The query string is not examined, so `?sort_by=price` is not flagged. A path containing both characters is reported as an underscore finding.
+
+## How to fix it
+
+```
+https://example.com/blog/blue-running-shoes
+```
+
+Change the slug at the source, in the CMS field or the route definition, then 301-redirect the old path so links and rankings follow.
+
+Renaming URLs is not free. On an established page, the redirect and the lost link equity can cost more than the separator is worth. Fix the convention going forward and migrate old URLs only when you are changing them anyway.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks that URLs use hyphens, not underscores
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Use hyphens (-) to separate words in URLs, not underscores (_). Google treats hyphens as word separators but treats underscores as word joiners. 'blue-shoes' = 'blue' + 'shoes', but 'blue_shoes' = 'blueshoes'. This affects keyword matching and SEO. Replace underscores with hyphens and set up redirects from old URLs.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["url/*"]
 enable = ["url/hyphens"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [url/slug-convention](/rules/url/slug-convention): whether the site mixes separators rather than using one.
+- [url/lowercase](/rules/url/lowercase): the other per-path convention check.
+- [url/slug-keywords](/rules/url/slug-keywords): whether the slug says anything about the page.
+- [url/special-chars](/rules/url/special-chars): characters that need encoding rather than replacing.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Keep a simple URL structure, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/url-structure)
+- [RFC 3986: Uniform Resource Identifier](https://datatracker.ietf.org/doc/html/rfc3986)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Every path containing an underscore is listed with its page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/index.mdx
+++ b/docs/rules/url/index.mdx
@@ -3,7 +3,7 @@ title: "URL Structure"
 description: "URL structure, length, and formatting"
 ---
 
-URL structure, length, and formatting
+URL Structure rules read the address of each crawled page: its case, its word separators, its length and depth, its query parameters and its trailing slash. Most of them are conventions rather than defects, so their severities are low and their findings are worth applying to new URLs rather than retrofitting to old ones. The exception is `url/slug-convention`, which measures the site against its own dominant form and reports the minority, because mixed conventions are how duplicate-content and canonical bugs start.
 
 ## Rules
 
@@ -43,3 +43,5 @@ URL structure, length, and formatting
 [rules]
 disable = ["url/*"]
 ```
+
+Every audit reports URL Structure findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/url/index.mdx
+++ b/docs/rules/url/index.mdx
@@ -8,32 +8,32 @@ URL Structure rules read the address of each crawled page: its case, its word se
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Slug Keywords" icon="circle-info" href="/rules/url/slug-keywords">
-    Checks if URL slug contains relevant keywords
+  <Card title="Non-descriptive URL slug: numeric IDs and generic patterns" icon="circle-info" href="/rules/url/slug-keywords">
+    A slug like /p/48213 tells a reader and a crawler nothing. squirrel classifies the last path segment and flags the ID-shaped ones.
   </Card>
-  <Card title="Trailing Slash" icon="circle-info" href="/rules/url/trailing-slash">
-    Checks for consistent trailing slash usage
+  <Card title="Trailing slash: /page and /page/ are two different URLs" icon="circle-info" href="/rules/url/trailing-slash">
+    A file URL with a trailing slash is a mistake; a directory URL either has one or does not, consistently. squirrel reports the state of each path.
   </Card>
-  <Card title="URL Convention Consistency" icon="triangle-exclamation" href="/rules/url/slug-convention">
-    Finds URLs that break the site's own URL conventions
+  <Card title="Mixed URL conventions: finding the minority form" icon="triangle-exclamation" href="/rules/url/slug-convention">
+    Half your paths ending in a slash and half not is how canonical bugs start. squirrel computes your site's own norm and reports what deviates.
   </Card>
-  <Card title="URL Hyphens" icon="triangle-exclamation" href="/rules/url/hyphens">
-    Checks that URLs use hyphens, not underscores
+  <Card title="Underscores in URLs: why hyphens separate words" icon="triangle-exclamation" href="/rules/url/hyphens">
+    Google reads blue-shoes as two words and blue_shoes as one. squirrel flags every crawled path containing an underscore.
   </Card>
-  <Card title="URL Length" icon="circle-info" href="/rules/url/length">
-    Checks URL length for optimal SEO
+  <Card title="URL length: when a URL is long enough to be a problem" icon="circle-info" href="/rules/url/length">
+    Long URLs get truncated in results and shares, and usually signal deep nesting. squirrel measures the full URL and counts path segments.
   </Card>
-  <Card title="URL Lowercase" icon="triangle-exclamation" href="/rules/url/lowercase">
-    Checks that URLs are lowercase
+  <Card title="Uppercase in a URL: the duplicate content it creates" icon="triangle-exclamation" href="/rules/url/lowercase">
+    Most servers treat /Page and /page as two URLs serving the same content. squirrel flags every crawled path containing a capital letter.
   </Card>
-  <Card title="URL Parameters" icon="circle-info" href="/rules/url/parameters">
-    Checks for excessive URL parameters
+  <Card title="URL parameters: how many is too many, and what to do" icon="circle-info" href="/rules/url/parameters">
+    Every parameter combination is a separate URL to a crawler. squirrel counts the query parameters on each page and names the tracking ones.
   </Card>
-  <Card title="URL Special Characters" icon="triangle-exclamation" href="/rules/url/special-chars">
-    Checks for problematic special characters in URL path
+  <Card title="Special characters in a URL path: what breaks and why" icon="triangle-exclamation" href="/rules/url/special-chars">
+    Spaces, percent signs and non-ASCII characters in a path break when copied and pasted. squirrel decodes the path and reports what it finds.
   </Card>
-  <Card title="URL Stop Words" icon="circle-info" href="/rules/url/stop-words">
-    Flags common stop words in URL slugs
+  <Card title="Stop words in a URL slug: when to drop them" icon="circle-info" href="/rules/url/stop-words">
+    the, of and for add characters without adding meaning to a slug. squirrel counts them in each path and only reports the pile-ups.
   </Card>
 </CardGroup>
 

--- a/docs/rules/url/length.mdx
+++ b/docs/rules/url/length.mdx
@@ -1,9 +1,34 @@
 ---
-title: "URL Length"
-description: "Checks URL length for optimal SEO"
+title: "URL length: when a URL is long enough to be a problem"
+description: "Long URLs get truncated in results and shares, and usually signal deep nesting. squirrel measures the full URL and counts path segments."
 ---
 
-Checks URL length for optimal SEO
+## What URL length affects
+
+There is no ranking penalty for a long URL and no protocol limit worth worrying about at the sizes real pages use. What length affects is display and handling: search results and social cards truncate, messaging apps break long links across lines, and a URL nobody can read is a URL nobody edits by hand.
+
+Length is also a symptom. A URL with six path segments and four parameters usually describes a site structure that is deeper than it needs to be, or a filter combination that should not be its own indexable page.
+
+## What squirrel checks
+
+The rule runs on every crawled page and measures the full URL string, not just the path. It emits up to two checks:
+
+- `url-length` warns above 100 characters. Message: `URL is 128 characters (over 100)`, with the first 60 characters plus an ellipsis as the value.
+- `url-length` reports info above 75 characters. Message: `URL is 84 characters (recommended: <75)`, with the full URL as the value.
+- `url-length` passes otherwise. Message: `URL length is optimal (42 chars)`.
+- `url-depth` reports info when the path has more than four non-empty segments. Message: `URL has 5 path segments (deep nesting)`, with `Consider flattening site structure` as the value.
+
+Severity for the rule is info and the weight is 3, so this is a description rather than a defect. Both thresholds are fixed and not configurable.
+
+## How to fix it
+
+```
+https://example.com/guides/url-structure
+```
+
+Shorten the slug rather than the hierarchy where you can: the slug should carry the terms that describe the page and nothing else. Drop tracking parameters from URLs you link to internally, and flatten a path that repeats information already in the parent segment.
+
+An established URL is worth more than a shorter one. Apply this to new pages and leave old ones alone unless you are restructuring anyway.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks URL length for optimal SEO
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Shorter URLs are easier to read, share, and may rank better. Keep URLs under 75 characters when possible. URLs over 100 characters can be truncated in search results and social shares. Remove unnecessary parameters, stop words, and path segments. Use descriptive but concise slugs. Long URLs often indicate poor site architecture.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["url/*"]
 enable = ["url/length"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [url/parameters](/rules/url/parameters): the query string that usually makes a URL long.
+- [url/stop-words](/rules/url/stop-words): words in the slug that add length without meaning.
+- [url/slug-convention](/rules/url/slug-convention): path depth measured against the site's own norm.
+- [url/slug-keywords](/rules/url/slug-keywords): whether the length is buying anything.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Keep a simple URL structure, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/url-structure)
+- [What is a URL, MDN](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Every long URL is listed with its character count and segment depth. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/lowercase.mdx
+++ b/docs/rules/url/lowercase.mdx
@@ -1,9 +1,34 @@
 ---
-title: "URL Lowercase"
-description: "Checks that URLs are lowercase"
+title: "Uppercase in a URL: the duplicate content it creates"
+description: "Most servers treat /Page and /page as two URLs serving the same content. squirrel flags every crawled path containing a capital letter."
 ---
 
-Checks that URLs are lowercase
+## What URL case sensitivity is
+
+The path portion of a URL is case-sensitive in the URI specification, and most origin servers treat it that way. `/Products` and `/products` are two different resources as far as the protocol is concerned.
+
+When both answer with the same page, you have two URLs for one document. Links split between them, and a search engine has to pick one, which is a choice you would rather make yourself. The host is a separate matter: hostnames are case-insensitive, so `EXAMPLE.com` and `example.com` are the same origin.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the URL path only. It emits a single check named `url-lowercase`:
+
+- Warn when the path contains any character in the range A to Z. Message: `URL contains uppercase characters`, with the path as the value and its lowercased form as the expected value. Severity warning, weight 4.
+- Pass otherwise. Message: `URL is lowercase`.
+
+The query string and the hostname are not examined. Percent-encoded sequences in the path, which are uppercase hexadecimal by convention, are read as they appear and can trigger the warning.
+
+## How to fix it
+
+```nginx
+location ~ [A-Z] {
+  rewrite ^/(.*)$ /$1 permanent;  # lowercase upstream, then redirect
+}
+```
+
+Emit lowercase URLs from the CMS or the router, and redirect the mixed-case forms permanently rather than serving both. Set a self-referencing canonical on the lowercase version so any remaining links consolidate.
+
+Do not lowercase the query string with the same rule. Parameter values are often case-sensitive, and tokens or signatures break when they are folded.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that URLs are lowercase
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-URLs should be lowercase to prevent duplicate content issues. Most servers treat /Page and /page as different URLs, creating duplicates. Always use lowercase URLs and redirect uppercase variants. Configure your server or CMS to auto-lowercase URLs. This also improves URL consistency and readability.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["url/*"]
 enable = ["url/lowercase"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [url/slug-convention](/rules/url/slug-convention): whether the site mixes case rather than applying one rule.
+- [url/hyphens](/rules/url/hyphens): the other per-path convention check.
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): the canonical tag that consolidates the variants.
+- [url/trailing-slash](/rules/url/trailing-slash): the other way one page becomes two URLs.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Keep a simple URL structure, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/url-structure)
+- [RFC 3986, section 6.2.2.1: case normalization](https://datatracker.ietf.org/doc/html/rfc3986)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Every path containing a capital letter is listed with its lowercase form. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/lowercase.mdx
+++ b/docs/rules/url/lowercase.mdx
@@ -20,13 +20,14 @@ The query string and the hostname are not examined. Percent-encoded sequences in
 
 ## How to fix it
 
-```nginx
-location ~ [A-Z] {
-  rewrite ^/(.*)$ /$1 permanent;  # lowercase upstream, then redirect
+```js
+// compute the lowercase destination, then redirect to it
+if (path !== path.toLowerCase()) {
+  return Response.redirect(new URL(path.toLowerCase(), origin), 301);
 }
 ```
 
-Emit lowercase URLs from the CMS or the router, and redirect the mixed-case forms permanently rather than serving both. Set a self-referencing canonical on the lowercase version so any remaining links consolidate.
+Emit lowercase URLs from the CMS or the router, and redirect the mixed-case forms permanently rather than serving both. The redirect has to build the lowercase target itself. A plain nginx `rewrite` that captures and re-emits the path preserves its case and redirects `/Products` to `/Products`, which is a loop. Set a self-referencing canonical on the lowercase version so any remaining links consolidate.
 
 Do not lowercase the query string with the same rule. Parameter values are often case-sensitive, and tokens or signatures break when they are folded.
 

--- a/docs/rules/url/parameters.mdx
+++ b/docs/rules/url/parameters.mdx
@@ -1,5 +1,5 @@
 ---
-title: "URL parameters: how many is too many and what to do about them"
+title: "URL parameters: how many is too many, and what to do"
 description: "Every parameter combination is a separate URL to a crawler. squirrel counts the query parameters on each page and names the tracking ones."
 ---
 

--- a/docs/rules/url/parameters.mdx
+++ b/docs/rules/url/parameters.mdx
@@ -7,7 +7,7 @@ description: "Every parameter combination is a separate URL to a crawler. squirr
 
 A query parameter creates a new URL. Three filters with five values each produce well over a hundred addresses for one listing, and a crawler has no way to know in advance that most of them return near-identical content.
 
-The cost is crawl budget spent on combinations nobody searches for, and index entries competing with each other. Tracking parameters are the simplest case: `utm_source` and `gclid` change nothing about the page, so a URL carrying one is a duplicate of the same URL without it, and a self-referencing canonical is enough to resolve it.
+The cost is crawl budget spent on combinations nobody searches for, and index entries competing with each other. Tracking parameters are the simplest case: `utm_source` and `gclid` change nothing about the page, so a URL carrying one is a duplicate of the same URL without it, and pointing its canonical at the clean URL is the signal that says so. Canonical selection is still the search engine's decision, not an instruction it has to follow.
 
 ## What squirrel checks
 
@@ -26,7 +26,9 @@ Severity for the rule is info and the weight is 3. The threshold of three is fix
 <link rel="canonical" href="https://example.com/shoes" />
 ```
 
-Give every parameterised URL a canonical pointing at the clean version. For faceted navigation, decide which combinations deserve to be indexable, and keep the rest out with `noindex` or by not linking them with crawlable hrefs.
+Point a tracking or otherwise equivalent variant at the clean URL. Parameters that select different content are different pages: `?page=2` gets its own self-referencing canonical, not one pointing at page one.
+
+For faceted navigation, decide which combinations deserve to be indexable. Not linking the rest with crawlable hrefs limits discovery but does not keep them out of the index, because a URL can be found elsewhere. Keeping a URL out of the index takes a `noindex` the crawler is allowed to fetch and read.
 
 Move content-defining values into the path where they matter: `/shoes/running` reads better and behaves better than `/products?category=shoes&type=running`.
 

--- a/docs/rules/url/parameters.mdx
+++ b/docs/rules/url/parameters.mdx
@@ -1,9 +1,34 @@
 ---
-title: "URL Parameters"
-description: "Checks for excessive URL parameters"
+title: "URL parameters: how many is too many and what to do about them"
+description: "Every parameter combination is a separate URL to a crawler. squirrel counts the query parameters on each page and names the tracking ones."
 ---
 
-Checks for excessive URL parameters
+## What URL parameters cost
+
+A query parameter creates a new URL. Three filters with five values each produce well over a hundred addresses for one listing, and a crawler has no way to know in advance that most of them return near-identical content.
+
+The cost is crawl budget spent on combinations nobody searches for, and index entries competing with each other. Tracking parameters are the simplest case: `utm_source` and `gclid` change nothing about the page, so a URL carrying one is a duplicate of the same URL without it, and a self-referencing canonical is enough to resolve it.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reads the query string. It emits up to two checks:
+
+- `url-parameters` passes when there is no query string. Message: `URL has no query parameters`. No further checks run.
+- `url-parameters` warns above three parameters. Message: `URL has 5 parameters (excessive)`, with each parameter name listed.
+- `url-parameters` reports info at one to three parameters. Message: `URL has 2 parameter(s)`, with the names listed.
+- `tracking-parameters` reports info when any parameter name matches `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`, `fbclid`, `gclid`, `ref` or `source`, compared lowercased. Message: `URL contains tracking parameters`, with `Use canonical tags to prevent duplicate content` as the value.
+
+Severity for the rule is info and the weight is 3. The threshold of three is fixed and not configurable.
+
+## How to fix it
+
+```html
+<link rel="canonical" href="https://example.com/shoes" />
+```
+
+Give every parameterised URL a canonical pointing at the clean version. For faceted navigation, decide which combinations deserve to be indexable, and keep the rest out with `noindex` or by not linking them with crawlable hrefs.
+
+Move content-defining values into the path where they matter: `/shoes/running` reads better and behaves better than `/products?category=shoes&type=running`.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks for excessive URL parameters
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Excessive URL parameters can cause crawl budget waste and duplicate content. Each parameter combination creates a unique URL. Use parameter handling in Google Search Console to tell Google how to handle parameters. Consider using path segments instead of parameters for important content. Filter/sort parameters should be handled with canonical tags or robots meta.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["url/*"]
 enable = ["url/parameters"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): where the canonical for these URLs points.
+- [url/length](/rules/url/length): the length parameters usually add.
+- [crawl/pagination](/rules/crawl/pagination): the parameter pattern that should stay indexable.
+- [analytics/gtm-present](/rules/analytics/gtm-present): the tags that generate the tracking parameters.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Faceted navigation best practices, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/crawling-managing-faceted-navigation)
+- [Consolidate duplicate URLs, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Each URL is listed with its parameter names and count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/slug-convention.mdx
+++ b/docs/rules/url/slug-convention.mdx
@@ -1,9 +1,34 @@
 ---
-title: "URL Convention Consistency"
-description: "Finds URLs that break the site's own URL conventions"
+title: "Mixed URL conventions: finding the minority form on your site"
+description: "Half your paths ending in a slash and half not is how canonical bugs start. squirrel computes your site's own norm and reports what deviates."
 ---
 
-Finds URLs that break the site's own URL conventions
+## What URL convention consistency is
+
+Every other URL rule judges one address against a fixed idea of a good address. None of them can see that a site is internally inconsistent: most slugs kebab-case with a pocket of snake_case, most paths bare with a handful slash-terminated.
+
+The mixing is the problem, not the form. `/My_Page`, `/my-page` and `/my-page/` are three URLs to a crawler even when they serve one document, and a site that applies one convention everywhere has none of that ambiguity regardless of which convention it picked. So this rule computes the site's own dominant form per dimension and reports only the minority against it.
+
+## What squirrel checks
+
+The rule is site-wide and judges five dimensions independently. Three are computed across the whole site: the slug word separator, kebab-case against snake_case against camelCase; the URL letter case, all-lowercase against a path carrying uppercase; and the trailing slash, present against absent, over extensionless paths only. Two are computed per page type: whether the slug carries a date, and the path-segment depth.
+
+Three guards apply in order. The site needs at least 10 crawled pages. A site-wide dimension needs at least 10 pages that vote in it, and a per-page-type dimension at least 8. A dimension's most common value must hold at least 70% of its votes, or the site legitimately mixes and nothing in it is a deviant.
+
+The rule emits a single check named `slug-convention`:
+
+- Skipped below the page floor. Message: `Only 6 page(s) crawled; 10 needed to establish a URL convention norm`.
+- Skipped when no dimension clears the agreement floor. Message: `No URL convention reaches 70% agreement across enough comparable pages`.
+- Pass when every page follows the norms. Message: `All 240 page(s) follow the site's own URL conventions (slug word separator kebab-case 98%, trailing slash no trailing slash 91%)`.
+- Warn when deviants exist and cover under 20% of crawled pages, and fail at or above that share. Message: `14 of 240 page(s) deviate from the site's own URL conventions (slug word separator kebab-case 94%)`. Each item reads `9 of 210 pages use snake_case but the slug word separator norm is kebab-case`, with up to 10 example URLs.
+
+Suppression runs one way. A deviant that `url/lowercase` already warns on is dropped from the case dimension, and one that `url/hyphens` already warns on is dropped from the separator dimension, so a site is not accused twice for one root cause. A dimension whose deviants are all suppressed still appears in the message tail as `(deferred to url/hyphens)`. Reported items are capped at 10, example URLs at 10 per item. Severity warning, weight 3.
+
+## How to fix it
+
+Pick the form the majority of the site already uses, migrate the minority onto it, and 301-redirect the old paths. The report names the dominant form and its share, so the decision is already made for you.
+
+A section that deliberately differs, a dated archive or a deeper product tree, is fine. This rule computes date-in-slug and depth per page type for exactly that reason, so a blog with dated URLs and a docs tree without them are judged separately.
 
 | | |
 |---|---|
@@ -12,61 +37,6 @@ Finds URLs that break the site's own URL conventions
 | **Scope** | Site-wide |
 | **Severity** | warning |
 | **Weight** | 3/10 |
-
-## How it works
-
-Every other URL rule judges one URL against a fixed idea of a good URL. None of them
-can see that a site is internally inconsistent, which is what actually produces
-duplicate-content and canonical bugs: `/My_Page`, `/my-page` and `/my-page/` are
-three different URLs to a crawler even when they serve the same thing.
-
-So the mixing is the finding here, never an individual URL. The rule computes your
-site's own dominant convention in each of five dimensions and reports only the
-minority form standing against it:
-
-| Dimension | Scope | Compares |
-|---|---|---|
-| Slug word separator | site-wide | kebab-case vs snake_case vs camelCase |
-| URL letter case | site-wide | all-lowercase paths vs paths carrying uppercase |
-| Trailing slash | site-wide | present vs absent, on extensionless paths |
-| Date in slug | per page type | dated vs undated posts of the same type |
-| Path depth | per page type | path-segment count within one page type |
-
-A site that is uniformly snake_case, or uniformly slash-terminated, is clean here:
-there is no minority to report. The rule only ever describes the deviants against
-the dominant form.
-
-It stays quiet unless it has grounds to speak:
-
-- Fewer than 10 crawled pages: no site norm exists, so the rule is skipped.
-- Fewer than 10 pages voting in a site-wide dimension (or 8 pages of one page type
-  for the per-type dimensions): the dimension is dropped, not guessed at.
-- No form reaching 70% of a dimension: the site mixes deliberately there, so
-  nothing in it is a deviant.
-
-## Precedence over the per-page URL rules
-
-The per-page rules own their pages, and this rule defers to them so one root cause
-is never reported twice:
-
-- [URL Lowercase](/rules/url/lowercase) already warns on every path containing an
-  uppercase letter, so those pages are dropped from the letter-case dimension.
-- [URL Hyphens](/rules/url/hyphens) already warns on every path containing an
-  underscore, so those pages are dropped from the separator dimension.
-- [Trailing Slash](/rules/url/trailing-slash) only raises on paths with a file
-  extension, so this rule judges the trailing-slash dimension over extensionless
-  paths only.
-
-A dimension whose deviants are entirely deferred is still named in the finding, so
-nothing is silently dropped.
-
-## Solution
-
-Your site uses more than one URL convention: some paths follow one form and a
-minority follow another. Pick the dominant form already used by most of your site,
-migrate the minority onto it, and 301-redirect the old paths so links and rankings
-follow. If a section deliberately differs (a dated archive, a deeper product tree),
-that is fine: the point is that a handful of pages should not be the exception.
 
 ## Enable / disable
 
@@ -91,3 +61,30 @@ disable = ["url/*"]
 enable = ["url/slug-convention"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [url/lowercase](/rules/url/lowercase): the per-page rule the case dimension defers to.
+- [url/hyphens](/rules/url/hyphens): the per-page rule the separator dimension defers to.
+- [url/trailing-slash](/rules/url/trailing-slash): the per-page state this rule measures against the site norm.
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): the canonical bugs mixed conventions produce.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Keep a simple URL structure, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/url-structure)
+- [Consolidate duplicate URLs, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Each norm is reported with its agreement share, and each deviant group with example URLs. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/slug-convention.mdx
+++ b/docs/rules/url/slug-convention.mdx
@@ -17,12 +17,13 @@ Three guards apply in order. The site needs at least 10 crawled pages. A site-wi
 
 The rule emits a single check named `slug-convention`:
 
+- Skipped when there are no pages at all. Message: `No pages available for analysis`.
 - Skipped below the page floor. Message: `Only 6 page(s) crawled; 10 needed to establish a URL convention norm`.
 - Skipped when no dimension clears the agreement floor. Message: `No URL convention reaches 70% agreement across enough comparable pages`.
-- Pass when every page follows the norms. Message: `All 240 page(s) follow the site's own URL conventions (slug word separator kebab-case 98%, trailing slash no trailing slash 91%)`.
-- Warn when deviants exist and cover under 20% of crawled pages, and fail at or above that share. Message: `14 of 240 page(s) deviate from the site's own URL conventions (slug word separator kebab-case 94%)`. Each item reads `9 of 210 pages use snake_case but the slug word separator norm is kebab-case`, with up to 10 example URLs.
+- Pass when no unsuppressed deviation remains. Message: `All 240 page(s) follow the site's own URL conventions (URL letter case all-lowercase 100%, trailing slash no trailing slash 100%)`.
+- Warn when deviants exist and cover under 20% of crawled pages, and fail at or above that share. Message: `14 of 240 page(s) deviate from the site's own URL conventions (slug word separator kebab-case 94%)`. Each item reads `9 of 210 page(s) use camelCase but the slug word separator norm is kebab-case`, with up to 10 example URLs.
 
-Suppression runs one way. A deviant that `url/lowercase` already warns on is dropped from the case dimension, and one that `url/hyphens` already warns on is dropped from the separator dimension, so a site is not accused twice for one root cause. A dimension whose deviants are all suppressed still appears in the message tail as `(deferred to url/hyphens)`. Reported items are capped at 10, example URLs at 10 per item. Severity warning, weight 3.
+Suppression runs one way and is unconditional. A deviant URL whose path contains an uppercase letter is dropped from the case dimension, and one whose path contains an underscore is dropped from the separator dimension, because `url/lowercase` and `url/hyphens` own those pages. The test reads the URL characters directly rather than consulting whether those rules ran. A dimension that lost any deviant this way is named in the message tail as `(deferred to separator -> url/hyphens)`, so a snake_case minority stays visible without being reported twice. Reported items are capped at 10, example URLs at 10 per item. Severity warning, weight 3.
 
 ## How to fix it
 

--- a/docs/rules/url/slug-convention.mdx
+++ b/docs/rules/url/slug-convention.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Mixed URL conventions: finding the minority form on your site"
+title: "Mixed URL conventions: finding the minority form"
 description: "Half your paths ending in a slash and half not is how canonical bugs start. squirrel computes your site's own norm and reports what deviates."
 ---
 

--- a/docs/rules/url/slug-keywords.mdx
+++ b/docs/rules/url/slug-keywords.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Slug Keywords"
-description: "Checks if URL slug contains relevant keywords"
+title: "Non-descriptive URL slug: numeric IDs and generic patterns"
+description: "A slug like /p/48213 tells a reader and a crawler nothing. squirrel classifies the last path segment and flags the ID-shaped ones."
 ---
 
-Checks if URL slug contains relevant keywords
+## What a descriptive slug is
+
+The last segment of a path is the part that names the page. A descriptive slug uses the words a person would use for the content: `/blog/url-structure`. A non-descriptive one uses a database key: `/p/48213` or `/node/1204`.
+
+A descriptive slug helps in small, real ways. It appears in the search result and in a shared link, so a reader knows where they are going before they click, and it gives a search engine a few more terms about the page. It is not a ranking mechanism worth restructuring a site for; it is worth getting right when you choose the URL.
+
+## What squirrel checks
+
+The rule runs on every crawled page and looks only at the last non-empty path segment. It emits a single check named `slug-keywords`:
+
+- Pass when the URL is pagination, meaning the previous segment is `page`, `pages` or `p` and the last segment is all digits. Message: `Pagination URL (excluded from slug analysis)`.
+- Warn when the segment is all digits, or is eight or more hexadecimal characters. Message: `URL uses numeric/hash ID instead of descriptive slug`, with the segment as the value.
+- Warn when the segment matches `page`, `post`, `item`, `product`, `article` or `node` followed by an optional hyphen and digits. Message: `URL uses generic slug pattern`.
+- Info when the segment is under four characters and looks like a short ID, meaning one to eight alphanumeric characters with no doubled vowel. Message: `URL slug is very short, may lack keywords`.
+- Pass when splitting the segment on hyphens and underscores yields at least one word longer than two characters. Message: `URL appears to contain descriptive keywords`.
+- Info otherwise. Message: `URL slug may not be descriptive`.
+- Info on the root path. Message: `Root URL (no slug to analyze)`.
+
+Severity is info and the weight is 3.
+
+## How to fix it
+
+```
+https://example.com/products/merino-crew-socks
+```
+
+Build the slug from the title when the record is created and store it, so it stays stable when the title is later edited. Keep the ID in the database, not in the URL.
+
+Where the ID has to stay for routing, put the descriptive part first: `/products/merino-crew-socks-48213` reads correctly and still resolves. That form passes this check.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks if URL slug contains relevant keywords
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-URLs should contain keywords that describe the page content. Good: /blue-running-shoes. Bad: /product-12345 or /p?id=abc. Include primary keywords in the URL path, but avoid keyword stuffing. URLs should be readable by humans and give users an idea of page content before clicking. Dynamic parameters don't provide SEO value.
 
 ## Enable / disable
 
@@ -40,3 +64,29 @@ disable = ["url/*"]
 enable = ["url/slug-keywords"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [url/stop-words](/rules/url/stop-words): words in the slug that are not carrying meaning.
+- [url/slug-convention](/rules/url/slug-convention): the site's own separator and depth norms.
+- [url/length](/rules/url/length): how long the descriptive slug is allowed to get.
+- [core/meta-title](/rules/core/meta-title): the title the slug should be derived from.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Keep a simple URL structure, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/url-structure)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Each ID-shaped slug is listed with the segment that triggered it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/slug-keywords.mdx
+++ b/docs/rules/url/slug-keywords.mdx
@@ -16,7 +16,7 @@ The rule runs on every crawled page and looks only at the last non-empty path se
 - Pass when the URL is pagination, meaning the previous segment is `page`, `pages` or `p` and the last segment is all digits. Message: `Pagination URL (excluded from slug analysis)`.
 - Warn when the segment is all digits, or is eight or more hexadecimal characters. Message: `URL uses numeric/hash ID instead of descriptive slug`, with the segment as the value.
 - Warn when the segment matches `page`, `post`, `item`, `product`, `article` or `node` followed by an optional hyphen and digits. Message: `URL uses generic slug pattern`.
-- Info when the segment is under four characters and looks like a short ID, meaning one to eight alphanumeric characters with no doubled vowel. Message: `URL slug is very short, may lack keywords`.
+- Info when the segment is under four characters and looks like a short ID, meaning one to eight alphanumeric characters containing no two consecutive vowels. `xyz` qualifies; `aex` does not, and falls through to the descriptive branch below. Message: `URL slug is very short, may lack keywords`.
 - Pass when splitting the segment on hyphens and underscores yields at least one word longer than two characters. Message: `URL appears to contain descriptive keywords`.
 - Info otherwise. Message: `URL slug may not be descriptive`.
 - Info on the root path. Message: `Root URL (no slug to analyze)`.

--- a/docs/rules/url/special-chars.mdx
+++ b/docs/rules/url/special-chars.mdx
@@ -7,7 +7,7 @@ description: "Spaces, percent signs and non-ASCII characters in a path break whe
 
 A URL path is limited by RFC 3986 to a defined set of characters. Anything else has to be percent-encoded, which is why a space becomes `%20`. Some characters are reserved because they delimit parts of the URL: `?` starts the query, `#` starts the fragment, `&` and `=` separate parameters.
 
-Encoded characters work, but they travel badly. A path with `%20` in it gets mangled when pasted into a chat client, truncated by a link parser at the first unexpected character, or double-encoded by a system that cannot tell whether it has already been processed. Non-ASCII characters in a path are valid as internationalised URLs and display well in a browser while appearing as long percent sequences everywhere else.
+Encoding is correct and works. What varies is how the software around it behaves: link parsers that stop at the first unexpected character, systems that encode an already-encoded path a second time, tools that display the raw percent sequence rather than decoding it. Non-ASCII characters in a path are valid, and browsers show them decoded, but whether anything else does depends on the application. Sticking to unreserved characters removes the question.
 
 ## What squirrel checks
 

--- a/docs/rules/url/special-chars.mdx
+++ b/docs/rules/url/special-chars.mdx
@@ -1,9 +1,33 @@
 ---
-title: "URL Special Characters"
-description: "Checks for problematic special characters in URL path"
+title: "Special characters in a URL path: what breaks and why"
+description: "Spaces, percent signs and non-ASCII characters in a path break when copied and pasted. squirrel decodes the path and reports what it finds."
 ---
 
-Checks for problematic special characters in URL path
+## What counts as a problematic character
+
+A URL path is limited by RFC 3986 to a defined set of characters. Anything else has to be percent-encoded, which is why a space becomes `%20`. Some characters are reserved because they delimit parts of the URL: `?` starts the query, `#` starts the fragment, `&` and `=` separate parameters.
+
+Encoded characters work, but they travel badly. A path with `%20` in it gets mangled when pasted into a chat client, truncated by a link parser at the first unexpected character, or double-encoded by a system that cannot tell whether it has already been processed. Non-ASCII characters in a path are valid as internationalised URLs and display well in a browser while appearing as long percent sequences everywhere else.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the URL path only, decoded first with `decodeURIComponent`. It emits up to two checks:
+
+- `url-special-chars` warns when the decoded path contains any of `% & = # [ ] { } | \ ^ ~ \` < >`, or a space, or any character outside printable ASCII. Message: `URL path contains problematic characters`, with the categories found listed as items: `spaces`, `special characters`, `non-ASCII characters`. Severity warning, weight 4.
+- `url-special-chars` passes otherwise. Message: `URL path uses clean characters`.
+- `url-double-slash` warns when the path contains `//` anywhere after the first character. Message: `URL path contains double slashes`, with the path as the value.
+
+The space test looks at both the raw path, for a literal `%20` or whitespace, and the decoded path. The query string is not examined.
+
+## How to fix it
+
+```
+https://example.com/blog/cafe-guide
+```
+
+Generate slugs by transliterating to ASCII, lowercasing, and replacing anything left with a hyphen. Collapse repeated separators so a title with a colon and a space does not produce `--`.
+
+A site whose audience reads a non-Latin script has a real reason to use those characters in URLs, and browsers display them correctly. Disable the rule rather than transliterating a language into something its readers cannot recognise.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for problematic special characters in URL path
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Avoid special characters in URL paths. Characters like %, &, #, ?, = have special meanings and can cause issues. Spaces should be avoided (they become %20). Use only lowercase letters, numbers, and hyphens. Special characters can break links when copied, cause encoding issues, and look unprofessional. URL-encode if unavoidable.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["url/*"]
 enable = ["url/special-chars"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [url/lowercase](/rules/url/lowercase): case, the other thing a slug generator should normalise.
+- [url/hyphens](/rules/url/hyphens): the separator the generator should be using.
+- [i18n/lang-attribute](/rules/i18n/lang-attribute): the correct way to declare a page's language.
+- [links/invalid-links](/rules/links/invalid-links): links whose href does not parse at all.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [RFC 3986: Uniform Resource Identifier](https://datatracker.ietf.org/doc/html/rfc3986)
+- [Percent-encoding, MDN](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Each path is listed with the categories of character it contains. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/stop-words.mdx
+++ b/docs/rules/url/stop-words.mdx
@@ -1,9 +1,33 @@
 ---
-title: "URL Stop Words"
-description: "Flags common stop words in URL slugs"
+title: "Stop words in a URL slug: when to drop them"
+description: "the, of and for add characters without adding meaning to a slug. squirrel counts them in each path and only reports the pile-ups."
 ---
 
-Flags common stop words in URL slugs
+## What stop words are
+
+Stop words are the high-frequency function words of a language: articles, prepositions, auxiliaries. In a URL slug they take up characters and carry almost no information about what the page is.
+
+Dropping them is a style choice, not a correctness one. `best-running-shoes` is shorter and reads as well as `the-best-running-shoes-for-you`. Keeping one is right when removing it changes the meaning or makes the slug unreadable, which is why this rule only reports slugs that have accumulated several.
+
+## What squirrel checks
+
+The rule runs on every crawled page. It lowercases the URL path, splits it on hyphens, underscores and slashes, and counts the resulting words against a fixed list of 35 stop words.
+
+- Info when more than two stop words are found. Message: `URL contains 4 stop words`, with each word listed.
+- Pass when one or two are found. Message: `URL has minimal stop words`, with them listed.
+- Pass when none are found. Message: `URL has no stop words`.
+
+Severity is info and the weight is 2, the lowest in the URL Structure category. The list covers `a`, `an`, `and`, `are`, `as`, `at`, `be`, `but`, `by`, `for`, `from`, `has`, `have`, `in`, `is`, `it`, `of`, `on`, `or`, `our`, `that`, `the`, `their`, `there`, `they`, `this`, `to`, `was`, `were`, `what`, `which`, `will`, `with`, `would` and `your`. It is English-only, so a slug in another language is scored against English words and will usually pass.
+
+## How to fix it
+
+```
+https://example.com/blog/best-running-shoes
+```
+
+Strip stop words in the slug generator, before the slug is first published rather than after. Keep the word when the slug stops making sense without it: `state-of-the-art` is not improved by becoming `state-art`.
+
+Do not rewrite existing URLs for this. The finding is informational, and the redirect costs more than the characters save.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Flags common stop words in URL slugs
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 2/10 |
-
-## Solution
-
-Stop words (a, an, the, of, etc.) add length without SEO value. While not harmful, removing them makes URLs shorter and more focused. 'best-running-shoes' is better than 'the-best-running-shoes-for-you'. However, keep stop words if removing them makes the URL confusing or grammatically awkward.
 
 ## Enable / disable
 
@@ -40,3 +60,29 @@ disable = ["url/*"]
 enable = ["url/stop-words"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [url/slug-keywords](/rules/url/slug-keywords): whether the remaining words describe the page.
+- [url/length](/rules/url/length): the total the stop words contribute to.
+- [url/hyphens](/rules/url/hyphens): the separator this rule splits on.
+- [content/keyword-stuffing](/rules/content/keyword-stuffing): the opposite failure, too many meaningful words.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Keep a simple URL structure, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/url-structure)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Each slug is listed with the stop words it contains. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/stop-words.mdx
+++ b/docs/rules/url/stop-words.mdx
@@ -66,7 +66,7 @@ disable = ["*"]
 - [url/slug-keywords](/rules/url/slug-keywords): whether the remaining words describe the page.
 - [url/length](/rules/url/length): the total the stop words contribute to.
 - [url/hyphens](/rules/url/hyphens): the separator this rule splits on.
-- [content/keyword-stuffing](/rules/content/keyword-stuffing): the opposite failure, too many meaningful words.
+- [content/keyword-stuffing](/rules/content/keyword-stuffing): excessive repetition of one word in the page copy.
 
 URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
 

--- a/docs/rules/url/trailing-slash.mdx
+++ b/docs/rules/url/trailing-slash.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Trailing Slash"
-description: "Checks for consistent trailing slash usage"
+title: "Trailing slash: /page and /page/ are two different URLs"
+description: "A file URL with a trailing slash is a mistake; a directory URL either has one or does not, consistently. squirrel reports the state of each path."
 ---
 
-Checks for consistent trailing slash usage
+## What the trailing slash decides
+
+`/about` and `/about/` are distinct URLs. A server can serve the same content at both, redirect one to the other, or serve one and 404 the other. Which it does is a configuration choice, not a property of the web.
+
+Google's own guidance is that either convention is fine as long as you pick one and redirect the other, because serving both without a redirect means one page has two addresses. The convention most sites use is a trailing slash for directory-like paths and none for a path that names a file with an extension.
+
+## What squirrel checks
+
+The rule runs on every crawled page over the URL path only. A path is treated as a file when it ends in a dot followed by two to four alphanumeric characters. It emits a single check named `trailing-slash`:
+
+- Info on the root path. Message: `Root URL (trailing slash check not applicable)`.
+- Warn when a file-like path ends in a slash. Message: `File URL has trailing slash`, with the path as the value.
+- Pass when a file-like path does not. Message: `File URL correctly has no trailing slash`.
+- Info for any extensionless path, reporting the state rather than judging it. Message: `URL has trailing slash` or `URL has no trailing slash`, with `Ensure consistency across site` as the value.
+
+Severity is info and the weight is 3. Consistency across the site is not judged here: that is `url/slug-convention`, which computes the site's own dominant form and reports the minority against it.
+
+## How to fix it
+
+```nginx
+rewrite ^/(.*)/$ /$1 permanent;   # or the reverse, but only one
+```
+
+Pick a convention, apply it in the router, and redirect the other form permanently. Then make internal links, canonical tags and the sitemap all use the chosen form so no navigation takes the redirect.
+
+Do not redirect in both directions. A rule that adds a slash and another that removes it produce a loop.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks for consistent trailing slash usage
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Be consistent with trailing slashes across your site. /page and /page/ are technically different URLs. Pick one convention and stick to it. Configure your server to redirect one to the other. Most sites use trailing slashes for directories and no trailing slash for files. Use canonical tags to specify the preferred version.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["url/*"]
 enable = ["url/trailing-slash"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [url/slug-convention](/rules/url/slug-convention): whether the site mixes the two forms, which is the real finding.
+- [crawl/redirect-chain](/rules/crawl/redirect-chain): the hop a slash rule adds to every chain.
+- [crawl/canonical-chain](/rules/crawl/canonical-chain): the canonical that has to agree with the choice.
+- [url/lowercase](/rules/url/lowercase): the other way one page ends up with two addresses.
+
+URL Structure findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [To slash or not to slash, Google Search Central](https://developers.google.com/search/blog/2010/04/to-slash-or-not-to-slash)
+- [Consolidate duplicate URLs, Google Search Central](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the URL Structure section of the report. Each path is reported with its current trailing-slash state. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the URL Structure section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/url/trailing-slash.mdx
+++ b/docs/rules/url/trailing-slash.mdx
@@ -14,9 +14,10 @@ Google's own guidance is that either convention is fine as long as you pick one 
 The rule runs on every crawled page over the URL path only. A path is treated as a file when it ends in a dot followed by two to four alphanumeric characters. It emits a single check named `trailing-slash`:
 
 - Info on the root path. Message: `Root URL (trailing slash check not applicable)`.
-- Warn when a file-like path ends in a slash. Message: `File URL has trailing slash`, with the path as the value.
-- Pass when a file-like path does not. Message: `File URL correctly has no trailing slash`.
-- Info for any extensionless path, reporting the state rather than judging it. Message: `URL has trailing slash` or `URL has no trailing slash`, with `Ensure consistency across site` as the value.
+- Pass when a file-like path has no trailing slash. Message: `File URL correctly has no trailing slash`.
+- Info for every other non-root path, reporting the state rather than judging it. Message: `URL has trailing slash` or `URL has no trailing slash`, with `Ensure consistency across site` as the value.
+
+A fourth branch, `File URL has trailing slash`, exists in the code but cannot fire: the extension test anchors the extension to the end of the path, so `/report.pdf/` fails it and falls into the informational branch above. That branch therefore covers extensionless paths and anything else the extension test rejects.
 
 Severity is info and the weight is 3. Consistency across the site is not judged here: that is `url/slug-convention`, which computes the site's own dominant form and reports the minority against it.
 

--- a/docs/rules/video/index.mdx
+++ b/docs/rules/video/index.mdx
@@ -8,14 +8,14 @@ Video rules cover the three things a video needs beyond the file itself: structu
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Video Accessibility" icon="triangle-exclamation" href="/rules/video/video-accessible">
-    Checks for video captions and transcripts
+  <Card title="Video captions: the track element and why it is required" icon="triangle-exclamation" href="/rules/video/video-accessible">
+    A video with no captions excludes anyone who cannot hear it. squirrel checks every HTML video element for a caption or subtitle track.
   </Card>
-  <Card title="Video Schema" icon="triangle-exclamation" href="/rules/video/video-schema">
-    Checks for VideoObject schema on pages with video
+  <Card title="VideoObject schema: video on a page with no markup for it" icon="triangle-exclamation" href="/rules/video/video-schema">
+    Without VideoObject markup a search engine cannot tell there is a video on the page. squirrel detects video elements and embeds, then checks the schema.
   </Card>
-  <Card title="Video Thumbnail" icon="circle-info" href="/rules/video/video-thumbnail">
-    Checks that videos have poster/thumbnail images
+  <Card title="Video poster attribute: the frame shown before playback" icon="circle-info" href="/rules/video/video-thumbnail">
+    A video with no poster renders as a blank box until it buffers. squirrel checks every HTML video element for the poster attribute.
   </Card>
 </CardGroup>
 

--- a/docs/rules/video/index.mdx
+++ b/docs/rules/video/index.mdx
@@ -3,7 +3,7 @@ title: "Video"
 description: "Video content markup and accessibility"
 ---
 
-Video content markup and accessibility
+Video rules cover the three things a video needs beyond the file itself: structured data so a search engine knows what it is, captions so it is usable without sound, and a poster frame so the box is not blank while it buffers. The caption and poster checks read HTML video elements only, so a page whose video is an embedded iframe reports that it has none.
 
 ## Rules
 
@@ -25,3 +25,5 @@ Video content markup and accessibility
 [rules]
 disable = ["video/*"]
 ```
+
+Every audit reports Video findings next to the performance, security and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.

--- a/docs/rules/video/video-accessible.mdx
+++ b/docs/rules/video/video-accessible.mdx
@@ -5,7 +5,7 @@ description: "A video with no captions excludes anyone who cannot hear it. squir
 
 ## What a caption track is
 
-A `<track>` element inside a `<video>` points at a timed text file, usually WebVTT, that the browser renders as captions. `kind="captions"` is for a transcript that includes sound effects and speaker identification; `kind="subtitles"` is for a translation.
+A `<track>` element inside a `<video>` points at a timed text file, usually WebVTT, that the browser renders as captions. `kind="captions"` additionally carries relevant non-speech audio, such as sound effects and speaker identification, for a viewer who cannot hear the track. `kind="subtitles"` carries dialogue, either translated or in the same language as the audio.
 
 WCAG success criterion 1.2.2 requires captions for prerecorded audio in synchronised media at Level A, the lowest conformance level. They also help anyone watching without sound, which is most people on a phone in public, and the text is indexable in a way audio is not.
 

--- a/docs/rules/video/video-accessible.mdx
+++ b/docs/rules/video/video-accessible.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Video Accessibility"
-description: "Checks for video captions and transcripts"
+title: "Video captions: the track element and why it is required"
+description: "A video with no captions excludes anyone who cannot hear it. squirrel checks every HTML video element for a caption or subtitle track."
 ---
 
-Checks for video captions and transcripts
+## What a caption track is
+
+A `<track>` element inside a `<video>` points at a timed text file, usually WebVTT, that the browser renders as captions. `kind="captions"` is for a transcript that includes sound effects and speaker identification; `kind="subtitles"` is for a translation.
+
+WCAG success criterion 1.2.2 requires captions for prerecorded audio in synchronised media at Level A, the lowest conformance level. They also help anyone watching without sound, which is most people on a phone in public, and the text is indexable in a way audio is not.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `<video>` element, looking for a child `track[kind="captions"]` or `track[kind="subtitles"]`. It emits a single check named `video-accessible`:
+
+- Info when the page has no `<video>` element. Message: `No HTML5 video elements found`.
+- Pass when every video has a caption or subtitle track. Message: `All 3 video(s) have caption tracks`.
+- Info when some do. Message: `2/3 video(s) have caption tracks`.
+- Warn when none do. Message: `No videos have caption tracks`, with `Add <track> elements for accessibility` as the value. Severity warning, weight 4.
+
+Only HTML `<video>` elements are checked. A YouTube or Vimeo embed carries its own captions inside the iframe, which this rule cannot see, so a page whose video is entirely embedded reports `No HTML5 video elements found`.
+
+## How to fix it
+
+```html
+<video controls poster="/thumb.jpg">
+  <source src="/talk.mp4" type="video/mp4" />
+  <track kind="captions" src="/talk.en.vtt" srclang="en" label="English" default />
+</video>
+```
+
+Ship a WebVTT file alongside the video and reference it with `<track>`. Auto-generated captions are a starting point, not a deliverable: they get names, jargon and punctuation wrong, which is exactly the content someone relying on them needs.
+
+Publish a transcript on the page as well. It is readable, searchable and useful to people who would rather not watch.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks for video captions and transcripts
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Videos need captions for deaf/hard-of-hearing users and transcripts for SEO. Use `<track>` elements for captions. Provide text transcripts on the page. Auto-generated captions should be reviewed for accuracy. Captions also help when audio can't be played. Required by WCAG 2.1 Level A.
 
 ## Enable / disable
 
@@ -40,3 +64,30 @@ disable = ["video/*"]
 enable = ["video/video-accessible"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [video/video-schema](/rules/video/video-schema): the markup that describes the same video.
+- [video/video-thumbnail](/rules/video/video-thumbnail): the poster image on the same element.
+- [a11y/video-captions](/rules/a11y/video-captions): the accessibility check over the same markup.
+- [content/word-count](/rules/content/word-count): the transcript text that counts toward the page.
+
+Video findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The track element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track)
+- [Understanding captions (prerecorded), WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/captions-prerecorded.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Video section of the report. Each page is reported with how many of its videos carry a caption track. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Video section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/video/video-schema.mdx
+++ b/docs/rules/video/video-schema.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Video Schema"
-description: "Checks for VideoObject schema on pages with video"
+title: "VideoObject schema: video on a page with no markup for it"
+description: "Without VideoObject markup a search engine cannot tell there is a video on the page. squirrel detects video elements and embeds, then checks the schema."
 ---
 
-Checks for VideoObject schema on pages with video
+## What VideoObject is
+
+`VideoObject` is the schema.org type describing a video: its name, description, thumbnail and upload date, plus optional duration, content URL and embed URL. Google requires `name`, `description`, `thumbnailUrl` and `uploadDate` for a video to be eligible for its video features.
+
+Without it, a search engine sees an iframe or a `<video>` element and has no title, no description and no thumbnail to work with. The video may still be found, but it cannot appear as a video result.
+
+## What squirrel checks
+
+The rule runs on every crawled page. A page counts as having video when it contains any `<video>` element, or an `iframe` whose `src` contains `youtube` or `vimeo`. It emits a single check named `video-schema`:
+
+- Info when no video was detected. Message: `No video content detected`.
+- Pass when the page's schema types include `VideoObject`. Message: `VideoObject schema present for video content`.
+- Warn otherwise. Message: `Video content without VideoObject schema`, with `Add schema for video rich results` as the value. Severity warning, weight 5.
+
+Detection covers only YouTube and Vimeo iframes, so a video embedded from another host is not counted. The schema check reads the parser's list of schema types, which covers top-level and `@graph` nodes; it does not validate that the required properties are present.
+
+## How to fix it
+
+```json
+{"@context":"https://schema.org","@type":"VideoObject","name":"How to structure URLs","description":"…","thumbnailUrl":"https://example.com/thumb.jpg","uploadDate":"2026-03-12T09:00:00+11:00","duration":"PT6M14S","embedUrl":"https://www.youtube.com/embed/…"}
+```
+
+Emit the node from the same data that renders the player, so the title and description cannot drift from what the page shows. `uploadDate` needs a timezone offset, and `duration` is an ISO 8601 duration.
+
+Check the result in Google's Rich Results Test. This rule confirms the type exists, not that the required properties are there.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for VideoObject schema on pages with video
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Add VideoObject schema to pages with video content for rich results. Required: name, description, thumbnailUrl, uploadDate. Recommended: duration, contentUrl, embedUrl. Schema enables video carousels and previews in search results. Test with Google's Rich Results Test.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["video/*"]
 enable = ["video/video-schema"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [schema/video](/rules/schema/video): the structured data checks over the same node.
+- [video/video-thumbnail](/rules/video/video-thumbnail): the poster image, and the thumbnailUrl the schema needs.
+- [video/video-accessible](/rules/video/video-accessible): captions on the same videos.
+- [crawl/schema-noindex-conflict](/rules/crawl/schema-noindex-conflict): rich markup on a page that is not indexable.
+
+Video findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [Video structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/video)
+- [VideoObject, Schema.org](https://schema.org/VideoObject)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Video section of the report. Each page with video is reported with whether VideoObject markup is present. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Video section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/video/video-schema.mdx
+++ b/docs/rules/video/video-schema.mdx
@@ -5,9 +5,9 @@ description: "Without VideoObject markup a search engine cannot tell there is a 
 
 ## What VideoObject is
 
-`VideoObject` is the schema.org type describing a video: its name, description, thumbnail and upload date, plus optional duration, content URL and embed URL. Google requires `name`, `description`, `thumbnailUrl` and `uploadDate` for a video to be eligible for its video features.
+`VideoObject` is the schema.org type describing a video: its name, description, thumbnail and upload date, plus optional duration, content URL and embed URL. Google requires `name`, `thumbnailUrl` and `uploadDate`, and recommends `description`, for a video to be eligible for its video features.
 
-Without it, a search engine sees an iframe or a `<video>` element and has no title, no description and no thumbnail to work with. The video may still be found, but it cannot appear as a video result.
+Without it, a search engine has to infer the title, description and thumbnail from the page. Google can still discover a video that way, so the markup is not a precondition for appearing at all; what it does is describe the video accurately and open the enhancements that depend on it.
 
 ## What squirrel checks
 
@@ -25,7 +25,7 @@ Detection covers only YouTube and Vimeo iframes, so a video embedded from anothe
 {"@context":"https://schema.org","@type":"VideoObject","name":"How to structure URLs","description":"…","thumbnailUrl":"https://example.com/thumb.jpg","uploadDate":"2026-03-12T09:00:00+11:00","duration":"PT6M14S","embedUrl":"https://www.youtube.com/embed/…"}
 ```
 
-Emit the node from the same data that renders the player, so the title and description cannot drift from what the page shows. `uploadDate` needs a timezone offset, and `duration` is an ISO 8601 duration.
+Emit the node from the same data that renders the player, so the title and description cannot drift from what the page shows. `uploadDate` should include a timezone offset, since Google otherwise assumes Googlebot's own, and `duration` is an ISO 8601 duration.
 
 Check the result in Google's Rich Results Test. This rule confirms the type exists, not that the required properties are there.
 
@@ -73,7 +73,7 @@ Video findings ship in every audit next to the SEO, performance and agent experi
 ## References
 
 - [Video structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/video)
-- [VideoObject, Schema.org](https://schema.org/VideoObject)
+- [Video best practices, Google Search Central](https://developers.google.com/search/docs/appearance/video)
 
 ## Check your site
 

--- a/docs/rules/video/video-thumbnail.mdx
+++ b/docs/rules/video/video-thumbnail.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Video Thumbnail"
-description: "Checks that videos have poster/thumbnail images"
+title: "Video poster attribute: the frame shown before playback"
+description: "A video with no poster renders as a blank box until it buffers. squirrel checks every HTML video element for the poster attribute."
 ---
 
-Checks that videos have poster/thumbnail images
+## What the poster attribute is
+
+`poster` on a `<video>` element names an image the browser shows in the video's box until playback starts. Without it, the browser shows either nothing or the first frame, and the first frame of most videos is black.
+
+It is a perceived-performance measure as much as a design one. The poster is a normal image, so it loads at image speed and gives the reader something to look at while the video is still buffering. The equivalent for an embedded video is `thumbnailUrl` in the `VideoObject` schema, which is also what a search result uses.
+
+## What squirrel checks
+
+The rule runs on every crawled page over every `<video>` element and checks for a `poster` attribute. It emits a single check named `video-thumbnail`:
+
+- Info when the page has no `<video>` element. Message: `No HTML5 video elements found`.
+- Warn when any video has no `poster`. Message: `2 video(s) missing poster attribute`, with `Add poster images for better UX` as the value.
+- Pass otherwise. Message: `All 3 video(s) have poster images`.
+
+Only the presence of the attribute is checked. The image is not fetched, so a `poster` pointing at a 404 passes. Severity info, weight 3.
+
+## How to fix it
+
+```html
+<video controls poster="/talk-poster.jpg" width="1280" height="720">
+  <source src="/talk.mp4" type="video/mp4" />
+</video>
+```
+
+Use a frame from the video itself at 1280 by 720 or larger, and give the element `width` and `height` so the box is reserved before the poster loads.
+
+For an embedded video, the equivalent is `thumbnailUrl` on the `VideoObject` node.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks that videos have poster/thumbnail images
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Video poster images improve perceived performance and user experience. For HTML5 video, use the poster attribute. For embedded videos, thumbnailUrl in VideoObject schema. Thumbnails should be high quality, relevant to content, and properly sized (recommend 1280x720 or higher).
 
 ## Enable / disable
 
@@ -40,3 +62,30 @@ disable = ["video/*"]
 enable = ["video/video-thumbnail"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [video/video-schema](/rules/video/video-schema): the thumbnailUrl the schema needs for an embed.
+- [video/video-accessible](/rules/video/video-accessible): captions on the same element.
+- [images/dimensions](/rules/images/dimensions): the width and height that reserve the video's space.
+- [performance/lcp-hints](/rules/performance/lcp-hints): the poster, which is often the largest visible element.
+
+Video findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
+
+## References
+
+- [The video element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video)
+- [Video structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/video)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Video section of the report. Each page is reported with how many of its videos carry a poster. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Video section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/video/video-thumbnail.mdx
+++ b/docs/rules/video/video-thumbnail.mdx
@@ -68,7 +68,7 @@ disable = ["*"]
 - [video/video-schema](/rules/video/video-schema): the thumbnailUrl the schema needs for an embed.
 - [video/video-accessible](/rules/video/video-accessible): captions on the same element.
 - [images/dimensions](/rules/images/dimensions): the width and height that reserve the video's space.
-- [performance/lcp-hints](/rules/perf/lcp-hints): the poster, which is often the largest visible element.
+- [perf/lcp-hints](/rules/perf/lcp-hints): the poster, which is often the largest visible element.
 
 Video findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
 

--- a/docs/rules/video/video-thumbnail.mdx
+++ b/docs/rules/video/video-thumbnail.mdx
@@ -68,7 +68,7 @@ disable = ["*"]
 - [video/video-schema](/rules/video/video-schema): the thumbnailUrl the schema needs for an embed.
 - [video/video-accessible](/rules/video/video-accessible): captions on the same element.
 - [images/dimensions](/rules/images/dimensions): the width and height that reserve the video's space.
-- [performance/lcp-hints](/rules/performance/lcp-hints): the poster, which is often the largest visible element.
+- [performance/lcp-hints](/rules/perf/lcp-hints): the poster, which is often the largest visible element.
 
 Video findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
 

--- a/docs/rules/video/video-thumbnail.mdx
+++ b/docs/rules/video/video-thumbnail.mdx
@@ -7,7 +7,7 @@ description: "A video with no poster renders as a blank box until it buffers. sq
 
 `poster` on a `<video>` element names an image the browser shows in the video's box until playback starts. Without it, the browser shows either nothing or the first frame, and the first frame of most videos is black.
 
-It is a perceived-performance measure as much as a design one. The poster is a normal image, so it loads at image speed and gives the reader something to look at while the video is still buffering. The equivalent for an embedded video is `thumbnailUrl` in the `VideoObject` schema, which is also what a search result uses.
+It is a perceived-performance measure as much as a design one. The poster is a normal image, so it loads at image speed and gives the reader something to look at while the video is still buffering. An embedded player has no `poster`: its preview frame is configured through the provider. `thumbnailUrl` in the `VideoObject` schema is a separate thing, the image a search result uses, not the one the embed renders.
 
 ## What squirrel checks
 
@@ -29,7 +29,7 @@ Only the presence of the attribute is checked. The image is not fetched, so a `p
 
 Use a frame from the video itself at 1280 by 720 or larger, and give the element `width` and `height` so the box is reserved before the poster loads.
 
-For an embedded video, the equivalent is `thumbnailUrl` on the `VideoObject` node.
+For an embedded video, set the preview through the player or provider, and supply `thumbnailUrl` on the `VideoObject` node separately for search.
 
 | | |
 |---|---|
@@ -75,7 +75,7 @@ Video findings ship in every audit next to the SEO, performance and agent experi
 ## References
 
 - [The video element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video)
-- [Video structured data, Google Search Central](https://developers.google.com/search/docs/appearance/structured-data/video)
+- [Video best practices, Google Search Central](https://developers.google.com/search/docs/appearance/video)
 
 ## Check your site
 

--- a/docs/rules/video/video-thumbnail.mdx
+++ b/docs/rules/video/video-thumbnail.mdx
@@ -67,8 +67,8 @@ disable = ["*"]
 
 - [video/video-schema](/rules/video/video-schema): the thumbnailUrl the schema needs for an embed.
 - [video/video-accessible](/rules/video/video-accessible): captions on the same element.
-- [images/dimensions](/rules/images/dimensions): the width and height that reserve the video's space.
-- [perf/lcp-hints](/rules/perf/lcp-hints): the poster, which is often the largest visible element.
+- [images/dimensions](/rules/images/dimensions): width and height attributes that reserve space for images.
+- [perf/lcp-hints](/rules/perf/lcp-hints): likely LCP images that lack a preload.
 
 Video findings ship in every audit next to the SEO, performance and agent experience rules. See [Fix SEO issues with AI](https://squirrelscan.com/learn/fix-seo-issues-with-ai) for how an agent works through a report.
 


### PR DESCRIPTION
Rewrites the rule reference pages for batch C to the search-first template in `docs/rules/a11y/aria-labels.mdx`.

Every page gets a searchable title and description, a "what the term is" section, one bullet per check the rule actually emits with its exact report message and severity read from `packages/rules/src/`, a minimal fix, the existing metadata and enable/disable blocks, related rules, verified references and the audit CTA.

Each category was reviewed by a `codex exec` pass against the rule source before the next was committed, so most commits also carry the corrections to the category before them.

Tracking issue: https://github.com/squirrelscan/repo/issues/2050

## Categories

security 16, integrity 9, crawl 20, url 9, links 15, images 15, content 22, eeat 15, mobile 6, social 5, video 3, legal 4, i18n 2, analytics 2, adblock 3, gaps 2. **148 rule pages plus 17 index pages**, including the SEO score-group index.

## Verification

- `cd docs && make validate` (`tangly check --strict`) passes. All 13 CI checks pass.
- All 131 distinct reference URLs return 200 via `curl -sIL`.
- Every `/rules/<cat>/<slug>` link in a Related rules block resolves to a file that exists. Note that `tangly check --strict` does **not** validate these, so it is checked separately.
- Every `## Options` table matches the rule's zod schema. No rule with options lacks a table and no page without options carries one.
- All 592 Related rules half-lines were checked against the target rule's own `meta.description` and source. 22 misdescribed the target and are fixed.
- All 148 index cards carry their page's new title and description.

## Source corrections worth a second look

- **`crawl/html-size` and `crawl/pdf-size` quote Googlebot limits in their report messages.** Google's March 2026 crawler post documents 2MB per non-PDF URL and **64MB** for a PDF. The HTML default of 2MB is exact; the PDF default of 60MB sits 4MB under while the message calls it "the Googlebot 60MB limit". The old index card said 64MB. Worth an issue against the rule if you want the message reworded.
- **`legal/privacy-policy` listed its Scope as Per-page**; `meta.scope` is `"site"`. Corrected.
- **Every option table that said type `unknown` with default `undefined`** now carries the real zod defaults, under `[rule_options."<rule id>"]` rather than `[rules."<rule id>"]`.
- **Four unreachable branches documented as-is**: the `robots-conflict` warn in `crawl/robots-meta-conflict`, the file-with-trailing-slash warn in `url/trailing-slash`, the `via unknown` wording in `crawl/indexability`, and the `Invalid format` label in `links/invalid-links`.
- **`packages/rules/src/content/article-toc.ts` (`content/article-toc`) has no page** under `docs/rules/content`, so it was outside this rewrite.
- **`packages/rules/src/performance/` declares rule ids of `perf/<slug>`**, which is also the docs path. Link text and hrefs both use `perf`.

https://claude.ai/code/session_0174D96WamG9ZhJxRudpeniA
