### PR TITLE
docs(changelog): v0.0.95 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ How it works:
 
 ## [Unreleased]
 
+## v0.0.95
+
+Two fixes for scores that moved when nothing on the site had, one for local audits
+that reached out to the cloud, and an installer that works where GitHub does not.
+
 ### Changed
 
 - Audits of `localhost`, loopback, and private-network addresses no longer hand anything to a hosted runner: no publish, no run registration, no cloud rendering, and no site added to your dashboard. This covers `squirrel report --publish` as well as `squirrel audit`, and internal names such as `box.local` and `metadata.google.internal` as well as private IP ranges. The audit, its report, and the content-based cloud analysis are unchanged, and the CLI prints one line saying the report stayed local. Hosted services cannot reach those addresses, so a dashboard site for one could never be screenshotted, re-rendered, or re-audited.


### PR DESCRIPTION
Moves the Unreleased entries (#324, #325, #326, #327) under a v0.0.95 heading ahead of the release cut, and leaves an empty Unreleased heading above it. Docs-only.

https://claude.ai/code/session_0174D96WamG9ZhJxRudpeniA