### PR TITLE
fix(audit-engine): refuse producer-carried checks as this run's evidence (squirrelscan/repo#2063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ How it works:
 
 ## [Unreleased]
 
+### Fixed
+
+- Published cloud reports no longer count findings the CLI carried from its local
+  store as pages crawled this run. A machine with an old local audit database
+  could publish thousands of stale findings, which the cloud stored as first seen
+  today and scored as if every one of those pages had just been crawled, swinging
+  the health score by tens of points between identical runs. Carried findings keep
+  the date the cloud last saw them, and the audited-page count is now the pages the
+  crawl actually visited.
+- Two page URLs that differ only by their query string are two pages again.
+  Findings on `/p?id=1` and `/p?id=2` were stored under one URL, piling every
+  page's issues onto a single entry in the report.
+
 ## v0.0.94
 
 A one-line follow-up to v0.0.93 for the cloud audits that still ended before

--- a/packages/audit-engine/src/complete-store-fold.ts
+++ b/packages/audit-engine/src/complete-store-fold.ts
@@ -35,7 +35,7 @@
 
 import type { CheckResult, PageFindingRecord } from "@squirrelscan/core-contracts";
 import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
-import { DEFAULT_FOLD_LIMITS, foldOverflowChecks } from "@squirrelscan/rules/fold";
+import { DEFAULT_FOLD_LIMITS, foldGroupKey, foldOverflowChecks } from "@squirrelscan/rules/fold";
 import type { RuleRunResult } from "@squirrelscan/rules/types";
 
 import { reconstructPageRuleChecks } from "./reconstruct";
@@ -434,8 +434,10 @@ function retainCarried(
   const pageClasses = new Set<string>();
   for (const check of checks) {
     // The key the publish fold groups on, so a stamp lands on the class it will
-    // actually be summed into. NUL cannot appear in a check name.
-    const key = `${check.name}\u0000${check.status}`;
+    // actually be summed into — provenance included (#2063), or a class that
+    // splits into a carried and a fresh aggregate would be counted once, capped
+    // as one, and reconciled against whichever of the two happened to match.
+    const key = foldGroupKey(check);
     let counts = entry.classes.get(key);
     if (!counts) {
       counts = {
@@ -569,7 +571,7 @@ function reconcileCarriedAggregate(
   aggregate: CheckResult,
   classes: Map<string, CarriedClassCounts>
 ): void {
-  const counts = classes.get(`${aggregate.name}\u0000${aggregate.status}`);
+  const counts = classes.get(foldGroupKey(aggregate));
   // Untouched unless this class actually lost members; a fully-present class was
   // folded from every constituent and is already right.
   if (!counts || counts.members <= counts.retainedMembers) return;

--- a/packages/audit-engine/src/merge-core.ts
+++ b/packages/audit-engine/src/merge-core.ts
@@ -19,6 +19,41 @@ import { resolutionUrlHash } from "@squirrelscan/core-contracts/resolution";
 
 import { findingFingerprint } from "./fingerprint";
 
+const EMPTY_HASHES: readonly string[] = [];
+
+/**
+ * Every resolution-signal hash a page could have been published under (#2063).
+ *
+ * The signal's URL hashes are computed by the PRODUCER, so which normalizer it
+ * used is decided by whichever release the user is running — and #2063 changed
+ * that normalizer from a query-blind one to the query-preserving page identity
+ * the store is keyed by. A publisher on an older release therefore hashes
+ * `/p?id=1` as `/p`, and matching only the new spelling would read its signal as
+ * "this page is not in the failing set" — i.e. resolve a finding that is still
+ * there.
+ *
+ * So accept EITHER spelling. Every consequence of the extra hash is a carry: a
+ * hit in `notEvaluated` carries, a hit in `failing` carries, and a miss in
+ * `failing` is the only branch that resolves. The worst case is that two query
+ * URLs sharing a path both carry when only one still fails — over-carry, which a
+ * later run with matching versions resolves. Under-carry is the outcome that
+ * silently deletes a real finding, and this shape cannot produce it.
+ */
+function resolutionHashes(normalizedUrl: string): readonly string[] {
+  const q = normalizedUrl.indexOf("?");
+  if (q === -1) return [resolutionUrlHash(normalizedUrl)];
+  return [resolutionUrlHash(normalizedUrl), resolutionUrlHash(normalizedUrl.slice(0, q))];
+}
+
+/** True when `set` holds any of `hashes` (see {@link resolutionHashes}). */
+function hasAnyHash(set: Set<string> | undefined, hashes: readonly string[]): boolean {
+  if (!set) return false;
+  for (const h of hashes) {
+    if (set.has(h)) return true;
+  }
+  return false;
+}
+
 /** A finding flattened from a CheckResult, ready to key/persist. */
 export interface FlatFinding {
   normalizedUrl: string;
@@ -714,13 +749,13 @@ export function createMergeSession(
       // truncated (or absent — rule disabled, unknown shape, old CLI) gives no
       // authority and falls through to the pre-#1185 behavior.
       const checkKey = `${prior.ruleId}${KEY_SEP}${prior.checkName}`;
-      const priorHash = resolution ? resolutionUrlHash(prior.normalizedUrl) : "";
+      const priorHashes = resolution ? resolutionHashes(prior.normalizedUrl) : EMPTY_HASHES;
       // The check produced NO evaluated result for this page this run (the rule
       // `skipped` it — perf/ttfb without timing data — or emitted nothing for
       // it). Its absence from the fresh findings is not evidence the finding is
       // gone, so it can never resolve: carry regardless of what the sampled
       // payload suggests.
-      if (resolution?.notEvaluatedByCheck.get(checkKey)?.has(priorHash)) {
+      if (hasAnyHash(resolution?.notEvaluatedByCheck.get(checkKey), priorHashes)) {
         const carried: PageFindingRecord = { ...prior, provenance: "carried" };
         sink.persist(carried);
         sink.active(toMerged(carried, unrendered));
@@ -728,7 +763,7 @@ export function createMergeSession(
       }
       const failingSet = resolution?.failingByCheck.get(checkKey);
       if (failingSet) {
-        if (failingSet.has(priorHash)) {
+        if (hasAnyHash(failingSet, priorHashes)) {
           // Unlike the sample-guard carry below, this page WAS observed failing
           // this run — the signal is unsampled, so its presence is positive
           // evidence, not an absence we couldn't rule out. Refresh the

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -65,10 +65,12 @@ const REMOVED_STATUSES = new Set([404, 410]);
  * appeared for a 16-page crawl with every stale finding re-stamped as first seen
  * today (squirrelscan/repo#2063).
  *
- * Gated on the check being PAGE-ATTRIBUTED so a site-scope check can never be
- * dropped by a stray provenance tag: a replay is a per-page finding by
- * construction (`carriedFindingToCheck` always stamps a `pageUrl`), and a site
- * rule's check is scored from the shell verbatim.
+ * Gated on the check being PAGE-ATTRIBUTED, so the ordinary site-scope check —
+ * no `pageUrl`, no aggregate marker, scored from the shell verbatim — is never
+ * dropped by a stray provenance tag. The gate reads the CHECK's shape, not the
+ * rule's scope: a check carrying the aggregate marker and naming pages is treated
+ * as a page replay whichever rule emitted it, which is the only honest reading of
+ * a check that claims those pages.
  */
 function isReplayedCheck(check: CheckResult): boolean {
   return (
@@ -342,8 +344,11 @@ export interface CloudSmartAuditsResult {
    * this merge refused to treat as evidence from this run. Counted in BOTH modes:
    * complete mode takes its findings from the store, but the shell is still the
    * report body and a replay in it would sit in the union beside the cloud's own
-   * carry for the same page. One aggregate counts once however many pages it
-   * names; {@link replayedUnknownPages} is the per-page number.
+   * The UNIT differs by mode, deliberately: the sampled branch unfolds before it
+   * filters, so an aggregate counts as the per-page checks it stood for, while
+   * complete mode never unfolds and counts it once. Both count "checks refused at
+   * the filter", which is what the filter was handed. {@link replayedUnknownPages}
+   * is the per-page number and is comparable across both.
    */
   replayedChecksDropped: number;
   /**
@@ -457,8 +462,10 @@ export async function runCloudSmartAudits(
     // Site-scope checks stay: the tally fold scores those verbatim.
     //
     // Every rule KEEPS ITS KEY even when every check goes. The tally fold reads
-    // rule membership to decide which rules the shell already handled, so dropping
-    // an emptied rule would hand it to the carried-only branch twice.
+    // rule membership twice: `foldShellRules` gives a page rule its fresh-clean
+    // pass count, and `finish` skips the rules it already handled. An emptied rule
+    // dropped here would lose that pass count — the crawled pages it found nothing
+    // on would leave the denominator, which is the #918 inflation in miniature.
     freshResults = new Map<string, RuleRunResult>();
     for (const [ruleId, r] of Object.entries(input.ruleResults)) {
       const checks: CheckResult[] = [];

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -65,14 +65,42 @@ const REMOVED_STATUSES = new Set([404, 410]);
  * appeared for a 16-page crawl with every stale finding re-stamped as first seen
  * today (squirrelscan/repo#2063).
  *
- * Gated on `pageUrl` so a site-scope check can never be dropped by a stray
- * provenance tag: carried replays are per-page findings by construction
- * (`carriedFindingToCheck` always stamps a `pageUrl`).
+ * Gated on the check being PAGE-ATTRIBUTED so a site-scope check can never be
+ * dropped by a stray provenance tag: a replay is a per-page finding by
+ * construction (`carriedFindingToCheck` always stamps a `pageUrl`), and a site
+ * rule's check is scored from the shell verbatim.
  */
 function isReplayedCheck(check: CheckResult): boolean {
   return (
-    !!check.pageUrl && (check.provenance === "carried" || check.provenance === "unrendered")
+    isPageAttributed(check) &&
+    (check.provenance === "carried" || check.provenance === "unrendered")
   );
+}
+
+/**
+ * True when a check speaks for one or more PAGES: a per-page check carries a
+ * `pageUrl`, and a folded aggregate carries its affected pages in `pages[]`
+ * instead.
+ *
+ * Both forms matter. The sampled branch unfolds before it filters, so it only
+ * ever sees the first; the COMPLETE-store branch deliberately does not unfold —
+ * the shell's aggregates are its display surface — so there the second form is
+ * the one a replay arrives as.
+ *
+ * The aggregate test is deliberately `unfoldAggregateCheck`'s own gate, so the
+ * two branches agree on what an aggregate IS. A check carrying `pages` without
+ * the `aggregated` marker is not unfolded there and is not page-attributed here:
+ * either way it names no page this run is asked to believe in.
+ */
+function isPageAttributed(check: CheckResult): boolean {
+  if (check.pageUrl) return true;
+  return check.details?.aggregated === true && !!check.pages && check.pages.length > 0;
+}
+
+/** Every page a check speaks for, normalized to the store's page identity. */
+function attributedPages(check: CheckResult): string[] {
+  if (check.pageUrl) return [normalizePageUrl(check.pageUrl)];
+  return (check.pages ?? []).map(normalizePageUrl);
 }
 
 /**
@@ -311,8 +339,11 @@ export interface CloudSmartAuditsResult {
   removedPages: number;
   /**
    * (#2063) Published checks the producer had tagged `carried`/`unrendered` and
-   * this merge refused to treat as evidence from this run. Zero on the
-   * complete-store path (the store IS the evidence there).
+   * this merge refused to treat as evidence from this run. Counted in BOTH modes:
+   * complete mode takes its findings from the store, but the shell is still the
+   * report body and a replay in it would sit in the union beside the cloud's own
+   * carry for the same page. One aggregate counts once however many pages it
+   * names; {@link replayedUnknownPages} is the per-page number.
    */
   replayedChecksDropped: number;
   /**
@@ -390,6 +421,12 @@ export async function runCloudSmartAudits(
    * {@link CloudSmartAuditsResult.replayedUnknownPages}.
    */
   const replayedUrls = new Set<string>();
+  /**
+   * (#2063) The complete-store shell with its replays removed — what the tally
+   * fold and the union both read. Undefined in the sampled branch, which has no
+   * shell to speak of.
+   */
+  let shellResults: CloudSmartAuditsInput["ruleResults"] | undefined;
   if (completeStore) {
     // (#2063) IDENTITY CONTRACT. Complete mode is the one place where a page's
     // ABSENCE from the fresh set authorizes a resolve, and the fresh set was keyed
@@ -410,10 +447,38 @@ export async function runCloudSmartAudits(
     // audit-sized is ever resident. `freshResults` keeps the SHELL's rules: they
     // are the report surface and the site-scope rules' checks, exactly what the
     // materialized reconstruction passed through untouched.
+    //
+    // (#2063) Untouched EXCEPT for the replays. The shell is this run's evidence
+    // here, and it is also the report body — it flows into `freshForUnion` and
+    // then into the union, where a producer's replayed check would appear beside
+    // the cloud's own carry for the same page, with the producer's date, on a page
+    // this crawl never fetched. Complete mode does not unfold, so a replay arrives
+    // as a per-page check OR as a folded aggregate naming its pages; both go.
+    // Site-scope checks stay: the tally fold scores those verbatim.
+    //
+    // Every rule KEEPS ITS KEY even when every check goes. The tally fold reads
+    // rule membership to decide which rules the shell already handled, so dropping
+    // an emptied rule would hand it to the carried-only branch twice.
     freshResults = new Map<string, RuleRunResult>();
     for (const [ruleId, r] of Object.entries(input.ruleResults)) {
-      freshResults.set(ruleId, { meta: r.meta, checks: r.checks });
+      const checks: CheckResult[] = [];
+      for (const c of r.checks) {
+        if (isReplayedCheck(c)) {
+          replayedChecksDropped += 1;
+          for (const u of attributedPages(c)) replayedUrls.add(u);
+          continue;
+        }
+        checks.push(c);
+      }
+      freshResults.set(ruleId, { meta: r.meta, checks });
     }
+    // The same filtered shell the union gets, in the shape the tally fold takes.
+    // Passing the raw one would let a replay-tagged SITE rule's checks into a
+    // tally; page rules contribute counts rather than checks, so this is defence
+    // in depth rather than a second live path.
+    shellResults = Object.fromEntries(
+      Array.from(freshResults, ([ruleId, r]) => [ruleId, { meta: r.meta, checks: r.checks }]),
+    );
   } else {
     // A published report arrives already folded (#910): an over-cap per-rule
     // check array is collapsed into per-issue-class aggregates that carry every
@@ -440,7 +505,7 @@ export async function runCloudSmartAudits(
       for (const c of r.checks.flatMap(unfoldAggregateCheck)) {
         if (isReplayedCheck(c)) {
           replayedChecksDropped += 1;
-          replayedUrls.add(normalizePageUrl(c.pageUrl!));
+          for (const u of attributedPages(c)) replayedUrls.add(u);
           continue;
         }
         checks.push(c);
@@ -632,7 +697,7 @@ export async function runCloudSmartAudits(
 
   if (streamedComplete) {
     const fold = createCompleteStoreTallyFold({
-      ruleResults: input.ruleResults,
+      ruleResults: shellResults ?? input.ruleResults,
       crawledUrls,
       skippedPassCounts: completeStore.skippedPassCounts,
       carriedPageUrls,
@@ -696,7 +761,7 @@ export async function runCloudSmartAudits(
     // ORDER IS LOAD-BEARING — this MUST run before the deferred writes below.
     if (completeStore) {
       scoringTallies = await foldCompleteStoreTallies({
-        ruleResults: input.ruleResults,
+        ruleResults: shellResults ?? input.ruleResults,
         findingPages: completeStore.findingPages ?? emptyPageSource(),
         crawledUrls,
         skippedPassCounts: completeStore.skippedPassCounts,

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -312,11 +312,22 @@ export interface CloudSmartAuditsResult {
   /**
    * (#2063) Published checks the producer had tagged `carried`/`unrendered` and
    * this merge refused to treat as evidence from this run. Zero on the
-   * complete-store path (the store IS the evidence there). Surfaced for logging:
-   * a large number on a small crawl is a producer publishing a stale local store,
-   * which is worth seeing without re-reading the report JSON out of R2.
+   * complete-store path (the store IS the evidence there).
    */
   replayedChecksDropped: number;
+  /**
+   * (#2063) Of the pages those refused checks named, how many this cloud site has
+   * NEVER had — neither crawled this run nor known from any earlier audit.
+   *
+   * This is the number that says something is wrong; {@link
+   * replayedChecksDropped} on its own does not. A partial re-audit legitimately
+   * replays thousands of checks for pages the cloud knows perfectly well, and the
+   * cloud carries those from its own store as it always did. A producer naming
+   * pages the cloud has no record of is publishing from a store the cloud was
+   * never told about — 508 such pages against a 16-page crawl was the incident,
+   * and nothing in the report said so.
+   */
+  replayedUnknownPages: number;
   /**
    * (#1023 R-D3) True when scoring ran off the reconstructed complete store
    * (freshResults from findings + `syntheticPassCount` for fresh clean pages).
@@ -373,6 +384,12 @@ export async function runCloudSmartAudits(
   const sampledCheckPages = new Map<string, Set<string>>();
   /** (#2063) Producer-carried checks refused as this run's evidence. */
   let replayedChecksDropped = 0;
+  /**
+   * (#2063) The pages those refused checks named. Bounded by PAGES, not checks,
+   * and reduced after the merge to the ones this cloud site has never had — see
+   * {@link CloudSmartAuditsResult.replayedUnknownPages}.
+   */
+  const replayedUrls = new Set<string>();
   if (completeStore) {
     // (#2063) IDENTITY CONTRACT. Complete mode is the one place where a page's
     // ABSENCE from the fresh set authorizes a resolve, and the fresh set was keyed
@@ -423,6 +440,7 @@ export async function runCloudSmartAudits(
       for (const c of r.checks.flatMap(unfoldAggregateCheck)) {
         if (isReplayedCheck(c)) {
           replayedChecksDropped += 1;
+          replayedUrls.add(normalizePageUrl(c.pageUrl!));
           continue;
         }
         checks.push(c);
@@ -561,6 +579,17 @@ export async function runCloudSmartAudits(
   for (const url of session.activePageUrls) {
     if (!crawledUrls.has(url)) carriedPageUrls.add(url);
   }
+
+  // (#2063) Reduce the refused checks' pages to the ones this site has no record
+  // of. `activePageUrls` is already settled here (the session reads `priorPages`
+  // before the first finding streams), and it is exactly "every page the cloud
+  // knows", so a replayed page missing from it was never published to the cloud
+  // at all. The set is dropped straight after.
+  let replayedUnknownPages = 0;
+  for (const url of replayedUrls) {
+    if (!session.activePageUrls.has(url)) replayedUnknownPages += 1;
+  }
+  replayedUrls.clear();
 
   const streamedComplete = completeStore?.openPages;
   // Writing as the merge streams is safe ONLY when the reader is a cursor that has
@@ -757,6 +786,7 @@ export async function runCloudSmartAudits(
     persistedFindings,
     removedPages: removedUrls.size,
     replayedChecksDropped,
+    replayedUnknownPages,
     completeStore: !!completeStore,
   };
 }

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -374,6 +374,17 @@ export async function runCloudSmartAudits(
   /** (#2063) Producer-carried checks refused as this run's evidence. */
   let replayedChecksDropped = 0;
   if (completeStore) {
+    // (#2063) IDENTITY CONTRACT. Complete mode is the one place where a page's
+    // ABSENCE from the fresh set authorizes a resolve, and the fresh set was keyed
+    // by the PRODUCER (`buildStreamFindings`, container-side) while this set is
+    // keyed here. The two must use the same normalizer, which they do — same
+    // module, same release — so the contract is really a deploy one: ship the
+    // container image and the API from the same engine build. A container still
+    // keying pages query-blind would stream `/p` where this set has `/p?id=1`, and
+    // a prior on `/p?id=1` would then look crawled-clean and resolve. The damage
+    // is transient (the next audit re-creates a finding that is still there) and
+    // needs a publish from the NEW engine to have already keyed that page, so it
+    // is bounded by whatever audits are in flight across one deploy.
     for (const u of completeStore.crawledUrls) crawledUrls.add(normalizePageUrl(u));
     for (const u of statusByUrl.keys()) crawledUrls.add(u);
     for (const u of removedUrls) crawledUrls.delete(u);
@@ -727,6 +738,16 @@ export async function runCloudSmartAudits(
     unionRuleResults,
     ...(scoringTallies ? { scoringTallies } : {}),
     coverage: {
+      // Pages this run EVIDENCED, which after #2063 is the pages it crawled: the
+      // replayed checks that used to pad this are gone. It is deliberately the
+      // same set the score and `site_pages` are built from rather than the
+      // publish's raw crawl count, so the three cannot disagree — a coverage line
+      // claiming more pages than `knownPages` would be describing pages the
+      // report has no findings, passes or page rows for. On the SAMPLED path that
+      // leaves a residual gap, unchanged by #2063 and owned by #1167: a page
+      // crawled clean whose every check was clipped from the publish sample is
+      // evidenced by nothing, so it counts as carried rather than audited. The
+      // complete-store path (#1023) is the fix for that and has no such gap.
       auditedPages: crawledUrls.size,
       knownPages: session.activePageUrls.size,
       carriedFindings: carriedCount - unrenderedCount,

--- a/packages/audit-engine/src/merge-promise.ts
+++ b/packages/audit-engine/src/merge-promise.ts
@@ -21,7 +21,7 @@ import type {
 // `/types` (leaf type module) not the barrel — see scoring.ts. (#195)
 import { unfoldAggregateCheck } from "@squirrelscan/rules/fold";
 import type { RuleRunResult } from "@squirrelscan/rules/types";
-import { normalizeUrl } from "@squirrelscan/utils/url";
+import { normalizePageUrl } from "@squirrelscan/utils/url";
 
 import {
   computeMerge,
@@ -48,6 +48,32 @@ import {
 
 /** 404/410 = page gone → stale its findings (not carry). */
 const REMOVED_STATUSES = new Set([404, 410]);
+
+/**
+ * True when a published check is a REPLAY, not evidence from this run (#2063).
+ *
+ * The producers tag every check they publish: `carried` = re-injected from the
+ * producer's own finding store for a page this run did NOT crawl, `unrendered` =
+ * a finding on a page no audit has ever rendered. Neither was observed by the
+ * crawl being published, so neither may count as a crawled page or as a fresh
+ * finding here — the cloud has its own store and its own history, and it decides
+ * what to carry from that.
+ *
+ * The laundering this guards against is not hypothetical: a CLI whose LOCAL store
+ * held 3,200 open findings on 508 URLs last seen weeks earlier published them as
+ * carried, the server counted all 508 as crawled this run, and 129 "audited pages"
+ * appeared for a 16-page crawl with every stale finding re-stamped as first seen
+ * today (squirrelscan/repo#2063).
+ *
+ * Gated on `pageUrl` so a site-scope check can never be dropped by a stray
+ * provenance tag: carried replays are per-page findings by construction
+ * (`carriedFindingToCheck` always stamps a `pageUrl`).
+ */
+function isReplayedCheck(check: CheckResult): boolean {
+  return (
+    !!check.pageUrl && (check.provenance === "carried" || check.provenance === "unrendered")
+  );
+}
 
 /**
  * Rows buffered before a merge flush (#1876).
@@ -284,6 +310,14 @@ export interface CloudSmartAuditsResult {
   persistedFindings: number;
   removedPages: number;
   /**
+   * (#2063) Published checks the producer had tagged `carried`/`unrendered` and
+   * this merge refused to treat as evidence from this run. Zero on the
+   * complete-store path (the store IS the evidence there). Surfaced for logging:
+   * a large number on a small crawl is a producer publishing a stale local store,
+   * which is worth seeing without re-reading the report JSON out of R2.
+   */
+  replayedChecksDropped: number;
+  /**
    * (#1023 R-D3) True when scoring ran off the reconstructed complete store
    * (freshResults from findings + `syntheticPassCount` for fresh clean pages).
    * The caller uses it to fold `syntheticPassCount` into `report.passed`
@@ -324,7 +358,7 @@ export async function runCloudSmartAudits(
   const statusByUrl = new Map<string, number>();
   const removedUrls = new Set<string>();
   for (const ps of input.pageStatuses) {
-    const u = normalizeUrl(ps.url);
+    const u = normalizePageUrl(ps.url);
     statusByUrl.set(u, ps.status);
     if (REMOVED_STATUSES.has(ps.status)) removedUrls.add(u);
   }
@@ -337,8 +371,10 @@ export async function runCloudSmartAudits(
   let freshResults: Map<string, RuleRunResult>;
   const crawledUrls = new Set<string>();
   const sampledCheckPages = new Map<string, Set<string>>();
+  /** (#2063) Producer-carried checks refused as this run's evidence. */
+  let replayedChecksDropped = 0;
   if (completeStore) {
-    for (const u of completeStore.crawledUrls) crawledUrls.add(normalizeUrl(u));
+    for (const u of completeStore.crawledUrls) crawledUrls.add(normalizePageUrl(u));
     for (const u of statusByUrl.keys()) crawledUrls.add(u);
     for (const u of removedUrls) crawledUrls.delete(u);
     // (#1873) NOT reconstructed here. The complete findings are folded into
@@ -358,16 +394,35 @@ export async function runCloudSmartAudits(
     // findings — otherwise every over-cap rule is silently dropped by the
     // `if (!c.pageUrl) continue` gate and contributes zero findings/occurrences
     // to the union store and score (#916). No-op on un-folded checks.
+    //
+    // (#2063) The unfolded checks are then split by provenance and the REPLAYED
+    // ones dropped. `freshResults` is the only thing this branch derives
+    // `crawledUrls`, `freshFindings` and the union's fresh side from, so dropping
+    // them here is what keeps a producer's carry-over out of all three at once:
+    // it cannot make a page look crawled, cannot be persisted as a finding first
+    // seen today, and cannot be scored twice (the cloud's OWN carry for the same
+    // page is replayed from the store, with the date the cloud last saw it).
+    //
+    // A published carry the cloud store has never seen simply does not exist here
+    // — the cloud reports what the cloud has observed, not what some machine's
+    // local database remembers.
     freshResults = new Map<string, RuleRunResult>();
     for (const [ruleId, r] of Object.entries(input.ruleResults)) {
-      const checks = r.checks.flatMap(unfoldAggregateCheck);
+      const checks: CheckResult[] = [];
+      for (const c of r.checks.flatMap(unfoldAggregateCheck)) {
+        if (isReplayedCheck(c)) {
+          replayedChecksDropped += 1;
+          continue;
+        }
+        checks.push(c);
+      }
       freshResults.set(ruleId, { meta: r.meta, checks });
     }
-    // Crawled this run = every page that produced a check (page-scope checks
+    // Crawled this run = every page that produced a FRESH check (page-scope checks
     // carry a pageUrl) ∪ every page in pageStatuses, minus the removed ones.
     for (const r of freshResults.values()) {
       for (const c of r.checks) {
-        if (c.pageUrl) crawledUrls.add(normalizeUrl(c.pageUrl));
+        if (c.pageUrl) crawledUrls.add(normalizePageUrl(c.pageUrl));
       }
     }
     for (const u of statusByUrl.keys()) crawledUrls.add(u);
@@ -378,8 +433,13 @@ export async function runCloudSmartAudits(
     // length. Record each such check's retained (sampled) urls so the merge can
     // carry — not resolve — a still-failing page clipped out of the sample. Keyed
     // `${ruleId}|${checkName}` to match computeMerge's lookup.
+    // (#2063) A wholly-replayed aggregate is skipped: its `pages` are pages this
+    // run never looked at, and listing them as "in the sample" would turn the
+    // carry-guard on its head — absence from a sample the page was never eligible
+    // for would read as authoritative evidence the finding is gone.
     for (const [ruleId, r] of Object.entries(input.ruleResults)) {
       for (const c of r.checks) {
+        if (c.provenance === "carried" || c.provenance === "unrendered") continue;
         const truncated =
           typeof c.details?.pagesTruncated === "number" &&
           !!c.pages &&
@@ -391,7 +451,7 @@ export async function runCloudSmartAudits(
           set = new Set<string>();
           sampledCheckPages.set(key, set);
         }
-        for (const p of c.pages!) set.add(normalizeUrl(p));
+        for (const p of c.pages!) set.add(normalizePageUrl(p));
       }
     }
   }
@@ -412,7 +472,7 @@ export async function runCloudSmartAudits(
       const byUrl = new Map<string, CheckResult[]>();
       for (const c of r.checks) {
         if (!c.pageUrl) continue; // site-scope check — not a per-page finding
-        const u = normalizeUrl(c.pageUrl);
+        const u = normalizePageUrl(c.pageUrl);
         if (removedUrls.has(u)) continue;
         let arr = byUrl.get(u);
         if (!arr) {
@@ -438,7 +498,7 @@ export async function runCloudSmartAudits(
   let resolution: MergeResolutionInput | undefined;
   if (!completeStore && input.resolutionSignal) {
     const signalCrawled = new Set<string>();
-    for (const u of input.resolutionSignal.crawledUrls) signalCrawled.add(normalizeUrl(u));
+    for (const u of input.resolutionSignal.crawledUrls) signalCrawled.add(normalizePageUrl(u));
     const failingByCheck = new Map<string, Set<string>>();
     for (const [key, hashes] of Object.entries(input.resolutionSignal.failing)) {
       failingByCheck.set(key, new Set(hashes));
@@ -643,7 +703,7 @@ export async function runCloudSmartAudits(
             {
               meta: r.meta,
               checks: r.checks.filter(
-                (c) => !(c.pageUrl && removedUrls.has(normalizeUrl(c.pageUrl))),
+                (c) => !(c.pageUrl && removedUrls.has(normalizePageUrl(c.pageUrl))),
               ),
               // Preserve the complete-store fresh-clean pass count (#1023) — a
               // removed page was already excluded from crawledUrls before the
@@ -675,6 +735,7 @@ export async function runCloudSmartAudits(
     carriedLastSeen,
     persistedFindings,
     removedPages: removedUrls.size,
+    replayedChecksDropped,
     completeStore: !!completeStore,
   };
 }

--- a/packages/audit-engine/src/stream-findings.ts
+++ b/packages/audit-engine/src/stream-findings.ts
@@ -12,7 +12,7 @@
 
 import type { CheckResult, PageFindingRecord } from "@squirrelscan/core-contracts";
 import { unfoldAggregateCheck } from "@squirrelscan/rules/fold";
-import { normalizeUrl } from "@squirrelscan/utils/url";
+import { normalizePageUrl } from "@squirrelscan/utils/url";
 
 import { findingFingerprint } from "./fingerprint";
 import { findingKey, flattenChecks } from "./merge-core";
@@ -52,7 +52,12 @@ export function buildStreamFindings(
     const byUrl = new Map<string, CheckResult[]>();
     for (const c of checks) {
       if (!c.pageUrl) continue; // site-scope check — never a per-page finding
-      const u = normalizeUrl(c.pageUrl);
+      // (#2063) A carried/unrendered check is a REPLAY of something an earlier
+      // audit saw, not evidence from this crawl. Streaming it would persist it
+      // with this run's crawl id and today's first/last-seen — the complete-store
+      // path's version of the same laundering the sampled merge now refuses.
+      if (c.provenance === "carried" || c.provenance === "unrendered") continue;
+      const u = normalizePageUrl(c.pageUrl);
       const arr = byUrl.get(u);
       if (arr) arr.push(c);
       else byUrl.set(u, [c]);
@@ -115,7 +120,11 @@ export function buildSkippedPassCounts(
     const byPage = new Map<string, CheckResult[]>();
     for (const c of checks) {
       if (!c.pageUrl) continue;
-      const u = normalizeUrl(c.pageUrl);
+      // (#2063) Same exclusion as buildStreamFindings: a replayed fail would mark
+      // a page "dirty" that this run never visited, and the synthetic pass counts
+      // derived here must describe this crawl only.
+      if (c.provenance === "carried" || c.provenance === "unrendered") continue;
+      const u = normalizePageUrl(c.pageUrl);
       const arr = byPage.get(u);
       if (arr) arr.push(c);
       else byPage.set(u, [c]);

--- a/packages/audit-engine/tests/bounded-carried-merge.test.ts
+++ b/packages/audit-engine/tests/bounded-carried-merge.test.ts
@@ -437,6 +437,49 @@ describe("the report's carried side is bounded per rule (#1876)", () => {
     expect(streamed.coverage.carriedFindings).toBe(OVER_CAP);
   });
 
+  // #2063: the publish fold now keys groups on provenance as well as issue class,
+  // so one class can leave the retained sample as TWO aggregates. The budget's
+  // class accounting has to count them the same way — counting `(name, status)`
+  // alone capped the re-fold at one aggregate, silently merging the two and
+  // losing an occurrence, and then reconciled the survivor against a class key it
+  // no longer matched (its provenance and last-seen were deleted).
+  test("a class that splits by provenance keeps both aggregates and every occurrence", async () => {
+    const TOTAL = 30;
+    const backlog = Array.from(
+      { length: TOTAL },
+      (_, i) => `https://x.test/backlog/${String(i).padStart(4, "0")}`,
+    );
+    // One page inside the retained window that NO audit has ever rendered: it has
+    // no site_pages row, so the merge stamps its finding "unrendered" while the
+    // other 29 stay "carried".
+    const neverRendered = backlog[5]!;
+    const fixture: Fixture = {
+      rows: backlog.map((u) => row(u, "", PRIOR_AUDIT)),
+      pages: backlog.filter((u) => u !== neverRendered),
+      crawled: ["https://x.test/p/0"],
+      statuses: [{ url: "https://x.test/p/0", status: 200 }],
+    };
+    const [streamed] = await runStreamed(fixture);
+
+    const checks = streamed.unionRuleResults.get(RULE)!.checks;
+    const byProvenance = new Map(checks.map((c) => [c.provenance, c]));
+    expect([...byProvenance.keys()].sort()).toEqual(["carried", "unrendered"]);
+
+    const occurrences = checks.reduce(
+      (sum, c) => sum + ((c.details?.occurrences as number | undefined) ?? 1),
+      0,
+    );
+    expect(occurrences).toBe(TOTAL);
+    expect(byProvenance.get("carried")!.details?.occurrences).toBe(TOTAL - 1);
+    // An "unrendered" aggregate never claims a prior observation.
+    expect(byProvenance.get("unrendered")!.lastSeenAt).toBeUndefined();
+
+    // The score still saw every one of them — the bound is on the report body.
+    expect(streamed.scoringTallies!.get(RULE)!.tally.failed).toBe(TOTAL);
+    expect(streamed.coverage.carriedFindings).toBe(TOTAL - 1);
+    expect(streamed.coverage.unrenderedFindings).toBe(1);
+  });
+
   test("a class first seen after the budget is spent still reaches the report", async () => {
     // The budget is per RULE, so one loud issue class can spend all of it before a
     // second class is ever seen. Dropping the second class would lose it from the
@@ -513,12 +556,15 @@ describe("the report's carried side is bounded per rule (#1876)", () => {
     expect(checks[0]!.details?.pagesTruncated).toBe(400);
   });
 
-  test("a class the sample saw as all-carried but is not loses the claim", async () => {
-    // `foldGroup` stamps "carried" only when EVERY constituent is, so a uniform
-    // sample of a mixed class would have the aggregate assert an earlier audit saw
-    // findings no audit has ever rendered. The newest date has the mirror problem:
-    // it is a max over the group, so a dropped constituent carrying a later one
-    // would leave the badge reading stale.
+  test("a class whose unrendered member arrives after the budget still splits out", async () => {
+    // The two claims used to cancel each other: `foldGroup` stamps "carried" only
+    // when EVERY constituent is, so a class mixing carried and never-rendered
+    // findings folded to one aggregate asserting neither, and a newer date on a
+    // dropped constituent could not be shown without over-claiming.
+    //
+    // (#2063) They no longer share an aggregate, so each keeps its own claim —
+    // including the case the counters exist for, where the odd member arrives
+    // after the retained sample is full and is only visible through them.
     const rendered = Array.from(
       { length: 30 },
       (_, i) => `https://x.test/seen/${String(i).padStart(2, "0")}`,
@@ -538,12 +584,17 @@ describe("the report's carried side is bounded per rule (#1876)", () => {
     };
     const [streamed] = await runStreamed(fixture);
     const checks = streamed.unionRuleResults.get(RULE)!.checks;
-    expect(checks).toHaveLength(1);
-    // Mixed carried + unrendered: neither marker, which is what folding all 31
-    // real checks would have produced.
-    expect(checks[0]!.provenance).toBeUndefined();
-    expect(checks[0]!.lastSeenAt).toBeUndefined();
-    expect(checks[0]!.details?.occurrences).toBe(31);
+    const byProvenance = new Map(checks.map((c) => [c.provenance, c]));
+    expect([...byProvenance.keys()].sort()).toEqual(["carried", "unrendered"]);
+
+    // The 30 rendered pages keep their claim and their own newest date; the one
+    // page nothing has ever rendered keeps neither, and its later date — which
+    // used to be the thing that made the badge read stale — never reaches a
+    // carried aggregate at all.
+    expect(byProvenance.get("carried")!.details?.occurrences).toBe(30);
+    expect(byProvenance.get("carried")!.lastSeenAt).toBe(1_600_000_000_000);
+    expect(byProvenance.get("unrendered")!.lastSeenAt).toBeUndefined();
+    expect(byProvenance.get("unrendered")!.details?.occurrences ?? 1).toBe(1);
   });
 
   test("an all-carried class keeps the NEWEST last-seen, dropped checks included", async () => {
@@ -589,8 +640,10 @@ describe("the report's carried side is bounded per rule (#1876)", () => {
           payload: JSON.stringify({ details: { occurrences: 0.5, pagesTruncated: 400 } }),
         },
       ],
-      // `odd` has no site_pages row, so nothing has ever rendered it.
-      pages: backlog,
+      // `odd` is a rendered page like the rest, so it shares their class (#2063)
+      // and the drop this test is about actually happens — a different provenance
+      // would give it a class of its own, which is never over its own budget.
+      pages: [...backlog, odd],
       crawled: ["https://x.test/p/0"],
       statuses: [{ url: "https://x.test/p/0", status: 200 }],
     };
@@ -598,8 +651,7 @@ describe("the report's carried side is bounded per rule (#1876)", () => {
     const checks = streamed.unionRuleResults.get(RULE)!.checks;
     expect(checks).toHaveLength(1);
     expect(checks[0]!.details?.pagesTruncated).toBe(400);
-    // Mixed carried + unrendered, so neither marker survives.
-    expect(checks[0]!.provenance).toBeUndefined();
+    expect(checks[0]!.provenance).toBe("carried");
   });
 
   test("a class weighing zero is not rounded UP by the stamp", async () => {

--- a/packages/audit-engine/tests/carried-provenance-merge.test.ts
+++ b/packages/audit-engine/tests/carried-provenance-merge.test.ts
@@ -665,3 +665,56 @@ describe("#2063 — the container streams this run's evidence only", () => {
     expect(counts).toEqual({ [RULE]: { "title-length": 1 } });
   });
 });
+
+describe("#2063 — a rule emptied by the filter still scores its crawled pages", () => {
+  const REAL_RULE = "core/meta-title";
+  /** Every check this rule published is a replay, so the filter empties it. */
+  const EMPTIED_RULE = "content/word-count";
+  const wordCountMeta = { ...pageMeta, id: "word-count", name: "Word Count", category: "content" };
+  const CRAWLED = FRESH_PAGES[0]!;
+
+  async function* noOpenPages(): AsyncGenerator<{
+    normalizedUrl: string;
+    fresh: PageFindingRecord[];
+    prior: PageFindingRecord[];
+  }> {
+    // Nothing open for this site.
+  }
+
+  // The filter must empty a rule's checks without removing the RULE. The tally
+  // fold reads rule membership to hand a page rule its fresh-clean pass count —
+  // the crawled pages it found nothing on — so an emptied rule dropped from the
+  // shell would silently leave the pass denominator.
+  test("its fresh-clean pass count survives the filter", async () => {
+    const result = await runCloudSmartAudits({
+      store: new MemStore(),
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        [REAL_RULE]: { meta: pageMeta, checks: [warnCheck(CRAWLED)] },
+        [EMPTIED_RULE]: {
+          meta: wordCountMeta,
+          checks: [
+            warnCheck(CARRIED_PAGES[0]!, { provenance: "carried" as const, lastSeenAt: AUGUST }),
+            warnCheck(CARRIED_PAGES[1]!, { provenance: "unrendered" as const }),
+          ],
+        },
+      },
+      pageStatuses: [],
+      now: NOW,
+      completeStore: { openPages: noOpenPages(), crawledUrls: [CRAWLED] },
+    });
+
+    // The rule survives with no checks at all…
+    expect(result.unionRuleResults.get(EMPTIED_RULE)!.checks).toHaveLength(0);
+    // …and the one crawled page still counts as a pass for it. Drop the rule key
+    // and this entry does not exist.
+    const tally = result.scoringTallies!.get(EMPTIED_RULE);
+    expect(tally).toBeDefined();
+    expect(tally!.tally.passed).toBe(1);
+    expect(tally!.tally.warnings).toBe(0);
+
+    expect(result.replayedChecksDropped).toBe(2);
+    expect(result.coverage.auditedPages).toBe(1);
+  });
+});

--- a/packages/audit-engine/tests/carried-provenance-merge.test.ts
+++ b/packages/audit-engine/tests/carried-provenance-merge.test.ts
@@ -1,0 +1,371 @@
+// #2063 — a published check the producer tagged `carried` is NOT evidence.
+//
+// The CLI publishes the UNION of this run's crawl and its own local finding
+// store, tagging the replayed half `provenance: "carried"`. The cloud merge used
+// to read every check's `pageUrl` as a page crawled this run, so a machine whose
+// local store still held findings from an audit weeks earlier turned them into
+// cloud findings first seen today, on pages the crawl never visited: 129
+// "audited pages" for a 16-page crawl, and a health score that swung 38 points
+// between two runs of the same site three minutes apart.
+//
+// Second half of the same bug: the cloud keyed those pages with a query-BLIND
+// normalizer, so 384 `?id=N` pages collapsed into one `page_findings` row.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  CheckResult,
+  FindingState,
+  PageFindingRecord,
+  SitePageRecord,
+} from "@squirrelscan/core-contracts";
+
+import { resolutionCheckKey, resolutionUrlHash } from "@squirrelscan/core-contracts/resolution";
+
+import { findingKey } from "../src/merge-core";
+import { runCloudSmartAudits, type SmartAuditStore } from "../src/merge-promise";
+import { calculateHealthScore } from "../src/scoring";
+
+class MemStore implements SmartAuditStore {
+  findings = new Map<string, PageFindingRecord>();
+  pages = new Map<string, SitePageRecord>();
+
+  private key(f: { normalizedUrl: string; ruleId: string; checkName: string; locator: string }) {
+    return findingKey(f.normalizedUrl, f.ruleId, f.checkName, f.locator);
+  }
+
+  async getFindings(_siteKey: string, states?: FindingState[]): Promise<PageFindingRecord[]> {
+    const all = [...this.findings.values()];
+    return states ? all.filter((f) => states.includes(f.state)) : all;
+  }
+  async getSitePages(): Promise<SitePageRecord[]> {
+    return [...this.pages.values()];
+  }
+  async upsertFindings(findings: PageFindingRecord[]): Promise<void> {
+    for (const f of findings) this.findings.set(this.key(f), { ...f });
+  }
+  async upsertSitePages(pages: SitePageRecord[]): Promise<void> {
+    for (const p of pages) this.pages.set(p.normalizedUrl, { ...p });
+  }
+  async markPageRemoved(
+    siteKey: string,
+    normalizedUrl: string,
+    crawlId: string,
+    lastStatus: number,
+  ): Promise<void> {
+    this.pages.set(normalizedUrl, {
+      siteKey,
+      normalizedUrl,
+      lastStatus,
+      state: "removed",
+      lastSeenCrawlId: crawlId,
+      lastSeenAt: Date.now(),
+    });
+    for (const [k, f] of this.findings) {
+      if (f.normalizedUrl === normalizedUrl && f.state === "open") {
+        this.findings.set(k, { ...f, state: "stale", lastSeenCrawlId: crawlId });
+      }
+    }
+  }
+  async markPagesRemoved(
+    siteKey: string,
+    pages: Array<{ normalizedUrl: string; lastStatus: number }>,
+    crawlId: string,
+  ): Promise<void> {
+    for (const p of pages)
+      await this.markPageRemoved(siteKey, p.normalizedUrl, crawlId, p.lastStatus);
+  }
+  async compactFindings(): Promise<number> {
+    return 0;
+  }
+}
+
+const pageMeta = {
+  id: "meta-title",
+  name: "Meta Title",
+  description: "Pages should have a title",
+  category: "core",
+  scope: "page" as const,
+  severity: "warning" as const,
+  weight: 10,
+};
+
+/** Epoch ms for 2026-08-19 — the "last seen" on the real report's carried half. */
+const AUGUST = Date.UTC(2026, 7, 19, 12, 0, 0);
+const NOW = Date.UTC(2026, 8, 11, 17, 11, 27);
+
+function warnCheck(pageUrl: string, overrides: Partial<CheckResult> = {}): CheckResult {
+  return {
+    name: "meta-title",
+    status: "warn",
+    message: "Title is too short",
+    pageUrl,
+    ...overrides,
+  };
+}
+
+function passCheck(pageUrl: string): CheckResult {
+  return { name: "meta-title", status: "pass", message: "ok", pageUrl };
+}
+
+/** The 16 pages this run actually crawled: 2 warn, 14 clean. */
+const FRESH_PAGES = Array.from({ length: 16 }, (_, i) => `https://gaijin.test/p/${i}`);
+/** 400 pages only the PRODUCER's local store knows about. */
+const CARRIED_PAGES = Array.from({ length: 400 }, (_, i) => `https://gaijin.test/old/${i}`);
+
+function freshChecks(): CheckResult[] {
+  return [
+    ...FRESH_PAGES.slice(0, 2).map((u) => warnCheck(u)),
+    ...FRESH_PAGES.slice(2).map((u) => passCheck(u)),
+  ];
+}
+
+function carriedChecks(): CheckResult[] {
+  return CARRIED_PAGES.map((u) => warnCheck(u, { provenance: "carried", lastSeenAt: AUGUST }));
+}
+
+describe("#2063 — producer-carried checks are not this run's evidence", () => {
+  test("a 16-page crawl published with 400 carried pages audits 16 pages", async () => {
+    const store = new MemStore();
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        "core/meta-title": { meta: pageMeta, checks: [...freshChecks(), ...carriedChecks()] },
+      },
+      // The CLI ships only non-2xx statuses, so the crawled set comes from the
+      // fresh checks alone — exactly the shape that laundered before.
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    expect(r.coverage.auditedPages).toBe(16);
+    expect(r.coverage.knownPages).toBe(16);
+    expect(r.replayedChecksDropped).toBe(400);
+
+    // Nothing on a carried page reached the store, so nothing was stamped as
+    // first seen today on a page this crawl never opened.
+    const persisted = await store.getFindings("web_1");
+    expect(persisted).toHaveLength(2);
+    for (const f of persisted) {
+      expect(CARRIED_PAGES).not.toContain(f.normalizedUrl);
+      expect(f.firstSeenAt).toBe(NOW);
+    }
+    expect([...store.pages.keys()].sort()).toEqual([...FRESH_PAGES].sort());
+  });
+
+  test("the carried half cannot move the score", async () => {
+    const withCarried = await runCloudSmartAudits({
+      store: new MemStore(),
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        "core/meta-title": { meta: pageMeta, checks: [...freshChecks(), ...carriedChecks()] },
+      },
+      pageStatuses: [],
+      now: NOW,
+    });
+    const freshOnly = await runCloudSmartAudits({
+      store: new MemStore(),
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: { "core/meta-title": { meta: pageMeta, checks: freshChecks() } },
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    expect(withCarried.coverage).toEqual(freshOnly.coverage);
+    expect(calculateHealthScore({ results: withCarried.unionRuleResults }).overall).toBe(
+      calculateHealthScore({ results: freshOnly.unionRuleResults }).overall,
+    );
+  });
+
+  test("the cloud's OWN carry still works, with the date the cloud last saw it", async () => {
+    const store = new MemStore();
+    // Run 1: the cloud crawls and sees /p/0 warn.
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: { "core/meta-title": { meta: pageMeta, checks: freshChecks() } },
+      pageStatuses: [],
+      now: AUGUST,
+    });
+    // Run 2: only /p/1 re-crawled. /p/0 is published as CARRIED by the producer
+    // — the cloud must carry it off its own store, not off the payload.
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_2",
+      ruleResults: {
+        "core/meta-title": {
+          meta: pageMeta,
+          checks: [
+            warnCheck(FRESH_PAGES[1]!),
+            warnCheck(FRESH_PAGES[0]!, { provenance: "carried", lastSeenAt: 1 }),
+          ],
+        },
+      },
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    expect(r.coverage.auditedPages).toBe(1);
+    expect(r.coverage.carriedFindings).toBe(1);
+    // The cloud's own last-seen (run 1), NOT the bogus `lastSeenAt: 1` the
+    // producer published.
+    expect(r.carriedLastSeen.get(`${FRESH_PAGES[0]}|core/meta-title|meta-title`)).toBe(AUGUST);
+
+    const carried = (await store.getFindings("web_1", ["open"])).find(
+      (f) => f.normalizedUrl === FRESH_PAGES[0],
+    );
+    expect(carried!.provenance).toBe("carried");
+    expect(carried!.firstSeenAt).toBe(AUGUST);
+    expect(carried!.lastSeenAt).toBe(AUGUST); // never re-stamped to publish time
+  });
+
+  test("a wholly-carried folded aggregate is refused too", async () => {
+    const store = new MemStore();
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        "core/meta-title": {
+          meta: pageMeta,
+          checks: [
+            ...freshChecks(),
+            {
+              name: "meta-title",
+              status: "warn",
+              message: "Title is too short (+399 more pages)",
+              pages: CARRIED_PAGES,
+              details: { aggregated: true, occurrences: 400, pagesTruncated: 400 },
+              provenance: "carried",
+              lastSeenAt: AUGUST,
+            },
+          ],
+        },
+      },
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    expect(r.coverage.auditedPages).toBe(16);
+    expect(r.replayedChecksDropped).toBe(400);
+    expect(await store.getFindings("web_1")).toHaveLength(2);
+  });
+});
+
+describe("#2063 — query strings are part of a page's identity", () => {
+  const Q1 = "https://gaijin.test/p?id=1";
+  const Q2 = "https://gaijin.test/p?id=2";
+
+  test("/p?id=1 and /p?id=2 are two findings, not one", async () => {
+    const store = new MemStore();
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        "core/meta-title": { meta: pageMeta, checks: [warnCheck(Q1), warnCheck(Q2)] },
+      },
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    expect(r.coverage.auditedPages).toBe(2);
+    const urls = (await store.getFindings("web_1")).map((f) => f.normalizedUrl).sort();
+    expect(urls).toEqual([Q1, Q2]);
+    expect([...store.pages.keys()].sort()).toEqual([Q1, Q2]);
+  });
+
+  test("re-crawling one query page resolves only that page's finding", async () => {
+    const store = new MemStore();
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        "core/meta-title": { meta: pageMeta, checks: [warnCheck(Q1), warnCheck(Q2)] },
+      },
+      pageStatuses: [],
+      now: AUGUST,
+    });
+    // Run 2: /p?id=1 is fixed, /p?id=2 not re-crawled.
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_2",
+      ruleResults: { "core/meta-title": { meta: pageMeta, checks: [passCheck(Q1)] } },
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    const byUrl = new Map((await store.getFindings("web_1")).map((f) => [f.normalizedUrl, f]));
+    expect(byUrl.get(Q1)!.state).toBe("resolved");
+    expect(byUrl.get(Q2)!.state).toBe("open");
+    expect(byUrl.get(Q2)!.provenance).toBe("carried");
+  });
+
+  // A publisher on an older release hashed the resolution signal query-BLIND. If
+  // the merge only recognized the new spelling it would read "not in the failing
+  // set" and resolve a finding that is still there — so both spellings count, and
+  // the only thing an unmatched hash can cause is a carry.
+  test("a query-blind resolution signal from an older publisher still carries", async () => {
+    const store = new MemStore();
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        "core/meta-title": { meta: pageMeta, checks: [warnCheck(Q1), warnCheck(Q2)] },
+      },
+      pageStatuses: [],
+      now: AUGUST,
+    });
+
+    // Run 2 crawls both pages. Q1's warn was clipped out of the published sample,
+    // so the payload carries no check for it at all — only the signal knows.
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_2",
+      ruleResults: { "core/meta-title": { meta: pageMeta, checks: [warnCheck(Q2)] } },
+      pageStatuses: [],
+      resolutionSignal: {
+        crawledUrls: [Q1, Q2],
+        // Hashed the OLD way: `normalizeUrl` collapsed both to https://x.test/p.
+        failing: {
+          [resolutionCheckKey("core/meta-title", "meta-title")]: [
+            resolutionUrlHash("https://gaijin.test/p"),
+          ],
+        },
+      },
+      now: NOW,
+    });
+
+    const byUrl = new Map((await store.getFindings("web_1")).map((f) => [f.normalizedUrl, f]));
+    expect(byUrl.get(Q1)!.state).toBe("open");
+    expect(byUrl.get(Q1)!.provenance).toBe("carried");
+  });
+
+  test("the trailing slash still collapses, so an existing store is not re-keyed", async () => {
+    const store = new MemStore();
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        "core/meta-title": {
+          meta: pageMeta,
+          checks: [warnCheck("https://gaijin.test/about/"), warnCheck("https://gaijin.test/about")],
+        },
+      },
+      pageStatuses: [],
+      now: NOW,
+    });
+    expect(r.coverage.auditedPages).toBe(1);
+  });
+});

--- a/packages/audit-engine/tests/carried-provenance-merge.test.ts
+++ b/packages/audit-engine/tests/carried-provenance-merge.test.ts
@@ -143,6 +143,10 @@ describe("#2063 — producer-carried checks are not this run's evidence", () => 
     expect(r.coverage.auditedPages).toBe(16);
     expect(r.coverage.knownPages).toBe(16);
     expect(r.replayedChecksDropped).toBe(400);
+    // Every one of those 400 pages is one this cloud site has no record of —
+    // the number that separates a stale local store from an ordinary partial
+    // re-audit, which replays pages the cloud knows.
+    expect(r.replayedUnknownPages).toBe(400);
 
     // Nothing on a carried page reached the store, so nothing was stamped as
     // first seen today on a page this crawl never opened.
@@ -213,6 +217,10 @@ describe("#2063 — producer-carried checks are not this run's evidence", () => 
 
     expect(r.coverage.auditedPages).toBe(1);
     expect(r.coverage.carriedFindings).toBe(1);
+    // The producer replayed a page the cloud DOES know, so nothing is unknown:
+    // an ordinary partial re-audit must not look like the incident.
+    expect(r.replayedChecksDropped).toBe(1);
+    expect(r.replayedUnknownPages).toBe(0);
     // The cloud's own last-seen (run 1), NOT the bogus `lastSeenAt: 1` the
     // producer published.
     expect(r.carriedLastSeen.get(`${FRESH_PAGES[0]}|core/meta-title|meta-title`)).toBe(AUGUST);

--- a/packages/audit-engine/tests/carried-provenance-merge.test.ts
+++ b/packages/audit-engine/tests/carried-provenance-merge.test.ts
@@ -24,6 +24,7 @@ import { resolutionCheckKey, resolutionUrlHash } from "@squirrelscan/core-contra
 
 import { findingKey } from "../src/merge-core";
 import { runCloudSmartAudits, type SmartAuditStore } from "../src/merge-promise";
+import { buildSkippedPassCounts, buildStreamFindings } from "../src/stream-findings";
 import { calculateHealthScore } from "../src/scoring";
 
 class MemStore implements SmartAuditStore {
@@ -375,5 +376,292 @@ describe("#2063 — query strings are part of a page's identity", () => {
       now: NOW,
     });
     expect(r.coverage.auditedPages).toBe(1);
+  });
+});
+
+describe("#2063 — the sample sets describe this run only", () => {
+  const RULE = "core/meta-title";
+  const CHECK = "meta-title";
+  /** A page the crawl visited and whose finding the fresh sample clipped out. */
+  const CLIPPED = "https://gaijin.test/p/3";
+
+  /**
+   * A truncated aggregate: it retains `pages` but declares a bigger
+   * `pagesTruncated`, which is the marker that makes its page list a SAMPLE and
+   * so non-authoritative for the merge.
+   */
+  function truncatedAggregate(
+    pages: string[],
+    total: number,
+    overrides: Partial<CheckResult> = {},
+  ): CheckResult {
+    return {
+      name: CHECK,
+      status: "warn",
+      message: `Title is too short (+${total - 1} more pages)`,
+      pages,
+      details: { aggregated: true, occurrences: total, pagesTruncated: total },
+      ...overrides,
+    };
+  }
+
+  // Without the replay exclusion the CARRIED aggregate's retained pages join the
+  // sample set, and a page it happens to name then reads as "in the sample,
+  // produced no fresh finding" — the one shape that resolves a finding the crawl
+  // never re-examined. The fresh aggregate is what makes the branch reachable:
+  // its sample is the authority, and it clipped this page out.
+  test("a carried aggregate's pages never become this run's sample", async () => {
+    const store = new MemStore();
+    await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: { [RULE]: { meta: pageMeta, checks: freshChecks() } },
+      pageStatuses: [],
+      now: AUGUST,
+    });
+    // Run 1 left /p/0 and /p/1 failing. Give /p/3 a finding too, so run 2 has a
+    // prior on a page its fresh sample clips.
+    await store.upsertFindings([
+      {
+        siteKey: "web_1",
+        normalizedUrl: CLIPPED,
+        ruleId: RULE,
+        checkName: CHECK,
+        locator: "",
+        status: "warn",
+        severity: "warning",
+        message: "Title is too short",
+        value: null,
+        expected: null,
+        payload: null,
+        fingerprint: "fp-clipped",
+        firstSeenAt: AUGUST,
+        lastSeenAt: AUGUST,
+        lastSeenCrawlId: "audit_1",
+        provenance: "fresh",
+        state: "open",
+      },
+    ]);
+
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_2",
+      ruleResults: {
+        [RULE]: {
+          meta: pageMeta,
+          checks: [
+            // Every page crawled again, so the whole site is in `crawledUrls`.
+            ...FRESH_PAGES.map((u) => passCheck(u)),
+            // This run's failing pages, SAMPLED — /p/3 was clipped out of it.
+            truncatedAggregate([FRESH_PAGES[0]!, FRESH_PAGES[1]!], 40),
+            // The producer's replay, whose own sample happens to name /p/3.
+            truncatedAggregate([CLIPPED, ...CARRIED_PAGES.slice(0, 99)], 400, {
+              provenance: "carried",
+              lastSeenAt: AUGUST,
+            }),
+          ],
+        },
+      },
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    const clipped = (await store.getFindings("web_1")).find((f) => f.normalizedUrl === CLIPPED);
+    expect(clipped!.state).toBe("open");
+    expect(clipped!.provenance).toBe("carried");
+    // The sampled branch unfolds before it filters, so the aggregate is counted
+    // as the 100 per-page checks it stands for, not as one object.
+    expect(r.replayedChecksDropped).toBe(100);
+  });
+
+  test("an unrendered check is refused on the same terms as a carried one", async () => {
+    const store = new MemStore();
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: {
+        [RULE]: {
+          meta: pageMeta,
+          checks: [
+            ...freshChecks(),
+            warnCheck(CARRIED_PAGES[0]!, { provenance: "unrendered" }),
+            truncatedAggregate(CARRIED_PAGES.slice(0, 50), 400, { provenance: "unrendered" }),
+          ],
+        },
+      },
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    expect(r.coverage.auditedPages).toBe(16);
+    expect(r.replayedChecksDropped).toBe(51); // 1 per-page + the 50 the aggregate unfolds to
+    expect(await store.getFindings("web_1")).toHaveLength(2);
+    for (const check of r.unionRuleResults.get(RULE)!.checks) {
+      expect(CARRIED_PAGES).not.toContain(check.pageUrl ?? "");
+    }
+  });
+});
+
+describe("#2063 — complete-store mode keeps replays out of the union", () => {
+  const RULE = "core/meta-title";
+  const SITE_RULE = "crawl/robots-txt";
+  const siteMeta = {
+    id: "robots-txt",
+    name: "Robots.txt",
+    description: "A site should serve robots.txt",
+    category: "crawl",
+    scope: "site" as const,
+    severity: "warning" as const,
+    weight: 10,
+  };
+  const CRAWLED = FRESH_PAGES[0]!;
+  const REPLAYED = CARRIED_PAGES[0]!;
+
+  /** The staged shell: one real page check, one replay, one replayed aggregate,
+   *  and a site-scope check that must survive all of it. */
+  function shell() {
+    return {
+      [RULE]: {
+        meta: pageMeta,
+        checks: [
+          warnCheck(CRAWLED),
+          warnCheck(REPLAYED, { provenance: "carried" as const, lastSeenAt: 1 }),
+          {
+            name: "meta-title",
+            status: "warn" as const,
+            message: "Title is too short (+399 more pages)",
+            pages: CARRIED_PAGES.slice(0, 100),
+            details: { aggregated: true, occurrences: 400, pagesTruncated: 400 },
+            provenance: "carried" as const,
+            lastSeenAt: AUGUST,
+          },
+        ],
+      },
+      [SITE_RULE]: {
+        meta: siteMeta,
+        checks: [{ name: "robots-exists", status: "warn" as const, message: "No robots.txt" }],
+      },
+    };
+  }
+
+  async function* noFindingPages(): AsyncGenerator<PageFindingRecord[]> {
+    // This audit ingested nothing for these rules.
+  }
+  async function* noOpenPages(): AsyncGenerator<{
+    normalizedUrl: string;
+    fresh: PageFindingRecord[];
+    prior: PageFindingRecord[];
+  }> {
+    // The site has no open findings at all.
+  }
+
+  function assertClean(result: Awaited<ReturnType<typeof runCloudSmartAudits>>) {
+    // Complete mode does NOT unfold, so the aggregate is refused as one check.
+    expect(result.replayedChecksDropped).toBe(2);
+    expect(result.coverage.auditedPages).toBe(1);
+
+    const checks = result.unionRuleResults.get(RULE)!.checks;
+    for (const check of checks) {
+      expect(check.pageUrl ?? "").not.toBe(REPLAYED);
+      expect(check.lastSeenAt).toBeUndefined();
+      expect(check.pages ?? []).toHaveLength(0);
+    }
+    expect(checks.map((c) => c.pageUrl)).toEqual([CRAWLED]);
+
+    // A genuine site-scope check is scored from the shell verbatim and must not
+    // be swept up by a page-attribution filter.
+    expect(result.unionRuleResults.get(SITE_RULE)!.checks).toHaveLength(1);
+  }
+
+  test("the materialized variant", async () => {
+    const result = await runCloudSmartAudits({
+      store: new MemStore(),
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: shell(),
+      pageStatuses: [],
+      now: NOW,
+      completeStore: {
+        findingPages: noFindingPages(),
+        priorOpenFindings: [],
+        crawledUrls: [CRAWLED],
+      },
+    });
+    assertClean(result);
+  });
+
+  test("the streamed variant", async () => {
+    const result = await runCloudSmartAudits({
+      store: new MemStore(),
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: shell(),
+      pageStatuses: [],
+      now: NOW,
+      completeStore: { openPages: noOpenPages(), crawledUrls: [CRAWLED] },
+    });
+    assertClean(result);
+  });
+});
+
+describe("#2063 — the container streams this run's evidence only", () => {
+  const RULE = "core/meta-title";
+  const CRAWLED = FRESH_PAGES[0]!;
+  const REPLAYED = CARRIED_PAGES[0]!;
+
+  /** The pre-sample report the container flattens: one real finding, one replay
+   *  of each kind, and a replayed aggregate. */
+  function ruleResults() {
+    return {
+      [RULE]: {
+        meta: pageMeta,
+        checks: [
+          warnCheck(CRAWLED),
+          warnCheck(REPLAYED, { provenance: "carried" as const, lastSeenAt: AUGUST }),
+          warnCheck(CARRIED_PAGES[1]!, { provenance: "unrendered" as const }),
+          {
+            name: "meta-title",
+            status: "warn" as const,
+            message: "Title is too short (+9 more pages)",
+            pages: CARRIED_PAGES.slice(2, 12),
+            details: { aggregated: true, occurrences: 10 },
+            provenance: "carried" as const,
+            lastSeenAt: AUGUST,
+          },
+        ],
+      },
+    };
+  }
+
+  // Streaming a replay would persist it under THIS run's crawl id with today's
+  // first/last-seen — the complete-store path's version of the laundering the
+  // sampled merge refuses.
+  test("buildStreamFindings streams the crawl's finding and none of the replays", () => {
+    const lines = buildStreamFindings(ruleResults(), NOW);
+
+    expect(lines.map((l) => l.normalizedUrl)).toEqual([CRAWLED]);
+    expect(lines[0]!.provenance).toBe("fresh");
+    expect(lines[0]!.firstSeenAt).toBe(NOW);
+  });
+
+  test("buildSkippedPassCounts does not let a replayed fail make a page dirty", () => {
+    // /p/1 is clean apart from a REPLAYED warn, so its pass is a whole-page pass,
+    // not a passing sibling on a dirty page. Counting it here would add a pass
+    // unit the reconstruction already counts as a clean page.
+    const counts = buildSkippedPassCounts({
+      [RULE]: {
+        checks: [
+          warnCheck(CRAWLED),
+          { name: "title-length", status: "pass", message: "ok", pageUrl: CRAWLED },
+          warnCheck(FRESH_PAGES[1]!, { provenance: "carried" as const, lastSeenAt: AUGUST }),
+          { name: "title-length", status: "pass", message: "ok", pageUrl: FRESH_PAGES[1]! },
+        ],
+      },
+    });
+
+    expect(counts).toEqual({ [RULE]: { "title-length": 1 } });
   });
 });

--- a/packages/rules/src/fold.ts
+++ b/packages/rules/src/fold.ts
@@ -522,7 +522,16 @@ export function foldOverflowChecks(
   out.sort((a, b) => {
     const nameDiff = a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
     if (nameDiff !== 0) return nameDiff;
-    return a.status < b.status ? -1 : a.status > b.status ? 1 : 0;
+    const statusDiff = a.status < b.status ? -1 : a.status > b.status ? 1 : 0;
+    if (statusDiff !== 0) return statusDiff;
+    // (#2063) Provenance splits a class into up to three aggregates, so the pair
+    // above no longer separates them and Array#sort is free to leave them in
+    // whatever order the groups were built — which is rule execution order, and
+    // that is nondeterministic (#114). Ordering on the full group key is what
+    // keeps a repeat audit byte-identical.
+    const ka = foldGroupKey(a);
+    const kb = foldGroupKey(b);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
   });
 
   // No rule emits >maxChecks distinct issue classes; slice keeps the invariant

--- a/packages/rules/src/fold.ts
+++ b/packages/rules/src/fold.ts
@@ -173,6 +173,27 @@ export interface PublishDegradeLimits extends PublishSampleLimits {
   maxPageStatusBytes?: number;
 }
 
+/**
+ * Fold identity for a check: its issue class AND its provenance (#2063).
+ *
+ * Provenance is part of the key, not a property the fold tries to reconcile
+ * afterwards, because {@link foldGroup} can only keep a "carried"/"unrendered"
+ * label when EVERY constituent carries it — a mixed group folds to an aggregate
+ * with no provenance at all, i.e. one that reads as evidence from this run. On a
+ * site big enough to overflow `maxChecksPerRule` that is silent laundering:
+ * exactly the rules with hundreds of stale carried pages are the ones that
+ * overflow, and the aggregate they fold into claims every one of those pages was
+ * crawled. Keying on provenance keeps each aggregate homogeneous, so the label is
+ * always available and the consumer can tell replay from evidence.
+ *
+ * NUL cannot appear in a check name or status, so the parts can't collide.
+ */
+export function foldGroupKey(check: CheckResult): string {
+  const provenance =
+    check.provenance === "carried" || check.provenance === "unrendered" ? check.provenance : "";
+  return `${check.name}\u0000${check.status}\u0000${provenance}`;
+}
+
 /** Default publish sample: the primary caps applied on every publish (#1167). */
 export const DEFAULT_PUBLISH_SAMPLE: PublishSampleLimits = {
   maxPagesPerCheck: PUBLISH_LIMITS.maxPagesPerCheckPublish,
@@ -251,7 +272,7 @@ export function slimPageChecksForShell(checks: CheckResult[]): CheckResult[] {
   // never > maxChecks, so the trailing slice-to-cap can't drop a class). Fold keeps the
   // full pages[] (≤5000) so sampleChecksForPublish can stamp the true pre-clip count as
   // `details.pagesTruncated`; occurrences carries the folded per-page check count.
-  const classes = new Set(pageIssues.map((c) => `${c.name}\u0000${c.status}`)).size;
+  const classes = new Set(pageIssues.map(foldGroupKey)).size;
   const folded = sampleChecksForPublish(
     foldOverflowChecks(pageIssues, { ...DEFAULT_FOLD_LIMITS, maxChecks: classes }),
   );
@@ -485,7 +506,7 @@ export function foldOverflowChecks(
   // Group per issue class, first-seen order. NUL cannot appear in a check name.
   const groups = new Map<string, CheckResult[]>();
   for (const check of checks) {
-    const key = `${check.name}\u0000${check.status}`;
+    const key = foldGroupKey(check);
     const group = groups.get(key);
     if (group) group.push(check);
     else groups.set(key, [check]);

--- a/packages/rules/src/resolution.ts
+++ b/packages/rules/src/resolution.ts
@@ -12,7 +12,7 @@
 import type { CheckResult, ResolutionSignal } from "@squirrelscan/core-contracts";
 import { RESOLUTION_SIGNAL_LIMITS } from "@squirrelscan/core-contracts/limits";
 import { resolutionCheckKey, resolutionUrlHash } from "@squirrelscan/core-contracts/resolution";
-import { normalizeUrl } from "@squirrelscan/utils/url";
+import { normalizePageUrl } from "@squirrelscan/utils/url";
 
 /**
  * Build the resolution signal from a report's pre-sample rule results + the
@@ -55,13 +55,18 @@ export function buildResolutionSignal(
   // stays in, and the collision instead makes the *other* page carry too —
   // over-carry, never a wrong resolve.
   const evaluated = new Map<string, Set<string>>();
-  // The same page URL recurs across many checks/rules; normalizeUrl (URL
+  // (#2063) Hashed on the QUERY-PRESERVING page identity, the same key the merge
+  // stores findings under. A consumer on an older release hashed these
+  // query-blind; it recognizes both spellings (see merge-core's resolutionHashes),
+  // and the mismatch it cannot resolve only ever makes it carry, never resolve.
+  //
+  // The same page URL recurs across many checks/rules; normalizePageUrl (URL
   // parsing) dominates the build cost, so memoize per unique URL.
   const normalizeCache = new Map<string, string>();
   const normalized = (url: string): string => {
     let norm = normalizeCache.get(url);
     if (norm === undefined) {
-      norm = normalizeUrl(url);
+      norm = normalizePageUrl(url);
       normalizeCache.set(url, norm);
     }
     return norm;
@@ -80,6 +85,13 @@ export function buildResolutionSignal(
   for (const [ruleId, rule] of Object.entries(ruleResults)) {
     for (const check of rule.checks) {
       if (check.status !== "pass" && check.status !== "warn" && check.status !== "fail") continue;
+      // (#2063) A carried/unrendered check is a replay of an earlier observation,
+      // not something this run evaluated. It can only mislead here — the pages it
+      // names were not crawled, so the consumer never consults them — while eating
+      // the signal's own budget: a producer replaying thousands of stale findings
+      // would push the pages this crawl DID evaluate past `maxChecks` and out of
+      // the signal entirely, which costs real resolutions.
+      if (check.provenance === "carried" || check.provenance === "unrendered") continue;
       const aggregated = check.details?.aggregated === true;
       const pageUrls = check.pageUrl
         ? [check.pageUrl]

--- a/packages/rules/tests/fold.test.ts
+++ b/packages/rules/tests/fold.test.ts
@@ -150,10 +150,42 @@ describe("foldOverflowChecks", () => {
     const [allCarried] = foldOverflowChecks(carried, SMALL);
     expect(allCarried!.provenance).toBe("carried");
     expect(allCarried!.lastSeenAt).toBe(1005);
+  });
 
-    const mixed = [...carried.slice(0, 5), failCheck({ pageUrl: "https://example.com/fresh" })];
-    const [notCarried] = foldOverflowChecks(mixed, SMALL);
-    expect(notCarried!.provenance).toBeUndefined();
+  // #2063: a fresh check and a carried one are different issue CLASSES, not one
+  // class the fold has to compromise over. Before, the mixed group folded to a
+  // single aggregate with no provenance — which reads as evidence from this run,
+  // so a rule with enough carried pages to overflow the cap laundered every one
+  // of them into "crawled today".
+  test("a mixed group folds into one aggregate per provenance, each keeping its label", () => {
+    const carried = Array.from({ length: 6 }, (_, i) =>
+      failCheck({
+        pageUrl: `https://example.com/p/${i}`,
+        provenance: "carried",
+        lastSeenAt: 1000 + i,
+      }),
+    );
+    const mixed = [
+      ...carried.slice(0, 5),
+      failCheck({ pageUrl: "https://example.com/fresh-a" }),
+      failCheck({ pageUrl: "https://example.com/fresh-b" }),
+    ];
+
+    const folded = foldOverflowChecks(mixed, SMALL);
+    expect(folded).toHaveLength(2);
+
+    const carriedAgg = folded.find((c) => c.provenance === "carried");
+    expect(carriedAgg!.details?.occurrences).toBe(5);
+    expect(carriedAgg!.lastSeenAt).toBe(1004);
+    expect(carriedAgg!.details?.pagesTruncated).toBe(5);
+
+    const freshAgg = folded.find((c) => c.provenance === undefined);
+    expect(freshAgg!.details?.occurrences).toBe(2);
+    expect(freshAgg!.lastSeenAt).toBeUndefined();
+    expect(freshAgg!.pages).toEqual([
+      "https://example.com/fresh-a",
+      "https://example.com/fresh-b",
+    ]);
   });
 
   // #1652: folding must not launder "never rendered by any audit" into
@@ -167,7 +199,8 @@ describe("foldOverflowChecks", () => {
     expect(aggregate!.provenance).toBe("unrendered");
     expect(aggregate!.lastSeenAt).toBeUndefined();
 
-    // Mixed with a genuinely carried check → neither claim holds for the whole.
+    // Mixed with a genuinely carried check → the two stay apart (#2063), so
+    // neither claim is ever made about the other's pages.
     const mixed = [
       ...unrendered.slice(0, 5),
       failCheck({
@@ -176,7 +209,10 @@ describe("foldOverflowChecks", () => {
         lastSeenAt: 900,
       }),
     ];
-    expect(foldOverflowChecks(mixed, SMALL)[0]!.provenance).toBeUndefined();
+    const folded = foldOverflowChecks(mixed, SMALL);
+    expect(folded.map((c) => c.provenance).sort()).toEqual(["carried", "unrendered"]);
+    expect(folded.find((c) => c.provenance === "unrendered")!.lastSeenAt).toBeUndefined();
+    expect(folded.find((c) => c.provenance === "carried")!.lastSeenAt).toBe(900);
   });
 
   test("a pathological rule with more distinct issue classes than the cap still slices to the cap", () => {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,6 +2,8 @@
 
 export {
   normalizeUrl,
+  normalizePageUrl,
+  stripUrlQuery,
   isValidUrl,
   isInternalUrl,
   getOrigin,

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -307,7 +307,12 @@ export function parseUserUrl(input: string): UrlParseResult {
  * Normalize a URL for comparison/deduplication
  * - Lowercases scheme and host (case-insensitive per RFC)
  * - Preserves pathname case (case-sensitive on most servers)
- * - Removes trailing slashes and hash fragments
+ * - Removes trailing slashes, QUERY STRINGS and hash fragments
+ *
+ * Query-BLIND by design: this is the right key for "is this the same resource"
+ * comparisons (sitemap ↔ crawl matching, incoming-link buckets, external-URL
+ * cache keys). It is the WRONG key for a page's identity in a store — see
+ * {@link normalizePageUrl} (#2063).
  */
 export function normalizeUrl(url: string): string {
   try {
@@ -323,6 +328,57 @@ export function normalizeUrl(url: string): string {
   } catch {
     return url;
   }
+}
+
+/**
+ * Normalize a URL for use as a PAGE IDENTITY (squirrelscan/repo#2063).
+ *
+ * Same as {@link normalizeUrl} — lowercased scheme + host, preserved path case,
+ * no trailing slash, no fragment — except that it KEEPS the query string.
+ *
+ * Two URLs that differ only by query are two different request targets serving
+ * two different documents, and the crawler already treats them that way: its own
+ * normalizer (`@squirrelscan/crawler` frontier) keeps the query after stripping
+ * tracking parameters, so every page record, finding and report check the
+ * producers emit is keyed query-preserving. Re-keying them with `normalizeUrl`
+ * server-side collapsed a whole catalogue into one row — 384 `?id=N` pages became
+ * a single `page_findings` URL carrying 362 copies of the same rule's finding.
+ *
+ * Use this wherever a URL identifies a PAGE (findings, site pages, crawled sets,
+ * resolution hashes). `normalizeUrl` stays the right call for comparisons that
+ * are deliberately query-blind (sitemap ↔ crawl matching, link-count buckets,
+ * external-URL cache keys).
+ *
+ * The query is preserved VERBATIM, parameter order included: `?a=1&b=2` and
+ * `?b=2&a=1` are distinct frontier entries upstream, and re-sorting here would
+ * key the store differently from the crawler that produced the URL.
+ */
+export function normalizePageUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    let path = parsed.pathname;
+    if (path.endsWith("/") && path !== "/") {
+      path = path.slice(0, -1);
+    }
+    const scheme = parsed.protocol.toLowerCase();
+    const host = parsed.host.toLowerCase();
+    return `${scheme}//${host}${path}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Drop a normalized page URL's query string — the pre-#2063 page identity.
+ *
+ * Exists ONLY for backward compatibility at version boundaries: a publisher on
+ * an older release hashed/keyed pages query-blind, so a consumer that has moved
+ * to {@link normalizePageUrl} has to recognize the old spelling too. Returns the
+ * input unchanged when there is no query.
+ */
+export function stripUrlQuery(url: string): string {
+  const q = url.indexOf("?");
+  return q === -1 ? url : url.slice(0, q);
 }
 
 /**

--- a/packages/utils/tests/normalize-page-url.test.ts
+++ b/packages/utils/tests/normalize-page-url.test.ts
@@ -1,0 +1,53 @@
+// #2063 — the page identity used by the finding store keeps the query string.
+//
+// `normalizeUrl` drops it, which is right for "is this the same resource"
+// comparisons and wrong for "which page is this": a catalogue of 384
+// `?id=N` pages collapsed into one stored URL carrying 362 copies of the same
+// rule's finding.
+
+import { describe, expect, test } from "bun:test";
+
+import { normalizePageUrl, normalizeUrl, stripUrlQuery } from "../src/url";
+
+describe("normalizePageUrl", () => {
+  test("keeps the query string, which normalizeUrl drops", () => {
+    const a = "https://x.test/p?id=1";
+    const b = "https://x.test/p?id=2";
+
+    expect(normalizePageUrl(a)).toBe(a);
+    expect(normalizePageUrl(b)).toBe(b);
+    expect(normalizePageUrl(a)).not.toBe(normalizePageUrl(b));
+
+    // The old identity — one page where there are two.
+    expect(normalizeUrl(a)).toBe(normalizeUrl(b));
+  });
+
+  test("keeps parameter order verbatim (the crawler's frontier entries differ)", () => {
+    expect(normalizePageUrl("https://x.test/p?a=1&b=2")).toBe("https://x.test/p?a=1&b=2");
+    expect(normalizePageUrl("https://x.test/p?b=2&a=1")).toBe("https://x.test/p?b=2&a=1");
+  });
+
+  test("otherwise matches normalizeUrl: lowercased scheme/host, kept path case, no trailing slash, no fragment", () => {
+    expect(normalizePageUrl("HTTPS://X.TEST/About/")).toBe("https://x.test/About");
+    expect(normalizePageUrl("https://x.test/p#section")).toBe("https://x.test/p");
+    expect(normalizePageUrl("https://x.test/")).toBe("https://x.test/");
+    expect(normalizePageUrl("https://x.test/p?id=1#frag")).toBe("https://x.test/p?id=1");
+  });
+
+  test("returns unparseable input unchanged", () => {
+    expect(normalizePageUrl("not a url")).toBe("not a url");
+  });
+});
+
+describe("stripUrlQuery", () => {
+  test("recovers the pre-#2063 spelling of a page identity", () => {
+    expect(stripUrlQuery("https://x.test/p?id=1")).toBe("https://x.test/p");
+    expect(stripUrlQuery(normalizePageUrl("https://x.test/p?id=1"))).toBe(
+      normalizeUrl("https://x.test/p?id=1"),
+    );
+  });
+
+  test("leaves a query-less URL alone", () => {
+    expect(stripUrlQuery("https://x.test/p")).toBe("https://x.test/p");
+  });
+});


### PR DESCRIPTION
Fixes the engine half of squirrelscan/repo#2063. The private half (the API's one-off repair for the affected site) is a separate PR on the monorepo.

## What was wrong

A published cloud report is the UNION of the crawl the CLI just ran and the CLI's own local finding store, with the replayed half tagged `provenance: "carried"`. `runCloudSmartAudits` read every published check's `pageUrl` as a page crawled this run, so a machine whose local store still held an old audit turned that audit into cloud state: findings stamped first-seen-today on pages the crawl never opened, and 129 "audited pages" for a 16-page crawl.

Two runs of the same site, three minutes apart, identical config, scored 50 and 88.

The second half of the same bug: page identity in the store used `normalizeUrl`, which strips the query string, so 384 `/tools/…/project?id=N` pages collapsed into one `page_findings` URL carrying 362 copies of one rule's finding.

## What changed

**Carried checks are not evidence.** `runCloudSmartAudits` drops checks tagged `carried`/`unrendered` from `crawledUrls`, from `freshFindings`, from the union's fresh side and from the #1167 sample sets. The cloud's OWN carry is untouched: it is replayed from the cloud store with the date the cloud last saw it. The count of refused checks is returned as `replayedChecksDropped` so an inflated publish is visible without re-reading the report out of R2.

**And it says when it happens.** #2063 ran for a month with nothing reporting it, and the count of refused checks cannot report it either: an ordinary partial re-audit replays thousands of them for pages the cloud knows perfectly well. `replayedUnknownPages` counts the pages a producer named that this site has NO record of, which is the mechanism rather than a proxy for it. 508 such pages against a 16-page crawl was the incident. The API logs on that number.

**The fold keys on provenance.** `foldOverflowChecks` grouped on `(name, status)` only, and `foldGroup` can keep a "carried" label only when every constituent carries it — so a mixed group folded to an aggregate with no provenance, which reads as evidence from this run. On a site big enough to overflow `maxChecksPerRule`, exactly the rules with hundreds of stale carried pages are the ones that overflow. Groups are now homogeneous, the sort tie-breaks on the same key so a repeat audit stays byte-identical, and `complete-store-fold` counts classes the same way.

**Complete-store mode too.** The staged shell is that path's report body, and it flows into the union — so a replay in it would sit beside the cloud's own carry for the same page, with the producer's date, on a page the crawl never fetched. Complete mode deliberately does not unfold, so the filter there matches page checks AND folded aggregates by their `pages[]`, and the same filtered shell is what the tally fold reads. Genuine site-scope checks are kept: the fold scores those verbatim.

**Same exclusion on the other producers.** `buildStreamFindings` and `buildSkippedPassCounts` skip replayed checks (the complete-store path's version of the same laundering), and `buildResolutionSignal` stops spending its budget on pages the run never evaluated.

**Query strings are part of a page's identity.** New `normalizePageUrl` in `@squirrelscan/utils` — identical to `normalizeUrl` (lowercased scheme/host, preserved path case, no trailing slash, no fragment) except it keeps the query verbatim, parameter order included.

I chose (a), a new function for the page-identity path, not (b), changing `normalizeUrl`. I checked every caller: `site-query.ts` (incoming-link buckets), `cloaking-probe.ts` and `adapter.ts` (sitemap ↔ crawl matching), and `api/services/providers/dead-links.ts` (external-URL cache key) all want the query-BLIND comparison, and the crawler and threat-intel packages have their own normalizers. Only the finding-store path was wrong, so only it moved: `merge-promise.ts`, `stream-findings.ts` and `rules/resolution.ts`.

The trailing-slash collapse is deliberately unchanged, which keeps every existing `page_findings` row keyed as it is today. Only pages with a query string re-key.

**Version skew.** The resolution signal's URL hashes are computed by the publisher, so an older CLI hashes them query-blind. `merge-core` now accepts either spelling. Every consequence of the extra hash is a carry: a hit in `notEvaluated` carries, a hit in `failing` carries, and a miss in `failing` is the only branch that resolves. The worst case is two query URLs sharing a path both carrying when one still fails.

## Acceptance criteria

- [x] `runCloudSmartAudits` excludes `provenance: "carried"` checks from `crawledUrls` and `freshFindings`; a report whose only checks for page P are carried leaves P untouched, never persisted with first/last-seen = publish time — `carried-provenance-merge.test.ts`, "a 16-page crawl published with 400 carried pages audits 16 pages" asserts the store holds 2 rows, none on a carried URL
- [x] `coverage.auditedPages` equals the pages the CLI actually crawled — same test, 16 fresh + 400 carried pages gives `auditedPages: 16`. See the note below on the residual sampling gap
- [x] Published carried checks keep their original `lastSeenAt`, or are dropped, never re-stamped to now — they are dropped from the union, and the cloud's own carry keeps the cloud's date ("the cloud's OWN carry still works, with the date the cloud last saw it")
- [x] Two URLs differing only by query string do not merge into one `normalized_url` — "/p?id=1 and /p?id=2 are two findings, not one", plus a re-crawl test showing only the re-crawled one resolves

## Evidence

```
packages/utils     bunx tsgo --noEmit          clean
packages/rules     bunx tsgo --noEmit          clean
packages/audit-engine bunx tsgo --noEmit       clean

bun run scripts/test-suites.ts --run rules     2235 pass, 0 fail
bun run scripts/test-suites.ts --run report     332 pass, 0 fail
packages/audit-engine  5 merge/scoring files     81 pass, 0 fail
packages/audit-engine  3 golden files            11 pass, 0 fail  (re-run after the complete-store filter)
packages/utils         url + normalize-page-url  19 pass, 0 fail
apps/cli               4 publish files           21 pass, 0 fail
packages/crawler       3 store files             22 pass, 0 fail

bun run format:check   clean       bun run lint   clean
```

Against `origin/main` the original eight tests are **7 fail / 1 pass**. The single pass is the trailing-slash case, which is a pure regression guard: reverting the normalizer preserves that behaviour by design. The older-publisher test does fail on main, because main never creates the query-specific store key in the first place.

Each later test was checked the same way, by removing the one line it is meant to protect: the sample-set exclusion, the complete-store filter, and the two `stream-findings` guards each fail their own tests and nothing else.

## What this does NOT fix

Replaying the incident's stored report through the fixed engine drops 3,232 replayed checks and reports 401 pages the cloud has no record of, but still lands on 111 audited pages rather than 16. The residue is 258 checks the CLI tagged **`fresh`** on 88 pages it did not crawl, concentrated in exactly three rules (`ax/token-weight` 87, `perf/unminified-js` 86, `perf/critical-request-chains` 85). Every one of those 88 URLs also appears CARRIED in the same report, from other rules, so the report contradicts itself.

The server cannot refuse those: a `fresh` label is the producer's assertion that it observed the page, and there is nothing else to check it against. Filed as squirrelscan/repo#2072 with the evidence. It is a producer-side tagging gap, so the fix ships with a CLI release rather than a deploy.

## Codex review

Three findings, all addressed:

1. **[P1] The complete-store report builder dropped a provenance group.** Real, and mine: `complete-store-fold.ts` counted `(name, status)` classes and used that count as the re-fold's `maxChecks`, so a class splitting into a carried and an unrendered aggregate was capped at one, merged, and lost an occurrence — then reconciled against a key it no longer matched, deleting its provenance and last-seen. Fixed by keying the accumulator, the cap and the reconciliation on the shared `foldGroupKey`. Regression test added, plus two existing tests updated: they asserted the old mixed-provenance behaviour, which no longer exists.

2. **[P1] Mixed-version complete ingest could wrongly resolve a query-specific finding.** Correct in principle, not fixed — documented as an identity contract at `merge-promise.ts`. Complete mode is the one place absence authorises a resolve, and the fresh set is keyed by the container while the crawled set is keyed by the API. They come from the same module in the same release, so this is a deploy constraint: ship the container image and the API from one engine build. Triggering it needs an audit in flight across that deploy AND a prior new-engine publish for the same site; the damage is one early resolve that the next audit re-creates. A mechanism to detect the producer's normalisation would need the run's whole ingested URL set, which the page-at-a-time cursor exists to avoid materialising.

3. **[P2] Acceptance criterion 2 after publish sampling.** Real and pre-existing, filed as squirrelscan/repo#2067 rather than fixed here. A page crawled clean whose every check was clipped from the #1167 sample is evidenced by nothing in the payload, so it is not counted as audited. `resolutionSignal.crawledUrls` holds the unsampled list but is deliberately kept out of `crawledUrls` — unioning it drops those pages from `carriedPageUrls` and loses their synthetic pass from the denominator, moving the score. Fixing it properly needs a coverage page set that does not double as the scoring set, and `knownPages`/`site_pages` have to move with it. Commented at the coverage return.

Codex also noted the fold comparator ignored provenance, making equivalent groups' order input-dependent; the sort now tie-breaks on the full group key.

https://claude.ai/code/session_0174D96WamG9ZhJxRudpeniA
