### PR TITLE
docs(rules): restore the phrasing the perf rule-count guard matches

### DIFF
--- a/docs/rules/performance/index.mdx
+++ b/docs/rules/performance/index.mdx
@@ -4,7 +4,7 @@ description: "The Performance score group: page speed and loading behavior"
 icon: "gauge"
 ---
 
-Performance is one of the four score groups on every report, alongside SEO, Security and Agents. It measures page speed and loading behaviour: the markup patterns behind LCP, CLS and INP, render blocking, resource weight, caching, compression and delivery. The group is a single category of 30 rules, most of which run against the HTML and response headers, with a few that need [browser rendering](/guides/browser-rendering) for measurements only a real browser can take.
+Performance is one of the four score groups on every report, alongside SEO, Security and Agents. It measures page speed and loading behaviour: the markup patterns behind LCP, CLS and INP, render blocking, resource weight, caching, compression and delivery. The group is a single category with 30 rules, most of which run against the HTML and response headers, with a few that need [browser rendering](/guides/browser-rendering) for measurements only a real browser can take.
 
 See [Core Web Vitals](https://squirrelscan.com/learn/core-web-vitals) for how an agent works through a report.
 


### PR DESCRIPTION
One preposition. Unblocks squirrelscan/repo#2077, whose gitlink bump pulls these docs into the private monorepo's test run.

## What broke

The private repo pins this page's rule count against `loadAllRules()` with a literal regex, `/single category with (\d+) rules/` (`apps/api/tests/routes/rule-count-consistency.test.ts`, the `#1156 #1661` guard). The docs rewrite reworded the sentence to "a single category **of** 30 rules", so the regex stops matching and two tests fail:

- `performance/index.mdx: prose count for 'perf' matches the live count` — the guard reports the surface as moved
- `every prose "N rules" claim is accounted for` — with the listed regex no longer matching, that same "30 rules" becomes an unaccounted prose claim

## What was NOT wrong

The number. Live `perf` is 30, and both surfaces on this page say 30. This restores the preposition and changes nothing else.

I checked the rest of the guard's surface while here, against live counts from `loadAllRules()` (282 rules total):

| surface | state |
|---|---|
| `rules/index.mdx` "All 282 audit rules" | matches |
| `rules/index.mdx` "**282 rules** across" | matches |
| `rules/security/index.mdx` "safe link practices (16 rules)" | matches |
| `rules/performance/index.mdx` "single category … 30 rules" | fixed here |
| every `<Card>` count on every category index | agrees with live |

The `gaps` and `adblock` cards have no live category by design: `gaps` is cloud-only and excluded by the guard, and `adblock` is the legacy alias of `blocking`, which has the 3 rules the card claims.

## Validation

```
cd docs && make validate
tangly v0.4.0
Pages: 393    Orphans: 1
  ✓ All checks passed
```

Docs-only, so the code CI paths are skipped.

## A note for whoever owns this next

A private test asserting an exact English phrase in a public repo will keep breaking on every docs copy edit, and the break lands on an unrelated PR — this one surfaced as a red "Test - API" on a gitlink bump that had nothing to do with docs. The guard's own comment acknowledges the tradeoff: matching a listed phrase is what stops it attributing a bare "N rules" to the wrong category. Worth considering a looser shape on the private side, for example `single category (?:of|with) (\d+) rules`, so wording can move without breaking a build. Not done here, since that is a private-repo change and this PR needs to stay docs-only.

https://claude.ai/code/session_0174D96WamG9ZhJxRudpeniA
