### PR TITLE
test(audit-engine): pin the mixed-fold laundering path (squirrelscan/repo#2072)

### DIFF
--- a/packages/audit-engine/tests/carried-provenance-merge.test.ts
+++ b/packages/audit-engine/tests/carried-provenance-merge.test.ts
@@ -23,6 +23,8 @@ import type {
 import { resolutionCheckKey, resolutionUrlHash } from "@squirrelscan/core-contracts/resolution";
 
 import { findingKey } from "../src/merge-core";
+import { foldOverflowChecks, sampleChecksForPublish } from "@squirrelscan/rules/fold";
+import { REPORT_LIMITS } from "@squirrelscan/core-contracts/limits";
 import { runCloudSmartAudits, type SmartAuditStore } from "../src/merge-promise";
 import { buildSkippedPassCounts, buildStreamFindings } from "../src/stream-findings";
 import { calculateHealthScore } from "../src/scoring";
@@ -716,5 +718,91 @@ describe("#2063 — a rule emptied by the filter still scores its crawled pages"
 
     expect(result.replayedChecksDropped).toBe(2);
     expect(result.coverage.auditedPages).toBe(1);
+  });
+});
+
+// squirrelscan/repo#2072 — the residue in the incident report, end to end.
+//
+// 258 checks in that report are tagged `fresh` on 88 pages the crawl never
+// fetched, in three rules, and no server can refuse a `fresh` label. Every one of
+// them carries `details.pagesTruncated`, which only `unfoldAggregateCheck` leaves
+// on a per-page check — so they are the expansion of a SAMPLED AGGREGATE that
+// reached the server with no provenance at all.
+//
+// An aggregate loses its label when its fold group is MIXED, and a rule emitting
+// two checks per page overflows `maxChecksPerRule` as soon as the producer's local
+// store is large: 16 crawled pages + 481 replayed is 994 checks for one rule. The
+// real report stamps `pagesTruncated: 497` on those checks, which is exactly
+// 16 + 481 for one check name — the arithmetic is what identifies the path.
+//
+// Provenance-keyed fold groups split that into a fresh aggregate and a carried
+// one, and the merge refuses the carried one. This test is the whole chain,
+// producer fold through server merge, because neither half alone would catch it.
+describe("#2072 — a mixed group over the fold cap cannot launder its carried half", () => {
+  const RULE = "ax/token-weight";
+  const tokenMeta = { ...pageMeta, id: "token-weight", name: "Token Weight", category: "ax" };
+  const CRAWLED = Array.from({ length: 16 }, (_, i) => `https://x.test/p/${i}`);
+  const REPLAYED = Array.from({ length: 481 }, (_, i) => `https://x.test/old/${i}?id=${i}`);
+
+  /** Two checks per page, for both halves — what the rule emits before publish. */
+  function prePublishChecks(): CheckResult[] {
+    const ratio = (url: string, replayed: boolean): CheckResult => ({
+      name: "token-weight-ratio",
+      status: "warn",
+      message: "Visible text is under 15% of the page HTML",
+      pageUrl: url,
+      items: [{ id: url, label: "~7%", sourcePages: [url] }],
+      ...(replayed ? { provenance: "carried" as const, lastSeenAt: AUGUST } : {}),
+    });
+    const budget = (url: string, replayed: boolean): CheckResult => ({
+      name: "token-weight-budget",
+      status: "pass",
+      message: "within budget",
+      pageUrl: url,
+      ...(replayed ? { provenance: "carried" as const, lastSeenAt: AUGUST } : {}),
+    });
+    return [
+      ...CRAWLED.flatMap((u) => [ratio(u, false), budget(u, false)]),
+      ...REPLAYED.flatMap((u) => [ratio(u, true), budget(u, true)]),
+    ];
+  }
+
+  test("the publish fold labels each half and the merge refuses the replayed one", async () => {
+    const all = prePublishChecks();
+    // The premise: without the overflow no fold runs and the test proves nothing.
+    expect(all.length).toBeGreaterThan(REPORT_LIMITS.maxChecksPerRule);
+
+    const published = sampleChecksForPublish(foldOverflowChecks(all));
+    // Two issue classes x two provenances, not the two unlabelled aggregates the
+    // issue-class-only key produced.
+    expect(published).toHaveLength(4);
+
+    const carriedAggregates = published.filter((c) => c.provenance === "carried");
+    expect(carriedAggregates).toHaveLength(2);
+    for (const agg of carriedAggregates) {
+      expect(agg.lastSeenAt).toBe(AUGUST);
+      expect(agg.details?.pagesTruncated).toBe(REPLAYED.length);
+    }
+    // The fresh half is unlabelled, which is what fresh looks like on the wire.
+    const freshAggregates = published.filter((c) => c.provenance === undefined);
+    expect(freshAggregates).toHaveLength(2);
+    for (const agg of freshAggregates) expect(agg.pages).toHaveLength(CRAWLED.length);
+
+    const store = new MemStore();
+    const r = await runCloudSmartAudits({
+      store,
+      siteKey: "web_1",
+      crawlId: "audit_1",
+      ruleResults: { [RULE]: { meta: tokenMeta, checks: published } },
+      pageStatuses: [],
+      now: NOW,
+    });
+
+    expect(r.coverage.auditedPages).toBe(CRAWLED.length);
+    expect([...store.pages.keys()].sort()).toEqual([...CRAWLED].sort());
+
+    const persisted = await store.getFindings("web_1");
+    expect(persisted).toHaveLength(CRAWLED.length);
+    for (const f of persisted) expect(REPLAYED).not.toContain(f.normalizedUrl);
   });
 });


### PR DESCRIPTION
Closes squirrelscan/repo#2072. Branches off main after #326; it does not stack on an open PR.

## The premise changed

#2072 was filed on my own measurement: replaying the incident report through the fixed engine still reported 111 audited pages for a 16-page crawl, and the residue was 258 checks tagged `fresh` on 88 pages the crawl never fetched, in three rules. I expected the cause to be `tagCarriedCheck` failing to label them, and said so in the issue.

It is not. The mechanism is the one #326 already fixed, so this PR adds the test that proves it rather than a second fix.

## How the residue is actually produced

Every one of those 258 checks carries `details.pagesTruncated`. Nothing puts that on a per-page check except `unfoldAggregateCheck`, which copies an aggregate's `details` onto each page it expands. So they are the expansion of a sampled AGGREGATE that reached the server with no provenance at all, and an unlabelled aggregate is indistinguishable from evidence.

An aggregate loses its label when its fold group is mixed: `foldGroup` keeps "carried" only when every constituent carries it. A rule emitting two checks per page overflows `maxChecksPerRule` as soon as the producer's local store is large. For `ax/token-weight` on that site: 16 crawled pages + 481 replayed, two checks each, is 994 checks, so the rule folds, and each `(name, status)` class folded one mixed group into one unlabelled aggregate.

The arithmetic is what settles it. The real report stamps `pagesTruncated: 497` on those checks. 16 + 481 = 497, for one check name. The three affected rules are exactly the ones that emit more than one check per page; the rules with large carried sets but one check per page stayed under the 500 cap, never folded, and are correctly tagged per check in the same report.

Ruled out along the way, recorded on the issue so nobody redoes them: `tagCarriedCheck` cannot miss, since `carriedLastSeen` is keyed `(normalizedUrl, ruleId, checkName)` and a replay carries exactly those; the rule cache is not it, since the run three minutes later on the same machine has zero of these; template fanout is not it, since #1951 records a cluster's verdicts before `pageUrl` is stamped; and the pages were not crawled, since a crawled page in that report carries about 200 checks and these carry two to six.

## What this adds

One test driving the whole chain: build the pre-publish shape (16 crawled + 481 replayed, two checks per page), fold and sample it the way publish does, then merge the result. It asserts the fold emits four aggregates rather than two, that the carried pair keeps `provenance: "carried"`, `lastSeenAt` and `pagesTruncated: 481`, and that the merge then audits 16 pages, writes 16 site pages and persists 16 findings with nothing on a replayed URL.

Neither half would catch this alone. The fold change is invisible without a merge asserting the resulting pages, and the merge filter is invisible without a fold that labels what it produces.

Verified by mutation: reverting `foldGroupKey` to `(name, status)` fails this test and nothing else in the file.

No CHANGELOG entry. There is no behaviour change here; the fix shipped in #326, whose entry already covers it.

## Evidence

```
packages/audit-engine  bunx tsgo --noEmit        clean
packages/audit-engine  4 merge/parity files      74 pass, 0 fail
bun run scripts/test-suites.ts --run rules     2235 pass, 0 fail
bun run format:check   clean       bun run lint   clean
```

One rules run reported a single failure on a 5s timeout under load; a clean re-run is 2235/0 and the diff touches no rules code.

## What is still open

An old CLI keeps producing unlabelled mixed aggregates until users upgrade, and the server cannot refuse them: a `fresh` label is the producer asserting it observed the page. The window closes when the fold change ships in v0.0.95 and people update.

The server could narrow it sooner by refusing page attributions absent from `report.resolutionSignal.crawledUrls`, which is unsampled and authoritative for what the run crawled. I have not done that here because the signal's crawled list is capped with no marker for having been clipped, so a large crawl could drop genuine fresh findings. That is a design call with a data-loss failure mode and it should be someone's decision, not a side effect of this PR.

https://claude.ai/code/session_0174D96WamG9ZhJxRudpeniA
