### PR TITLE
docs(cli): local audits are free but capped at 10,000 pages, not unlimited

### DIFF
--- a/docs/configuration/crawler.mdx
+++ b/docs/configuration/crawler.mdx
@@ -60,7 +60,7 @@ squirrel audit https://example.com -m 100
 
 The resolution order is **`--max-pages` / `-m` > non-default `[crawler] max_pages` > coverage-mode default** (`quick` 25, `surface` 100, `full` 500).
 
-**Note:** The CLI enforces a hard cap (currently 10,000 pages) regardless of config or plan - local audits are free and unlimited, and this cap never changes based on your account. When a crawl stops because it hit the limit, the CLI prints a hint naming `--max-pages` and the cap; see [Hitting the page limit](/crawl#hitting-the-page-limit).
+**Note:** The CLI enforces a hard cap (currently 10,000 pages) regardless of config or plan. Local audits are free, and this cap never changes based on your account. When a crawl stops because it hit the limit, the CLI prints a hint naming `--max-pages` and the cap; see [Hitting the page limit](/crawl#hitting-the-page-limit).
 
 **Cloud audits are different:** an audit dispatched from the dashboard (on-demand or [scheduled](/cloud/scheduled-audits)) is capped per plan instead - see [max pages per cloud audit](/cloud/credits#max-pages-per-cloud-audit).
 

--- a/docs/developers/mcp.mdx
+++ b/docs/developers/mcp.mdx
@@ -88,7 +88,7 @@ All tools require authentication. Write tools are marked; everything else only r
 
 Three tools deserve a closer look:
 
-- **`run_audit` has a confirm rail.** The first call returns a credit estimate instead of starting anything expensive; the agent is expected to show it to you and call again with `confirm: true`. Every audit costs at least the 50-credit base, so expect the confirm step on each run. A `max_credits` argument acts as a hard spend guard: the audit refuses to start if the estimate exceeds it.
+- **`run_audit` has a confirm rail.** When the estimate is above the auto-run threshold (50 credits by default), the first call returns the estimate instead of starting; the agent shows it to you and calls again with `confirm: true`. An estimate at or under the threshold starts immediately, and an agent that already has your approval can pass `confirm: true` on the first call. A `max_credits` argument acts as a hard spend guard: the audit refuses to start if the estimate exceeds it.
 - **`delete_website` has the same confirm rail.** The first call previews what happens (the domain, how many audits and open issues stay attached to the old id) without deleting anything; the agent confirms with you and calls again with `confirm: true`. Deletion is soft: nothing is destroyed, and re-adding the domain later registers a fresh website with a new id.
 - **`create_api_key` is scope-gated.** It needs credentials carrying the reserved `keys:write` scope. OAuth login grants it (you consented on the approval screen); plain API keys never carry it, and keys minted by this tool can't mint further keys. No escalation loops.
 

--- a/docs/guides/local-audits-cli.mdx
+++ b/docs/guides/local-audits-cli.mdx
@@ -4,7 +4,7 @@ description: "Run a full website audit from your terminal with no account and no
 icon: "terminal"
 ---
 
-Local audits are free, unlimited, and need no login. The `squirrel` CLI crawls a site on your machine and runs the deterministic audit rules against it, so you can check a live URL or your own localhost dev server without spending a thing. By the end of this guide you will have installed the CLI, run an audit, and read the report in the format that suits you.
+Local audits are free and need no login, up to the CLI's 10,000-page cap per crawl. The `squirrel` CLI crawls a site on your machine and runs the deterministic audit rules against it, so you can check a live URL or your own localhost dev server without spending a thing. By the end of this guide you will have installed the CLI, run an audit, and read the report in the format that suits you.
 
 <Info>
 Local audits run the deterministic rules only. The cloud-backed rules (AI analysis, technology detection, browser rendering) need an account and credits: see [Cloud audits](/guides/cloud-audits). Everything below works logged out.


### PR DESCRIPTION
Two docs pages said local audits are unlimited. The CLI enforces MAX_PAGES_CAP = 10,000 pages per crawl (packages/core-contracts/src/limits.ts), which crawler.mdx itself states two words earlier. Reworded both sentences.

Second commit: docs/developers/mcp.mdx said to expect the run_audit confirm step on every run. The rail is gated on estimate > auto-run threshold (50 credits by default, apps/api audit-tools.ts), so an estimate at or under it starts immediately and confirm: true on the first call skips the round-trip. Closes #330.

https://claude.ai/code/session_0174D96WamG9ZhJxRudpeniA