### PR TITLE
docs(rules): search-first rewrite, a11y

### DIFF
--- a/docs/rules/a11y/accesskeys.mdx
+++ b/docs/rules/a11y/accesskeys.mdx
@@ -7,7 +7,7 @@ description: "Two elements claiming the same accesskey means one shortcut is unr
 
 `accesskey` asks the browser to bind a keyboard shortcut to an element. The modifier combination is chosen by the browser and the platform, not by the page, so the same markup produces different key presses on Windows, macOS and Linux.
 
-The attribute is rarely worth using. Its values collide with browser and screen reader shortcuts that users already rely on, and there is no way to discover the binding from the page. When it is used, each value has to be unique: if two elements claim the same key, which one the shortcut reaches is left to the browser.
+The attribute is rarely worth using. Its values collide with browser and screen reader shortcuts that users already rely on, and the binding stays invisible unless the page spells it out somewhere. When it is used, each value has to be unique: if two elements claim the same key, which one the shortcut reaches is left to the browser.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/accesskeys.mdx
+++ b/docs/rules/a11y/accesskeys.mdx
@@ -63,7 +63,7 @@ disable = ["*"]
 - [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism that replaces most uses of `accesskey`.
 - [a11y/tabindex](/rules/a11y/tabindex): the other attribute that overrides default keyboard behavior.
 - [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): duplicate identifiers on focusable elements.
-- [a11y/landmark-regions](/rules/a11y/landmark-regions): the structure screen readers navigate by instead.
+- [a11y/landmark-regions](/rules/a11y/landmark-regions): whether the page has `main`, `nav` and `footer` landmarks to navigate by instead.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/accesskeys.mdx
+++ b/docs/rules/a11y/accesskeys.mdx
@@ -1,9 +1,30 @@
 ---
-title: "Access Keys"
-description: "Checks that accesskey values are unique"
+title: "accesskey: why duplicate shortcuts break and how to check"
+description: "Two elements claiming the same accesskey means one shortcut is unreachable. squirrel lists every duplicated access key on every page."
 ---
 
-Checks that accesskey values are unique
+## What accesskey is
+
+`accesskey` asks the browser to bind a keyboard shortcut to an element. The modifier combination is chosen by the browser and the platform, not by the page, so the same markup produces different key presses on Windows, macOS and Linux.
+
+The attribute is rarely worth using. Its values collide with browser and screen reader shortcuts that users already rely on, and there is no way to discover the binding from the page. When it is used, each value has to be unique: if two elements claim the same key, which one the shortcut reaches is left to the browser.
+
+## What squirrel checks
+
+One check, at severity warning. It collects every element carrying an `accesskey` attribute, matching the attribute name case-insensitively, and lowercases each value before comparing.
+
+- `accesskeys-unique` warns when a value is claimed by more than one element. Report message: `N duplicate access key(s) found`. Each item names the value and its claimants, for example `accesskey="s" used by: button#save, a#search`.
+- `accesskeys` passes with `N access key(s) are unique`.
+- `accesskeys` returns info with `No access keys defined` when the page has none.
+
+## How to fix it
+
+```html
+<button accesskey="s">Save</button>
+<a href="/search" accesskey="f">Find</a>
+```
+
+Give each element a distinct character, or remove the attribute. Dropping `accesskey` entirely is a legitimate fix, since landmarks and a skip link cover the same navigation need without stealing key presses.
 
 | | |
 |---|---|
@@ -12,10 +33,6 @@ Checks that accesskey values are unique
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Access keys provide keyboard shortcuts for elements. Duplicate access keys cause only one to work, confusing users. Ensure each accesskey value is unique. Consider whether access keys are necessary at all, as they can conflict with browser/OS shortcuts.
 
 ## Enable / disable
 
@@ -40,3 +57,30 @@ disable = ["a11y/*"]
 enable = ["a11y/accesskeys"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism that replaces most uses of `accesskey`.
+- [a11y/tabindex](/rules/a11y/tabindex): the other attribute that overrides default keyboard behavior.
+- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): duplicate identifiers on focusable elements.
+- [a11y/landmark-regions](/rules/a11y/landmark-regions): the structure screen readers navigate by instead.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [accesskey, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/accesskey)
+- [Understanding SC 2.1.1 Keyboard, W3C](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each duplicated key is listed with every element claiming it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-allowed-attr.mdx
+++ b/docs/rules/a11y/aria-allowed-attr.mdx
@@ -1,9 +1,36 @@
 ---
-title: "ARIA Allowed Attributes"
-description: "Checks that ARIA attributes are allowed on their elements"
+title: "ARIA attributes that are not allowed on an element"
+description: "role=presentation with an aria-label, or a decorative image with one, contradicts itself. squirrel reports both on every page."
 ---
 
-Checks that ARIA attributes are allowed on their elements
+## What an allowed ARIA attribute is
+
+Every ARIA role supports a defined set of states and properties, and an attribute outside that set has no effect at best and a wrong effect at worst.
+
+Two combinations contradict themselves outright. `role="presentation"` and `role="none"` strip an element's semantics, so giving it a name asks assistive technology to announce something it has been told to ignore. `alt=""` marks an image as decorative for the same reason, so an `aria-label` on that image says the opposite of the `alt`.
+
+## What squirrel checks
+
+One check, `aria-allowed-attr`, at severity warning. It walks every element carrying at least one `aria-*` attribute and reports those two contradictions.
+
+- An element with `role="presentation"` or `role="none"` that also has `aria-label`, `aria-labelledby` or `aria-describedby`. Item text: `div[role="presentation"]: aria-label not allowed`.
+- An `<img>` with `alt=""` that also has `aria-label` or `aria-labelledby`. Item text: `img[alt=""]: aria-label conflicts with decorative intent`.
+- Warn with `N element(s) with inappropriate ARIA attributes`, listing up to ten items plus a count of the rest.
+- Pass with `All ARIA attributes are appropriate for their elements`.
+
+The check is deliberately narrow. It does not walk the full role-to-attribute matrix from the ARIA specification, and misspelled attribute names are left to `a11y/aria-valid-attr`.
+
+## How to fix it
+
+```html
+<img src="divider.svg" alt="">
+
+<div role="presentation">
+  <p>Layout wrapper with no semantics of its own.</p>
+</div>
+```
+
+Decide which of the two you meant. If the element carries meaning, drop the presentational role and keep the label. If it does not, drop the label.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks that ARIA attributes are allowed on their elements
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## Solution
-
-Some ARIA attributes are not appropriate for certain roles or elements. For example, role='presentation' should not have aria-label since it removes semantic meaning. Remove conflicting attributes or reconsider the element's role.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-allowed-attr"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-valid-attr](/rules/a11y/aria-valid-attr): attribute names that are not in the ARIA vocabulary.
+- [a11y/aria-valid-attr-value](/rules/a11y/aria-valid-attr-value): valid names carrying values of the wrong type.
+- [a11y/aria-roles](/rules/a11y/aria-roles): role values that do not exist.
+- [images/alt-text](/rules/images/alt-text): the `alt` side of the decorative-image decision.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The presentation role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role)
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+- [ARIA in HTML, W3C](https://www.w3.org/TR/html-aria/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each contradiction is listed with the element and the offending attribute. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-allowed-attr.mdx
+++ b/docs/rules/a11y/aria-allowed-attr.mdx
@@ -7,7 +7,7 @@ description: "role=presentation with an aria-label, or a decorative image with o
 
 Every ARIA role supports a defined set of states and properties, and an attribute outside that set has no effect at best and a wrong effect at worst.
 
-Two combinations contradict themselves outright. `role="presentation"` and `role="none"` strip an element's semantics, so giving it a name asks assistive technology to announce something it has been told to ignore. `alt=""` marks an image as decorative for the same reason, so an `aria-label` on that image says the opposite of the `alt`.
+Two combinations contradict themselves outright. `role="presentation"` and `role="none"` ask the browser to drop an element's semantics, and a global ARIA property such as `aria-label` reverses that request: the specification's conflict resolution tells the browser to ignore the presentational role and keep the native semantics instead. `alt=""` marks an image as decorative, so an `aria-label` on that image says the opposite of the `alt`.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/aria-command-name.mdx
+++ b/docs/rules/a11y/aria-command-name.mdx
@@ -1,9 +1,34 @@
 ---
-title: "ARIA Command Name"
-description: "Checks that command elements have accessible names"
+title: "Command roles: buttons, links and menu items need names"
+description: "Anything that performs an action has to announce what it does. squirrel lists every command element on a page with no accessible name."
 ---
 
-Checks that command elements have accessible names
+## What a command element is
+
+ARIA groups the roles that perform a single action as commands: `button`, `link`, `menuitem`, `menuitemcheckbox` and `menuitemradio`. Native `<button>` and `<a href>` carry the first two implicitly.
+
+A command with no accessible name is announced as bare role, so the user hears "menu item" with no idea what it does. Visible text is usually enough; icon-only commands need `aria-label`, `aria-labelledby`, a nested `<img>` with `alt`, or an `<svg><title>`.
+
+## What squirrel checks
+
+One check, `aria-command-name`, at severity error. It covers three sets: every element with one of the five command roles, every `<button>` with no explicit `role`, and every `<a href>` with no explicit `role`.
+
+- Fail when such an element has none of the following: a non-empty `aria-label`; an `aria-labelledby` pointing at an element with text; a non-empty `title`; text content; a nested `<img>` with non-empty `alt`; a nested `<svg><title>` with text. Report message: `N command element(s) without accessible names`. Items are listed as `div[role="menuitem"]`, `button[type="submit"]` or `a[href="/checkout"]`, truncating a long `href` at 30 characters, with up to ten shown and a count of the rest.
+- Pass with `All command elements have accessible names`.
+
+This rule overlaps `a11y/button-name` and `a11y/link-text` on purpose. It is the one that also reaches menu items built from `<div>` and `<span>`.
+
+## How to fix it
+
+```html
+<div role="menuitem" aria-label="Duplicate row">
+  <svg aria-hidden="true">...</svg>
+</div>
+```
+
+Put the name on the element that carries the role, not on a child, and hide any decorative icon inside it with `aria-hidden="true"`.
+
+A link wrapping only a background-image logo is the usual false positive. There is no markup for squirrel to read, and there is nothing for a screen reader to read either, so the fix is the same: add `aria-label`.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that command elements have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Command elements (buttons, links, menu items) must have accessible names. Add text content, aria-label, aria-labelledby, or title attribute. For icon-only buttons, use aria-label to describe the action (e.g., aria-label='Close').
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-command-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/button-name](/rules/a11y/button-name): the same defect scoped to buttons, including `<input type="button">`.
+- [a11y/link-text](/rules/a11y/link-text): links that have a name but a useless one.
+- [a11y/aria-labels](/rules/a11y/aria-labels): buttons and interactive `<svg>` elements.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): menu items that are named but sit outside a menu.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The button role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role)
+- [Accessible name and description computation, W3C](https://www.w3.org/TR/accname-1.2/)
+- [Providing accessible names and descriptions, WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unnamed command is listed with a selector you can search for. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-deprecated-role.mdx
+++ b/docs/rules/a11y/aria-deprecated-role.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Deprecated ARIA Roles"
-description: "Checks for deprecated or abstract ARIA roles"
+title: "Deprecated and abstract ARIA roles, and what to use instead"
+description: "role=directory is deprecated and abstract roles were never meant for markup. squirrel names every one it finds and its replacement."
 ---
 
-Checks for deprecated or abstract ARIA roles
+## What a deprecated or abstract role is
+
+WAI-ARIA marks a role deprecated when it has been superseded. `directory` is the current example: ARIA 1.2 deprecates it in favor of `list`.
+
+Abstract roles are a separate problem. The specification uses them to organise the role taxonomy, and states that they must not be used in content. `command`, `composite`, `input`, `landmark`, `range`, `roletype`, `section`, `sectionhead`, `select`, `structure`, `widget` and `window` all exist only as base types for the concrete roles that extend them. An element carrying one gets no semantics from it.
+
+## What squirrel checks
+
+One check, `aria-deprecated-role`, at severity error. It reads every `role` attribute, lowercases it, splits it on whitespace to handle fallback chains, and looks each token up in its list of the deprecated `directory` role plus the twelve abstract roles.
+
+- Fail when any token matches. Report message: `N deprecated/abstract role(s) found`. Each item names the element, the role and the replacement, for example `ul[role="directory"]: Use 'list' instead` or `div[role="widget"]: Abstract role - use specific widget types`. Up to ten items are shown with a count of the rest.
+- Pass with `No deprecated ARIA roles found` when the page uses roles but none match.
+- Info with `No ARIA roles found`.
+
+## How to fix it
+
+```html
+<ul role="list">
+  <li>Ada Lovelace</li>
+  <li>Grace Hopper</li>
+</ul>
+```
+
+Replace the role with the concrete one the message names. For an abstract role, pick the specific descendant that matches what the element does: `button` or `link` rather than `command`, `slider` or `progressbar` rather than `range`, `dialog` rather than `window`.
+
+Removing the attribute is often better than replacing it. A `<ul>` already has an implicit `list` role, so `role="list"` is only needed where CSS such as `list-style: none` has stripped the semantics in Safari.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks for deprecated or abstract ARIA roles
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 6/10 |
-
-## Solution
-
-Avoid deprecated or abstract ARIA roles. Use the recommended alternatives. Abstract roles are never meant to be used directly - they're base types that other roles extend. Replace with specific, concrete roles.
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-deprecated-role"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-roles](/rules/a11y/aria-roles): role values that are not in the vocabulary at all.
+- [a11y/aria-required-children](/rules/a11y/aria-required-children): roles that need particular children once you switch to a concrete one.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): the same relationship seen from the child.
+- [a11y/list-structure](/rules/a11y/list-structure): native lists carrying elements they should not.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Abstract roles, WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/#abstract_roles)
+- [directory role, WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/#directory)
+- [ARIA roles, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each offending role is listed with the element and its recommended replacement. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-deprecated-role.mdx
+++ b/docs/rules/a11y/aria-deprecated-role.mdx
@@ -7,7 +7,7 @@ description: "role=directory is deprecated and abstract roles were never meant f
 
 WAI-ARIA marks a role deprecated when it has been superseded. `directory` is the current example: ARIA 1.2 deprecates it in favor of `list`.
 
-Abstract roles are a separate problem. The specification uses them to organise the role taxonomy, and states that they must not be used in content. `command`, `composite`, `input`, `landmark`, `range`, `roletype`, `section`, `sectionhead`, `select`, `structure`, `widget` and `window` all exist only as base types for the concrete roles that extend them. An element carrying one gets no semantics from it.
+Abstract roles are a separate problem. The specification uses them to organize the role taxonomy, and states that they must not be used in content. `command`, `composite`, `input`, `landmark`, `range`, `roletype`, `section`, `sectionhead`, `select`, `structure`, `widget` and `window` all exist only as base types for the concrete roles that extend them. An element carrying one gets no semantics from it.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/aria-dialog-name.mdx
+++ b/docs/rules/a11y/aria-dialog-name.mdx
@@ -28,7 +28,7 @@ Two checks, at rule severity error. Both accept the same three name sources: a n
 
 Point `aria-labelledby` at the heading the dialog already shows. That keeps the announced name and the visible title in step, which is what a voice control user needs to open and close it by name.
 
-A dialog rendered into the page but never opened is still reported. That is correct: the name has to be in the markup before the dialog is shown, not added at open time.
+A dialog rendered into the page but never opened is still reported, because the rule reads a static snapshot of the markup. A name your script adds at open time is invisible to it, so keeping the name in the markup is the simplest way to satisfy both the audit and the announcement.
 
 | | |
 |---|---|

--- a/docs/rules/a11y/aria-dialog-name.mdx
+++ b/docs/rules/a11y/aria-dialog-name.mdx
@@ -1,9 +1,34 @@
 ---
-title: "ARIA Dialog Name"
-description: "Checks that dialog elements have accessible names"
+title: "Dialog accessible name: role=dialog and the dialog element"
+description: "A modal with no name leaves screen reader users guessing what just opened. squirrel checks ARIA dialogs and native dialogs separately."
 ---
 
-Checks that dialog elements have accessible names
+## What a dialog name is
+
+A dialog interrupts the page, so a screen reader announces it on open. With no accessible name the announcement is just "dialog", and the user has to explore to find out what appeared.
+
+The name comes from `aria-labelledby` pointing at the dialog's own heading, from `aria-label`, or from `title`. Text inside the dialog does not become its name: unlike a button, a dialog's content is its content, not its label.
+
+## What squirrel checks
+
+Two checks, at rule severity error. Both accept the same three name sources: a non-empty `aria-label`, a non-empty `title`, or an `aria-labelledby` pointing at an element that has text.
+
+- `aria-dialog-name` covers elements with `role="dialog"` or `role="alertdialog"`. It fails with `N ARIA dialog(s) without accessible names`, listing each as `dialog#id` or bare role name, up to ten with a count of the rest. It passes with `All N ARIA dialog(s) have accessible names`.
+- `dialog-name` covers native `<dialog>` elements that carry no explicit dialog role. Browsers announce the native element's role on their own, so a missing name here warns rather than fails: `N native <dialog>(s) without accessible names`. It passes with `All N native <dialog>(s) have accessible names`.
+- When the page has neither kind, one info check reports `No dialog elements found`.
+
+## How to fix it
+
+```html
+<div role="dialog" aria-modal="true" aria-labelledby="settings-title">
+  <h2 id="settings-title">Settings</h2>
+  ...
+</div>
+```
+
+Point `aria-labelledby` at the heading the dialog already shows. That keeps the announced name and the visible title in step, which is what a voice control user needs to open and close it by name.
+
+A dialog rendered into the page but never opened is still reported. That is correct: the name has to be in the markup before the dialog is shown, not added at open time.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that dialog elements have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Elements with role='dialog' or role='alertdialog' (and native `<dialog>`) must have an accessible name. Add aria-label with a descriptive label, or use aria-labelledby pointing to a visible heading inside the dialog. A title attribute also works but is less preferred. Without a name, screen reader users won't know the purpose of the dialog.
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-dialog-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): the page behind a modal, hidden but still tabbable.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): states a role must declare, such as `aria-checked` on a checkbox.
+- [a11y/aria-labels](/rules/a11y/aria-labels): the close button most dialogs put in the corner.
+- [a11y/frame-title](/rules/a11y/frame-title): the same naming problem for embedded frames.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The dialog element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog)
+- [The dialog role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role)
+- [Dialog (Modal) pattern, WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. ARIA dialogs are reported as errors and native ones as warnings, in separate checks. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-hidden-body.mdx
+++ b/docs/rules/a11y/aria-hidden-body.mdx
@@ -1,9 +1,33 @@
 ---
-title: "ARIA Hidden Body"
-description: "Ensures document body is not set to aria-hidden"
+title: "aria-hidden on body or html: the whole page disappears"
+description: "aria-hidden=true on the body or html element hides every element from assistive technology. squirrel checks both, at the highest weight."
 ---
 
-Ensures document body is not set to aria-hidden
+## What aria-hidden does
+
+`aria-hidden="true"` removes an element and everything inside it from the accessibility tree. The element stays on screen and stays in the tab order. It stops existing only for a screen reader.
+
+That is the right tool for a decorative icon next to a text label. Applied to `<body>` or `<html>` it removes the entire page, and a screen reader reports an empty document.
+
+## What squirrel checks
+
+One check, `aria-hidden-body`, at severity error and weight 10, the highest in the category.
+
+- Fail when `<html>` or `<body>` carries `aria-hidden="true"`. The message names the culprit: `Document <html> element is aria-hidden`, or `Document <body> is aria-hidden`. The finding carries the issue `Page content is inaccessible to assistive technology` and the fix `Remove aria-hidden from body/html element`.
+- Pass with `Document body is not hidden from assistive technology`.
+
+The value comparison is exact, so `aria-hidden="True"` is not reported even though it has the same effect in some browsers.
+
+## How to fix it
+
+```html
+<body>
+  <div id="app">...</div>
+  <div role="dialog" aria-modal="true">...</div>
+</body>
+```
+
+Remove the attribute. The usual reason it got there is a modal library trying to hide the page behind an open dialog. Use `aria-modal="true"` on the dialog, or apply `aria-hidden` to the dialog's siblings, never to an ancestor of the dialog itself.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Ensures document body is not set to aria-hidden
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 10/10 |
-
-## Solution
-
-Never set aria-hidden='true' on the `<body>` element. This makes the entire page invisible to assistive technology. If you need to hide content when a modal is open, add aria-hidden to sibling elements of the modal, not to body.
 
 ## Enable / disable
 
@@ -40,3 +60,30 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-hidden-body"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): hidden regions that still contain tabbable elements.
+- [a11y/aria-dialog-name](/rules/a11y/aria-dialog-name): the modal that usually causes this.
+- [a11y/aria-allowed-attr](/rules/a11y/aria-allowed-attr): other ARIA attributes that contradict what the element is.
+- [content/hidden-text](/rules/content/hidden-text): content hidden visually rather than from assistive technology.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [aria-hidden, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden)
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. This one is either present or it is not, so a single finding covers the page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-hidden-body.mdx
+++ b/docs/rules/a11y/aria-hidden-body.mdx
@@ -1,13 +1,13 @@
 ---
-title: "aria-hidden on body or html: the whole page disappears"
-description: "aria-hidden=true on the body or html element hides every element from assistive technology. squirrel checks both, at the highest weight."
+title: "aria-hidden on body or html: what it breaks"
+description: "aria-hidden=true on the body or html element asks assistive technology to ignore the entire page. squirrel checks both, at the highest weight."
 ---
 
 ## What aria-hidden does
 
 `aria-hidden="true"` removes an element and everything inside it from the accessibility tree. The element stays on screen and stays in the tab order. It stops existing only for a screen reader.
 
-That is the right tool for a decorative icon next to a text label. Applied to `<body>` or `<html>` it removes the entire page, and a screen reader reports an empty document.
+That is the right tool for a decorative icon next to a text label. On `<body>` or `<html>` it asks for the whole document to be ignored. Browsers differ in how far they honor that, and some refuse it outright on those two elements, but the markup is wrong either way and no page should depend on which browser is reading it.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/aria-hidden-focus.mdx
+++ b/docs/rules/a11y/aria-hidden-focus.mdx
@@ -1,9 +1,33 @@
 ---
-title: "ARIA Hidden Focus"
-description: "Ensures aria-hidden elements do not contain focusable content"
+title: "Focusable elements inside aria-hidden: the tab trap"
+description: "A hidden element that still takes focus lets keyboard users tab into nothing. squirrel finds them, and tells anti-spam honeypots apart."
 ---
 
-Ensures aria-hidden elements do not contain focusable content
+## What the conflict is
+
+`aria-hidden="true"` removes a subtree from the accessibility tree. It does not remove it from the tab order. A link or button inside a hidden region can still be reached with Tab, and when it is, a screen reader user has focus on something their screen reader refuses to describe.
+
+The two states have to agree. Either the region is available, in which case it should not be `aria-hidden`, or it is not, in which case nothing inside it should be focusable.
+
+## What squirrel checks
+
+Two checks, at rule severity error. The rule walks every `[aria-hidden="true"]` element and tests the element itself and each descendant for focusability. Focusable means matching `a[href]`, `button:not([disabled])`, `input:not([disabled]):not([type="hidden"])`, `select:not([disabled])`, `textarea:not([disabled])`, `[contenteditable="true"]`, `audio[controls]`, `video[controls]` or `details > summary`, or carrying any `tabindex` other than `-1`. The `tabindex` lookup is case-insensitive, so React's `tabIndex` in server-rendered markup is caught.
+
+- `aria-hidden-focus` fails with `N focusable element(s) inside aria-hidden`. Items read `a#archive`, or `div (self is focusable)` when the hidden container is itself focusable. Up to ten are listed with a count of the rest.
+- `aria-hidden-focus-honeypot` warns with `N focusable element(s) inside aria-hidden appear to be an anti-spam honeypot`, carrying the value `Add tabindex="-1" (and autocomplete="off") to remove the honeypot from the tab order`. An element qualifies only when all three hold: it is an `<input>`, its `id` or `name` contains `hp`, `honeypot` or `trap` as a hyphen- or underscore-delimited token, and it sits inside a `<form>`. Requiring all three keeps a genuine bug on an unrelated hidden control from being quietly downgraded.
+- With nothing focusable found, the check passes as `No focusable elements inside aria-hidden regions`, or returns info with `No aria-hidden elements found`.
+
+## How to fix it
+
+```html
+<div aria-hidden="true">
+  <a href="/archive" tabindex="-1">Archive</a>
+</div>
+```
+
+Either drop `aria-hidden` from the container or set `tabindex="-1"` on every focusable descendant.
+
+Where the region is meant to be invisible as well, `display: none` or the `hidden` attribute is the better fix. Neither leaves the element focusable, so the two states cannot drift apart again.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Ensures aria-hidden elements do not contain focusable content
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Elements with aria-hidden='true' should not contain focusable content. When an element is hidden from assistive technology but still focusable, keyboard users can tab to it but screen reader users won't know what they're interacting with. Either remove aria-hidden or make children non-focusable with tabindex='-1'.
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-hidden-focus"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-hidden-body](/rules/a11y/aria-hidden-body): the same attribute applied to the whole document.
+- [a11y/tabindex](/rules/a11y/tabindex): positive values that reorder the tab sequence.
+- [a11y/focus-visible](/rules/a11y/focus-visible): whether the ring is drawn once focus lands somewhere.
+- [a11y/aria-dialog-name](/rules/a11y/aria-dialog-name): the modal pattern that produces most of these.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [aria-hidden, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden)
+- [tabindex, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex)
+- [Understanding SC 2.4.3 Focus Order, W3C](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Honeypot fields are reported separately, as warnings rather than errors. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-hidden-focus.mdx
+++ b/docs/rules/a11y/aria-hidden-focus.mdx
@@ -11,7 +11,7 @@ The two states have to agree. Either the region is available, in which case it s
 
 ## What squirrel checks
 
-Two checks, at rule severity error. The rule walks every `[aria-hidden="true"]` element and tests the element itself and each descendant for focusability. Focusable means matching `a[href]`, `button:not([disabled])`, `input:not([disabled]):not([type="hidden"])`, `select:not([disabled])`, `textarea:not([disabled])`, `[contenteditable="true"]`, `audio[controls]`, `video[controls]` or `details > summary`, or carrying any `tabindex` other than `-1`. The `tabindex` lookup is case-insensitive, so React's `tabIndex` in server-rendered markup is caught.
+Two checks, at rule severity error. The rule walks every `[aria-hidden="true"]` element and tests the element itself first. A focusable container is reported and its descendants are not examined; otherwise every descendant is tested. Focusable means matching `a[href]`, `button:not([disabled])`, `input:not([disabled]):not([type="hidden"])`, `select:not([disabled])`, `textarea:not([disabled])`, `[contenteditable="true"]`, `audio[controls]`, `video[controls]` or `details > summary`, or carrying any `tabindex` other than `-1`. The `tabindex` lookup is case-insensitive, so React's `tabIndex` in server-rendered markup is caught.
 
 - `aria-hidden-focus` fails with `N focusable element(s) inside aria-hidden`. Items read `a#archive`, or `div (self is focusable)` when the hidden container is itself focusable. Up to ten are listed with a count of the rest.
 - `aria-hidden-focus-honeypot` warns with `N focusable element(s) inside aria-hidden appear to be an anti-spam honeypot`, carrying the value `Add tabindex="-1" (and autocomplete="off") to remove the honeypot from the tab order`. An element qualifies only when all three hold: it is an `<input>`, its `id` or `name` contains `hp`, `honeypot` or `trap` as a hyphen- or underscore-delimited token, and it sits inside a `<form>`. Requiring all three keeps a genuine bug on an unrelated hidden control from being quietly downgraded.
@@ -65,7 +65,7 @@ disable = ["*"]
 
 - [a11y/aria-hidden-body](/rules/a11y/aria-hidden-body): the same attribute applied to the whole document.
 - [a11y/tabindex](/rules/a11y/tabindex): positive values that reorder the tab sequence.
-- [a11y/focus-visible](/rules/a11y/focus-visible): whether the ring is drawn once focus lands somewhere.
+- [a11y/focus-visible](/rules/a11y/focus-visible): the static scan for `outline: none` shipped without a `:focus-visible` fallback.
 - [a11y/aria-dialog-name](/rules/a11y/aria-dialog-name): the modal pattern that produces most of these.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
@@ -74,7 +74,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 
 - [aria-hidden, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden)
 - [tabindex, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex)
-- [Understanding SC 2.4.3 Focus Order, W3C](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)
+- [aria-hidden element is not focusable, W3C ACT rules](https://www.w3.org/WAI/standards-guidelines/act/rules/6cfa84/)
 
 ## Check your site
 

--- a/docs/rules/a11y/aria-input-field-name.mdx
+++ b/docs/rules/a11y/aria-input-field-name.mdx
@@ -1,9 +1,36 @@
 ---
-title: "ARIA Input Field Name"
-description: "Checks that input fields have accessible names"
+title: "Input fields with no accessible name, ARIA and native"
+description: "Text boxes, comboboxes and sliders that announce nothing. squirrel checks the nine ARIA input roles alongside native inputs and selects."
 ---
 
-Checks that input fields have accessible names
+## What an input field name is
+
+Every field a user types into or drags needs a name, or the screen reader announces only its role: "edit text", "slider", "combo box". The name normally comes from a `<label>`, and from `aria-label` or `aria-labelledby` where a visible label does not fit.
+
+ARIA defines nine input roles for custom widgets: `checkbox`, `combobox`, `listbox`, `radio`, `searchbox`, `slider`, `spinbutton`, `switch` and `textbox`. A `<div>` carrying one of them needs a name exactly as a native control does, and gets nothing for free.
+
+## What squirrel checks
+
+One check, `aria-input-field-name`, at severity error. It covers three sets: every element with one of the nine input roles; every `<input>` with no explicit `role`, excluding types `hidden`, `submit`, `button`, `reset` and `image`; and every `<textarea>` and `<select>` with no explicit `role`.
+
+A name is resolved from, in order: `aria-label`, `aria-labelledby`, a `<label for="...">` matching the field's `id`, a wrapping `<label>`, `title`, then `placeholder`.
+
+- Fail with `N input field(s) without accessible names`. Items are listed as `div[role="textbox"]`, `input[name="q"]`, `input[type="text"]`, `textarea` or `select`, up to ten with a count of the rest.
+- Pass with `All input fields have accessible names`.
+
+`placeholder` counts here as a last resort. That makes this rule more forgiving than `a11y/form-labels`, which rejects it, so a placeholder-only field passes this check and fails that one.
+
+## How to fix it
+
+```html
+<div role="slider" aria-label="Volume"
+     aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+     tabindex="0"></div>
+```
+
+Name the element that carries the role. A custom widget also needs the state attributes its role requires, which is a separate check.
+
+For native controls a visible `<label>` is still the better answer, because it names the field and enlarges its click target at the same time.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks that input fields have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-All input fields need accessible names. Best options: 1) Use `<label for='inputId'>`. 2) Use aria-label or aria-labelledby. 3) Wrap input in `<label>`. Placeholder alone is not sufficient as it disappears when typing.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-input-field-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/form-labels](/rules/a11y/form-labels): the stricter pass over native controls, where `placeholder` does not count.
+- [a11y/aria-toggle-field-name](/rules/a11y/aria-toggle-field-name): checkboxes, radios and switches specifically.
+- [a11y/select-name](/rules/a11y/select-name): dropdowns specifically.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): the state attributes a custom input role has to declare.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Labeling controls, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/forms/labels/)
+- [ARIA roles, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Custom widgets and native controls are listed together, each with a selector. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-labels.mdx
+++ b/docs/rules/a11y/aria-labels.mdx
@@ -5,7 +5,7 @@ description: "Buttons, links and inputs with no visible text and no aria-label h
 
 ## What aria-label is
 
-`aria-label` gives an element a name that assistive technology reads out when the element has no visible text. A button that only contains an icon, an `<a>` wrapping an image, or an `<svg>` with a click handler has nothing a screen reader can announce. The user hears "button" and nothing else.
+`aria-label` gives an element a name that assistive technology reads out when the element has no visible text. A button whose only content is an unlabeled icon, an `<a>` wrapping an image with no `alt`, or an `<svg>` with a click handler and no `<title>` has nothing a screen reader can announce. The user hears "button" and nothing else.
 
 Most elements do not need it. Visible text is the accessible name, so `<button>Save</button>` is complete. `aria-label` is for the cases where the visible label is a picture, or the visible text is not the whole story ("Close" on a dialog is clearer as `aria-label="Close settings"`). `aria-labelledby` does the same job by pointing at existing text, and `<title>` inside an `<svg>` names the graphic.
 

--- a/docs/rules/a11y/aria-labels.mdx
+++ b/docs/rules/a11y/aria-labels.mdx
@@ -1,9 +1,33 @@
 ---
-title: "ARIA Labels"
-description: "Checks that interactive elements have accessible names"
+title: "aria-label: which elements need one and how to check"
+description: "Buttons, links and inputs with no visible text and no aria-label have no name for screen readers. squirrel finds every one on every page."
 ---
 
-Checks that interactive elements have accessible names
+## What aria-label is
+
+`aria-label` gives an element a name that assistive technology reads out when the element has no visible text. A button that only contains an icon, an `<a>` wrapping an image, or an `<svg>` with a click handler has nothing a screen reader can announce. The user hears "button" and nothing else.
+
+Most elements do not need it. Visible text is the accessible name, so `<button>Save</button>` is complete. `aria-label` is for the cases where the visible label is a picture, or the visible text is not the whole story ("Close" on a dialog is clearer as `aria-label="Close settings"`). `aria-labelledby` does the same job by pointing at existing text, and `<title>` inside an `<svg>` names the graphic.
+
+## What squirrel checks
+
+The rule runs on every crawled page and reports two checks:
+
+- `aria-buttons`: every `<button>` and every element with `role="button"`. A button fails when it has no text content, no `aria-label`, no `aria-labelledby`, no `title`, no `<img alt>` inside it and no `<svg><title>` inside it. Report message: `N button(s) without accessible names`, with the id or class of each one. Severity error.
+- `aria-svg`: every `<svg>` that carries an `onclick` or a `tabindex`. It warns when the svg has no `aria-label`, no `aria-labelledby` and no `<title>` child. Report message: `N interactive SVG(s) without accessible names`.
+
+
+## How to fix it
+
+```html
+<button aria-label="Close settings">
+  <svg aria-hidden="true">...</svg>
+</button>
+```
+
+Put the label on the interactive element, not on the icon inside it, and hide the icon from assistive technology with `aria-hidden="true"`. For an svg that is itself clickable, add `<title>` as its first child or an `aria-label` on the `<svg>`.
+
+A common false positive is a button whose only content is an icon font glyph in a pseudo-element. squirrel sees an empty button. Add `aria-label`, which is the correct fix anyway.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks that interactive elements have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 6/10 |
-
-## Solution
-
-All interactive elements (buttons, links, inputs) need accessible names for screen readers. Use: visible text content, aria-label for icon-only buttons, aria-labelledby to reference existing text, or the title attribute as a fallback. Icon buttons especially need aria-label: `<button aria-label='Close'>`×`</button>`. Test with a screen reader or browser accessibility inspector.
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-labels"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/button-name](/rules/a11y/button-name): the axe-core check for the same defect, run on rendered pages.
+- [a11y/link-text](/rules/a11y/link-text): links whose text is "click here" or an image with no alt.
+- [a11y/form-labels](/rules/a11y/form-labels): inputs with no `<label>` or `aria-label`.
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): focusable elements hidden from assistive technology, the mirror problem.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [aria-label, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+- [Providing accessible names and descriptions, WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/)
+- [Accessible name and description computation, W3C](https://www.w3.org/TR/accname-1.2/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unlabeled button is listed by page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-labels.mdx
+++ b/docs/rules/a11y/aria-labels.mdx
@@ -63,7 +63,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/button-name](/rules/a11y/button-name): the axe-core check for the same defect, run on rendered pages.
+- [a11y/button-name](/rules/a11y/button-name): the same defect checked over a wider set, including `<input type="button">` and nested labels.
 - [a11y/link-text](/rules/a11y/link-text): links whose text is "click here" or an image with no alt.
 - [a11y/form-labels](/rules/a11y/form-labels): inputs with no `<label>` or `aria-label`.
 - [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): focusable elements hidden from assistive technology, the mirror problem.
@@ -72,7 +72,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 
 ## References
 
-- [aria-label, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+- [aria-label, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
 - [Providing accessible names and descriptions, WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/)
 - [Accessible name and description computation, W3C](https://www.w3.org/TR/accname-1.2/)
 

--- a/docs/rules/a11y/aria-meter-name.mdx
+++ b/docs/rules/a11y/aria-meter-name.mdx
@@ -1,9 +1,34 @@
 ---
-title: "ARIA Meter Name"
-description: "Checks that meter elements have accessible names"
+title: "Accessible name for a meter element and role=meter"
+description: "A gauge that announces only a number tells a screen reader user nothing. squirrel checks native meter elements and role=meter."
 ---
 
-Checks that meter elements have accessible names
+## What a meter is
+
+`<meter>` displays a scalar value inside a known range: disk usage, a test score, a battery level. It is not `<progress>`, which shows how far a task has got.
+
+Neither element takes its name from the text between its tags. That text is fallback content for browsers without support, so a screen reader reading a nameless meter announces a bare number with no idea what it measures.
+
+## What squirrel checks
+
+One check, `aria-meter-name`, at severity error. It covers every element with `role="meter"`, and every native `<meter>` that carries no explicit `role`.
+
+A name is accepted from a non-empty `aria-label`, an `aria-labelledby` pointing at an element with text, a non-empty `title`, or a `<label for="...">` matching the element's `id`.
+
+- Fail with `N meter element(s) without accessible names`. Every offender is listed, as `meter#id` or `div[role="meter"]`.
+- Pass with `All meter elements have accessible names`.
+- Info with `No meter elements found`.
+
+## How to fix it
+
+```html
+<label for="disk">Disk usage</label>
+<meter id="disk" min="0" max="100" low="60" high="85" value="72">72%</meter>
+```
+
+Associate a visible `<label>` where the page shows one, and fall back to `aria-label` where the surrounding layout already makes the meaning obvious to sighted users.
+
+If you are describing progress through a task rather than a measurement, use `<progress>` instead. The naming requirement is the same, but the role communicates something different.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that meter elements have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Meter elements must have accessible names to describe what they're measuring. Add aria-label, aria-labelledby, or an associated `<label>`. Example: `<meter aria-label='Battery level' value='0.8'>`80%`</meter>`
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-meter-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-progressbar-name](/rules/a11y/aria-progressbar-name): the same check for `<progress>` and `role="progressbar"`.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): `role="meter"` also has to declare `aria-valuenow`.
+- [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): sliders and spin buttons, which have the same naming problem.
+- [a11y/form-labels](/rules/a11y/form-labels): the `<label>` element this rule accepts.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The meter element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meter)
+- [The meter role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/meter_role)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unnamed meter is listed, with no cap on the count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-meter-name.mdx
+++ b/docs/rules/a11y/aria-meter-name.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 - [a11y/aria-progressbar-name](/rules/a11y/aria-progressbar-name): the same check for `<progress>` and `role="progressbar"`.
 - [a11y/aria-required-attr](/rules/a11y/aria-required-attr): `role="meter"` also has to declare `aria-valuenow`.
 - [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): sliders and spin buttons, which have the same naming problem.
-- [a11y/form-labels](/rules/a11y/form-labels): the `<label>` element this rule accepts.
+- [a11y/form-labels](/rules/a11y/form-labels): native inputs, textareas and selects with no associated label.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/aria-progressbar-name.mdx
+++ b/docs/rules/a11y/aria-progressbar-name.mdx
@@ -28,7 +28,7 @@ A name is accepted from a non-empty `aria-label`, an `aria-labelledby` pointing 
 
 An indeterminate progress bar, one with no `value`, still needs a name. It is announced as busy, and the name is the only thing that says what is busy.
 
-For a custom `role="progressbar"`, add `aria-valuenow`, `aria-valuemin` and `aria-valuemax` alongside the name. The name says what is happening; those say how far it has got.
+For a custom `role="progressbar"`, add `aria-valuenow` alongside the name so the widget reports its position. Leave `aria-valuenow` off when the progress is indeterminate, which is how that state is signalled, and leave `aria-valuemin` and `aria-valuemax` off unless the range differs from the default 0 to 100.
 
 | | |
 |---|---|
@@ -65,7 +65,7 @@ disable = ["*"]
 ## Related rules
 
 - [a11y/aria-meter-name](/rules/a11y/aria-meter-name): the same check for `<meter>` and `role="meter"`.
-- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): the value attributes a progress bar role should carry.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): required state attributes for the widget roles that have them, `meter` and `slider` among them.
 - [a11y/aria-valid-attr-value](/rules/a11y/aria-valid-attr-value): those values having to be numbers.
 - [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): the sibling naming check over input roles.
 

--- a/docs/rules/a11y/aria-progressbar-name.mdx
+++ b/docs/rules/a11y/aria-progressbar-name.mdx
@@ -1,9 +1,34 @@
 ---
-title: "ARIA Progressbar Name"
-description: "Checks that progressbar elements have accessible names"
+title: "Accessible name for a progress bar and role=progressbar"
+description: "A progress bar with no name announces a percentage and nothing else. squirrel checks native progress elements and role=progressbar."
 ---
 
-Checks that progressbar elements have accessible names
+## What a progress bar is
+
+`<progress>` shows how far a task has got: an upload, an install, a multi-step form. ARIA's `role="progressbar"` says the same thing about a custom widget.
+
+The text between the tags is fallback content for browsers without support, not a name. Without `aria-label`, `aria-labelledby`, `title` or a `<label>`, a screen reader announces "progress bar, 50 percent" and leaves the user to guess what is at 50 percent.
+
+## What squirrel checks
+
+One check, `aria-progressbar-name`, at severity error. It covers every element with `role="progressbar"`, and every native `<progress>` that carries no explicit `role`.
+
+A name is accepted from a non-empty `aria-label`, an `aria-labelledby` pointing at an element with text, a non-empty `title`, or a `<label for="...">` matching the element's `id`.
+
+- Fail with `N progressbar element(s) without accessible names`. Every offender is listed, as `progress#id` or `div[role="progressbar"]`.
+- Pass with `All progressbar elements have accessible names`.
+- Info with `No progressbar elements found`.
+
+## How to fix it
+
+```html
+<label for="upload">Upload progress</label>
+<progress id="upload" value="50" max="100">50%</progress>
+```
+
+An indeterminate progress bar, one with no `value`, still needs a name. It is announced as busy, and the name is the only thing that says what is busy.
+
+For a custom `role="progressbar"`, add `aria-valuenow`, `aria-valuemin` and `aria-valuemax` alongside the name. The name says what is happening; those say how far it has got.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that progressbar elements have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Progressbar elements must have accessible names to describe what process is being tracked. Add aria-label, aria-labelledby, or an associated `<label>`. Example: `<progress aria-label='Upload progress' value='50' max='100'>`50%`</progress>`
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-progressbar-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-meter-name](/rules/a11y/aria-meter-name): the same check for `<meter>` and `role="meter"`.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): the value attributes a progress bar role should carry.
+- [a11y/aria-valid-attr-value](/rules/a11y/aria-valid-attr-value): those values having to be numbers.
+- [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): the sibling naming check over input roles.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The progress element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress)
+- [The progressbar role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/progressbar_role)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unnamed progress bar is listed, with no cap on the count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-required-attr.mdx
+++ b/docs/rules/a11y/aria-required-attr.mdx
@@ -1,9 +1,46 @@
 ---
-title: "ARIA Required Attributes"
-description: "Checks that elements have required ARIA attributes for their roles"
+title: "Required ARIA attributes for a role, and what is missing"
+description: "role=checkbox with no aria-checked has a state screen readers cannot read. squirrel checks the roles whose attributes are mandatory."
 ---
 
-Checks that elements have required ARIA attributes for their roles
+## What a required ARIA attribute is
+
+A role tells assistive technology what an element is. Some roles also need a state or property before they mean anything: a checkbox that never says whether it is checked, a slider that never reports its position, a heading with no level.
+
+Native HTML supplies these on its own. `<input type="checkbox">` carries its checked state in the DOM. The moment you build the same control out of a `<div>` and a role, you own the state as well.
+
+## What squirrel checks
+
+One check, `aria-required-attr`, at severity error. It reads every element with a `role`, takes the first token of the attribute, and looks it up in a table of roles and their required attributes:
+
+| Role | Required |
+|---|---|
+| `checkbox`, `radio`, `switch` | `aria-checked` |
+| `combobox` | `aria-expanded` |
+| `heading` | `aria-level` |
+| `meter`, `slider` | `aria-valuenow` |
+| `option` | `aria-selected` |
+| `scrollbar` | `aria-controls`, `aria-valuenow` |
+
+`separator` and `spinbutton` are in the table with nothing required, so they never produce a finding.
+
+- Fail with `N element(s) missing required ARIA attributes`. Items read `div[role="checkbox"]: missing aria-checked`, up to ten with a count of the rest.
+- Pass with `All elements have required ARIA attributes`.
+- Info with `No elements with ARIA roles found`.
+
+The check tests presence, not value, so `aria-checked=""` satisfies it. Whether the value is legal is `a11y/aria-valid-attr-value`.
+
+## How to fix it
+
+```html
+<div role="checkbox" aria-checked="false" tabindex="0">
+  Email me about new releases
+</div>
+```
+
+Keep the attribute in step with the visible state in your event handler, or the announcement drifts away from the control.
+
+In a role fallback chain such as `role="doc-subtitle heading"`, squirrel looks up only the first token. A chain whose first entry is unrecognized is therefore not checked against the second.
 
 | | |
 |---|---|
@@ -12,10 +49,6 @@ Checks that elements have required ARIA attributes for their roles
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Some ARIA roles require specific attributes to be present. For example, role='checkbox' requires aria-checked, role='slider' requires aria-valuenow. Add the missing required attributes with appropriate values.
 
 ## Enable / disable
 
@@ -40,3 +73,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-required-attr"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-valid-attr-value](/rules/a11y/aria-valid-attr-value): whether the value you supplied is legal for that attribute.
+- [a11y/aria-required-children](/rules/a11y/aria-required-children): the child roles a container role has to contain.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): the same relationship seen from the child.
+- [a11y/aria-toggle-field-name](/rules/a11y/aria-toggle-field-name): the name those checkbox and switch roles also need.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+- [ARIA attributes, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each element is listed with the role it declares and the attribute it is missing. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-required-children.mdx
+++ b/docs/rules/a11y/aria-required-children.mdx
@@ -1,9 +1,37 @@
 ---
-title: "ARIA Required Children"
-description: "Checks that elements with certain roles have required child roles"
+title: "ARIA roles that require particular child roles"
+description: "role=list with no listitem, or role=tablist with no tab, is an incomplete widget. squirrel checks thirteen container roles for their children."
 ---
 
-Checks that elements with certain roles have required child roles
+## What a required child role is
+
+Composite ARIA roles are containers, and the specification says what they must contain. A `tablist` holds `tab` elements. A `list` holds `listitem` elements. A `menu` holds menu items.
+
+When the children are missing, assistive technology gets a container that promises a widget and delivers nothing. Screen readers commonly announce the container and then find no items to move between.
+
+## What squirrel checks
+
+One check, `aria-required-children`, at severity error. It covers thirteen container roles: `feed`, `grid`, `list`, `listbox`, `menu`, `menubar`, `radiogroup`, `row`, `rowgroup`, `tablist`, `table`, `tree` and `treegrid`.
+
+For each element with one of those explicit roles it looks for a satisfying descendant at any depth. A descendant satisfies the container when it carries one of the required roles explicitly, or when a native equivalent is present: `<li>` for `listitem`, `<tr>` for `row`, `<td>` or `<th>` for `cell`, `<option>` for `option`, `<article>` for `article`. A container that is itself the native element also counts, so `<ul role="list">` with `<li>` children passes, as do `<table role="table">` with `<tr>` and `<select role="listbox">` with `<option>`.
+
+An empty container is skipped, on the assumption it is populated later. A finding needs the element to have at least one child element or some text.
+
+- Fail with `N element(s) missing required child roles`. Items read `div[role="tablist"]: needs child with role=tab`, up to ten with a count of the rest.
+- Pass with `All elements have required child roles`, which is also what a page using none of these roles reports.
+
+## How to fix it
+
+```html
+<div role="tablist" aria-label="Account settings">
+  <button role="tab" aria-selected="true" aria-controls="profile">Profile</button>
+  <button role="tab" aria-selected="false" aria-controls="billing">Billing</button>
+</div>
+```
+
+Give the container the children its role demands, or drop the role and let the native elements speak for themselves.
+
+squirrel searches at any depth, so an intermediate wrapper does not trip the check. The ARIA specification is stricter: owned elements must be direct children, or connected with `aria-owns`. A widget that passes here can still be wrong in a browser, so keep the required children directly inside the container.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks that elements with certain roles have required child roles
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Some ARIA roles require specific child roles. For example, role='list' must contain role='listitem', role='menu' must contain menu items. Add the required child elements with appropriate roles.
 
 ## Enable / disable
 
@@ -40,3 +64,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-required-children"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): the same relationship checked from the child upwards.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): the state attributes those children need.
+- [a11y/list-structure](/rules/a11y/list-structure): native `<ul>` and `<ol>` with the wrong children.
+- [a11y/aria-roles](/rules/a11y/aria-roles): whether the role you typed exists at all.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+- [ARIA roles, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+- [Understanding SC 1.3.1 Info and Relationships, W3C](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each container is listed with the child role it is missing. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-required-children.mdx
+++ b/docs/rules/a11y/aria-required-children.mdx
@@ -31,7 +31,7 @@ An empty container is skipped, on the assumption it is populated later. A findin
 
 Give the container the children its role demands, or drop the role and let the native elements speak for themselves.
 
-squirrel searches at any depth, so an intermediate wrapper does not trip the check. The ARIA specification is stricter: owned elements must be direct children, or connected with `aria-owns`. A widget that passes here can still be wrong in a browser, so keep the required children directly inside the container.
+squirrel searches at any depth, so an intermediate wrapper does not trip the check. Nor does it check the other half of the relationship: an element can be a DOM descendant and still not be owned by the container in the way the role expects, and `aria-owns` can pull in elements from elsewhere in the document. A widget that passes here can still be wrong in a browser.
 
 | | |
 |---|---|

--- a/docs/rules/a11y/aria-required-parent.mdx
+++ b/docs/rules/a11y/aria-required-parent.mdx
@@ -1,9 +1,38 @@
 ---
-title: "ARIA Required Parent"
-description: "Checks that elements with certain roles have required parent roles"
+title: "ARIA roles that require a particular parent role"
+description: "role=listitem outside a list, or a tab outside a tablist, loses its meaning. squirrel checks explicit roles and native li, tr, td and option."
 ---
 
-Checks that elements with certain roles have required parent roles
+## What a required parent role is
+
+Some ARIA roles only mean something inside a container. A `tab` belongs to a `tablist`, an `option` to a `listbox`, a `listitem` to a `list`. Assistive technology reads the pair together to say "tab 2 of 5" or "list, 12 items".
+
+Take the child out of its container and both halves break. The child is announced with a role that implies a position it cannot report, and the container never appears.
+
+## What squirrel checks
+
+One check, `aria-required-parent`, at severity error, in two passes.
+
+The first pass covers thirteen child roles and their permitted parents: `cell`, `columnheader`, `gridcell` and `rowheader` need a `row`; `listitem` needs a `list` or `group`; `menuitem`, `menuitemcheckbox` and `menuitemradio` need a `menu`, `menubar` or `group`; `option` needs a `listbox` or `group`; `row` needs a `grid`, `rowgroup`, `table` or `treegrid`; `rowgroup` needs a `grid`, `table` or `treegrid`; `tab` needs a `tablist`; `treeitem` needs a `tree` or `group`.
+
+For each element it walks up the ancestor chain comparing effective roles. An effective role is the explicit `role` when there is one, otherwise an implicit role mapped from the tag: `<ul>`, `<ol>` and `<dl>` are lists, `<table>` a table, `<tr>` a row, `<td>` a cell, `<th>` a column header, `<select>` a listbox, `<nav>` a navigation landmark. An `<input>` maps by its `type`, and an `<a>` counts as a link only when it has an `href`.
+
+The second pass repeats the test for native elements carrying no explicit role: `<li>`, `<option>`, `<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>` and `<tfoot>`.
+
+- Fail with `N element(s) missing required parent role`. Items read `div[role="tab"]: needs parent with role=tablist`, or `li (implicit role="listitem"): needs parent with role=list|group`, up to ten with a count of the rest.
+- Pass with `All elements have required parent roles`.
+
+## How to fix it
+
+```html
+<div role="tablist" aria-label="Account settings">
+  <button role="tab" aria-selected="true">Profile</button>
+</div>
+```
+
+Move the child inside the container, or give the container the matching role.
+
+The ancestor walk has no depth limit, so a `<div>` sitting between a `<ul>` and its `<li>` still satisfies this rule even though HTML does not allow it. `a11y/listitem` checks the direct parent and catches that case.
 
 | | |
 |---|---|
@@ -12,10 +41,6 @@ Checks that elements with certain roles have required parent roles
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Some ARIA roles must be contained within specific parent roles. For example, role='listitem' must be within role='list', role='option' must be within role='listbox'. Restructure your markup to ensure proper parent-child relationships.
 
 ## Enable / disable
 
@@ -40,3 +65,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-required-parent"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-required-children](/rules/a11y/aria-required-children): the same relationship checked from the container downwards.
+- [a11y/listitem](/rules/a11y/listitem): `<li>` elements whose immediate parent is not a list.
+- [a11y/dlitem](/rules/a11y/dlitem): the equivalent for `<dt>` and `<dd>`.
+- [a11y/aria-roles](/rules/a11y/aria-roles): whether the roles involved exist at all.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+- [ARIA in HTML, W3C](https://www.w3.org/TR/html-aria/)
+- [Understanding SC 1.3.1 Info and Relationships, W3C](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each element is listed with the parent role it needs and does not have. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-roles.mdx
+++ b/docs/rules/a11y/aria-roles.mdx
@@ -17,7 +17,7 @@ One check, `aria-roles`, at severity error. It reads every `[role]` element, tri
 - Pass with `N element(s) with valid ARIA roles`.
 - Info with `No ARIA roles found`.
 
-Two limits are worth knowing. Every token in a fallback chain is validated, so `role="doc-subtitle heading"` is reported even though a browser resolves it to `heading`. And the vocabulary is core ARIA only, so the DPUB-ARIA and Graphics-ARIA module roles are all reported as invalid.
+Two limits are worth knowing. Every token in a fallback chain is validated, so `role="doc-subtitle heading"` is reported even though the chain is written correctly: a browser that supports `doc-subtitle` uses it, and one that does not falls through to `heading`. And the vocabulary is core ARIA only, so the DPUB-ARIA and Graphics-ARIA module roles are all reported as invalid.
 
 ## How to fix it
 

--- a/docs/rules/a11y/aria-roles.mdx
+++ b/docs/rules/a11y/aria-roles.mdx
@@ -1,9 +1,33 @@
 ---
-title: "ARIA Valid Roles"
-description: "Checks for valid ARIA role values"
+title: "Invalid ARIA role values and how to check them"
+description: "A misspelled or invented role gives an element no semantics at all. squirrel validates every role attribute against the ARIA vocabulary."
 ---
 
-Checks for valid ARIA role values
+## What a valid role is
+
+WAI-ARIA defines a closed vocabulary of role names. A value outside it is discarded: the element keeps whatever semantics its tag already had, and the intended role never reaches assistive technology. Nothing warns you, which is what makes a typo such as `role="buton"` expensive.
+
+The `role` attribute accepts a whitespace-separated fallback chain, and a browser uses the first token it recognizes. That makes `role="doc-subtitle heading"` legitimate markup even though only the second token is core ARIA.
+
+## What squirrel checks
+
+One check, `aria-roles`, at severity error. It reads every `[role]` element, trims the value, splits it on whitespace, lowercases each token and looks it up in a set of 83 role names covering document structure, widgets, composite widgets, landmarks, live regions and window roles.
+
+- Fail with `N invalid ARIA role(s) found`. Items read `div: role="buton"`, up to ten with a count of the rest.
+- Pass with `N element(s) with valid ARIA roles`.
+- Info with `No ARIA roles found`.
+
+Two limits are worth knowing. Every token in a fallback chain is validated, so `role="doc-subtitle heading"` is reported even though a browser resolves it to `heading`. And the vocabulary is core ARIA only, so the DPUB-ARIA and Graphics-ARIA module roles are all reported as invalid.
+
+## How to fix it
+
+```html
+<div role="button" tabindex="0">Save</div>
+```
+
+Fix the spelling, or drop the attribute. A native `<button>` needs no role at all, and replacing the `<div>` removes this finding along with the keyboard handling you would otherwise have to write.
+
+squirrel lowercases each token before comparing, so `role="BUTTON"` is accepted here. Write roles in lowercase anyway: the ARIA specification defines them that way.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for valid ARIA role values
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Use only valid ARIA role values as defined in the WAI-ARIA specification. Common mistakes include using made-up roles or misspelling valid roles. Roles are case-sensitive and must be lowercase. Multiple roles can be specified, separated by spaces, but the first valid role is used.
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-roles"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-deprecated-role](/rules/a11y/aria-deprecated-role): roles that exist but should not be used.
+- [a11y/aria-valid-attr](/rules/a11y/aria-valid-attr): the same problem in `aria-*` attribute names.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): the attributes a valid role then has to declare.
+- [a11y/aria-allowed-attr](/rules/a11y/aria-allowed-attr): attributes that contradict the role you chose.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [ARIA roles, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
+- [Definition of roles, WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/#role_definitions)
+- [ARIA in HTML, W3C](https://www.w3.org/TR/html-aria/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each unrecognized role is listed with the element carrying it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-text.mdx
+++ b/docs/rules/a11y/aria-text.mdx
@@ -1,9 +1,34 @@
 ---
-title: "ARIA Text"
-description: "Checks that elements with role='text' have no focusable descendants"
+title: "role=text with focusable children: why it breaks"
+description: "role=text flattens a subtree into one announced string, so a link inside it cannot be operated. squirrel reports every case it finds."
 ---
 
-Checks that elements with role='text' have no focusable descendants
+## What role=text is
+
+`role="text"` asks assistive technology to treat an element's whole subtree as a single flat string, so a heading broken across several `<span>` elements is announced as one phrase instead of several fragments.
+
+It is not defined in the WAI-ARIA 1.2 recommendation, nor in the 1.3 working draft, so it is a vendor extension and support varies. Where it is honored, the subtree stops being a set of separate objects, and anything interactive inside it stops being reachable as a separate object too.
+
+## What squirrel checks
+
+One check, `aria-text`, at severity warning. It finds every `[role="text"]` element and looks for focusable descendants. Focusable means matching `a[href]`, `button`, `input`, `select` or `textarea`, or carrying any `tabindex` other than `-1`. The `tabindex` lookup is case-insensitive, so React's `tabIndex` in server-rendered markup is caught.
+
+- Warn with `N role="text" element(s) with focusable descendants`. Items read `span#hero-title (2 focusable)`, up to ten with a count of the rest.
+- Pass with `All N role="text" element(s) have no focusable descendants`.
+- Info with `No elements with role="text" found`.
+
+## How to fix it
+
+```html
+<h2>
+  <span>Read our</span>
+  <a href="/report">2026 accessibility report</a>
+</h2>
+```
+
+Take `role="text"` off the container, or move the interactive element outside it. Keeping both means the link is announced as part of a sentence with no way to activate it.
+
+If the goal was to stop a screen reader chopping a heading into pieces, the usual cause is extra markup for styling. Removing the wrapper elements, or setting them to `display: inline`, fixes the announcement without a vendor role.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that elements with role='text' have no focusable descendants
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Elements with role='text' tell screen readers to treat the content as a single text string. If focusable elements (links, buttons, inputs) are nested inside, screen reader users cannot interact with them properly. Remove role='text' from the parent, or restructure so focusable elements are outside the role='text' container.
 
 ## Enable / disable
 
@@ -40,3 +61,30 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-text"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): the same conflict between a hidden region and the tab order.
+- [a11y/aria-roles](/rules/a11y/aria-roles): `text` is outside the core vocabulary, so this role is reported there too.
+- [a11y/link-text](/rules/a11y/link-text): the accessible name the link inside still needs.
+- [a11y/empty-heading](/rules/a11y/empty-heading): headings whose content does not reach assistive technology at all.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Definition of roles, WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/#role_definitions)
+- [Understanding SC 2.1.1 Keyboard, W3C](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each container is listed with a count of the focusable elements inside it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-toggle-field-name.mdx
+++ b/docs/rules/a11y/aria-toggle-field-name.mdx
@@ -73,7 +73,7 @@ disable = ["*"]
 
 - [a11y/aria-required-attr](/rules/a11y/aria-required-attr): `aria-checked`, which those same roles must declare.
 - [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): the wider naming sweep across input roles.
-- [a11y/form-labels](/rules/a11y/form-labels): the `<label>` association this rule accepts.
+- [a11y/form-labels](/rules/a11y/form-labels): the same label association checked across inputs, textareas and selects.
 - [a11y/form-field-multiple-labels](/rules/a11y/form-field-multiple-labels): two labels pointing at one control.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/a11y/aria-toggle-field-name.mdx
+++ b/docs/rules/a11y/aria-toggle-field-name.mdx
@@ -1,9 +1,41 @@
 ---
-title: "ARIA Toggle Field Name"
-description: "Checks that toggle fields (checkbox, radio, switch) have accessible names"
+title: "Checkboxes, radios and switches with no accessible name"
+description: "A checkbox that announces only its role gives no reason to tick it. squirrel checks toggle roles and native checkbox and radio inputs."
 ---
 
-Checks that toggle fields (checkbox, radio, switch) have accessible names
+## What a toggle field name is
+
+A toggle carries two pieces of information: what it controls, and whether it is on. ARIA covers the second with `aria-checked`. The first is the accessible name, and without it a screen reader says "checkbox, not checked" and stops.
+
+Native checkboxes and radios take their name from a `<label>`. Custom toggles built from a `<div>` with `role="switch"` take theirs from `aria-label`, `aria-labelledby` or their own text content.
+
+## What squirrel checks
+
+One check, `aria-toggle-field-name`, at severity error. It covers every element with `role="checkbox"`, `role="radio"` or `role="switch"`, plus native `input[type="checkbox"]` and `input[type="radio"]` that carry no explicit `role`.
+
+A name is accepted from a non-empty `aria-label`, an `aria-labelledby` pointing at an element with text, a non-empty `title`, the element's own text content, a `<label for="...">` matching its `id`, or an ancestor `<label>` with text.
+
+- Fail with `N toggle field(s) without accessible names`. Items read `div[role="switch"]`, `checkbox[name="terms"]` or `radio[name="plan"][value="pro"]`, up to ten with a count of the rest.
+- Pass with `All toggle fields have accessible names`.
+
+## How to fix it
+
+```html
+<label>
+  <input type="checkbox" name="terms">
+  I accept the terms
+</label>
+```
+
+Wrapping is the shortest fix for a native control, and it makes the words clickable as well.
+
+For a custom toggle, put the name on the element with the role and keep `aria-checked` in step with the visible state:
+
+```html
+<div role="switch" aria-checked="false" aria-label="Dark mode" tabindex="0"></div>
+```
+
+A group of radios needs one name per radio, not one for the group. The group label belongs on a `<fieldset>` with a `<legend>`, or on a `role="radiogroup"` container.
 
 | | |
 |---|---|
@@ -12,10 +44,6 @@ Checks that toggle fields (checkbox, radio, switch) have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Toggle fields need accessible names to describe what they control. Use `<label for='id'>`, aria-label, aria-labelledby, or wrap in `<label>`. Example: `<label>``<input type='checkbox'>` Subscribe to newsletter`</label>`
 
 ## Enable / disable
 
@@ -40,3 +68,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-toggle-field-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): `aria-checked`, which those same roles must declare.
+- [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): the wider naming sweep across input roles.
+- [a11y/form-labels](/rules/a11y/form-labels): the `<label>` association this rule accepts.
+- [a11y/form-field-multiple-labels](/rules/a11y/form-field-multiple-labels): two labels pointing at one control.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The checkbox role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/checkbox_role)
+- [The switch role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/switch_role)
+- [Labeling controls, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/forms/labels/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Native and custom toggles are listed together, each with a selector. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-tooltip-name.mdx
+++ b/docs/rules/a11y/aria-tooltip-name.mdx
@@ -1,9 +1,34 @@
 ---
-title: "ARIA Tooltip Name"
-description: "Checks that tooltip elements have accessible names"
+title: "role=tooltip with no content: what to check"
+description: "A tooltip with nothing to announce leaves the control it explains unexplained. squirrel checks every role=tooltip element on the page."
 ---
 
-Checks that tooltip elements have accessible names
+## What a tooltip is
+
+`role="tooltip"` marks a small pop-up that describes the control it belongs to. Unlike a dialog, its own content is its accessible name, and the control points at it with `aria-describedby` so a screen reader reads the two together.
+
+That makes an empty tooltip pointless. The control announces a description that resolves to nothing, and the user is left with the same question the tooltip was there to answer.
+
+## What squirrel checks
+
+One check, `aria-tooltip-name`, at severity error. It finds every `[role="tooltip"]` element.
+
+A name is accepted from a non-empty `aria-label`, an `aria-labelledby` pointing at an element with text, or the tooltip's own text content. Unlike the other naming rules, `title` does not count here.
+
+- Fail with `N tooltip(s) without accessible content`. Every offender is listed, as `div#tip-save` or bare tag name.
+- Pass with `N tooltip(s) have accessible names`.
+- Info with `No tooltip elements found`.
+
+## How to fix it
+
+```html
+<button aria-describedby="tip-save">Save</button>
+<div role="tooltip" id="tip-save">Saves without leaving the page</div>
+```
+
+Put the description in the tooltip's text. The `id` and the `aria-describedby` value have to match, and the `id` has to be unique or the reference lands on the wrong node.
+
+A tooltip rendered empty and filled by script when it opens is reported. Ship the text in the markup and toggle visibility instead, which keeps the description available to the control at all times.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that tooltip elements have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Tooltip elements with role='tooltip' must have accessible content. The tooltip content serves as its accessible name. Ensure tooltips have text content or use aria-label for icon-based tooltips.
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-tooltip-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/duplicate-id-aria](/rules/a11y/duplicate-id-aria): the `aria-describedby` reference resolving to a duplicated or missing id.
+- [a11y/aria-dialog-name](/rules/a11y/aria-dialog-name): the naming rule for the heavier pop-up.
+- [a11y/aria-labels](/rules/a11y/aria-labels): the icon button most tooltips are attached to.
+- [a11y/aria-valid-attr](/rules/a11y/aria-valid-attr): typos in `aria-describedby` itself.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The tooltip role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tooltip_role)
+- [aria-describedby, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
+- [Providing accessible names and descriptions, WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every empty tooltip is listed, with no cap on the count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-treeitem-name.mdx
+++ b/docs/rules/a11y/aria-treeitem-name.mdx
@@ -1,9 +1,40 @@
 ---
-title: "ARIA Treeitem Name"
-description: "Checks that treeitem elements have accessible names"
+title: "role=treeitem: naming every node in a tree"
+description: "A tree node that announces only its position in the tree is unusable. squirrel checks every role=treeitem for something to read out."
 ---
 
-Checks that treeitem elements have accessible names
+## What a treeitem is
+
+A tree presents nested items a user can expand and collapse: a file browser, a category picker, a table of contents. Each node carries `role="treeitem"` and a screen reader announces its name along with its level and position.
+
+The name normally comes from the node's own text. Icon-only nodes, and nodes whose label sits in a sibling element, need `aria-label` or `aria-labelledby` instead.
+
+## What squirrel checks
+
+One check, `aria-treeitem-name`, at severity error. It finds every `[role="treeitem"]` element.
+
+A name is accepted from a non-empty `aria-label`, an `aria-labelledby` pointing at an element with text, the node's own text content, or a nested `<img>` with non-empty `alt`.
+
+- Fail with `N treeitem(s) without accessible names`. Items read `li#node-3` or bare tag name, up to ten with a count of the rest.
+- Pass with `N treeitem(s) have accessible names`.
+- Info with `No treeitem elements found`.
+
+Text content is read from the whole subtree, so a node whose only text lives inside a nested group counts as named. That is generous: check the announced name in a screen reader before trusting a pass on a deeply nested tree.
+
+## How to fix it
+
+```html
+<li role="treeitem" aria-expanded="false">
+  <span>Invoices</span>
+  <ul role="group">
+    <li role="treeitem">2026-Q1.pdf</li>
+  </ul>
+</li>
+```
+
+Keep the node's own label in the node and its children in a nested `role="group"`. That is also what makes the level and position announcements correct.
+
+An icon-only node needs `aria-label` on the `treeitem` itself, not on the icon inside it.
 
 | | |
 |---|---|
@@ -12,10 +43,6 @@ Checks that treeitem elements have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Treeitem elements must have accessible names. Add text content, aria-label, or aria-labelledby. The text content within the treeitem typically serves as its name.
 
 ## Enable / disable
 
@@ -40,3 +67,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-treeitem-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): a `treeitem` needs a `tree` or `group` above it.
+- [a11y/aria-required-children](/rules/a11y/aria-required-children): the `tree` container needs those items in return.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): state attributes the surrounding widget roles declare.
+- [a11y/aria-labels](/rules/a11y/aria-labels): the general icon-only naming problem.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The treeitem role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/treeitem_role)
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unnamed node is listed with a selector you can search for. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-treeitem-name.mdx
+++ b/docs/rules/a11y/aria-treeitem-name.mdx
@@ -72,7 +72,7 @@ disable = ["*"]
 
 - [a11y/aria-required-parent](/rules/a11y/aria-required-parent): a `treeitem` needs a `tree` or `group` above it.
 - [a11y/aria-required-children](/rules/a11y/aria-required-children): the `tree` container needs those items in return.
-- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): state attributes the surrounding widget roles declare.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): required state attributes for the roles that have them. `treeitem` is not one of them.
 - [a11y/aria-labels](/rules/a11y/aria-labels): the general icon-only naming problem.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/a11y/aria-valid-attr-value.mdx
+++ b/docs/rules/a11y/aria-valid-attr-value.mdx
@@ -5,7 +5,7 @@ description: "aria-checked=yes and aria-level=two are ignored by browsers. squir
 
 ## What a valid ARIA value is
 
-Each ARIA attribute declares a value type, and a value outside that type is discarded. `aria-checked="yes"` leaves the control with no checked state at all, which is worse than omitting the attribute, because the markup looks correct.
+Each ARIA attribute declares a value type. ARIA specifies how a user agent should handle a value outside that type, and the handling is per attribute: some fall back to a default, some are ignored. `aria-checked="yes"` cannot be relied on to produce a checked state, which is worse than omitting the attribute, because the markup looks correct.
 
 The types are: booleans that take only `true` or `false`; booleans that also accept `undefined`; tristates that add `mixed`; enumerated tokens with a fixed list; token lists; integers; and numbers.
 
@@ -19,7 +19,7 @@ One check, `aria-valid-attr-value`, at severity error. It reads every `aria-*` a
 | Boolean or undefined | `aria-expanded`, `aria-grabbed`, `aria-hidden`, `aria-selected` | `true`, `false`, `undefined`, empty |
 | Tristate | `aria-checked`, `aria-pressed` | `true`, `false`, `mixed` |
 | Token | `aria-autocomplete`, `aria-current`, `aria-haspopup`, `aria-invalid`, `aria-live`, `aria-orientation`, `aria-sort` | each attribute's own list |
-| Token list | `aria-dropeffect`, `aria-relevant` | any number of that attribute's tokens |
+| Token list | `aria-dropeffect`, `aria-relevant` | one or more of that attribute's tokens |
 | Integer | `aria-level` | a whole number, negative allowed |
 | Number | `aria-valuemax`, `aria-valuemin`, `aria-valuenow` | a decimal number, or empty |
 
@@ -35,7 +35,7 @@ Attributes outside the table are skipped, so a name that is not in the ARIA voca
 <div id="filters" aria-live="polite">...</div>
 ```
 
-Use the literal strings the type expects. `aria-expanded="1"` and `aria-expanded="yes"` both mean nothing; `aria-expanded="false"` is the value.
+Use the literal strings the type expects. `aria-expanded="1"` and `aria-expanded="yes"` are both outside the type and neither reliably produces a collapsed state. `aria-expanded="false"` is the value.
 
 Comparison is case-insensitive, so `aria-checked="TRUE"` passes. Write the values in lowercase anyway, so the markup matches the specification and the next reader.
 

--- a/docs/rules/a11y/aria-valid-attr-value.mdx
+++ b/docs/rules/a11y/aria-valid-attr-value.mdx
@@ -75,8 +75,8 @@ disable = ["*"]
 
 - [a11y/aria-valid-attr](/rules/a11y/aria-valid-attr): the attribute name itself not existing.
 - [a11y/aria-required-attr](/rules/a11y/aria-required-attr): the attributes a role must declare in the first place.
-- [a11y/aria-allowed-attr](/rules/a11y/aria-allowed-attr): valid values that contradict the element's role.
-- [a11y/aria-progressbar-name](/rules/a11y/aria-progressbar-name): the widget whose `aria-valuenow` this check type-checks.
+- [a11y/aria-allowed-attr](/rules/a11y/aria-allowed-attr): ARIA attributes that are not allowed on the element carrying them.
+- [a11y/aria-progressbar-name](/rules/a11y/aria-progressbar-name): progress bars with no accessible name, the widget whose `aria-valuenow` this check type-checks.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/aria-valid-attr-value.mdx
+++ b/docs/rules/a11y/aria-valid-attr-value.mdx
@@ -1,9 +1,43 @@
 ---
-title: "ARIA Valid Attribute Values"
-description: "Checks for valid values in ARIA attributes"
+title: "Invalid ARIA attribute values and the types they need"
+description: "aria-checked=yes and aria-level=two are ignored by browsers. squirrel type-checks 26 ARIA attributes against their allowed values."
 ---
 
-Checks for valid values in ARIA attributes
+## What a valid ARIA value is
+
+Each ARIA attribute declares a value type, and a value outside that type is discarded. `aria-checked="yes"` leaves the control with no checked state at all, which is worse than omitting the attribute, because the markup looks correct.
+
+The types are: booleans that take only `true` or `false`; booleans that also accept `undefined`; tristates that add `mixed`; enumerated tokens with a fixed list; token lists; integers; and numbers.
+
+## What squirrel checks
+
+One check, `aria-valid-attr-value`, at severity error. It reads every `aria-*` attribute on every element, trims and lowercases the value, and validates it against a table of 26 attributes:
+
+| Type | Attributes | Accepted |
+|---|---|---|
+| Boolean | `aria-busy`, `aria-disabled`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-readonly`, `aria-required` | `true`, `false` |
+| Boolean or undefined | `aria-expanded`, `aria-grabbed`, `aria-hidden`, `aria-selected` | `true`, `false`, `undefined`, empty |
+| Tristate | `aria-checked`, `aria-pressed` | `true`, `false`, `mixed` |
+| Token | `aria-autocomplete`, `aria-current`, `aria-haspopup`, `aria-invalid`, `aria-live`, `aria-orientation`, `aria-sort` | each attribute's own list |
+| Token list | `aria-dropeffect`, `aria-relevant` | any number of that attribute's tokens |
+| Integer | `aria-level` | a whole number, negative allowed |
+| Number | `aria-valuemax`, `aria-valuemin`, `aria-valuenow` | a decimal number, or empty |
+
+- Fail with `N ARIA attribute(s) with invalid values`. Items name the element, the attribute and the reason: `div[aria-checked]: must be 'true', 'false', or 'mixed', got 'yes'`, or `h2[aria-level]: must be an integer, got 'two'`. Up to ten are shown with a count of the rest.
+- Pass with `All ARIA attribute values are valid`.
+
+Attributes outside the table are skipped, so a name that is not in the ARIA vocabulary passes here and fails `a11y/aria-valid-attr`.
+
+## How to fix it
+
+```html
+<button aria-pressed="false" aria-controls="filters">Filters</button>
+<div id="filters" aria-live="polite">...</div>
+```
+
+Use the literal strings the type expects. `aria-expanded="1"` and `aria-expanded="yes"` both mean nothing; `aria-expanded="false"` is the value.
+
+Comparison is case-insensitive, so `aria-checked="TRUE"` passes. Write the values in lowercase anyway, so the markup matches the specification and the next reader.
 
 | | |
 |---|---|
@@ -12,10 +46,6 @@ Checks for valid values in ARIA attributes
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Ensure ARIA attribute values match the expected type. Boolean attributes should be 'true' or 'false'. Enumerated attributes like aria-current have specific allowed values. Numeric attributes like aria-level must be numbers. Check the WAI-ARIA specification for valid values.
 
 ## Enable / disable
 
@@ -40,3 +70,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-valid-attr-value"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-valid-attr](/rules/a11y/aria-valid-attr): the attribute name itself not existing.
+- [a11y/aria-required-attr](/rules/a11y/aria-required-attr): the attributes a role must declare in the first place.
+- [a11y/aria-allowed-attr](/rules/a11y/aria-allowed-attr): valid values that contradict the element's role.
+- [a11y/aria-progressbar-name](/rules/a11y/aria-progressbar-name): the widget whose `aria-valuenow` this check type-checks.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [ARIA attributes, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes)
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+- [aria-current, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each finding names the attribute, the value you supplied and the type it needed. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-valid-attr.mdx
+++ b/docs/rules/a11y/aria-valid-attr.mdx
@@ -1,9 +1,33 @@
 ---
-title: "ARIA Valid Attributes"
-description: "Checks for valid ARIA attribute names"
+title: "Invalid aria-* attribute names, aria-labeledby included"
+description: "A misspelled ARIA attribute is ignored by every browser and warns nobody. squirrel checks each aria-* name against the ARIA vocabulary."
 ---
 
-Checks for valid ARIA attribute names
+## What a valid ARIA attribute name is
+
+ARIA defines a fixed set of `aria-*` state and property names. Anything outside it is an unknown attribute: it sits in the DOM, it validates as HTML, and it does nothing. No console warning, no visible change, nothing.
+
+The mistakes cluster in a few places. `aria-labeledby` with one `l` is the classic, because the correct spelling doubles it. `aria-role` does not exist; the attribute is plain `role`. And anything invented to look like ARIA, such as `aria-title`, falls straight through.
+
+## What squirrel checks
+
+One check, `aria-valid-attr`, at severity error. It walks every element on the page, reads every attribute, lowercases the ones beginning with `aria-`, and looks each up in a set of 53 valid names.
+
+- Fail with `N invalid ARIA attribute(s) found`. Items read `div: aria-labeledby`, up to ten with a count of the rest.
+- Pass with `All ARIA attributes are valid`, which is also what a page carrying no ARIA at all reports.
+
+The check is about names only. Whether the value is legal is `a11y/aria-valid-attr-value`, and whether the attribute belongs on that particular element is `a11y/aria-allowed-attr`.
+
+## How to fix it
+
+```html
+<h2 id="settings-title">Settings</h2>
+<div role="dialog" aria-labelledby="settings-title">...</div>
+```
+
+Correct the spelling against the ARIA attribute list. If the name you wanted does not exist, the information usually belongs in `aria-label`, `aria-describedby` or `aria-roledescription`.
+
+A component library that spreads arbitrary props onto a DOM node is the usual source of a page full of these. Filter the props at the boundary rather than fixing the attributes one at a time.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks for valid ARIA attribute names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Use only valid ARIA attribute names as defined in the WAI-ARIA specification. Common typos include 'aria-labeledby' (should be 'aria-labelledby'), 'aria-role' (should be 'role'), and 'aria-description' vs 'aria-describedby'. Consult MDN or the WAI-ARIA spec for the complete list of valid attributes.
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/aria-valid-attr"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-valid-attr-value](/rules/a11y/aria-valid-attr-value): a correct name carrying a value of the wrong type.
+- [a11y/aria-allowed-attr](/rules/a11y/aria-allowed-attr): a correct name on an element that contradicts it.
+- [a11y/aria-roles](/rules/a11y/aria-roles): the same class of typo in the `role` attribute.
+- [a11y/duplicate-id-aria](/rules/a11y/duplicate-id-aria): ARIA references that point at nothing.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [ARIA attributes, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes)
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+- [aria-labelledby, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each unrecognized attribute is listed with the element carrying it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/aria-valid-attr.mdx
+++ b/docs/rules/a11y/aria-valid-attr.mdx
@@ -5,7 +5,7 @@ description: "A misspelled ARIA attribute is ignored by every browser and warns 
 
 ## What a valid ARIA attribute name is
 
-ARIA defines a fixed set of `aria-*` state and property names. Anything outside it is an unknown attribute: it sits in the DOM, it validates as HTML, and it does nothing. No console warning, no visible change, nothing.
+ARIA defines a fixed set of `aria-*` state and property names. Anything outside it is an unknown attribute: the parser keeps it in the DOM, it fails HTML and ARIA conformance checking, and it does nothing at runtime. No console warning, no visible change, nothing.
 
 The mistakes cluster in a few places. `aria-labeledby` with one `l` is the classic, because the correct spelling doubles it. `aria-role` does not exist; the attribute is plain `role`. And anything invented to look like ARIA, such as `aria-title`, falls straight through.
 

--- a/docs/rules/a11y/autocomplete-tokens.mdx
+++ b/docs/rules/a11y/autocomplete-tokens.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Autocomplete Tokens"
-description: "Checks that name, email, phone, address and payment fields carry the correct autocomplete token"
+title: "autocomplete: the right token for every form field"
+description: "Name, email, address and payment fields with a missing or wrong autocomplete token break autofill. squirrel finds every one on every page."
 ---
 
-Checks that name, email, phone, address and payment fields carry the correct autocomplete token
+## What autocomplete is
+
+`autocomplete` names what a form field collects, using a fixed vocabulary defined by the HTML standard: `given-name`, `email`, `tel`, `address-line1`, `postal-code`, `cc-number` and the rest of the autofill field names. Browsers and password managers read the token and fill the field from data the user has already saved. WCAG success criterion 1.3.5 requires it on fields that collect information about the user.
+
+Fields that collect anything else do not need a token. A search box, a quantity, a coupon code and a message body are all outside the vocabulary. A token the browser does not recognize is discarded, so a near miss such as `firstname` behaves exactly like no token at all.
+
+## What squirrel checks
+
+The rule infers each field's purpose from its `name`, `id`, associated `<label>` and `placeholder`, then compares the `autocomplete` value against that purpose. Only fields whose purpose is unambiguous count, so a field named `capacity` is never read as a city. It emits one check, `autocomplete-tokens`, at severity warning.
+
+- Fail when a field carries a token that is not in the spec, or a token belonging to a different purpose. Report message: `N field(s) carry the wrong autocomplete token`, extended to `N field(s) carry the wrong autocomplete token, M carry none` when the page has both problems.
+- Warn when an identified field has no token, or sets `autocomplete="off"` or `autocomplete="on"`. Report message: `N identified field(s) missing an autocomplete token`.
+- Pass with `N identified field(s) carry the correct autocomplete token`.
+- Skipped with `No name, email, phone, address or payment fields found` when no field on the page has an identifiable purpose.
+
+Each finding names the field with a CSS selector, quotes its opening tag and states the expected token, for example `email field is tagged autocomplete="username" (expected "email")`.
+
+## How to fix it
+
+```html
+<label for="ship-street">Address line 1</label>
+<input id="ship-street" name="shippingAddressLine1" type="text"
+       autocomplete="shipping address-line1">
+```
+
+The token goes on the field itself, never on the wrapper. Tokens accept the `section-*`, `shipping`/`billing` and `home`/`work`/`mobile` prefixes, so both `shipping address-line1` and `address-line1` satisfy the check.
+
+`autocomplete="off"` is reported rather than accepted. Browsers ignore it on personal data, so it does not stop autofill, only the accurate kind.
 
 | | |
 |---|---|
@@ -12,33 +39,6 @@ Checks that name, email, phone, address and payment fields carry the correct aut
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## What it checks
-
-The rule works out what each field is for from its `name`, `id`, label and placeholder, then checks the `autocomplete` token against that purpose. Only fields whose purpose is unambiguous are considered, so a field called `capacity` is never read as a city and `hotel` is never read as a phone number.
-
-| Outcome | When |
-|---|---|
-| `pass` | Every identified field carries a correct token |
-| `warn` | An identified field has no token, or turns autofill off |
-| `fail` | A token is not in the spec, or belongs to a different purpose |
-| `skipped` | No field on the page has an identifiable purpose |
-
-Each finding names the exact node with a selector and the field's opening tag.
-
-## Solution
-
-Give every field that collects a person's own data the matching WHATWG autofill token, e.g. `autocomplete="given-name"`, `"email"`, `"tel"`, `"address-line1"`, `"postal-code"`, `"cc-number"`. Browsers and password managers fill those fields in one tap, which is the difference between a completed checkout and an abandoned one, and WCAG 2.1 success criterion 1.3.5 (Identify Input Purpose) requires it.
-
-Tokens may be prefixed with `section-*`, `shipping`/`billing` and `home`/`work`/`mobile`:
-
-```html
-<label for="ship-street">Address line 1</label>
-<input id="ship-street" name="shippingAddressLine1" type="text"
-       autocomplete="shipping address-line1" enterkeyhint="next">
-```
-
-A token the browser does not recognise is ignored outright, so a typo like `autocomplete="firstname"` is worse than nothing: use `given-name`. Avoid `autocomplete="off"` on personal data. It does not stop autofill in modern browsers, it only stops the accurate kind.
 
 ## Enable / disable
 
@@ -63,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/autocomplete-tokens"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/form-labels](/rules/a11y/form-labels): the label the token is inferred from, when there is one.
+- [a11y/input-types](/rules/a11y/input-types): the other half of the same fix, `type="email"` next to `autocomplete="email"`.
+- [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): fields that have no accessible name at all.
+- [a11y/paste-inputs](/rules/a11y/paste-inputs): fields that block paste, which breaks password managers the same way.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The autocomplete attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
+- [Autofill, HTML Standard](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill)
+- [Understanding SC 1.3.5 Identify Input Purpose, W3C](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every field with a missing or mismatched token is listed with its expected value. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/autocomplete-tokens.mdx
+++ b/docs/rules/a11y/autocomplete-tokens.mdx
@@ -66,10 +66,10 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/form-labels](/rules/a11y/form-labels): the label the token is inferred from, when there is one.
+- [a11y/form-labels](/rules/a11y/form-labels): inputs, textareas and selects with no associated label.
 - [a11y/input-types](/rules/a11y/input-types): the other half of the same fix, `type="email"` next to `autocomplete="email"`.
 - [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): fields that have no accessible name at all.
-- [a11y/paste-inputs](/rules/a11y/paste-inputs): fields that block paste, which breaks password managers the same way.
+- [a11y/paste-inputs](/rules/a11y/paste-inputs): fields whose `onpaste`, `oncopy` or `oncut` handler cancels the event.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/autocomplete-tokens.mdx
+++ b/docs/rules/a11y/autocomplete-tokens.mdx
@@ -18,7 +18,7 @@ The rule infers each field's purpose from its `name`, `id`, associated `<label>`
 - Pass with `N identified field(s) carry the correct autocomplete token`.
 - Skipped with `No name, email, phone, address or payment fields found` when no field on the page has an identifiable purpose.
 
-Each finding names the field with a CSS selector, quotes its opening tag and states the expected token, for example `email field is tagged autocomplete="username" (expected "email")`.
+Each finding names the field with a CSS selector, quotes its opening tag and states the expected token, for example `email field is tagged autocomplete="name" (expected "email")`.
 
 ## How to fix it
 

--- a/docs/rules/a11y/autocomplete-tokens.mdx
+++ b/docs/rules/a11y/autocomplete-tokens.mdx
@@ -5,7 +5,7 @@ description: "Name, email, address and payment fields with a missing or wrong au
 
 ## What autocomplete is
 
-`autocomplete` names what a form field collects, using a fixed vocabulary defined by the HTML standard: `given-name`, `email`, `tel`, `address-line1`, `postal-code`, `cc-number` and the rest of the autofill field names. Browsers and password managers read the token and fill the field from data the user has already saved. WCAG success criterion 1.3.5 requires it on fields that collect information about the user.
+`autocomplete` names what a form field collects, using a fixed vocabulary defined by the HTML standard: `given-name`, `email`, `tel`, `address-line1`, `postal-code`, `cc-number` and the rest of the autofill field names. Browsers and password managers read the token and fill the field from data the user has already saved. WCAG success criterion 1.3.5 Identify Input Purpose, Level AA, asks that the purpose of such a field be programmatically determinable, and an `autocomplete` token is the technique W3C documents for meeting it.
 
 Fields that collect anything else do not need a token. A search box, a quantity, a coupon code and a message body are all outside the vocabulary. A token the browser does not recognize is discarded, so a near miss such as `firstname` behaves exactly like no token at all.
 
@@ -30,7 +30,7 @@ Each finding names the field with a CSS selector, quotes its opening tag and sta
 
 The token goes on the field itself, never on the wrapper. Tokens accept the `section-*`, `shipping`/`billing` and `home`/`work`/`mobile` prefixes, so both `shipping address-line1` and `address-line1` satisfy the check.
 
-`autocomplete="off"` is reported rather than accepted. Browsers ignore it on personal data, so it does not stop autofill, only the accurate kind.
+`autocomplete="off"` is reported rather than accepted. It suppresses the browser's ordinary autocomplete suggestions, but browsers and password managers make exceptions for credentials, so it is a poor way to keep a field out of autofill and a good way to lose the accurate kind.
 
 | | |
 |---|---|

--- a/docs/rules/a11y/button-name.mdx
+++ b/docs/rules/a11y/button-name.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Button Name"
-description: "Checks that all buttons have accessible names"
+title: "Accessible names for buttons: what counts and how to check"
+description: "A button with only an icon has no name for a screen reader. squirrel lists every button on every page that has nothing to announce."
 ---
 
-Checks that all buttons have accessible names
+## What an accessible name is
+
+The accessible name is the string a screen reader announces for a control. Browsers compute it from a fixed order of sources: `aria-labelledby` first, then `aria-label`, then the element's own text content, then `title`. An `<input type="button">` uses its `value` attribute.
+
+A button with visible text already has a name. The problem case is a button whose whole content is a picture: an icon `<svg>`, a background image, or a font glyph in a pseudo-element. The user hears "button" and nothing else.
+
+## What squirrel checks
+
+One check, `button-name`, at severity error. It covers every `<button>`, every element with `role="button"`, and every `<input>` of type `button`, `submit` or `reset`.
+
+- Fail when such an element has none of the following: a non-empty `aria-label`; an `aria-labelledby` pointing at an element that has text; a non-empty `title`; text content; a `value`; a nested `<img>` with non-empty `alt`; a nested `<svg><title>` with text; or a nested element carrying `aria-label`. Report message: `Buttons without accessible names`. Up to ten offenders are listed as `button#id`, `button.class`, `input[name="..."]` or `input[type="..."]`, with a count of any remainder.
+- Pass with `All buttons have accessible names`.
+- Info with `No buttons found` when the page has none.
+
+## How to fix it
+
+```html
+<button aria-label="Close settings">
+  <svg aria-hidden="true">...</svg>
+</button>
+```
+
+Put the label on the button, not on the icon inside it, and hide the icon from assistive technology with `aria-hidden="true"` so it is not announced twice.
+
+A button whose only content is an icon-font glyph in a `::before` pseudo-element is the common false positive. squirrel sees an empty button because the glyph is not in the markup. Adding `aria-label` is the correct fix in that case anyway.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks that all buttons have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Buttons must have accessible names. Options: 1) Add text content inside the button. 2) Use aria-label for icon buttons. 3) Use aria-labelledby to reference visible text. 4) Use title attribute (less preferred). For `<input type='button'>`, use the value attribute.
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/button-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-labels](/rules/a11y/aria-labels): the same defect on buttons and on interactive `<svg>` elements.
+- [a11y/aria-command-name](/rules/a11y/aria-command-name): the wider sweep across buttons, links and menu items.
+- [a11y/label-content-name-mismatch](/rules/a11y/label-content-name-mismatch): buttons that have a name, but not the one on screen.
+- [a11y/link-text](/rules/a11y/link-text): the equivalent problem on links.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The button element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button)
+- [Accessible name and description computation, W3C](https://www.w3.org/TR/accname-1.2/)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unnamed button is listed by page with a selector you can search for. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/color-contrast.mdx
+++ b/docs/rules/a11y/color-contrast.mdx
@@ -15,8 +15,8 @@ One check, `color-contrast`, at severity warning. It runs four passes over what 
 
 - Inline styles: any element whose `style` sets both `color` and `background` or `background-color` to a hex value, an `rgb()`/`rgba()` value or one of 32 named colors. squirrel computes the WCAG ratio and reports anything under 4.5:1 as `span: #999 on #fff (2.85:1)`. `transparent` is treated as white.
 - Class names: elements whose `class` matches a known low-contrast pattern. That covers Tailwind-style `text-gray-3xx` and `text-gray-4xx` and the slate, zinc, neutral and stone equivalents, Bootstrap's `text-muted` and `text-secondary`, the generic `text-light`, `text-subtle`, `text-disabled` and `text-placeholder`, and `opacity-2x`/`opacity-3x`.
-- `<style>` blocks: rules that set a `color` to a known-light value such as `#ccc`, `#ddd`, `#eee`, `#999`, `#aaa`, `#bbb`, `#c0c0c0`, `#d3d3d3` or `#dcdcdc`, or an `rgb()` whose first channel falls between 180 and 229. Capped at five findings.
-- Raw source: the same light hex values plus `lightgray`, `lightgrey`, `silver`, and `color: white` or `color: #fff`, counted as `Light gray text: N instance(s)`.
+- `<style>` blocks: any rule that declares a `color` and contains a known-light value anywhere inside it. That covers `#ccc`, `#ddd`, `#eee`, `#999`, `#aaa`, `#bbb`, `#c0c0c0`, `#d3d3d3`, `#dcdcdc` and an `rgb()` whose first channel falls between 180 and 229. The match is over the whole rule, so `.x { color: #000; background: #ccc }` is reported even though the light value is the background. Capped at five findings.
+- Raw source: four separate patterns over the whole HTML, each counted on its own. `color: #ccc`, `#ddd`, `#eee`, `#999`, `#aaa` or `#bbb` and `color: lightgray`, `lightgrey` or `silver` are both counted as `Light gray text: N instance(s)`; `color: white` or `color: #fff` as `White text (verify background): N instance(s)`; and a `color:` set to a three-digit hex drawn from `d`, `e` and `f`, such as `#eef`, as `Very light text color: N instance(s)`.
 
 Findings are deduplicated, and the check reports `N potential color contrast issue(s)` with up to ten items. With nothing found it passes as `No obvious contrast issues detected`, and on a page with no styled elements at all it returns info with `Limited contrast analysis available`.
 
@@ -81,7 +81,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 
 ## Check your site
 
-Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every measurable low-contrast pair is listed with its computed ratio. Local audits are free.
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. The first ten deduplicated findings are listed, and inline color pairs carry their computed ratio. Local audits are free.
 
 <CardGroup cols={2}>
   <Card title="Install squirrel" icon="terminal" href="/quickstart">

--- a/docs/rules/a11y/color-contrast.mdx
+++ b/docs/rules/a11y/color-contrast.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Color Contrast"
-description: "Checks for color contrast issues in styles and classes"
+title: "Color contrast: the 4.5:1 rule and how to check it"
+description: "Light gray text on white fails WCAG AA. squirrel flags low-contrast inline styles, CSS colors and known low-contrast utility classes."
 ---
 
-Checks for color contrast issues in styles and classes
+## What color contrast is
+
+Contrast ratio compares the relative luminance of text and its background on a scale from 1:1 to 21:1. WCAG success criterion 1.4.3 Contrast (Minimum), Level AA, requires 4.5:1 for normal text and 3:1 for large text, where large means 18 point, or 14 point bold, and up.
+
+The ratio is a property of the rendered pixels, so it depends on the stylesheet, the theme and any image behind the text. Static markup can only ever show part of the picture.
+
+## What squirrel checks
+
+One check, `color-contrast`, at severity warning. It runs four passes over what the HTML makes visible, and applies the 4.5:1 threshold to everything it measures. The 3:1 large-text allowance is not applied, so a large heading at 3.5:1 is still reported.
+
+- Inline styles: any element whose `style` sets both `color` and `background` or `background-color` to a hex value, an `rgb()`/`rgba()` value or one of 32 named colors. squirrel computes the WCAG ratio and reports anything under 4.5:1 as `span: #999 on #fff (2.85:1)`. `transparent` is treated as white.
+- Class names: elements whose `class` matches a known low-contrast pattern. That covers Tailwind-style `text-gray-3xx` and `text-gray-4xx` and the slate, zinc, neutral and stone equivalents, Bootstrap's `text-muted` and `text-secondary`, the generic `text-light`, `text-subtle`, `text-disabled` and `text-placeholder`, and `opacity-2x`/`opacity-3x`.
+- `<style>` blocks: rules that set a `color` to a known-light value such as `#ccc`, `#ddd`, `#eee`, `#999`, `#aaa`, `#bbb`, `#c0c0c0`, `#d3d3d3` or `#dcdcdc`, or an `rgb()` whose first channel falls between 180 and 229. Capped at five findings.
+- Raw source: the same light hex values plus `lightgray`, `lightgrey`, `silver`, and `color: white` or `color: #fff`, counted as `Light gray text: N instance(s)`.
+
+Findings are deduplicated, and the check reports `N potential color contrast issue(s)` with up to ten items. With nothing found it passes as `No obvious contrast issues detected`, and on a page with no styled elements at all it returns info with `Limited contrast analysis available`.
+
+## How to fix it
+
+```css
+.muted {
+  color: #595959; /* 7:1 on white */
+}
+```
+
+Darken the foreground or lighten the background until the pair clears 4.5:1, and check the pair, not the color alone.
+
+White text is the usual false positive. `color: white` is reported without knowing the background, so a dark theme trips it on every heading. The class-name pass has the same problem in reverse: a utility class named for a color says nothing about the surface it lands on.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks for color contrast issues in styles and classes
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Text must have sufficient contrast with its background for readability. WCAG AA requires 4.5:1 for normal text and 3:1 for large text (18px+ or 14px+ bold). Use tools like WebAIM Contrast Checker to verify. Common issues: light gray text, text over images without overlay. Don't rely on color alone to convey information - add icons or text labels.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/color-contrast"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/link-in-text-block](/rules/a11y/link-in-text-block): links told apart from body text by color alone.
+- [content/hidden-text](/rules/content/hidden-text): text hidden outright rather than made faint.
+- [a11y/focus-visible](/rules/a11y/focus-visible): the focus ring, which needs contrast of its own.
+- [mobile/font-size](/rules/mobile/font-size): small type, which makes a marginal ratio worse.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Understanding SC 1.4.3 Contrast (Minimum), W3C](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+- [Contrast ratio, WCAG 2.2](https://www.w3.org/TR/WCAG22/#dfn-contrast-ratio)
+- [Color contrast, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every measurable low-contrast pair is listed with its computed ratio. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/color-contrast.mdx
+++ b/docs/rules/a11y/color-contrast.mdx
@@ -68,7 +68,7 @@ disable = ["*"]
 
 - [a11y/link-in-text-block](/rules/a11y/link-in-text-block): links told apart from body text by color alone.
 - [content/hidden-text](/rules/content/hidden-text): text hidden outright rather than made faint.
-- [a11y/focus-visible](/rules/a11y/focus-visible): the focus ring, which needs contrast of its own.
+- [a11y/focus-visible](/rules/a11y/focus-visible): `outline: none` in the page source with no `:focus-visible` fallback.
 - [mobile/font-size](/rules/mobile/font-size): small type, which makes a marginal ratio worse.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/a11y/definition-list.mdx
+++ b/docs/rules/a11y/definition-list.mdx
@@ -1,9 +1,42 @@
 ---
-title: "Definition List Structure"
-description: "Checks that definition lists contain only dt and dd elements"
+title: "Definition list structure: what belongs inside a dl"
+description: "A stray paragraph between the terms of a dl breaks the pairing screen readers rely on. squirrel checks every definition list on the page."
 ---
 
-Checks that definition lists contain only dt and dd elements
+## What a definition list is
+
+`<dl>` pairs terms with descriptions: a glossary, a set of metadata fields, a key-value table without the table. Screen readers announce the pairing, so a term is read together with the description that follows it.
+
+The pairing only works when the structure is intact. HTML allows `<dt>` and `<dd>` as the direct children of a `<dl>`, or a set of `<div>` wrappers each holding one group. Anything else between them, a `<p>` or a `<span>` or a loose `<li>`, breaks the grouping.
+
+## What squirrel checks
+
+One check, `definition-list`, at severity error. It reads the direct children of every `<dl>`.
+
+- Fail when a direct child is anything other than `<dt>`, `<dd>` or `<div>`, or when a `<div>` child holds anything other than `<dt>` and `<dd>`. Report message: `N definition list(s) with invalid structure`. Each list is named `dl#id`, `dl.class` or bare `dl`, and every offending list is listed.
+- Pass with `N definition list(s) are properly structured`.
+- Info with `No definition lists found`.
+
+The check reports the list, not the child, and stops at the first bad child in each one. It also inspects `<div>` wrappers one level deep, so a `<div>` containing another `<div>` is reported.
+
+## How to fix it
+
+```html
+<dl>
+  <div>
+    <dt>Shipping</dt>
+    <dd>Free over 50 EUR</dd>
+  </div>
+  <div>
+    <dt>Returns</dt>
+    <dd>30 days, no questions</dd>
+  </div>
+</dl>
+```
+
+Move anything that is not a term or a description outside the `<dl>`, or wrap each pair in a `<div>` and put your styling hooks there.
+
+HTML also permits `<script>` and `<template>` as children of a `<dl>`. squirrel reports those, so a list with an inline template inside it is a false positive worth ignoring.
 
 | | |
 |---|---|
@@ -12,10 +45,6 @@ Checks that definition lists contain only dt and dd elements
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Definition lists (`<dl>`) should only contain `<dt>` (term) and `<dd>` (description) elements as direct children. Optionally, they can be wrapped in `<div>` for styling. Do not put other elements like `<p>`, `<span>`, or `<li>` directly inside `<dl>`.
 
 ## Enable / disable
 
@@ -40,3 +69,31 @@ disable = ["a11y/*"]
 enable = ["a11y/definition-list"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/dlitem](/rules/a11y/dlitem): `<dt>` and `<dd>` sitting outside a `<dl>` altogether.
+- [a11y/list-structure](/rules/a11y/list-structure): the same check for `<ul>` and `<ol>`.
+- [a11y/listitem](/rules/a11y/listitem): orphaned `<li>` elements.
+- [a11y/table-headers](/rules/a11y/table-headers): the other way to present key-value data.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The dl element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl)
+- [The dl element, HTML Standard](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element)
+- [Understanding SC 1.3.1 Info and Relationships, W3C](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each malformed list is listed by id or class. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/definition-list.mdx
+++ b/docs/rules/a11y/definition-list.mdx
@@ -75,7 +75,7 @@ disable = ["*"]
 - [a11y/dlitem](/rules/a11y/dlitem): `<dt>` and `<dd>` sitting outside a `<dl>` altogether.
 - [a11y/list-structure](/rules/a11y/list-structure): the same check for `<ul>` and `<ol>`.
 - [a11y/listitem](/rules/a11y/listitem): orphaned `<li>` elements.
-- [a11y/table-headers](/rules/a11y/table-headers): the other way to present key-value data.
+- [a11y/table-headers](/rules/a11y/table-headers): data tables with no `<th>` cells, the other way to present key-value data.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/dlitem.mdx
+++ b/docs/rules/a11y/dlitem.mdx
@@ -5,7 +5,7 @@ description: "A dt or dd that is not inside a dl loses the term-description pair
 
 ## What an orphaned dt or dd is
 
-`<dt>` and `<dd>` mean nothing on their own. Their semantics come from the `<dl>` that contains them: this term goes with that description. Outside a `<dl>` the browser exposes them as generic containers and a screen reader announces two unrelated blocks of text.
+`<dt>` and `<dd>` earn their meaning from the `<dl>` that contains them: this term goes with that description. Outside a `<dl>` the elements still map to term and definition roles, but the grouping that pairs them is gone, so a screen reader has no relationship to announce and the reader hears two unrelated blocks of text.
 
 The usual cause is a component that renders a term-description pair without rendering the list around it, or a refactor that moved the wrapper and left the items behind.
 

--- a/docs/rules/a11y/dlitem.mdx
+++ b/docs/rules/a11y/dlitem.mdx
@@ -13,7 +13,7 @@ The usual cause is a component that renders a term-description pair without rend
 
 One check, `dlitem`, at severity error. For every `<dt>` and `<dd>` it looks at the immediate parent. That parent is valid when it is a `<dl>`, or a `<div>` whose own parent is a `<dl>`.
 
-- Fail with `N dt/dd element(s) not inside a dl`. Items quote the first 20 characters of the element's text, as `dt: "Shipping address..."`, up to ten with a count of the rest.
+- Fail with `N dt/dd element(s) not inside a dl`. Items quote the first 20 characters of the element's text, as `dt: "Shipping address for..."`, up to ten with a count of the rest.
 - Pass with `All dt/dd elements are inside definition lists`.
 - Info with `No dt/dd elements found`.
 

--- a/docs/rules/a11y/dlitem.mdx
+++ b/docs/rules/a11y/dlitem.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Definition List Item"
-description: "Checks that dt and dd elements are inside a dl"
+title: "dt and dd outside a dl: orphaned definition list items"
+description: "A dt or dd that is not inside a dl loses the term-description pairing entirely. squirrel finds every orphan on every page."
 ---
 
-Checks that dt and dd elements are inside a dl
+## What an orphaned dt or dd is
+
+`<dt>` and `<dd>` mean nothing on their own. Their semantics come from the `<dl>` that contains them: this term goes with that description. Outside a `<dl>` the browser exposes them as generic containers and a screen reader announces two unrelated blocks of text.
+
+The usual cause is a component that renders a term-description pair without rendering the list around it, or a refactor that moved the wrapper and left the items behind.
+
+## What squirrel checks
+
+One check, `dlitem`, at severity error. For every `<dt>` and `<dd>` it looks at the immediate parent. That parent is valid when it is a `<dl>`, or a `<div>` whose own parent is a `<dl>`.
+
+- Fail with `N dt/dd element(s) not inside a dl`. Items quote the first 20 characters of the element's text, as `dt: "Shipping address..."`, up to ten with a count of the rest.
+- Pass with `All dt/dd elements are inside definition lists`.
+- Info with `No dt/dd elements found`.
+
+Exactly one wrapper level is allowed. A `<dl>` containing a `<section>` containing the `<dt>` is reported, which matches HTML: only `<div>` may wrap a group.
+
+## How to fix it
+
+```html
+<dl>
+  <dt>Shipping address</dt>
+  <dd>12 Rue de Rivoli, Paris</dd>
+</dl>
+```
+
+Wrap the orphans in a `<dl>`. If the pair is not really a term and a description, use a heading and a paragraph instead, which carry the right semantics without a container.
+
+Where a component renders one pair at a time, render the `<dl>` in the parent and the `<div>` group in the component, so every item ships inside a list.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks that dt and dd elements are inside a dl
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-The `<dt>` and `<dd>` elements must be contained within a `<dl>` (definition list). Move orphaned dt/dd elements inside a `<dl>` container.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/dlitem"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/definition-list](/rules/a11y/definition-list): the container's own structure.
+- [a11y/listitem](/rules/a11y/listitem): the same orphan problem for `<li>`.
+- [a11y/list-structure](/rules/a11y/list-structure): `<ul>` and `<ol>` with children that do not belong.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): the ARIA equivalent of a missing container.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The dt element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dt)
+- [The dl element, HTML Standard](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element)
+- [Understanding SC 1.3.1 Info and Relationships, W3C](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each orphan is listed with the opening words of its text. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/duplicate-id-active.mdx
+++ b/docs/rules/a11y/duplicate-id-active.mdx
@@ -68,7 +68,7 @@ disable = ["*"]
 ## Related rules
 
 - [a11y/duplicate-id-aria](/rules/a11y/duplicate-id-aria): ids referenced by ARIA attributes, duplicated or missing.
-- [a11y/form-labels](/rules/a11y/form-labels): the `<label for>` association a duplicate id silently breaks.
+- [a11y/form-labels](/rules/a11y/form-labels): controls with no associated label, which is what a duplicate id leaves behind.
 - [a11y/form-field-multiple-labels](/rules/a11y/form-field-multiple-labels): the same collision seen from the label side.
 - [a11y/accesskeys](/rules/a11y/accesskeys): the other identifier that has to be unique.
 

--- a/docs/rules/a11y/duplicate-id-active.mdx
+++ b/docs/rules/a11y/duplicate-id-active.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Duplicate ID Active"
-description: "Checks that active, focusable elements have unique IDs"
+title: "Duplicate id on a focusable element: what it breaks"
+description: "Two inputs sharing an id break label association and focus management. squirrel checks every focusable element that carries an id."
 ---
 
-Checks that active, focusable elements have unique IDs
+## What a duplicate id breaks
+
+An `id` has to be unique in a document. When it is not, everything that resolves an id takes the first match and ignores the rest: `document.getElementById`, a `<label for>`, an `aria-labelledby`, a fragment link, a focus call.
+
+On a focusable element that means the second control silently loses its label, and code that moves focus by id always lands on the first one. The page looks correct and behaves wrongly, usually only for the users who navigate by keyboard.
+
+## What squirrel checks
+
+One check, `duplicate-id-active`, at severity error. It gathers focusable elements that carry an `id`: `a[href]`, `button`, `input`, `select` and `textarea` with an `id`, plus any element that has both an `id` and a `tabindex` other than `-1`. The `tabindex` lookup is case-insensitive, so React's `tabIndex` in server-rendered markup counts.
+
+- Fail with `N duplicate ID(s) on focusable elements`. Items read `"submit" (3 occurrences)`, up to ten with a count of the rest.
+- Pass with `All focusable elements have unique IDs`.
+- Info with `No focusable elements with IDs found`.
+
+Counting happens only across that focusable set. A collision between a focusable `<input id="main">` and a non-focusable `<section id="main">` is not reported here, so this check is narrower than a full duplicate-id sweep.
+
+## How to fix it
+
+```html
+<label for="email-header">Email</label>
+<input id="email-header" name="email" type="email">
+
+<label for="email-footer">Email</label>
+<input id="email-footer" name="email" type="email">
+```
+
+Give each instance its own id. A repeated newsletter form in the header and the footer is the classic source, and prefixing by location is enough.
+
+Where a component can appear more than once on a page, generate the id inside the component and pass it to both the `<label for>` and the control, so the pair can never drift apart.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks that active, focusable elements have unique IDs
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Duplicate IDs on focusable elements (links, buttons, inputs) break keyboard navigation and label associations. Browsers only recognize the first element with a given ID, so labels, focus management, and ARIA references will target the wrong element. Ensure every focusable element with an id attribute has a unique value.
 
 ## Enable / disable
 
@@ -40,3 +64,31 @@ disable = ["a11y/*"]
 enable = ["a11y/duplicate-id-active"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/duplicate-id-aria](/rules/a11y/duplicate-id-aria): ids referenced by ARIA attributes, duplicated or missing.
+- [a11y/form-labels](/rules/a11y/form-labels): the `<label for>` association a duplicate id silently breaks.
+- [a11y/form-field-multiple-labels](/rules/a11y/form-field-multiple-labels): the same collision seen from the label side.
+- [a11y/accesskeys](/rules/a11y/accesskeys): the other identifier that has to be unique.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The id attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/id)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [H44: Using label elements to associate text labels with form controls, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H44)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each repeated id is listed with the number of elements claiming it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/duplicate-id-aria.mdx
+++ b/docs/rules/a11y/duplicate-id-aria.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Duplicate ID ARIA"
-description: "Checks that IDs used in ARIA attributes are unique"
+title: "ARIA references pointing at duplicate or missing ids"
+description: "aria-labelledby resolving to two elements, or to none, names the wrong thing silently. squirrel checks all eight ARIA id references."
 ---
 
-Checks that IDs used in ARIA attributes are unique
+## What an ARIA id reference is
+
+Eight ARIA attributes work by pointing at other elements by id: `aria-labelledby`, `aria-describedby`, `aria-controls`, `aria-owns`, `aria-activedescendant`, `aria-flowto`, `aria-details` and `aria-errormessage`. Each accepts a whitespace-separated list of ids.
+
+A reference that resolves to nothing produces no name and no error. A reference that resolves to two elements takes the first, which may not be the one you meant. Either way the failure is invisible until someone uses a screen reader.
+
+## What squirrel checks
+
+One check, `duplicate-id-aria`, at severity error. It collects every id named by those eight attributes, splitting each value on whitespace, then counts every `id` on the page and compares.
+
+- Fail with `N problematic ID(s) in ARIA attributes`. Items read `"settings-title" (2 occurrences)` for a duplicate, or `"settings-title" (not found)` for a dangling reference. Up to ten are shown with a count of the rest.
+- Pass with `All ARIA ID references are valid and unique`.
+- Info with `No ARIA ID references found`.
+
+Both failure modes land in one check, so read the item text to tell them apart. The rule inspects only the ids ARIA references. Unreferenced duplicates elsewhere on the page are out of scope.
+
+## How to fix it
+
+```html
+<h2 id="billing-heading">Billing</h2>
+<section aria-labelledby="billing-heading">...</section>
+```
+
+For a dangling reference, check the target still exists. Ids that disappear during a refactor are the common cause, and so are ids added by a framework at runtime that never make it into the server-rendered markup.
+
+For a duplicate, rename one of the two. A component rendered twice on the same page needs a generated id, not a hard-coded one.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that IDs used in ARIA attributes are unique
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-IDs referenced by ARIA attributes (aria-labelledby, aria-describedby, aria-controls, etc.) must be unique on the page. Duplicate IDs cause assistive technology to potentially reference the wrong element. Rename duplicate IDs to be unique.
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/duplicate-id-aria"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): the same uniqueness rule on focusable elements.
+- [a11y/aria-valid-attr](/rules/a11y/aria-valid-attr): a typo in the referencing attribute itself.
+- [a11y/aria-dialog-name](/rules/a11y/aria-dialog-name): a dialog name that depends on one of these references resolving.
+- [a11y/aria-tooltip-name](/rules/a11y/aria-tooltip-name): the `aria-describedby` target most often missing.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [aria-labelledby, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
+- [The id attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/id)
+- [WAI-ARIA 1.2, W3C](https://www.w3.org/TR/wai-aria-1.2/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Duplicates and dangling references appear together, distinguished by the item text. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/duplicate-id-aria.mdx
+++ b/docs/rules/a11y/duplicate-id-aria.mdx
@@ -5,9 +5,9 @@ description: "aria-labelledby resolving to two elements, or to none, names the w
 
 ## What an ARIA id reference is
 
-Eight ARIA attributes work by pointing at other elements by id: `aria-labelledby`, `aria-describedby`, `aria-controls`, `aria-owns`, `aria-activedescendant`, `aria-flowto`, `aria-details` and `aria-errormessage`. Each accepts a whitespace-separated list of ids.
+Eight ARIA attributes work by pointing at other elements by id: `aria-labelledby`, `aria-describedby`, `aria-controls`, `aria-owns`, `aria-activedescendant`, `aria-flowto`, `aria-details` and `aria-errormessage`. Most take a whitespace-separated list; `aria-activedescendant`, `aria-details` and `aria-errormessage` take a single id. squirrel splits all eight on whitespace either way.
 
-A reference that resolves to nothing produces no name and no error. A reference that resolves to two elements takes the first, which may not be the one you meant. Either way the failure is invisible until someone uses a screen reader.
+A reference that resolves to nothing loses whatever it was contributing, be that a name, a description or a relationship, and reports no error. A reference that resolves to two elements takes the first, which may not be the one you meant. Either way the failure is invisible until someone uses a screen reader.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/empty-heading.mdx
+++ b/docs/rules/a11y/empty-heading.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Empty Headings"
-description: "Checks that heading elements have visible content"
+title: "Empty headings: what counts as empty and how to check"
+description: "A heading with no text still shows up in the screen reader outline, as a blank entry. squirrel flags every one on every page."
 ---
 
-Checks that heading elements have visible content
+## What an empty heading is
+
+Screen readers build a navigable outline from the headings on a page, and users jump between them to find a section. A heading with nothing to announce becomes a blank rung in that ladder: it is counted, it is landed on, and it says nothing.
+
+Headings usually end up empty for one of two reasons. A `<h2>` is used as a styling hook around an image or an icon, or a heading is rendered before its content arrives and left in place when the content does not.
+
+## What squirrel checks
+
+One check, `empty-heading`, at severity warning. It reads every `<h1>` through `<h6>`, skipping any with `aria-hidden="true"`.
+
+Content is accepted from the heading's text, a non-empty `aria-label`, an `aria-labelledby` pointing at an element with text, or a nested `<img>` with non-empty `alt`.
+
+- Warn with `N empty heading(s) found`. Items read `h2#promo`, `h3.subtitle` or a bare tag name, up to ten with a count of the rest.
+- Pass with `All headings have content`.
+- Info with `No headings found`.
+
+## How to fix it
+
+```html
+<h2>
+  <img src="/logo-partner.svg" alt="Northwind Traders">
+</h2>
+```
+
+Give the heading text, or a name through `alt` on the image inside it. A heading that only exists for its styling is better written as a `<div>` or a `<p>`, which keeps the visual design and takes the blank entry out of the outline.
+
+A heading whose text is supplied by CSS, through `content` on a pseudo-element, is reported. That is correct: pseudo-element text is not reliably exposed to assistive technology, so the fix is to put the words in the markup.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks that heading elements have visible content
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Headings (h1-h6) must have text content for screen readers to announce. Empty headings create confusing navigation. Either add text content, use aria-label, or remove the empty heading element.
 
 ## Enable / disable
 
@@ -40,3 +62,31 @@ disable = ["a11y/*"]
 enable = ["a11y/empty-heading"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/heading-order](/rules/a11y/heading-order): levels that skip, once the headings have content.
+- [content/heading-hierarchy](/rules/content/heading-hierarchy): the same outline judged for structure and SEO.
+- [core/h1](/rules/core/h1): whether the page has a single top-level heading at all.
+- [a11y/aria-text](/rules/a11y/aria-text): headings flattened with a vendor role instead of fixed.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The heading elements, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
+- [Understanding SC 2.4.6 Headings and Labels, W3C](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html)
+- [H42: Using h1-h6 to identify headings, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H42)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each blank heading is listed by level and by id or class. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/empty-heading.mdx
+++ b/docs/rules/a11y/empty-heading.mdx
@@ -68,7 +68,7 @@ disable = ["*"]
 - [a11y/heading-order](/rules/a11y/heading-order): levels that skip, once the headings have content.
 - [content/heading-hierarchy](/rules/content/heading-hierarchy): the same outline judged for structure and SEO.
 - [core/h1](/rules/core/h1): whether the page has a single top-level heading at all.
-- [a11y/aria-text](/rules/a11y/aria-text): headings flattened with a vendor role instead of fixed.
+- [a11y/aria-text](/rules/a11y/aria-text): `role="text"` containers that swallow focusable elements, a role sometimes reached for on split headings.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/focus-visible.mdx
+++ b/docs/rules/a11y/focus-visible.mdx
@@ -7,14 +7,14 @@ description: "Removing the focus outline leaves keyboard users with no idea wher
 
 When a keyboard user tabs through a page the browser draws a ring around the focused element. `outline: none` deletes it, and without a replacement the user is navigating blind. WCAG success criterion 2.4.7 Focus Visible, Level AA, requires that the indicator exist.
 
-`:focus-visible` is the modern way to restyle it. The browser matches it only when it judges an indicator useful, which covers keyboard focus and skips ordinary mouse clicks, so a custom ring can be styled without reappearing every time someone clicks a button.
+`:focus-visible` is the modern way to restyle it. The browser decides when an indicator is warranted rather than matching every focus event, so in practice a keyboard user gets the ring and someone clicking a button does not. The heuristic is the browser's, not the page's: text inputs generally match on a mouse click too, and a user preference can force the indicator on everywhere.
 
 ## What squirrel checks
 
 This rule scans the page source as text, covering inline `<style>` blocks and `style` attributes. Rules in a linked stylesheet are not fetched, so they are invisible to it. Severity is warning.
 
 - `focus-outline-global` fails when the source contains a universal-selector rule that removes the outline, matching the shape `* { ... outline: none }` or `outline: 0`. Report message: `Global outline removal detected`, with the value `* { outline: none } removes focus for all elements`.
-- `focus-outline` warns when `outline: none` or `outline: 0` appears anywhere and `:focus-visible` does not. Report message: `outline:none found - ensure alternative focus styles exist`, with the value `Consider using :focus-visible for custom focus styles`.
+- `focus-outline` warns when no global removal pattern matched, `outline: none` or `outline: 0` appears anywhere, and `:focus-visible` does not. The two branches are exclusive, so a page with global removal never produces this warning. Report message: `outline:none found - ensure alternative focus styles exist`, with the value `Consider using :focus-visible for custom focus styles`.
 - `focus-modern` passes when `:focus-visible` or `:focus-within` appears, with the message `Modern focus selectors in use` and the matched selector as its value.
 - `focus-visible` returns info with `Focus styles not analyzed (requires CSS inspection)` when none of the above matched.
 
@@ -31,7 +31,7 @@ This rule scans the page source as text, covering inline `<style>` blocks and `s
 }
 ```
 
-Keep both rules together: the first draws the ring for keyboard users, the second suppresses it for pointer users, and neither leaves anyone without an indicator.
+Keep both rules together: the first draws the ring where the browser judges an indicator useful, the second removes the default ring everywhere else. Between them nobody navigating by keyboard is left without an indicator.
 
 Because the match is textual, `outline: none` inside a comment or a minified vendor bundle is still reported. The reverse is more common: a site whose focus styles live in an external stylesheet returns info even when the styles are correct.
 
@@ -72,7 +72,7 @@ disable = ["*"]
 - [a11y/tabindex](/rules/a11y/tabindex): positive `tabindex` values that scramble the order the ring moves in.
 - [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): elements that take focus while hidden from assistive technology.
 - [a11y/skip-link](/rules/a11y/skip-link): letting keyboard users jump past repeated navigation.
-- [a11y/color-contrast](/rules/a11y/color-contrast): the contrast the focus ring itself needs.
+- [a11y/color-contrast](/rules/a11y/color-contrast): text against its background, the contrast check squirrel does run. It does not measure the ring itself.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/focus-visible.mdx
+++ b/docs/rules/a11y/focus-visible.mdx
@@ -1,9 +1,39 @@
 ---
-title: "Focus Visible"
-description: "Checks for focus indicator styles"
+title: "focus-visible: keeping a visible keyboard focus ring"
+description: "Removing the focus outline leaves keyboard users with no idea where they are. squirrel flags outline:none with no :focus-visible fallback."
 ---
 
-Checks for focus indicator styles
+## What a focus indicator is
+
+When a keyboard user tabs through a page the browser draws a ring around the focused element. `outline: none` deletes it, and without a replacement the user is navigating blind. WCAG success criterion 2.4.7 Focus Visible, Level AA, requires that the indicator exist.
+
+`:focus-visible` is the modern way to restyle it. The browser matches it only when it judges an indicator useful, which covers keyboard focus and skips ordinary mouse clicks, so a custom ring can be styled without reappearing every time someone clicks a button.
+
+## What squirrel checks
+
+This rule scans the page source as text, covering inline `<style>` blocks and `style` attributes. Rules in a linked stylesheet are not fetched, so they are invisible to it. Severity is warning.
+
+- `focus-outline-global` fails when the source contains a universal-selector rule that removes the outline, matching the shape `* { ... outline: none }` or `outline: 0`. Report message: `Global outline removal detected`, with the value `* { outline: none } removes focus for all elements`.
+- `focus-outline` warns when `outline: none` or `outline: 0` appears anywhere and `:focus-visible` does not. Report message: `outline:none found - ensure alternative focus styles exist`, with the value `Consider using :focus-visible for custom focus styles`.
+- `focus-modern` passes when `:focus-visible` or `:focus-within` appears, with the message `Modern focus selectors in use` and the matched selector as its value.
+- `focus-visible` returns info with `Focus styles not analyzed (requires CSS inspection)` when none of the above matched.
+
+## How to fix it
+
+```css
+:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+```
+
+Keep both rules together: the first draws the ring for keyboard users, the second suppresses it for pointer users, and neither leaves anyone without an indicator.
+
+Because the match is textual, `outline: none` inside a comment or a minified vendor bundle is still reported. The reverse is more common: a site whose focus styles live in an external stylesheet returns info even when the styles are correct.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks for focus indicator styles
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Keyboard users need visible focus indicators to know where they are on the page. Never use outline: none without providing an alternative focus style. Modern approach: use :focus-visible to show focus only for keyboard users, not mouse clicks. Ensure focus indicators have at least 3:1 contrast. Test by tabbing through your page - can you always see where focus is?
 
 ## Enable / disable
 
@@ -40,3 +66,31 @@ disable = ["a11y/*"]
 enable = ["a11y/focus-visible"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/tabindex](/rules/a11y/tabindex): positive `tabindex` values that scramble the order the ring moves in.
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): elements that take focus while hidden from assistive technology.
+- [a11y/skip-link](/rules/a11y/skip-link): letting keyboard users jump past repeated navigation.
+- [a11y/color-contrast](/rules/a11y/color-contrast): the contrast the focus ring itself needs.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [:focus-visible, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible)
+- [Understanding SC 2.4.7 Focus Visible, W3C](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html)
+- [F78: Failure due to styling out the focus indicator, W3C](https://www.w3.org/WAI/WCAG22/Techniques/failures/F78)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Global outline removal is reported first, since it affects every control. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/form-field-multiple-labels.mdx
+++ b/docs/rules/a11y/form-field-multiple-labels.mdx
@@ -5,7 +5,7 @@ description: "A control with two labels is announced inconsistently across scree
 
 ## What multiple labels means
 
-A form control is meant to have one accessible name. Two `<label>` elements pointing at the same control leave it to the browser to decide what to do, and browsers do not agree: some concatenate, some announce the first, some announce the last.
+A form control has one accessible name. When two `<label>` elements point at the same control, HTML says the name is the label texts concatenated in document order, which is legal and usually unhelpful: the user hears both strings run together, in whatever order the markup happens to be in.
 
 Extra text about a field is a description, not a second name. That is what `aria-describedby` is for, and screen readers announce it after the name rather than fighting with it.
 
@@ -66,7 +66,7 @@ disable = ["*"]
 ## Related rules
 
 - [a11y/form-labels](/rules/a11y/form-labels): controls with no label at all.
-- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): a duplicated id, which is how one label ends up naming two controls.
+- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): a duplicated id, which sends a `<label for>` to the first match and leaves the control you meant unlabeled.
 - [a11y/label-content-name-mismatch](/rules/a11y/label-content-name-mismatch): a label that disagrees with the visible text.
 - [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): the resolved name once the labels are sorted out.
 

--- a/docs/rules/a11y/form-field-multiple-labels.mdx
+++ b/docs/rules/a11y/form-field-multiple-labels.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Multiple Labels"
-description: "Checks that form fields don't have multiple labels"
+title: "One control, two labels: why multiple labels confuse"
+description: "A control with two labels is announced inconsistently across screen readers. squirrel counts the labels on every input on the page."
 ---
 
-Checks that form fields don't have multiple labels
+## What multiple labels means
+
+A form control is meant to have one accessible name. Two `<label>` elements pointing at the same control leave it to the browser to decide what to do, and browsers do not agree: some concatenate, some announce the first, some announce the last.
+
+Extra text about a field is a description, not a second name. That is what `aria-describedby` is for, and screen readers announce it after the name rather than fighting with it.
+
+## What squirrel checks
+
+One check, `form-field-multiple-labels`, at severity warning. It covers every `<input>` except types `hidden`, `submit`, `button` and `reset`, plus every `<textarea>` and `<select>`.
+
+For each control it counts every `<label for="...">` whose value matches the control's `id`, and adds one when the control has an ancestor `<label>`.
+
+- Warn when the count is more than one. Report message: `N input(s) with multiple labels`. Items read `email (2 labels)`, naming the control by its `name`, falling back to its `id` and then its tag. Every offender is listed, and the finding carries the suggestion `Use aria-describedby for additional descriptions`.
+- Pass with `No inputs have multiple labels`.
+- Info with `No form inputs found`.
+
+## How to fix it
+
+```html
+<label for="pw">Password</label>
+<input id="pw" type="password" aria-describedby="pw-hint">
+<p id="pw-hint">At least 12 characters, including a number.</p>
+```
+
+Keep one label and move the rest into `aria-describedby`. The description can point at several ids, so a hint and an error message can coexist.
+
+A control wrapped in a `<label>` that also has a separate `<label for>` pointing at it is the usual shape, and it usually arrives when a wrapper is added for click-target reasons. Removing the wrapper `<label>` and keeping the explicit association fixes both.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks that form fields don't have multiple labels
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Form inputs should have only one associated label. Multiple labels can confuse assistive technology. If you need multiple text descriptions, use aria-describedby for supplementary text instead of multiple labels.
 
 ## Enable / disable
 
@@ -40,3 +62,31 @@ disable = ["a11y/*"]
 enable = ["a11y/form-field-multiple-labels"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/form-labels](/rules/a11y/form-labels): controls with no label at all.
+- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): a duplicated id, which is how one label ends up naming two controls.
+- [a11y/label-content-name-mismatch](/rules/a11y/label-content-name-mismatch): a label that disagrees with the visible text.
+- [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): the resolved name once the labels are sorted out.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The label element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label)
+- [aria-describedby, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
+- [Labeling controls, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/forms/labels/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each control is listed with the number of labels pointing at it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/form-labels.mdx
+++ b/docs/rules/a11y/form-labels.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Form labels: which inputs need one and how to check"
-description: "An input with only a placeholder has no name for a screen reader. squirrel lists every unlabeled input, textarea and select on every page."
+description: "An input labelled only by its placeholder loses its label the moment someone types. squirrel lists every unlabeled input, textarea and select."
 ---
 
 ## What a form label is
 
 A `<label>` gives a form control its accessible name, and clicking the label moves focus into the control. Two forms work: `<label for="id">` matching the control's `id`, or a `<label>` that wraps the control.
 
-Where a visible label does not fit the design, `aria-label` or `aria-labelledby` supplies the name instead. A `placeholder` does not: it disappears the moment the user types, and it is a hint, not a name. Buttons, hidden inputs and image inputs are named by other means and are out of scope.
+Where a visible label does not fit the design, `aria-label` or `aria-labelledby` supplies the name instead. A `placeholder` is only a last-resort fallback in the name computation, and squirrel does not accept it: it disappears the moment the user types, so a form labelled that way is unusable as soon as it is filled in. Buttons, hidden inputs and image inputs are named by other means and are out of scope.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/form-labels.mdx
+++ b/docs/rules/a11y/form-labels.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Form Labels"
-description: "Checks that form inputs have associated labels"
+title: "Form labels: which inputs need one and how to check"
+description: "An input with only a placeholder has no name for a screen reader. squirrel lists every unlabeled input, textarea and select on every page."
 ---
 
-Checks that form inputs have associated labels
+## What a form label is
+
+A `<label>` gives a form control its accessible name, and clicking the label moves focus into the control. Two forms work: `<label for="id">` matching the control's `id`, or a `<label>` that wraps the control.
+
+Where a visible label does not fit the design, `aria-label` or `aria-labelledby` supplies the name instead. A `placeholder` does not: it disappears the moment the user types, and it is a hint, not a name. Buttons, hidden inputs and image inputs are named by other means and are out of scope.
+
+## What squirrel checks
+
+One check, `form-labels`, at severity error. It covers every `<input>` except types `hidden`, `submit`, `button`, `reset` and `image`, plus every `<textarea>` and `<select>`.
+
+- Fail when a control has none of the following: an ancestor `<label>`; a `<label for="...">` whose value matches the control's `id`; an `aria-label`; an `aria-labelledby`; a `title`. Report message: `N form input(s) without labels`. Each control is listed by its `name`, falling back to its `id` and then to its type.
+- Pass with `All form inputs have labels`.
+- Info with `No form inputs found`.
+
+A `title` attribute satisfies this check. It shows only on hover, so it is a weaker fix than a real label, but it does produce an accessible name.
+
+## How to fix it
+
+```html
+<label for="email">Email address</label>
+<input id="email" name="email" type="email" autocomplete="email">
+```
+
+The `for` value and the `id` must match exactly, and `id` must be unique on the page or the association silently lands on the wrong control.
+
+A search field sitting next to a magnifying-glass button is the usual false positive to argue about. The button has a name, the input does not, and squirrel is right to report it: give the input its own `aria-label`.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that form inputs have associated labels
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 6/10 |
-
-## Solution
-
-Every form input needs an accessible label for screen readers. Options: 1) Use `<label for='inputId'>`Label`</label>` with matching id. 2) Wrap the input inside `<label>`Label `<input>``</label>`. 3) Use aria-label or aria-labelledby for inputs where visible labels aren't feasible. Placeholders are not sufficient substitutes for labels. Hidden inputs, submit buttons, and image buttons don't need labels.
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/form-labels"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): the same sweep including elements with input ARIA roles.
+- [a11y/select-name](/rules/a11y/select-name): dropdowns specifically.
+- [a11y/form-field-multiple-labels](/rules/a11y/form-field-multiple-labels): the opposite failure, two labels on one control.
+- [a11y/autocomplete-tokens](/rules/a11y/autocomplete-tokens): the autofill token that belongs on the same field.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The label element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label)
+- [Labeling controls, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/forms/labels/)
+- [H44: Using label elements to associate text labels with form controls, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H44)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unlabeled control is listed by its name attribute. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/frame-title.mdx
+++ b/docs/rules/a11y/frame-title.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Frame Title"
-description: "Checks that iframes and frames have title attributes"
+title: "iframe title: naming embedded frames for screen readers"
+description: "An iframe with no title is announced as just 'frame'. squirrel checks every iframe and frame element on the page."
 ---
 
-Checks that iframes and frames have title attributes
+## What an iframe title is
+
+An iframe is a separate document embedded in the page. A screen reader user reaching one hears its title, decides whether to enter it, and either steps inside or moves past. With no title the announcement is "frame", and the only way to find out what is in it is to go in.
+
+The `title` attribute supplies that name. `aria-label` and `aria-labelledby` do the same job.
+
+## What squirrel checks
+
+One check, `frame-title`, at severity error. It covers every `<iframe>` and `<frame>`, skipping any with `aria-hidden="true"` or with `role="presentation"` or `role="none"`.
+
+- Fail when the element has no non-empty `title`, no non-empty `aria-label` and no `aria-labelledby`. Report message: `N iframe(s) without title attribute`. Items are identified by `name` first, then `id`, then the hostname taken from the `src`, as `iframe (www.youtube.com)`. Up to ten are shown with a count of the rest.
+- Pass with `N iframe(s) have title attributes`.
+- Info with `No iframes found`.
+
+Findings are labelled `iframe` even when the element is a legacy `<frame>`.
+
+## How to fix it
+
+```html
+<iframe src="https://www.youtube.com/embed/xyz"
+        title="Product demo, 3 minutes"></iframe>
+```
+
+Describe the content, not the technology. Most embed snippets ship `title="YouTube video player"`, which names the vendor rather than the video, and every embed on the site ends up with the same name.
+
+An iframe carrying an ad or a tracking pixel still needs a name. "Advertisement" is a reasonable one. squirrel also skips frames marked `aria-hidden="true"` or `role="presentation"`, so a genuinely presentational frame can be excluded that way.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that iframes and frames have title attributes
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-All iframes must have a title attribute describing their content. This helps screen reader users understand what the iframe contains. Example: `<iframe src='video.html' title='Product demo video'>`
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/frame-title"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/video-captions](/rules/a11y/video-captions): captions inside the embedded player itself.
+- [a11y/object-alt](/rules/a11y/object-alt): the same naming requirement for `<object>`.
+- [a11y/aria-dialog-name](/rules/a11y/aria-dialog-name): another container announced by name before it is entered.
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): hidden frames that are still reachable by keyboard.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The iframe element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe)
+- [H64: Using the title attribute of the iframe element, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H64)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each unnamed frame is listed by name, id or the host it loads from. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/frame-title.mdx
+++ b/docs/rules/a11y/frame-title.mdx
@@ -64,10 +64,10 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/video-captions](/rules/a11y/video-captions): captions inside the embedded player itself.
+- [a11y/video-captions](/rules/a11y/video-captions): recognizes a YouTube, Vimeo or Wistia iframe and asks you to confirm captions in the player.
 - [a11y/object-alt](/rules/a11y/object-alt): the same naming requirement for `<object>`.
 - [a11y/aria-dialog-name](/rules/a11y/aria-dialog-name): another container announced by name before it is entered.
-- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): hidden frames that are still reachable by keyboard.
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): focusable controls inside a hidden region. Frames only count there when they carry an explicit `tabindex`.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/heading-order.mdx
+++ b/docs/rules/a11y/heading-order.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Heading order: why skipping from h1 to h3 matters"
-description: "Screen reader users navigate by heading level, so a skipped level hides a whole section. squirrel checks document order on every page."
+description: "Screen reader users navigate by heading level, and a skipped level makes the outline harder to follow. squirrel checks document order on every page."
 ---
 
 ## What heading order is

--- a/docs/rules/a11y/heading-order.mdx
+++ b/docs/rules/a11y/heading-order.mdx
@@ -68,7 +68,7 @@ disable = ["*"]
 
 - [content/heading-hierarchy](/rules/content/heading-hierarchy): the same outline judged for structure and SEO.
 - [a11y/empty-heading](/rules/a11y/empty-heading): headings in the outline with nothing to announce.
-- [core/h1](/rules/core/h1): the top of the outline.
+- [core/h1](/rules/core/h1): whether the page has an `<h1>`, and only one of them.
 - [a11y/landmark-regions](/rules/a11y/landmark-regions): the other structure screen readers navigate by.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/a11y/heading-order.mdx
+++ b/docs/rules/a11y/heading-order.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Heading Order"
-description: "Checks that heading levels don't skip"
+title: "Heading order: why skipping from h1 to h3 matters"
+description: "Screen reader users navigate by heading level, so a skipped level hides a whole section. squirrel checks document order on every page."
 ---
 
-Checks that heading levels don't skip
+## What heading order is
+
+Heading levels are an outline, not a type scale. A screen reader user pressing 2 moves between second-level headings and expects everything under one of them to belong to it. Skipping from `<h1>` to `<h3>` implies a missing section, and the user has to guess whether they missed something.
+
+Going back up a level is not a skip. An `<h3>` followed by an `<h2>` closes one section and opens the next.
+
+## What squirrel checks
+
+One check, `heading-order`, at severity warning. It reads every `<h1>` through `<h6>` in document order and compares each level with the one before it.
+
+- Warn when a heading is more than one level deeper than its predecessor. Report message: `N heading level skip(s) detected`. Every skip is listed, as `H3 after H1`.
+- Pass with `Heading levels follow correct order`.
+- Info with `No headings found`.
+
+The first heading on a page is never counted as a skip, whatever its level, so a page that starts at `<h3>` passes this check. Whether the page has a top-level heading at all is `core/h1`.
+
+## How to fix it
+
+```html
+<h1>Pricing</h1>
+<h2>Plans</h2>
+<h3>Team</h3>
+<h2>Frequently asked questions</h2>
+```
+
+Pick the level from the position in the outline and set the size in CSS. If an `<h3>` looks right because you want smaller text, style the `<h2>` instead.
+
+Two independent components stacked on a page are the usual source. Each renders a sensible internal outline, and the combination skips a level at the seam. Passing the starting level into the component as a prop solves it.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks that heading levels don't skip
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Headings should follow a logical hierarchy without skipping levels. Screen reader users navigate by headings, so skipping from H1 to H3 is confusing. Correct order: H1 -> H2 -> H3 (not H1 -> H3). You can have multiple headings at the same level, and you can go back up (H3 -> H2 is fine). Think of headings as an outline - they should make sense when read alone.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/heading-order"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [content/heading-hierarchy](/rules/content/heading-hierarchy): the same outline judged for structure and SEO.
+- [a11y/empty-heading](/rules/a11y/empty-heading): headings in the outline with nothing to announce.
+- [core/h1](/rules/core/h1): the top of the outline.
+- [a11y/landmark-regions](/rules/a11y/landmark-regions): the other structure screen readers navigate by.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The heading elements, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
+- [Understanding SC 1.3.1 Info and Relationships, W3C](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [G141: Organizing a page using headings, W3C](https://www.w3.org/WAI/WCAG22/Techniques/general/G141)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each skip is listed with the level that jumped and the level before it. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/html-lang-valid.mdx
+++ b/docs/rules/a11y/html-lang-valid.mdx
@@ -1,9 +1,33 @@
 ---
-title: "HTML Lang Valid"
-description: "Checks that the html lang attribute has a valid language code"
+title: "html lang: valid values and what a missing one breaks"
+description: "Without a lang attribute a screen reader guesses the pronunciation, often wrongly. squirrel checks the html element on every page."
 ---
 
-Checks that the html lang attribute has a valid language code
+## What the lang attribute is
+
+`lang` on `<html>` declares what language the document is written in, as a BCP 47 tag. A screen reader uses it to choose a voice and a set of pronunciation rules. Read English with a French synthesiser and most of it is unintelligible.
+
+The tag has a primary subtag, `en`, optionally followed by script and region subtags, `en-GB` or `zh-Hans-CN`. The primary subtag is the part that matters for pronunciation; the region subtag usually selects an accent.
+
+## What squirrel checks
+
+Two check names, at rule severity error. Only one runs per page.
+
+- `html-has-lang` fails when `<html>` has no `lang` attribute at all. Report message: `HTML element missing lang attribute`, with the expected value `lang="en" or appropriate language code`. Nothing else is checked.
+- `html-lang-valid` fails when the value is empty, or when its primary subtag is neither one of the 190 ISO 639-1 codes the rule knows nor a plain two or three letter sequence. Report message: `Invalid lang attribute: empty value` or `Invalid lang attribute: invalid primary language 'english'`, with the expected value `Valid BCP 47 language tag (e.g., 'en', 'en-US', 'es')`.
+- `html-lang-valid` passes with `Valid lang attribute: "en-GB"`.
+
+Two limits follow from that shape check. Any two or three lowercase letters pass, so an invented code such as `qq` is accepted. And script and region subtags are not validated at all, so `en-ZZ` passes.
+
+## How to fix it
+
+```html
+<html lang="en-GB">
+```
+
+Set it on the `<html>` element of every page, including error pages and pages rendered by a framework's fallback layout. A region subtag is worth adding when the accent matters, and harmless when it does not.
+
+For a page whose main content is in another language, change this attribute rather than adding `lang` further down. Marking individual passages is what `a11y/valid-lang` covers.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks that the html lang attribute has a valid language code
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-The lang attribute on `<html>` should be a valid BCP 47 language tag. Use two-letter ISO 639-1 codes like 'en' for English, 'es' for Spanish, 'fr' for French. You can add region subtags like 'en-US' or 'en-GB'. This helps screen readers use correct pronunciation.
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/html-lang-valid"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/valid-lang](/rules/a11y/valid-lang): `lang` on every other element on the page.
+- [a11y/html-xml-lang-mismatch](/rules/a11y/html-xml-lang-mismatch): `lang` and `xml:lang` disagreeing.
+- [i18n/lang-attribute](/rules/i18n/lang-attribute): the same declaration seen from the internationalization side.
+- [i18n/hreflang](/rules/i18n/hreflang): the language signals sent to search engines instead.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The lang attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang)
+- [Declaring language in HTML, W3C Internationalization](https://www.w3.org/International/questions/qa-html-language-declarations)
+- [Understanding SC 3.1.1 Language of Page, W3C](https://www.w3.org/WAI/WCAG22/Understanding/language-of-page.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. A missing attribute and an invalid value are reported as different checks. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/html-lang-valid.mdx
+++ b/docs/rules/a11y/html-lang-valid.mdx
@@ -13,8 +13,8 @@ The tag has a primary subtag, `en`, optionally followed by script and region sub
 
 Two check names, at rule severity error. Only one runs per page.
 
-- `html-has-lang` fails when `<html>` has no `lang` attribute at all. Report message: `HTML element missing lang attribute`, with the expected value `lang="en" or appropriate language code`. Nothing else is checked.
-- `html-lang-valid` fails when the value is empty, or when its primary subtag is neither one of the 190 ISO 639-1 codes the rule knows nor a plain two or three letter sequence. Report message: `Invalid lang attribute: empty value` or `Invalid lang attribute: invalid primary language 'english'`, with the expected value `Valid BCP 47 language tag (e.g., 'en', 'en-US', 'es')`.
+- `html-has-lang` fails when `<html>` has no `lang` attribute, and also when it has `lang=""`, since the rule tests the attribute for truthiness. Report message: `HTML element missing lang attribute`, with the expected value `lang="en" or appropriate language code`. Nothing else is checked.
+- `html-lang-valid` fails when the value is whitespace only, or when its primary subtag is neither one of the 190 ISO 639-1 codes the rule knows nor a plain two or three letter sequence. Report message: `Invalid lang attribute: empty value` or `Invalid lang attribute: invalid primary language 'english'`, with the expected value `Valid BCP 47 language tag (e.g., 'en', 'en-US', 'es')`.
 - `html-lang-valid` passes with `Valid lang attribute: "en-GB"`.
 
 Two limits follow from that shape check. Any two or three lowercase letters pass, so an invented code such as `qq` is accepted. And script and region subtags are not validated at all, so `en-ZZ` passes.

--- a/docs/rules/a11y/html-xml-lang-mismatch.mdx
+++ b/docs/rules/a11y/html-xml-lang-mismatch.mdx
@@ -5,7 +5,7 @@ description: "When both attributes are present and name different languages, a s
 
 ## What xml:lang is
 
-`xml:lang` is the XML spelling of the language declaration. It matters in XHTML served as `application/xhtml+xml`, where the XML parser reads it and ignores plain `lang`. In an ordinary HTML document it is redundant, and most pages that carry it inherited it from an old doctype.
+`xml:lang` is the XML spelling of the language declaration. It matters in XHTML served as `application/xhtml+xml`, where it takes precedence over plain `lang`. In an ordinary HTML document it is redundant, and most pages that carry it inherited it from an old doctype.
 
 Carrying both is allowed, but the specification requires them to agree. When they disagree, which one wins depends on how the document was parsed, so the announced language depends on the content type rather than on anything visible.
 
@@ -16,8 +16,8 @@ One check, `html-xml-lang-mismatch`, at severity error. It reads `lang` and `xml
 - Fail when both are present and the primary subtags differ. Report message: `lang="en" and xml:lang="fr" don't match`, with the issue `Base languages must match` and the fix `Set both to the same value or remove xml:lang`.
 - Warn when both are present and the primary subtags match but the full values differ, such as `en` against `en-gb`. Report message: `lang="en" and xml:lang="en-gb" differ slightly`, noting `Base languages match but subtags differ`.
 - Warn when `xml:lang` is present and `lang` is not. Report message: `xml:lang present without lang attribute`, suggesting `Add lang attribute for HTML5 compatibility`.
-- Pass with `lang and xml:lang attributes match` when the two values are identical.
-- Info with `Only lang attribute present (recommended for HTML5)` in every other case. That branch also covers a page with neither attribute, where the message reads oddly. Whether `lang` exists at all is `a11y/html-lang-valid`.
+- Pass with `lang and xml:lang attributes match` when both values are non-empty and identical.
+- Info with `Only lang attribute present (recommended for HTML5)` in every other case. Every branch above tests the trimmed, lowercased value for truthiness, so an empty or whitespace-only attribute counts as absent and lands here. So does a page with neither attribute, where the message reads oddly. Whether `lang` exists at all is `a11y/html-lang-valid`.
 
 Values are lowercased before comparison and before being quoted in the message, so a report shows `en-gb` where the markup said `en-GB`.
 

--- a/docs/rules/a11y/html-xml-lang-mismatch.mdx
+++ b/docs/rules/a11y/html-xml-lang-mismatch.mdx
@@ -1,9 +1,35 @@
 ---
-title: "HTML XML Lang Mismatch"
-description: "Checks that lang and xml:lang attributes match on html element"
+title: "lang and xml:lang disagreeing on the html element"
+description: "When both attributes are present and name different languages, a screen reader can pick the wrong voice. squirrel compares them."
 ---
 
-Checks that lang and xml:lang attributes match on html element
+## What xml:lang is
+
+`xml:lang` is the XML spelling of the language declaration. It matters in XHTML served as `application/xhtml+xml`, where the XML parser reads it and ignores plain `lang`. In an ordinary HTML document it is redundant, and most pages that carry it inherited it from an old doctype.
+
+Carrying both is allowed, but the specification requires them to agree. When they disagree, which one wins depends on how the document was parsed, so the announced language depends on the content type rather than on anything visible.
+
+## What squirrel checks
+
+One check, `html-xml-lang-mismatch`, at severity error. It reads `lang` and `xml:lang` from `<html>`, trimmed and lowercased, and compares the primary subtag of each.
+
+- Fail when both are present and the primary subtags differ. Report message: `lang="en" and xml:lang="fr" don't match`, with the issue `Base languages must match` and the fix `Set both to the same value or remove xml:lang`.
+- Warn when both are present and the primary subtags match but the full values differ, such as `en` against `en-gb`. Report message: `lang="en" and xml:lang="en-gb" differ slightly`, noting `Base languages match but subtags differ`.
+- Warn when `xml:lang` is present and `lang` is not. Report message: `xml:lang present without lang attribute`, suggesting `Add lang attribute for HTML5 compatibility`.
+- Pass with `lang and xml:lang attributes match` when the two values are identical.
+- Info with `Only lang attribute present (recommended for HTML5)` in every other case. That branch also covers a page with neither attribute, where the message reads oddly. Whether `lang` exists at all is `a11y/html-lang-valid`.
+
+Values are lowercased before comparison and before being quoted in the message, so a report shows `en-gb` where the markup said `en-GB`.
+
+## How to fix it
+
+```html
+<html lang="en-GB">
+```
+
+For an HTML document, delete `xml:lang`. It does nothing, and deleting it removes the possibility of the two drifting apart.
+
+For a document genuinely served as XML, set both to exactly the same string.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks that lang and xml:lang attributes match on html element
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 6/10 |
-
-## Solution
-
-If both lang and xml:lang are present on the `<html>` element, they must have the same base language. Mismatches can cause screen readers to announce content in the wrong language. Typically, you only need lang for HTML5 documents.
 
 ## Enable / disable
 
@@ -40,3 +62,31 @@ disable = ["a11y/*"]
 enable = ["a11y/html-xml-lang-mismatch"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/html-lang-valid](/rules/a11y/html-lang-valid): whether `lang` exists and holds a usable value.
+- [a11y/valid-lang](/rules/a11y/valid-lang): `lang` on elements below `<html>`.
+- [i18n/lang-attribute](/rules/i18n/lang-attribute): the same declaration checked for internationalization.
+- [core/doctype](/rules/core/doctype): the doctype that usually explains why `xml:lang` is there.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The lang attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang)
+- [Declaring language in HTML, W3C Internationalization](https://www.w3.org/International/questions/qa-html-language-declarations)
+- [Tags for identifying languages, RFC 5646](https://datatracker.ietf.org/doc/html/rfc5646)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. A different language fails, a different region subtag only warns. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/identical-links-same-purpose.mdx
+++ b/docs/rules/a11y/identical-links-same-purpose.mdx
@@ -15,7 +15,7 @@ One check, `identical-links-same-purpose`, at severity warning. It reads every `
 
 Destinations are normalized before comparison: the `href` is lowercased, trailing slashes are stripped and the query string is dropped. So `/pricing`, `/pricing/` and `/pricing?ref=nav` all count as one destination.
 
-- Warn when one text maps to more than one destination. Report message: `N link text(s) lead to different destinations`. Items read `"learn more" → 3 different URLs`, up to ten with a count of the rest, carrying the suggestion `Make link text unique to differentiate destinations`.
+- Warn when one text maps to more than one destination. Report message: `N link text(s) lead to different destinations`. Items read `"learn more" → 3 different URLs`, capped at the first ten, carrying the suggestion `Make link text unique to differentiate destinations`.
 - Pass with `Identical link texts go to same destinations`.
 - Info with `No links found`.
 

--- a/docs/rules/a11y/identical-links-same-purpose.mdx
+++ b/docs/rules/a11y/identical-links-same-purpose.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 - [a11y/link-text](/rules/a11y/link-text): generic phrases and links with no text at all.
 - [a11y/label-content-name-mismatch](/rules/a11y/label-content-name-mismatch): an `aria-label` that does not contain the visible words.
 - [links/anchor-text](/rules/links/anchor-text): the same text judged as a ranking signal.
-- [a11y/link-text](/rules/a11y/link-text): links with no accessible text at all, which land in the same list as blanks.
+- [a11y/link-in-text-block](/rules/a11y/link-in-text-block): links in body text whose markup removes the underline.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/identical-links-same-purpose.mdx
+++ b/docs/rules/a11y/identical-links-same-purpose.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Identical Links Same Purpose"
-description: "Checks that links with identical text go to the same destination"
+title: "Identical link text pointing at different pages"
+description: "Two links reading 'Learn more' that go to different places are indistinguishable in a screen reader's link list. squirrel finds them."
 ---
 
-Checks that links with identical text go to the same destination
+## What the problem is
+
+Screen readers can present every link on a page as a list, sorted and read out of context. In that list two entries reading "Learn more" are the same entry twice, and there is no way to tell which one leads where.
+
+The opposite case is fine and expected: the same text pointing at the same page, in a nav bar and again in the footer, is one destination described consistently.
+
+## What squirrel checks
+
+One check, `identical-links-same-purpose`, at severity warning. It reads every `a[href]`, taking the link's trimmed and lowercased text along with its `href`, and skips links with no text, text shorter than two characters, or an `href` beginning with `#`.
+
+Destinations are normalized before comparison: the `href` is lowercased, trailing slashes are stripped and the query string is dropped. So `/pricing`, `/pricing/` and `/pricing?ref=nav` all count as one destination.
+
+- Warn when one text maps to more than one destination. Report message: `N link text(s) lead to different destinations`. Items read `"learn more" → 3 different URLs`, up to ten with a count of the rest, carrying the suggestion `Make link text unique to differentiate destinations`.
+- Pass with `Identical link texts go to same destinations`.
+- Info with `No links found`.
+
+URLs are compared as written, so a link to `/pricing` and one to `https://example.com/pricing` are treated as different destinations even though they resolve to the same page. That is the most common false positive here.
+
+## How to fix it
+
+```html
+<a href="/plans/team">Learn more about the Team plan</a>
+<a href="/plans/enterprise">Learn more about Enterprise</a>
+```
+
+Extend the visible text. Where the design cannot take more words, keep the short label visible and put the full phrase in `aria-label`, making sure the visible words appear inside it.
 
 | | |
 |---|---|
@@ -12,10 +37,6 @@ Checks that links with identical text go to the same destination
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Links with the same visible text should go to the same URL. When identical link text leads to different destinations, it confuses screen reader users who navigate by listing links. Make link text unique or more descriptive to differentiate destinations.
 
 ## Enable / disable
 
@@ -40,3 +61,31 @@ disable = ["a11y/*"]
 enable = ["a11y/identical-links-same-purpose"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/link-text](/rules/a11y/link-text): generic phrases and links with no text at all.
+- [a11y/label-content-name-mismatch](/rules/a11y/label-content-name-mismatch): an `aria-label` that does not contain the visible words.
+- [links/anchor-text](/rules/links/anchor-text): the same text judged as a ranking signal.
+- [a11y/aria-labels](/rules/a11y/aria-labels): naming the icon-only links that appear in the same list.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Understanding SC 2.4.4 Link Purpose (In Context), W3C](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html)
+- [Understanding SC 3.2.4 Consistent Identification, W3C](https://www.w3.org/WAI/WCAG22/Understanding/consistent-identification.html)
+- [The a element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each repeated phrase is listed with how many destinations it points at. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/identical-links-same-purpose.mdx
+++ b/docs/rules/a11y/identical-links-same-purpose.mdx
@@ -67,7 +67,7 @@ disable = ["*"]
 - [a11y/link-text](/rules/a11y/link-text): generic phrases and links with no text at all.
 - [a11y/label-content-name-mismatch](/rules/a11y/label-content-name-mismatch): an `aria-label` that does not contain the visible words.
 - [links/anchor-text](/rules/links/anchor-text): the same text judged as a ranking signal.
-- [a11y/aria-labels](/rules/a11y/aria-labels): naming the icon-only links that appear in the same list.
+- [a11y/link-text](/rules/a11y/link-text): links with no accessible text at all, which land in the same list as blanks.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/image-redundant-alt.mdx
+++ b/docs/rules/a11y/image-redundant-alt.mdx
@@ -15,8 +15,8 @@ One check, `image-redundant-alt`, at severity warning. It reads every `img[alt]`
 
 - The alt matches one of 42 patterns. Those cover the prefixes `image of`, `photo of`, `photograph of`, `picture of`, `graphic of`, `icon of`, `illustration of`, `diagram of`, `screenshot of`, `chart of`, `graph of`, `figure of` and `infographic of`, the bare nouns on their own, `logo`, `banner`, `img`, `thumbnail`, `hero image`, `cover image`, `featured image`, `placeholder`, `untitled`, `spacer`, `divider`, and bare file extensions such as `.jpg` and `.png`.
 - The alt matches the `src` filename. Both are lowercased and stripped of hyphens, underscores and spaces, and the filename must be longer than three characters. Item: `alt="hero-banner" matches filename`.
-- The alt is repeated in the parent element's text. This needs the alt to be longer than ten characters and the parent's text to be shorter than three times the alt, so a caption-sized repeat is caught and a long article is not. Item: `"Annual report cov..." duplicates surrounding text`.
-- The alt is repeated in a `<figcaption>`. The image has to be inside a `<figure>`, the alt longer than five characters, and the caption has to equal or contain it. Item: `"Annual report cov..." duplicates figcaption`.
+- The alt is repeated in the parent element's text. This needs the alt to be longer than ten characters and the parent's text to be shorter than three times the alt, so a caption-sized repeat is caught and a long article is not. Item: `"Annual revenue chart..." duplicates surrounding text`.
+- The alt is repeated in a `<figcaption>`. The image has to be inside a `<figure>`, the alt longer than five characters, and the caption has to equal or contain it. Item: `"Annual revenue chart..." duplicates figcaption`.
 
 Findings are deduplicated, then reported as `N image(s) with redundant alt text`, up to ten with a count of the rest. With nothing found the check passes as `No redundant image alt text found`, and a page with no `alt` at all returns info with `No images with alt text found`.
 

--- a/docs/rules/a11y/image-redundant-alt.mdx
+++ b/docs/rules/a11y/image-redundant-alt.mdx
@@ -69,9 +69,9 @@ disable = ["*"]
 ## Related rules
 
 - [images/alt-text](/rules/images/alt-text): images with no `alt` attribute at all.
-- [images/figure-figcaption](/rules/images/figure-figcaption): the figure and caption pairing this rule inspects.
+- [images/figure-figcaption](/rules/images/figure-figcaption): whether `<figure>` and `<figcaption>` are used correctly in the first place.
 - [a11y/input-image-alt](/rules/a11y/input-image-alt): `<input type="image">`, which needs `alt` as a button name.
-- [images/filename-quality](/rules/images/filename-quality): the filenames this rule compares against.
+- [images/filename-quality](/rules/images/filename-quality): whether those filenames are descriptive to begin with.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/image-redundant-alt.mdx
+++ b/docs/rules/a11y/image-redundant-alt.mdx
@@ -15,7 +15,7 @@ One check, `image-redundant-alt`, at severity warning. It reads every `img[alt]`
 
 - The alt matches one of 42 patterns. Those cover the prefixes `image of`, `photo of`, `photograph of`, `picture of`, `graphic of`, `icon of`, `illustration of`, `diagram of`, `screenshot of`, `chart of`, `graph of`, `figure of` and `infographic of`, the bare nouns on their own, `logo`, `banner`, `img`, `thumbnail`, `hero image`, `cover image`, `featured image`, `placeholder`, `untitled`, `spacer`, `divider`, and bare file extensions such as `.jpg` and `.png`.
 - The alt matches the `src` filename. Both are lowercased and stripped of hyphens, underscores and spaces, and the filename must be longer than three characters. Item: `alt="hero-banner" matches filename`.
-- The alt is repeated in the parent element's text. This needs the alt to be longer than ten characters and the parent's text to be shorter than three times the alt, so a caption-sized repeat is caught and a long article is not. Item: `"Annual revenue chart..." duplicates surrounding text`.
+- The alt is repeated in the parent element's text. This needs the parent's text to be strictly longer than the alt and shorter than three times it, and the alt itself longer than ten characters, so a caption-sized repeat is caught while an exact-match parent and a long article are both left alone. Item: `"Annual revenue chart..." duplicates surrounding text`.
 - The alt is repeated in a `<figcaption>`. The image has to be inside a `<figure>`, the alt longer than five characters, and the caption has to equal or contain it. Item: `"Annual revenue chart..." duplicates figcaption`.
 
 Findings are deduplicated, then reported as `N image(s) with redundant alt text`, up to ten with a count of the rest. With nothing found the check passes as `No redundant image alt text found`, and a page with no `alt` at all returns info with `No images with alt text found`.
@@ -79,7 +79,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 
 - [The img element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
 - [Understanding SC 1.1.1 Non-text Content, W3C](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
-- [Images tutorial, W3C WAI](https://www.w3.org/WAI/tutorials/images/)
+- [Tips and tricks for images, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/images/tips/)
 
 ## Check your site
 

--- a/docs/rules/a11y/image-redundant-alt.mdx
+++ b/docs/rules/a11y/image-redundant-alt.mdx
@@ -1,9 +1,38 @@
 ---
-title: "Redundant Image Alt"
-description: "Checks that image alt text is not redundant with surrounding text"
+title: "Redundant alt text: image of, filenames and captions"
+description: "Screen readers already announce that it is an image, so alt starting with 'photo of' wastes the announcement. squirrel checks four ways."
 ---
 
-Checks that image alt text is not redundant with surrounding text
+## What redundant alt text is
+
+A screen reader announces an image as an image before it reads the `alt`. Starting the text with "Image of" or "Photo of" repeats that, and the user hears "image, image of a woman at a laptop".
+
+The other kind of redundancy is duplication. Alt text that repeats the caption underneath it, or the paragraph around it, gets announced twice. Alt text that is just the filename is worse: it is announced once and means nothing.
+
+## What squirrel checks
+
+One check, `image-redundant-alt`, at severity warning. It reads every `img[alt]` with a non-empty `alt` and runs four tests. An empty `alt`, which marks a decorative image, is skipped.
+
+- The alt matches one of 42 patterns. Those cover the prefixes `image of`, `photo of`, `photograph of`, `picture of`, `graphic of`, `icon of`, `illustration of`, `diagram of`, `screenshot of`, `chart of`, `graph of`, `figure of` and `infographic of`, the bare nouns on their own, `logo`, `banner`, `img`, `thumbnail`, `hero image`, `cover image`, `featured image`, `placeholder`, `untitled`, `spacer`, `divider`, and bare file extensions such as `.jpg` and `.png`.
+- The alt matches the `src` filename. Both are lowercased and stripped of hyphens, underscores and spaces, and the filename must be longer than three characters. Item: `alt="hero-banner" matches filename`.
+- The alt is repeated in the parent element's text. This needs the alt to be longer than ten characters and the parent's text to be shorter than three times the alt, so a caption-sized repeat is caught and a long article is not. Item: `"Annual report cov..." duplicates surrounding text`.
+- The alt is repeated in a `<figcaption>`. The image has to be inside a `<figure>`, the alt longer than five characters, and the caption has to equal or contain it. Item: `"Annual report cov..." duplicates figcaption`.
+
+Findings are deduplicated, then reported as `N image(s) with redundant alt text`, up to ten with a count of the rest. With nothing found the check passes as `No redundant image alt text found`, and a page with no `alt` at all returns info with `No images with alt text found`.
+
+## How to fix it
+
+```html
+<figure>
+  <img src="q3-revenue.png"
+       alt="Revenue rising from 4.1M to 6.8M between January and September">
+  <figcaption>Q3 revenue</figcaption>
+</figure>
+```
+
+Write what the image shows, not what kind of file it is. Where a caption already describes the image, the alt should add what the caption leaves out, or be empty if it adds nothing.
+
+A logo whose correct alt is the company name, sitting in a file named after the company, trips the filename test. `<img src="northwind.svg" alt="Northwind">` is right, and reported.
 
 | | |
 |---|---|
@@ -12,10 +41,6 @@ Checks that image alt text is not redundant with surrounding text
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Image alt text should not start with 'image of', 'photo of', 'picture of', etc. Screen readers already announce that it's an image. Alt text should describe the content or function, not state the obvious. Also avoid duplicating adjacent text in the alt.
 
 ## Enable / disable
 
@@ -40,3 +65,31 @@ disable = ["a11y/*"]
 enable = ["a11y/image-redundant-alt"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [images/alt-text](/rules/images/alt-text): images with no `alt` attribute at all.
+- [images/figure-figcaption](/rules/images/figure-figcaption): the figure and caption pairing this rule inspects.
+- [a11y/input-image-alt](/rules/a11y/input-image-alt): `<input type="image">`, which needs `alt` as a button name.
+- [images/filename-quality](/rules/images/filename-quality): the filenames this rule compares against.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The img element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
+- [Understanding SC 1.1.1 Non-text Content, W3C](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
+- [Images tutorial, W3C WAI](https://www.w3.org/WAI/tutorials/images/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each finding says which of the four tests it tripped. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/index.mdx
+++ b/docs/rules/a11y/index.mdx
@@ -10,188 +10,188 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 ## Rules
 
 <CardGroup cols={2}>
-  <Card title="Access Keys" icon="triangle-exclamation" href="/rules/a11y/accesskeys">
-    Checks that accesskey values are unique
+  <Card title="accesskey: why duplicate shortcuts break and how to check" icon="triangle-exclamation" href="/rules/a11y/accesskeys">
+    Two elements claiming the same accesskey means one shortcut is unreachable.
   </Card>
-  <Card title="ARIA Allowed Attributes" icon="triangle-exclamation" href="/rules/a11y/aria-allowed-attr">
-    Checks that ARIA attributes are allowed on their elements
+  <Card title="ARIA attributes that are not allowed on an element" icon="triangle-exclamation" href="/rules/a11y/aria-allowed-attr">
+    role=presentation with an aria-label, or a decorative image with one, contradicts itself.
   </Card>
-  <Card title="ARIA Command Name" icon="circle-exclamation" href="/rules/a11y/aria-command-name">
-    Checks that command elements have accessible names
+  <Card title="Command roles: buttons, links and menu items need names" icon="circle-exclamation" href="/rules/a11y/aria-command-name">
+    Anything that performs an action has to announce what it does.
   </Card>
-  <Card title="ARIA Dialog Name" icon="circle-exclamation" href="/rules/a11y/aria-dialog-name">
-    Checks that dialog elements have accessible names
+  <Card title="Dialog accessible name: role=dialog and the dialog element" icon="circle-exclamation" href="/rules/a11y/aria-dialog-name">
+    A modal with no name leaves screen reader users guessing what just opened.
   </Card>
-  <Card title="ARIA Hidden Body" icon="circle-exclamation" href="/rules/a11y/aria-hidden-body">
-    Ensures document body is not set to aria-hidden
+  <Card title="aria-hidden on body or html: what it breaks" icon="circle-exclamation" href="/rules/a11y/aria-hidden-body">
+    aria-hidden=true on the body or html element asks assistive technology to ignore the entire page.
   </Card>
-  <Card title="ARIA Hidden Focus" icon="circle-exclamation" href="/rules/a11y/aria-hidden-focus">
-    Ensures aria-hidden elements do not contain focusable content
+  <Card title="Focusable elements inside aria-hidden: the tab trap" icon="circle-exclamation" href="/rules/a11y/aria-hidden-focus">
+    A hidden element that still takes focus lets keyboard users tab into nothing.
   </Card>
-  <Card title="ARIA Input Field Name" icon="circle-exclamation" href="/rules/a11y/aria-input-field-name">
-    Checks that input fields have accessible names
+  <Card title="Input fields with no accessible name, ARIA and native" icon="circle-exclamation" href="/rules/a11y/aria-input-field-name">
+    Text boxes, comboboxes and sliders that announce nothing.
   </Card>
-  <Card title="ARIA Labels" icon="circle-exclamation" href="/rules/a11y/aria-labels">
-    Checks that interactive elements have accessible names
+  <Card title="aria-label: which elements need one and how to check" icon="circle-exclamation" href="/rules/a11y/aria-labels">
+    Buttons, links and inputs with no visible text and no aria-label have no name for screen readers.
   </Card>
-  <Card title="ARIA Meter Name" icon="circle-exclamation" href="/rules/a11y/aria-meter-name">
-    Checks that meter elements have accessible names
+  <Card title="Accessible name for a meter element and role=meter" icon="circle-exclamation" href="/rules/a11y/aria-meter-name">
+    A gauge that announces only a number tells a screen reader user nothing.
   </Card>
-  <Card title="ARIA Progressbar Name" icon="circle-exclamation" href="/rules/a11y/aria-progressbar-name">
-    Checks that progressbar elements have accessible names
+  <Card title="Accessible name for a progress bar and role=progressbar" icon="circle-exclamation" href="/rules/a11y/aria-progressbar-name">
+    A progress bar with no name announces a percentage and nothing else.
   </Card>
-  <Card title="ARIA Required Attributes" icon="circle-exclamation" href="/rules/a11y/aria-required-attr">
-    Checks that elements have required ARIA attributes for their roles
+  <Card title="Required ARIA attributes for a role, and what is missing" icon="circle-exclamation" href="/rules/a11y/aria-required-attr">
+    role=checkbox with no aria-checked has a state screen readers cannot read.
   </Card>
-  <Card title="ARIA Required Children" icon="circle-exclamation" href="/rules/a11y/aria-required-children">
-    Checks that elements with certain roles have required child roles
+  <Card title="ARIA roles that require particular child roles" icon="circle-exclamation" href="/rules/a11y/aria-required-children">
+    role=list with no listitem, or role=tablist with no tab, is an incomplete widget.
   </Card>
-  <Card title="ARIA Required Parent" icon="circle-exclamation" href="/rules/a11y/aria-required-parent">
-    Checks that elements with certain roles have required parent roles
+  <Card title="ARIA roles that require a particular parent role" icon="circle-exclamation" href="/rules/a11y/aria-required-parent">
+    role=listitem outside a list, or a tab outside a tablist, loses its meaning.
   </Card>
-  <Card title="ARIA Text" icon="triangle-exclamation" href="/rules/a11y/aria-text">
-    Checks that elements with role='text' have no focusable descendants
+  <Card title="role=text with focusable children: why it breaks" icon="triangle-exclamation" href="/rules/a11y/aria-text">
+    role=text flattens a subtree into one announced string, so a link inside it cannot be operated.
   </Card>
-  <Card title="ARIA Toggle Field Name" icon="circle-exclamation" href="/rules/a11y/aria-toggle-field-name">
-    Checks that toggle fields (checkbox, radio, switch) have accessible names
+  <Card title="Checkboxes, radios and switches with no accessible name" icon="circle-exclamation" href="/rules/a11y/aria-toggle-field-name">
+    A checkbox that announces only its role gives no reason to tick it.
   </Card>
-  <Card title="ARIA Tooltip Name" icon="circle-exclamation" href="/rules/a11y/aria-tooltip-name">
-    Checks that tooltip elements have accessible names
+  <Card title="role=tooltip with no content: what to check" icon="circle-exclamation" href="/rules/a11y/aria-tooltip-name">
+    A tooltip with nothing to announce leaves the control it explains unexplained.
   </Card>
-  <Card title="ARIA Treeitem Name" icon="circle-exclamation" href="/rules/a11y/aria-treeitem-name">
-    Checks that treeitem elements have accessible names
+  <Card title="role=treeitem: naming every node in a tree" icon="circle-exclamation" href="/rules/a11y/aria-treeitem-name">
+    A tree node that announces only its position in the tree is unusable.
   </Card>
-  <Card title="ARIA Valid Attribute Values" icon="circle-exclamation" href="/rules/a11y/aria-valid-attr-value">
-    Checks for valid values in ARIA attributes
+  <Card title="Invalid ARIA attribute values and the types they need" icon="circle-exclamation" href="/rules/a11y/aria-valid-attr-value">
+    aria-checked=yes and aria-level=two are ignored by browsers.
   </Card>
-  <Card title="ARIA Valid Attributes" icon="circle-exclamation" href="/rules/a11y/aria-valid-attr">
-    Checks for valid ARIA attribute names
+  <Card title="Invalid aria-* attribute names, aria-labeledby included" icon="circle-exclamation" href="/rules/a11y/aria-valid-attr">
+    A misspelled ARIA attribute is ignored by every browser and warns nobody.
   </Card>
-  <Card title="ARIA Valid Roles" icon="circle-exclamation" href="/rules/a11y/aria-roles">
-    Checks for valid ARIA role values
+  <Card title="Invalid ARIA role values and how to check them" icon="circle-exclamation" href="/rules/a11y/aria-roles">
+    A misspelled or invented role gives an element no semantics at all.
   </Card>
-  <Card title="Autocomplete Tokens" icon="triangle-exclamation" href="/rules/a11y/autocomplete-tokens">
-    Checks that name, email, phone, address and payment fields carry the correct autocomplete token
+  <Card title="autocomplete: the right token for every form field" icon="triangle-exclamation" href="/rules/a11y/autocomplete-tokens">
+    Name, email, address and payment fields with a missing or wrong autocomplete token break autofill.
   </Card>
-  <Card title="Button Name" icon="circle-exclamation" href="/rules/a11y/button-name">
-    Checks that all buttons have accessible names
+  <Card title="Accessible names for buttons: what counts and how to check" icon="circle-exclamation" href="/rules/a11y/button-name">
+    A button with only an icon has no name for a screen reader.
   </Card>
-  <Card title="Color Contrast" icon="triangle-exclamation" href="/rules/a11y/color-contrast">
-    Checks for color contrast issues in styles and classes
+  <Card title="Color contrast: the 4.5:1 rule and how to check it" icon="triangle-exclamation" href="/rules/a11y/color-contrast">
+    Light gray text on white fails WCAG AA.
   </Card>
-  <Card title="Definition List Item" icon="circle-exclamation" href="/rules/a11y/dlitem">
-    Checks that dt and dd elements are inside a dl
+  <Card title="dt and dd outside a dl: orphaned definition list items" icon="circle-exclamation" href="/rules/a11y/dlitem">
+    A dt or dd that is not inside a dl loses the term-description pairing entirely.
   </Card>
-  <Card title="Definition List Structure" icon="circle-exclamation" href="/rules/a11y/definition-list">
-    Checks that definition lists contain only dt and dd elements
+  <Card title="Definition list structure: what belongs inside a dl" icon="circle-exclamation" href="/rules/a11y/definition-list">
+    A stray paragraph between the terms of a dl breaks the pairing screen readers rely on.
   </Card>
-  <Card title="Deprecated ARIA Roles" icon="circle-exclamation" href="/rules/a11y/aria-deprecated-role">
-    Checks for deprecated or abstract ARIA roles
+  <Card title="Deprecated and abstract ARIA roles, and what to use instead" icon="circle-exclamation" href="/rules/a11y/aria-deprecated-role">
+    role=directory is deprecated and abstract roles were never meant for markup.
   </Card>
-  <Card title="Duplicate ID Active" icon="circle-exclamation" href="/rules/a11y/duplicate-id-active">
-    Checks that active, focusable elements have unique IDs
+  <Card title="Duplicate id on a focusable element: what it breaks" icon="circle-exclamation" href="/rules/a11y/duplicate-id-active">
+    Two inputs sharing an id break label association and focus management.
   </Card>
-  <Card title="Duplicate ID ARIA" icon="circle-exclamation" href="/rules/a11y/duplicate-id-aria">
-    Checks that IDs used in ARIA attributes are unique
+  <Card title="ARIA references pointing at duplicate or missing ids" icon="circle-exclamation" href="/rules/a11y/duplicate-id-aria">
+    aria-labelledby resolving to two elements, or to none, names the wrong thing silently.
   </Card>
-  <Card title="Empty Headings" icon="triangle-exclamation" href="/rules/a11y/empty-heading">
-    Checks that heading elements have visible content
+  <Card title="Empty headings: what counts as empty and how to check" icon="triangle-exclamation" href="/rules/a11y/empty-heading">
+    A heading with no text still shows up in the screen reader outline, as a blank entry.
   </Card>
-  <Card title="Focus Visible" icon="triangle-exclamation" href="/rules/a11y/focus-visible">
-    Checks for focus indicator styles
+  <Card title="focus-visible: keeping a visible keyboard focus ring" icon="triangle-exclamation" href="/rules/a11y/focus-visible">
+    Removing the focus outline leaves keyboard users with no idea where they are.
   </Card>
-  <Card title="Form Labels" icon="circle-exclamation" href="/rules/a11y/form-labels">
-    Checks that form inputs have associated labels
+  <Card title="Form labels: which inputs need one and how to check" icon="circle-exclamation" href="/rules/a11y/form-labels">
+    An input labelled only by its placeholder loses its label the moment someone types.
   </Card>
-  <Card title="Frame Title" icon="circle-exclamation" href="/rules/a11y/frame-title">
-    Checks that iframes and frames have title attributes
+  <Card title="iframe title: naming embedded frames for screen readers" icon="circle-exclamation" href="/rules/a11y/frame-title">
+    An iframe with no title is announced as just 'frame'.
   </Card>
-  <Card title="Heading Order" icon="triangle-exclamation" href="/rules/a11y/heading-order">
-    Checks that heading levels don't skip
+  <Card title="Heading order: why skipping from h1 to h3 matters" icon="triangle-exclamation" href="/rules/a11y/heading-order">
+    Screen reader users navigate by heading level, and a skipped level makes the outline harder to follow.
   </Card>
-  <Card title="HTML Lang Valid" icon="circle-exclamation" href="/rules/a11y/html-lang-valid">
-    Checks that the html lang attribute has a valid language code
+  <Card title="html lang: valid values and what a missing one breaks" icon="circle-exclamation" href="/rules/a11y/html-lang-valid">
+    Without a lang attribute a screen reader guesses the pronunciation, often wrongly.
   </Card>
-  <Card title="HTML XML Lang Mismatch" icon="circle-exclamation" href="/rules/a11y/html-xml-lang-mismatch">
-    Checks that lang and xml:lang attributes match on html element
+  <Card title="lang and xml:lang disagreeing on the html element" icon="circle-exclamation" href="/rules/a11y/html-xml-lang-mismatch">
+    When both attributes are present and name different languages, a screen reader can pick the wrong voice.
   </Card>
-  <Card title="Identical Links Same Purpose" icon="triangle-exclamation" href="/rules/a11y/identical-links-same-purpose">
-    Checks that links with identical text go to the same destination
+  <Card title="Identical link text pointing at different pages" icon="triangle-exclamation" href="/rules/a11y/identical-links-same-purpose">
+    Two links reading 'Learn more' that go to different places are indistinguishable in a screen reader's link list.
   </Card>
-  <Card title="Input Image Alt" icon="circle-exclamation" href="/rules/a11y/input-image-alt">
-    Checks that input type='image' elements have alt text
+  <Card title="input type=image without alt: an unnamed submit button" icon="circle-exclamation" href="/rules/a11y/input-image-alt">
+    An image input is a submit button drawn as a picture, and with no alt it announces nothing.
   </Card>
-  <Card title="Input Types" icon="triangle-exclamation" href="/rules/a11y/input-types">
-    Checks that fields use the right input type and keyboard hint, and that forms keep native validation
+  <Card title="Input type, enterkeyhint and novalidate on forms" icon="triangle-exclamation" href="/rules/a11y/input-types">
+    type=text where type=email belongs costs mobile users the right keyboard.
   </Card>
-  <Card title="Label Content Name Mismatch" icon="circle-exclamation" href="/rules/a11y/label-content-name-mismatch">
-    Checks that visible label text is part of accessible name
+  <Card title="Visible label missing from the accessible name" icon="circle-exclamation" href="/rules/a11y/label-content-name-mismatch">
+    A button showing 'Search' with aria-label 'Find products' may not respond when a user speaks its visible label.
   </Card>
-  <Card title="Landmark Regions" icon="circle-info" href="/rules/a11y/landmark-regions">
-    Checks for proper landmark regions (main, nav, footer)
+  <Card title="Landmark regions: main, nav and footer on every page" icon="circle-info" href="/rules/a11y/landmark-regions">
+    Screen reader users jump between landmarks instead of reading top to bottom.
   </Card>
-  <Card title="Link in Text Block" icon="triangle-exclamation" href="/rules/a11y/link-in-text-block">
-    Checks that links in text blocks are visually distinguishable
+  <Card title="Links in a paragraph told apart by color alone" icon="triangle-exclamation" href="/rules/a11y/link-in-text-block">
+    A link inside body text needs more than color to be visible.
   </Card>
-  <Card title="Link Text" icon="triangle-exclamation" href="/rules/a11y/link-text">
-    Checks for descriptive link text
+  <Card title="Link text: why 'click here' fails and what to use" icon="triangle-exclamation" href="/rules/a11y/link-text">
+    Links reading 'click here', and links wrapping an unlabeled icon, give screen reader users nothing to go on.
   </Card>
-  <Card title="List Item Context" icon="circle-exclamation" href="/rules/a11y/listitem">
-    Checks that li elements are inside ul, ol, or menu
+  <Card title="Orphaned li: list items outside ul, ol or menu" icon="circle-exclamation" href="/rules/a11y/listitem">
+    An li whose parent is not a list is announced as a plain block of text.
   </Card>
-  <Card title="List Structure" icon="circle-exclamation" href="/rules/a11y/list-structure">
-    Checks that ul and ol elements contain only li elements
+  <Card title="ul and ol with children that are not list items" icon="circle-exclamation" href="/rules/a11y/list-structure">
+    A div between the li elements of a list changes what a screen reader announces.
   </Card>
-  <Card title="Meta Refresh" icon="circle-exclamation" href="/rules/a11y/meta-refresh">
-    Checks for meta refresh redirects that can disorient users
+  <Card title="meta http-equiv=refresh: redirects and auto-refresh" icon="circle-exclamation" href="/rules/a11y/meta-refresh">
+    A timed redirect moves the page out from under a screen reader user mid-sentence.
   </Card>
-  <Card title="Multiple Labels" icon="triangle-exclamation" href="/rules/a11y/form-field-multiple-labels">
-    Checks that form fields don't have multiple labels
+  <Card title="One control, two labels: why multiple labels confuse" icon="triangle-exclamation" href="/rules/a11y/form-field-multiple-labels">
+    A control with two labels is announced inconsistently across screen readers.
   </Card>
-  <Card title="Object Alt Text" icon="triangle-exclamation" href="/rules/a11y/object-alt">
-    Checks that object elements have alternative content
+  <Card title="object elements with no alternative content" icon="triangle-exclamation" href="/rules/a11y/object-alt">
+    An embedded object with no fallback is announced as nothing at all.
   </Card>
-  <Card title="One Main Landmark" icon="triangle-exclamation" href="/rules/a11y/landmark-one-main">
-    Checks that the page has exactly one main landmark
+  <Card title="One main landmark per page, and what happens without" icon="triangle-exclamation" href="/rules/a11y/landmark-one-main">
+    A page with no main landmark, or with two, breaks the jump-to-content shortcut screen reader users rely on.
   </Card>
-  <Card title="Paste Inputs" icon="triangle-exclamation" href="/rules/a11y/paste-inputs">
-    Detects form inputs that prevent pasting
+  <Card title="Inputs that block paste, and why that fails users" icon="triangle-exclamation" href="/rules/a11y/paste-inputs">
+    Blocking paste forces people to retype passwords by hand.
   </Card>
-  <Card title="Redundant Image Alt" icon="triangle-exclamation" href="/rules/a11y/image-redundant-alt">
-    Checks that image alt text is not redundant with surrounding text
+  <Card title="Redundant alt text: image of, filenames and captions" icon="triangle-exclamation" href="/rules/a11y/image-redundant-alt">
+    Screen readers already announce that it is an image, so alt starting with 'photo of' wastes the announcement.
   </Card>
-  <Card title="Select Name" icon="circle-exclamation" href="/rules/a11y/select-name">
-    Checks that select elements have accessible names
+  <Card title="Dropdowns with no accessible name: naming a select" icon="circle-exclamation" href="/rules/a11y/select-name">
+    A select announced only as 'combo box' gives no clue what it changes.
   </Card>
-  <Card title="Skip Link" icon="triangle-exclamation" href="/rules/a11y/skip-link">
-    Checks for bypass mechanisms for keyboard navigation
+  <Card title="Skip to content: bypassing repeated navigation" icon="triangle-exclamation" href="/rules/a11y/skip-link">
+    Keyboard users tab through the whole navigation on every page without a bypass.
   </Card>
-  <Card title="Tabindex Values" icon="triangle-exclamation" href="/rules/a11y/tabindex">
-    Checks for appropriate tabindex values
+  <Card title="Positive tabindex and why it breaks the tab order" icon="triangle-exclamation" href="/rules/a11y/tabindex">
+    tabindex=1 pulls an element to the front of the tab order for the entire page.
   </Card>
-  <Card title="Table Cell Headers" icon="circle-exclamation" href="/rules/a11y/td-headers-attr">
-    Checks that td headers attribute references valid th ids
+  <Card title="td headers attribute pointing at a missing th id" icon="circle-exclamation" href="/rules/a11y/td-headers-attr">
+    A headers attribute naming an id that does not exist leaves the cell unassociated.
   </Card>
-  <Card title="Table Duplicate Name" icon="triangle-exclamation" href="/rules/a11y/table-duplicate-name">
-    Checks that data tables have unique accessible names
+  <Card title="Tables sharing a name, and tables with none" icon="triangle-exclamation" href="/rules/a11y/table-duplicate-name">
+    Several tables on one page need distinct names or a screen reader's table list is unusable.
   </Card>
-  <Card title="Table Headers" icon="triangle-exclamation" href="/rules/a11y/table-headers">
-    Checks that data tables have proper headers
+  <Card title="Table headers: why a data table needs th cells" icon="triangle-exclamation" href="/rules/a11y/table-headers">
+    A table built from styled td cells has no header relationships for a screen reader.
   </Card>
-  <Card title="TH Has Data Cells" icon="triangle-exclamation" href="/rules/a11y/th-has-data-cells">
-    Checks that table headers have associated data cells
+  <Card title="th cells with no data cells: a layout table in disguise" icon="triangle-exclamation" href="/rules/a11y/th-has-data-cells">
+    A header with no data in its row or column usually means the table is really a layout.
   </Card>
-  <Card title="Touch Targets" icon="triangle-exclamation" href="/rules/a11y/touch-targets">
-    Checks for minimum touch target sizing hints
+  <Card title="Touch target size: the 24 and 44 pixel minimums" icon="triangle-exclamation" href="/rules/a11y/touch-targets">
+    Buttons and links smaller than a fingertip are hard to hit on a phone.
   </Card>
-  <Card title="Valid Lang Attributes" icon="triangle-exclamation" href="/rules/a11y/valid-lang">
-    Checks that all lang attributes on the page have valid values
+  <Card title="lang on elements below html: validating every tag" icon="triangle-exclamation" href="/rules/a11y/valid-lang">
+    A quoted passage marked with a bad lang tag is read in the wrong voice.
   </Card>
-  <Card title="Video Captions" icon="triangle-exclamation" href="/rules/a11y/video-captions">
-    Checks that videos have captions or transcripts
+  <Card title="Video captions: track elements and embedded players" icon="triangle-exclamation" href="/rules/a11y/video-captions">
+    A video with no caption track excludes deaf and hard of hearing viewers.
   </Card>
-  <Card title="Zoom Disabled" icon="circle-exclamation" href="/rules/a11y/zoom-disabled">
-    Checks if viewport meta tag disables user zoom
+  <Card title="user-scalable=no: viewport settings that block zoom" icon="circle-exclamation" href="/rules/a11y/zoom-disabled">
+    A viewport that caps the zoom level stops low-vision users enlarging text.
   </Card>
 </CardGroup>
 

--- a/docs/rules/a11y/index.mdx
+++ b/docs/rules/a11y/index.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Accessibility"
-description: "Accessibility for users with disabilities"
+description: "61 audit rules covering accessible names, ARIA, forms, structure, tables, language and zoom, run on every crawled page."
 ---
 
-Accessibility for users with disabilities
+squirrelscan runs 61 accessibility rules against every page it crawls. They cover accessible names for buttons, links and form controls, ARIA roles and attributes, heading and landmark structure, tables, language declarations and viewport settings. Every finding names the element with a selector and quotes the exact report message, so a coding agent can go straight to the markup that needs changing.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 
 ## Rules
 

--- a/docs/rules/a11y/index.mdx
+++ b/docs/rules/a11y/index.mdx
@@ -3,7 +3,7 @@ title: "Accessibility"
 description: "61 audit rules covering accessible names, ARIA, forms, structure, tables, language and zoom, run on every crawled page."
 ---
 
-squirrelscan runs 61 accessibility rules against every page it crawls. They cover accessible names for buttons, links and form controls, ARIA roles and attributes, heading and landmark structure, tables, language declarations and viewport settings. Every finding names the element with a selector and quotes the exact report message, so a coding agent can go straight to the markup that needs changing.
+squirrelscan runs 61 accessibility rules against every page it crawls. They cover accessible names for buttons, links and form controls, ARIA roles and attributes, heading and landmark structure, tables, language declarations and viewport settings. Each page below quotes the exact report message a rule emits, and most findings identify the offending element by selector, id or quoted text, so a coding agent can go straight to the markup that needs changing.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/input-image-alt.mdx
+++ b/docs/rules/a11y/input-image-alt.mdx
@@ -25,7 +25,7 @@ One check, `input-image-alt`, at severity error and weight 8. It finds every `in
 
 Name the action. Everything that applies to a normal submit button applies here, so if the equivalent `<button>` would read "Search", that is the `alt`.
 
-An image input is not a decorative image, so `alt=""` does not apply. An empty `alt` here leaves a button that submits the form with nothing to announce, and squirrel reports it.
+An image input is not a decorative image, so `alt=""` does not apply: it leaves a button that submits the form with no name of its own. squirrel reports it unless the element also carries an `aria-label` or `aria-labelledby`, either of which names it instead.
 
 If the coordinates are not needed, `<button type="submit">` with an `<img>` or an inline `<svg>` inside it is easier to name and easier to style.
 

--- a/docs/rules/a11y/input-image-alt.mdx
+++ b/docs/rules/a11y/input-image-alt.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Input Image Alt"
-description: "Checks that input type='image' elements have alt text"
+title: "input type=image without alt: an unnamed submit button"
+description: "An image input is a submit button drawn as a picture, and with no alt it announces nothing. squirrel checks every one on the page."
 ---
 
-Checks that input type='image' elements have alt text
+## What an image input is
+
+`<input type="image">` is a submit button that uses a graphic instead of a label. It submits the form and sends the click coordinates with it, which is why it still turns up in old search forms and image maps.
+
+Because it is a button, its `alt` is its accessible name, not a description of the picture. A magnifying glass icon on a search form is named "Search", not "magnifying glass".
+
+## What squirrel checks
+
+One check, `input-image-alt`, at severity error and weight 8. It finds every `input[type="image"]`.
+
+- Fail when the element has no non-empty `alt`, no non-empty `aria-label` and no `aria-labelledby`. Report message: `N image input(s) without alt text`. Every offender is listed, identified by its `name`, then by the filename taken from its `src`, then as `input[type=image]`.
+- Pass with `N image input(s) have alt text`.
+- Info with `No image inputs found`.
+
+## How to fix it
+
+```html
+<input type="image" src="/icons/search.svg" alt="Search">
+```
+
+Name the action. Everything that applies to a normal submit button applies here, so if the equivalent `<button>` would read "Search", that is the `alt`.
+
+An image input is not a decorative image, so `alt=""` does not apply. An empty `alt` here leaves a button that submits the form with nothing to announce, and squirrel reports it.
+
+If the coordinates are not needed, `<button type="submit">` with an `<img>` or an inline `<svg>` inside it is easier to name and easier to style.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks that input type='image' elements have alt text
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Image inputs (input type='image') are submit buttons that use an image. They must have alt text describing the button's action. Example: `<input type='image' src='submit.png' alt='Submit form'>`
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/input-image-alt"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/button-name](/rules/a11y/button-name): the same requirement for ordinary buttons.
+- [images/alt-text](/rules/images/alt-text): `alt` on content images rather than on controls.
+- [a11y/image-redundant-alt](/rules/a11y/image-redundant-alt): alt text that exists but repeats the obvious.
+- [a11y/form-labels](/rules/a11y/form-labels): the other controls in the same form.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [input type=image, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/image)
+- [Understanding SC 1.1.1 Non-text Content, W3C](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
+- [H36: Using alt attributes on images used as submit buttons, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H36)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unnamed image input is listed, with no cap on the count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/input-image-alt.mdx
+++ b/docs/rules/a11y/input-image-alt.mdx
@@ -66,7 +66,7 @@ disable = ["*"]
 - [a11y/button-name](/rules/a11y/button-name): the same requirement for ordinary buttons.
 - [images/alt-text](/rules/images/alt-text): `alt` on content images rather than on controls.
 - [a11y/image-redundant-alt](/rules/a11y/image-redundant-alt): alt text that exists but repeats the obvious.
-- [a11y/form-labels](/rules/a11y/form-labels): the other controls in the same form.
+- [a11y/form-labels](/rules/a11y/form-labels): the other controls in the same form, checked for an associated label.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/input-types.mdx
+++ b/docs/rules/a11y/input-types.mdx
@@ -1,9 +1,47 @@
 ---
-title: "Input Types"
-description: "Checks that fields use the right input type and keyboard hint, and that forms keep native validation"
+title: "Input type, enterkeyhint and novalidate on forms"
+description: "type=text where type=email belongs costs mobile users the right keyboard. squirrel checks three ways a form opts out of browser help."
 ---
 
-Checks that fields use the right input type and keyboard hint, and that forms keep native validation
+## What the browser gives you for free
+
+A typed input brings a matching mobile keyboard and a validation pass with it. `type="email"` shows the at sign, `type="tel"` shows a keypad, `type="url"` shows a slash. `type="text"` shows the full QWERTY layout and nothing else.
+
+`enterkeyhint` relabels the return key on that keyboard, so it reads Next through a form and Send or Done at the end. And `novalidate` turns off the browser's constraint validation for a whole form, which is the right call only when your own code has taken the job over.
+
+## What squirrel checks
+
+Three checks, at rule severity warning.
+
+`input-types` compares each field's `type` against the purpose inferred from its `name`, `id`, label and placeholder.
+
+- Fail when a digit-string field such as a postal code, phone number or card number uses `type="number"`. Report message: `N digit-string field(s) use type="number"`, extended with `, M other field(s) use the wrong type` when both problems appear. Items read `postal code field uses type="number", which strips leading zeros and drops non-numeric input`.
+- Warn when a field is `type="text"` where a specific type is correct. Report message: `N field(s) use type="text" where a specific type is correct`, with items reading `type="text" where type="email" is correct`. An `inputmode` that delivers the same keyboard is accepted instead: `email`, `tel` and `url` for their matching types, and `numeric` or `decimal` for `number`.
+- Pass with `N field(s) use the correct input type`, or skip with `No inputs with an evident type found`.
+
+`enterkeyhint` looks at forms with three or more data fields.
+
+- Warn when no field in such a form sets `enterkeyhint`. Report message: `N multi-field form(s) set no enterkeyhint`, with items reading `5-field form, no field sets enterkeyhint`.
+- Pass with `N multi-field form(s) set enterkeyhint`, or skip with `No forms with 3 or more fields found`.
+
+`form-novalidate` looks at forms carrying the `novalidate` attribute.
+
+- Warn when such a form still declares constraints and ships nothing of its own to replace them. Constraints means any of `required`, `pattern`, `min`, `max`, `minlength`, `maxlength` or `step`, or a self-validating type: `email`, `url`, `number`, `date`, `time`, `month` or `week`. Report message: `N form(s) set novalidate but still rely on browser constraints`.
+- Pass with `N form(s) set novalidate deliberately`, or skip with `No forms set novalidate`.
+
+A replacement counts when the form has `onsubmit` or `oninvalid`, when it contains an element matching `[oninvalid]`, `[aria-invalid]`, `[aria-errormessage]`, `[role="alert"]`, `[aria-live]`, `[data-error]`, `[data-validate]`, `[data-val]` or `[data-rules]`, or when the page's inline scripts mention `checkValidity`, `reportValidity`, `setCustomValidity`, react-hook-form, Formik, jQuery Validate, Parsley or just-validate.
+
+## How to fix it
+
+```html
+<input type="email" name="email" autocomplete="email" enterkeyhint="next" required>
+<input type="text" inputmode="numeric" name="postcode"
+       autocomplete="postal-code" enterkeyhint="done" required>
+```
+
+Use `type="number"` only for quantities you would do arithmetic on. For a digit string, keep `type="text"` and add `inputmode="numeric"`: that gives the keypad without stripping leading zeros or discarding anything that is not a valid float.
+
+The `novalidate` check is about intent, not about the attribute. A form that validates in JavaScript and shows its own messages passes, because one of the custom-validation signals is present.
 
 | | |
 |---|---|
@@ -12,38 +50,6 @@ Checks that fields use the right input type and keyboard hint, and that forms ke
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## What it checks
-
-Three ways markup opts out of help the browser gives for free. Each check reports the exact node with a selector and its opening tag.
-
-### `input-types`
-
-`fail` when a digit string uses `type="number"` (a postal code, phone number, card number or security code). `warn` when `type="text"` is used where `email`, `tel`, `url` or `number` is correct. A field that already sets a matching `inputmode` is a deliberate choice and is left alone.
-
-### `enterkeyhint`
-
-`warn` when a form with three or more fields sets `enterkeyhint` on none of them. Shorter forms are skipped.
-
-### `form-novalidate`
-
-`warn` only on a genuine intent mismatch: the form sets `novalidate`, still declares constraints (`required`, `pattern`, `min`/`max`, `minlength`/`maxlength`, `step`, or a validating input type), and ships no validation of its own. A form with an error region, an `onsubmit` handler, `aria-invalid`, or a page that calls `checkValidity()` is left alone, as is a `novalidate` form with no constraints to disable.
-
-## Solution
-
-Use the input type that matches the data. `type="email"`, `type="tel"`, `type="url"` and `type="number"` each summon the right mobile keyboard and bring free browser validation with them, while `type="text"` gives users the full QWERTY keyboard and no help at all.
-
-Never use `type="number"` for a digit string such as a postal code, phone number or card number: it strips leading zeros, adds a spinner, and silently discards anything that is not a valid float. If you need a numeric keypad without those side effects, keep `type="text"` and add `inputmode="numeric"`:
-
-```html
-<label for="zip">ZIP code</label>
-<input id="zip" name="postalCode" type="text" inputmode="numeric"
-       autocomplete="postal-code" enterkeyhint="next">
-```
-
-On forms with several fields, set `enterkeyhint="next"` on each field and `enterkeyhint="send"` or `"done"` on the last one so the mobile return key says what it does.
-
-Only add `novalidate` when your own JavaScript takes over validation. On a form that still declares `required` or `pattern` and ships no replacement, it removes the browser's error messages and hands users nothing back.
 
 ## Enable / disable
 
@@ -68,3 +74,31 @@ disable = ["a11y/*"]
 enable = ["a11y/input-types"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/autocomplete-tokens](/rules/a11y/autocomplete-tokens): the autofill token that belongs on the same fields.
+- [a11y/form-labels](/rules/a11y/form-labels): the label the purpose is partly inferred from.
+- [a11y/paste-inputs](/rules/a11y/paste-inputs): the other way forms make typing harder than it needs to be.
+- [mobile/font-size](/rules/mobile/font-size): text size on the same screens these keyboards appear on.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [inputmode, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode)
+- [enterkeyhint, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/enterkeyhint)
+- [Constraint validation, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Constraint_validation)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. The three checks are reported separately, so you can act on one without the others. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/input-types.mdx
+++ b/docs/rules/a11y/input-types.mdx
@@ -78,7 +78,7 @@ disable = ["*"]
 ## Related rules
 
 - [a11y/autocomplete-tokens](/rules/a11y/autocomplete-tokens): the autofill token that belongs on the same fields.
-- [a11y/form-labels](/rules/a11y/form-labels): the label the purpose is partly inferred from.
+- [a11y/form-labels](/rules/a11y/form-labels): inputs, textareas and selects with no `<label>`, `aria-label` or `title`.
 - [a11y/paste-inputs](/rules/a11y/paste-inputs): the other way forms make typing harder than it needs to be.
 - [mobile/font-size](/rules/mobile/font-size): text size on the same screens these keyboards appear on.
 

--- a/docs/rules/a11y/label-content-name-mismatch.mdx
+++ b/docs/rules/a11y/label-content-name-mismatch.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Visible label missing from the accessible name"
-description: "A button showing 'Search' with aria-label 'Find products' cannot be activated by voice. squirrel compares the two on every control."
+description: "A button showing 'Search' with aria-label 'Find products' may not respond when a user speaks its visible label. squirrel compares the two."
 ---
 
 ## What label in name means
 
-Voice control users say what they see: "click Search". The software matches the spoken words against the control's accessible name, not against the pixels. When the name does not contain the visible words the command does nothing, and there is no error explaining why.
+Voice control users say what they see: "click Search". The software matches the spoken words against the control's accessible name, not against the pixels. When the name does not contain the visible words that command fails, with no error explaining why, and the user has to find another way in.
 
 WCAG success criterion 2.5.3 Label in Name, Level A, requires the visible label text to be part of the accessible name. Adding context around it is fine; replacing it is not.
 

--- a/docs/rules/a11y/label-content-name-mismatch.mdx
+++ b/docs/rules/a11y/label-content-name-mismatch.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Label Content Name Mismatch"
-description: "Checks that visible label text is part of accessible name"
+title: "Visible label missing from the accessible name"
+description: "A button showing 'Search' with aria-label 'Find products' cannot be activated by voice. squirrel compares the two on every control."
 ---
 
-Checks that visible label text is part of accessible name
+## What label in name means
+
+Voice control users say what they see: "click Search". The software matches the spoken words against the control's accessible name, not against the pixels. When the name does not contain the visible words the command does nothing, and there is no error explaining why.
+
+WCAG success criterion 2.5.3 Label in Name, Level A, requires the visible label text to be part of the accessible name. Adding context around it is fine; replacing it is not.
+
+## What squirrel checks
+
+One check, `label-content-name-mismatch`, at severity error. It looks at elements carrying both an `aria-label` and visible text: `button`, `a`, `input`, `select`, and anything with `role="button"` or `role="link"`.
+
+Visible text is gathered by walking the element's child nodes, skipping any subtree marked `aria-hidden="true"` or carrying the `hidden` attribute. Both strings are lowercased and their whitespace collapsed before comparison.
+
+- Fail when the `aria-label` does not contain the visible text as a substring. Report message: `N element(s) where visible text doesn't match accessible name`. Items read `button: visible="search" vs aria-label="find products"`, truncating each side at 20 characters, up to ten with a count of the rest. The finding carries the issue `Voice control users may not be able to activate these controls`.
+- Pass with `Visible labels match accessible names`.
+- Info with `No elements with aria-label and visible text found`.
+
+## How to fix it
+
+```html
+<button aria-label="Search products">Search</button>
+```
+
+Start the `aria-label` with the visible words and add the extra context after them. That satisfies both the voice command and the screen reader.
+
+A badge inside the control is the usual false positive. `<button aria-label="Notifications">Notifications <span>3</span></button>` has visible text "notifications 3", which the label does not contain. Mark the badge `aria-hidden="true"`, or include the count in the label.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks that visible label text is part of accessible name
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-For controls with visible labels, the accessible name should contain the visible text. Voice control users say what they see - if the accessible name doesn't include the visible label, voice commands won't work. Example: A button showing 'Search' should not have aria-label='Find products'.
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/label-content-name-mismatch"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/button-name](/rules/a11y/button-name): controls with no accessible name at all.
+- [a11y/link-text](/rules/a11y/link-text): link names that exist but say nothing useful.
+- [a11y/aria-labels](/rules/a11y/aria-labels): where `aria-label` is the right answer rather than the problem.
+- [a11y/form-field-multiple-labels](/rules/a11y/form-field-multiple-labels): two labels competing to name one control.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Understanding SC 2.5.3 Label in Name, W3C](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html)
+- [aria-label, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
+- [Accessible name and description computation, W3C](https://www.w3.org/TR/accname-1.2/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each finding shows the visible text and the accessible name side by side. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/label-content-name-mismatch.mdx
+++ b/docs/rules/a11y/label-content-name-mismatch.mdx
@@ -15,7 +15,7 @@ One check, `label-content-name-mismatch`, at severity error. It looks at element
 
 Visible text is gathered by walking the element's child nodes, skipping any subtree marked `aria-hidden="true"` or carrying the `hidden` attribute. Both strings are lowercased and their whitespace collapsed before comparison.
 
-- Fail when the `aria-label` does not contain the visible text as a substring. Report message: `N element(s) where visible text doesn't match accessible name`. Items read `button: visible="search" vs aria-label="find products"`, truncating each side at 20 characters, up to ten with a count of the rest. The finding carries the issue `Voice control users may not be able to activate these controls`.
+- Fail when the `aria-label` does not contain the visible text as a substring. Report message: `N element(s) where visible text doesn't match accessible name`. Items read `button: visible="search" vs aria-label="find products"`, truncating each side at 20 characters. Only the first ten are listed. The finding carries the issue `Voice control users may not be able to activate these controls`.
 - Pass with `Visible labels match accessible names`.
 - Info with `No elements with aria-label and visible text found`.
 

--- a/docs/rules/a11y/landmark-one-main.mdx
+++ b/docs/rules/a11y/landmark-one-main.mdx
@@ -71,8 +71,8 @@ disable = ["*"]
 
 - [a11y/landmark-regions](/rules/a11y/landmark-regions): the wider sweep across `main`, `nav` and `footer`.
 - [a11y/skip-link](/rules/a11y/skip-link): the bypass check, which accepts `<main>` only alongside a `<nav>` landmark or an early heading.
-- [a11y/heading-order](/rules/a11y/heading-order): the other structure screen readers navigate by.
-- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): roles that need a landmark or container above them.
+- [a11y/heading-order](/rules/a11y/heading-order): heading levels that skip, the other structure screen readers navigate by.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): roles such as `listitem` and `tab` that need a particular container role above them.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/landmark-one-main.mdx
+++ b/docs/rules/a11y/landmark-one-main.mdx
@@ -15,7 +15,7 @@ One check, `landmark-one-main`, at rule severity warning. It counts every `<main
 
 - Warn with `Page has no main landmark` when the count is zero, expecting `One <main> element or role='main'`.
 - Pass with `Page has exactly one main landmark` when the count is one.
-- Fail with `Page has N main landmarks (should be 1)` when the count is above one. Each is listed as `main#id`, `main.class` or a bare tag name, with the issue `Multiple main landmarks confuse navigation`.
+- Fail with `Page has N main landmarks (should be 1)` when the count is above one. Each is listed by its own tag, as `tag#id`, `tag.class` or a bare tag name, so a `<div role="main">` appears as `div#content`. The finding carries the issue `Multiple main landmarks confuse navigation`.
 
 Having none is a warning while having several is a failure. That is deliberate: a missing landmark degrades navigation, while duplicated ones actively mislead.
 
@@ -70,7 +70,7 @@ disable = ["*"]
 ## Related rules
 
 - [a11y/landmark-regions](/rules/a11y/landmark-regions): the wider sweep across `main`, `nav` and `footer`.
-- [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism that accepts `<main>` as an alternative.
+- [a11y/skip-link](/rules/a11y/skip-link): the bypass check, which accepts `<main>` only alongside a `<nav>` landmark or an early heading.
 - [a11y/heading-order](/rules/a11y/heading-order): the other structure screen readers navigate by.
 - [a11y/aria-required-parent](/rules/a11y/aria-required-parent): roles that need a landmark or container above them.
 

--- a/docs/rules/a11y/landmark-one-main.mdx
+++ b/docs/rules/a11y/landmark-one-main.mdx
@@ -1,9 +1,39 @@
 ---
-title: "One Main Landmark"
-description: "Checks that the page has exactly one main landmark"
+title: "One main landmark per page, and what happens without"
+description: "A page with no main landmark, or with two, breaks the jump-to-content shortcut screen reader users rely on. squirrel counts them."
 ---
 
-Checks that the page has exactly one main landmark
+## What the main landmark is
+
+`<main>` marks the primary content of a page, the part that is not header, navigation, sidebar or footer. Screen readers offer a shortcut straight to it, which is how a user skips the same navigation on every page without a skip link.
+
+Exactly one per page is the rule. Zero means the shortcut has nowhere to go. Two means the user has to guess which one holds the content they came for.
+
+## What squirrel checks
+
+One check, `landmark-one-main`, at rule severity warning. It counts every `<main>` element and every element with `role="main"`.
+
+- Warn with `Page has no main landmark` when the count is zero, expecting `One <main> element or role='main'`.
+- Pass with `Page has exactly one main landmark` when the count is one.
+- Fail with `Page has N main landmarks (should be 1)` when the count is above one. Each is listed as `main#id`, `main.class` or a bare tag name, with the issue `Multiple main landmarks confuse navigation`.
+
+Having none is a warning while having several is a failure. That is deliberate: a missing landmark degrades navigation, while duplicated ones actively mislead.
+
+## How to fix it
+
+```html
+<header>...</header>
+<nav aria-label="Primary">...</nav>
+<main>
+  <h1>Pricing</h1>
+  ...
+</main>
+<footer>...</footer>
+```
+
+Wrap the page's own content, and only that, in a single `<main>`. Headers, navigation and footers stay outside it.
+
+Two main landmarks usually means a layout component renders one and a page component renders another. Decide which layer owns it, and take it out of the other.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks that the page has exactly one main landmark
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Each page should have exactly one `<main>` element or element with role='main'. This helps screen reader users quickly navigate to the primary content. Multiple main landmarks confuse navigation. Use `<aside>`, `<nav>`, or other landmarks for secondary content.
 
 ## Enable / disable
 
@@ -40,3 +66,31 @@ disable = ["a11y/*"]
 enable = ["a11y/landmark-one-main"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/landmark-regions](/rules/a11y/landmark-regions): the wider sweep across `main`, `nav` and `footer`.
+- [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism that accepts `<main>` as an alternative.
+- [a11y/heading-order](/rules/a11y/heading-order): the other structure screen readers navigate by.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): roles that need a landmark or container above them.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The main element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main)
+- [Landmark regions, WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
+- [Page regions, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/page-structure/regions/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. A missing landmark warns, duplicated landmarks fail and are listed individually. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/landmark-regions.mdx
+++ b/docs/rules/a11y/landmark-regions.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Landmark Regions"
-description: "Checks for proper landmark regions (main, nav, footer)"
+title: "Landmark regions: main, nav and footer on every page"
+description: "Screen reader users jump between landmarks instead of reading top to bottom. squirrel reports which of the three a page has."
 ---
 
-Checks for proper landmark regions (main, nav, footer)
+## What a landmark region is
+
+Landmarks divide a page into named areas a screen reader can jump between: `<main>` for the content, `<nav>` for navigation, `<header>`, `<footer>` and `<aside>` for the furniture around it. A user presses one key to move between them instead of tabbing through the header on every page.
+
+The semantic elements carry their roles implicitly, so `<nav>` needs no `role="navigation"`. The ARIA roles exist for markup that cannot use the elements.
+
+## What squirrel checks
+
+Three checks, at rule severity info and weight 3. This rule reports structure rather than failure, which is why its weight is the lowest in the category.
+
+- `landmark-main` warns with `No <main> landmark found` and the value `Add <main> element around primary content`, or warns with `Multiple main landmarks (N)` and the value `Pages should have exactly one <main> element`, or passes with `Main landmark present`.
+- `landmark-nav` passes with `N navigation landmark(s) found`, or returns info with `No <nav> landmark found`.
+- `landmark-footer` passes with `Footer landmark present`, or returns info with `No <footer> landmark found`.
+
+Only `main` warns. Navigation and footer landmarks are useful but not required, so their absence is reported as information.
+
+## How to fix it
+
+```html
+<header>...</header>
+<nav aria-label="Primary">...</nav>
+<main>...</main>
+<footer>...</footer>
+```
+
+Use the elements rather than the roles wherever the markup allows it. They are shorter, they cannot be misspelled, and they keep the visual structure and the announced structure in one place.
+
+Where a page has more than one `<nav>`, give each an `aria-label` so a screen reader can tell "Primary navigation" from "Breadcrumb". Landmarks of the same type are otherwise announced identically.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks for proper landmark regions (main, nav, footer)
 | **Scope** | Per-page |
 | **Severity** | info |
 | **Weight** | 3/10 |
-
-## Solution
-
-Landmark regions help screen reader users navigate page structure. Use semantic HTML5 elements: `<main>` for primary content, `<nav>` for navigation, `<header>` for page header, `<footer>` for footer, `<aside>` for sidebars, and `<section>`/`<article>` for content sections. Alternatively, use ARIA roles: role='main', role='navigation', etc. Each page should have exactly one `<main>` element.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/landmark-regions"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/landmark-one-main](/rules/a11y/landmark-one-main): the stricter check on the `<main>` count.
+- [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism landmarks can stand in for.
+- [a11y/heading-order](/rules/a11y/heading-order): the outline users navigate alongside landmarks.
+- [a11y/aria-labels](/rules/a11y/aria-labels): naming repeated landmarks so they can be told apart.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Page regions, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/page-structure/regions/)
+- [Landmark regions, WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
+- [The main element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. The three landmarks are reported as separate checks, so a missing footer does not hide a missing main. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/landmark-regions.mdx
+++ b/docs/rules/a11y/landmark-regions.mdx
@@ -68,7 +68,7 @@ disable = ["*"]
 
 - [a11y/landmark-one-main](/rules/a11y/landmark-one-main): the stricter check on the `<main>` count.
 - [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism landmarks can stand in for.
-- [a11y/heading-order](/rules/a11y/heading-order): the outline users navigate alongside landmarks.
+- [a11y/heading-order](/rules/a11y/heading-order): heading levels that skip a step in the outline users navigate alongside landmarks.
 - [a11y/aria-labels](/rules/a11y/aria-labels): accessible names for buttons and interactive `<svg>` elements inside those regions.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/a11y/landmark-regions.mdx
+++ b/docs/rules/a11y/landmark-regions.mdx
@@ -69,7 +69,7 @@ disable = ["*"]
 - [a11y/landmark-one-main](/rules/a11y/landmark-one-main): the stricter check on the `<main>` count.
 - [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism landmarks can stand in for.
 - [a11y/heading-order](/rules/a11y/heading-order): the outline users navigate alongside landmarks.
-- [a11y/aria-labels](/rules/a11y/aria-labels): naming repeated landmarks so they can be told apart.
+- [a11y/aria-labels](/rules/a11y/aria-labels): accessible names for buttons and interactive `<svg>` elements inside those regions.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/link-in-text-block.mdx
+++ b/docs/rules/a11y/link-in-text-block.mdx
@@ -7,7 +7,7 @@ description: "A link inside body text needs more than color to be visible. squir
 
 A link inside a paragraph has to be distinguishable from the words around it. Color alone does not do that, because a reader with a color vision deficiency may see the link and the surrounding text as the same shade.
 
-WCAG success criterion 1.4.1 Use of Color, Level A, covers this. An underline is the simplest answer. The alternative accepted by WCAG technique G183 is a color with at least 3:1 contrast against the surrounding text, plus an extra visual cue on hover and focus.
+WCAG success criterion 1.4.1 Use of Color, Level A, covers this. An underline is the simplest answer. The alternative documented in WCAG technique G183 is a link color with at least 3:1 contrast against the surrounding static text, on top of each color meeting its own contrast requirement against the background.
 
 ## What squirrel checks
 
@@ -15,7 +15,7 @@ One check, `link-in-text-block`, at severity warning. It looks inside text-beari
 
 For each `a[href]` inside one of those, it flags two markup patterns:
 
-- an inline `style` that mentions `text-decoration` and either sets it to `none` or does not mention `underline`
+- an inline `style` that contains the substring `text-decoration` and either contains `none` anywhere in the value or does not contain `underline`. The tests are plain substring matches over the whole attribute, so `text-decoration: underline; display: none` also matches.
 - a `class` containing `no-underline` or `text-decoration-none`
 
 Findings are reported as `N link(s) in text may lack underlines`, quoting the first 30 characters of each link's text, capped at the first ten. The finding carries the note `Links need visual distinction beyond color` and the suggestion `Ensure 3:1 contrast with surrounding text or add underlines`. With nothing flagged the check passes as `Links in text blocks appear distinguishable`, and with no links in text at all it returns info with `No links found in text blocks`.
@@ -69,7 +69,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/color-contrast](/rules/a11y/color-contrast): the contrast ratio the alternative approach depends on.
+- [a11y/color-contrast](/rules/a11y/color-contrast): text against its background. It does not measure link text against the words around it, which is what G183 needs.
 - [a11y/link-text](/rules/a11y/link-text): what those links say once they are visible.
 - [a11y/focus-visible](/rules/a11y/focus-visible): the keyboard equivalent of the same problem.
 - [links/anchor-text](/rules/links/anchor-text): the same links judged as ranking signals.

--- a/docs/rules/a11y/link-in-text-block.mdx
+++ b/docs/rules/a11y/link-in-text-block.mdx
@@ -1,9 +1,39 @@
 ---
-title: "Link in Text Block"
-description: "Checks that links in text blocks are visually distinguishable"
+title: "Links in a paragraph told apart by color alone"
+description: "A link inside body text needs more than color to be visible. squirrel flags links whose markup removes the underline."
 ---
 
-Checks that links in text blocks are visually distinguishable
+## What the requirement is
+
+A link inside a paragraph has to be distinguishable from the words around it. Color alone does not do that, because a reader with a color vision deficiency may see the link and the surrounding text as the same shade.
+
+WCAG success criterion 1.4.1 Use of Color, Level A, covers this. An underline is the simplest answer. The alternative accepted by WCAG technique G183 is a color with at least 3:1 contrast against the surrounding text, plus an extra visual cue on hover and focus.
+
+## What squirrel checks
+
+One check, `link-in-text-block`, at severity warning. It looks inside text-bearing elements only: `<p>`, `<li>`, `<td>`, `<th>`, `<dd>`, `<blockquote>` and `<figcaption>`.
+
+For each `a[href]` inside one of those, it flags two markup patterns:
+
+- an inline `style` that mentions `text-decoration` and either sets it to `none` or does not mention `underline`
+- a `class` containing `no-underline` or `text-decoration-none`
+
+Findings are reported as `N link(s) in text may lack underlines`, quoting the first 30 characters of each link's text, up to ten with a count of the rest. The finding carries the note `Links need visual distinction beyond color` and the suggestion `Ensure 3:1 contrast with surrounding text or add underlines`. With nothing flagged the check passes as `Links in text blocks appear distinguishable`, and with no links in text at all it returns info with `No links found in text blocks`.
+
+Only inline styles and those two class names are visible to it. A stylesheet rule setting `a { text-decoration: none }` is not fetched, so a pass here is not evidence that the links are distinguishable.
+
+## How to fix it
+
+```css
+article a {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+```
+
+Underline links in running text and reserve the undecorated style for navigation and buttons, where position already says what they are.
+
+`text-underline-offset` and `text-decoration-thickness` make an underline sit comfortably under the text, which removes most of the reason designers take it off.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks that links in text blocks are visually distinguishable
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Links within text blocks must be distinguishable by more than just color (for color-blind users). Use underlines, bold, borders, or other visual indicators. Exception: Links can rely on color alone if the contrast ratio between link and surrounding text is at least 3:1 and you provide additional cues on hover/focus.
 
 ## Enable / disable
 
@@ -40,3 +66,31 @@ disable = ["a11y/*"]
 enable = ["a11y/link-in-text-block"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/color-contrast](/rules/a11y/color-contrast): the contrast ratio the alternative approach depends on.
+- [a11y/link-text](/rules/a11y/link-text): what those links say once they are visible.
+- [a11y/focus-visible](/rules/a11y/focus-visible): the keyboard equivalent of the same problem.
+- [links/anchor-text](/rules/links/anchor-text): the same links judged as ranking signals.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Understanding SC 1.4.1 Use of Color, W3C](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)
+- [G183: Using a contrast ratio of 3:1 with surrounding text, W3C](https://www.w3.org/WAI/WCAG22/Techniques/general/G183)
+- [text-decoration, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each flagged link is quoted by its opening words. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/link-in-text-block.mdx
+++ b/docs/rules/a11y/link-in-text-block.mdx
@@ -18,7 +18,7 @@ For each `a[href]` inside one of those, it flags two markup patterns:
 - an inline `style` that mentions `text-decoration` and either sets it to `none` or does not mention `underline`
 - a `class` containing `no-underline` or `text-decoration-none`
 
-Findings are reported as `N link(s) in text may lack underlines`, quoting the first 30 characters of each link's text, up to ten with a count of the rest. The finding carries the note `Links need visual distinction beyond color` and the suggestion `Ensure 3:1 contrast with surrounding text or add underlines`. With nothing flagged the check passes as `Links in text blocks appear distinguishable`, and with no links in text at all it returns info with `No links found in text blocks`.
+Findings are reported as `N link(s) in text may lack underlines`, quoting the first 30 characters of each link's text, capped at the first ten. The finding carries the note `Links need visual distinction beyond color` and the suggestion `Ensure 3:1 contrast with surrounding text or add underlines`. With nothing flagged the check passes as `Links in text blocks appear distinguishable`, and with no links in text at all it returns info with `No links found in text blocks`.
 
 Only inline styles and those two class names are visible to it. A stylesheet rule setting `a { text-decoration: none }` is not fetched, so a pass here is not evidence that the links are distinguishable.
 

--- a/docs/rules/a11y/link-text.mdx
+++ b/docs/rules/a11y/link-text.mdx
@@ -65,7 +65,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/aria-labels](/rules/a11y/aria-labels): the icon-only case, including `<svg>` elements that are themselves clickable.
+- [a11y/aria-labels](/rules/a11y/aria-labels): accessible names for buttons and clickable `<svg>` elements. It does not look at links.
 - [a11y/identical-links-same-purpose](/rules/a11y/identical-links-same-purpose): identical link text pointing at different pages.
 - [a11y/label-content-name-mismatch](/rules/a11y/label-content-name-mismatch): an `aria-label` that does not contain the visible words.
 - [links/anchor-text](/rules/links/anchor-text): the same text read as a ranking signal rather than a name.

--- a/docs/rules/a11y/link-text.mdx
+++ b/docs/rules/a11y/link-text.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Link Text"
-description: "Checks for descriptive link text"
+title: "Link text: why 'click here' fails and what to use"
+description: "Links reading 'click here', and links wrapping an unlabeled icon, give screen reader users nothing to go on. squirrel lists both kinds."
 ---
 
-Checks for descriptive link text
+## What descriptive link text is
+
+Screen readers can list every link on a page and read them one after another, stripped of the sentence around them. A list of twelve links that all say "read more" is unusable. WCAG success criterion 2.4.4 Link Purpose (In Context), Level A, asks that the purpose be clear from the link text, or from the sentence or list item it sits in.
+
+An icon-only link has the same problem in a harder form: there is no text at all. It needs an `aria-label`, an `<svg><title>`, or an image with `alt`.
+
+## What squirrel checks
+
+Two checks, at rule severity warning. Both walk every `a[href]`, skipping fragment-only links whose `href` starts with `#` and links using an unsafe scheme such as `javascript:`.
+
+- `link-text-empty` fails when a link has neither an accessible name from `aria-labelledby`, `aria-label` or `title`, nor accessible content: text, an `<img>` with non-empty `alt`, an `<svg>` carrying a `<title>`, `aria-label` or `aria-labelledby`, or a `[role="img"]` with an `aria-label`. Report message: `N link(s) with no accessible text`. Each item is the first 50 characters of the `href`, labelled with the reason: `empty`, `svg-no-name`, `icon-font` or `role-img-no-name`.
+- `link-text-generic` warns when the link's accessible name, or its text, lowercased and stripped of punctuation, exactly matches one of 54 generic phrases. The list includes `click here`, `here`, `read more`, `learn more`, `more`, `link`, `download`, `view`, `sign up`, `submit`, `next`, `view details`, `website` and `discover`. Report message: `N link(s) with generic text`, listing each distinct phrase once.
+- `link-text` passes with `All links have descriptive text` when neither problem appears on a page that has links.
+
+## How to fix it
+
+```html
+<a href="/pricing">View our pricing plans</a>
+
+<a href="/search" aria-label="Search">
+  <svg aria-hidden="true">...</svg>
+</a>
+```
+
+Write the destination into the link text. Where the design demands a short label, keep the short text visible and put the full phrase in `aria-label`, making sure the visible words appear inside it.
+
+Matching is exact, so a download button whose visible label is precisely `Download` is reported even when the heading above it names the file. Lengthening the text to "Download the Q3 report" clears it.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks for descriptive link text
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Link text should describe the destination, not generic phrases like 'click here'. Screen reader users often navigate by links, hearing them out of context. Good: 'View our pricing plans'. Bad: 'Click here'. For icon-only links, add aria-label: `<a href='/search' aria-label='Search'>``<svg>`...`</svg>``</a>`. Empty links are especially problematic - add text or aria-label.
 
 ## Enable / disable
 
@@ -40,3 +62,31 @@ disable = ["a11y/*"]
 enable = ["a11y/link-text"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/aria-labels](/rules/a11y/aria-labels): the icon-only case, including `<svg>` elements that are themselves clickable.
+- [a11y/identical-links-same-purpose](/rules/a11y/identical-links-same-purpose): identical link text pointing at different pages.
+- [a11y/label-content-name-mismatch](/rules/a11y/label-content-name-mismatch): an `aria-label` that does not contain the visible words.
+- [links/anchor-text](/rules/links/anchor-text): the same text read as a ranking signal rather than a name.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Understanding SC 2.4.4 Link Purpose (In Context), W3C](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html)
+- [The a element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
+- [H30: Providing link text that describes the purpose of a link, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H30)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Empty links are listed by href, generic ones by phrase. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/list-structure.mdx
+++ b/docs/rules/a11y/list-structure.mdx
@@ -7,7 +7,7 @@ description: "A div between the li elements of a list changes what a screen read
 
 A screen reader announces a list by its item count: "list, 6 items". That count comes from the direct children of the `<ul>` or `<ol>`, so anything else sitting at that level either breaks the count or breaks the list entirely.
 
-The children have to be `<li>`, or elements carrying `role="listitem"` for markup that cannot use the tag. Wrappers added for styling belong inside the `<li>`, not around it.
+HTML allows `<li>` and script-supporting elements as the children of a `<ul>` or `<ol>`, and nothing else. squirrel additionally accepts an element carrying `role="listitem"`, which restores the semantics for markup that cannot use the tag even though it is not conforming HTML. Either way, wrappers added for styling belong inside the `<li>`, not around it.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/list-structure.mdx
+++ b/docs/rules/a11y/list-structure.mdx
@@ -1,9 +1,39 @@
 ---
-title: "List Structure"
-description: "Checks that ul and ol elements contain only li elements"
+title: "ul and ol with children that are not list items"
+description: "A div between the li elements of a list changes what a screen reader announces. squirrel checks the direct children of every list."
 ---
 
-Checks that ul and ol elements contain only li elements
+## What list structure is
+
+A screen reader announces a list by its item count: "list, 6 items". That count comes from the direct children of the `<ul>` or `<ol>`, so anything else sitting at that level either breaks the count or breaks the list entirely.
+
+The children have to be `<li>`, or elements carrying `role="listitem"` for markup that cannot use the tag. Wrappers added for styling belong inside the `<li>`, not around it.
+
+## What squirrel checks
+
+One check, `list-structure`, at severity error. It reads the direct children of every `<ul>` and `<ol>`.
+
+- Fail when a direct child is anything other than `<li>`, an element with `role="listitem"`, `<script>` or `<template>`. Report message: `N list(s) with invalid child elements`. Each list is named `ul#nav`, `ol.steps` or a bare tag, up to ten with a count of the rest.
+- Pass with `N list(s) are properly structured`.
+- Info with `No ul/ol lists found`.
+
+`<script>` and `<template>` are allowed, matching HTML's rule that script-supporting elements may appear between list items. The check reports the list rather than the offending child, and stops at the first bad child in each list.
+
+## How to fix it
+
+```html
+<ul>
+  <li>
+    <div class="card">
+      <h3>Team</h3>
+    </div>
+  </li>
+</ul>
+```
+
+Move the wrapper inside the `<li>`. If the container is a grid or a flex layout, put the display property on the `<ul>` and let the `<li>` elements be the grid items.
+
+Where the markup genuinely cannot use `<li>`, `role="list"` on the container and `role="listitem"` on each child restores the semantics. Both halves are needed: one without the other leaves the list broken in a different way.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks that ul and ol elements contain only li elements
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Lists (`<ul>` and `<ol>`) should only contain `<li>` elements as direct children. For custom components, you can also use elements with role='listitem'. Move other content inside `<li>` elements.
 
 ## Enable / disable
 
@@ -40,3 +66,31 @@ disable = ["a11y/*"]
 enable = ["a11y/list-structure"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/listitem](/rules/a11y/listitem): `<li>` elements whose parent is not a list.
+- [a11y/definition-list](/rules/a11y/definition-list): the same check for `<dl>`.
+- [a11y/aria-required-children](/rules/a11y/aria-required-children): `role="list"` with no items inside it.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): the same relationship seen from the item.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The ul element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul)
+- [The list role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/list_role)
+- [Understanding SC 1.3.1 Info and Relationships, W3C](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each malformed list is listed by id or class. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/listitem.mdx
+++ b/docs/rules/a11y/listitem.mdx
@@ -69,7 +69,7 @@ disable = ["*"]
 - [a11y/list-structure](/rules/a11y/list-structure): the same problem seen from the list.
 - [a11y/dlitem](/rules/a11y/dlitem): the equivalent for `<dt>` and `<dd>`.
 - [a11y/aria-required-parent](/rules/a11y/aria-required-parent): the ancestor-chain version of this check.
-- [a11y/aria-required-children](/rules/a11y/aria-required-children): a `role="list"` container with nothing inside it.
+- [a11y/aria-required-children](/rules/a11y/aria-required-children): a non-empty `role="list"` container with no item descendant. Empty containers are skipped there.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/listitem.mdx
+++ b/docs/rules/a11y/listitem.mdx
@@ -1,9 +1,36 @@
 ---
-title: "List Item Context"
-description: "Checks that li elements are inside ul, ol, or menu"
+title: "Orphaned li: list items outside ul, ol or menu"
+description: "An li whose parent is not a list is announced as a plain block of text. squirrel checks the immediate parent of every list item."
 ---
 
-Checks that li elements are inside ul, ol, or menu
+## What an orphaned list item is
+
+An `<li>` gets its meaning from the list around it. Outside one, the browser exposes it as a generic container: no item count, no position, no way to move between siblings with a screen reader shortcut.
+
+It usually happens when a wrapper is inserted for layout, or when a component renders items without rendering the list.
+
+## What squirrel checks
+
+One check, `listitem`, at severity error. For every `<li>` it reads the immediate parent.
+
+- Fail when that parent is not `<ul>`, `<ol>`, `<menu>` or an element with `role="list"`. Report message: `N li element(s) not inside a list`. Items read `li#step-2`, or `li: "Enter your email..."` quoting the first 20 characters of the text, up to ten with a count of the rest.
+- Pass with `N list item(s) are inside lists`.
+- Info with `No li elements found`.
+
+Only the immediate parent counts. A `<div>` between the `<ul>` and its items is reported here, while `a11y/aria-required-parent` walks the whole ancestor chain and lets it through.
+
+## How to fix it
+
+```html
+<ul class="grid">
+  <li>Team</li>
+  <li>Business</li>
+</ul>
+```
+
+Delete the wrapper and style the `<ul>` directly. CSS grid and flexbox both work on a list element, so the wrapper is rarely doing anything the list cannot.
+
+Where a component renders one item, move the `<ul>` up into the parent that renders the collection, so every item is emitted inside a list.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks that li elements are inside ul, ol, or menu
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-The `<li>` element must be contained within a `<ul>`, `<ol>`, or `<menu>` element. Orphaned list items lose their semantic meaning. Wrap them in an appropriate list container.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/listitem"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/list-structure](/rules/a11y/list-structure): the same problem seen from the list.
+- [a11y/dlitem](/rules/a11y/dlitem): the equivalent for `<dt>` and `<dd>`.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): the ancestor-chain version of this check.
+- [a11y/aria-required-children](/rules/a11y/aria-required-children): a `role="list"` container with nothing inside it.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The li element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li)
+- [The listitem role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listitem_role)
+- [Understanding SC 1.3.1 Info and Relationships, W3C](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each orphan is listed by id, or by the opening words of its text. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/listitem.mdx
+++ b/docs/rules/a11y/listitem.mdx
@@ -13,7 +13,7 @@ It usually happens when a wrapper is inserted for layout, or when a component re
 
 One check, `listitem`, at severity error. For every `<li>` it reads the immediate parent.
 
-- Fail when that parent is not `<ul>`, `<ol>`, `<menu>` or an element with `role="list"`. Report message: `N li element(s) not inside a list`. Items read `li#step-2`, or `li: "Enter your email..."` quoting the first 20 characters of the text, up to ten with a count of the rest.
+- Fail when that parent is not `<ul>`, `<ol>`, `<menu>` or an element with `role="list"`. Report message: `N li element(s) not inside a list`. Items read `li#step-2`, or `li: "Enter your email add..."` quoting the first 20 characters of the text, up to ten with a count of the rest.
 - Pass with `N list item(s) are inside lists`.
 - Info with `No li elements found`.
 

--- a/docs/rules/a11y/meta-refresh.mdx
+++ b/docs/rules/a11y/meta-refresh.mdx
@@ -14,8 +14,8 @@ Both take control away from the reader. Someone using a screen reader, or readin
 One check name per case, at rule severity error. The rule finds the first `<meta>` whose `http-equiv` is `refresh`, matched case-insensitively, and parses its `content` as a number of seconds optionally followed by `;url=`.
 
 - `meta-refresh-redirect` warns with `Immediate meta refresh redirect found` when a url is present and the delay is zero, carrying the issue `Use server-side 301/302 redirect instead`.
-- `meta-refresh-redirect` fails with `Meta refresh redirect after N seconds` when a url is present and the delay is above zero, carrying the issue `Timed redirects disorient users`.
-- `meta-refresh-auto` fails with `Page auto-refreshes every N seconds` when there is no url and the delay is under 20 seconds, carrying the issue `Frequent refresh disrupts screen reader users`.
+- `meta-refresh-redirect` fails with `Meta refresh redirect after N seconds` when a url is present and the delay is anything other than zero, which includes a negative or unparsable value, carrying the issue `Timed redirects disorient users`.
+- `meta-refresh-auto` fails with `Page auto-refreshes every N seconds` when there is no url and the delay parses to a number above zero and under 20, carrying the issue `Frequent refresh disrupts screen reader users`.
 - `meta-refresh-auto` warns with `Page auto-refreshes every N seconds` when there is no url and the delay is 20 seconds or more, suggesting `Provide user control over refresh`.
 - `meta-refresh` passes with `No meta refresh found`.
 

--- a/docs/rules/a11y/meta-refresh.mdx
+++ b/docs/rules/a11y/meta-refresh.mdx
@@ -70,10 +70,10 @@ disable = ["*"]
 
 ## Related rules
 
-- [links/redirect-chains](/rules/links/redirect-chains): the server-side redirects this rule points you towards.
+- [links/redirect-chains](/rules/links/redirect-chains): URLs that redirect and links pointing at them, once the redirect moves to the server.
 - [a11y/zoom-disabled](/rules/a11y/zoom-disabled): another meta tag that takes control away from the user.
 - [core/robots-meta](/rules/core/robots-meta): the other directives that live in the same `<head>`.
-- [a11y/skip-link](/rules/a11y/skip-link): keeping keyboard users oriented within a page that stays put.
+- [a11y/skip-link](/rules/a11y/skip-link): whether the page offers any way past its repeated navigation.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/meta-refresh.mdx
+++ b/docs/rules/a11y/meta-refresh.mdx
@@ -1,9 +1,40 @@
 ---
-title: "Meta Refresh"
-description: "Checks for meta refresh redirects that can disorient users"
+title: "meta http-equiv=refresh: redirects and auto-refresh"
+description: "A timed redirect moves the page out from under a screen reader user mid-sentence. squirrel reads the content value and grades it."
 ---
 
-Checks for meta refresh redirects that can disorient users
+## What meta refresh is
+
+`<meta http-equiv="refresh" content="5;url=/new">` asks the browser to load another page after a delay. With no `url` it reloads the current page on a timer instead.
+
+Both take control away from the reader. Someone using a screen reader, or reading slowly, or filling in a form, gets moved without warning and with no way to stop it. WCAG success criterion 2.2.1 Timing Adjustable, Level A, covers time limits like this, and techniques F40 and F41 name meta refresh specifically as a way to fail it.
+
+## What squirrel checks
+
+One check name per case, at rule severity error. The rule finds the first `<meta>` whose `http-equiv` is `refresh`, matched case-insensitively, and parses its `content` as a number of seconds optionally followed by `;url=`.
+
+- `meta-refresh-redirect` warns with `Immediate meta refresh redirect found` when a url is present and the delay is zero, carrying the issue `Use server-side 301/302 redirect instead`.
+- `meta-refresh-redirect` fails with `Meta refresh redirect after N seconds` when a url is present and the delay is above zero, carrying the issue `Timed redirects disorient users`.
+- `meta-refresh-auto` fails with `Page auto-refreshes every N seconds` when there is no url and the delay is under 20 seconds, carrying the issue `Frequent refresh disrupts screen reader users`.
+- `meta-refresh-auto` warns with `Page auto-refreshes every N seconds` when there is no url and the delay is 20 seconds or more, suggesting `Provide user control over refresh`.
+- `meta-refresh` passes with `No meta refresh found`.
+
+Every finding carries the raw `content` string as its value. The 20 second boundary is squirrel's own, not a threshold from the standard.
+
+Two gaps are worth knowing. Only the first matching `<meta>` is examined, and a `content="0"` with no url matches none of the branches, so it produces no finding at all.
+
+## How to fix it
+
+For a redirect, do it on the server:
+
+```
+HTTP/1.1 301 Moved Permanently
+Location: https://example.com/new
+```
+
+A 301 or 302 never renders the old page, so nothing is read out and then replaced. It is also the version search engines follow cleanly.
+
+For content that has to stay current, fetch and update the region in place with `aria-live="polite"` rather than reloading the document, and give the user a control to pause it.
 
 | | |
 |---|---|
@@ -12,10 +43,6 @@ Checks for meta refresh redirects that can disorient users
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Avoid using `<meta http-equiv='refresh'>` for redirects or auto-refresh. They can disorient users, especially those using screen readers. Use server-side redirects (301/302) instead. If content must refresh, provide a user control and warn users beforehand.
 
 ## Enable / disable
 
@@ -40,3 +67,31 @@ disable = ["a11y/*"]
 enable = ["a11y/meta-refresh"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [links/redirect-chains](/rules/links/redirect-chains): the server-side redirects this rule points you towards.
+- [a11y/zoom-disabled](/rules/a11y/zoom-disabled): another meta tag that takes control away from the user.
+- [core/robots-meta](/rules/core/robots-meta): the other directives that live in the same `<head>`.
+- [a11y/skip-link](/rules/a11y/skip-link): keeping keyboard users oriented within a page that stays put.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [F40: Failure due to using meta redirect with a time limit, W3C](https://www.w3.org/WAI/WCAG22/Techniques/failures/F40)
+- [F41: Failure due to using meta refresh to reload the page, W3C](https://www.w3.org/WAI/WCAG22/Techniques/failures/F41)
+- [meta http-equiv=refresh, HTML Standard](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. The finding quotes the raw content value so you can see the delay and the target. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/object-alt.mdx
+++ b/docs/rules/a11y/object-alt.mdx
@@ -1,9 +1,33 @@
 ---
-title: "Object Alt Text"
-description: "Checks that object elements have alternative content"
+title: "object elements with no alternative content"
+description: "An embedded object with no fallback is announced as nothing at all. squirrel checks every object element on the page."
 ---
 
-Checks that object elements have alternative content
+## What alternative content is
+
+`<object>` embeds an external resource: a PDF, an SVG, a legacy plugin document. When the resource cannot be displayed, the browser falls back to whatever sits between the opening and closing tags, and assistive technology uses the same content to describe the embed.
+
+With nothing between the tags and no label, a screen reader has an element it can find and nothing to say about it.
+
+## What squirrel checks
+
+One check, `object-alt`, at severity warning and weight 6. It covers every `<object>`, skipping any with `aria-hidden="true"` or with `role="presentation"` or `role="none"`.
+
+- Fail when the element has no non-empty `aria-label`, no `aria-labelledby` and no text content between its tags. Report message: `N object element(s) without alternative content`. Every offender is listed, identified by `name`, then by the subtype of its `type` as `object[type="pdf"]`, then by the filename from its `data` attribute as `object (report.pdf)`, then as a bare `object`.
+- Pass with `N object element(s) have alternative content`.
+- Info with `No object elements found`.
+
+## How to fix it
+
+```html
+<object data="/reports/q3.pdf" type="application/pdf" aria-label="Q3 report">
+  <a href="/reports/q3.pdf">Download the Q3 report (PDF, 1.2 MB)</a>
+</object>
+```
+
+Put a real fallback between the tags. A link to the resource is the most useful one, because it works for a browser that cannot render the embed and for a screen reader user who would rather open the file directly.
+
+For an inline SVG or an image, `<img>` is usually the better element. It has an `alt` attribute, it is easier to make responsive, and it avoids this rule entirely.
 
 | | |
 |---|---|
@@ -12,10 +36,6 @@ Checks that object elements have alternative content
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 6/10 |
-
-## Solution
-
-Object elements need alternative content for when the embedded content can't be displayed or for assistive technology. Add content between `<object>` tags as fallback, or use aria-label/aria-labelledby.
 
 ## Enable / disable
 
@@ -40,3 +60,31 @@ disable = ["a11y/*"]
 enable = ["a11y/object-alt"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/frame-title](/rules/a11y/frame-title): the same naming requirement for `<iframe>`.
+- [images/alt-text](/rules/images/alt-text): `alt` on images, the more common form of the same idea.
+- [a11y/video-captions](/rules/a11y/video-captions): the alternative content video needs.
+- [a11y/input-image-alt](/rules/a11y/input-image-alt): image inputs, which need `alt` as a button name.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The object element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/object)
+- [Understanding SC 1.1.1 Non-text Content, W3C](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
+- [H53: Using the body of the object element, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H53)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unlabeled object is listed, with no cap on the count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/object-alt.mdx
+++ b/docs/rules/a11y/object-alt.mdx
@@ -13,7 +13,7 @@ With nothing between the tags and no label, a screen reader has an element it ca
 
 One check, `object-alt`, at severity warning and weight 6. It covers every `<object>`, skipping any with `aria-hidden="true"` or with `role="presentation"` or `role="none"`.
 
-- Fail when the element has no non-empty `aria-label`, no `aria-labelledby` and no text content between its tags. Report message: `N object element(s) without alternative content`. Every offender is listed, identified by `name`, then by the subtype of its `type` as `object[type="pdf"]`, then by the filename from its `data` attribute as `object (report.pdf)`, then as a bare `object`.
+- Warn when the element has no non-empty `aria-label`, no `aria-labelledby` and no text content between its tags. Report message: `N object element(s) without alternative content`. Every offender is listed, identified by `name`, then by the subtype of its `type` as `object[type="pdf"]`, then by the filename from its `data` attribute as `object (report.pdf)`, then as a bare `object`.
 - Pass with `N object element(s) have alternative content`.
 - Info with `No object elements found`.
 

--- a/docs/rules/a11y/object-alt.mdx
+++ b/docs/rules/a11y/object-alt.mdx
@@ -5,9 +5,9 @@ description: "An embedded object with no fallback is announced as nothing at all
 
 ## What alternative content is
 
-`<object>` embeds an external resource: a PDF, an SVG, a legacy plugin document. When the resource cannot be displayed, the browser falls back to whatever sits between the opening and closing tags, and assistive technology uses the same content to describe the embed.
+`<object>` embeds an external resource: a PDF, an SVG, a legacy plugin document. When the resource cannot be displayed, the browser falls back to whatever sits between the opening and closing tags, and that fallback is what a reader gets instead.
 
-With nothing between the tags and no label, a screen reader has an element it can find and nothing to say about it.
+With nothing between the tags and no label, a screen reader has an element it can find and nothing to say about it. Where the embedded resource does render, the fallback is not shown, so the resource has to carry its own accessibility as well.
 
 ## What squirrel checks
 
@@ -25,7 +25,7 @@ One check, `object-alt`, at severity warning and weight 6. It covers every `<obj
 </object>
 ```
 
-Put a real fallback between the tags. A link to the resource is the most useful one, because it works for a browser that cannot render the embed and for a screen reader user who would rather open the file directly.
+Put a real fallback between the tags. A link to the resource is the most useful one, because it is what a browser shows when it cannot render the embed. It is not a substitute for making the embedded document accessible when the embed does render.
 
 For an inline SVG or an image, `<img>` is usually the better element. It has an `alt` attribute, it is easier to make responsive, and it avoids this rule entirely.
 

--- a/docs/rules/a11y/paste-inputs.mdx
+++ b/docs/rules/a11y/paste-inputs.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Paste Inputs"
-description: "Detects form inputs that prevent pasting"
+title: "Inputs that block paste, and why that fails users"
+description: "Blocking paste forces people to retype passwords by hand. squirrel finds onpaste, oncopy and oncut handlers that cancel the event."
 ---
 
-Detects form inputs that prevent pasting
+## What paste blocking is
+
+Some forms cancel the paste event on password and confirmation fields, on the theory that retyping proves the user knows the value. It proves nothing, and it costs a lot.
+
+A password manager cannot fill the field. A long generated password has to be transcribed by hand, which produces exactly the typos the field was trying to prevent. Users with a motor impairment, and users on a phone, lose the only practical way to enter a long string. The usual result is that people pick shorter, weaker passwords.
+
+## What squirrel checks
+
+One check, `paste-inputs`, at severity warning. It covers `<input>` of type `text`, `password`, `email`, `tel`, `url` or `search`, `<input>` with no `type` at all, and `<textarea>`.
+
+For each it reads the `onpaste`, `oncopy` and `oncut` attributes and flags any whose value contains, case-insensitively, `return false`, `return!1`, `preventDefault`, `event.returnValue=false` or `event.returnValue=!1`.
+
+- Fail with `N input(s) prevent paste`. Items read `password (blocks: paste, copy)`, naming the field by its `name`, falling back to `id`, then `placeholder`, then type. Every offender is listed.
+- Pass with `No paste-blocking inputs detected`.
+- Info with `No text inputs found`.
+
+Only inline handler attributes are read. A listener attached with `addEventListener` is invisible here, so a pass is not proof that paste works. Test it by hand on the fields that matter.
+
+## How to fix it
+
+```html
+<input type="password" name="password" autocomplete="new-password">
+```
+
+Delete the handler. There is no version of this that helps, and the standards bodies that used to recommend it have withdrawn the advice.
+
+If the goal was to stop users pasting the wrong value into a confirmation field, drop the confirmation field instead and offer a show-password toggle. That catches real typos and leaves paste working.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Detects form inputs that prevent pasting
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Remove any JavaScript that prevents pasting in form inputs. Blocking paste forces users to manually type passwords, email addresses, or other data, which increases errors and frustrates users with password managers. Users with motor impairments may rely on paste functionality. Remove onpaste='return false', event.preventDefault() on paste events, and similar anti-paste code.
 
 ## Enable / disable
 
@@ -40,3 +62,31 @@ disable = ["a11y/*"]
 enable = ["a11y/paste-inputs"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/autocomplete-tokens](/rules/a11y/autocomplete-tokens): the tokens password managers need to fill the field at all.
+- [a11y/input-types](/rules/a11y/input-types): the other ways a form refuses help the browser offers.
+- [a11y/form-labels](/rules/a11y/form-labels): naming the same fields.
+- [a11y/touch-targets](/rules/a11y/touch-targets): the other thing that makes a form hard to complete on a phone.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Element: paste event, MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/paste_event)
+- [The autocomplete attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
+- [Understanding SC 3.3.2 Labels or Instructions, W3C](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each field is listed with which of paste, copy and cut it blocks. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/paste-inputs.mdx
+++ b/docs/rules/a11y/paste-inputs.mdx
@@ -7,7 +7,7 @@ description: "Blocking paste forces people to retype passwords by hand. squirrel
 
 Some forms cancel the paste event on password and confirmation fields, on the theory that retyping proves the user knows the value. It proves nothing, and it costs a lot.
 
-A password manager cannot fill the field. A long generated password has to be transcribed by hand, which produces exactly the typos the field was trying to prevent. Users with a motor impairment, and users on a phone, lose the only practical way to enter a long string. The usual result is that people pick shorter, weaker passwords.
+Anyone transferring a password by copy and paste, from a manager, a note or another window, cannot enter it that way. A long generated password has to be transcribed by hand, which produces exactly the typos the field was trying to prevent. Users with a motor impairment, and users on a phone, lose the only practical way to enter a long string. The usual result is that people pick shorter, weaker passwords.
 
 ## What squirrel checks
 
@@ -65,7 +65,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/autocomplete-tokens](/rules/a11y/autocomplete-tokens): the tokens password managers need to fill the field at all.
+- [a11y/autocomplete-tokens](/rules/a11y/autocomplete-tokens): autofill tokens on identifiable name, contact, address and payment fields.
 - [a11y/input-types](/rules/a11y/input-types): the other ways a form refuses help the browser offers.
 - [a11y/form-labels](/rules/a11y/form-labels): naming the same fields.
 - [a11y/touch-targets](/rules/a11y/touch-targets): the other thing that makes a form hard to complete on a phone.
@@ -76,7 +76,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 
 - [Element: paste event, MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/paste_event)
 - [The autocomplete attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
-- [Understanding SC 3.3.2 Labels or Instructions, W3C](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)
+- [Understanding SC 3.3.8 Accessible Authentication (Minimum), W3C](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html)
 
 ## Check your site
 

--- a/docs/rules/a11y/paste-inputs.mdx
+++ b/docs/rules/a11y/paste-inputs.mdx
@@ -67,8 +67,8 @@ disable = ["*"]
 
 - [a11y/autocomplete-tokens](/rules/a11y/autocomplete-tokens): autofill tokens on identifiable name, contact, address and payment fields.
 - [a11y/input-types](/rules/a11y/input-types): the other ways a form refuses help the browser offers.
-- [a11y/form-labels](/rules/a11y/form-labels): naming the same fields.
-- [a11y/touch-targets](/rules/a11y/touch-targets): the other thing that makes a form hard to complete on a phone.
+- [a11y/form-labels](/rules/a11y/form-labels): whether those same password and text fields have an associated label.
+- [a11y/touch-targets](/rules/a11y/touch-targets): interactive elements with an inline dimension under 44 pixels.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
 

--- a/docs/rules/a11y/select-name.mdx
+++ b/docs/rules/a11y/select-name.mdx
@@ -1,9 +1,37 @@
 ---
-title: "Select Name"
-description: "Checks that select elements have accessible names"
+title: "Dropdowns with no accessible name: naming a select"
+description: "A select announced only as 'combo box' gives no clue what it changes. squirrel checks every select element on the page."
 ---
 
-Checks that select elements have accessible names
+## What a select name is
+
+A `<select>` announces its role and its current value. Without a name, that is all a screen reader user gets: "combo box, United Kingdom". Whether that is a shipping country, a billing country or a language is left to them to work out.
+
+The name comes from a `<label>`, from `aria-label` or `aria-labelledby`, or from `title`. It does not come from the first `<option>`: a "Choose a country" placeholder is announced as the current value, not as a label, and it disappears the moment a selection is made.
+
+## What squirrel checks
+
+One check, `select-name`, at severity error and weight 8. It covers every `<select>` on the page.
+
+A name is accepted from a non-empty `aria-label`, an `aria-labelledby` pointing at an element with text, a `<label for="...">` matching the element's `id`, an ancestor `<label>` with text, or a non-empty `title`.
+
+- Fail with `N select element(s) without accessible names`. Every offender is listed as `select[name="country"]`, `select#country` or a bare `select`.
+- Pass with `N select element(s) have accessible names`.
+- Info with `No select elements found`.
+
+## How to fix it
+
+```html
+<label for="country">Shipping country</label>
+<select id="country" name="country" autocomplete="shipping country">
+  <option value="">Choose a country</option>
+  <option value="GB">United Kingdom</option>
+</select>
+```
+
+A visible `<label>` is the best answer, because it also makes the words clickable. Where the layout has no room, `aria-label` on the `<select>` does the job.
+
+A native `<select>` styled to look like a custom dropdown still needs its name on the `<select>` element itself, not on the wrapper that provides the visuals.
 
 | | |
 |---|---|
@@ -12,10 +40,6 @@ Checks that select elements have accessible names
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 8/10 |
-
-## Solution
-
-Select elements need accessible labels. Use `<label for='selectId'>`Label`</label>`, wrap in `<label>`, or use aria-label/aria-labelledby.
 
 ## Enable / disable
 
@@ -40,3 +64,31 @@ disable = ["a11y/*"]
 enable = ["a11y/select-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/form-labels](/rules/a11y/form-labels): the same requirement across inputs and textareas.
+- [a11y/aria-input-field-name](/rules/a11y/aria-input-field-name): custom dropdowns built with `role="combobox"` or `role="listbox"`.
+- [a11y/aria-required-children](/rules/a11y/aria-required-children): a `role="listbox"` with no options inside it.
+- [a11y/autocomplete-tokens](/rules/a11y/autocomplete-tokens): the autofill token a country or state select should carry.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The select element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/select)
+- [Labeling controls, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/forms/labels/)
+- [Understanding SC 4.1.2 Name, Role, Value, W3C](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every unnamed select is listed, with no cap on the count. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/skip-link.mdx
+++ b/docs/rules/a11y/skip-link.mdx
@@ -1,9 +1,55 @@
 ---
-title: "Skip Link"
-description: "Checks for bypass mechanisms for keyboard navigation"
+title: "Skip to content: bypassing repeated navigation"
+description: "Keyboard users tab through the whole navigation on every page without a bypass. squirrel accepts a skip link or landmark structure."
 ---
 
-Checks for bypass mechanisms for keyboard navigation
+## What a bypass mechanism is
+
+Every page on a site repeats the same header and navigation. A mouse user's eye skips it. A keyboard user presses Tab through all of it, on every page, before reaching the content.
+
+WCAG success criterion 2.4.1 Bypass Blocks, Level A, requires a way past it. A skip link is the classic answer: a link at the very top of the document, hidden until it takes focus, pointing at the main content. Landmarks also satisfy the criterion, because a screen reader user can jump straight to `<main>`.
+
+## What squirrel checks
+
+One check, `skip-link`, at severity warning. It gathers five signals and grades the combination rather than requiring any one of them.
+
+- A skip link, matched as `a[href^="#main"]`, `a[href^="#content"]`, `a[href="#skip"]`, or a link with the class `skip-link`, `skip-to-content` or `skip-nav`.
+- Failing that, any `a[href^="#"]` whose text contains `skip`, `jump to content` or `go to main`.
+- A `<main>` element or `[role="main"]`.
+- An `<h1>` or `<h2>` appearing within the first 2000 characters of the body's serialized HTML, which is far enough in for a nav bar and not far enough for real content.
+- A `<nav>` element or `[role="navigation"]`.
+
+The verdict follows from those:
+
+- Pass with `Skip link found` when either skip-link signal is present.
+- Pass with `Bypass mechanism available via landmarks` when a main landmark is present together with a nav landmark or an early heading.
+- Warn with `No bypass mechanism for repetitive content` otherwise, listing whichever signals were found and suggesting `Add skip link or ensure <main> landmark with <nav> landmark`.
+
+Every finding carries the list of detected methods, so a pass tells you which mechanism it credited.
+
+## How to fix it
+
+```html
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <nav aria-label="Primary">...</nav>
+  <main id="main" tabindex="-1">...</main>
+```
+
+```css
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+.skip-link:focus {
+  left: 0;
+  top: 0;
+}
+```
+
+The link has to be the first focusable element in the document, or the user tabs through part of the header before finding it. Hide it with off-screen positioning rather than `display: none`, which would take it out of the tab order entirely.
+
+`tabindex="-1"` on the target matters. Without it some browsers move the scroll position but leave focus where it was, so the next Tab press goes back to the navigation.
 
 | | |
 |---|---|
@@ -12,10 +58,6 @@ Checks for bypass mechanisms for keyboard navigation
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Skip links allow keyboard users to bypass repetitive navigation and jump directly to main content. Add a hidden link at the very beginning of your page: `<a href='#main-content' class='skip-link'>`Skip to main content`</a>`. Style it to become visible on focus. Ensure the target (#main-content) has tabindex='-1' if it's not naturally focusable. Alternative: use landmark roles like `<main>` which screen readers can navigate to directly.
 
 ## Enable / disable
 
@@ -40,3 +82,31 @@ disable = ["a11y/*"]
 enable = ["a11y/skip-link"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/landmark-one-main](/rules/a11y/landmark-one-main): the `<main>` landmark this rule accepts as an alternative.
+- [a11y/landmark-regions](/rules/a11y/landmark-regions): the `<nav>` landmark that completes the landmark route.
+- [a11y/focus-visible](/rules/a11y/focus-visible): making the skip link visible once it takes focus.
+- [a11y/tabindex](/rules/a11y/tabindex): positive values that would move the skip link out of first position.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Understanding SC 2.4.1 Bypass Blocks, W3C](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks.html)
+- [G1: Adding a link at the top of each page that goes directly to the main content area, W3C](https://www.w3.org/WAI/WCAG22/Techniques/general/G1)
+- [Page regions, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/page-structure/regions/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. A pass names which bypass mechanism it credited, so you can see what it found. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/skip-link.mdx
+++ b/docs/rules/a11y/skip-link.mdx
@@ -85,9 +85,9 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/landmark-one-main](/rules/a11y/landmark-one-main): the `<main>` landmark, which clears this rule only alongside a `<nav>` landmark or an early heading.
+- [a11y/landmark-one-main](/rules/a11y/landmark-one-main): whether the page has exactly one `<main>`, which clears this rule only alongside a `<nav>` landmark or an early heading.
 - [a11y/landmark-regions](/rules/a11y/landmark-regions): the `<nav>` landmark that completes the landmark route.
-- [a11y/focus-visible](/rules/a11y/focus-visible): making the skip link visible once it takes focus.
+- [a11y/focus-visible](/rules/a11y/focus-visible): `outline: none` with no `:focus-visible` replacement, which is what would hide the skip link.
 - [a11y/tabindex](/rules/a11y/tabindex): positive values that would move the skip link out of first position.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/a11y/skip-link.mdx
+++ b/docs/rules/a11y/skip-link.mdx
@@ -85,7 +85,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/landmark-one-main](/rules/a11y/landmark-one-main): the `<main>` landmark this rule accepts as an alternative.
+- [a11y/landmark-one-main](/rules/a11y/landmark-one-main): the `<main>` landmark, which clears this rule only alongside a `<nav>` landmark or an early heading.
 - [a11y/landmark-regions](/rules/a11y/landmark-regions): the `<nav>` landmark that completes the landmark route.
 - [a11y/focus-visible](/rules/a11y/focus-visible): making the skip link visible once it takes focus.
 - [a11y/tabindex](/rules/a11y/tabindex): positive values that would move the skip link out of first position.

--- a/docs/rules/a11y/tabindex.mdx
+++ b/docs/rules/a11y/tabindex.mdx
@@ -1,9 +1,32 @@
 ---
-title: "Tabindex Values"
-description: "Checks for appropriate tabindex values"
+title: "Positive tabindex and why it breaks the tab order"
+description: "tabindex=1 pulls an element to the front of the tab order for the entire page. squirrel flags every positive value on every page."
 ---
 
-Checks for appropriate tabindex values
+## What tabindex does
+
+`tabindex="0"` puts an element into the tab order at its position in the document. `tabindex="-1"` takes it out of the tab order while leaving it focusable from script, which is what a modal's container or a skip link's target needs.
+
+A positive value creates a second, earlier sequence. Every element with a positive `tabindex` is visited in ascending order before anything with `0` or a natural position. One `tabindex="1"` anywhere on a page therefore reorders the whole page, and adding a form field later puts it in a place nobody expects.
+
+## What squirrel checks
+
+One rule, two check names, at severity warning. It reads every element carrying a `tabindex`, matching the attribute name case-insensitively so React's `tabIndex` in server-rendered markup counts, and parses the value as an integer. Values of `0` and `-1` are skipped, and a non-numeric value such as `auto` is ignored.
+
+- `tabindex-very-high` fails with `N element(s) with very high tabindex values` for values above 100, carrying the issue `Very high tabindex values indicate misuse`. Items read `div#hero (tabindex=9999)`, up to ten with a count of the rest.
+- `tabindex-positive` warns with `N element(s) with positive tabindex` for values from 1 to 100, suggesting `Use natural document order instead`.
+- `tabindex` passes with `Tabindex values are appropriate (0 or -1)` when the page uses the attribute and no value is positive.
+- `tabindex` returns info with `No tabindex attributes found`.
+
+## How to fix it
+
+```html
+<div role="button" tabindex="0">Save</div>
+```
+
+Delete the number and reorder the markup instead. Source order is what the tab sequence follows, and CSS can move things visually without touching it. Where visual and source order disagree badly, that is usually a layout problem worth fixing on its own.
+
+Use `tabindex="-1"` for things focus should reach only from script: a dialog container, the target of a skip link, a region you move focus to after a route change.
 
 | | |
 |---|---|
@@ -12,10 +35,6 @@ Checks for appropriate tabindex values
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-Avoid positive tabindex values (1, 2, 3...) as they override natural tab order and confuse keyboard users. Use tabindex='0' to add elements to tab order, tabindex='-1' to make elements focusable via JavaScript only. Rely on natural document order for tab sequence.
 
 ## Enable / disable
 
@@ -40,3 +59,31 @@ disable = ["a11y/*"]
 enable = ["a11y/tabindex"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/focus-visible](/rules/a11y/focus-visible): whether the ring is drawn once focus arrives.
+- [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): focusable elements inside a region hidden from assistive technology.
+- [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism a positive `tabindex` can push out of first place.
+- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): the other attribute problem specific to focusable elements.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [tabindex, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex)
+- [Understanding SC 2.4.3 Focus Order, W3C](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)
+- [H4: Creating a logical tab order, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H4)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Values above 100 are reported separately, since they almost always mean the attribute is being misused. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/tabindex.mdx
+++ b/docs/rules/a11y/tabindex.mdx
@@ -11,7 +11,7 @@ A positive value creates a second, earlier sequence. Every element with a positi
 
 ## What squirrel checks
 
-One rule, two check names, at severity warning. It reads every element carrying a `tabindex`, matching the attribute name case-insensitively so React's `tabIndex` in server-rendered markup counts, and parses the value as an integer. Values of `0` and `-1` are skipped, and a non-numeric value such as `auto` is ignored.
+One rule, three check names, at severity warning. It reads every element carrying a `tabindex`, matching the attribute name case-insensitively so React's `tabIndex` in server-rendered markup counts, and parses the value as an integer. Values of `0` and `-1` are skipped, and a non-numeric value such as `auto` is ignored.
 
 - `tabindex-very-high` fails with `N element(s) with very high tabindex values` for values above 100, carrying the issue `Very high tabindex values indicate misuse`. Items read `div#hero (tabindex=9999)`. Only the first ten are listed, and no count of the remainder is reported.
 - `tabindex-positive` warns with `N element(s) with positive tabindex` for values from 1 to 100, suggesting `Use natural document order instead`.

--- a/docs/rules/a11y/tabindex.mdx
+++ b/docs/rules/a11y/tabindex.mdx
@@ -13,7 +13,7 @@ A positive value creates a second, earlier sequence. Every element with a positi
 
 One rule, two check names, at severity warning. It reads every element carrying a `tabindex`, matching the attribute name case-insensitively so React's `tabIndex` in server-rendered markup counts, and parses the value as an integer. Values of `0` and `-1` are skipped, and a non-numeric value such as `auto` is ignored.
 
-- `tabindex-very-high` fails with `N element(s) with very high tabindex values` for values above 100, carrying the issue `Very high tabindex values indicate misuse`. Items read `div#hero (tabindex=9999)`, up to ten with a count of the rest.
+- `tabindex-very-high` fails with `N element(s) with very high tabindex values` for values above 100, carrying the issue `Very high tabindex values indicate misuse`. Items read `div#hero (tabindex=9999)`. Only the first ten are listed, and no count of the remainder is reported.
 - `tabindex-positive` warns with `N element(s) with positive tabindex` for values from 1 to 100, suggesting `Use natural document order instead`.
 - `tabindex` passes with `Tabindex values are appropriate (0 or -1)` when the page uses the attribute and no value is positive.
 - `tabindex` returns info with `No tabindex attributes found`.

--- a/docs/rules/a11y/tabindex.mdx
+++ b/docs/rules/a11y/tabindex.mdx
@@ -62,7 +62,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [a11y/focus-visible](/rules/a11y/focus-visible): whether the ring is drawn once focus arrives.
+- [a11y/focus-visible](/rules/a11y/focus-visible): focus-indicator styles, scanned for `outline: none` without a `:focus-visible` fallback.
 - [a11y/aria-hidden-focus](/rules/a11y/aria-hidden-focus): focusable elements inside a region hidden from assistive technology.
 - [a11y/skip-link](/rules/a11y/skip-link): the bypass mechanism a positive `tabindex` can push out of first place.
 - [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): the other attribute problem specific to focusable elements.

--- a/docs/rules/a11y/table-duplicate-name.mdx
+++ b/docs/rules/a11y/table-duplicate-name.mdx
@@ -1,9 +1,41 @@
 ---
-title: "Table Duplicate Name"
-description: "Checks that data tables have unique accessible names"
+title: "Tables sharing a name, and tables with none"
+description: "Several tables on one page need distinct names or a screen reader's table list is unusable. squirrel checks captions and labels."
 ---
 
-Checks that data tables have unique accessible names
+## What a table name is
+
+Screen readers let users list the tables on a page and jump to one. That list shows each table's accessible name, which comes from a `<caption>`, from `aria-label`, or from `aria-labelledby`.
+
+With one table on the page the name is a convenience. With several it is the only thing distinguishing them, and two tables both called "Results" are the same entry twice.
+
+## What squirrel checks
+
+Two check names, at rule severity warning and weight 3. The rule looks at tables that are not `role="presentation"` or `role="none"`, and does nothing at all unless there is more than one: with none it returns info with `No data tables found`, and with exactly one it returns info with `Only one table found`.
+
+A name is taken from `aria-label`, from `aria-labelledby` pointing at elements with text, or from a `<caption>`.
+
+- `table-duplicate-name` warns with `N duplicate table name(s) found` when two or more tables share a name, compared lowercased and trimmed. Items read `"revenue by quarter" (2 tables)`, and the finding suggests `Give each table a unique caption or aria-label`.
+- `tables-without-names` warns with `N table(s) without accessible names`, noting `Add caption or aria-label to distinguish tables`.
+- `table-duplicate-name` passes with `All tables have unique accessible names` when neither problem appears.
+
+## How to fix it
+
+```html
+<table>
+  <caption>Revenue by quarter, 2025</caption>
+  ...
+</table>
+
+<table>
+  <caption>Revenue by quarter, 2026</caption>
+  ...
+</table>
+```
+
+A `<caption>` is the better of the two options because it is visible. Everyone gets the label, not only screen reader users, and it cannot drift out of sync with the heading above the table.
+
+Where the design has no room for a caption, `aria-label` on the `<table>` does the job. Where a heading above the table already names it, point `aria-labelledby` at that heading's `id`.
 
 | | |
 |---|---|
@@ -12,10 +44,6 @@ Checks that data tables have unique accessible names
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 3/10 |
-
-## Solution
-
-When a page has multiple data tables, each should have a unique accessible name to help users distinguish between them. Use `<caption>`, aria-label, or aria-labelledby with unique text for each table.
 
 ## Enable / disable
 
@@ -40,3 +68,31 @@ disable = ["a11y/*"]
 enable = ["a11y/table-duplicate-name"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/table-headers](/rules/a11y/table-headers): whether those tables have `<th>` cells at all.
+- [a11y/th-has-data-cells](/rules/a11y/th-has-data-cells): headers with no data under them, usually a layout table.
+- [a11y/td-headers-attr](/rules/a11y/td-headers-attr): explicit header associations in complex tables.
+- [a11y/duplicate-id-aria](/rules/a11y/duplicate-id-aria): the `aria-labelledby` reference resolving correctly.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Caption and summary, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/tables/caption-summary/)
+- [The caption element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/caption)
+- [Understanding SC 1.3.1 Info and Relationships, W3C](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Duplicate names and missing names are reported as separate checks. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/table-headers.mdx
+++ b/docs/rules/a11y/table-headers.mdx
@@ -13,11 +13,11 @@ Styling a `<td>` to look like a header gives none of that. It looks identical an
 
 One check, `table-headers`, at severity warning. It covers every `<table>` except those with `role="presentation"` or `role="none"`.
 
-- Warn when a table contains no `<th>` at all. Report message: `N table(s) without <th> headers`. Each is listed as `Table 1`, numbered by document order, and every offender is listed.
+- Warn when a table contains no `<th>` at all. Report message: `N table(s) without <th> headers`. Each is listed as `Table 1`, numbered in document order across the tables the rule looked at, and every offender is listed.
 - Pass with `All N data table(s) have headers`.
 - Info with `No data tables found`.
 
-The check tests presence only. Whether the headers carry `scope`, whether the table has a `<caption>`, and whether each header has data under it are separate questions, covered by `a11y/th-has-data-cells` and `a11y/td-headers-attr`.
+The check tests presence only. It does not look at `scope` or at `<caption>`, and no rule in this category does. Whether each header has data under it is `a11y/th-has-data-cells`, and whether explicit `headers` references resolve is `a11y/td-headers-attr`.
 
 ## How to fix it
 
@@ -92,7 +92,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 
 ## Check your site
 
-Run `squirrel audit https://example.com` and open the Accessibility section of the report. Tables are numbered by document order, so Table 3 is the third one in the source. Local audits are free.
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Table 3 means the third non-presentational table in document order. Local audits are free.
 
 <CardGroup cols={2}>
   <Card title="Install squirrel" icon="terminal" href="/quickstart">

--- a/docs/rules/a11y/table-headers.mdx
+++ b/docs/rules/a11y/table-headers.mdx
@@ -1,9 +1,47 @@
 ---
-title: "Table Headers"
-description: "Checks that data tables have proper headers"
+title: "Table headers: why a data table needs th cells"
+description: "A table built from styled td cells has no header relationships for a screen reader. squirrel checks every data table for th elements."
 ---
 
-Checks that data tables have proper headers
+## What a table header is
+
+A `<th>` is what turns a grid of text into a table a screen reader can navigate. Moving between cells, it announces the column and row header along with the value, so a user hears "Revenue, Q3, 6.8M" instead of "6.8M".
+
+Styling a `<td>` to look like a header gives none of that. It looks identical and reads as another data cell.
+
+## What squirrel checks
+
+One check, `table-headers`, at severity warning. It covers every `<table>` except those with `role="presentation"` or `role="none"`.
+
+- Warn when a table contains no `<th>` at all. Report message: `N table(s) without <th> headers`. Each is listed as `Table 1`, numbered by document order, and every offender is listed.
+- Pass with `All N data table(s) have headers`.
+- Info with `No data tables found`.
+
+The check tests presence only. Whether the headers carry `scope`, whether the table has a `<caption>`, and whether each header has data under it are separate questions, covered by `a11y/th-has-data-cells` and `a11y/td-headers-attr`.
+
+## How to fix it
+
+```html
+<table>
+  <caption>Revenue by quarter</caption>
+  <thead>
+    <tr>
+      <th scope="col">Quarter</th>
+      <th scope="col">Revenue</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Q3</th>
+      <td>6.8M</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Use `<th>` for both the column headings and the row labels, and add `scope` so the direction is unambiguous. Two lines of CSS restore whatever styling the `<td>` had.
+
+A table used purely for layout should carry `role="presentation"`, which removes it from this check and from the table list a screen reader builds.
 
 | | |
 |---|---|
@@ -12,10 +50,6 @@ Checks that data tables have proper headers
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Data tables need proper headers for screen reader users to understand relationships. Use `<th>` for header cells, not styled `<td>`. Add scope='col' or scope='row' to clarify header direction. For complex tables, use id and headers attributes to associate data cells with headers. Include a `<caption>` to describe the table's purpose. Layout tables should have role='presentation'.
 
 ## Enable / disable
 
@@ -40,3 +74,31 @@ disable = ["a11y/*"]
 enable = ["a11y/table-headers"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/th-has-data-cells](/rules/a11y/th-has-data-cells): headers with no data cell in their row or column.
+- [a11y/td-headers-attr](/rules/a11y/td-headers-attr): explicit header associations for complex tables.
+- [a11y/table-duplicate-name](/rules/a11y/table-duplicate-name): naming several tables on one page.
+- [a11y/list-structure](/rules/a11y/list-structure): the other structure that loses its meaning when built from generic elements.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Tables tutorial, W3C WAI](https://www.w3.org/WAI/tutorials/tables/)
+- [The table element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table)
+- [H51: Using table markup to present tabular information, W3C](https://www.w3.org/WAI/WCAG22/Techniques/html/H51)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Tables are numbered by document order, so Table 3 is the third one in the source. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/td-headers-attr.mdx
+++ b/docs/rules/a11y/td-headers-attr.mdx
@@ -74,7 +74,7 @@ disable = ["*"]
 
 - [a11y/table-headers](/rules/a11y/table-headers): whether the table has `<th>` cells to point at.
 - [a11y/th-has-data-cells](/rules/a11y/th-has-data-cells): headers with no data in their row or column.
-- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): duplicated ids, which make a reference ambiguous.
+- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): duplicated ids on focusable elements. It does not cover `<th>` ids, so header collisions have to be caught by hand.
 - [a11y/table-duplicate-name](/rules/a11y/table-duplicate-name): telling several tables apart.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
@@ -82,7 +82,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 ## References
 
 - [The headers attribute, HTML Standard](https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-headers)
-- [Tables with irregular headers, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/tables/irregular/)
+- [Tables with multi-level headers, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/tables/multi-level/)
 - [The td element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td)
 
 ## Check your site

--- a/docs/rules/a11y/td-headers-attr.mdx
+++ b/docs/rules/a11y/td-headers-attr.mdx
@@ -1,9 +1,42 @@
 ---
-title: "Table Cell Headers"
-description: "Checks that td headers attribute references valid th ids"
+title: "td headers attribute pointing at a missing th id"
+description: "A headers attribute naming an id that does not exist leaves the cell unassociated. squirrel checks every reference in every table."
 ---
 
-Checks that td headers attribute references valid th ids
+## What the headers attribute is
+
+In a complex table, `headers` on a `<td>` names the ids of the `<th>` cells that describe it. A screen reader reads those headers before the value, which is how a cell in a multi-level table announces "Revenue, Europe, Q3, 6.8M".
+
+Simple tables do not need it. One row of column headers and one column of row headers is fully described by `scope="col"` and `scope="row"`. `headers` is for tables with split or stacked headers, where scope cannot express the relationship.
+
+## What squirrel checks
+
+One check, `td-headers-attr`, at severity error and weight 6. For each `<table>` it collects the ids of every `th[id]` in that table, then reads every `td[headers]` and splits the value on whitespace.
+
+- Fail when a referenced id does not belong to a `<th>` in the same table. Report message: `N invalid header reference(s) in table cells`. Items read `td references non-existent header "q3" (content: "6.8M...")`, quoting the first 15 characters of the cell. Up to ten are shown with a count of the rest.
+- Pass with `All td headers attributes reference valid th ids`.
+- Info with `No td elements with headers attribute found`, or `No tables found`.
+
+References are scoped per table, so a `headers` value pointing at a `<th>` in a different table is reported even though the id exists on the page.
+
+## How to fix it
+
+```html
+<table>
+  <tr>
+    <td></td>
+    <th id="q3" scope="col">Q3</th>
+  </tr>
+  <tr>
+    <th id="eu" scope="row">Europe</th>
+    <td headers="eu q3">6.8M</td>
+  </tr>
+</table>
+```
+
+Every id in the `headers` value has to exist on a `<th>` in the same table. Ids that were renamed during a refactor are the usual cause, and so are ids generated per row that do not match the ones generated per header.
+
+If the table is simple enough for `scope` alone, drop the `headers` attributes entirely. Fewer references means fewer to keep in sync.
 
 | | |
 |---|---|
@@ -12,10 +45,6 @@ Checks that td headers attribute references valid th ids
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 6/10 |
-
-## Solution
-
-When using the headers attribute on `<td>` elements to associate cells with headers, ensure each id in the headers attribute matches an existing `<th>` element's id in the same table.
 
 ## Enable / disable
 
@@ -40,3 +69,31 @@ disable = ["a11y/*"]
 enable = ["a11y/td-headers-attr"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/table-headers](/rules/a11y/table-headers): whether the table has `<th>` cells to point at.
+- [a11y/th-has-data-cells](/rules/a11y/th-has-data-cells): headers with no data in their row or column.
+- [a11y/duplicate-id-active](/rules/a11y/duplicate-id-active): duplicated ids, which make a reference ambiguous.
+- [a11y/table-duplicate-name](/rules/a11y/table-duplicate-name): telling several tables apart.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The headers attribute, HTML Standard](https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-headers)
+- [Tables with irregular headers, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/tables/irregular/)
+- [The td element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each broken reference is listed with the id it names and the cell's opening text. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/th-has-data-cells.mdx
+++ b/docs/rules/a11y/th-has-data-cells.mdx
@@ -19,7 +19,7 @@ For each `<th>` in that grid it looks for a `<td>` in the same row, then in the 
 - Pass with `All table headers have associated data cells`.
 - Info with `No data tables found`.
 
-Building the grid is what makes the check work on tables with merged cells. A header spanning two columns is credited with the data under both.
+Building the grid is what makes the check work on tables with merged cells, but the test runs per grid slot. A header spanning two columns whose own row has no data cell is judged column by column, so data under one of the two columns does not clear the other.
 
 ## How to fix it
 
@@ -31,7 +31,7 @@ For a table that is really a layout, say so:
 </table>
 ```
 
-That removes it from this check, from the table list a screen reader offers, and from every other table rule. Better still, replace it with CSS grid or flexbox, which is what the layout wanted in the first place.
+That removes it from this check, from `a11y/table-headers` and from `a11y/table-duplicate-name`, which all skip presentational tables. `a11y/td-headers-attr` looks at every table regardless. Better still, replace it with CSS grid or flexbox, which is what the layout wanted in the first place.
 
 For a real data table, check that each header has cells under or beside it. A header row followed by nothing, left in place while the data loads, produces this finding on the served HTML.
 

--- a/docs/rules/a11y/th-has-data-cells.mdx
+++ b/docs/rules/a11y/th-has-data-cells.mdx
@@ -1,9 +1,39 @@
 ---
-title: "TH Has Data Cells"
-description: "Checks that table headers have associated data cells"
+title: "th cells with no data cells: a layout table in disguise"
+description: "A header with no data in its row or column usually means the table is really a layout. squirrel builds the grid and checks each one."
 ---
 
-Checks that table headers have associated data cells
+## What an orphaned header is
+
+A `<th>` describes the cells in its row or its column. A header with no `<td>` anywhere in either direction describes nothing, and a screen reader announces a header relationship that leads nowhere.
+
+Almost always this means the table is being used for layout. The `<th>` came from a template that expected data, and the cells around it are all headers or all empty.
+
+## What squirrel checks
+
+One check, `th-has-data-cells`, at severity warning. For each table that is not `role="presentation"` or `role="none"`, it builds a two-dimensional grid, expanding `colspan` and `rowspan` so every grid slot maps to the cell that occupies it. Both span attributes are read case-insensitively.
+
+For each `<th>` in that grid it looks for a `<td>` in the same row, then in the same column.
+
+- Warn when neither is found. Report message: `N <th> element(s) without associated data cells`. Items quote the header's first 30 characters, or read `row 2, col 3` when the header has no text. Up to ten are shown with a count of the rest, and a header that spans several slots is reported once.
+- Pass with `All table headers have associated data cells`.
+- Info with `No data tables found`.
+
+Building the grid is what makes the check work on tables with merged cells. A header spanning two columns is credited with the data under both.
+
+## How to fix it
+
+For a table that is really a layout, say so:
+
+```html
+<table role="presentation">
+  ...
+</table>
+```
+
+That removes it from this check, from the table list a screen reader offers, and from every other table rule. Better still, replace it with CSS grid or flexbox, which is what the layout wanted in the first place.
+
+For a real data table, check that each header has cells under or beside it. A header row followed by nothing, left in place while the data loads, produces this finding on the served HTML.
 
 | | |
 |---|---|
@@ -12,10 +42,6 @@ Checks that table headers have associated data cells
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Each `<th>` element should be associated with at least one `<td>` data cell in the same row or column. Orphaned header cells without data cells usually indicate the table is being misused for layout purposes. If the table is for layout, add role='presentation'. Otherwise, ensure every header has corresponding data cells.
 
 ## Enable / disable
 
@@ -40,3 +66,31 @@ disable = ["a11y/*"]
 enable = ["a11y/th-has-data-cells"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/table-headers](/rules/a11y/table-headers): data tables with no `<th>` at all.
+- [a11y/td-headers-attr](/rules/a11y/td-headers-attr): explicit associations pointing at ids that do not exist.
+- [a11y/table-duplicate-name](/rules/a11y/table-duplicate-name): naming the tables that survive this check.
+- [a11y/aria-required-parent](/rules/a11y/aria-required-parent): rows and cells sitting outside the structure they need.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Tables with two headers, W3C WAI tutorials](https://www.w3.org/WAI/tutorials/tables/two-headers/)
+- [The th element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th)
+- [The presentation role, MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each orphaned header is quoted by its text, or located by row and column. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/th-has-data-cells.mdx
+++ b/docs/rules/a11y/th-has-data-cells.mdx
@@ -71,7 +71,7 @@ disable = ["*"]
 
 - [a11y/table-headers](/rules/a11y/table-headers): data tables with no `<th>` at all.
 - [a11y/td-headers-attr](/rules/a11y/td-headers-attr): explicit associations pointing at ids that do not exist.
-- [a11y/table-duplicate-name](/rules/a11y/table-duplicate-name): naming the tables that survive this check.
+- [a11y/table-duplicate-name](/rules/a11y/table-duplicate-name): unique accessible names for the tables that survive this check.
 - [a11y/aria-required-parent](/rules/a11y/aria-required-parent): rows and cells sitting outside the structure they need.
 
 Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.

--- a/docs/rules/a11y/touch-targets.mdx
+++ b/docs/rules/a11y/touch-targets.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Touch Targets"
-description: "Checks for minimum touch target sizing hints"
+title: "Touch target size: the 24 and 44 pixel minimums"
+description: "Buttons and links smaller than a fingertip are hard to hit on a phone. squirrel flags interactive elements sized below 44 pixels inline."
 ---
 
-Checks for minimum touch target sizing hints
+## What a touch target is
+
+A touch target is the region that reacts to a tap: a button, a link, a checkbox, anything with a click handler. WCAG sets two thresholds for it. Success criterion 2.5.8 Target Size (Minimum), Level AA, asks for 24 by 24 CSS pixels. Success criterion 2.5.5 Target Size (Enhanced), Level AAA, asks for 44 by 44.
+
+Size comes from the element's box, not its text. Padding on a small icon button raises the target; a larger font on a text link does not. The AA criterion also has a spacing exception: an undersized target passes if a 24 pixel circle centred on it does not overlap the circle of any other target.
+
+## What squirrel checks
+
+One check, `touch-targets`, at severity warning. It reads inline `style` attributes only, so it never needs a stylesheet or a rendered page.
+
+- Warn when a `<button>`, `<a>`, `<input type="submit">`, `<input type="button">` or `[role="button"]` sets an inline `width` or `height` below 44 pixels. Values in `rem` and `em` are converted at 16 pixels to the unit. Report message: `N element(s) with potentially small touch targets`, with the value `Ensure minimum 44x44px touch targets`.
+- Info in every other case, with the message `Touch target sizes require CSS analysis` and the value `Verify buttons/links are at least 44x44px`.
+
+The rule uses 44 pixels, the enhanced threshold, as its cutoff. An info result means nothing was measurable, not that the page passes: a target sized by a stylesheet or a utility class is invisible to this check.
+
+## How to fix it
+
+```css
+.icon-button {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 12px;
+}
+```
+
+Set the minimum on the interactive element itself, and grow it with padding rather than font size so the label stays the size you designed.
+
+The common false positive is an element with a small inline `width` that sits inside generous padding, where the real hit area is fine. squirrel only sees the declared width, so check the rendered box before changing anything.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks for minimum touch target sizing hints
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 4/10 |
-
-## Solution
-
-Touch targets (buttons, links) should be at least 44x44 pixels for accessibility (WCAG 2.5.5) and usability. Increase size with padding rather than just increasing font size. Ensure at least 8px spacing between adjacent targets. For inline links in text, provide sufficient line-height. This helps users with motor impairments and improves mobile usability for everyone.
 
 ## Enable / disable
 
@@ -40,3 +63,30 @@ disable = ["a11y/*"]
 enable = ["a11y/touch-targets"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [mobile/tap-targets](/rules/mobile/tap-targets): the same defect from the mobile usability side.
+- [a11y/link-in-text-block](/rules/a11y/link-in-text-block): inline links that are hard to see rather than hard to hit.
+- [a11y/zoom-disabled](/rules/a11y/zoom-disabled): a viewport that stops users enlarging a target they cannot hit.
+- [mobile/font-size](/rules/mobile/font-size): text too small to read on the same screens.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Understanding SC 2.5.8 Target Size (Minimum), W3C](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)
+- [Understanding SC 2.5.5 Target Size (Enhanced), W3C](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every element with an undersized inline dimension is listed by page. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/touch-targets.mdx
+++ b/docs/rules/a11y/touch-targets.mdx
@@ -7,16 +7,16 @@ description: "Buttons and links smaller than a fingertip are hard to hit on a ph
 
 A touch target is the region that reacts to a tap: a button, a link, a checkbox, anything with a click handler. WCAG sets two thresholds for it. Success criterion 2.5.8 Target Size (Minimum), Level AA, asks for 24 by 24 CSS pixels. Success criterion 2.5.5 Target Size (Enhanced), Level AAA, asks for 44 by 44.
 
-Size comes from the element's box, not its text. Padding on a small icon button raises the target; a larger font on a text link does not. The AA criterion also has a spacing exception: an undersized target passes if a 24 pixel circle centered on it does not overlap the circle of any other target.
+Size comes from the element's box. Padding enlarges the target without enlarging the text, while font size changes both, since an inline link's box is derived from its content. The AA criterion also has a spacing exception: an undersized target passes when a 24 pixel circle centered on it does not intersect another target, nor the circle of another undersized target.
 
 ## What squirrel checks
 
 One check, `touch-targets`, at severity warning. It reads inline `style` attributes only, so it never needs a stylesheet or a rendered page.
 
-- Warn when a `<button>`, `<a>`, `<input type="submit">`, `<input type="button">` or `[role="button"]` sets an inline `width` or `height` below 44 pixels. Values in `rem` and `em` are converted at 16 pixels to the unit. Report message: `N element(s) with potentially small touch targets`, with the value `Ensure minimum 44x44px touch targets`.
-- Info in every other case, with the message `Touch target sizes require CSS analysis` and the value `Verify buttons/links are at least 44x44px`.
+- Warn when a `<button>`, `<a>`, `<input type="submit">`, `<input type="button">` or `[role="button"]` has an inline style declaring a `width` or `height` below 44 pixels. The match is an unanchored search for an integer followed by `px`, `rem` or `em`, so `min-width: 20px` counts and `width: 1.5rem` is not measured at all. `rem` and `em` are converted at 16 pixels to the unit. Width and height are counted separately, so one element can add two to the tally. Report message: `N element(s) with potentially small touch targets`, with the value `Ensure minimum 44x44px touch targets`. The check emits no items, only the count.
+- Info whenever the tally is zero, with the message `Touch target sizes require CSS analysis` and the value `Verify buttons/links are at least 44x44px`.
 
-The rule uses 44 pixels, the enhanced threshold, as its cutoff. An info result means nothing was measurable, not that the page passes: a target sized by a stylesheet or a utility class is invisible to this check.
+The rule uses 44 pixels, the enhanced threshold, as its cutoff. An info result means no undersized inline dimension was found, which is not the same as the page passing: a target sized by a stylesheet or a utility class is invisible to this check.
 
 ## How to fix it
 
@@ -80,7 +80,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 
 ## Check your site
 
-Run `squirrel audit https://example.com` and open the Accessibility section of the report. Every element with an undersized inline dimension is listed by page. Local audits are free.
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. The finding is a per-page count of undersized inline dimensions, not a list of elements. Local audits are free.
 
 <CardGroup cols={2}>
   <Card title="Install squirrel" icon="terminal" href="/quickstart">

--- a/docs/rules/a11y/touch-targets.mdx
+++ b/docs/rules/a11y/touch-targets.mdx
@@ -7,7 +7,7 @@ description: "Buttons and links smaller than a fingertip are hard to hit on a ph
 
 A touch target is the region that reacts to a tap: a button, a link, a checkbox, anything with a click handler. WCAG sets two thresholds for it. Success criterion 2.5.8 Target Size (Minimum), Level AA, asks for 24 by 24 CSS pixels. Success criterion 2.5.5 Target Size (Enhanced), Level AAA, asks for 44 by 44.
 
-Size comes from the element's box, not its text. Padding on a small icon button raises the target; a larger font on a text link does not. The AA criterion also has a spacing exception: an undersized target passes if a 24 pixel circle centred on it does not overlap the circle of any other target.
+Size comes from the element's box, not its text. Padding on a small icon button raises the target; a larger font on a text link does not. The AA criterion also has a spacing exception: an undersized target passes if a 24 pixel circle centered on it does not overlap the circle of any other target.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/valid-lang.mdx
+++ b/docs/rules/a11y/valid-lang.mdx
@@ -1,9 +1,35 @@
 ---
-title: "Valid Lang Attributes"
-description: "Checks that all lang attributes on the page have valid values"
+title: "lang on elements below html: validating every tag"
+description: "A quoted passage marked with a bad lang tag is read in the wrong voice. squirrel validates every lang attribute except the one on html."
 ---
 
-Checks that all lang attributes on the page have valid values
+## What lang on an element does
+
+`lang` on `<html>` sets the document's language. `lang` on any element below it overrides that for its subtree, which is how a French quotation inside an English article gets read with French pronunciation.
+
+WCAG success criterion 3.1.2 Language of Parts, Level AA, asks for it wherever the language changes. An invalid tag is worse than none: the browser cannot resolve it, and the passage falls back to the page language or to whatever the screen reader guesses.
+
+## What squirrel checks
+
+One check, `valid-lang`, at severity warning. It reads every `[lang]` element except `<html>`, which `a11y/html-lang-valid` handles on its own.
+
+A value is accepted when its primary subtag, the part before the first hyphen, is one of the 190 ISO 639-1 codes the rule knows, or is any two or three lowercase letters.
+
+- Warn with `N element(s) with invalid lang attribute`. Items read `span#quote: lang="english"`, up to ten with a count of the rest.
+- Pass with `All lang attributes are valid`, which requires the page to carry `lang` on more than one element.
+- Info with `No additional lang attributes found`.
+
+A page with `lang` only on `<html>` therefore reports info here, not pass. And because any two or three letter primary subtag is accepted by shape, an invented code such as `qq` passes. Region and script subtags are not validated at all.
+
+## How to fix it
+
+```html
+<p>She ended with <span lang="fr">plus ca change</span>.</p>
+```
+
+Use the short code, not the language's name. `lang="french"` and `lang="en-english"` are both invalid, and both are common.
+
+Mark the change where it happens, on the smallest element that contains the foreign text. Marking a whole article when one sentence changes makes the rest of it read wrongly.
 
 | | |
 |---|---|
@@ -12,10 +38,6 @@ Checks that all lang attributes on the page have valid values
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-All lang attributes should use valid BCP 47 language tags. This includes lang attributes on any element, not just `<html>`. Use lang to mark up content in a different language from the page default.
 
 ## Enable / disable
 
@@ -40,3 +62,31 @@ disable = ["a11y/*"]
 enable = ["a11y/valid-lang"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [a11y/html-lang-valid](/rules/a11y/html-lang-valid): the document-level declaration on `<html>`.
+- [a11y/html-xml-lang-mismatch](/rules/a11y/html-xml-lang-mismatch): `lang` and `xml:lang` disagreeing on that element.
+- [i18n/lang-attribute](/rules/i18n/lang-attribute): the same declaration checked for internationalization.
+- [i18n/hreflang](/rules/i18n/hreflang): the language signals sent to search engines.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The lang attribute, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang)
+- [Understanding SC 3.1.2 Language of Parts, W3C](https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts.html)
+- [Tags for identifying languages, RFC 5646](https://datatracker.ietf.org/doc/html/rfc5646)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each element is listed with the invalid value it carries. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/valid-lang.mdx
+++ b/docs/rules/a11y/valid-lang.mdx
@@ -7,7 +7,7 @@ description: "A quoted passage marked with a bad lang tag is read in the wrong v
 
 `lang` on `<html>` sets the document's language. `lang` on any element below it overrides that for its subtree, which is how a French quotation inside an English article gets read with French pronunciation.
 
-WCAG success criterion 3.1.2 Language of Parts, Level AA, asks for it wherever the language changes. An invalid tag is worse than none: the browser cannot resolve it, and the passage falls back to the page language or to whatever the screen reader guesses.
+WCAG success criterion 3.1.2 Language of Parts, Level AA, asks for it wherever the language changes. An invalid tag is worse than none: it is exposed as given, and what a screen reader does with a tag it cannot resolve is up to the screen reader.
 
 ## What squirrel checks
 

--- a/docs/rules/a11y/video-captions.mdx
+++ b/docs/rules/a11y/video-captions.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Video Captions"
-description: "Checks that videos have captions or transcripts"
+title: "Video captions: track elements and embedded players"
+description: "A video with no caption track excludes deaf and hard of hearing viewers. squirrel checks native video and flags third-party embeds."
 ---
 
-Checks that videos have captions or transcripts
+## What captions are
+
+Captions carry the dialogue and the meaningful sounds of a video as timed text. They are what makes a video usable without audio, for a deaf or hard of hearing viewer and for everyone watching with the sound off.
+
+For a native `<video>` they come from a `<track>` element pointing at a WebVTT file. WCAG success criterion 1.2.2 Captions (Prerecorded), Level A, requires them for prerecorded video with audio.
+
+## What squirrel checks
+
+Two check names, at rule severity warning.
+
+- `video-captions` runs when the page has at least one `<video>`. It warns with `N video(s) without caption tracks` for any `<video>` with no `track[kind="captions"]` and no `track[kind="subtitles"]`, listing each by the first 50 characters of its `src`, or of its first `<source>`'s `src`, or as `inline video` when neither exists. With every video covered it passes as `All videos have caption tracks`.
+- `video-embeds` returns info with `N embedded video(s) detected` and the value `Verify captions are enabled in embed settings` when the page has an `<iframe>` whose `src` contains `youtube`, `vimeo` or `wistia`.
+- With neither native video nor a recognised embed, one info check reports `No videos detected`.
+
+squirrel cannot see inside a third-party player, so the embed check is a prompt rather than a verdict. Confirm captions in the platform's own settings.
+
+## How to fix it
+
+```html
+<video controls>
+  <source src="/demo.mp4" type="video/mp4">
+  <track kind="captions" src="/demo-en.vtt" srclang="en" label="English" default>
+</video>
+```
+
+Add one `<track>` per language, and mark the default one. `kind="captions"` is for viewers who cannot hear the audio, so it includes sound effects and speaker changes; `kind="subtitles"` is a translation for viewers who can.
+
+Automatic captions from a hosting platform are a starting point, not a finish. Review them for names, jargon and numbers, which is where they fail most.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks that videos have captions or transcripts
 | **Scope** | Per-page |
 | **Severity** | warning |
 | **Weight** | 5/10 |
-
-## Solution
-
-All video content needs captions for deaf/hard-of-hearing users (WCAG 1.2.2). Add `<track kind='captions' src='captions.vtt' srclang='en'>` to video elements. For embedded videos (YouTube, Vimeo), enable captions in the embed settings. Also provide a text transcript for complex content. Auto-generated captions should be reviewed for accuracy.
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/video-captions"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [video/video-accessible](/rules/video/video-accessible): the wider accessibility check on video markup.
+- [a11y/frame-title](/rules/a11y/frame-title): naming the iframe an embedded player sits in.
+- [a11y/object-alt](/rules/a11y/object-alt): alternative content for other embedded media.
+- [video/video-schema](/rules/video/video-schema): the structured data that describes the same video to search engines.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [The track element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track)
+- [Understanding SC 1.2.2 Captions (Prerecorded), W3C](https://www.w3.org/WAI/WCAG22/Understanding/captions-prerecorded.html)
+- [Captions and subtitles, W3C WAI](https://www.w3.org/WAI/media/av/captions/)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Native videos are reported by source file, embeds only as a prompt to check the player. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/video-captions.mdx
+++ b/docs/rules/a11y/video-captions.mdx
@@ -15,7 +15,7 @@ Two check names, at rule severity warning.
 
 - `video-captions` runs when the page has at least one `<video>`. It warns with `N video(s) without caption tracks` for any `<video>` with no `track[kind="captions"]` and no `track[kind="subtitles"]`, listing each by the first 50 characters of its `src`, or of its first `<source>`'s `src`, or as `inline video` when neither exists. With every video covered it passes as `All videos have caption tracks`.
 - `video-embeds` returns info with `N embedded video(s) detected` and the value `Verify captions are enabled in embed settings` when the page has an `<iframe>` whose `src` contains `youtube`, `vimeo` or `wistia`.
-- With neither native video nor a recognised embed, one info check reports `No videos detected`.
+- With neither native video nor a recognized embed, one info check reports `No videos detected`.
 
 squirrel cannot see inside a third-party player, so the embed check is a prompt rather than a verdict. Confirm captions in the platform's own settings.
 
@@ -28,7 +28,7 @@ squirrel cannot see inside a third-party player, so the embed check is a prompt 
 </video>
 ```
 
-Add one `<track>` per language, and mark the default one. `kind="captions"` is for viewers who cannot hear the audio, so it includes sound effects and speaker changes; `kind="subtitles"` is a translation for viewers who can.
+Add one `<track>` per language, and mark the default one. `kind="captions"` is for viewers who cannot hear the audio, so it carries sound effects and speaker changes alongside the dialogue. `kind="subtitles"` carries the dialogue only, transcribed or translated, for viewers who can hear but need the words.
 
 Automatic captions from a hosting platform are a starting point, not a finish. Review them for names, jargon and numbers, which is where they fail most.
 
@@ -66,7 +66,7 @@ disable = ["*"]
 
 ## Related rules
 
-- [video/video-accessible](/rules/video/video-accessible): the wider accessibility check on video markup.
+- [video/video-accessible](/rules/video/video-accessible): the same native caption-track presence check, reported differently and with no embed detection.
 - [a11y/frame-title](/rules/a11y/frame-title): naming the iframe an embedded player sits in.
 - [a11y/object-alt](/rules/a11y/object-alt): alternative content for other embedded media.
 - [video/video-schema](/rules/video/video-schema): the structured data that describes the same video to search engines.

--- a/docs/rules/a11y/zoom-disabled.mdx
+++ b/docs/rules/a11y/zoom-disabled.mdx
@@ -1,9 +1,36 @@
 ---
-title: "Zoom Disabled"
-description: "Checks if viewport meta tag disables user zoom"
+title: "user-scalable=no: viewport settings that block zoom"
+description: "A viewport that caps the zoom level stops low-vision users enlarging text. squirrel parses the viewport meta tag on every page."
 ---
 
-Checks if viewport meta tag disables user zoom
+## What the viewport meta tag does
+
+`<meta name="viewport">` tells a mobile browser how to lay out the page. Its `content` value is a comma-separated list of directives, and three of them constrain zoom: `user-scalable`, `maximum-scale` and `minimum-scale`.
+
+Someone with low vision may enlarge a page several times over to read it. Capping the zoom takes that away, and nothing on screen explains why pinching does nothing. WCAG success criterion 1.4.4 Resize Text, Level AA, requires text to scale to 200 percent without losing content or function.
+
+## What squirrel checks
+
+One check, `zoom-disabled`, at severity error. It reads the first `meta[name="viewport"]` on the page and parses its `content`, tolerating whitespace around each `=`.
+
+- Fail with `Viewport restricts user zoom` when any of the following appears. Each match is listed as an item, and the finding carries the raw viewport string along with the note `maximum-scale should be ≥ 5`.
+  - `user-scalable` set to `no`, `0` or `false`
+  - `maximum-scale` below 5
+  - `minimum-scale` above 1
+- Pass with `User zoom is not restricted`.
+- Info with `No viewport meta tag found`.
+
+The `maximum-scale` cutoff of 5 matches the threshold Lighthouse uses. It is stricter than WCAG's 200 percent, so a page with `maximum-scale=3` fails this rule while meeting the success criterion.
+
+## How to fix it
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+```
+
+That is the whole tag for almost every site. `width=device-width` and `initial-scale=1` set the layout, and leaving the scale directives out means the browser's own limits apply.
+
+`user-scalable=no` is usually added to stop a mobile browser zooming in when a form field takes focus. Raising the input's font size removes that behavior without removing the user's ability to zoom.
 
 | | |
 |---|---|
@@ -12,10 +39,6 @@ Checks if viewport meta tag disables user zoom
 | **Scope** | Per-page |
 | **Severity** | error |
 | **Weight** | 7/10 |
-
-## Solution
-
-Never disable user zoom - it's critical for users with low vision. Remove user-scalable=no and maximum-scale=1.0 from your viewport meta tag. Good: `<meta name='viewport' content='width=device-width, initial-scale=1'>`. Bad: `<meta name='viewport' content='width=device-width, user-scalable=no, maximum-scale=1.0'>`. Users must be able to zoom up to at least 500% (WCAG 1.4.4 requires 200%, but browsers limit to 500%).
 
 ## Enable / disable
 
@@ -40,3 +63,31 @@ disable = ["a11y/*"]
 enable = ["a11y/zoom-disabled"]
 disable = ["*"]
 ```
+
+## Related rules
+
+- [mobile/viewport-zoom](/rules/mobile/viewport-zoom): the same directives judged for mobile usability.
+- [mobile/viewport](/rules/mobile/viewport): whether the tag is present and well formed at all.
+- [mobile/font-size](/rules/mobile/font-size): the text size that makes zooming necessary.
+- [a11y/touch-targets](/rules/a11y/touch-targets): targets too small to hit at the default zoom level.
+
+Accessibility findings ship in every audit next to the SEO, performance and agent experience rules. See [Website security scan with AI](https://squirrelscan.com/learn/audit-website-security-with-ai) for how an agent works through a report.
+
+## References
+
+- [Viewport meta element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Viewport_meta_element)
+- [Understanding SC 1.4.4 Resize Text, W3C](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
+- [F69: Failure when resizing visually rendered text up to 200 percent, W3C](https://www.w3.org/WAI/WCAG22/Techniques/failures/F69)
+
+## Check your site
+
+Run `squirrel audit https://example.com` and open the Accessibility section of the report. Each offending directive is listed separately, alongside the raw viewport string. Local audits are free.
+
+<CardGroup cols={2}>
+  <Card title="Install squirrel" icon="terminal" href="/quickstart">
+    One command to install, one to run your first audit.
+  </Card>
+  <Card title="See a sample report" icon="file-text" href="https://squirrelscan.com/reports/squirrelscan-sample">
+    What the Accessibility section looks like on a real site.
+  </Card>
+</CardGroup>

--- a/docs/rules/a11y/zoom-disabled.mdx
+++ b/docs/rules/a11y/zoom-disabled.mdx
@@ -20,7 +20,7 @@ One check, `zoom-disabled`, at severity error. It reads the first `meta[name="vi
 - Pass with `User zoom is not restricted`.
 - Info with `No viewport meta tag found`.
 
-The `maximum-scale` cutoff of 5 matches the threshold Lighthouse uses. It is stricter than WCAG's 200 percent, so a page with `maximum-scale=3` fails this rule while meeting the success criterion.
+The `maximum-scale` cutoff of 5 matches the threshold Lighthouse uses. It is stricter than WCAG's 200 percent, so a page with `maximum-scale=3` fails this rule and can still meet the success criterion, provided text reaches 200 percent without losing content or function.
 
 ## How to fix it
 
@@ -77,7 +77,7 @@ Accessibility findings ship in every audit next to the SEO, performance and agen
 
 - [Viewport meta element, MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Viewport_meta_element)
 - [Understanding SC 1.4.4 Resize Text, W3C](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
-- [F69: Failure when resizing visually rendered text up to 200 percent, W3C](https://www.w3.org/WAI/WCAG22/Techniques/failures/F69)
+- [Meta viewport allows for zoom, W3C ACT rules](https://www.w3.org/WAI/standards-guidelines/act/rules/b4f0c3/)
 
 ## Check your site
 


### PR DESCRIPTION
Rewrites the accessibility rule documentation to the search-first template established by `docs/rules/a11y/aria-labels.mdx` on the base branch.

Tracking issue: https://github.com/squirrelscan/repo/issues/2050

## Categories done so far

| Category | Pages |
|---|---|
| a11y | 61 rule pages + the category index |

Every page follows the template order: frontmatter with a searchable title and a symptom-first description, `## What <term> is`, `## What squirrel checks`, `## How to fix it`, the existing metadata table and `## Enable / disable` block unchanged, `## Related rules`, `## References`, and the CTA.

## Facts

Every check name, fail/warn condition and report message is copied verbatim from `packages/rules/src/a11y/*.ts`. Where the rule source contradicted the old page text, the source won:

- The a11y rules contain no axe-core. The template page described `a11y/button-name` as an axe-core passthrough run on rendered pages; every a11y rule is a hand-written static-HTML check that mirrors an axe rule name. That line is corrected.
- `a11y/aria-roles`' solution text says roles are case-sensitive and must be lowercase, but the implementation lowercases each token before lookup.
- `a11y/touch-targets`' solution text cites WCAG 2.5.5 and 44px, which is the Level AAA enhanced threshold. The Level AA minimum, 2.5.8, is 24x24. Both are now stated.

Gaps in the rules themselves are documented on the pages rather than papered over, so a reader does not read a pass as proof: `focus-visible` and `color-contrast` never fetch external stylesheets, `touch-targets` reads inline styles only, `meta-refresh` emits nothing for `content="0"` with no url, and `aria-required-parent` walks the whole ancestor chain where HTML requires a direct parent.

## Checks

- `make validate` in `docs/` (tangly check --strict) passes.
- All 114 reference URLs return 200, and all come from MDN, w3.org (WAI, TR) or html.spec.whatwg.org.
- Every internal `/rules/` link resolves to a page that exists.

https://claude.ai/code/session_0174D96WamG9ZhJxRudpeniA