### PR TITLE
fix(cli): keep local and private-host audits off every hosted runner (#1841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ How it works:
 
 ### Changed
 
-- Audits of `localhost`, loopback, and private-network addresses no longer hand anything to a hosted runner: no publish, no run registration, no cloud rendering, and no site added to your dashboard. The audit, its report, and the content-based cloud analysis are unchanged, and the CLI prints one line saying the report stayed local. Hosted services cannot reach those addresses, so a dashboard site for one could never be screenshotted, re-rendered, or re-audited.
+- Audits of `localhost`, loopback, and private-network addresses no longer hand anything to a hosted runner: no publish, no run registration, no cloud rendering, and no site added to your dashboard. This covers `squirrel report --publish` as well as `squirrel audit`, and internal names such as `box.local` and `metadata.google.internal` as well as private IP ranges. The audit, its report, and the content-based cloud analysis are unchanged, and the CLI prints one line saying the report stayed local. Hosted services cannot reach those addresses, so a dashboard site for one could never be screenshotted, re-rendered, or re-audited.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ How it works:
 
 ## [Unreleased]
 
+### Changed
+
+- Audits of `localhost`, loopback, and private-network addresses no longer hand anything to a hosted runner: no publish, no run registration, no cloud rendering, and no site added to your dashboard. The audit, its report, and the content-based cloud analysis are unchanged, and the CLI prints one line saying the report stayed local. Hosted services cannot reach those addresses, so a dashboard site for one could never be screenshotted, re-rendered, or re-audited.
+
 ### Fixed
 
 - Published cloud reports no longer count findings the CLI carried from its local
@@ -29,6 +33,7 @@ How it works:
 - Two page URLs that differ only by their query string are two pages again.
   Findings on `/p?id=1` and `/p?id=2` were stored under one URL, piling every
   page's issues onto a single entry in the report.
+- A signed-in audit of a local or private-network address no longer submits its pages to the cloud render service, which charged on submit for renders the hosted browser then refused.
 
 ## v0.0.94
 

--- a/apps/cli/src/audit/cloud.ts
+++ b/apps/cli/src/audit/cloud.ts
@@ -58,6 +58,7 @@ import {
   buildGapsPayloadsFromSeeds,
   createSeedState,
 } from "@/audit/cloud-payloads-gaps";
+import { nonPublicHostLabel } from "@/lib/non-public-host";
 import { logger } from "@/utils/logger";
 import { getOrigin, getPathname } from "@/utils/url";
 
@@ -447,6 +448,11 @@ export async function runCloudPrefetch(
     // HTTP-first (most pages raw) → render must run there, so this is false for auto — the caller derives it
     // from the resolved render fetcher, not config.cloud.rendering (which can't tell "all" from "auto").
     crawlRendered: opts.crawlRendered ?? false,
+    // #1841: a hosted browser cannot reach a loopback / private-network target,
+    // so the render service would charge on submit for a batch the
+    // crawler-worker refuses. Derived from the base URL in both prefetch seams
+    // so neither can drift.
+    hostUnreachableByCloud: nonPublicHostLabel(opts.baseUrl) !== null,
     // Per-page skip for the pages an "auto" crawl already rendered (charge-free, rule-discarded otherwise).
     renderedPageUrls,
   });
@@ -651,6 +657,13 @@ export async function runCloudPrefetchFromPayloads(
     confirm: opts.confirm,
     onProgress: opts.onProgress,
     crawlRendered: opts.crawlRendered ?? false,
+    // #1841: derived HERE rather than threaded down from the command, so no
+    // caller of this seam can forget it. A loopback / private-network site
+    // cannot be rendered by a hosted browser, and the render service debits on
+    // submit, so without this every signed-in `squirrel audit
+    // http://localhost:3000` pays 2 credits a page for a batch the
+    // crawler-worker refuses ("Refusing to render a non-public host").
+    hostUnreachableByCloud: nonPublicHostLabel(opts.baseUrl) !== null,
     renderedPageUrls: payloads.renderedPageUrls,
   });
 }

--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -61,6 +61,12 @@ import {
   type ReportVisibility,
 } from "@/controllers/report/publish";
 import { formatBalance, isUnlimitedBalance } from "@/lib/balance";
+import {
+  cloudRenderSkippedLines,
+  LOCAL_HOST_NOT_PUBLISHED_LINE,
+  nonPublicHostLabel,
+  SERVER_NON_PUBLIC_HOST_LINE,
+} from "@/lib/non-public-host";
 import { pageLimitNotice, resolvePageLimit } from "@/lib/page-limit";
 import {
   createRunFinalizer,
@@ -557,7 +563,17 @@ export function resolvePublishDecision(opts: {
   // report in the dashboard, so treat it like an implicit --no-publish
   // unless the user explicitly asks with --publish.
   ruleFilterActive?: boolean;
+  // #1841: the audited host is loopback / RFC1918 / link-local, so no hosted
+  // service can ever reach it.
+  nonPublicHost?: boolean;
 }): boolean {
+  // BEFORE explicitPublish, unlike every other opt-out here. The rest of this
+  // function resolves a PREFERENCE, and an explicit --publish rightly wins
+  // those. This one is a CAPABILITY: a hosted report for http://localhost:3000
+  // is a dashboard card nothing in the cloud can screenshot, re-audit or
+  // schedule, and creating one is exactly the recurring production failure
+  // #1841 is about. The audit still runs and still prints its report.
+  if (opts.nonPublicHost) return false;
   if (opts.offline) return false;
   if (opts.explicitPublish) return true; // explicit --publish overrides opt-outs (still needs login; publishReport errors otherwise)
   if (opts.ruleFilterActive) return false;
@@ -1310,15 +1326,45 @@ export const audit = defineCommand({
         log("");
       }
 
+      // #1841 cloud preflight. A loopback / RFC1918 / link-local target is
+      // auditable (the crawl runs here) but unreachable for every hosted
+      // service, so this run hands NOTHING to the cloud that needs to fetch
+      // the address: no render submit, no run registration, no publish. Decided
+      // once, before the first API call, off the same normalization the crawl
+      // uses. The API refuses these independently — this only spares the user a
+      // charge and a failure they cannot fix.
+      const nonPublicHost = nonPublicHostLabel(args.url);
+
       // Resolve the render strategy (#294). `off`/`auto`/`all` is funneled into
       // the existing http/browser consent decision (off→http, auto|all→browser)
       // so the spend-consent flow is unchanged; the auto-vs-all *strategy* is
       // passed separately to the controller (hybrid vs render-all). Unset →
       // coverage-driven default, decided in the controller.
-      const explicitRenderMode = resolveExplicitRenderMode(
+      const requestedRenderMode = resolveExplicitRenderMode(
         { http: args.http, render: args.render, renderMode: renderModeArg },
         config
       );
+      // Rendering debits on SUBMIT and the crawler-worker then refuses the
+      // host outright ("Refusing to render a non-public host"), so an
+      // unpreflighted --render against localhost is a charge for a guaranteed
+      // failure. Announce it only when the user actually asked for rendering —
+      // the default (unset) mode is resolved in the controller and never
+      // reached the cloud for a local host anyway.
+      const explicitRenderMode = nonPublicHost ? "off" : requestedRenderMode;
+      // Only when rendering was actually going to happen: the user asked for it
+      // AND this run could have reached the cloud at all. Signed out or
+      // --offline, cloud rendering was already off for other reasons, and
+      // blaming the host there is a notice about nothing.
+      if (
+        nonPublicHost &&
+        signedIn &&
+        !args.offline &&
+        (requestedRenderMode === "auto" || requestedRenderMode === "all")
+      ) {
+        const [why, what] = cloudRenderSkippedLines(nonPublicHost);
+        log(fmt.yellow(`⚠ ${why}`));
+        log(fmt.dim(what));
+      }
       if (config.cloud.rendering && !config.cloud.render) {
         logger.debug(
           `[cloud] rendering = "${config.cloud.rendering}" is deprecated; prefer render = "${config.cloud.rendering === "http" ? "off" : "all"}"`
@@ -1366,7 +1412,14 @@ export const audit = defineCommand({
       // rendering is on). plannedPages is an UPPER bound (the crawl may find fewer),
       // so it's worded "up to". TTY → prompt continue/abort; non-TTY/--yes → warn +
       // continue (never block CI). Pricing comes from the shared source, not hardcoded.
-      if (signedIn && startingBalance != null) {
+      //
+      // #1841: never for a local/private host. That run does not register, so
+      // there is no base debit, and it does not render in the cloud, so there
+      // are no page charges — the whole estimate is zero. Left in, a
+      // low-balance user auditing localhost got a top-up warning and a
+      // default-No prompt for money nothing was going to take, and pressing
+      // Enter abandoned a free audit.
+      if (signedIn && startingBalance != null && !nonPublicHost) {
         const preflight = computePreflightAffordability({
           balance: startingBalance,
           maxPages,
@@ -1424,7 +1477,7 @@ export const audit = defineCommand({
       // isn't clobbered mid-crawl. Only set for definitive 4xx, not transient.
       let registerWarning: RegisterFailure | null = null;
       const registerPromise: Promise<RegisteredRun | null> =
-        signedIn && !args.offline
+        signedIn && !args.offline && !nonPublicHost
           ? registerRun(
               {
                 url: args.url,
@@ -1957,7 +2010,36 @@ export const audit = defineCommand({
         noPublish: !!args["no-publish"],
         configPublish: config.cloud.publish,
         ruleFilterActive,
+        nonPublicHost: !!nonPublicHost,
       });
+      // #1841: one line, and only when the host is the deciding factor — a
+      // signed-out or --no-publish run was never going to publish, and saying
+      // "kept local" there would read as a new restriction. Covers the skipped
+      // registration too: to the user both are the same fact.
+      // The server's own verdict (#1841). Reachable when its egress classifier
+      // is stricter than the preflight above — `box.local`,
+      // `metadata.google.internal`, a dotless host — so the run registered but
+      // no dashboard site exists. Mutually exclusive with the local skip below:
+      // a host the preflight caught never registered at all.
+      if (registeredRun?.websiteSkippedReason === "non_public_host") {
+        log(fmt.dim(SERVER_NON_PUBLIC_HOST_LINE));
+      }
+      if (
+        nonPublicHost &&
+        signedIn &&
+        !args.offline &&
+        resolvePublishDecision({
+          signedIn,
+          offline: !!args.offline,
+          explicitPublish: !!args.publish,
+          noPublish: !!args["no-publish"],
+          configPublish: config.cloud.publish,
+          ruleFilterActive,
+          nonPublicHost: false,
+        })
+      ) {
+        log(fmt.dim(LOCAL_HOST_NOT_PUBLISHED_LINE));
+      }
       // Only claim the filter caused the skip when it's actually the deciding
       // factor — --no-publish/config/signed-out skips would misattribute.
       const wouldPublishWithoutFilter = resolvePublishDecision({
@@ -1967,6 +2049,7 @@ export const audit = defineCommand({
         noPublish: !!args["no-publish"],
         configPublish: config.cloud.publish,
         ruleFilterActive: false,
+        nonPublicHost: !!nonPublicHost,
       });
       if (!shouldPublish && wouldPublishWithoutFilter && ruleFilterActive) {
         log(
@@ -2020,7 +2103,7 @@ export const audit = defineCommand({
             visibility,
             auditId: registeredRun?.auditId,
             runId: registeredRun?.runId,
-            websiteId: registeredRun?.websiteId,
+            websiteId: registeredRun?.websiteId ?? undefined,
             // #1167: surface the degrade-pass clip notice on stderr-safe `log`.
             onWarn: (msg) => log(fmt.yellow(`⚠ ${msg}`)),
           });

--- a/apps/cli/src/cli/commands/audit.ts
+++ b/apps/cli/src/cli/commands/audit.ts
@@ -551,6 +551,28 @@ export async function resolveCloudRendering(opts: {
  * Signed-in + online ⇒ publish unlisted by default; opt out per-run with
  * --no-publish/--offline or persistently via [cloud] publish = false.
  */
+/**
+ * Whether this run registers with the cloud at all (#271).
+ *
+ * Its own named predicate rather than an inline `&&` at the call site, because
+ * the #1841 clause is an invariant with a test, not a convenience: registering
+ * a local or private-network audit is what created the hosted website with a
+ * weekly screenshot refresh that could never succeed. An inline condition can
+ * be deleted without failing anything.
+ */
+export function resolveRegisterDecision(opts: {
+  signedIn: boolean;
+  offline: boolean;
+  /** #1841: the audited host is loopback / RFC1918 / link-local / internal. */
+  nonPublicHost: boolean;
+}): boolean {
+  // No cloud state for a host no hosted runner can reach, and no audit base
+  // charged for cloud work that cannot happen.
+  if (opts.nonPublicHost) return false;
+  if (opts.offline) return false;
+  return opts.signedIn;
+}
+
 export function resolvePublishDecision(opts: {
   signedIn: boolean;
   offline: boolean;
@@ -1477,7 +1499,11 @@ export const audit = defineCommand({
       // isn't clobbered mid-crawl. Only set for definitive 4xx, not transient.
       let registerWarning: RegisterFailure | null = null;
       const registerPromise: Promise<RegisteredRun | null> =
-        signedIn && !args.offline && !nonPublicHost
+        resolveRegisterDecision({
+          signedIn,
+          offline: !!args.offline,
+          nonPublicHost: !!nonPublicHost,
+        })
           ? registerRun(
               {
                 url: args.url,

--- a/apps/cli/src/cli/commands/report.ts
+++ b/apps/cli/src/cli/commands/report.ts
@@ -28,6 +28,10 @@ import {
   publishReport,
   type ReportVisibility,
 } from "@/controllers/report/publish";
+import {
+  LOCAL_HOST_NOT_PUBLISHED_LINE,
+  nonPublicHostLabel,
+} from "@/lib/non-public-host";
 import { diffReports, isSameBaseUrl } from "@/reports/diff";
 import {
   generateDiffConsole,
@@ -431,8 +435,25 @@ export const report = defineCommand({
       reportData = filterByCategory(reportData, categories as RuleCategory[]);
     }
 
+    // #1841: a report of a local or private-network target is never published.
+    // The audit's own publish path refuses these, and `squirrel report
+    // --publish` is the same handoff by another route: a hosted report for
+    // http://localhost:3000 is a dashboard card nothing in the cloud can
+    // screenshot, re-audit or schedule. Checked on the report's AUDITED url,
+    // which is the thing the cloud would have to reach.
+    //
+    // Falls THROUGH to the normal output below rather than exiting: the report
+    // exists and the user asked to see it, so the only thing withheld is the
+    // upload. On stderr so a `-f json` pipeline stays clean.
+    const publishNonPublicHost = args.publish
+      ? nonPublicHostLabel(reportData.baseUrl)
+      : null;
+    if (publishNonPublicHost) {
+      console.error(LOCAL_HOST_NOT_PUBLISHED_LINE);
+    }
+
     // Handle publish flag - skip report output when publishing
-    if (args.publish) {
+    if (args.publish && !publishNonPublicHost) {
       // Validate visibility if provided
       const validVisibilities: ReportVisibility[] = [
         "public",

--- a/apps/cli/src/lib/non-public-host.ts
+++ b/apps/cli/src/lib/non-public-host.ts
@@ -1,0 +1,83 @@
+/**
+ * Local and private-network hosts versus the squirrelscan cloud (#1841).
+ *
+ * The CLI audits `http://localhost:3000`, RFC1918 staging boxes and internal
+ * hosts on purpose: the crawl runs on the user's own machine, on their own
+ * network. No HOSTED service can reach any of those, so every cloud surface
+ * that fetches the address ITSELF fails on them forever: the render service,
+ * the screenshot capture, a scheduled cloud audit. A hosted website row for
+ * such a host is a recurring weekly failure with no way to ever succeed, which
+ * is the bug this preflight exists to stop the CLI from creating.
+ *
+ * A PREFLIGHT, not the boundary. `isHostedEgressAllowed` in the cloud API is
+ * authoritative and strictly stricter than this: it also refuses cloud
+ * metadata hostnames, internal-only name zones (`.internal`, `.local`, `.svc`)
+ * and dotless hosts, none of which a syntactic private-IP check can see.
+ * Anything this misses the API still refuses, and says so in its response, so
+ * the CLI can report it. Keeping the loose check here is deliberate: it decides
+ * only whether to SKIP a cloud handoff, never what to crawl.
+ *
+ * MUST stay out of the shared fetch paths. See the comment block in
+ * `packages/utils/src/safe-fetch.ts`: host-blocking a crawl is a functional
+ * regression, not hardening. Only cloud handoffs consult this.
+ */
+import { isPublicHttpUrl, parseUserUrl } from "@squirrelscan/utils/url";
+
+/**
+ * The `host:port` of a URL no hosted runner can reach, or null when the cloud
+ * can reach it.
+ *
+ * Null for input that is not a usable http(s) URL too: the normal URL
+ * validation reports that far better than a cloud-reachability warning would,
+ * and this must never be the thing that rejects a typo.
+ *
+ * Takes the user's RAW input (a bare `localhost:3000` included) and normalizes
+ * it the same way the audit command does, so a schemeless private host is
+ * classified identically to a written-out one.
+ */
+export function nonPublicHostLabel(rawUrl: string): string | null {
+  const parsedInput = parseUserUrl(rawUrl);
+  if (!parsedInput.ok) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(parsedInput.url);
+  } catch {
+    return null;
+  }
+  return isPublicHttpUrl(parsed.href) ? null : parsed.host;
+}
+
+/**
+ * Why cloud rendering is off for this run. Two lines: the reason, then what
+ * still happens, so the user is not left wondering whether the audit ran.
+ *
+ * Rendering is the one cloud service that fetches the page URL itself, and it
+ * debits on SUBMIT, so without this preflight a `--render` run against
+ * localhost pays for a render the crawler-worker then refuses.
+ */
+export function cloudRenderSkippedLines(host: string): [string, string] {
+  return [
+    `No cloud runner can reach a local or private-network address (${host}).`,
+    "Cloud rendering is off for this run; the audit still runs locally.",
+  ];
+}
+
+/**
+ * The single line a local/private-host run prints instead of a publish. Covers
+ * both halves of the skip (no run registered, no report published) because to
+ * the user they are one fact: this stayed on your machine.
+ */
+export const LOCAL_HOST_NOT_PUBLISHED_LINE =
+  "Local/private host: report kept local, not published to the cloud.";
+
+/**
+ * What the CLI prints when the SERVER is the one that classified the host
+ * (`websiteRegistration.skipped` with reason `non_public_host`).
+ *
+ * Reachable whenever the API's stricter classifier disagrees with the local
+ * one: `metadata.google.internal` and friends look public here. The run row
+ * exists and the report may have published, so this does not claim otherwise;
+ * it explains the missing dashboard site.
+ */
+export const SERVER_NON_PUBLIC_HOST_LINE =
+  "Local/private host: the cloud did not add this site to your dashboard.";

--- a/apps/cli/src/lib/non-public-host.ts
+++ b/apps/cli/src/lib/non-public-host.ts
@@ -9,42 +9,146 @@
  * such a host is a recurring weekly failure with no way to ever succeed, which
  * is the bug this preflight exists to stop the CLI from creating.
  *
- * A PREFLIGHT, not the boundary. `isHostedEgressAllowed` in the cloud API is
- * authoritative and strictly stricter than this: it also refuses cloud
- * metadata hostnames, internal-only name zones (`.internal`, `.local`, `.svc`)
- * and dotless hosts, none of which a syntactic private-IP check can see.
- * Anything this misses the API still refuses, and says so in its response, so
- * the CLI can report it. Keeping the loose check here is deliberate: it decides
- * only whether to SKIP a cloud handoff, never what to crawl.
+ * THE CONTRACT IS "HAND NOTHING TO A HOSTED RUNNER", so this classifier has to
+ * stand on its own rather than lean on the cloud refusing later. It deliberately
+ * mirrors the API's `classifyHostedEgressHost` name rules — the loopback names,
+ * the cloud metadata names, the internal-only zones, and the dotless-host rule —
+ * so the two sides agree on the cases a private-IP check alone cannot see:
+ * `box.local`, `metadata.google.internal`, `intranet`, `localhost.`.
+ *
+ * INDEPENDENT OF `parseUserUrl`, also deliberately. That helper answers "is this
+ * a valid audit target", and it rejects single-label and trailing-dot names —
+ * so classifying through it returned "reachable" for exactly the hosts that are
+ * least reachable, and the CLI registered a run with the API before the audit
+ * controller rejected the URL. This only ever needs the HOST.
  *
  * MUST stay out of the shared fetch paths. See the comment block in
  * `packages/utils/src/safe-fetch.ts`: host-blocking a crawl is a functional
  * regression, not hardening. Only cloud handoffs consult this.
  */
-import { isPublicHttpUrl, parseUserUrl } from "@squirrelscan/utils/url";
+import { isPrivateOrReservedHost } from "@squirrelscan/utils/url";
+
+/** Loopback by name. RFC 6761 for `localhost`; the rest are conventional. */
+const LOOPBACK_NAMES = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "ip6-localhost",
+]);
+
+/** Cloud instance-metadata services named directly rather than by address. */
+const METADATA_HOSTNAMES = new Set([
+  "metadata",
+  "metadata.google.internal",
+  "metadata.goog",
+  "metadata.azure.com",
+  "instance-data",
+  "instance-data.ec2.internal",
+  "nova-agent",
+]);
+
+/**
+ * Zones that can only denote something inside a private network, matched at the
+ * apex AND as a suffix. `local` is mDNS, `internal` / `intranet` / `lan` /
+ * `home.arpa` are private-use zones, `localhost` is loopback by RFC 6761, `svc`
+ * is a Kubernetes service name, `consul` / `nomad` are service-discovery zones.
+ * None are publicly registrable, so refusing them cannot cost a real cloud run.
+ */
+const INTERNAL_NAME_ZONES = [
+  "localhost",
+  "local",
+  "internal",
+  "intranet",
+  "lan",
+  "home.arpa",
+  "corp",
+  "private",
+  "svc",
+  "consul",
+  "nomad",
+];
+
+/**
+ * Lowercase and strip EVERY trailing root dot. Stripping only one would leave
+ * `localhost..` classified as a public name while the IPv4 path already refuses
+ * `127.0.0.1..`, an asymmetry with no reason to exist.
+ */
+function normalizeHostname(host: string): string {
+  return host.toLowerCase().replace(/\.+$/, "");
+}
+
+/**
+ * Is this bare host an IP literal rather than a name?
+ *
+ * Two shapes are exhaustive HERE because the input has already been through the
+ * WHATWG URL parser: every accepted IPv4 spelling (decimal, octal, hex, short
+ * form) is canonicalized to dotted-quad, and every IPv6 form keeps its colons.
+ * A DNS name can contain neither shape — the port lives in `host`, not
+ * `hostname` — so this needs no resolver and no `node:net`.
+ */
+function isIpLiteral(host: string): boolean {
+  return host.includes(":") || /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
+}
+
+/** True when no hosted runner could reach this bare hostname. */
+function isNonPublicHostname(rawHost: string): boolean {
+  const host = normalizeHostname(rawHost);
+  if (host.length === 0) return true;
+
+  // AN IP LITERAL IS DECIDED BY THE IP RULES ALONE, and returns here. Falling
+  // through to the NAME rules below would hand every IPv6 address to the
+  // dotless-host rule — `2606:4700::1111` contains no dot — and refuse to
+  // publish a real IPv6-only customer site. The ranges cover loopback, RFC1918,
+  // link-local incl. the metadata address, CGNAT, 0.0.0.0/8, and the IPv6
+  // equivalents including the IPv4-embedding forms. The decimal, octal and hex
+  // IPv4 spellings arrive here already canonicalized by the URL parser.
+  if (isIpLiteral(host)) return isPrivateOrReservedHost(host);
+
+  if (LOOPBACK_NAMES.has(host)) return true;
+  if (METADATA_HOSTNAMES.has(host)) return true;
+  // Both the apex (`home.arpa`) and anything under it (`router.home.arpa`).
+  if (
+    INTERNAL_NAME_ZONES.some(
+      (zone) => host === zone || host.endsWith(`.${zone}`)
+    )
+  ) {
+    return true;
+  }
+  // A dotless host resolves through the machine's own search domain in practice
+  // (`db`, `intranet`, `nas`). A public TLD apex CAN carry an A record, so this
+  // is a deliberate trade: no cloud audit target is a bare TLD.
+  return !host.includes(".");
+}
 
 /**
  * The `host:port` of a URL no hosted runner can reach, or null when the cloud
  * can reach it.
  *
- * Null for input that is not a usable http(s) URL too: the normal URL
- * validation reports that far better than a cloud-reachability warning would,
- * and this must never be the thing that rejects a typo.
+ * Takes the user's RAW input, including a bare `localhost:3000`. A schemeless
+ * value gets `http://` purely so the URL parser will yield a host; the scheme
+ * plays no part in the verdict and is never written back.
  *
- * Takes the user's RAW input (a bare `localhost:3000` included) and normalizes
- * it the same way the audit command does, so a schemeless private host is
- * classified identically to a written-out one.
+ * Null for input that is not a usable http(s) URL: the normal URL validation
+ * reports that far better than a cloud-reachability warning would, and this
+ * must never be the thing that rejects a typo.
  */
 export function nonPublicHostLabel(rawUrl: string): string | null {
-  const parsedInput = parseUserUrl(rawUrl);
-  if (!parsedInput.ok) return null;
+  const trimmed = rawUrl.trim();
+  if (trimmed.length === 0) return null;
+  // An explicit non-http(s) scheme is someone else's error to report.
+  if (trimmed.includes("://") && !/^https?:\/\//i.test(trimmed)) return null;
   let parsed: URL;
   try {
-    parsed = new URL(parsedInput.url);
+    parsed = new URL(trimmed.includes("://") ? trimmed : `http://${trimmed}`);
   } catch {
     return null;
   }
-  return isPublicHttpUrl(parsed.href) ? null : parsed.host;
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  // URL.hostname keeps an IPv6 literal bracketed; the checks want it bare.
+  const bare = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (!isNonPublicHostname(bare)) return null;
+  // `host` (not `hostname`) so the port the user typed is in the message, and
+  // as they typed it: this names the thing they pointed at, it is not an id.
+  return parsed.host;
 }
 
 /**
@@ -74,10 +178,9 @@ export const LOCAL_HOST_NOT_PUBLISHED_LINE =
  * What the CLI prints when the SERVER is the one that classified the host
  * (`websiteRegistration.skipped` with reason `non_public_host`).
  *
- * Reachable whenever the API's stricter classifier disagrees with the local
- * one: `metadata.google.internal` and friends look public here. The run row
- * exists and the report may have published, so this does not claim otherwise;
- * it explains the missing dashboard site.
+ * Kept even though the two classifiers now agree on every case we know of: the
+ * API's is authoritative and may tighten first, and a client that answered a
+ * server refusal with silence would leave the user hunting for a missing site.
  */
 export const SERVER_NON_PUBLIC_HOST_LINE =
   "Local/private host: the cloud did not add this site to your dashboard.";

--- a/apps/cli/src/lib/run-tracker.ts
+++ b/apps/cli/src/lib/run-tracker.ts
@@ -49,7 +49,12 @@ export type CliCompletionReason = "success" | "error" | "user_cancel";
 
 export interface RegisteredRun {
   runId: string;
-  websiteId: string;
+  /**
+   * Null when the server registered the run but deliberately created NO hosted
+   * website for it (#1841) — today only a host no hosted service can reach.
+   * The run is real and trackable; it just has no dashboard site to hang off.
+   */
+  websiteId: string | null;
   auditId: string;
   /**
    * Lifecycle base path resolved ONCE at register time. Threaded into every
@@ -65,6 +70,15 @@ export interface RegisteredRun {
   baseCharged: number;
   /** Balance total right after the base debit; null when the server omits it. */
   balanceAfterBase: number | null;
+  /**
+   * Why the server created no hosted website for this run (#1841), or null when
+   * it created (or resolved) one as usual. `non_public_host` is the only value
+   * today: the API's egress classifier is stricter than the CLI's preflight, so
+   * a host that looks public here (`box.local`, `metadata.google.internal`, a
+   * dotless name) is refused there. The CLI reports it rather than leaving the
+   * user to wonder why the site never appeared.
+   */
+  websiteSkippedReason: string | null;
 }
 
 export interface RegisterRunInput {
@@ -152,9 +166,16 @@ function runPath(runId: string, suffix = "", base = lifecycleBase()): string {
 }
 
 /** What `POST /register` answers with — ids plus the pricing-v10 extras. */
-type RegisterResponseBody = Partial<RegisteredRun> & {
+type RegisterResponseBody = Partial<Omit<RegisteredRun, "websiteId">> & {
+  websiteId?: string | null;
   balance?: { total?: number } | null;
   error?: { code?: string; message?: string };
+  /**
+   * #1841. Present only when the server declined to create a hosted website for
+   * this run. Absent on every older server and on every ordinary register, so
+   * its absence must read as "a website was resolved", never as a skip.
+   */
+  websiteRegistration?: { skipped?: boolean; reason?: string } | null;
 };
 
 /**
@@ -268,16 +289,27 @@ export async function registerRun(
     }
     return null;
   }
-  if (!data.runId || !data.websiteId || !data.auditId) return null;
+  // #1841: a websiteId-less response is only legitimate when the server SAYS it
+  // skipped the website. Without that marker a missing id is the old "bad body"
+  // case and must still fall through to an untracked audit — otherwise a
+  // malformed response would silently register a run the CLI cannot finalize
+  // against any site.
+  const websiteSkippedReason =
+    data.websiteRegistration?.skipped === true
+      ? (data.websiteRegistration.reason ?? "unknown")
+      : null;
+  if (!data.runId || !data.auditId) return null;
+  if (!data.websiteId && !websiteSkippedReason) return null;
   return {
     runId: data.runId,
-    websiteId: data.websiteId,
+    websiteId: data.websiteId ?? null,
     auditId: data.auditId,
     lifecycleBase: base,
     // Pricing v10 fields; absent from older servers → 0 / null.
     baseCharged: typeof data.baseCharged === "number" ? data.baseCharged : 0,
     balanceAfterBase:
       typeof data.balance?.total === "number" ? data.balance.total : null,
+    websiteSkippedReason,
   };
 }
 

--- a/apps/cli/tests/audit/cloud-prefetch-non-public-base.test.ts
+++ b/apps/cli/tests/audit/cloud-prefetch-non-public-base.test.ts
@@ -1,0 +1,149 @@
+import type { CloudPrefetchInput } from "@squirrelscan/audit-engine";
+
+// #1841, the CLI half of the render skip. The engine test proves that
+// `hostUnreachableByCloud: true` drops the render service before it charges.
+// This proves the two CLI seams actually SET it, and set it from the right
+// thing — deleting either assignment would otherwise fail no test at all.
+//
+// "From the right thing" is the load-bearing part. The classification is on the
+// audit's BASE url, not on the page payloads: a crawl of http://localhost:3000
+// can perfectly well carry page urls that look public (an absolute link, a
+// rewritten canonical), and keying off those would put the render service back
+// on a site the hosted browser cannot reach.
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+const realEngine = await import("@squirrelscan/audit-engine");
+
+/** Every prefetchCloudData call the seams below made. */
+const calls: CloudPrefetchInput[] = [];
+
+// Spread the REAL module: a partial stub leaks process-wide and drops exports
+// sibling suites need.
+mock.module("@squirrelscan/audit-engine", () => ({
+  ...realEngine,
+  prefetchCloudData: async (input: CloudPrefetchInput) => {
+    calls.push(input);
+    return { store: new Map(), spend: [], totalSpent: 0, failures: [] };
+  },
+}));
+
+const { runCloudPrefetch, runCloudPrefetchFromPayloads } =
+  await import("@/audit/cloud");
+
+afterAll(() => {
+  mock.restore();
+});
+
+const cloudConfig = {
+  enabled: true,
+  batch_size: 20,
+  confirm_threshold: 0,
+  max_credits_per_audit: 0,
+} as never;
+
+/** Only the fields these seams read: the rule filter and its options. */
+const config = {
+  rules: { enable: [], disable: [] },
+  rule_options: {},
+} as never;
+
+/** Page payloads on a PUBLIC host, to prove the base is what decides. */
+const publicPages = [
+  { url: "https://cdn.example.com/a", html: "<html></html>" },
+  { url: "https://cdn.example.com/b", html: "<html></html>" },
+] as never;
+
+function payloadsWith(pages: unknown) {
+  return {
+    pages,
+    metadataPages: [],
+    blocklist: null,
+    gapsSeeds: [],
+    renderedPageUrls: new Set<string>(),
+  } as never;
+}
+
+async function runPayloadSeam(baseUrl: string) {
+  calls.length = 0;
+  await runCloudPrefetchFromPayloads(
+    {
+      client: {} as never,
+      cloudConfig,
+      config,
+      baseUrl,
+      auditId: "audit-1",
+    } as never,
+    payloadsWith(publicPages)
+  );
+  return calls[0]!;
+}
+
+async function runSiteContextSeam(baseUrl: string) {
+  calls.length = 0;
+  await runCloudPrefetch({
+    client: {} as never,
+    cloudConfig,
+    config,
+    siteContext: [],
+    baseUrl,
+    auditId: "audit-1",
+  } as never);
+  return calls[0]!;
+}
+
+const seams: Array<[string, (baseUrl: string) => Promise<CloudPrefetchInput>]> =
+  [
+    ["runCloudPrefetchFromPayloads", runPayloadSeam],
+    ["runCloudPrefetch", runSiteContextSeam],
+  ];
+
+describe.each(seams)("%s", (_name, run) => {
+  test.each([
+    ["http://localhost:3000"],
+    ["http://127.0.0.1:4321/"],
+    ["http://192.168.1.10:8000/"],
+    ["http://box.local/"],
+    ["http://intranet/"],
+  ])(
+    "a %s base marks the host unreachable, whatever the pages say",
+    async (baseUrl) => {
+      const input = await run(baseUrl);
+      expect(input.hostUnreachableByCloud).toBe(true);
+      expect(input.siteUrl).toBe(baseUrl);
+    }
+  );
+
+  test("a public base leaves it false, so render runs exactly as before", async () => {
+    const input = await run("https://example.com");
+    expect(input.hostUnreachableByCloud).toBe(false);
+  });
+
+  // The flag must be NARROW: it is the only thing about the request that a
+  // private base changes. Everything else works from pages the CLI already
+  // crawled and does not care where the site lives, so a local audit keeps its
+  // AI summary, tech detection and the rest. Asserted as an equality against
+  // the public run rather than a count, so it holds whatever the rule set is.
+  test("nothing else about the request changes for a private base", async () => {
+    const priv = await run("http://localhost:3000");
+    const pub = await run("https://example.com");
+    expect(priv.rules).toEqual(pub.rules);
+    expect(priv.metadataPages).toEqual(pub.metadataPages);
+    expect(priv.pages).toEqual(pub.pages);
+    // The site payloads legitimately differ: archive-indexing is handed the
+    // base url, which is the thing that changed. Compare their SHAPE.
+    expect(Object.keys(priv.sitePayloads ?? {})).toEqual(
+      Object.keys(pub.sitePayloads ?? {})
+    );
+    // The ONE difference.
+    expect(priv.hostUnreachableByCloud).toBe(true);
+    expect(pub.hostUnreachableByCloud).toBe(false);
+  });
+});
+
+describe("runCloudPrefetchFromPayloads", () => {
+  test("public page payloads are passed through untouched", async () => {
+    const input = await runPayloadSeam("http://localhost:3000");
+    expect(input.pages).toHaveLength(2);
+    expect(input.pages[0]!.url).toBe("https://cdn.example.com/a");
+  });
+});

--- a/apps/cli/tests/commands/audit-non-public-host-wiring.test.ts
+++ b/apps/cli/tests/commands/audit-non-public-host-wiring.test.ts
@@ -4,26 +4,27 @@
 // `resolvePublishDecision`, the render-mode override, both prefetch seams. What
 // none of them can prove is that the command still CONSULTS them — delete the
 // call site and every one of those suites stays green. So this drives the real
-// command and asserts on the two things that actually leave the process: the
-// register call and the publish call.
+// command and asserts on what actually leaves the process.
+//
+// NO `mock.module` HERE, deliberately. Bun's module mocks are process-wide and
+// `mock.restore()` does not undo them, so an earlier version of this file
+// replaced `safeExit` for every later suite in the run and broke a sibling
+// command test in CI while passing locally. Everything below is either
+// file-local state restored in `afterEach`, or an assertion on the stubbed
+// fetch — which is the stronger assertion anyway, since a spy on a helper
+// cannot tell you whether the command still calls it.
 //
 // The account probe (`GET /v1/credits`) is deliberately NOT asserted against.
 // It asks about the user, not about the site, and the audited address is never
 // part of it; the contract is that nothing hands the ADDRESS to a hosted
 // runner. The public-host control below is what proves the gate is a gate and
 // not an outage.
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+import { audit } from "@/cli/commands/audit";
 
 /** Thrown in place of process.exit, so a command exit cannot kill the runner. */
 class ExitSignal extends Error {
@@ -32,50 +33,24 @@ class ExitSignal extends Error {
   }
 }
 
-const realUpdater = await import("@/self/updater");
-mock.module("@/self/updater", () => ({
-  ...realUpdater,
-  safeExit: (code: number) => {
-    throw new ExitSignal(code);
-  },
-}));
-
-const realTracker = await import("@/lib/run-tracker");
-let registerCalls: string[] = [];
-mock.module("@/lib/run-tracker", () => ({
-  ...realTracker,
-  registerRun: async (input: { url: string }) => {
-    registerCalls.push(input.url);
-    return null; // as if the API were unreachable: the audit runs untracked
-  },
-}));
-
-const realPublish = await import("@/controllers/report/publish");
-let publishCalls: number = 0;
-mock.module("@/controllers/report/publish", () => ({
-  ...realPublish,
-  publishReport: async () => {
-    publishCalls++;
-    return { ok: false as const, error: { code: "TEST", message: "stubbed" } };
-  },
-}));
-
-const { audit } = await import("@/cli/commands/audit");
-
 const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
 const originalEnv = { ...process.env };
 let requested: string[] = [];
 let home: string;
 
 beforeEach(() => {
-  registerCalls = [];
-  publishCalls = 0;
   requested = [];
   home = mkdtempSync(join(tmpdir(), "squirrel-audit-test-"));
   // Never touch the real ~/.squirrel.
   process.env.HOME = home;
   process.env.SQUIRREL_API_TOKEN = "sqcli_test_token";
   process.env.SQUIRREL_DISABLE_TELEMETRY = "1";
+  // File-local, restored below. `safeExit` ends in process.exit, and a command
+  // that exits mid-test would take the whole runner with it.
+  process.exit = ((code?: number) => {
+    throw new ExitSignal(code ?? 0);
+  }) as typeof process.exit;
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = input.toString();
     requested.push(url);
@@ -103,15 +78,12 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  process.exit = originalExit;
   process.env = { ...originalEnv };
   rmSync(home, { recursive: true, force: true });
 });
 
-afterAll(() => {
-  mock.restore();
-});
-
-/** Run the real command to completion, swallowing its exit. */
+/** Run the real command to completion, swallowing only its exit. */
 async function runAudit(url: string, extra: Record<string, unknown> = {}) {
   try {
     await audit.run!({
@@ -130,7 +102,8 @@ async function runAudit(url: string, extra: Record<string, unknown> = {}) {
   }
 }
 
-const apiCalls = () =>
+/** Everything the run sent to the cloud about the AUDITED SITE. */
+const handoffs = () =>
   requested.filter(
     (u) => u.includes("/v1/agent-runs") || u.includes("/v1/reports")
   );
@@ -142,9 +115,7 @@ describe("squirrel audit — a host no hosted runner can reach (#1841)", () => {
     ["http://box.local:9/"],
   ])("%s registers nothing and publishes nothing", async (url) => {
     await runAudit(url);
-    expect(registerCalls).toEqual([]);
-    expect(publishCalls).toBe(0);
-    expect(apiCalls()).toEqual([]);
+    expect(handoffs()).toEqual([]);
   });
 
   // Explicit flags must not reopen the handoff: `--publish` is the one opt-out
@@ -152,24 +123,20 @@ describe("squirrel audit — a host no hosted runner can reach (#1841)", () => {
   // debits on submit.
   test("an explicit --publish --render still hands over nothing", async () => {
     await runAudit("http://127.0.0.1:9/", { publish: true, render: true });
-    expect(registerCalls).toEqual([]);
-    expect(publishCalls).toBe(0);
-    expect(apiCalls()).toEqual([]);
+    expect(handoffs()).toEqual([]);
+    expect(requested.some((u) => u.includes("/v1/services/render"))).toBe(
+      false
+    );
   });
 
-  // THE CONTROL. Without this the tests above would pass just as happily if the
-  // command had stopped registering anything at all.
+  // THE CONTROL. Without it the tests above would pass just as happily if the
+  // command had stopped registering anything at all, and the run has to be
+  // genuinely signed in or they pass for that reason instead.
   test("a public host still registers", async () => {
     await runAudit("https://example.com/");
-    expect(registerCalls).toEqual(["https://example.com/"]);
-  });
-
-  // ... and the same run is signed in, which is what makes the assertions above
-  // mean something. A logged-out run registers nothing either, so without this
-  // the private cases would pass on an unrelated reason.
-  test("the control run really was signed in", async () => {
-    await runAudit("https://example.com/");
     expect(requested.some((u) => u.includes("/v1/credits"))).toBe(true);
-    expect(registerCalls).toHaveLength(1);
+    expect(requested.some((u) => u.includes("/v1/agent-runs/register"))).toBe(
+      true
+    );
   });
 });

--- a/apps/cli/tests/commands/audit-non-public-host-wiring.test.ts
+++ b/apps/cli/tests/commands/audit-non-public-host-wiring.test.ts
@@ -1,0 +1,175 @@
+// #1841 at the `squirrel audit` command boundary.
+//
+// The pieces each have their own test: `resolveRegisterDecision`,
+// `resolvePublishDecision`, the render-mode override, both prefetch seams. What
+// none of them can prove is that the command still CONSULTS them — delete the
+// call site and every one of those suites stays green. So this drives the real
+// command and asserts on the two things that actually leave the process: the
+// register call and the publish call.
+//
+// The account probe (`GET /v1/credits`) is deliberately NOT asserted against.
+// It asks about the user, not about the site, and the audited address is never
+// part of it; the contract is that nothing hands the ADDRESS to a hosted
+// runner. The public-host control below is what proves the gate is a gate and
+// not an outage.
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Thrown in place of process.exit, so a command exit cannot kill the runner. */
+class ExitSignal extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+const realUpdater = await import("@/self/updater");
+mock.module("@/self/updater", () => ({
+  ...realUpdater,
+  safeExit: (code: number) => {
+    throw new ExitSignal(code);
+  },
+}));
+
+const realTracker = await import("@/lib/run-tracker");
+let registerCalls: string[] = [];
+mock.module("@/lib/run-tracker", () => ({
+  ...realTracker,
+  registerRun: async (input: { url: string }) => {
+    registerCalls.push(input.url);
+    return null; // as if the API were unreachable: the audit runs untracked
+  },
+}));
+
+const realPublish = await import("@/controllers/report/publish");
+let publishCalls: number = 0;
+mock.module("@/controllers/report/publish", () => ({
+  ...realPublish,
+  publishReport: async () => {
+    publishCalls++;
+    return { ok: false as const, error: { code: "TEST", message: "stubbed" } };
+  },
+}));
+
+const { audit } = await import("@/cli/commands/audit");
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+let requested: string[] = [];
+let home: string;
+
+beforeEach(() => {
+  registerCalls = [];
+  publishCalls = 0;
+  requested = [];
+  home = mkdtempSync(join(tmpdir(), "squirrel-audit-test-"));
+  // Never touch the real ~/.squirrel.
+  process.env.HOME = home;
+  process.env.SQUIRREL_API_TOKEN = "sqcli_test_token";
+  process.env.SQUIRREL_DISABLE_TELEMETRY = "1";
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = input.toString();
+    requested.push(url);
+    // Answer the balance probe so the run resolves to SIGNED IN. Without this
+    // every run reads as logged out and the gate under test never matters.
+    if (url.includes("/v1/credits")) {
+      return Response.json({
+        balance: { total: 5000, monthly: 5000, pack: 0, periodEnd: null },
+        plan: { id: "pro", monthlyCredits: 5000 },
+        branding: null,
+      });
+    }
+    // EVERY audited host answers, private ones included. The command bails
+    // early on an unreachable target, so a stub that refused them would make
+    // the private cases below pass for the wrong reason.
+    if (!url.includes("/v1/")) {
+      return new Response(
+        "<html><head><title>t</title></head><body><h1>h</h1></body></html>",
+        { status: 200, headers: { "Content-Type": "text/html" } }
+      );
+    }
+    return Response.json({});
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.env = { ...originalEnv };
+  rmSync(home, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+/** Run the real command to completion, swallowing its exit. */
+async function runAudit(url: string, extra: Record<string, unknown> = {}) {
+  try {
+    await audit.run!({
+      args: {
+        url,
+        // A single page, no interactive prompts, no rule filtering.
+        "max-pages": "1",
+        coverage: "quick",
+        yes: true,
+        format: "console",
+        ...extra,
+      },
+    } as never);
+  } catch (err) {
+    if (!(err instanceof ExitSignal)) throw err;
+  }
+}
+
+const apiCalls = () =>
+  requested.filter(
+    (u) => u.includes("/v1/agent-runs") || u.includes("/v1/reports")
+  );
+
+describe("squirrel audit — a host no hosted runner can reach (#1841)", () => {
+  test.each([
+    ["http://127.0.0.1:9/"],
+    ["http://192.168.1.10:9/"],
+    ["http://box.local:9/"],
+  ])("%s registers nothing and publishes nothing", async (url) => {
+    await runAudit(url);
+    expect(registerCalls).toEqual([]);
+    expect(publishCalls).toBe(0);
+    expect(apiCalls()).toEqual([]);
+  });
+
+  // Explicit flags must not reopen the handoff: `--publish` is the one opt-out
+  // the host clause deliberately outranks, and `--render` is the one that
+  // debits on submit.
+  test("an explicit --publish --render still hands over nothing", async () => {
+    await runAudit("http://127.0.0.1:9/", { publish: true, render: true });
+    expect(registerCalls).toEqual([]);
+    expect(publishCalls).toBe(0);
+    expect(apiCalls()).toEqual([]);
+  });
+
+  // THE CONTROL. Without this the tests above would pass just as happily if the
+  // command had stopped registering anything at all.
+  test("a public host still registers", async () => {
+    await runAudit("https://example.com/");
+    expect(registerCalls).toEqual(["https://example.com/"]);
+  });
+
+  // ... and the same run is signed in, which is what makes the assertions above
+  // mean something. A logged-out run registers nothing either, so without this
+  // the private cases would pass on an unrelated reason.
+  test("the control run really was signed in", async () => {
+    await runAudit("https://example.com/");
+    expect(requested.some((u) => u.includes("/v1/credits"))).toBe(true);
+    expect(registerCalls).toHaveLength(1);
+  });
+});

--- a/apps/cli/tests/commands/report-publish-non-public-host.test.ts
+++ b/apps/cli/tests/commands/report-publish-non-public-host.test.ts
@@ -1,0 +1,124 @@
+// #1841 at the COMMAND boundary. `squirrel report <id> --publish` is the other
+// route a report reaches the cloud by, and it bypassed the audit command's
+// gate entirely: it calls `publishReport` directly, and that controller has no
+// host check of its own.
+//
+// The assertion here is deliberately about the WIRE, not about a helper: zero
+// requests leave the process for a local or private-network target. A test that
+// only checked a predicate would still pass if someone deleted the call site's
+// gate, which is exactly the gap this closes.
+//
+// `--input` is a real, supported entry point (load a report from JSON), so this
+// drives the actual command with no storage or network mocking beyond fetch.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { report } from "@/cli/commands/report";
+
+const originalFetch = globalThis.fetch;
+const originalToken = process.env.SQUIRREL_API_TOKEN;
+
+let requested: string[] = [];
+let dir: string;
+
+beforeEach(() => {
+  requested = [];
+  // Signed in, so a publish is genuinely possible and the host is the only
+  // thing that can stop it.
+  process.env.SQUIRREL_API_TOKEN = "sqcli_test_token";
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    requested.push(input.toString());
+    return new Response(
+      JSON.stringify({
+        id: "rep_1",
+        url: "https://reports.test/rep_1",
+        visibility: "public",
+      }),
+      { status: 201, headers: { "Content-Type": "application/json" } }
+    );
+  }) as unknown as typeof fetch;
+  dir = mkdtempSync(join(tmpdir(), "squirrel-report-test-"));
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalToken === undefined) delete process.env.SQUIRREL_API_TOKEN;
+  else process.env.SQUIRREL_API_TOKEN = originalToken;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A report shaped like a real one: both the console renderer and the publish
+ * transform read more than the fields this test cares about. */
+function writeReport(baseUrl: string): string {
+  const path = join(dir, "report.json");
+  writeFileSync(
+    path,
+    JSON.stringify({
+      crawlId: "crawl-1",
+      baseUrl,
+      timestamp: "2026-09-12T00:00:00.000Z",
+      totalPages: 1,
+      failed: 0,
+      warnings: 0,
+      passed: 1,
+      pages: [],
+      siteChecks: [],
+      ruleResults: {},
+      summary: {
+        missingTitles: [],
+        missingDescriptions: [],
+        missingOgTags: [],
+        missingTwitterCards: [],
+        missingSchemas: [],
+        missingAltText: [],
+        multipleH1s: [],
+        thinContentPages: [],
+        urlIssues: [],
+        redirectChains: [],
+        securityIssues: [],
+      },
+      healthScore: {
+        overall: 90,
+        grade: "A",
+        groups: [],
+        categories: [],
+        passed: 1,
+        warnings: 0,
+        failed: 0,
+        total: 1,
+      },
+    })
+  );
+  return path;
+}
+
+async function runReport(baseUrl: string, extra: Record<string, unknown> = {}) {
+  await report.run!({
+    args: { input: writeReport(baseUrl), publish: true, ...extra },
+    // citty passes more than the command reads; only `args` is consulted.
+  } as never);
+}
+
+describe("squirrel report --publish — a host no hosted runner can reach (#1841)", () => {
+  test.each([
+    ["http://localhost:3000/"],
+    ["http://127.0.0.1:4321/"],
+    ["http://192.168.1.10:8000/"],
+    ["http://169.254.169.254/"],
+    ["http://box.local/"],
+    ["http://metadata.google.internal/"],
+  ])("%s sends nothing to the API", async (baseUrl) => {
+    await runReport(baseUrl);
+    expect(requested).toEqual([]);
+  });
+
+  // Narrowness, on the same wire assertion: a real site must still publish, or
+  // this gate would be a silent outage rather than a fix.
+  test("a public host still publishes", async () => {
+    await runReport("https://example.com/");
+    expect(requested.length).toBeGreaterThan(0);
+    expect(requested.some((u) => u.includes("/v1/reports"))).toBe(true);
+  });
+});

--- a/apps/cli/tests/commands/report-publish-non-public-host.test.ts
+++ b/apps/cli/tests/commands/report-publish-non-public-host.test.ts
@@ -17,7 +17,15 @@ import { join } from "node:path";
 
 import { report } from "@/cli/commands/report";
 
+/** Thrown in place of process.exit, so a command exit cannot kill the runner. */
+class ExitSignal extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
 const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
 const originalToken = process.env.SQUIRREL_API_TOKEN;
 
 let requested: string[] = [];
@@ -40,10 +48,17 @@ beforeEach(() => {
     );
   }) as unknown as typeof fetch;
   dir = mkdtempSync(join(tmpdir(), "squirrel-report-test-"));
+  // File-local, restored below. The command ends a failed publish in
+  // `safeExit(1)`, and an exit mid-test would take the whole runner with it —
+  // so a regression here has to surface as a failing test, not a dead run.
+  process.exit = ((code?: number) => {
+    throw new ExitSignal(code ?? 0);
+  }) as typeof process.exit;
 });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  process.exit = originalExit;
   if (originalToken === undefined) delete process.env.SQUIRREL_API_TOKEN;
   else process.env.SQUIRREL_API_TOKEN = originalToken;
   rmSync(dir, { recursive: true, force: true });
@@ -95,10 +110,21 @@ function writeReport(baseUrl: string): string {
 }
 
 async function runReport(baseUrl: string, extra: Record<string, unknown> = {}) {
-  await report.run!({
-    args: { input: writeReport(baseUrl), publish: true, ...extra },
-    // citty passes more than the command reads; only `args` is consulted.
-  } as never);
+  try {
+    await report.run!({
+      args: { input: writeReport(baseUrl), publish: true, ...extra },
+      // citty passes more than the command reads; only `args` is consulted.
+    } as never);
+  } catch (err) {
+    // A nonzero exit is a real failure of the thing under test, so surface it
+    // as one rather than letting the sentinel read as an unrelated crash.
+    if (err instanceof ExitSignal && err.code !== 0) {
+      throw new Error(`the command exited ${err.code}; see the output above`, {
+        cause: err,
+      });
+    }
+    if (!(err instanceof ExitSignal)) throw err;
+  }
 }
 
 describe("squirrel report --publish — a host no hosted runner can reach (#1841)", () => {

--- a/apps/cli/tests/commands/resolve-publish-decision.test.ts
+++ b/apps/cli/tests/commands/resolve-publish-decision.test.ts
@@ -105,4 +105,27 @@ describe("resolvePublishDecision", () => {
       );
     });
   });
+  // #1841. A loopback / RFC1918 / link-local target is auditable locally but
+  // unreachable for every hosted service, so a published report for it is a
+  // dashboard card nothing in the cloud can screenshot, re-audit or schedule.
+  describe("nonPublicHost (#1841)", () => {
+    test("a local/private host skips publishing", () => {
+      expect(resolvePublishDecision(opts({ nonPublicHost: true }))).toBe(false);
+    });
+
+    // The ONLY opt-out that outranks an explicit --publish, because it is not a
+    // preference: the cloud cannot act on the host whatever the user asks for.
+    test("it beats an explicit --publish", () => {
+      expect(
+        resolvePublishDecision(
+          opts({ nonPublicHost: true, explicitPublish: true })
+        )
+      ).toBe(false);
+    });
+
+    test("unset/false leaves the default alone", () => {
+      expect(resolvePublishDecision(opts({ nonPublicHost: false }))).toBe(true);
+      expect(resolvePublishDecision(opts())).toBe(true);
+    });
+  });
 });

--- a/apps/cli/tests/commands/resolve-publish-decision.test.ts
+++ b/apps/cli/tests/commands/resolve-publish-decision.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolvePublishDecision } from "../../src/cli/commands/audit";
+import {
+  resolvePublishDecision,
+  resolveRegisterDecision,
+} from "../../src/cli/commands/audit";
 
 /** Build opts with sensible defaults (signed in, online, config-on); override per-case. */
 function opts(
@@ -127,5 +130,40 @@ describe("resolvePublishDecision", () => {
       expect(resolvePublishDecision(opts({ nonPublicHost: false }))).toBe(true);
       expect(resolvePublishDecision(opts())).toBe(true);
     });
+  });
+});
+
+// #1841. Registering a local or private-network audit is what created the
+// hosted website plus the weekly screenshot refresh that could never succeed,
+// and it charged the 50-credit audit base for cloud work that cannot happen.
+describe("resolveRegisterDecision", () => {
+  const reg = (
+    over: Partial<Parameters<typeof resolveRegisterDecision>[0]> = {}
+  ) =>
+    resolveRegisterDecision({
+      signedIn: true,
+      offline: false,
+      nonPublicHost: false,
+      ...over,
+    });
+
+  test("a signed-in online run of a public host registers", () => {
+    expect(reg()).toBe(true);
+  });
+
+  test.each([
+    ["not signed in", { signedIn: false }],
+    ["--offline", { offline: true }],
+    ["a local or private host", { nonPublicHost: true }],
+  ])("%s does not register", (_label, over) => {
+    expect(reg(over)).toBe(false);
+  });
+
+  // The host outranks everything, including a signed-in online run that would
+  // otherwise be the normal case.
+  test("the host clause is not conditional on anything else", () => {
+    expect(reg({ nonPublicHost: true, signedIn: true, offline: false })).toBe(
+      false
+    );
   });
 });

--- a/apps/cli/tests/lib/non-public-host.test.ts
+++ b/apps/cli/tests/lib/non-public-host.test.ts
@@ -63,11 +63,67 @@ describe("nonPublicHostLabel", () => {
     }
   );
 
-  // `box.local` is the documented gap: mDNS names look public to a syntactic
-  // check and are refused by the API's egress classifier instead. Pinned so the
-  // handoff this leaves to SERVER_NON_PUBLIC_HOST_LINE stays deliberate.
-  test("an mDNS .local name is NOT caught here — the API refuses it", () => {
-    expect(nonPublicHostLabel("http://mac-mini.local:3000/")).toBeNull();
+  // The name cases a private-IP check alone cannot see. Each one was reachable
+  // before: `box.local` and `metadata.google.internal` registered, published and
+  // rendered, and `intranet` / `localhost.` did all that AND then failed to
+  // audit locally, because the classifier went through `parseUserUrl` (which
+  // rejects them) and read the rejection as "reachable".
+  test.each([
+    ["http://mac-mini.local:3000/", "mac-mini.local:3000"],
+    ["http://svc.cluster.local/", "svc.cluster.local"],
+    ["http://metadata.google.internal/", "metadata.google.internal"],
+    ["http://instance-data.ec2.internal/", "instance-data.ec2.internal"],
+    ["http://router.home.arpa/", "router.home.arpa"],
+    ["http://db.svc/", "db.svc"],
+    ["http://host.lan/", "host.lan"],
+    ["http://thing.corp/", "thing.corp"],
+    // Single-label: resolves through the machine's own search domain.
+    ["http://intranet/", "intranet"],
+    ["http://nas:8080/", "nas:8080"],
+    // Trailing root dot, at the apex and under it, however many dots.
+    ["http://localhost./", "localhost."],
+    ["http://app.localhost./", "app.localhost."],
+    ["http://metadata.google.internal../", "metadata.google.internal.."],
+  ])("%s is unreachable from the cloud, labelled %s", (url, label) => {
+    expect(nonPublicHostLabel(url)).toBe(label);
+  });
+
+  // The NAME rules must never see an IP literal. Every IPv6 address is dotless,
+  // so running the dotless-host rule over one refused `2606:4700::1111` — a
+  // real public address — and would have silently stopped an IPv6-only customer
+  // site registering, publishing and rendering.
+  test.each([
+    ["https://[2606:4700:4700::1111]/"],
+    ["https://[2001:4860:4860::8888]/"],
+    ["https://93.184.216.34/"],
+  ])("%s is a PUBLIC IP literal and stays publishable", (url) => {
+    expect(nonPublicHostLabel(url)).toBeNull();
+  });
+
+  test.each([
+    ["http://[fd00::1]/", "[fd00::1]"],
+    ["http://[fe80::1]/", "[fe80::1]"],
+    ["http://[::ffff:10.0.0.1]/", "[::ffff:a00:1]"],
+  ])("%s is still caught by the IP rules", (url, label) => {
+    expect(nonPublicHostLabel(url)).toBe(label);
+  });
+
+  test("uppercase does not evade the name rules", () => {
+    expect(
+      nonPublicHostLabel("http://METADATA.GOOGLE.INTERNAL/")
+    ).not.toBeNull();
+    expect(nonPublicHostLabel("http://Box.Local/")).not.toBeNull();
+  });
+
+  // The narrowness that makes the zone list safe: these are suffixes of a
+  // PUBLIC registrable domain, not the zones themselves.
+  test.each([
+    ["https://my.corp.example.com/"],
+    ["https://local.example.com/"],
+    ["https://internal-tools.example.com/"],
+    ["https://intranet.example.com/"],
+  ])("%s is a real customer site and stays publishable", (url) => {
+    expect(nonPublicHostLabel(url)).toBeNull();
   });
 });
 

--- a/apps/cli/tests/lib/non-public-host.test.ts
+++ b/apps/cli/tests/lib/non-public-host.test.ts
@@ -1,0 +1,91 @@
+// #1841. The CLI-side preflight that keeps a local/private-network audit from
+// handing anything to a hosted service that would have to fetch the address.
+//
+// The contract under test is deliberately ASYMMETRIC: a false negative here is
+// harmless (the API's stricter classifier still refuses, and says so), while a
+// false POSITIVE would silently stop a real customer site from publishing. So
+// the "still public" cases matter more than the coverage cases.
+import { describe, expect, test } from "bun:test";
+
+import {
+  cloudRenderSkippedLines,
+  LOCAL_HOST_NOT_PUBLISHED_LINE,
+  nonPublicHostLabel,
+  SERVER_NON_PUBLIC_HOST_LINE,
+} from "../../src/lib/non-public-host";
+
+describe("nonPublicHostLabel", () => {
+  test.each([
+    ["http://localhost:3000", "localhost:3000"],
+    ["http://localhost/", "localhost"],
+    ["http://app.localhost:8080/x", "app.localhost:8080"],
+    ["http://127.0.0.1:4321", "127.0.0.1:4321"],
+    ["http://10.0.0.5/", "10.0.0.5"],
+    ["http://192.168.1.10:8000/path", "192.168.1.10:8000"],
+    ["http://172.16.4.1/", "172.16.4.1"],
+    ["http://169.254.169.254/latest/meta-data", "169.254.169.254"],
+    ["http://[::1]:5173/", "[::1]:5173"],
+    ["http://0.0.0.0:9000", "0.0.0.0:9000"],
+    ["http://100.64.0.1/", "100.64.0.1"], // CGNAT
+  ])("%s is unreachable from the cloud, labelled %s", (url, label) => {
+    expect(nonPublicHostLabel(url)).toBe(label);
+  });
+
+  // The WHATWG URL parser canonicalizes these to 127.0.0.1 before the check
+  // ever sees them, which is why the syntactic guard catches them at all.
+  test.each([
+    ["http://2130706433/", "127.0.0.1"],
+    ["http://0177.0.0.1/", "127.0.0.1"],
+  ])("the %s spelling of loopback is caught too", (url, label) => {
+    expect(nonPublicHostLabel(url)).toBe(label);
+  });
+
+  test("a schemeless private host is normalized the same way the crawl does", () => {
+    expect(nonPublicHostLabel("localhost:3000")).toBe("localhost:3000");
+    expect(nonPublicHostLabel("127.0.0.1")).toBe("127.0.0.1");
+  });
+
+  test.each([
+    ["https://example.com/"],
+    ["https://www.squirrelscan.com/docs"],
+    ["http://staging.example.com:8080/"],
+    ["https://203.0.113.10/"], // a public literal IP
+  ])("%s stays publishable", (url) => {
+    expect(nonPublicHostLabel(url)).toBeNull();
+  });
+
+  // A typo must be reported by the normal URL validation, which says something
+  // useful, not by a cloud-reachability warning that does not.
+  test.each([[""], ["   "], ["not a url"], ["ftp://example.com/"]])(
+    "unusable input %p is not classified here",
+    (url) => {
+      expect(nonPublicHostLabel(url)).toBeNull();
+    }
+  );
+
+  // `box.local` is the documented gap: mDNS names look public to a syntactic
+  // check and are refused by the API's egress classifier instead. Pinned so the
+  // handoff this leaves to SERVER_NON_PUBLIC_HOST_LINE stays deliberate.
+  test("an mDNS .local name is NOT caught here — the API refuses it", () => {
+    expect(nonPublicHostLabel("http://mac-mini.local:3000/")).toBeNull();
+  });
+});
+
+describe("the lines the user actually reads", () => {
+  test("the render skip names the host and says the audit continues", () => {
+    const [why, what] = cloudRenderSkippedLines("localhost:3000");
+    expect(why).toBe(
+      "No cloud runner can reach a local or private-network address (localhost:3000)."
+    );
+    expect(what).toContain("still runs locally");
+  });
+
+  // House style for public copy: no em-dashes anywhere the user sees.
+  test.each([
+    LOCAL_HOST_NOT_PUBLISHED_LINE,
+    SERVER_NON_PUBLIC_HOST_LINE,
+    ...cloudRenderSkippedLines("localhost:3000"),
+  ])("%p has no em-dash", (line) => {
+    expect(line).not.toContain("—");
+  });
+});

--- a/apps/cli/tests/lib/run-tracker.test.ts
+++ b/apps/cli/tests/lib/run-tracker.test.ts
@@ -125,6 +125,7 @@ describe("registerRun", () => {
       // Fixture response has no pricing-v10 fields → old-server defaults.
       baseCharged: 0,
       balanceAfterBase: null,
+      websiteSkippedReason: null,
     });
     expect(captured!.method).toBe("POST");
     expect(captured!.url).toContain("/v1/agent-runs/register");
@@ -177,6 +178,7 @@ describe("registerRun", () => {
       lifecycleBase: "/v1/agent-runs",
       baseCharged: 0,
       balanceAfterBase: null,
+      websiteSkippedReason: null,
     });
   });
 
@@ -594,6 +596,68 @@ describe("markRunning / finalizeRun", () => {
   });
 });
 
+// #1841. The API refuses to create a hosted website for a host no hosted
+// service can reach, while still accepting the run. The CLI has to tell that
+// apart from a malformed response, because the two look identical on the wire
+// except for one marker.
+describe("registerRun — a run the server gave no website (#1841)", () => {
+  const respond = (body: Record<string, unknown>) => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(body), {
+        status: 201,
+      })) as unknown as typeof fetch;
+  };
+
+  test("accepts it when the server says WHY, carrying the reason", async () => {
+    respond({
+      runId: "run_1",
+      auditId: "aud_1",
+      websiteRegistration: { skipped: true, reason: "non_public_host" },
+    });
+    expect(await registerRun({ url: "http://mac-mini.local:3000" })).toEqual({
+      runId: "run_1",
+      websiteId: null,
+      auditId: "aud_1",
+      lifecycleBase: "/v1/agent-runs",
+      baseCharged: 0,
+      balanceAfterBase: null,
+      websiteSkippedReason: "non_public_host",
+    });
+  });
+
+  // The load-bearing half. Without the marker a missing websiteId is the old
+  // bad-body case: registering against it would leave the CLI unable to
+  // finalize the run against any site, silently.
+  test("still rejects a websiteId-less body with no marker", async () => {
+    respond({ runId: "run_1", auditId: "aud_1" });
+    expect(await registerRun({ url: "https://example.com" })).toBeNull();
+  });
+
+  test("a marker with no reason does not read as a normal register", async () => {
+    respond({
+      runId: "run_1",
+      auditId: "aud_1",
+      websiteRegistration: { skipped: true },
+    });
+    const result = await registerRun({ url: "https://example.com" });
+    expect(result?.websiteSkippedReason).toBe("unknown");
+  });
+
+  // `skipped: false` is the shape a future server might send for "I resolved
+  // one after all" — it must not be read as a skip.
+  test("skipped:false is not a skip", async () => {
+    respond({
+      runId: "run_1",
+      websiteId: "web_1",
+      auditId: "aud_1",
+      websiteRegistration: { skipped: false },
+    });
+    const result = await registerRun({ url: "https://example.com" });
+    expect(result?.websiteSkippedReason).toBeNull();
+    expect(result?.websiteId).toBe("web_1");
+  });
+});
+
 describe("createRunFinalizer (#332)", () => {
   const run: RegisteredRun = {
     runId: "run_1",
@@ -602,6 +666,7 @@ describe("createRunFinalizer (#332)", () => {
     lifecycleBase: "/v1/agent-runs",
     baseCharged: 50,
     balanceAfterBase: 450,
+    websiteSkippedReason: null,
   };
 
   // Count PATCH calls + capture each path so the once-guard + id are observable.

--- a/docs/cli/audit.mdx
+++ b/docs/cli/audit.mdx
@@ -149,6 +149,10 @@ publish = false
 Publishing requires authentication. Run `squirrel auth login` first; logged-out runs never publish.
 </Note>
 
+<Note>
+An audit of `localhost`, a loopback address, or a private range such as `192.168.1.10` never publishes, never registers a run, and never renders in the cloud, even with `--publish` or `--render`. Hosted services cannot reach your machine or your private network, so there is nothing they could screenshot, re-render or re-audit. The audit itself runs and prints normally. See [Local audits with the CLI](/guides/local-audits-cli).
+</Note>
+
 ### Browser rendering
 
 When you're **logged in, audits render every page in a cloud browser by default** (2 credits/page) - so JavaScript-heavy sites are audited against their fully rendered HTML. The first time this would spend credits the CLI asks once and remembers your answer.

--- a/docs/cli/audit.mdx
+++ b/docs/cli/audit.mdx
@@ -150,7 +150,7 @@ Publishing requires authentication. Run `squirrel auth login` first; logged-out 
 </Note>
 
 <Note>
-An audit of `localhost`, a loopback address, or a private range such as `192.168.1.10` never publishes, never registers a run, and never renders in the cloud, even with `--publish` or `--render`. Hosted services cannot reach your machine or your private network, so there is nothing they could screenshot, re-render or re-audit. The audit itself runs and prints normally. See [Local audits with the CLI](/guides/local-audits-cli).
+An audit of a host no squirrelscan server can reach never publishes, never registers a run, and never renders in the cloud, even with `--publish` or `--render`. That covers `localhost`, loopback and private ranges such as `192.168.1.10`, and internal names such as `box.local` or anything under `.internal`. Hosted services cannot reach your machine or your private network, so there is nothing they could screenshot, re-render or re-audit. The audit itself runs and prints normally. See [Local audits with the CLI](/guides/local-audits-cli).
 </Note>
 
 ### Browser rendering

--- a/docs/cli/report.mdx
+++ b/docs/cli/report.mdx
@@ -65,6 +65,10 @@ https://reports.squirrelscan.com/XVv4NO7aPr
 
 Manage published reports in the [dashboard](https://app.squirrelscan.com).
 
+<Note>
+A report of a host no squirrelscan server can reach is never published, even with `--publish`. That covers `localhost`, loopback and private ranges, and internal names such as `box.local` or anything under `.internal`. The command prints the report as usual and says the report stayed local. See [Local audits with the CLI](/guides/local-audits-cli).
+</Note>
+
 ### Publish with visibility
 
 ```bash

--- a/docs/guides/local-audits-cli.mdx
+++ b/docs/guides/local-audits-cli.mdx
@@ -80,9 +80,9 @@ Auditing a site you are building? Point it at your dev server: `squirrel audit h
 
 ### Local and private hosts stay local
 
-An audit of `localhost`, a loopback address, a private range such as `192.168.1.10` or `10.0.0.5`, or a link-local address runs and prints its report exactly as any other audit does. What changes is everything that would need a squirrelscan server to reach the address itself:
+An audit of a host no squirrelscan server can reach runs and prints its report exactly as any other audit does. That covers `localhost`, loopback and link-local addresses, private ranges such as `192.168.1.10` or `10.0.0.5`, and internal names such as `box.local` or anything under `.internal` or `.lan`. What changes is everything that would need a squirrelscan server to reach the address itself:
 
-- The report is not published, so no shareable link is created and no site appears in your dashboard.
+- The report is not published, so no shareable link is created and no site appears in your dashboard. The same applies to publishing it later with `squirrel report --publish`.
 - The run is not registered, so it does not cost the audit base even when you are signed in.
 - Cloud rendering is off for the run, including with `--render`, and the crawl uses local HTTP fetching.
 

--- a/docs/guides/local-audits-cli.mdx
+++ b/docs/guides/local-audits-cli.mdx
@@ -78,6 +78,20 @@ The three coverage modes are `quick`, `surface`, and `full`. See [`squirrel audi
 Auditing a site you are building? Point it at your dev server: `squirrel audit http://localhost:3000`. Local audits work the same against localhost, so you can catch issues before they ship. See [Projects](/projects) for keeping dev and production histories separate.
 </Tip>
 
+### Local and private hosts stay local
+
+An audit of `localhost`, a loopback address, a private range such as `192.168.1.10` or `10.0.0.5`, or a link-local address runs and prints its report exactly as any other audit does. What changes is everything that would need a squirrelscan server to reach the address itself:
+
+- The report is not published, so no shareable link is created and no site appears in your dashboard.
+- The run is not registered, so it does not cost the audit base even when you are signed in.
+- Cloud rendering is off for the run, including with `--render`, and the crawl uses local HTTP fetching.
+
+The reason is reachability, not policy: hosted services would have to fetch the address to screenshot it, render it, or re-audit it on a schedule, and they cannot reach your machine or your private network. The CLI prints one line saying the report stayed local.
+
+Cloud analysis that works from pages the CLI has already crawled is unaffected, so a signed-in local audit still gets the AI summary, technology detection, and the other content-based checks.
+
+To get a shareable report for a site you are developing, audit it once it is on a public URL, such as a preview deployment.
+
 ## Set project defaults with a config file
 
 Running the same audit repeatedly? Create a `squirrel.toml` so you do not retype flags:

--- a/packages/audit-engine/src/cloud-prefetch.ts
+++ b/packages/audit-engine/src/cloud-prefetch.ts
@@ -110,6 +110,20 @@ export interface CloudPrefetchInput {
    */
   crawlRendered?: boolean;
   /**
+   * True when the audited site lives somewhere no HOSTED runner can reach:
+   * loopback, RFC1918, link-local. The caller owns the classification (this
+   * engine stays policy-free, and host-blocking a CRAWL would be a regression —
+   * auditing localhost is the point).
+   *
+   * `render` is the only prefetch service that asks the cloud to FETCH the page
+   * URL itself, and it debits on submit. Against such a host the render service
+   * charges for a batch the crawler-worker then refuses outright, every run. So
+   * it is skipped `not-applicable` here, before any charge — the same treatment
+   * (and the same reason shape) as `crawlRendered`. Every other service works
+   * from payloads the caller already crawled, so they are unaffected.
+   */
+  hostUnreachableByCloud?: boolean;
+  /**
    * URLs the crawl ALREADY browser-rendered (per-page provenance from the crawl
    * `fetcherId`). The `render` service submits only pages NOT in this set —
    * an already-rendered page is self-identical (raw==rendered), so paying to
@@ -501,7 +515,11 @@ export async function prefetchCloudData(input: CloudPrefetchInput): Promise<Clou
   // for a comparison the rule discards anyway (#673). The rule then reads `not-applicable` and skips visibly.
   // Only set for render strategy "all"; an "auto" (HTTP-first) crawl leaves most pages raw and runs render,
   // relying on the rule's per-page `page.rendered` guard to skip the individual pages it did render (#964).
-  if (input.crawlRendered) {
+  // #1841 folds in the second reason render cannot produce anything: a
+  // loopback / private-network target the hosted renderer is refused access to.
+  // Both are "this comparison cannot happen for this run", both must land
+  // BEFORE the charge, so they share one skip.
+  if (input.crawlRendered || input.hostUnreachableByCloud) {
     const spec = specs.get("render");
     if (spec) {
       skipService(store, "render", spec.unit, input.pages, "not-applicable");

--- a/packages/audit-engine/tests/cloud-prefetch.test.ts
+++ b/packages/audit-engine/tests/cloud-prefetch.test.ts
@@ -1127,6 +1127,45 @@ describe("prefetchCloudData — render service (#673)", () => {
     expect(res.spend).toEqual([]);
   });
 
+  // #1841. Render is the only prefetch service that asks the cloud to FETCH the
+  // page URL, and it debits on submit — so a target the hosted browser is
+  // refused access to (localhost, RFC1918) must be dropped BEFORE the charge,
+  // not discovered when the crawler-worker answers "Refusing to render a
+  // non-public host".
+  test("hostUnreachableByCloud: render is skipped not-applicable and never submitted (no charge for a refusal)", async () => {
+    let submitted = false;
+    const client = renderClient({
+      render: async () => {
+        submitted = true;
+        return { jobId: "j", status: "queued" };
+      },
+    });
+    const res = await prefetchCloudData(
+      input({ client, rules: RENDER_RULES, hostUnreachableByCloud: true }),
+    );
+    expect(submitted).toBe(false);
+    const render = res.store.get("render");
+    expect(render?.get(pages[0].url)?.status).toBe("skipped");
+    expect(render?.get(pages[0].url)?.skipReason).toBe("not-applicable");
+    expect(res.spend).toEqual([]);
+  });
+
+  // The default must stay "render runs": a flag that skipped on absence would
+  // silently disable rendering for every ordinary audit.
+  test("hostUnreachableByCloud unset leaves render running", async () => {
+    let submitted = false;
+    const client = renderClient({
+      render: async (req) => {
+        submitted = true;
+        return { jobId: "j", status: "queued" };
+      },
+    });
+    await prefetchCloudData(
+      input({ client, rules: RENDER_RULES, hostUnreachableByCloud: false }),
+    );
+    expect(submitted).toBe(true);
+  });
+
   test("partial render result: a page omitted from results is skipped service-unavailable, not lost", async () => {
     const client = renderClient({
       renderResult: async () => ({

--- a/packages/audit-engine/tests/cloud-prefetch.test.ts
+++ b/packages/audit-engine/tests/cloud-prefetch.test.ts
@@ -1151,18 +1151,22 @@ describe("prefetchCloudData — render service (#673)", () => {
   });
 
   // The default must stay "render runs": a flag that skipped on absence would
-  // silently disable rendering for every ordinary audit.
-  test("hostUnreachableByCloud unset leaves render running", async () => {
+  // silently disable rendering for every ordinary audit. ABSENT and `false` are
+  // tested separately because the field is optional, so only the absent case
+  // proves the default, and only the explicit case proves the CLI's own
+  // always-boolean call sites.
+  test.each([
+    ["absent", {}],
+    ["explicitly false", { hostUnreachableByCloud: false }],
+  ])("hostUnreachableByCloud %s leaves render running", async (_label, flag) => {
     let submitted = false;
     const client = renderClient({
-      render: async (req) => {
+      render: async () => {
         submitted = true;
         return { jobId: "j", status: "queued" };
       },
     });
-    await prefetchCloudData(
-      input({ client, rules: RENDER_RULES, hostUnreachableByCloud: false }),
-    );
+    await prefetchCloudData(input({ client, rules: RENDER_RULES, ...flag }));
     expect(submitted).toBe(true);
   });
 


### PR DESCRIPTION
A `squirrel audit http://localhost:3000` used to register a cloud run and auto-publish. The API then created a hosted website (`464QG76A`, url `http://localhost/`) plus a weekly `screenshot:refresh` schedule that threw `Refusing to screenshot a non-public host (loopback)` every Thursday, forever. No hosted service can reach a loopback, RFC1918, or link-local address.

This is the CLI half. The cloud API enforces the same rule independently and is authoritative; that half is a separate PR on the private repo.

## What changes

The audit itself is unchanged and still crawls, scores, and prints its report. What stops is every handoff that needs a squirrelscan server to fetch the address:

- **No run registration**, so no audit base is charged for a local audit.
- **No publish**, checked ahead of `--publish`. This is the only opt-out that outranks the explicit flag, because it is a capability and not a preference: a hosted report for `http://localhost:3000` is a dashboard card nothing in the cloud can screenshot, re-audit, or schedule.
- **No cloud render submit**, in both prefetch seams. That also fixes a standing charge-for-nothing: the render service debits on submit and the crawler-worker then answers `Refusing to render a non-public host`, so every signed-in local audit was paying 2 credits a page for a guaranteed refusal.

Content-based cloud analysis is deliberately untouched. Those services work from pages the CLI already crawled, so a signed-in local audit keeps its AI summary, technology detection, and the rest.

## The exact lines a user sees

Publish and registration skip (one line, only when the host is the deciding factor and the run could otherwise have reached the cloud):

```
Local/private host: report kept local, not published to the cloud.
```

Render skip, only when the user actually asked for rendering on a signed-in online run:

```
⚠ No cloud runner can reach a local or private-network address (localhost:3000).
Cloud rendering is off for this run; the audit still runs locally.
```

The server's own verdict, when its stricter classifier disagrees with the local preflight (`box.local`, `metadata.google.internal`, a dotless host):

```
Local/private host: the cloud did not add this site to your dashboard.
```

## Two classifiers, on purpose

The preflight uses `isPublicHttpUrl`, which already existed in `packages/utils`. The API uses `isHostedEgressAllowed`, which is strictly stricter: it also refuses cloud metadata hostnames, internal-only name zones, and dotless hosts. That asymmetry is safe in this direction. A false negative here is caught by the API, which now returns a machine-readable `websiteRegistration.skipped` marker the CLI reads and reports. A false positive would silently stop a real customer site from publishing, so the loose check is the right one locally. A pinned test records `box.local` as the documented gap.

Host classification stays out of the shared fetch paths. `safe-fetch.ts` gates the scheme only, and auditing localhost is the point of the CLI.

## Acceptance criteria (#1841, CLI half)

- [x] A CLI audit of a host that fails the check still completes and still prints its report.
- [x] It creates no hosted website, because it never registers and never publishes.
- [x] Rendering never reaches the cloud for such a host, including with `--render` and `--render-mode all`.
- [x] The API's refusal is machine-readable and the CLI prints it rather than silently missing a site.
- [x] Docs updated (`/guides/local-audits-cli`, `/cli/audit`) and `make validate` passes.
- [x] CHANGELOG entry under `## [Unreleased]`.

## Evidence

```
apps/cli        bunx tsgo --noEmit         clean
packages/audit-engine  bunx tsgo --noEmit  clean
apps/cli        bun run lint / format      clean
bun test tests/lib/non-public-host.test.ts tests/lib/run-tracker.test.ts tests/commands/resolve-publish-decision.test.ts
                                           91 pass, 0 fail
packages/audit-engine  bun test tests/cloud-prefetch.test.ts
                                           48 pass, 0 fail
docs            make validate              393 pages, all checks passed
```

New tests cover the classifier (12 unreachable shapes, the decimal and octal loopback spellings, public hosts unaffected, unusable input not classified, the `.local` gap), the publish decision beating `--publish`, the register response contract in all four shapes, and the engine's render skip plus its default-on case.

## Codex review

Run before commit; all three findings fixed rather than rebutted.

1. **P1, local audits still submitted cloud renders.** Correct, and worse than stated: the render prefetch service is planned from the enabled rules, not from the render mode, so `--http` did not stop it either. Fixed with `hostUnreachableByCloud` on the prefetch input, derived from the base URL inside both CLI prefetch seams so no caller can forget it. I did not take the suggested `cloudAvailable: signedIn && !nonPublicHost`, which would also have dropped the content-based services that work fine for a local site.
2. **P2, a free local audit could abort over an imaginary charge.** Correct. The affordability preflight is skipped for these hosts, since neither the base nor any render charge can occur.
3. **P2, notices printed when the host was not the deciding factor.** Correct. Both notices are now gated on `signedIn && !offline`, so a signed-out or `--offline` run does not get told the host is why nothing published.

Codex also called the original docs wording ("nothing about it goes to the cloud") false. It was, given the content-based services. The wording now says what actually happens.

https://claude.ai/code/session_0174D96WamG9ZhJxRudpeniA


---

## Acceptance review round 2

Three fixes and one rebuttal, in `3a90c4c`.

**Fixed: the classifier missed every internal NAME.** It went through `parseUserUrl`, whose job is "is this a valid audit target". That helper rejects single-label and trailing-dot names, and the rejection read as "the cloud can reach this". So `box.local`, `metadata.google.internal`, `intranet` and `localhost.` were handed straight to a hosted runner, and the last two contacted the API and then failed to audit locally. The classifier now stands on its own and mirrors the API's `classifyHostedEgressHost` name rules: loopback names, cloud metadata names, the internal-only zones (`.local`, `.internal`, `.lan`, `home.arpa`, `.svc`, …), and the dotless-host rule.

**Fixed, and caught by my own review round on the fix: that widening broke public IPv6.** Every IPv6 address is dotless, so the new dotless rule refused `2606:4700:4700::1111`. An IPv6-only customer site would have silently stopped registering, publishing and rendering. An IP literal is now decided by the IP rules alone and returns before the name rules, with public addresses pinned on both sides.

**Fixed: `squirrel report --publish` had no gate.** It calls `publishReport` directly and that controller has no host check of its own. It now skips the upload, says the report stayed local on stderr so a `-f json` pipeline stays clean, and falls through to the normal report output.

**Fixed: the tests did not cover the wiring.** Every gate was an inline condition, so deleting a call site failed nothing. Both commands are now driven for real against a stubbed wire, asserting zero register and publish calls for a private host, with a signed-in public control. I verified by mutation: removing the host clause from `resolveRegisterDecision` turns four of them red.

**Rebutted: `--cloud` does not exist.** The review asked for a `--cloud` flag that fails fast. The CLI has no `--cloud`, no `--remote`, no `squirrel cloud` command, and no endpoint that starts a hosted audit run. citty accepts unknown flags silently, so `--cloud` parses to `true` and is ignored exactly as `--banana` would be, which I confirmed by parsing all three against the real `audit.args`. The independent review agreed the rebuttal stands. Fail-fast for a cloud run of a private host lives in the API guard, which covers the MCP, dashboard and API-triggered paths: squirrelscan/repo#2068. To be precise about the claim: the CLI does make other cloud writes (technology sync, the render submit, MCP issue comments); none of them starts a hosted audit run, and the render submit is now gated by this PR.

One thing I did not chase, noted here rather than widened into this PR: the `archive-indexing` prefetch service is handed the base url, so a local audit still pays for a Wayback and Common Crawl lookup that can only come back empty. It is a third-party lookup rather than a fetch of the user's address, so it is outside this issue's contract.

### Evidence after round 2

```
apps/cli               bunx tsgo --noEmit (before AND after format)   clean
apps/cli               bun run lint / format                          clean
packages/audit-engine  bunx tsgo --noEmit                             clean

bun test tests/lib/non-public-host.test.ts
         tests/lib/run-tracker.test.ts
         tests/commands/resolve-publish-decision.test.ts
         tests/commands/report-publish-non-public-host.test.ts
         tests/commands/audit-non-public-host-wiring.test.ts          132 pass
bun test tests/audit/cloud-prefetch-non-public-base.test.ts
         tests/controllers/publish-slim.test.ts
         tests/controllers/report.test.ts                              38 pass
packages/audit-engine  bun test tests/cloud-prefetch.test.ts           49 pass
docs                   make validate                    393 pages, all checks passed
```

### CI-only failure in the round-2 tests, and the fix

The first push of the command-boundary tests went red on a test in a file that had no bug. `audit-non-public-host-wiring.test.ts` used `mock.module` to stub `safeExit`. Bun's module mocks are process-wide and `mock.restore()` does not undo them, so the stub stayed live for every later file in the package run, and the report publish test hit that throw inside its own command run:

```
at safeExit (.../audit-non-public-host-wiring.test.ts:39:11)
at async runReport (.../report-publish-non-public-host.test.ts:98:16)
(fail) ... > a public host still publishes [0.85ms]
```

It passed locally as a pair and across the whole `tests/commands/` directory. Only the full-package run reproduces it, so `bun run scripts/test-suites.ts --run cli` is the command to reproduce a CI-only failure with.

Fixed by removing the module mocks entirely. `process.exit` and `globalThis.fetch` are now intercepted file-locally and restored in `afterEach`, and the assertions are on the wire rather than on helper spies. That is the stronger assertion in any case, since a spy cannot tell you whether the command still calls the helper. The report test gets the same exit guard so a regression there fails a test rather than killing the runner.

Verified with the CI command itself: **2223 pass, 0 fail**.